### PR TITLE
SALTO-5163_omit_missing_users_okta_adapter

### DIFF
--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -91,3 +91,9 @@ okta {
 | Name                                        | Default when undefined            | Description
 |---------------------------------------------|-----------------------------------|------------
 | name                                        | .*                                | A regex used to filter instances by matching the regex to their name value
+
+### Deploy configuration options
+
+| Name                         | Default when undefined | Description
+|------------------------------|------------------------|------------
+| [omitMissingUsers]           | false                  | Configure if to omit users during deploy on types that allow it

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -59,7 +59,7 @@ import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } fr
 import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
 import { isClassicEngineOrg } from './utils'
-import { omitMissingUsersHandler } from './fix_elements'
+import { createFixElementFunctions } from './fix_elements'
 
 const { awu } = collections.asynciterable
 
@@ -183,7 +183,7 @@ export default class OktaAdapter implements AdapterOperations {
         objects.concatObjects
       )
     )
-    this.fixElementsFunc = combineElementFixers([omitMissingUsersHandler({ client, config })])
+    this.fixElementsFunc = combineElementFixers(createFixElementFunctions({ client, config }))
   }
 
   @logDuration('generating types from swagger')

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -33,12 +33,11 @@ import {
   OktaDuckTypeApiConfig,
   validateOktaFetchConfig,
   DEPLOY_CONFIG,
+  OktaDeployConfig,
 } from './config'
 import { createConnection } from './client/connection'
 import { OKTA } from './constants'
 import { getAdminUrl } from './client/admin'
-
-type UserDeployConfig = configUtils.UserDeployConfig
 
 const log = logger(module)
 const { validateClientConfig, validateCredentials } = clientUtils
@@ -93,7 +92,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   const deploy = configUtils.mergeWithDefaultConfig(
     DEFAULT_CONFIG[DEPLOY_CONFIG] ?? {},
     config?.value?.deploy
-  ) as UserDeployConfig
+  ) as OktaDeployConfig
 
   validateClientConfig(CLIENT_CONFIG, client)
   validateSwaggerApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
@@ -157,6 +156,7 @@ export const adapter: Adapter = {
       deploy: adapterOperations.deploy.bind(adapterOperations),
       fetch: async args => adapterOperations.fetch(args),
       deployModifiers: adapterOperations.deployModifiers,
+      fixElements: adapterOperations.fixElements.bind(adapterOperations),
     }
   },
   validateCredentials: async config => validateCredentials(

--- a/packages/okta-adapter/src/change_validators/user.ts
+++ b/packages/okta-adapter/src/change_validators/user.ts
@@ -22,7 +22,7 @@ import { values } from '@salto-io/lowerdash'
 import { paginate } from '../client/pagination'
 import OktaClient from '../client/client'
 import { OktaConfig, FETCH_CONFIG } from '../config'
-import { DEFAULT_CONVERT_USERS_IDS_VALUE, getUsers, getUsersFromInstances, USER_MAPPING } from '../user_utils'
+import { DEFAULT_CONVERT_USERS_IDS_VALUE, getUsers, getUsersFromInstances, OMIT_MISSING_USERS_CONFIGURATION_LINK, USER_MAPPING } from '../user_utils'
 
 const { isDefined } = values
 const { createPaginator } = clientUtils
@@ -80,6 +80,6 @@ export const usersValidator: (client: OktaClient, config: OktaConfig) =>
           elemID: instance.elemID,
           severity: 'Error',
           message: 'Instance references users which don\'t exist in target environment',
-          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsersByInstanceId[instance.elemID.getFullName()].join(', ')}.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.`,
+          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsersByInstanceId[instance.elemID.getFullName()].join(', ')}.\nIn order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames or configure omitMissingUsers: ${OMIT_MISSING_USERS_CONFIGURATION_LINK}`,
         }))
     }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, CORE_ANNOTATIONS, ActionName, BuiltinTypes, ObjectType, Field, createRestriction } from '@salto-io/adapter-api'
+import { ElemID, CORE_ANNOTATIONS, ActionName, ObjectType, Field, createRestriction, BuiltinTypes } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
 import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME, AUTOMATION_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, DEVICE_ASSURANCE } from './constants'
@@ -53,13 +53,14 @@ export type OktaFetchConfig = configUtils.UserFetchConfig & {
 
 export type OktaSwaggerApiConfig = configUtils.AdapterSwaggerApiConfig<OktaActionName>
 export type OktaDuckTypeApiConfig = configUtils.AdapterDuckTypeApiConfig
+export type OktaDeployConfig = UserDeployConfig & { omitMissingUsers?: boolean }
 
 export type OktaConfig = {
   [CLIENT_CONFIG]?: OktaClientConfig
   [FETCH_CONFIG]: OktaFetchConfig
   [API_DEFINITIONS_CONFIG]: OktaSwaggerApiConfig
   [PRIVATE_API_DEFINITIONS_CONFIG]: OktaDuckTypeApiConfig
-  [DEPLOY_CONFIG]?: UserDeployConfig
+  [DEPLOY_CONFIG]?: OktaDeployConfig
 }
 
 const DEFAULT_ID_FIELDS = ['name']
@@ -1876,7 +1877,11 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
       ),
     },
     [DEPLOY_CONFIG]: {
-      refType: createUserDeployConfigType(OKTA, changeValidatorConfigType),
+      refType: createUserDeployConfigType(
+        OKTA,
+        changeValidatorConfigType,
+        { omitMissingUsers: { refType: BuiltinTypes.BOOLEAN } }
+      ),
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createSwaggerAdapterApiConfigType({

--- a/packages/okta-adapter/src/fix_elements/fallback_user.ts
+++ b/packages/okta-adapter/src/fix_elements/fallback_user.ts
@@ -1,0 +1,117 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import {
+  ChangeError,
+  ElemID,
+  InstanceElement,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { resolvePath, setPath } from '@salto-io/adapter-utils'
+import { values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { paginate } from '../client/pagination'
+import { DEPLOY_CONFIG } from '../config'
+import { TYPES_WITH_USERS, getUsers, getUsersFromInstances, USER_MAPPING } from '../user_utils'
+import { FixElementsHandler } from './types'
+
+const { createPaginator } = clientUtils
+
+const omitUsersChangeWarning = (
+  instance: InstanceElement,
+  missingUsers: string[],
+): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Warning',
+  message: `${missingUsers.length} usernames will be omitted`,
+  detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsers.join(', ')}.\nIf you continue, they will be omitted`,
+})
+
+const isStringArray = (value: unknown): value is string[] =>
+  Array.isArray(value) && value.every(s => _.isString(s))
+
+const getUsersToOmitAndNewValue = (instance: InstanceElement, users: Set<string>):
+  { usersToOmit: string[]; path: ElemID; newValue: string[] }[] => {
+  if (!TYPES_WITH_USERS.has(instance.elemID.typeName)) {
+    return []
+  }
+  const userPaths = USER_MAPPING[instance.elemID.typeName]
+  const pathsAsElemIds = _.uniq(userPaths.map(path => instance.elemID.createNestedID(...path)))
+  return pathsAsElemIds.flatMap(path => {
+    const usersArray = resolvePath(instance, path)
+    if (!isStringArray(usersArray)) {
+      return []
+    }
+    const [newValue, usersToOmit] = _.partition(usersArray, user => users.has(user))
+    if (_.isEmpty(usersToOmit)) {
+      return []
+    }
+    return [{ usersToOmit, path, newValue }]
+  })
+}
+
+const omitUsers = (
+  users: Set<string>,
+) => (instance: InstanceElement): undefined |
+{ fixedInstance: InstanceElement; missingUsers: string[] } => {
+  const missingUsersPaths = getUsersToOmitAndNewValue(instance, users)
+  if (_.isEmpty(missingUsersPaths)) {
+    return undefined
+  }
+  const fixedInstance = instance.clone()
+  missingUsersPaths
+    .forEach(({ path, newValue }) =>
+      setPath(fixedInstance, path, newValue))
+  return { fixedInstance, missingUsers: _.uniq(missingUsersPaths.flatMap(({ usersToOmit }) => usersToOmit)) }
+}
+
+const isInstanceWithUsers = (element: unknown): element is InstanceElement =>
+  isInstanceElement(element) && TYPES_WITH_USERS.has(element.elemID.typeName)
+
+/**
+ * Change missing users (emails) to fallback user.
+ * If fallback user is not provided, do nothing
+ * The errors returned will vary:
+ * 1. If provided fallback user is valid, return warning severity errors
+ * 2. If provided fallback user is not valid, return error severity errors
+ */
+export const omitMissingUsersHandler: FixElementsHandler = (
+  { config, client }
+) => async elements => {
+  const { omitMissingUsers } = config[DEPLOY_CONFIG] || {}
+  if (!omitMissingUsers) {
+    return { fixedElements: [], errors: [] }
+  }
+  const paginator = createPaginator({
+    client,
+    paginationFuncCreator: paginate,
+  })
+
+  const instancesWithUsers = elements.filter(isInstanceWithUsers)
+
+  const usersFromInstances = getUsersFromInstances(instancesWithUsers)
+
+  const usersInTarget = new Set((await getUsers(paginator, { userIds: usersFromInstances, property: 'profile.login' }))
+    .map(user => user.profile.login))
+
+  const fixedElementsAndOmittedUsers = instancesWithUsers
+    .map(omitUsers(usersInTarget))
+    .filter(values.isDefined)
+  const errors = fixedElementsAndOmittedUsers.map(({ fixedInstance, missingUsers }) =>
+    omitUsersChangeWarning(fixedInstance, missingUsers))
+  return { fixedElements: fixedElementsAndOmittedUsers.map(({ fixedInstance }) => fixedInstance), errors }
+}

--- a/packages/okta-adapter/src/fix_elements/index.ts
+++ b/packages/okta-adapter/src/fix_elements/index.ts
@@ -13,4 +13,4 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { omitMissingUsersHandler } from './fallback_user'
+export { omitMissingUsersHandler } from './missing_users'

--- a/packages/okta-adapter/src/fix_elements/index.ts
+++ b/packages/okta-adapter/src/fix_elements/index.ts
@@ -13,4 +13,13 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-export { omitMissingUsersHandler } from './missing_users'
+import { FixElementsFunc } from '@salto-io/adapter-api'
+import { omitMissingUsersHandler } from './missing_users'
+import { FixElementsArgs } from './types'
+
+
+export const createFixElementFunctions = (
+  args: FixElementsArgs
+): FixElementsFunc[] => ([
+  omitMissingUsersHandler(args),
+])

--- a/packages/okta-adapter/src/fix_elements/index.ts
+++ b/packages/okta-adapter/src/fix_elements/index.ts
@@ -1,0 +1,16 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+export { omitMissingUsersHandler } from './fallback_user'

--- a/packages/okta-adapter/src/fix_elements/missing_users.ts
+++ b/packages/okta-adapter/src/fix_elements/missing_users.ts
@@ -37,7 +37,7 @@ const omitUsersChangeWarning = (
 ): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Warning',
-  message: `${missingUsers.length} usernames will be omitted`,
+  message: `${missingUsers.length} users will be omitted`,
   detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsers.join(', ')}.\nIf you continue, they will be omitted`,
 })
 
@@ -75,7 +75,7 @@ const omitUsers = (
   const fixedInstance = instance.clone()
   missingUsersPaths
     .forEach(({ path, newValue }) =>
-      setPath(fixedInstance, path, newValue))
+      setPath(fixedInstance, path, _.isEmpty(newValue) ? undefined : newValue))
   return { fixedInstance, missingUsers: _.uniq(missingUsersPaths.flatMap(({ usersToOmit }) => usersToOmit)) }
 }
 
@@ -107,7 +107,6 @@ export const omitMissingUsersHandler: FixElementsHandler = (
 
   const usersInTarget = new Set((await getUsers(paginator, { userIds: usersFromInstances, property: 'profile.login' }))
     .map(user => user.profile.login))
-
   const fixedElementsAndOmittedUsers = instancesWithUsers
     .map(omitUsers(usersInTarget))
     .filter(values.isDefined)

--- a/packages/okta-adapter/src/fix_elements/missing_users.ts
+++ b/packages/okta-adapter/src/fix_elements/missing_users.ts
@@ -34,12 +34,15 @@ const { createPaginator } = clientUtils
 const omitUsersChangeWarning = (
   instance: InstanceElement,
   missingUsers: string[],
-): ChangeError => ({
-  elemID: instance.elemID,
-  severity: 'Warning',
-  message: `${missingUsers.length} users will be omitted`,
-  detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${missingUsers.join(', ')}.\nIf you continue, they will be omitted`,
-})
+): ChangeError => {
+  const isSingular = missingUsers.length === 1
+  return {
+    elemID: instance.elemID,
+    severity: 'Warning',
+    message: `${missingUsers.length} user${isSingular ? '' : 's'} will be omitted`,
+    detailedMessage: `The following ${isSingular ? 'user is' : 'users are'} referenced by this instance, but do not exist in the target environment: ${missingUsers.join(', ')}.\nIf you continue, they will be omitted`,
+  }
+}
 
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every(s => _.isString(s))

--- a/packages/okta-adapter/src/fix_elements/types.ts
+++ b/packages/okta-adapter/src/fix_elements/types.ts
@@ -1,0 +1,25 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { FixElementsFunc } from '@salto-io/adapter-api'
+import OktaClient from '../client/client'
+import { OktaConfig } from '../config'
+
+export type FixElementsArgs = {
+  client: OktaClient
+  config: OktaConfig
+}
+
+export type FixElementsHandler = (args: FixElementsArgs) => FixElementsFunc

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -70,7 +70,7 @@ export const USER_MAPPING: Record<string, string[][]> = {
   EndUserSupport: [['technicalContactId']],
 }
 
-const TYPES_WITH_USERS = new Set(Object.keys(USER_MAPPING))
+export const TYPES_WITH_USERS = new Set(Object.keys(USER_MAPPING))
 
 export const getUsersFromInstances = (instances: InstanceElement[]): string[] => _.uniq(
   instances

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -28,6 +28,7 @@ const { makeArray } = collections.array
 
 export const DEFAULT_CONVERT_USERS_IDS_VALUE = true
 export const DEFAULT_GET_USERS_STRATEGY = 'searchQuery'
+export const OMIT_MISSING_USERS_CONFIGURATION_LINK = 'https://help.salto.io/en/articles/8817969-element-references-users-which-don-t-exist-in-target-environment-okta'
 const USER_CHUNK_SIZE = 200
 
 export type User = {

--- a/packages/okta-adapter/test/change_validators/user.test.ts
+++ b/packages/okta-adapter/test/change_validators/user.test.ts
@@ -18,6 +18,7 @@ import { DEFAULT_CONFIG } from '../../src/config'
 import { usersValidator } from '../../src/change_validators/user'
 import { OKTA, GROUP_RULE_TYPE_NAME, ACCESS_POLICY_RULE_TYPE_NAME } from '../../src/constants'
 import OktaClient from '../../src/client/client'
+import { OMIT_MISSING_USERS_CONFIGURATION_LINK } from '../../src/user_utils'
 
 describe('usersValidator', () => {
   const client = new OktaClient({
@@ -65,13 +66,13 @@ describe('usersValidator', () => {
         elemID: policyInstance.elemID,
         severity: 'Error',
         message,
-        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: e@e, z@z.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.',
+        detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: e@e, z@z.\nIn order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames or configure omitMissingUsers: ${OMIT_MISSING_USERS_CONFIGURATION_LINK}`,
       },
       {
         elemID: ruleInstance.elemID,
         severity: 'Error',
         message,
-        detailedMessage: 'The following users are referenced by this instance, but do not exist in the target environment: e@e.\nIn order to deploy this instance, add these users to your target environment or edit this instance to use valid usernames.',
+        detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: e@e.\nIn order to deploy this instance, add these users to your target environment, edit this instance to use valid usernames or configure omitMissingUsers: ${OMIT_MISSING_USERS_CONFIGURATION_LINK}`,
       },
     ])
   })

--- a/packages/okta-adapter/test/fix_elements/missing_users.test.ts
+++ b/packages/okta-adapter/test/fix_elements/missing_users.test.ts
@@ -1,0 +1,117 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ElemID, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
+import OktaClient from '../../src/client/client'
+import * as userUtilsModule from '../../src/user_utils'
+import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
+import { DEPLOY_CONFIG, OktaConfig } from '../../src/config'
+import { omitMissingUsersHandler } from '../../src/fix_elements'
+
+const createUsersValue = (includeUsers: string[] | undefined, excludeUsers: string[] | undefined): Values => ({
+  conditions: {
+    people: {
+      users: {
+        ...(includeUsers ? { include: includeUsers } : {}),
+        ...(excludeUsers ? { exclude: excludeUsers } : {}),
+      },
+    },
+  },
+})
+
+const createMockUser = (login: string): userUtilsModule.User => ({
+  id: 'bar',
+  profile: {
+    login,
+  },
+})
+
+describe('missing_users', () => {
+  const EXIST_USER = 'exist.user@salto.io'
+  const EXIST_USER2 = 'exist.user+2@salto.io'
+  const NOT_EXIST_USER = 'not.exist.user@salto.io'
+  const NOT_EXIST_USER2 = 'not.exist.user+2@salto.io'
+  const ALL_MOCK_USERS = [EXIST_USER, EXIST_USER2, NOT_EXIST_USER, NOT_EXIST_USER2]
+  const mockClient = {} as OktaClient
+  const mockGetUsers = jest.spyOn(userUtilsModule, 'getUsers').mockResolvedValue([createMockUser(EXIST_USER), createMockUser(EXIST_USER2)])
+  const accessPolicyType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
+  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+  const pushGroupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_TYPE_NAME) })
+  const accessPolicyInstance = new InstanceElement('foo', accessPolicyType, createUsersValue(ALL_MOCK_USERS, [NOT_EXIST_USER, NOT_EXIST_USER]))
+  const groupRuleInstance = new InstanceElement('foo', groupRuleType, createUsersValue(undefined, [NOT_EXIST_USER, EXIST_USER]))
+  const groupPushInstance = new InstanceElement('foo', pushGroupType, { notUsersKnownPath: [NOT_EXIST_USER] })
+  const missingUsersHandlerInput = [accessPolicyInstance, groupRuleInstance, groupPushInstance]
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+  describe('when config does not contain "omitMissingUsers" flag', () => {
+    const mockConfig = {
+      [DEPLOY_CONFIG]: {},
+    } as OktaConfig
+    it('should return empty fixElements list and empty errors list', async () => {
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      expect(result.errors).toHaveLength(0)
+      expect(result.fixedElements).toHaveLength(0)
+      expect(mockGetUsers).not.toHaveBeenCalled()
+    })
+  })
+  describe('when config contains "omitMissingUsers" flag = false', () => {
+    const mockConfig = {
+      [DEPLOY_CONFIG]: {
+        omitMissingUsers: false,
+      },
+    } as OktaConfig
+    it('should return empty fixElements list and empty errors list', async () => {
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      expect(result.errors).toHaveLength(0)
+      expect(result.fixedElements).toHaveLength(0)
+      expect(mockGetUsers).not.toHaveBeenCalled()
+    })
+  })
+  describe('when config contains "omitMissingUsers" flag = true', () => {
+    const mockConfig = {
+      [DEPLOY_CONFIG]: {
+        omitMissingUsers: true,
+      },
+    } as OktaConfig
+    it('should return fixElements list and errors list correctly', async () => {
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      expect(result.errors).toHaveLength(2)
+      expect(result.errors).toEqual([
+        expect.objectContaining({
+          message: '2 users will be omitted',
+          severity: 'Warning',
+          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${NOT_EXIST_USER}, ${NOT_EXIST_USER2}.
+If you continue, they will be omitted`,
+        }),
+        expect.objectContaining({
+          message: '1 users will be omitted',
+          severity: 'Warning',
+          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${NOT_EXIST_USER}.
+If you continue, they will be omitted`,
+        }),
+      ])
+      expect(result.fixedElements).toEqual([
+        expect.objectContaining({
+          value: createUsersValue([EXIST_USER, EXIST_USER2], undefined),
+        }),
+        expect.objectContaining({
+          value: createUsersValue(undefined, [EXIST_USER]),
+        }),
+      ])
+      expect(mockGetUsers.mock.calls[0][1]).toEqual({ userIds: expect.arrayContaining(ALL_MOCK_USERS), property: 'profile.login' })
+    })
+  })
+})

--- a/packages/okta-adapter/test/fix_elements/missing_users.test.ts
+++ b/packages/okta-adapter/test/fix_elements/missing_users.test.ts
@@ -97,9 +97,9 @@ describe('missing_users', () => {
 If you continue, they will be omitted`,
         }),
         expect.objectContaining({
-          message: '1 users will be omitted',
+          message: '1 user will be omitted',
           severity: 'Warning',
-          detailedMessage: `The following users are referenced by this instance, but do not exist in the target environment: ${NOT_EXIST_USER}.
+          detailedMessage: `The following user is referenced by this instance, but do not exist in the target environment: ${NOT_EXIST_USER}.
 If you continue, they will be omitted`,
         }),
       ])

--- a/packages/okta-adapter/test/fix_elements/missing_users.test.ts
+++ b/packages/okta-adapter/test/fix_elements/missing_users.test.ts
@@ -18,7 +18,7 @@ import OktaClient from '../../src/client/client'
 import * as userUtilsModule from '../../src/user_utils'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
 import { DEPLOY_CONFIG, OktaConfig } from '../../src/config'
-import { omitMissingUsersHandler } from '../../src/fix_elements'
+import { omitMissingUsersHandler } from '../../src/fix_elements/missing_users'
 
 const createUsersValue = (includeUsers: string[] | undefined, excludeUsers: string[] | undefined): Values => ({
   conditions: {
@@ -32,7 +32,7 @@ const createUsersValue = (includeUsers: string[] | undefined, excludeUsers: stri
 })
 
 const createMockUser = (login: string): userUtilsModule.User => ({
-  id: 'bar',
+  id: 'mockId',
   profile: {
     login,
   },
@@ -43,7 +43,9 @@ describe('missing_users', () => {
   const EXIST_USER2 = 'exist.user+2@salto.io'
   const NOT_EXIST_USER = 'not.exist.user@salto.io'
   const NOT_EXIST_USER2 = 'not.exist.user+2@salto.io'
-  const ALL_MOCK_USERS = [EXIST_USER, EXIST_USER2, NOT_EXIST_USER, NOT_EXIST_USER2]
+  // Verify that logic works for ids as well
+  const EXIST_USER_ID = 'mockId'
+  const ALL_MOCK_USERS = [EXIST_USER, EXIST_USER2, NOT_EXIST_USER, NOT_EXIST_USER2, EXIST_USER_ID]
   const mockClient = {} as OktaClient
   const mockGetUsers = jest.spyOn(userUtilsModule, 'getUsers').mockResolvedValue([createMockUser(EXIST_USER), createMockUser(EXIST_USER2)])
   const accessPolicyType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
@@ -105,7 +107,7 @@ If you continue, they will be omitted`,
       ])
       expect(result.fixedElements).toEqual([
         expect.objectContaining({
-          value: createUsersValue([EXIST_USER, EXIST_USER2], undefined),
+          value: createUsersValue([EXIST_USER, EXIST_USER2, EXIST_USER_ID], undefined),
         }),
         expect.objectContaining({
           value: createUsersValue(undefined, [EXIST_USER]),


### PR DESCRIPTION
---



---
_Release Notes_: 
_Okta Adapter_:
- Add `FixElement`
- Add `omitMissingUsers` flag to deploy configuration
- When the flag is true, every list of users that contains users that do not exist in the target environment, will be modified such that the missing users will be removed from it (if the list gets empty then the whole path will be removed from the instance). A change error with severity `Warning` will be attached to that instance 


---
_User Notifications_: 
None
