### PR TITLE
SALTO-5274: Salesforce CustomField extra information feature

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -210,6 +210,7 @@ export const FIELD_ANNOTATIONS = {
   LOCAL_ONLY: 'localOnly',
   ROLLUP_SUMMARY_FILTER_OPERATION: 'rollupSummaryFilterOperation',
   METADATA_RELATIONSHIP_CONTROLLING_FIELD: 'metadataRelationshipControllingField',
+  DEFAULTED_ON_CREATE: 'defaultedOnCreate',
 } as const
 
 export const VALUE_SET_FIELDS = {

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -36,6 +36,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   toolingDepsOfCurrentNamespace: false,
   fixRetrieveFilePaths: true,
   extraDependenciesV2: true,
+  extendedCustomFieldInformation: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
@@ -24,6 +24,7 @@ import { getSObjectFieldElement, apiName, toCustomField, isSubfieldOfCompound } 
 import { isInstanceOfType, ensureSafeFilterFetch } from './utils'
 import { CustomField } from '../client/types'
 import { createSkippedListConfigChangeFromError } from '../config_change'
+import { FetchProfile } from '../types'
 
 const log = logger(module)
 const { awu, keyByAsync } = collections.asynciterable
@@ -34,6 +35,7 @@ const createFieldValue = async (
   field: SObjField,
   objectName: string,
   objCompoundFieldNames: Record<string, string>,
+  fetchProfile: FetchProfile,
   systemFields?: string[],
 ): Promise<CustomField> => {
   // temporary hack to maintain the current implementation of the code in transformer.ts
@@ -45,6 +47,7 @@ const createFieldValue = async (
     field,
     { apiName: objectName },
     objCompoundFieldNames,
+    fetchProfile,
     systemFields,
   )
   const customField = await toCustomField(dummyField, false)
@@ -65,6 +68,7 @@ const createFieldValue = async (
 const addSObjectInformationToInstance = async (
   instance: InstanceElement,
   sobject: DescribeSObjectResult,
+  fetchProfile: FetchProfile,
   systemFields?: string[],
 ): Promise<void> => {
   // Add information to the object type
@@ -103,7 +107,7 @@ const addSObjectInformationToInstance = async (
   const sobjectFields = await Promise.all(
     sobject.fields
       .filter(field => !isSubfieldOfCompound(field)) // Filter out nested fields of compound fields
-      .map(field => createFieldValue(field, sobject.name, objCompoundFieldNames, systemFields))
+      .map(field => createFieldValue(field, sobject.name, objCompoundFieldNames, fetchProfile, systemFields))
   )
 
   const addedFieldNames: string[] = []
@@ -159,6 +163,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
           description => addSObjectInformationToInstance(
             customObjectInstances[description.name],
             description,
+            config.fetchProfile,
             config.systemFields,
           )
         )

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -94,6 +94,7 @@ export type OptionalFeatures = {
   useLabelAsAlias?: boolean
   fixRetrieveFilePaths?: boolean
   organizationWideSharingDefaults?: boolean
+  extendedCustomFieldInformation?: boolean
 }
 
 export type ChangeValidatorName = (
@@ -733,6 +734,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
     fixRetrieveFilePaths: { refType: BuiltinTypes.BOOLEAN },
     organizationWideSharingDefaults: { refType: BuiltinTypes.BOOLEAN },
+    extendedCustomFieldInformation: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -44,7 +44,7 @@ import { CustomField, FilterItem, CustomObject, CustomPicklistValue,
 import SalesforceClient from '../../src/client/client'
 import Connection from '../../src/client/jsforce'
 import mockClient from '../client'
-import { createValueSetEntry } from '../utils'
+import { createValueSetEntry, defaultFilterContext } from '../utils'
 import { LAYOUT_TYPE_ID } from '../../src/filters/layouts'
 import { mockValueTypeField, mockDescribeValueResult, mockFileProperties, mockSObjectField } from '../connection'
 import { allMissingSubTypes } from '../../src/transformers/salesforce_types'
@@ -173,21 +173,21 @@ describe('transformer', () => {
       it('should fetch lookup relationships with restricted deletion', async () => {
         _.set(salesforceReferenceField, 'restrictedDelete', true)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         await assertReferenceFieldTransformation(fieldElement, ['Group', 'User'], Types.primitiveDataTypes.Lookup)
       })
 
       it('should fetch lookup relationships with allowed related record deletion when restrictedDelete set to false', async () => {
         _.set(salesforceReferenceField, 'restrictedDelete', false)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         await assertReferenceFieldTransformation(fieldElement, ['Group', 'User'], Types.primitiveDataTypes.Lookup)
       })
 
       it('should fetch lookup relationships with allowed related record deletion when restrictedDelete is undefined', async () => {
         _.set(salesforceReferenceField, 'restrictedDelete', undefined)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         await assertReferenceFieldTransformation(fieldElement, ['Group', 'User'], Types.primitiveDataTypes.Lookup)
       })
 
@@ -196,7 +196,7 @@ describe('transformer', () => {
         salesforceReferenceField.updateable = true
         salesforceReferenceField.writeRequiresMasterRead = true
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         await assertReferenceFieldTransformation(fieldElement, ['Group', 'User'], Types.primitiveDataTypes.MasterDetail)
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.REPARENTABLE_MASTER_DETAIL]).toBe(true)
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.WRITE_REQUIRES_MASTER_READ]).toBe(true)
@@ -206,7 +206,8 @@ describe('transformer', () => {
         salesforceReferenceField.cascadeDelete = true
         salesforceReferenceField.updateable = false
         delete salesforceReferenceField.writeRequiresMasterRead
-        const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField, {})
+        const fieldElement = getSObjectFieldElement(dummyElem, salesforceReferenceField,
+          {}, {}, defaultFilterContext.fetchProfile)
         await assertReferenceFieldTransformation(fieldElement, ['Group', 'User'], Types.primitiveDataTypes.MasterDetail)
         expect(fieldElement.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.REPARENTABLE_MASTER_DETAIL]).toBe(false)
@@ -261,14 +262,14 @@ describe('transformer', () => {
 
       it('should fetch rollup summary field', async () => {
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceRollupSummaryField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.Summary)
       })
 
       it('should not fetch summary field if it is a calculated formula', async () => {
         salesforceRollupSummaryField.calculatedFormula = 'dummy formula'
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceRollupSummaryField,
-          serviceIds)
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         expect(await fieldElement.getType()).not.toEqual(Types.primitiveDataTypes.Summary)
       })
     })
@@ -322,7 +323,8 @@ describe('transformer', () => {
         const scale = 6
         salesforceNumberField.precision = precision
         salesforceNumberField.scale = scale
-        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNumberField, serviceIds)
+        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNumberField, serviceIds,
+          {}, defaultFilterContext.fetchProfile)
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.PRECISION]).toEqual(precision)
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.SCALE]).toEqual(scale)
         expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.Number)
@@ -332,7 +334,8 @@ describe('transformer', () => {
         const precision = 8
         salesforceNumberField.type = 'int'
         salesforceNumberField.digits = precision
-        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNumberField, serviceIds)
+        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNumberField, serviceIds,
+          {}, defaultFilterContext.fetchProfile)
         expect(fieldElement.annotations[FIELD_ANNOTATIONS.PRECISION]).toEqual(precision)
         expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.Number)
       })
@@ -355,7 +358,7 @@ describe('transformer', () => {
           restrictedPicklist: true,
           precision: 3,
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, {})
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, {}, {}, defaultFilterContext.fetchProfile)
       })
       it('should add value set annotation', () => {
         expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.VALUE_SET, [
@@ -381,7 +384,7 @@ describe('transformer', () => {
           extraTypeInfo: 'plaintextarea',
           length: 5000,
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, {})
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, {}, {}, defaultFilterContext.fetchProfile)
       })
       it('should get long text area field type', () => {
         expect(field.refType.type).toBe(Types.primitiveDataTypes.LongTextArea)
@@ -397,7 +400,7 @@ describe('transformer', () => {
           extraTypeInfo: 'richtextarea',
           length: 5000,
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, {})
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, {}, {}, defaultFilterContext.fetchProfile)
       })
       it('should get html field type', () => {
         expect(field.refType.type).toBe(Types.primitiveDataTypes.Html)
@@ -411,7 +414,7 @@ describe('transformer', () => {
           soapType: 'xsd:string',
           type: 'encryptedstring',
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, {})
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, {}, {}, defaultFilterContext.fetchProfile)
       })
       it('should get html field type', () => {
         expect(field.refType.type).toBe(Types.primitiveDataTypes.EncryptedText)
@@ -468,7 +471,8 @@ describe('transformer', () => {
           dummyElem,
           salesforceAddressField,
           serviceIds,
-          { OtherAddress: 'OtherAddress' }
+          { OtherAddress: 'OtherAddress' },
+          defaultFilterContext.fetchProfile,
         )
         expect(await fieldElement.getType()).toEqual(Types.compoundDataTypes.Address)
       })
@@ -517,7 +521,7 @@ describe('transformer', () => {
       it('should fetch idLookup & typed id fields as serviceId', async () => {
         salesforceIdField = _.cloneDeep(origSalesforceIdField)
         const fieldElement = getSObjectFieldElement(dummyElem, salesforceIdField,
-          serviceIds, {})
+          serviceIds, {}, defaultFilterContext.fetchProfile)
         expect(isServiceId((await fieldElement.getType())))
           .toEqual(true)
       })
@@ -572,7 +576,8 @@ describe('transformer', () => {
             dummyElem,
             salesforceAutoNumberField,
             serviceIds,
-            {}
+            {},
+            defaultFilterContext.fetchProfile,
           )
           expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.AutoNumber)
           expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
@@ -587,7 +592,8 @@ describe('transformer', () => {
             dummyElem,
             salesforceAutoNumberField,
             serviceIds,
-            {}
+            {},
+            defaultFilterContext.fetchProfile,
           )
           expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.AutoNumber)
           expect(fieldElement.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
@@ -646,13 +652,15 @@ describe('transformer', () => {
           dummyElem,
           salesforceNameField,
           serviceIds,
-          { Name: 'Name' }
+          { Name: 'Name' },
+          defaultFilterContext.fetchProfile
         )
         expect(await fieldElement.getType()).toEqual(Types.compoundDataTypes.Name)
       })
 
       it('should fetch name field as text type when no name compound field in object', async () => {
-        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNameField, serviceIds, {})
+        const fieldElement = getSObjectFieldElement(dummyElem, salesforceNameField, serviceIds,
+          {}, defaultFilterContext.fetchProfile)
         expect(await fieldElement.getType()).toEqual(Types.primitiveDataTypes.Text)
       })
     })
@@ -696,7 +704,7 @@ describe('transformer', () => {
           unique: false,
           updateable: true,
         }
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds)
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, defaultFilterContext.fetchProfile)
       })
       it('should create a field with a valid name', () => {
         expect(field.name).not.toInclude('%')
@@ -715,7 +723,7 @@ describe('transformer', () => {
           soapType: 'xsd:string',
           type: 'string',
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds)
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, defaultFilterContext.fetchProfile)
       })
       it('should have a type of formula', () => {
         expect(field.refType.type?.elemID.name).toEqual('FormulaText')
@@ -742,7 +750,7 @@ describe('transformer', () => {
           soapType: 'xsd:boolean',
           type: 'boolean',
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds)
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, defaultFilterContext.fetchProfile)
       })
       it('should set the _default annotation on the field', () => {
         expect(field.annotations[FIELD_ANNOTATIONS.DEFAULT_VALUE]).toEqual(true)
@@ -763,7 +771,7 @@ describe('transformer', () => {
           type: 'boolean',
           updateable: true,
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds)
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, defaultFilterContext.fetchProfile)
       })
       it('should set the _default annotation on the field', () => {
         expect(field.annotations[FIELD_ANNOTATIONS.DEFAULT_VALUE]).toEqual(false)
@@ -777,13 +785,53 @@ describe('transformer', () => {
           name: 'LastModifiedDate',
           type: 'datetime',
         })
-        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, ['LastModifiedDate'])
+        field = getSObjectFieldElement(dummyElem, fieldDefinition, serviceIds, {}, defaultFilterContext.fetchProfile, ['LastModifiedDate'])
       })
       it('should create a field that is hidden and not required, creatable and updatable', () => {
         expect(field.annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         expect(field.annotations[FIELD_ANNOTATIONS.CREATABLE]).toBeFalsy()
         expect(field.annotations[FIELD_ANNOTATIONS.UPDATEABLE]).toBeFalsy()
         expect(field.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]).toBeTruthy()
+      })
+    })
+    describe('extendedCustomFieldInformation', () => {
+      let fieldDefinition: SalesforceField
+      beforeEach(() => {
+        fieldDefinition = mockSObjectField({
+          name: 'LastModifiedDate',
+          type: 'datetime',
+          [FIELD_ANNOTATIONS.DEFAULTED_ON_CREATE]: true,
+        })
+      })
+      describe('when feature is enabled', () => {
+        it('should return field with extended field information values', () => {
+          const field = getSObjectFieldElement(
+            dummyElem,
+            fieldDefinition,
+            serviceIds,
+            {},
+            {
+              ...defaultFilterContext.fetchProfile,
+              isFeatureEnabled: _feature => true,
+            }
+          )
+          expect(field.annotations[FIELD_ANNOTATIONS.DEFAULTED_ON_CREATE]).toEqual(true)
+        })
+      })
+      describe('when feature is disabled', () => {
+        it('should return field without extended field information values', () => {
+          const field = getSObjectFieldElement(
+            dummyElem,
+            fieldDefinition,
+            serviceIds,
+            {},
+            {
+              ...defaultFilterContext.fetchProfile,
+              isFeatureEnabled: _feature => false,
+            }
+          )
+          expect(field.annotations[FIELD_ANNOTATIONS.DEFAULTED_ON_CREATE]).toBeUndefined()
+        })
       })
     })
   })


### PR DESCRIPTION
Implemented a feature that adds extra information on the fetched `CustomFields`.

---

Disabled by default. The current extraInformation I've added is for `defaultedOnCreate`
You can see diff on the opportunity object here as an example: https://github.com/salto-io/tamir-sf/commit/64e6bbeb40f41201ff2f4f75d6cccd1b9d52c491

---
_Release Notes_: 
Salesforce Adapter:
- Added the optional feature `extraCustomFieldInformation` that extends the annotations of the `CustomFields` when enabled.

---
_User Notifications_: 
Salesforce:
- When enabling the feature `extraCustomFieldInformation`, expect to see new values on each `CustomField`.
