### PR TITLE
SALTO 5266: Modify jql in queue

### DIFF
--- a/packages/jira-adapter/src/filters/queue_fetch.ts
+++ b/packages/jira-adapter/src/filters/queue_fetch.ts
@@ -54,6 +54,8 @@ const QUEUES_CATAGORIES_RESPONSE_SCHEME = Joi.object({
 
 const isQueuesCatagoriesResponse = createSchemeGuard<QueuesCatagoriesResponse>(QUEUES_CATAGORIES_RESPONSE_SCHEME)
 
+const replaceTypeWithIssueType = (input: string): string => input.replace(/\btype\b/g, 'issuetype')
+
 const addQueueStarAndPriority = async (
   projectKeysToQueues: Record<string, InstanceElement[]>,
   client: JiraClient,
@@ -90,6 +92,9 @@ const filter: FilterCreator = ({ config, client }) => ({
       .forEach(instance => {
         instance.value.columns = instance.value.fields
         delete instance.value.fields
+        if (instance.value.jql) {
+          instance.value.jql = replaceTypeWithIssueType(instance.value.jql)
+        }
       })
 
     const projectKeysToQueues = _.groupBy(


### PR DESCRIPTION
In this PR I changed the jql query in queue such that the wotd `type` will be replaced with `issuetype`. 

---

_Additional context for reviewer_
In the jql section in queue, you can write `type =` or `issuetype = ` and it references to the same thing. 
The desired field name is `issuetype` so in order for our template expression generator to identify the field, I changed the jql query. 
More context can be found in [this ticket](https://salto-io.atlassian.net/browse/INCIDENT-11717). 

---
_Release Notes_: 
_Jira Adapter:_
Modify jql in queue. 

---
_User Notifications_: 
None
