### PR TITLE
SALTO 5270: Add Secuiry to workspaceId

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -541,7 +541,7 @@ export default class JiraAdapter implements AdapterOperations {
       return { elements: [] }
     }
 
-    const workspaceId = await getWorkspaceId(this.client)
+    const workspaceId = await getWorkspaceId(this.client, this.userConfig)
     if (workspaceId === undefined) {
       return { elements: [] }
     }

--- a/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
@@ -150,7 +150,7 @@ const filterCreator: FilterCreator = ({ config, client, fetchQuery }) => ({
       changes,
       change => getChangeData(change).elemID.typeName === OBJECT_TYPE_ORDER_TYPE
     )
-    const workspaceId = await getWorkspaceId(client)
+    const workspaceId = await getWorkspaceId(client, config)
     if (workspaceId === undefined) {
       log.error(`Skip deployment of ${OBJECT_TYPE_ORDER_TYPE} types because workspaceId is undefined`)
       const errors = relevantChanges.map(change => createSaltoElementError({

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -154,7 +154,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       && getChangeData(change).elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE
     )
 
-    const workspaceId = await getWorkspaceId(client)
+    const workspaceId = await getWorkspaceId(client, config)
     if (workspaceId === undefined) {
       log.error(`Skip deployment of ${OBJECT_TYPE_ATTRIBUTE_TYPE} types because workspaceId is undefined`)
       const errors = attributesChanges.map(change => createSaltoElementError({

--- a/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_deploy_filter.ts
@@ -51,7 +51,9 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         SUPPORTED_TYPES.has(getChangeData(change).elemID.typeName)
         && isInstanceChange(change)
     )
-    const workspaceId = await getWorkspaceId(client)
+    const hasAssetsChanges = jsmTypesChanges.some(change =>
+      ASSETS_SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName))
+    const workspaceId = hasAssetsChanges ? await getWorkspaceId(client, config) : undefined
     const additionalUrlVars = workspaceId ? { workspaceId } : undefined
 
     const typeFixedChanges = jsmTypesChanges


### PR DESCRIPTION
Currently, when customers have JSM Free but not JSM premium, they might get an errors for trying to access a source they don't have permission to. I wanted to add security that prevents the fetch or deployment from failing for not good reason. 

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
