### PR TITLE
SALTO-5259: fix a bug in screen filter that assumes originalFieldsIds is defined - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -15,6 +15,7 @@
 */
 import { AdditionChange, BuiltinTypes, Change, ChangeDataType, CORE_ANNOTATIONS, Field, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isModificationChange, isReferenceExpression, ListType, MapType, ModificationChange, ReferenceExpression, Value, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { naclCase } from '@salto-io/adapter-utils'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
@@ -25,6 +26,7 @@ import { deployTabs, SCREEN_TAB_TYPE_NAME } from './screenable_tab'
 import { findObject } from '../../utils'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
 
 const SCREEN_TYPE_NAME = 'Screen'
 
@@ -121,6 +123,7 @@ const filter: FilterCreator = ({ config, client }) => ({
             element.value.tabs.map(
               (tab: Values, position: number) => {
                 const fieldIds = tab.fields && tab.fields.map((field: Values) => field.id)
+                log.info(`add to ScreenTab "${tab.name}" in the Screen "${element.value.name}" originalFieldsIds: ${fieldIds}`)
                 return {
                   ...tab,
                   fields: fieldIds,
@@ -143,8 +146,11 @@ const filter: FilterCreator = ({ config, client }) => ({
       .filter(change => !_.isEmpty(change.data.before.value.tabs))
       .forEach(change => {
         Object.values(change.data.before.value.tabs).forEach((tab: Value): void => {
-          if (tab.originalFieldsIds.ids) {
+          if (tab.originalFieldsIds?.ids) {
             tab.fields = tab.originalFieldsIds.ids
+          } else {
+            // this should not happen if there are fields in the tab
+            log.info(`ScreenTab "${tab.name}" in the Screen "${change.data.before.value.name}" has no originalFieldsIds`)
           }
         })
       })

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -107,14 +107,14 @@ describe('screenFilter', () => {
     let fieldInstance2: InstanceElement
     let fieldReference: ReferenceExpression
     let fieldUnresolvedReference: UnresolvedReference
-    let screenWithFieldReferences: InstanceElement
+    let screenInstance: InstanceElement
     beforeEach(() => {
       fieldType = new ObjectType({ elemID: new ElemID(JIRA, 'field') })
       fieldInstance1 = new InstanceElement('instance', fieldType, { id: '1' })
       fieldInstance2 = new InstanceElement('instance', fieldType, { id: '2' })
       fieldReference = new ReferenceExpression(fieldInstance1.elemID)
       fieldUnresolvedReference = new UnresolvedReference(fieldInstance2.elemID)
-      screenWithFieldReferences = new InstanceElement(
+      screenInstance = new InstanceElement(
         'instance',
         screenType,
         {
@@ -125,23 +125,46 @@ describe('screenFilter', () => {
       )
     })
     it('should convert the field references to their original ids', async () => {
-      const afterInstance = screenWithFieldReferences.clone()
+      const afterInstance = screenInstance.clone()
       afterInstance.value.description = 'desc'
-      await filter.preDeploy?.([toChange({ before: screenWithFieldReferences, after: afterInstance })])
-      expect(screenWithFieldReferences.value).toEqual({
+      await filter.preDeploy?.([toChange({ before: screenInstance, after: afterInstance })])
+      expect(screenInstance.value).toEqual({
         tabs: {
           tab1: { name: 'tab1', position: 0, fields: ['1', '2'], originalFieldsIds: { ids: ['1', '2'] } },
         },
       })
     })
     it('should not convert the field references to their original ids when the ids are not exist ', async () => {
-      screenWithFieldReferences.value.tabs.tab1.originalFieldsIds = { ids: undefined }
-      const afterInstance = screenWithFieldReferences.clone()
+      screenInstance.value.tabs.tab1.originalFieldsIds = { ids: undefined }
+      const afterInstance = screenInstance.clone()
       afterInstance.value.description = 'desc'
-      await filter.preDeploy?.([toChange({ before: screenWithFieldReferences, after: afterInstance })])
-      expect(screenWithFieldReferences.value).toEqual({
+      await filter.preDeploy?.([toChange({ before: screenInstance, after: afterInstance })])
+      expect(screenInstance.value).toEqual({
         tabs: {
           tab1: { name: 'tab1', position: 0, fields: [fieldReference, fieldUnresolvedReference], originalFieldsIds: { ids: undefined } },
+        },
+      })
+    })
+    it('should do nothing if the screenTab has no fields', async () => {
+      screenInstance.value.tabs.tab1.fields = undefined
+      screenInstance.value.tabs.tab1.originalFieldsIds = undefined
+      const afterInstance = screenInstance.clone()
+      afterInstance.value.description = 'desc'
+      await filter.preDeploy?.([toChange({ before: screenInstance, after: afterInstance })])
+      expect(screenInstance.value).toEqual({
+        tabs: {
+          tab1: { name: 'tab1', position: 0 },
+        },
+      })
+    })
+    it('should do nothing if the screenTab has no originalFieldsIds', async () => {
+      screenInstance.value.tabs.tab1.originalFieldsIds = undefined
+      const afterInstance = screenInstance.clone()
+      afterInstance.value.description = 'desc'
+      await filter.preDeploy?.([toChange({ before: screenInstance, after: afterInstance })])
+      expect(screenInstance.value).toEqual({
+        tabs: {
+          tab1: { name: 'tab1', position: 0, fields: [fieldReference, fieldUnresolvedReference] },
         },
       })
     })


### PR DESCRIPTION
_fix a bug in screen filter that assumes originalFieldsIds is defined - Jira_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
