### PR TITLE
SALTO-5257: Adjust supported types for classic engine orgs (Okta)

### DIFF
--- a/packages/adapter-components/src/config/config_change.ts
+++ b/packages/adapter-components/src/config/config_change.ts
@@ -23,7 +23,7 @@ const CLIENT_CONFIG = 'client'
 
 export const TYPE_TO_EXCLUDE = 'typeToExclude'
 export const DISABLE_PRIVATE_API = 'disablePrivateAPI'
-type ConfigSuggestionType = 'typeToExclude' | 'disablePrivateAPI'
+type ConfigSuggestionType = 'typeToExclude' | 'disablePrivateAPI' | 'enableFetchFlag'
 
 export type ConfigChangeSuggestion = {
   type: ConfigSuggestionType
@@ -54,15 +54,19 @@ export const getUpdatedCofigFromConfigChanges = ({
 
   const shouldDisablePrivateApi = configChanges.find(configChange => configChange.type === DISABLE_PRIVATE_API)
 
-  const updatedFetchConfig = typesToExclude.length > 0
-    ? {
-      ...currentConfig.value[FETCH_CONFIG],
-      exclude: [
-        ...currentConfig.value[FETCH_CONFIG].exclude,
-        ...typesToExclude.map(typeName => ({ type: typeName })),
-      ],
-    }
-    : currentConfig.value[FETCH_CONFIG]
+  const fetchFlagsToEnable = configChanges
+    .filter(configChange => configChange.type === 'enableFetchFlag')
+    .map(configChange => configChange.value)
+    .filter(isDefined)
+
+  const updatedFetchConfig = {
+    ...currentConfig.value[FETCH_CONFIG],
+    exclude: [
+      ...currentConfig.value[FETCH_CONFIG].exclude,
+      ...Object.values(typesToExclude.map(typeName => ({ type: typeName }))),
+    ],
+    ...Object.fromEntries(fetchFlagsToEnable.map(flagName => ([[flagName], true]))),
+  }
 
   const updatedClientconfig = shouldDisablePrivateApi
     ? { ...currentConfig.value[CLIENT_CONFIG], usePrivateAPI: false }

--- a/packages/adapter-components/test/config/config_change.test.ts
+++ b/packages/adapter-components/test/config/config_change.test.ts
@@ -33,6 +33,8 @@ describe('config_change', () => {
           exclude: [
             { type: 'Type1' },
           ],
+          fetchFlag1: false,
+          someFlag: false,
         },
       }
     )
@@ -57,5 +59,58 @@ describe('config_change', () => {
     expect(configChange?.message).toContain('r1')
     expect(configChange?.message).toContain('r2')
     expect(configChange?.message).toContain('can not fetch private api')
+  })
+  describe('enableFetchFlag config suggestions', () => {
+    it('should enable fetch flags when there are enableFetchFlag config suggestions', () => {
+      const updatedConfig = getUpdatedCofigFromConfigChanges({
+        configChanges: [
+          { type: 'enableFetchFlag', value: 'fetchFlag1', reason: 'r1' },
+          { type: 'enableFetchFlag', value: 'fetchFlag2', reason: 'r2' },
+        ],
+        currentConfig: config,
+        configType,
+      })
+      expect(updatedConfig?.config).toBeDefined()
+      expect(updatedConfig?.config[0].value).toEqual(
+        {
+          fetch: {
+            include: [
+              { type: 'aType' },
+            ],
+            exclude: [
+              { type: 'Type1' },
+            ],
+            fetchFlag1: true,
+            fetchFlag2: true,
+            someFlag: false,
+          },
+        }
+      )
+    })
+    it('should not change fetch flags when there are no enbaleFetchFlag config suggestions', () => {
+      const updatedConfig = getUpdatedCofigFromConfigChanges({
+        configChanges: [
+          { type: 'typeToExclude', value: 'bType', reason: 'r1' },
+        ],
+        currentConfig: config,
+        configType,
+      })
+      expect(updatedConfig?.config).toBeDefined()
+      expect(updatedConfig?.config[0].value).toEqual(
+        {
+          fetch: {
+            include: [
+              { type: 'aType' },
+            ],
+            exclude: [
+              { type: 'Type1' },
+              { type: 'bType' },
+            ],
+            fetchFlag1: false,
+            someFlag: false,
+          },
+        }
+      )
+    })
   })
 })

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -21,7 +21,7 @@ import { logger } from '@salto-io/logging'
 import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
-import { OktaConfig, API_DEFINITIONS_CONFIG, CLIENT_CONFIG, configType, FETCH_CONFIG } from './config'
+import { OktaConfig, API_DEFINITIONS_CONFIG, CLIENT_CONFIG, configType, FETCH_CONFIG, getSupportedTypes } from './config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -58,6 +58,7 @@ import addImportantValues from './filters/add_important_values'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
+import { isClassicEngineOrg } from './utils'
 
 const { awu } = collections.asynciterable
 
@@ -168,7 +169,7 @@ export default class OktaAdapter implements AdapterOperations {
         {
           client,
           paginator,
-          config,
+          config: this.userConfig,
           getElemIdFunc,
           elementsSource,
           fetchQuery: this.fetchQuery,
@@ -274,11 +275,30 @@ export default class OktaAdapter implements AdapterOperations {
     }
   }
 
+  private async handleClassicEngineOrg(): Promise<configUtils.ConfigChangeSuggestion | undefined> {
+    const { isClassicOrg: isClassicOrgByConfig } = this.userConfig[FETCH_CONFIG]
+    const isClassicOrg = isClassicOrgByConfig ?? await isClassicEngineOrg(this.client)
+    if (isClassicOrg) {
+      // update supported types to exclude types that are not supported in classic orgs
+      this.userConfig[API_DEFINITIONS_CONFIG].supportedTypes = getSupportedTypes({
+        isClassicOrg,
+        supportedTypes: this.userConfig[API_DEFINITIONS_CONFIG].supportedTypes,
+      })
+      return {
+        type: 'enableFetchFlag',
+        value: 'isClassicOrg',
+        reason: 'We detected that your Okta organization is using the Classic Engine, therefore, certain types of data that are only compatible with newer versions were not fetched.',
+      }
+    }
+    return undefined
+  }
+
   @logDuration('fetching account configuration')
   async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     log.debug('going to fetch okta account configuration..')
     const { convertUsersIds, getUsersStrategy } = this.userConfig[FETCH_CONFIG]
-    const { elements, errors, configChanges } = await this.getAllElements(progressReporter)
+    const classicOrgConfigSuggestion = await this.handleClassicEngineOrg()
+    const { elements, errors, configChanges: getElementsConfigChanges } = await this.getAllElements(progressReporter)
 
     const usersPromise = convertUsersIds
       ? getUsers(
@@ -293,8 +313,13 @@ export default class OktaAdapter implements AdapterOperations {
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
     const filterResult = await this.createFiltersRunner(usersPromise).onFetch(elements) || {}
 
-    const updatedConfig = configChanges && this.configInstance
-      ? configUtils.getUpdatedCofigFromConfigChanges({ configChanges, currentConfig: this.configInstance, configType })
+    const configChanges = (getElementsConfigChanges ?? []).concat(classicOrgConfigSuggestion ?? [])
+    const updatedConfig = !_.isEmpty(configChanges) && this.configInstance
+      ? configUtils.getUpdatedCofigFromConfigChanges({
+        configChanges,
+        currentConfig: this.configInstance,
+        configType,
+      })
       : undefined
     return {
       elements,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1789,7 +1789,7 @@ export const getSupportedTypes = ({
   isClassicOrg: boolean
   supportedTypes: Record<string, string[]>
 }): Record<string, string[]> =>
-  (isClassicOrg ? _.omit(supportedTypes, CLASSIC_ENGINE_UNSUPPORTED_TYPES) : SUPPORTED_TYPES)
+  (isClassicOrg ? _.omit(supportedTypes, CLASSIC_ENGINE_UNSUPPORTED_TYPES) : supportedTypes)
 
 export type ChangeValidatorName = (
   | 'createCheckDeploymentBasedOnConfig'

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { ElemID, CORE_ANNOTATIONS, ActionName, BuiltinTypes, ObjectType, Field, createRestriction } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
-import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME, AUTOMATION_TYPE_NAME } from './constants'
+import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME, AUTOMATION_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, DEVICE_ASSURANCE } from './constants'
 import { DEFAULT_CONVERT_USERS_IDS_VALUE, DEFAULT_GET_USERS_STRATEGY } from './user_utils'
 
 type UserDeployConfig = configUtils.UserDeployConfig
@@ -43,6 +43,7 @@ export type OktaStatusActionName = 'activate' | 'deactivate'
 export type OktaActionName = ActionName | OktaStatusActionName
 type GetUsersStrategy = 'searchQuery' | 'allUsers'
 export type OktaFetchConfig = configUtils.UserFetchConfig & {
+  isClassicOrg?: boolean
   convertUsersIds?: boolean
   enableMissingReferences?: boolean
   includeGroupMemberships?: boolean
@@ -1778,6 +1779,18 @@ export const DEFAULT_CONFIG: OktaConfig = {
   },
 }
 
+const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [DEVICE_ASSURANCE, AUTHENTICATOR_TYPE_NAME, ACCESS_POLICY_TYPE_NAME,
+  PROFILE_ENROLLMENT_POLICY_TYPE_NAME]
+
+export const getSupportedTypes = ({
+  isClassicOrg,
+  supportedTypes,
+}: {
+  isClassicOrg: boolean
+  supportedTypes: Record<string, string[]>
+}): Record<string, string[]> =>
+  (isClassicOrg ? _.omit(supportedTypes, CLASSIC_ENGINE_UNSUPPORTED_TYPES) : SUPPORTED_TYPES)
+
 export type ChangeValidatorName = (
   | 'createCheckDeploymentBasedOnConfig'
   | 'application'
@@ -1858,6 +1871,7 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
               [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: ['searchQuery', 'allUsers'] }),
             },
           },
+          isClassicOrg: { refType: BuiltinTypes.BOOLEAN },
         }
       ),
     },

--- a/packages/okta-adapter/src/utils.ts
+++ b/packages/okta-adapter/src/utils.ts
@@ -13,10 +13,35 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+import _ from 'lodash'
 import { logger } from '@salto-io/logging'
+import OktaClient from './client/client'
 
 const log = logger(module)
+
+type OktaOrgResponse = {
+  pipeline: string
+}
+
+const isOktaOrgResponse = (value: unknown): value is OktaOrgResponse => _.isObject(value) && 'pipeline' in value
+
+/**
+ * Determine if an account is Classic Engine Org or Okta Identity Engine Org
+ */
+export const isClassicEngineOrg = async (oktaClient: OktaClient): Promise<boolean> => {
+  try {
+    const { data } = await oktaClient.getSinglePage({ url: '/.well-known/okta-organization' })
+    if (!isOktaOrgResponse(data)) {
+      log.debug('Recived invalid response when trying to determine org type')
+      return false
+    }
+    // pipeline is idx for Okta Identity Engine, and v1 for Classic Engine
+    return data.pipeline === 'v1'
+  } catch (err) {
+    log.debug('Failed to determine org type, defaults to Identity Engine Account')
+    return false
+  }
+}
 
 /**
  * Extract id from okta's _links object urls

--- a/packages/okta-adapter/test/utils.test.ts
+++ b/packages/okta-adapter/test/utils.test.ts
@@ -13,7 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { extractIdFromUrl } from '../src/utils'
+import { MockInterface } from '@salto-io/test-utils'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { mockClient } from './utils'
+import OktaClient from '../src/client/client'
+import { extractIdFromUrl, isClassicEngineOrg } from '../src/utils'
 
 describe('okta utils', () => {
   describe('extractIdFromUrl', () => {
@@ -24,6 +28,33 @@ describe('okta utils', () => {
       expect(extractIdFromUrl(link)).toEqual('1234567')
       expect(extractIdFromUrl(link2)).toEqual('abc123')
       expect(extractIdFromUrl(invalidLink)).toBeUndefined()
+    })
+  })
+  describe('isClassicEngineOrg', () => {
+    let mockConnection: MockInterface<clientUtils.APIConnection>
+    let client: OktaClient
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+      const { client: cli, connection } = mockClient()
+      mockConnection = connection
+      client = cli
+    })
+    it('should return true for classic engine org', async () => {
+      mockConnection.get.mockResolvedValue({ status: 200, data: { pipeline: 'v1' } })
+      expect(await isClassicEngineOrg(client)).toBeTruthy()
+    })
+    it('should return false for identity engine org', async () => {
+      mockConnection.get.mockResolvedValue({ status: 200, data: { pipeline: 'idx' } })
+      expect(await isClassicEngineOrg(client)).toBeFalsy()
+    })
+    it('should return false for invalid response', async () => {
+      mockConnection.get.mockResolvedValue({ status: 200, data: { org: 'org' } })
+      expect(await isClassicEngineOrg(client)).toBeFalsy()
+    })
+    it('should return false for error', async () => {
+      mockConnection.get.mockRejectedValue(new Error('error'))
+      expect(await isClassicEngineOrg(client)).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
Some types are not supported with the Classic Engine, we would like to avoid fetching them (currently we return fetch warnings)

---

_Additional context for reviewer_

---
_Release Notes_: 
_Okta_adapter_:
- Accounts with Okta Classic Engine will no longer get warnings when fetching Okta Identity Engine types fails.
---
_User Notifications_: 
None