### PR TITLE
SALTO-5155: Added CV for Jsm project addition

### DIFF
--- a/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
+++ b/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
@@ -40,8 +40,8 @@ export const addJsmProjectValidator: ChangeValidator = async (changes, elementsS
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
-      message: 'Cannot add this project because JSM is disabled in the service.',
-      detailedMessage: 'Please enable JSM through the service in order to add this element',
+      message: 'JSM Project cannot be deployed to instance without JSM',
+      detailedMessage: 'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
     }))
     .toArray()
 }

--- a/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
+++ b/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
@@ -1,0 +1,48 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isAdditionChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { PROJECT_TYPE, SERVICE_DESK } from '../constants'
+import { hasJiraServiceDeskLicense } from '../utils'
+
+const { awu } = collections.asynciterable
+
+/*
+* This validator prevents addition of jsm project when Jsm is diable in the Service.
+*/
+export const addJsmProjectValidator: ChangeValidator = async (changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    return []
+  }
+  const isJsmEnabledInService = await hasJiraServiceDeskLicense(elementsSource)
+  if (isJsmEnabledInService === true) {
+    return []
+  }
+
+  return awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
+    .filter(project => project.value.projectTypeKey === SERVICE_DESK)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Cannot add this project because JSM is disabled in the service.',
+      detailedMessage: 'Please enable JSM through the service in order to add this element',
+    }))
+    .toArray()
+}

--- a/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
+++ b/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
@@ -21,14 +21,13 @@ import { hasJiraServiceDeskLicense } from '../utils'
 const { awu } = collections.asynciterable
 
 /*
-* This validator prevents addition of jsm project when Jsm is diable in the Service.
+* This validator prevents addition of jsm project when JSM is disabled in the service.
 */
 export const addJsmProjectValidator: ChangeValidator = async (changes, elementsSource) => {
   if (elementsSource === undefined) {
     return []
   }
-  const isJsmEnabledInService = await hasJiraServiceDeskLicense(elementsSource)
-  if (isJsmEnabledInService === true) {
+  if (await hasJiraServiceDeskLicense(elementsSource) === true) {
     return []
   }
 

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -62,6 +62,7 @@ import { deleteLastQueueValidator } from './last_queue'
 import { defaultAdditionQueueValidator } from './default_addition_queue'
 import { defaultAttributeValidator } from './assets/default_attribute'
 import { automationToAssetsValidator } from './automation/automation_to_assets'
+import { addJsmProjectValidator } from './adding_jsm_project'
 
 const {
   deployTypesNotSupportedValidator,
@@ -121,6 +122,7 @@ export default (
     defaultAdditionQueueValidator: defaultAdditionQueueValidator(config),
     automationToAssets: automationToAssetsValidator(config),
     defaultAttributeValidator: defaultAttributeValidator(config, client),
+    addJsmProject: addJsmProjectValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -241,6 +241,7 @@ export type ChangeValidatorName = (
   | 'defaultAttributeValidator'
   | 'boardColumnConfig'
   | 'automationToAssets'
+  | 'addJsmProject'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -294,6 +295,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     defaultAdditionQueueValidator: { refType: BuiltinTypes.BOOLEAN },
     defaultAttributeValidator: { refType: BuiltinTypes.BOOLEAN },
     automationToAssets: { refType: BuiltinTypes.BOOLEAN },
+    addJsmProject: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -128,16 +128,13 @@ export const isJiraSoftwareFreeLicense = async (
 }
 
 /*
-* Cheks if the Jira service has a service desk license. The default is to assume that it doesn't.
+* Checks if the Jira service has a service desk license. The default is to assume that it doesn't.
 */
 export const hasJiraServiceDeskLicense = async (
   elementsSource: ReadOnlyElementsSource
 ): Promise<boolean> => {
-  if (!await elementsSource.has(ACCOUNT_INFO_ELEM_ID)) {
-    return false
-  }
   const accountInfo = await elementsSource.get(ACCOUNT_INFO_ELEM_ID)
-  if (!isInstanceElement(accountInfo)
+  if (accountInfo === undefined || !isInstanceElement(accountInfo)
   || accountInfo.value.license?.applications === undefined) {
     log.error('account info instance or its license not found in elements source, treating the account as free one')
     return false

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -127,6 +127,29 @@ export const isJiraSoftwareFreeLicense = async (
   return mainApplication.plan === JIRA_FREE_PLAN
 }
 
+/*
+* Cheks if the Jira service has a service desk license. The default is to assume that it doesn't.
+*/
+export const hasJiraServiceDeskLicense = async (
+  elementsSource: ReadOnlyElementsSource
+): Promise<boolean> => {
+  if (!await elementsSource.has(ACCOUNT_INFO_ELEM_ID)) {
+    return false
+  }
+  const accountInfo = await elementsSource.get(ACCOUNT_INFO_ELEM_ID)
+  if (!isInstanceElement(accountInfo)
+  || accountInfo.value.license?.applications === undefined) {
+    log.error('account info instance or its license not found in elements source, treating the account as free one')
+    return false
+  }
+  const mainApplication = accountInfo.value.license.applications.find((app: Value) => app.id === 'jira-servicedesk')
+  if (mainApplication?.plan === undefined) {
+    log.warn('could not find license of jira-software, treating the account as free one')
+    return false
+  }
+  return true
+}
+
 export const renameKey = (object: Value, { from, to }: { from: string; to: string }): void => {
   if (object[from] !== undefined) {
     object[to] = object[from]

--- a/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
+++ b/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
@@ -55,8 +55,8 @@ describe('addJsmProjectValidator', () => {
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
-        message: 'Cannot add this project because JSM is disabled in the service.',
-        detailedMessage: 'Please enable JSM through the service in order to add this element',
+        message: 'JSM Project cannot be deployed to instance without JSM',
+        detailedMessage: 'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
       },
     ])
   })
@@ -67,8 +67,8 @@ describe('addJsmProjectValidator', () => {
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
-        message: 'Cannot add this project because JSM is disabled in the service.',
-        detailedMessage: 'Please enable JSM through the service in order to add this element',
+        message: 'JSM Project cannot be deployed to instance without JSM',
+        detailedMessage: 'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
       },
     ])
   })
@@ -84,8 +84,8 @@ describe('addJsmProjectValidator', () => {
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
-        message: 'Cannot add this project because JSM is disabled in the service.',
-        detailedMessage: 'Please enable JSM through the service in order to add this element',
+        message: 'JSM Project cannot be deployed to instance without JSM',
+        detailedMessage: 'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
       },
     ])
   })
@@ -103,8 +103,8 @@ describe('addJsmProjectValidator', () => {
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
-        message: 'Cannot add this project because JSM is disabled in the service.',
-        detailedMessage: 'Please enable JSM through the service in order to add this element',
+        message: 'JSM Project cannot be deployed to instance without JSM',
+        detailedMessage: 'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
+++ b/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
@@ -1,0 +1,174 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, ReadOnlyElementsSource, toChange, SeverityLevel } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { PROJECT_TYPE } from '../../src/constants'
+import { createEmptyType } from '../utils'
+import { addJsmProjectValidator } from '../../src/change_validators/adding_jsm_project'
+
+describe('addJsmProjectValidator', () => {
+  let elementsSource: ReadOnlyElementsSource
+  let projectInstace: InstanceElement
+  let accountInfoInstance: InstanceElement
+  beforeEach(() => {
+    projectInstace = new InstanceElement(
+      'projectInstace',
+      createEmptyType(PROJECT_TYPE),
+      {
+        projectTypeKey: 'service_desk',
+        description: 'test',
+      }
+    )
+    accountInfoInstance = new InstanceElement(
+      '_config',
+      createEmptyType('AccountInfo'),
+      {
+        license: {
+          applications: [
+            {
+              id: 'jira-software',
+              plan: 'PAID',
+            },
+          ],
+        },
+      }
+    )
+  })
+  it('should return error is if JSM is disabled in the service and trying to add JSM project', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+      {
+        elemID: projectInstace.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot add this project because JSM is disabled in the service.',
+        detailedMessage: 'Please enable JSM through the service in order to add this element',
+      },
+    ])
+  })
+  it('should return error if account info is not found', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    elementsSource = buildElementsSourceFromElements([])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+      {
+        elemID: projectInstace.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot add this project because JSM is disabled in the service.',
+        detailedMessage: 'Please enable JSM through the service in order to add this element',
+      },
+    ])
+  })
+  it('should return error if account info does not have license', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    accountInfoInstance = new InstanceElement(
+      '_config',
+      createEmptyType('AccountInfo'),
+      {}
+    )
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+      {
+        elemID: projectInstace.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot add this project because JSM is disabled in the service.',
+        detailedMessage: 'Please enable JSM through the service in order to add this element',
+      },
+    ])
+  })
+  it('should return error if account info does not have applications', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    accountInfoInstance = new InstanceElement(
+      '_config',
+      createEmptyType('AccountInfo'),
+      {
+        license: {},
+      }
+    )
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+      {
+        elemID: projectInstace.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot add this project because JSM is disabled in the service.',
+        detailedMessage: 'Please enable JSM through the service in order to add this element',
+      },
+    ])
+  })
+  it('should not return error if it is not JSM project', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    projectInstace.value.projectTypeKey = 'business'
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+  })
+  it('should not return error if JSM is enabled in the service as Free edition', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    accountInfoInstance = new InstanceElement(
+      '_config',
+      createEmptyType('AccountInfo'),
+      {
+        license: {
+          applications: [
+            {
+              id: 'jira-software',
+              plan: 'FREE',
+            },
+            {
+              id: 'jira-servicedesk',
+              plan: 'FREE',
+            },
+          ],
+        },
+      }
+    )
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+  })
+  it('should not return error if JSM is enabled in the service as Paid edition', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    accountInfoInstance = new InstanceElement(
+      '_config',
+      createEmptyType('AccountInfo'),
+      {
+        license: {
+          applications: [
+            {
+              id: 'jira-software',
+              plan: 'PAID',
+            },
+            {
+              id: 'jira-servicedesk',
+              plan: 'PAID',
+            },
+          ],
+        },
+      }
+    )
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+  })
+  it('should not return error for modification changes', async () => {
+    const projAfter = projectInstace.clone()
+    projAfter.value.description = 'new description'
+    const changes = [toChange({ before: projectInstace, after: projAfter })]
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+  })
+  it('should not return error if elementsSource is undefined', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    expect(await addJsmProjectValidator(changes, undefined)).toEqual([])
+  })
+})


### PR DESCRIPTION
In this PR I added a cv that prevent the deployment of JSM project when JSM is not enabled in the service. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter:_
Added a CV that prevents addition of JSM project when JSM is disabled in the service. 

---
_User Notifications_: 
None
