### PR TITLE
SALTO-5206: Do not create warnings on Standard Fields that lack permissions (bugfix)

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -317,7 +317,7 @@ const removeFieldsWithNoPermission = async (
       type.fields[fieldName]?.annotations[permissionAnnotation],
       fieldValue)
     return {
-      message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,
+      message: `The field ${fieldName} was not deployed because it lacks the '${permissionAnnotation}' permission`,
       severity: 'Warning',
       elemID: instance.elemID,
     }

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -82,22 +82,40 @@ describe('Custom Object Instances CRUD', () => {
           [constants.API_NAME]: 'NumField',
         },
       },
-      NotCreatable: {
+      NotCreatable__c: {
         refType: BuiltinTypes.STRING,
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: false,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
           [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-          [constants.API_NAME]: 'NotCreatable',
+          [constants.API_NAME]: 'NotCreatable__c',
         },
       },
-      NotUpdateable: {
+      NotCreatableStandardField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: false,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
+          [constants.API_NAME]: 'NotCreatableStandardField',
+        },
+      },
+      NotUpdateable__c: {
         refType: BuiltinTypes.STRING,
         annotations: {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
           [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-          [constants.API_NAME]: 'NotCreatable',
+          [constants.API_NAME]: 'NotCreatable__c',
+        },
+      },
+      NotUpdateableStandardField: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+          [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
+          [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
+          [constants.API_NAME]: 'NotUpdateableStandardField',
         },
       },
       AnotherField: {
@@ -148,7 +166,8 @@ describe('Custom Object Instances CRUD', () => {
     customObject,
     {
       SaltoName: 'existingInstance',
-      NotCreatable: 'DontSendMeOnCreate',
+      NotCreatable__c: 'DontSendMeOnCreate',
+      NotCreatableStandardField: 'SendMeOnCreate',
       NumField: 1,
       Address: {
         city: 'Tel-Aviv',
@@ -183,7 +202,8 @@ describe('Custom Object Instances CRUD', () => {
     customObject,
     {
       SaltoName: 'anotherExistingInstanceWithThing\'',
-      NotCreatable: 'DontSendMeOnCreate',
+      NotCreatable__c: 'DontSendMeOnCreate',
+      NotCreatableStandardField: 'SendMeOnCreate',
     }
   )
   const anotherExistingInstanceRecordValues = {
@@ -200,7 +220,8 @@ describe('Custom Object Instances CRUD', () => {
     customObject,
     {
       SaltoName: 'existingInstanceWithNonUpdateableField',
-      NotUpdatable: 'DontSendMeOnUpdate',
+      NotUpdateable__c: 'DontSendMeOnUpdate',
+      NotUpdateableStandardField: 'SendMeOnUpdate',
     }
   )
   const newInstanceWithRefName = 'newInstanceWithRef'
@@ -233,7 +254,8 @@ describe('Custom Object Instances CRUD', () => {
     {
       SaltoName: 'newInstanceWithNonCreatableField',
       NumField: 4,
-      NotCreatable: 'ShouldNotBeCreated',
+      Id: '13212',
+      NotCreatable__c: 'ShouldNotBeCreated',
     }
   )
 
@@ -510,8 +532,8 @@ describe('Custom Object Instances CRUD', () => {
             expect(updateCall[3][0].SaltoName).toBeDefined()
             expect(updateCall[3][0].SaltoName).toEqual('existingInstance')
             // Because it turns into an update it should send it
-            expect(updateCall[3][0].NotCreatable).toBeDefined()
-            expect(updateCall[3][0].NotCreatable).toEqual('DontSendMeOnCreate')
+            expect(updateCall[3][0].NotCreatable__c).toBeDefined()
+            expect(updateCall[3][0].NotCreatable__c).toEqual('DontSendMeOnCreate')
             // Should deploy fields with no values as null
             expect(updateCall[3][0].FieldWithNoValue).toBeNull()
           })
@@ -527,13 +549,13 @@ describe('Custom Object Instances CRUD', () => {
             const newInstanceWithRefRecord = insertCall[3][0]
             expect(newInstanceWithRefRecord).toHaveProperty('SaltoName', 'newInstanceWithRef')
             expect(newInstanceWithRefRecord).toHaveProperty('AnotherField', 'Type')
-            expect(newInstanceWithRefRecord).not.toHaveProperty('NotCreatable')
+            expect(newInstanceWithRefRecord).not.toHaveProperty('NotCreatable__c')
             expect(newInstanceWithRefRecord).not.toHaveProperty('FieldWithNoValue')
 
             const newInstanceWithNonCreatableFieldRecord = insertCall[3][1]
             expect(newInstanceWithNonCreatableFieldRecord).toHaveProperty('SaltoName', 'newInstanceWithNonCreatableField')
             expect(newInstanceWithNonCreatableFieldRecord).toHaveProperty('NumField', 4)
-            expect(newInstanceWithNonCreatableFieldRecord).not.toHaveProperty('NotCreatable')
+            expect(newInstanceWithNonCreatableFieldRecord).not.toHaveProperty('NotCreatable__c')
           })
 
           it('Should have result with 2 applied changes, add 3 instances with new Id', async () => {
@@ -580,7 +602,7 @@ describe('Custom Object Instances CRUD', () => {
               .map(getChangeData)
               .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
 
-            expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
+            expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable__c')
           })
         })
         describe('When called with only new instances', () => {
@@ -659,7 +681,7 @@ describe('Custom Object Instances CRUD', () => {
                 .map(getChangeData)
                 .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
 
-              expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
+              expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable__c')
             })
           })
           describe('when group has circular dependencies', () => {
@@ -1002,7 +1024,8 @@ describe('Custom Object Instances CRUD', () => {
           const thirdChangeData = getChangeData(result.appliedChanges[2])
           expect(thirdChangeData).toBeDefined()
           expect(isInstanceElement(thirdChangeData)).toBeTruthy()
-          expect((thirdChangeData as InstanceElement).value).not.toHaveProperty('NotUpdateable')
+          expect((thirdChangeData as InstanceElement).value).not.toHaveProperty('NotUpdateable__c')
+          expect((thirdChangeData as InstanceElement).value.NotUpdateableStandardField).toEqual('SendMeOnUpdate')
         })
       })
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -254,7 +254,6 @@ describe('Custom Object Instances CRUD', () => {
     {
       SaltoName: 'newInstanceWithNonCreatableField',
       NumField: 4,
-      Id: '13212',
       NotCreatable__c: 'ShouldNotBeCreated',
     }
   )


### PR DESCRIPTION
Do not create warnings on Standard Fields that lack permissions

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
