### PR TITLE
SALTO-5215 - Salesforce: Improve dependency error text by updating the group names

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -505,9 +505,22 @@ export const SBAA_CONDITIONS_MET = 'sbaa__ConditionsMet__c'
 
 
 // Change Groups
-export const groupIdForInstanceChangeGroup = (action: ActionName, typeName: string): string => (
-  `${_.capitalize(action)} data instances of type '${typeName}'`
-)
+export const groupIdForInstanceChangeGroup = (action: ActionName, typeName: string): string => {
+  const toVerbalNoun = (actionName: ActionName): string => {
+    switch (actionName) {
+      case 'add':
+        return 'addition'
+      case 'modify':
+        return 'modification'
+      case 'remove':
+        return 'removal'
+      default:
+        // should not happen
+        return actionName
+    }
+  }
+  return `${_.capitalize(toVerbalNoun(action))} of data instances of type '${typeName}'`
+}
 export const ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP = groupIdForInstanceChangeGroup('add', 'Custom ApprovalRule and ApprovalCondition')
 export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -16,7 +16,7 @@
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { types } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { ActionName, CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
 
 export const { RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = clientUtils
 
@@ -428,9 +428,6 @@ export const KEY_PREFIX_LENGTH = 3
 // Magics
 export const DETECTS_PARENTS_INDICATOR = '##allMasterDetailFields##'
 
-// Change Groups
-export const ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP = 'add_Custom_ApprovalRule_and_ApprovalCondition_instances'
-
 // CPQ CustomObjects
 export const CPQ_NAMESPACE = 'SBQQ'
 export const CPQ_PRODUCT_RULE = 'SBQQ__ProductRule__c'
@@ -506,6 +503,15 @@ export const SBAA_APPROVAL_RULE = 'sbaa__ApprovalRule__c'
 // sbaa Fields
 export const SBAA_CONDITIONS_MET = 'sbaa__ConditionsMet__c'
 
+
+// Change Groups
+export const groupIdForInstanceChangeGroup = (action: ActionName, typeName: string): string => (
+  `${_.capitalize(action)} data instances of type '${typeName}'`
+)
+export const ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP = groupIdForInstanceChangeGroup('add', 'Custom ApprovalRule and ApprovalCondition')
+export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
+
+
 export const UNLIMITED_INSTANCES_VALUE = -1
 
 // Errors
@@ -549,7 +555,6 @@ export const isSalesforceError = (error: Error): error is SalesforceError => {
   const errorCode = _.get(error, ERROR_PROPERTIES.ERROR_CODE)
   return _.isString(errorCode) && (Object.values(SALESFORCE_ERRORS) as ReadonlyArray<string>).includes(errorCode)
 }
-
 
 // Artifacts
 export const SalesforceArtifacts = {

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -33,16 +33,18 @@ import {
   ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, SBAA_APPROVAL_CONDITION,
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
+  METADATA_CHANGE_GROUP,
+  groupIdForInstanceChangeGroup,
 } from './constants'
 
 const { awu } = collections.asynciterable
 
 const getGroupId = async (change: Change): Promise<string> => {
   if (!isInstanceChange(change) || !(await isInstanceOfCustomObjectChange(change))) {
-    return 'salesforce_metadata'
+    return METADATA_CHANGE_GROUP
   }
   const typeName = await safeApiName(await getChangeData(change).getType()) ?? 'UNKNOWN'
-  return `${change.action}_${typeName}_instances`
+  return groupIdForInstanceChangeGroup(change.action, typeName)
 }
 
 /**

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -151,12 +151,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(addInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherAddInstance.elemID.getFullName()))
         expect(changeGroupIds.get(addInstance.elemID.getFullName()))
-          .toEqual(`Add data instances of type '${customObjectName}'`)
+          .toEqual(`Addition of data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentAddInstance.elemID.getFullName()))
-          .toEqual(`Add data instances of type '${differentCustomObjectName}'`)
+          .toEqual(`Addition of data instances of type '${differentCustomObjectName}'`)
       })
     })
 
@@ -165,12 +165,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(removeInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherRemoveInstance.elemID.getFullName()))
         expect(changeGroupIds.get(removeInstance.elemID.getFullName()))
-          .toEqual(`Remove data instances of type '${customObjectName}'`)
+          .toEqual(`Removal of data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentRemoveInstance.elemID.getFullName()))
-          .toEqual(`Remove data instances of type '${differentCustomObjectName}'`)
+          .toEqual(`Removal of data instances of type '${differentCustomObjectName}'`)
       })
     })
 
@@ -179,12 +179,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(modifyInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherModifyInstance.elemID.getFullName()))
         expect(changeGroupIds.get(modifyInstance.elemID.getFullName()))
-          .toEqual(`Modify data instances of type '${customObjectName}'`)
+          .toEqual(`Modification of data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentModifyInstance.elemID.getFullName()))
-          .toEqual(`Modify data instances of type '${differentCustomObjectName}'`)
+          .toEqual(`Modification of data instances of type '${differentCustomObjectName}'`)
       })
     })
   })
@@ -234,8 +234,8 @@ describe('Group changes function', () => {
     it('should create correct groups', () => {
       expect(result.changeGroupIdMap.get('CustomApprovalRule')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
       expect(result.changeGroupIdMap.get('CustomApprovalCondition')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
-      expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('Add data instances of type \'sbaa__ApprovalRule__c\'')
-      expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('Add data instances of type \'sbaa__ApprovalCondition__c\'')
+      expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('Addition of data instances of type \'sbaa__ApprovalRule__c\'')
+      expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('Addition of data instances of type \'sbaa__ApprovalCondition__c\'')
     })
   })
 })

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -141,7 +141,7 @@ describe('Group changes function', () => {
           changeGroupIds.get(metadataInstance.elemID.getFullName())
         )
         expect(changeGroupIds.get(customObject.elemID.getFullName())).toEqual(
-          'salesforce_metadata'
+          'Salesforce Metadata'
         )
       })
     })
@@ -151,12 +151,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(addInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherAddInstance.elemID.getFullName()))
         expect(changeGroupIds.get(addInstance.elemID.getFullName()))
-          .toEqual(`add_${customObjectName}_instances`)
+          .toEqual(`Add data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentAddInstance.elemID.getFullName()))
-          .toEqual(`add_${differentCustomObjectName}_instances`)
+          .toEqual(`Add data instances of type '${differentCustomObjectName}'`)
       })
     })
 
@@ -165,12 +165,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(removeInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherRemoveInstance.elemID.getFullName()))
         expect(changeGroupIds.get(removeInstance.elemID.getFullName()))
-          .toEqual(`remove_${customObjectName}_instances`)
+          .toEqual(`Remove data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentRemoveInstance.elemID.getFullName()))
-          .toEqual(`remove_${differentCustomObjectName}_instances`)
+          .toEqual(`Remove data instances of type '${differentCustomObjectName}'`)
       })
     })
 
@@ -179,12 +179,12 @@ describe('Group changes function', () => {
         expect(changeGroupIds.get(modifyInstance.elemID.getFullName()))
           .toEqual(changeGroupIds.get(anotherModifyInstance.elemID.getFullName()))
         expect(changeGroupIds.get(modifyInstance.elemID.getFullName()))
-          .toEqual(`modify_${customObjectName}_instances`)
+          .toEqual(`Modify data instances of type '${customObjectName}'`)
       })
 
       it('should have a separate group for diff type', () => {
         expect(changeGroupIds.get(differentModifyInstance.elemID.getFullName()))
-          .toEqual(`modify_${differentCustomObjectName}_instances`)
+          .toEqual(`Modify data instances of type '${differentCustomObjectName}'`)
       })
     })
   })
@@ -234,8 +234,8 @@ describe('Group changes function', () => {
     it('should create correct groups', () => {
       expect(result.changeGroupIdMap.get('CustomApprovalRule')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
       expect(result.changeGroupIdMap.get('CustomApprovalCondition')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
-      expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('add_sbaa__ApprovalRule__c_instances')
-      expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('add_sbaa__ApprovalCondition__c_instances')
+      expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('Add data instances of type \'sbaa__ApprovalRule__c\'')
+      expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('Add data instances of type \'sbaa__ApprovalCondition__c\'')
     })
   })
 })


### PR DESCRIPTION
Change group names appear in user-visible error messages, so let's make them easier to understand by the end user.

---

TODO:
 - [ ] Final text from @tomermevorach 

---
_Release Notes_: 
Salesforce: Errors and warnings that contain the names of change groups are now clearer.

---
_User Notifications_: 
N/A