### PR TITLE
SALTO-5217 NS simple config

### DIFF
--- a/packages/adapter-api/src/constants.ts
+++ b/packages/adapter-api/src/constants.ts
@@ -35,6 +35,7 @@ export const CORE_ANNOTATIONS = {
   ALIAS: '_alias',
   IMPORTANT_VALUES: '_important_values',
   SELF_IMPORTANT_VALUES: '_self_important_values',
+  DESCRIPTION: '_description',
 }
 
 export const BUILTIN_TYPE_NAMES = {

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -79,7 +79,10 @@ const updatedFetchTarget = (
 }
 
 const includeFileCabinetFolders = (config: NetsuiteConfig): string[] =>
-  config.includeFileCabinetFolders?.map(folderName => `^${folderName}/.*`) ?? []
+  config.includeFileCabinetFolders?.map(
+    folderName =>
+      `^${folderName.startsWith('/') ? '' : '/'}${folderName}${folderName.endsWith('/') ? '' : '/'}.*`
+  ) ?? []
 
 const includeCustomRecords = (config: NetsuiteConfig): FetchTypeQueryParams[] => {
   if (config.includeCustomRecords === undefined || config.includeCustomRecords.length === 0) {

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -21,7 +21,7 @@ import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, INACTIVE_FIELDS } from '../constant
 import { removeCustomRecordTypePrefix } from '../types'
 import { fileCabinetTypesNames } from '../types/file_cabinet_types'
 import { ClientConfig, CriteriaQuery, FETCH_PARAMS, FetchParams, FetchTypeQueryParams, InstanceLimiterFunc, NetsuiteConfig, NetsuiteQueryParameters, QueryParams } from './types'
-import { ALL_TYPES_REGEX, DATA_FILE_TYPES, DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_INSTANCES_VALUE, FILE_CABINET, INCLUDE_ALL, UNLIMITED_INSTANCES_VALUE } from './constants'
+import { ALL_TYPES_REGEX, DATA_FILE_TYPES, DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_INSTANCES_VALUE, FILE_CABINET, GROUPS_TO_DATA_FILE_TYPES, INCLUDE_ALL, UNLIMITED_INSTANCES_VALUE } from './constants'
 import { validateConfig } from './validations'
 
 const log = logger(module)
@@ -119,9 +119,11 @@ const excludeDataFileTypes = (config: NetsuiteConfig): string[] => {
   if (config.includeDataFileTypes === undefined) {
     return []
   }
-  const dataFileTypesToInclude = config.includeDataFileTypes.join('|')
+  const dataFileTypesToInclude = new Set(
+    config.includeDataFileTypes.flatMap(group => GROUPS_TO_DATA_FILE_TYPES[group] ?? [])
+  )
   const dataFileTypesToExclude = Object.values(DATA_FILE_TYPES)
-    .filter(fileType => !(new RegExp(`\\b${fileType}\\b`, 'i')).test(dataFileTypesToInclude))
+    .filter(fileType => !dataFileTypesToInclude.has(fileType))
   if (dataFileTypesToExclude.length === 0) {
     return []
   }

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -17,10 +17,11 @@ import _ from 'lodash'
 import { regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement } from '@salto-io/adapter-api'
-import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT } from '../constants'
+import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, INACTIVE_FIELDS } from '../constants'
 import { removeCustomRecordTypePrefix } from '../types'
-import { ClientConfig, FETCH_PARAMS, FetchParams, InstanceLimiterFunc, NetsuiteConfig, NetsuiteQueryParameters, QueryParams } from './types'
-import { ALL_TYPES_REGEX, DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_INSTANCES_VALUE, UNLIMITED_INSTANCES_VALUE } from './constants'
+import { fileCabinetTypesNames } from '../types/file_cabinet_types'
+import { ClientConfig, CriteriaQuery, FETCH_PARAMS, FetchParams, FetchTypeQueryParams, InstanceLimiterFunc, NetsuiteConfig, NetsuiteQueryParameters, QueryParams } from './types'
+import { ALL_TYPES_REGEX, DATA_FILE_TYPES, DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_INSTANCES_VALUE, FILE_CABINET, INCLUDE_ALL, UNLIMITED_INSTANCES_VALUE } from './constants'
 import { validateConfig } from './validations'
 
 const log = logger(module)
@@ -77,11 +78,81 @@ const updatedFetchTarget = (
   }
 }
 
+const includeFileCabinetFolders = (config: NetsuiteConfig): string[] =>
+  config.includeFileCabinetFolders?.map(folderName => `^${folderName}/.*`) ?? []
+
+const includeCustomRecords = (config: NetsuiteConfig): FetchTypeQueryParams[] => {
+  if (config.includeCustomRecords === undefined || config.includeCustomRecords.length === 0) {
+    return []
+  }
+  if (config.includeCustomRecords.includes(INCLUDE_ALL)) {
+    return [{ name: ALL_TYPES_REGEX }]
+  }
+  return [{ name: config.includeCustomRecords.join('|') }]
+}
+
+const excludeInactiveRecords = (config: NetsuiteConfig): CriteriaQuery[] => {
+  if (config.includeInactiveRecords === undefined || config.includeInactiveRecords.includes(INCLUDE_ALL)) {
+    return []
+  }
+
+  const typesToInclude = config.includeInactiveRecords
+    .flatMap(typeName => (typeName === FILE_CABINET ? fileCabinetTypesNames : typeName))
+
+  const inactiveRecordsToExcludeRegex = typesToInclude.length === 0
+    ? ALL_TYPES_REGEX
+    // match all except for the exact strings in typesToInclude
+    : `(?!(${typesToInclude.join('|')})$).*`
+
+  return Object.values(INACTIVE_FIELDS).map(fieldName => ({
+    name: inactiveRecordsToExcludeRegex,
+    criteria: {
+      [fieldName]: true,
+    },
+  }))
+}
+
+const excludeDataFileTypes = (config: NetsuiteConfig): string[] => {
+  if (config.includeDataFileTypes === undefined) {
+    return []
+  }
+  const dataFileTypesToInclude = config.includeDataFileTypes.join('|')
+  const dataFileTypesToExclude = Object.values(DATA_FILE_TYPES)
+    .filter(fileType => !(new RegExp(`\\b${fileType}\\b`, 'i')).test(dataFileTypesToInclude))
+  if (dataFileTypesToExclude.length === 0) {
+    return []
+  }
+  const dataFileTypesToExcludeRegex = `.*\\.(${dataFileTypesToExclude.join('|')})`
+  return [
+    dataFileTypesToExcludeRegex.toLowerCase(),
+    dataFileTypesToExcludeRegex.toUpperCase(),
+  ]
+}
+
+const updatedFetchInclude = (config: NetsuiteConfig): QueryParams => ({
+  ...config.fetch.include,
+  fileCabinet: config.fetch.include.fileCabinet.concat(includeFileCabinetFolders(config)),
+  customRecords: (config.fetch.include.customRecords ?? []).concat(includeCustomRecords(config)),
+})
+
+const updatedFetchExclude = (config: NetsuiteConfig): QueryParams => ({
+  ...config.fetch.exclude,
+  types: config.fetch.exclude.types.concat(excludeInactiveRecords(config)),
+  fileCabinet: config.fetch.exclude.fileCabinet.concat(excludeDataFileTypes(config)),
+})
+
+const updatedFetchConfig = (config: NetsuiteConfig): FetchParams => ({
+  ...config.fetch,
+  include: updatedFetchInclude(config),
+  exclude: updatedFetchExclude(config),
+})
+
 const updatedConfig = (config: NetsuiteConfig): NetsuiteConfig => {
   log.debug('user netsuite adapter config: %o', loggableConfig(config))
   const updated: NetsuiteConfig = {
     ...config,
     fetchTarget: updatedFetchTarget(config),
+    fetch: updatedFetchConfig(config),
   }
   log.debug('updated netsuite adapter config: %o', loggableConfig(updated))
   return updated

--- a/packages/netsuite-adapter/src/config/constants.ts
+++ b/packages/netsuite-adapter/src/config/constants.ts
@@ -33,6 +33,8 @@ export const DEFAULT_MAX_INSTANCES_PER_TYPE = [
 export const UNLIMITED_INSTANCES_VALUE = -1
 export const DEFAULT_AXIOS_TIMEOUT_IN_MINUTES = 20
 
+export const INCLUDE_ALL = 'All'
+export const FILE_CABINET = 'FileCabinet'
 export const ALL_TYPES_REGEX = '.*'
 
 export const FILE_TYPES_TO_EXCLUDE_REGEX = '.*\\.(csv|pdf|eml|png|gif|jpeg|xls|xlsx|doc|docx|ppt|pptx)'
@@ -43,3 +45,27 @@ export const SUITEAPP_ID_FORMAT_REGEX = /^[a-z0-9]+(\.[a-z0-9]+){2}$/
 export const REQUIRED_FEATURE_SUFFIX = ':required'
 
 export const ERROR_MESSAGE_PREFIX = 'Received invalid adapter config input.'
+
+export const DATA_FILE_TYPES = {
+  DOC: 'DOC',
+  DOCX: 'DOCX',
+  EML: 'EML',
+  PNG: 'PNG',
+  GIF: 'GIF',
+  JPEG: 'JPEG',
+  PDF: 'PDF',
+  PPT: 'PPT',
+  PPTX: 'PPTX',
+  XLS: 'XLS',
+  XLSX: 'XLSX',
+  CSV: 'CSV',
+}
+
+export const DATA_FILE_TYPES_GROUPS = [
+  { name: 'Text Documents', fileTypes: [DATA_FILE_TYPES.DOC, DATA_FILE_TYPES.DOCX] },
+  { name: 'Emails', fileTypes: [DATA_FILE_TYPES.EML] },
+  { name: 'Images', fileTypes: [DATA_FILE_TYPES.PNG, DATA_FILE_TYPES.GIF, DATA_FILE_TYPES.JPEG] },
+  { name: 'PDFs', fileTypes: [DATA_FILE_TYPES.PDF] },
+  { name: 'Presentations', fileTypes: [DATA_FILE_TYPES.PPT, DATA_FILE_TYPES.PPTX] },
+  { name: 'Spreadsheets', fileTypes: [DATA_FILE_TYPES.XLS, DATA_FILE_TYPES.XLSX, DATA_FILE_TYPES.CSV] },
+].map(group => `${group.name} (${group.fileTypes.join(', ')})`)

--- a/packages/netsuite-adapter/src/config/constants.ts
+++ b/packages/netsuite-adapter/src/config/constants.ts
@@ -59,13 +59,18 @@ export const DATA_FILE_TYPES = {
   XLS: 'XLS',
   XLSX: 'XLSX',
   CSV: 'CSV',
-}
+} as const
 
-export const DATA_FILE_TYPES_GROUPS = [
+const DATA_FILE_TYPES_GROUPS = [
   { name: 'Text Documents', fileTypes: [DATA_FILE_TYPES.DOC, DATA_FILE_TYPES.DOCX] },
   { name: 'Emails', fileTypes: [DATA_FILE_TYPES.EML] },
   { name: 'Images', fileTypes: [DATA_FILE_TYPES.PNG, DATA_FILE_TYPES.GIF, DATA_FILE_TYPES.JPEG] },
   { name: 'PDFs', fileTypes: [DATA_FILE_TYPES.PDF] },
   { name: 'Presentations', fileTypes: [DATA_FILE_TYPES.PPT, DATA_FILE_TYPES.PPTX] },
   { name: 'Spreadsheets', fileTypes: [DATA_FILE_TYPES.XLS, DATA_FILE_TYPES.XLSX, DATA_FILE_TYPES.CSV] },
-].map(group => `${group.name} (${group.fileTypes.join(', ')})`)
+]
+
+export const GROUPS_TO_DATA_FILE_TYPES = Object.fromEntries(
+  DATA_FILE_TYPES_GROUPS.map(group =>
+    [`${group.name} (${group.fileTypes.join(', ')})`, group.fileTypes])
+)

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -164,6 +164,11 @@ export type SuiteAppClientConfig = {
   httpTimeoutLimitInMinutes?: number
 }
 
+export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
+  suiteAppConcurrencyLimit: 'suiteAppConcurrencyLimit',
+  httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
+}
+
 export type NetsuiteConfig = {
   // simple config
   includeAllSavedSearches?: boolean

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -20,7 +20,7 @@ import { config as configUtils } from '@salto-io/adapter-components'
 import { BIN, CURRENCY, CUSTOM_RECORD_TYPE, DATASET, EXCHANGE_RATE, INACTIVE_FIELDS, NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK } from '../constants'
 import { netsuiteSupportedTypes } from '../types'
 import { ITEM_TYPE_TO_SEARCH_STRING } from '../data_elements/types'
-import { ALL_TYPES_REGEX, DATA_FILE_TYPES_GROUPS, DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY, DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FILE_CABINET, FILE_TYPES_TO_EXCLUDE_REGEX, INCLUDE_ALL } from './constants'
+import { ALL_TYPES_REGEX, GROUPS_TO_DATA_FILE_TYPES, DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY, DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FILE_CABINET, FILE_TYPES_TO_EXCLUDE_REGEX, INCLUDE_ALL } from './constants'
 
 export type InstanceLimiterFunc = (type: string, instanceCount: number) => boolean
 export interface ObjectID {
@@ -680,8 +680,8 @@ export const configType = createMatchingObjectType<NetsuiteConfig>({
         [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto excludes certain rare and large file types. You can include these back.'
           + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-          enforce_value: false,
-          values: DATA_FILE_TYPES_GROUPS,
+          enforce_value: true,
+          values: Object.keys(GROUPS_TO_DATA_FILE_TYPES),
         }),
       },
     },

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -692,10 +692,6 @@ export const configType = createMatchingObjectType<NetsuiteConfig>({
         [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto fetches the Templates and Suitscripts folders.'
           + ' You can choose to include additional folders.'
           + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
-        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
-          enforce_value: true,
-          regex: '^/.*',
-        }),
       },
     },
     fetch: {

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -20,7 +20,7 @@ import { config as configUtils } from '@salto-io/adapter-components'
 import { BIN, CURRENCY, CUSTOM_RECORD_TYPE, DATASET, EXCHANGE_RATE, INACTIVE_FIELDS, NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK } from '../constants'
 import { netsuiteSupportedTypes } from '../types'
 import { ITEM_TYPE_TO_SEARCH_STRING } from '../data_elements/types'
-import { ALL_TYPES_REGEX, DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY, DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FILE_TYPES_TO_EXCLUDE_REGEX } from './constants'
+import { ALL_TYPES_REGEX, DATA_FILE_TYPES_GROUPS, DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY, DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FILE_CABINET, FILE_TYPES_TO_EXCLUDE_REGEX, INCLUDE_ALL } from './constants'
 
 export type InstanceLimiterFunc = (type: string, instanceCount: number) => boolean
 export interface ObjectID {
@@ -165,6 +165,14 @@ export type SuiteAppClientConfig = {
 }
 
 export type NetsuiteConfig = {
+  // simple config
+  includeAllSavedSearches?: boolean
+  includeCustomRecords?: string[]
+  includeInactiveRecords?: string[]
+  includeDataFileTypes?: string[]
+  includeFileCabinetFolders?: string[]
+
+  // complex config
   typesToSkip?: string[]
   filePathRegexSkipList?: string[]
   deploy?: DeployParams
@@ -180,6 +188,11 @@ export type NetsuiteConfig = {
 }
 
 export const CONFIG: lowerdashTypes.TypeKeysEnum<NetsuiteConfig> = {
+  includeAllSavedSearches: 'includeAllSavedSearches',
+  includeCustomRecords: 'includeCustomRecords',
+  includeInactiveRecords: 'includeInactiveRecords',
+  includeDataFileTypes: 'includeDataFileTypes',
+  includeFileCabinetFolders: 'includeFileCabinetFolders',
   typesToSkip: 'typesToSkip',
   filePathRegexSkipList: 'filePathRegexSkipList',
   deploy: 'deploy',
@@ -622,6 +635,64 @@ const deployConfigType = configUtils.createUserDeployConfigType(
 export const configType = createMatchingObjectType<NetsuiteConfig>({
   elemID: new ElemID(NETSUITE),
   fields: {
+    includeAllSavedSearches: {
+      refType: BuiltinTypes.BOOLEAN,
+      annotations: {
+        [CORE_ANNOTATIONS.ALIAS]: 'Include All Public Saved Searches',
+        [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto only includes referenced searches by default.'
+         + ' Turning this option on will make Salto fetch all public records.'
+         + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
+      },
+    },
+    includeCustomRecords: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.ALIAS]: 'Include custom records',
+        [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto will only fetch the custom records that are included in this list.'
+          + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          enforce_value: false,
+          values: [INCLUDE_ALL],
+        }),
+      },
+    },
+    includeInactiveRecords: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.ALIAS]: 'Include inactive records',
+        [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto will only fetch the inactive records that are included in this list.'
+          + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          enforce_value: true,
+          values: [INCLUDE_ALL, FILE_CABINET].concat(netsuiteSupportedTypes),
+        }),
+      },
+    },
+    includeDataFileTypes: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.ALIAS]: 'Re-introduce File Cabinet types',
+        [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto excludes certain rare and large file types. You can include these back.'
+          + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          enforce_value: false,
+          values: DATA_FILE_TYPES_GROUPS,
+        }),
+      },
+    },
+    includeFileCabinetFolders: {
+      refType: new ListType(BuiltinTypes.STRING),
+      annotations: {
+        [CORE_ANNOTATIONS.ALIAS]: 'Include additional File Cabinet folders',
+        [CORE_ANNOTATIONS.DESCRIPTION]: 'Salto fetches the Templates and Suitscripts folders.'
+          + ' You can choose to include additional folders.'
+          + ' [Learn more](https://help.salto.io/en/articles/customize-netsuite-config)',
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          enforce_value: true,
+          regex: '^/.*',
+        }),
+      },
+    },
     fetch: {
       refType: fetchConfigType,
       annotations: {
@@ -671,5 +742,12 @@ export const configType = createMatchingObjectType<NetsuiteConfig>({
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    [CORE_ANNOTATIONS.IMPORTANT_VALUES]: [
+      { value: CONFIG.includeAllSavedSearches, highlighted: true, indexed: false },
+      { value: CONFIG.includeCustomRecords, highlighted: true, indexed: false },
+      { value: CONFIG.includeInactiveRecords, highlighted: true, indexed: false },
+      { value: CONFIG.includeDataFileTypes, highlighted: true, indexed: false },
+      { value: CONFIG.includeFileCabinetFolders, highlighted: true, indexed: false },
+    ],
   },
 })

--- a/packages/netsuite-adapter/src/types.ts
+++ b/packages/netsuite-adapter/src/types.ts
@@ -19,7 +19,7 @@ import { fieldTypes } from './types/field_types'
 import { enums } from './autogen/types/enums'
 import { StandardType, getStandardTypes, isStandardTypeName, getStandardTypesNames } from './autogen/types'
 import { TypesMap } from './types/object_types'
-import { fileCabinetTypesNames, getFileCabinetTypes } from './types/file_cabinet_types'
+import { getFileCabinetTypes, isFileCabinetTypeName } from './types/file_cabinet_types'
 import { getConfigurationTypes } from './types/configuration_types'
 import { CONFIG_FEATURES, CUSTOM_FIELD_PREFIX, CUSTOM_RECORD_TYPE, CUSTOM_RECORD_TYPE_PREFIX, METADATA_TYPE, SOAP, INTERNAL_ID, SCRIPT_ID, PATH, CUSTOM_RECORD_TYPE_NAME_PREFIX, BUNDLE, INTEGRATION } from './constants'
 import { SUPPORTED_TYPES } from './data_elements/types'
@@ -48,7 +48,7 @@ export const isStandardInstanceOrCustomRecordType = (element: Element): boolean 
 export const isCustomRecordTypeName = (name: string): boolean => name.startsWith(CUSTOM_RECORD_TYPE_NAME_PREFIX)
 
 export const isFileCabinetType = (type: ObjectType | TypeReference): boolean =>
-  fileCabinetTypesNames.has(type.elemID.name)
+  isFileCabinetTypeName(type.elemID.name)
 
 export const isFileCabinetInstance = (element: Element): element is InstanceElement =>
   isInstanceElement(element) && isFileCabinetType(element.refType)
@@ -214,7 +214,7 @@ export const isBundleType = (type: ObjectType | TypeReference): boolean =>
 export const isBundleInstance = (element: Element): element is InstanceElement =>
   isInstanceElement(element) && isBundleType(element.refType)
 
-export const netsuiteSupportedTypes = [
+export const netsuiteSupportedTypes: ReadonlyArray<string> = [
   ...getStandardTypesNames(),
   ...SUPPORTED_TYPES,
   ...SUITEAPP_CONFIG_TYPE_NAMES,

--- a/packages/netsuite-adapter/src/types/file_cabinet_types.ts
+++ b/packages/netsuite-adapter/src/types/file_cabinet_types.ts
@@ -131,7 +131,15 @@ export const folderType = (): ObjectType => new ObjectType({
   path: [constants.NETSUITE, constants.TYPES_PATH, folderElemID.name],
 })
 
-export const fileCabinetTypesNames: ReadonlySet<string> = new Set(['file', 'folder'])
+export const fileCabinetTypesNames = [
+  fileElemID.name,
+  folderElemID.name,
+] as const
+
+const fileCabinetTypesNamesSet: ReadonlySet<string> = new Set(fileCabinetTypesNames)
+export const isFileCabinetTypeName = (name: string): boolean =>
+  fileCabinetTypesNamesSet.has(name)
+
 export const getFileCabinetTypes = (): Readonly<Record<string, ObjectType>> => ({
   file: fileType(),
   folder: folderType(),

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -18,7 +18,7 @@ import { ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import { InstanceLimiterFunc, configType } from '../../src/config/types'
 import { instanceLimiterCreator, netsuiteConfigFromConfig, fullFetchConfig } from '../../src/config/config_creator'
-import { DATA_FILE_TYPES_GROUPS, DEFAULT_MAX_INSTANCES_VALUE, UNLIMITED_INSTANCES_VALUE } from '../../src/config/constants'
+import { GROUPS_TO_DATA_FILE_TYPES, DEFAULT_MAX_INSTANCES_VALUE, UNLIMITED_INSTANCES_VALUE } from '../../src/config/constants'
 
 describe('netsuite config creator', () => {
   let config: InstanceElement
@@ -180,7 +180,7 @@ describe('netsuite config creator', () => {
       )
     })
     it('should return same fetch.exclude.fileCabinet when has all data file types', () => {
-      config.value.includeDataFileTypes = DATA_FILE_TYPES_GROUPS
+      config.value.includeDataFileTypes = Object.keys(GROUPS_TO_DATA_FILE_TYPES)
       expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual(
         config.value.fetch.exclude.fileCabinet
       )
@@ -194,11 +194,11 @@ describe('netsuite config creator', () => {
       ])
     })
     it('should return all but given data file types in fetch.exclude.fileCabinet', () => {
-      config.value.includeDataFileTypes = ['Text Documents (DOC, DOCX)', 'pdf']
+      config.value.includeDataFileTypes = ['Text Documents (DOC, DOCX)']
       expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual([
         ...config.value.fetch.exclude.fileCabinet,
-        '.*\\.(eml|png|gif|jpeg|ppt|pptx|xls|xlsx|csv)',
-        '.*\\.(EML|PNG|GIF|JPEG|PPT|PPTX|XLS|XLSX|CSV)',
+        '.*\\.(eml|png|gif|jpeg|pdf|ppt|pptx|xls|xlsx|csv)',
+        '.*\\.(EML|PNG|GIF|JPEG|PDF|PPT|PPTX|XLS|XLSX|CSV)',
       ])
     })
   })

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -13,11 +13,12 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+import { regex } from '@salto-io/lowerdash'
 import { ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import { InstanceLimiterFunc, configType } from '../../src/config/types'
 import { instanceLimiterCreator, netsuiteConfigFromConfig, fullFetchConfig } from '../../src/config/config_creator'
-import { DEFAULT_MAX_INSTANCES_VALUE, UNLIMITED_INSTANCES_VALUE } from '../../src/config/constants'
+import { DATA_FILE_TYPES_GROUPS, DEFAULT_MAX_INSTANCES_VALUE, UNLIMITED_INSTANCES_VALUE } from '../../src/config/constants'
 
 describe('netsuite config creator', () => {
   let config: InstanceElement
@@ -99,6 +100,131 @@ describe('netsuite config creator', () => {
           customrecord_cseg1: ['.*'],
         },
       })
+    })
+  })
+
+  describe('include custom records', () => {
+    it('should return same fetch.include.customRecords when undefined', () => {
+      config.value.includeCustomRecords = undefined
+      expect(netsuiteConfigFromConfig(config).fetch.include.customRecords).toEqual(
+        config.value.fetch.include.customRecords ?? []
+      )
+    })
+    it('should return same fetch.include.customRecords when empty', () => {
+      config.value.includeCustomRecords = []
+      expect(netsuiteConfigFromConfig(config).fetch.include.customRecords).toEqual(
+        config.value.fetch.include.customRecords ?? []
+      )
+    })
+    it('should return all types match in fetch.include.customRecords when has "All"', () => {
+      config.value.includeCustomRecords = ['All', 'customrecord2']
+      expect(netsuiteConfigFromConfig(config).fetch.include.customRecords).toEqual([
+        ...config.value.fetch.include.customRecords ?? [],
+        { name: '.*' },
+      ])
+    })
+    it('should return given types match in fetch.include.customRecords', () => {
+      config.value.includeCustomRecords = ['customrecord2', 'customrecord3']
+      expect(netsuiteConfigFromConfig(config).fetch.include.customRecords).toEqual([
+        ...config.value.fetch.include.customRecords ?? [],
+        { name: 'customrecord2|customrecord3' },
+      ])
+    })
+  })
+
+  describe('include inactive records', () => {
+    it('should return same fetch.exclude.types when undefined', () => {
+      config.value.includeInactiveRecords = undefined
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual(
+        config.value.fetch.exclude.types
+      )
+    })
+    it('should return same fetch.exclude.types when has "All"', () => {
+      config.value.includeInactiveRecords = ['All', 'workflow']
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual(
+        config.value.fetch.exclude.types
+      )
+    })
+    it('should return all types match in fetch.exclude.types when empty', () => {
+      config.value.includeInactiveRecords = []
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual([
+        ...config.value.fetch.exclude.types,
+        { name: '.*', criteria: { isinactive: true } },
+        { name: '.*', criteria: { inactive: true } },
+        { name: '.*', criteria: { isInactive: true } },
+      ])
+    })
+    it('should return all but given types match in fetch.exclude.types', () => {
+      config.value.includeInactiveRecords = ['workflow', 'FileCabinet']
+      const allExceptRegex = '(?!(workflow|file|folder)$).*'
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual([
+        ...config.value.fetch.exclude.types,
+        { name: allExceptRegex, criteria: { isinactive: true } },
+        { name: allExceptRegex, criteria: { inactive: true } },
+        { name: allExceptRegex, criteria: { isInactive: true } },
+      ])
+      expect(regex.isFullRegexMatch('workflow', allExceptRegex)).toBeFalsy()
+      expect(regex.isFullRegexMatch('file', allExceptRegex)).toBeFalsy()
+      expect(regex.isFullRegexMatch('folder', allExceptRegex)).toBeFalsy()
+      expect(regex.isFullRegexMatch('workflowactionscript', allExceptRegex)).toBeTruthy()
+      expect(regex.isFullRegexMatch('account', allExceptRegex)).toBeTruthy()
+      expect(regex.isFullRegexMatch('', allExceptRegex)).toBeTruthy()
+    })
+  })
+
+  describe('include data file types', () => {
+    it('should return same fetch.exclude.fileCabinet when undefined', () => {
+      config.value.includeDataFileTypes = undefined
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual(
+        config.value.fetch.exclude.fileCabinet
+      )
+    })
+    it('should return same fetch.exclude.fileCabinet when has all data file types', () => {
+      config.value.includeDataFileTypes = DATA_FILE_TYPES_GROUPS
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual(
+        config.value.fetch.exclude.fileCabinet
+      )
+    })
+    it('should return all data file types in fetch.exclude.fileCabinet when empty', () => {
+      config.value.includeDataFileTypes = []
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual([
+        ...config.value.fetch.exclude.fileCabinet,
+        '.*\\.(doc|docx|eml|png|gif|jpeg|pdf|ppt|pptx|xls|xlsx|csv)',
+        '.*\\.(DOC|DOCX|EML|PNG|GIF|JPEG|PDF|PPT|PPTX|XLS|XLSX|CSV)',
+      ])
+    })
+    it('should return all but given data file types in fetch.exclude.fileCabinet', () => {
+      config.value.includeDataFileTypes = ['Text Documents (DOC, DOCX)', 'pdf']
+      expect(netsuiteConfigFromConfig(config).fetch.exclude.fileCabinet).toEqual([
+        ...config.value.fetch.exclude.fileCabinet,
+        '.*\\.(eml|png|gif|jpeg|ppt|pptx|xls|xlsx|csv)',
+        '.*\\.(EML|PNG|GIF|JPEG|PPT|PPTX|XLS|XLSX|CSV)',
+      ])
+    })
+  })
+
+  describe('include file cabinet folders', () => {
+    it('should return same fetch.include.fileCabinet when undefined', () => {
+      config.value.includeFileCabinetFolders = undefined
+      expect(netsuiteConfigFromConfig(config).fetch.include.fileCabinet).toEqual(
+        config.value.fetch.include.fileCabinet
+      )
+    })
+    it('should return same fetch.include.fileCabinet when empty', () => {
+      config.value.includeFileCabinetFolders = []
+      expect(netsuiteConfigFromConfig(config).fetch.include.fileCabinet).toEqual(
+        config.value.fetch.include.fileCabinet
+      )
+    })
+    it('should return given folders in fetch.include.fileCabinet', () => {
+      config.value.includeFileCabinetFolders = ['/test1', '/test2/', 'test3/', 'test4']
+      expect(netsuiteConfigFromConfig(config).fetch.include.fileCabinet).toEqual([
+        ...config.value.fetch.include.fileCabinet,
+        '^/test1/.*',
+        '^/test2/.*',
+        '^/test3/.*',
+        '^/test4/.*',
+      ])
     })
   })
 

--- a/packages/netsuite-adapter/test/config/validations.test.ts
+++ b/packages/netsuite-adapter/test/config/validations.test.ts
@@ -25,6 +25,51 @@ describe('netsuite config validations', () => {
     config = await getDefaultAdapterConfig()
   })
 
+  describe('simple config', () => {
+    it('should not throw on a valid config', () => {
+      config.includeAllSavedSearches = true
+      config.includeCustomRecords = ['customrecord1', 'customrecord2']
+      config.includeInactiveRecords = ['All']
+      config.includeDataFileTypes = ['Documents (DOC, DOCX)', 'pdf']
+      config.includeFileCabinetFolders = ['/test1', '/test2/', 'test3/', 'test4']
+      expect(() => validateConfig(config)).not.toThrow()
+    })
+
+    it('should not throw on empty lists', () => {
+      config.includeAllSavedSearches = true
+      config.includeCustomRecords = []
+      config.includeInactiveRecords = []
+      config.includeDataFileTypes = []
+      config.includeFileCabinetFolders = []
+      expect(() => validateConfig(config)).not.toThrow()
+    })
+
+    it('should throw an error if includeAllSavedSearches is not boolean', () => {
+      config.includeAllSavedSearches = 'true'
+      expect(() => validateConfig(config)).toThrow('Expected "includeAllSavedSearches" to be a boolean')
+    })
+
+    it('should throw an error if includeCustomRecords', () => {
+      config.includeCustomRecords = 'customrecord1'
+      expect(() => validateConfig(config)).toThrow('includeCustomRecords should be a list of strings')
+    })
+
+    it('should throw an error if includeInactiveRecords', () => {
+      config.includeInactiveRecords = [true]
+      expect(() => validateConfig(config)).toThrow('includeInactiveRecords should be a list of strings')
+    })
+
+    it('should throw an error if includeDataFileTypes', () => {
+      config.includeDataFileTypes = ['Documents (DOC, DOCX)', 1]
+      expect(() => validateConfig(config)).toThrow('includeDataFileTypes should be a list of strings')
+    })
+
+    it('should throw an error if includeFileCabinetFolders', () => {
+      config.includeFileCabinetFolders = null
+      expect(() => validateConfig(config)).toThrow('includeFileCabinetFolders should be a list of strings')
+    })
+  })
+
   describe('fetch config', () => {
     it('should not throw on a valid fetch config', () => {
       expect(() => validateConfig(config)).not.toThrow()
@@ -297,7 +342,7 @@ describe('netsuite config validations', () => {
     })
   })
 
-  describe('cllient config', () => {
+  describe('client config', () => {
     describe('validate maxInstancesPerType', () => {
       it('should validate maxInstancesPerType is the correct object with valid NS types', () => {
         config.client = {


### PR DESCRIPTION
Add simple fields to NS adapter config - fields that should be used to easily set customized configuration.

- All simple fields are in the config type's `_important_values` annotation, ordered by their presentation order.
- The field's title is in the `_alias` annotation
- The field's description is in the `_description` annotation
  - Links are in a markdown format (`[Learn more](https://url...)`)
- The field's type should be inferred by the field's `refType`
- The field's suggested values are in the `_restriction.values` annotation
  - When `_restriction.enforce_value = false`, it means that the suggested values list is partial, and the adapter will receive also other values
  - There are some special values that the adapter defines: "All" means *include all* and translates to `.*`, "FileCabinet" translated to `['file', 'folder']`

---

_Additional context for reviewer_

TODO:
- [x] add validations
- [x] add tests

Next step will be to migrate the existing config by adding the simple fields, with values that match the config (e.g set `includeCustomRecords = ["All"]` if `fetch.include.customRecords = [{ name = ".*" }]`).

---
_Release Notes_: 
Netsuite Adapter:
- Add simple config

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
