### PR TITLE
Fix custom record type fields type in NS loadElementsFromFolder

### DIFF
--- a/packages/netsuite-adapter/src/filters/custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/custom_record_types.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { getChangeData, isAdditionChange, isObjectType, ObjectType } from '@salto-io/adapter-api'
+import { getChangeData, isAdditionChange, isObjectType, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
 import { getCustomField } from './data_types_custom_fields'
@@ -24,6 +24,7 @@ import { CUSTOM_FIELDS, CUSTOM_FIELDS_LIST } from '../custom_records/custom_reco
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
 import { andQuery, buildNetsuiteQuery, notQuery } from '../config/query'
 
+const { awu } = collections.asynciterable
 const { makeArray } = collections.array
 
 const toCustomRecordTypeReference = (type: ObjectType): string => `[${SCRIPT_ID}=${type.annotations[SCRIPT_ID]}]`
@@ -57,11 +58,18 @@ const removeInstancesAnnotation = (type: ObjectType): void => {
 
 const getElementsSourceCustomRecordTypes = async (
   elementsSourceIndex: LazyElementsSourceIndexes,
-  isPartial: boolean
+  isPartial: boolean,
+  existingTypeNames: Set<string>,
 ): Promise<ObjectType[]> => (
   isPartial ? Object.values((await elementsSourceIndex.getIndexes()).serviceIdRecordsIndex)
     .map(({ elemID, serviceID }) => ({ ...elemID.createTopLevelParentID(), serviceID }))
-    .filter(({ parent, path }) => parent.idType === 'type' && path.length === 1 && path[0] === SCRIPT_ID)
+    .filter(
+      ({ parent, path }) =>
+        parent.idType === 'type'
+        && !existingTypeNames.has(parent.getFullName())
+        && path.length === 1
+        && path[0] === SCRIPT_ID
+    )
     .map(({ serviceID, parent }) => new ObjectType({
       elemID: parent,
       annotations: {
@@ -71,18 +79,44 @@ const getElementsSourceCustomRecordTypes = async (
     })) : []
 )
 
+const getElementsSourceTypes = async (
+  elementsSource: ReadOnlyElementsSource,
+  isPartial: boolean,
+  existingTypeNames: Set<string>,
+): Promise<ObjectType[]> => (
+  isPartial ? awu(await elementsSource.list())
+    .filter(elemID => elemID.idType === 'type' && !existingTypeNames.has(elemID.getFullName()))
+    .map(elemID => new ObjectType({ elemID }))
+    .toArray() : []
+)
+
 const filterCreator: LocalFilterCreator = ({
   elementsSourceIndex,
+  elementsSource,
   isPartial,
   config,
 }) => ({
   name: 'customRecordTypesType',
   onFetch: async elements => {
     const types = elements.filter(isObjectType)
-    const customRecordTypeObjects = types.filter(isCustomRecordType)
-    const nameToType = _.keyBy(types, type => type.elemID.name)
+    const existingTypeNames = new Set(types.map(type => type.elemID.getFullName()))
+    const customRecordTypes = types.filter(isCustomRecordType)
+    const elementSourceTypes = await getElementsSourceTypes(
+      elementsSource,
+      isPartial,
+      existingTypeNames,
+    )
+    const elementSourceCustomRecordTypes = await getElementsSourceCustomRecordTypes(
+      elementsSourceIndex,
+      isPartial,
+      existingTypeNames,
+    )
+    const nameToType = _.keyBy(
+      types.concat(elementSourceTypes),
+      type => type.elemID.name,
+    )
     const customRecordTypesMap = _.keyBy(
-      customRecordTypeObjects.concat(await getElementsSourceCustomRecordTypes(elementsSourceIndex, isPartial)),
+      customRecordTypes.concat(elementSourceCustomRecordTypes),
       toCustomRecordTypeReference,
     )
     const fetchQuery = andQuery(
@@ -90,7 +124,7 @@ const filterCreator: LocalFilterCreator = ({
       notQuery(buildNetsuiteQuery(config.fetch.exclude))
     )
 
-    customRecordTypeObjects.forEach(type => {
+    customRecordTypes.forEach(type => {
       addFieldsToType(type, nameToType, customRecordTypesMap)
       removeCustomFieldsAnnotation(type)
       if (fetchQuery.isCustomRecordTypeMatch(type.elemID.name)) {

--- a/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
@@ -13,16 +13,20 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, ElemID, isObjectType, ObjectType } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { BuiltinTypes, ElemID, isObjectType, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { LocalFilterOpts } from '../../src/filter'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import filterCreator from '../../src/filters/custom_record_types'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { emptyQueryParams } from '../../src/config/config_creator'
 
+const { awu } = collections.asynciterable
+
 describe('custom record types filter', () => {
   let customRecordType: ObjectType
   let customRecordFieldRefType: ObjectType
+  let dataType: ObjectType
 
   const filterOpts = {
     config: { fetch: { include: { types: [{ name: '.*' }], fileCabinet: ['.*'] }, exclude: emptyQueryParams() } },
@@ -30,6 +34,11 @@ describe('custom record types filter', () => {
     elementsSourceIndex: {
       getIndexes: () => {
         throw new Error('should not call getIndexes')
+      },
+    },
+    elementsSource: {
+      list: () => {
+        throw new Error('should not call elementsSource.list')
       },
     },
   } as unknown as LocalFilterOpts
@@ -40,14 +49,22 @@ describe('custom record types filter', () => {
       annotations: {
         scriptid: 'customrecord1',
         customrecordcustomfields: {
-          customrecordcustomfield: [{
-            scriptid: 'custrecord_newfield',
-            fieldtype: 'TEXT',
-          }, {
-            scriptid: 'custrecord_ref',
-            fieldtype: 'SELECT',
-            selectrecordtype: `[${SCRIPT_ID}=customrecord2]`,
-          }],
+          customrecordcustomfield: [
+            {
+              scriptid: 'custrecord_newfield',
+              fieldtype: 'TEXT',
+            },
+            {
+              scriptid: 'custrecord_ref',
+              fieldtype: 'SELECT',
+              selectrecordtype: `[${SCRIPT_ID}=customrecord2]`,
+            },
+            {
+              scriptid: 'custrecord_account',
+              fieldtype: 'SELECT',
+              selectrecordtype: '-112',
+            },
+          ],
         },
         instances: [1, 2, 3],
         [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
@@ -60,12 +77,16 @@ describe('custom record types filter', () => {
         [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
       },
     })
+    dataType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'account'),
+    })
   })
   it('should add fields to type', async () => {
-    await filterCreator(filterOpts).onFetch?.([customRecordType, customRecordFieldRefType])
+    await filterCreator(filterOpts).onFetch?.([customRecordType, customRecordFieldRefType, dataType])
     expect(Object.keys(customRecordType.fields)).toEqual([
       'custom_custrecord_newfield',
       'custom_custrecord_ref',
+      'custom_custrecord_account',
     ])
     expect(customRecordType.fields.custom_custrecord_newfield.refType.elemID.name)
       .toEqual(BuiltinTypes.STRING.elemID.name)
@@ -82,6 +103,14 @@ describe('custom record types filter', () => {
       selectrecordtype: `[${SCRIPT_ID}=customrecord2]`,
       index: 1,
     })
+    expect(customRecordType.fields.custom_custrecord_account.refType.elemID.name)
+      .toEqual('account')
+    expect(customRecordType.fields.custom_custrecord_account.annotations).toEqual({
+      scriptid: 'custrecord_account',
+      fieldtype: 'SELECT',
+      selectrecordtype: '-112',
+      index: 2,
+    })
   })
   it('should add fields correctly on partial fetch', async () => {
     await filterCreator({
@@ -97,9 +126,14 @@ describe('custom record types filter', () => {
           },
         }),
       } as unknown as LazyElementsSourceIndexes),
+      elementsSource: {
+        list: async () => awu([dataType.elemID]),
+      } as unknown as ReadOnlyElementsSource,
     }).onFetch?.([customRecordType])
-    const refType = await customRecordType.fields.custom_custrecord_ref.getType()
-    expect(isObjectType(refType) && refType.isEqual(customRecordFieldRefType)).toBeTruthy()
+    const field1refType = await customRecordType.fields.custom_custrecord_ref.getType()
+    expect(isObjectType(field1refType) && field1refType.isEqual(customRecordFieldRefType)).toBeTruthy()
+    const field2refType = await customRecordType.fields.custom_custrecord_account.getType()
+    expect(field2refType.elemID.isEqual(dataType.elemID)).toBeTruthy()
   })
   it('should remove custom fields annotation', async () => {
     await filterCreator(filterOpts).onFetch?.([customRecordType])


### PR DESCRIPTION
In NS `loadElementsFromFolder` (apply-patch) we don't fetch the data types, so we need to use the elements source to get them, so we'll be able to set the field types in custom record type, instead of setting them to `unknown`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix custom record type fields type in NS loadElementsFromFolder (apply-patch)

---
_User Notifications_: 
None