### PR TITLE
SALTO-5261 Fix merge error on field type change in apply patch/changes

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -20,6 +20,7 @@ import {
   Value, toChange, isRemovalChange, getChangeData, isField, AuthorInformation, ReferenceInfo, ReferenceType,
   ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile, isInstanceElement, isObjectType,
   isModificationChange,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import {
@@ -878,7 +879,7 @@ export const loadWorkspace = async (
         modifiedFields
           .filter(field => element.fields[field.name] !== undefined)
           .forEach(field => {
-            element.fields[field.name].refType = field.refType
+            element.fields[field.name].refType = new TypeReference(field.refType.elemID)
           })
       })
   }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -19,8 +19,7 @@ import {
   Element, SaltoError, SaltoElementError, ElemID, InstanceElement, DetailedChange, Change,
   Value, toChange, isRemovalChange, getChangeData, isField, AuthorInformation, ReferenceInfo, ReferenceType,
   ReadOnlyElementsSource, isAdditionOrModificationChange, StaticFile, isInstanceElement, isObjectType,
-  isModificationChange,
-  TypeReference,
+  isModificationChange, TypeReference,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import {


### PR DESCRIPTION
There is a merge error that happens when there are state-only changes in a type, and a field type changed too.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Workspace:
- Fix merge error on field type change in apply patch/changes

---
_User Notifications_: 
None