### PR TITLE
SALTO-5110 add important-values by default (netsuite)

### DIFF
--- a/packages/netsuite-adapter/src/filters/add_important_values.ts
+++ b/packages/netsuite-adapter/src/filters/add_important_values.ts
@@ -53,7 +53,7 @@ const getImportantValues = (type: ObjectType): ImportantValues => [
 const filterCreator: LocalFilterCreator = ({ config }) => ({
   name: 'addImportantValues',
   onFetch: async elements => {
-    if (config.fetch.addImportantValues !== true) {
+    if (config.fetch.addImportantValues === false) {
       log.info('addImportantValues is disabled')
       return
     }

--- a/packages/netsuite-adapter/test/filters/add_important_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_important_values.test.ts
@@ -93,10 +93,10 @@ describe('add important values filter', () => {
     expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined)).toBeFalsy()
     expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)).toBeFalsy()
   })
-  it('should not add important values by default', async () => {
+  it('should add important values by default', async () => {
     await filterCreator(defaultOpts).onFetch?.(types)
-    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined)).toBeFalsy()
-    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)).toBeFalsy()
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] !== undefined)).toBeTruthy()
+    expect(types.some(elem => elem.annotations[CORE_ANNOTATIONS.SELF_IMPORTANT_VALUES] !== undefined)).toBeTruthy()
   })
   it('should add important values', async () => {
     await filterCreator(optsWithImportantValues).onFetch?.(types)


### PR DESCRIPTION
Change the default behavior of the `fetch.addImportantValues` config - so by default we'll add important values.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add important-values by default

---
_User Notifications_: 
Netsuite Adapter:
- The `_important_values` will be added to all types, and the `_self_important_values` will be added to all custom record types.