### PR TITLE
SALTO-4069: Salesforce MetadataRelationship with controlling field bugfix

### DIFF
--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -165,6 +165,9 @@ export class CustomField implements MetadataInfo {
   securityClassification?: string
   complianceGroup?: string
 
+  // CustomMetadata types
+  metadataRelationshipControllingField?: string
+
   constructor(
     public fullName: string,
     type: string,
@@ -182,8 +185,12 @@ export class CustomField implements MetadataInfo {
     relatedTo?: string[],
     relationshipName?: string,
     length?: number,
+    metadataRelationshipControllingField?: string,
   ) {
     this.type = type
+    if (metadataRelationshipControllingField !== undefined) {
+      this.metadataRelationshipControllingField = metadataRelationshipControllingField
+    }
     if (formula) {
       this.formula = formula
     } else {

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -209,6 +209,7 @@ export const FIELD_ANNOTATIONS = {
   // when true, the field should not be deployed to the service
   LOCAL_ONLY: 'localOnly',
   ROLLUP_SUMMARY_FILTER_OPERATION: 'rollupSummaryFilterOperation',
+  METADATA_RELATIONSHIP_CONTROLLING_FIELD: 'metadataRelationshipControllingField',
 } as const
 
 export const VALUE_SET_FIELDS = {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -106,10 +106,10 @@ export const metadataType = async (element: Readonly<Element>): Promise<string> 
 
 export const isCustomObject = async (element: Readonly<Element>): Promise<boolean> => {
   const res = isObjectType(element)
-  && await metadataType(element) === CUSTOM_OBJECT
-  // The last part is so we can tell the difference between a custom object
-  // and the original "CustomObject" type from salesforce (the latter will not have an API_NAME)
-  && element.annotations[API_NAME] !== undefined
+    && await metadataType(element) === CUSTOM_OBJECT
+    // The last part is so we can tell the difference between a custom object
+    // and the original "CustomObject" type from salesforce (the latter will not have an API_NAME)
+    && element.annotations[API_NAME] !== undefined
   return res
 }
 
@@ -936,7 +936,7 @@ export const isFormulaField = (element: Element): element is Field => {
 export const isNameField = async (field: Field): Promise<boolean> =>
   (isObjectType(await field.getType())
     && (field.refType.elemID.isEqual(Types.compoundDataTypes.Name.elemID)
-    || field.refType.elemID.isEqual(Types.compoundDataTypes.Name2.elemID)))
+      || field.refType.elemID.isEqual(Types.compoundDataTypes.Name2.elemID)))
 
 const transformCompoundValues = async (
   record: SalesforceRecord,
@@ -945,7 +945,7 @@ const transformCompoundValues = async (
   const compoundFieldsElemIDs = Object.values(Types.compoundDataTypes).map(o => o.elemID)
   const relevantCompoundFields = _.pickBy((await instance.getType()).fields,
     (field, fieldKey) => Object.keys(record).includes(fieldKey)
-    && !_.isUndefined(_.find(compoundFieldsElemIDs, e => field.refType.elemID.isEqual(e))))
+      && !_.isUndefined(_.find(compoundFieldsElemIDs, e => field.refType.elemID.isEqual(e))))
   if (_.isEmpty(relevantCompoundFields)) {
     return record
   }
@@ -1044,6 +1044,7 @@ export const toCustomField = async (
     field.annotations[FIELD_ANNOTATIONS.REFERENCE_TO],
     field.annotations[FIELD_ANNOTATIONS.RELATIONSHIP_NAME],
     field.annotations[FIELD_ANNOTATIONS.LENGTH],
+    field.annotations[FIELD_ANNOTATIONS.METADATA_RELATIONSHIP_CONTROLLING_FIELD],
   )
 
   // Skip the assignment of the following annotations that are defined as annotationType
@@ -1356,12 +1357,12 @@ export const getSObjectFieldElement = (
       // e.g. salesforce.user_app_menu_item.ApplicationId, salesforce.login_event.LoginHistoryId
       annotations[FIELD_ANNOTATIONS.REFERENCE_TO] = field.referenceTo
     }
-  // Compound Fields
+    // Compound Fields
   } else if (!_.isUndefined(COMPOUND_FIELDS_SOAP_TYPE_NAMES[field.type]) || field.nameField) {
     // Only fields that are compound in this object get compound type
     if (objCompoundFieldNames[field.name] !== undefined) {
       naclFieldType = field.nameField
-      // objCompoundFieldNames[field.name] is either 'Name' or 'Name2'
+        // objCompoundFieldNames[field.name] is either 'Name' or 'Name2'
         ? Types.compoundDataTypes[objCompoundFieldNames[field.name] as COMPOUND_FIELD_TYPE_NAMES]
         : Types.compoundDataTypes[COMPOUND_FIELDS_SOAP_TYPE_NAMES[field.type]]
     }

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -817,6 +817,23 @@ describe('transformer', () => {
         expect(customField.referenceTo).toBeUndefined()
       })
     })
+    describe('MetadataRelationship CustomField', () => {
+      const CONTROLLING_FIELD = 'TestControllingField__c'
+      it('should have controlling field value', async () => {
+        const metadataRelationshipField = new Field(
+          new ObjectType({ elemID }),
+          'RelationshipField',
+          Types.primitiveDataTypes.MetadataRelationship,
+          {
+            [LABEL]: 'Labelo',
+            [FIELD_ANNOTATIONS.METADATA_RELATIONSHIP_CONTROLLING_FIELD]: CONTROLLING_FIELD,
+          },
+        )
+        const customField = await toCustomField(metadataRelationshipField)
+        expect(customField[FIELD_ANNOTATIONS.METADATA_RELATIONSHIP_CONTROLLING_FIELD])
+          .toEqual(CONTROLLING_FIELD)
+      })
+    })
   })
 
   describe('await toCustomProperties', () => {


### PR DESCRIPTION
Fixed a bug where MetadataRelationship CustomFields with controlling field couldn't be deployed.

---

We simply didn't populate this value in `toCustomField` in the transformer.

---
_Release Notes_: 
Salesforce Adapter:
- Fixed a bug where MetadataRelationship CustomFields with controlling field couldn't be deployed.

---
_User Notifications_: 
_None_
