### PR TITLE
SALTO-5271: Support label attribute

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
@@ -21,7 +21,6 @@ import { JIRA } from '../../../../src/constants'
 export const createObjectTypeAttributeValues = (name: string, allElements: Element[]): Values => ({
   name,
   objectType: createReference(new ElemID(JIRA, 'ObjectType', 'instance', 'testSchema_Hardware_Assets@us'), allElements),
-  label: false,
   type: 0,
   editable: true,
   sortable: true,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -165,6 +165,7 @@ import portalGroupsFilter from './filters/portal_groups'
 import assetsObjectTypePath from './filters/assets/assets_object_type_path'
 import assetsObjectTypeChangeFields from './filters/assets/assets_object_type_change_fields'
 import assetsObjectTypeOrderFilter from './filters/assets/assets_object_type_order'
+import defaultAttributesFilter from './filters/assets/label_object_type_attribute'
 import changeAttributesPathFilter from './filters/assets/change_attributes_path'
 import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
@@ -354,6 +355,7 @@ export const DEFAULT_FILTERS = [
   assetsObjectTypePath,
   // Must run after assetsObjectTypePath
   changeAttributesPathFilter,
+  defaultAttributesFilter,
   assetsObjectTypeOrderFilter,
   deployAttributesFilter,
   deployJsmTypesFilter,

--- a/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
+++ b/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
@@ -29,6 +29,17 @@ export const deleteLabelAtttributeValidator: (
     if (elementsSource === undefined || !config.fetch.enableJsmExperimental) {
       return []
     }
+    const objectTypeAttributeRemovalChanges = await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isRemovalChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
+      .toArray()
+
+    if (objectTypeAttributeRemovalChanges.length === 0) {
+      return []
+    }
+
     const labelAttributesFullNames = await awu(await elementsSource.list())
       .filter(id => id.typeName === OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE)
       .map(id => elementsSource.get(id))
@@ -37,17 +48,12 @@ export const deleteLabelAtttributeValidator: (
       .map(instance => instance.value.labelAttribute.elemID.getFullName())
       .toArray()
 
-    return awu(changes)
-      .filter(isInstanceChange)
-      .filter(isRemovalChange)
-      .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
-      .filter(async instance => labelAttributesFullNames.includes(instance.elemID.getFullName()))
+    return objectTypeAttributeRemovalChanges
+      .filter(instance => labelAttributesFullNames.includes(instance.elemID.getFullName()))
       .map(instance => ({
         elemID: instance.elemID,
         severity: 'Error' as SeverityLevel,
         message: 'Cannot delete an objectType label attribute',
-        detailedMessage: 'Cannot delete this attribute, as it is the label attribute of it\'s objectType.',
+        detailedMessage: 'Cannot delete this attribute, as it is the label attribute of its objectType.',
       }))
-      .toArray()
   }

--- a/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
+++ b/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, SeverityLevel, isRemovalChange, isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE } from '../../constants'
+import { JiraConfig } from '../../config/config'
+
+const { awu } = collections.asynciterable
+
+/*
+* This validator prevents the deletion of the label attribute of an objectType.
+*/
+export const deleteLabelAtttributeValidator: (
+    config: JiraConfig,
+  ) => ChangeValidator = config => async (changes, elementsSource) => {
+    if (elementsSource === undefined || !config.fetch.enableJsmExperimental) {
+      return []
+    }
+    const labelAttributesFullNames = await awu(await elementsSource.list())
+      .filter(id => id.typeName === OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE)
+      .map(id => elementsSource.get(id))
+      .filter(isInstanceElement)
+      .filter(instance => isReferenceExpression(instance.value.labelAttribute))
+      .map(instance => instance.value.labelAttribute.elemID.getFullName())
+      .toArray()
+
+    return awu(changes)
+      .filter(isInstanceChange)
+      .filter(isRemovalChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
+      .filter(async instance => labelAttributesFullNames.includes(instance.elemID.getFullName()))
+      .map(instance => ({
+        elemID: instance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Cannot delete an objectType label attribute',
+        detailedMessage: 'Cannot delete this attribute, as it is the label attribute of it\'s objectType.',
+      }))
+      .toArray()
+  }

--- a/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
+++ b/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
@@ -53,7 +53,7 @@ export const deleteLabelAtttributeValidator: (
       .map(instance => ({
         elemID: instance.elemID,
         severity: 'Error' as SeverityLevel,
-        message: 'Cannot delete an objectType label attribute',
+        message: 'Cannot delete this attribute, as it is the label attribute of its Object Type.',
         detailedMessage: 'Cannot delete this attribute, as it is the label attribute of its objectType.',
       }))
   }

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -59,6 +59,7 @@ import { customFieldsWith10KOptionValidator } from './field_contexts/custom_fiel
 import { issueTypeHierarchyValidator } from './issue_type_hierarchy'
 import { automationProjectsValidator } from './automation/automation_projects'
 import { deleteLastQueueValidator } from './last_queue'
+import { deleteLabelAtttributeValidator } from './assets/label_attribute_removal'
 import { defaultAdditionQueueValidator } from './default_addition_queue'
 import { defaultAttributeValidator } from './assets/default_attribute'
 import { automationToAssetsValidator } from './automation/automation_to_assets'
@@ -123,6 +124,7 @@ export default (
     automationToAssets: automationToAssetsValidator(config),
     defaultAttributeValidator: defaultAttributeValidator(config, client),
     addJsmProject: addJsmProjectValidator,
+    deleteLabelAtttribute: deleteLabelAtttributeValidator(config),
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -242,6 +242,7 @@ export type ChangeValidatorName = (
   | 'boardColumnConfig'
   | 'automationToAssets'
   | 'addJsmProject'
+  | 'deleteLabelAtttribute'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -296,6 +297,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     defaultAttributeValidator: { refType: BuiltinTypes.BOOLEAN },
     automationToAssets: { refType: BuiltinTypes.BOOLEAN },
     addJsmProject: { refType: BuiltinTypes.BOOLEAN },
+    deleteLabelAtttribute: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -125,5 +125,6 @@ export const OBJECT_TYPE_ATTRIBUTE_TYPE = 'ObjectTypeAttribute'
 export const OBJECT_TYPE_ORDER_TYPE = 'ObjectTypeOrder'
 export const OBJECT_SCHMEA_REFERENCE_TYPE_TYPE = 'ObjectSchemaReferenceType'
 export const OBJECT_SCHMEA_DEFAULT_REFERENCE_TYPE_TYPE = 'ObjectSchemaDefaultReferenceType'
+export const OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE = 'ObjectTypeLabelAttribute'
 // almost constant functions
 export const fetchFailedWarnings = (name :string):string => `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -16,17 +16,19 @@
 
 import { config as configUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
-import { AdditionChange, Change, DeployResult, InstanceElement, createSaltoElementError, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isReferenceExpression, isRemovalChange, toChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { AdditionChange, Change, DeployResult, InstanceElement, ReadOnlyElementsSource, createSaltoElementError, getChangeData, isAdditionChange, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, isRemovalChange, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import Joi from 'joi'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
 import { FilterCreator } from '../../filter'
-import { OBJECT_TYPE_ATTRIBUTE_TYPE } from '../../constants'
+import { OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_TYPE } from '../../constants'
 import { getWorkspaceId } from '../../workspace_id'
 import JiraClient from '../../client/client'
 
 const log = logger(module)
+const { awu } = collections.asynciterable
 
 type AttributeParams = {
   id: string
@@ -97,21 +99,32 @@ const deployAttributeChanges = async ({
   client,
   workspaceId,
   objectTypeToEditableExistiningAttributes,
+  elementsSource,
 }: {
   jsmApiDefinitions: configUtils.AdapterDuckTypeApiConfig
   changes: Change<InstanceElement>[]
   client: JiraClient
   workspaceId: string
   objectTypeToEditableExistiningAttributes: Record<string, string[][]>
+  elementsSource: ReadOnlyElementsSource
 }): Promise<Omit<DeployResult, 'extraProperties'>> => {
   const additionalUrlVars = { workspaceId }
+  const objectTypeFullNames = await awu(await elementsSource.list())
+    .filter(id => id.typeName === OBJECT_TYPE_TYPE)
+    .map(id => elementsSource.get(id))
+    .filter(isInstanceElement)
+    .map(objectType => objectType.elemID.getFullName())
+    .toArray()
+
   return deployChanges(
     changes,
     async change => {
       if (DEFAULT_ATTRIBUTES.includes(getChangeData(change).value.name)) {
         return
       }
-      if (isRemovalChange(change) && getChangeData(change).value.name === 'Name') {
+      // The attribute is being deleted toghther with the object type
+      if (isRemovalChange(change)
+      && !objectTypeFullNames.includes(getChangeData(change).value.objectType.elemID.getFullName())) {
         return
       }
       const instance = getChangeData(change)
@@ -135,7 +148,7 @@ const deployAttributeChanges = async ({
 }
 
 /* This filter deploys JSM attribute changes using two different endpoints. */
-const filter: FilterCreator = ({ config, client }) => ({
+const filter: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'deployAttributesFilter',
   deploy: async changes => {
     const { jsmApiDefinitions } = config
@@ -197,6 +210,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       client,
       workspaceId,
       objectTypeToEditableExistiningAttributes,
+      elementsSource,
     })
 
     return {

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -109,7 +109,8 @@ const deployAttributeChanges = async ({
   elementsSource: ReadOnlyElementsSource
 }): Promise<Omit<DeployResult, 'extraProperties'>> => {
   const additionalUrlVars = { workspaceId }
-  const objectTypeFullNames = await awu(await elementsSource.list())
+  const remvoalChanges = changes.filter(isRemovalChange)
+  const objectTypeFullNames = remvoalChanges.length === 0 ? [] : await awu(await elementsSource.list())
     .filter(id => id.typeName === OBJECT_TYPE_TYPE)
     .map(id => elementsSource.get(id))
     .filter(isInstanceElement)

--- a/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
+++ b/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
@@ -102,7 +102,7 @@ const filterCreator: FilterCreator = ({ config, fetchQuery, client }) => ({
       }
       elements.push(labelAttributeInstance)
     })
-    // Remove label field field from attributes
+    // Remove label value from attributes
     objectTypeAttributeInstances.forEach(attribute => {
       delete attribute.value.label
     })
@@ -136,6 +136,8 @@ const filterCreator: FilterCreator = ({ config, fetchQuery, client }) => ({
     const deployResult = await deployChanges(
       relevantChanges.filter(isInstanceChange),
       async change => {
+        // We cover this case in a CV. Meaning that if we got here than the label attribute will be deleted
+        // With it's parent object type.
         if (isRemovalChange(change)) {
           return
         }

--- a/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
+++ b/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
@@ -1,0 +1,161 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { BuiltinTypes, CORE_ANNOTATIONS, createSaltoElementError, Element, ElemID, getChangeData, InstanceElement, isInstanceChange, isInstanceElement, isReferenceExpression, isRemovalChange, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { elements as adapterElements } from '@salto-io/adapter-components'
+import { invertNaclCase, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { deployChanges } from '../../deployment/standard_deployment'
+import { OBJECT_TYPE_TYPE, JIRA, OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE } from '../../constants'
+import { FilterCreator } from '../../filter'
+import { getWorkspaceId } from '../../workspace_id'
+
+const log = logger(module)
+
+const createLabelAttributeType = (): ObjectType => new ObjectType({
+  elemID: new ElemID(JIRA, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE),
+  fields: {
+    labelAttribute: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+    },
+    objectType: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: { [CORE_ANNOTATIONS.CREATABLE]: true },
+    },
+  },
+  path: [JIRA, adapterElements.TYPES_PATH, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE],
+  annotations: {
+    [CORE_ANNOTATIONS.CREATABLE]: true,
+    [CORE_ANNOTATIONS.UPDATABLE]: true,
+    [CORE_ANNOTATIONS.DELETABLE]: true,
+  },
+})
+
+const createLabelAttributeInstance = (
+  attributes: InstanceElement[],
+  labelAttributeType: ObjectType,
+  objectType: InstanceElement
+): InstanceElement | undefined => {
+  const name = naclCase(`${invertNaclCase(objectType.elemID.name)}_label_attribute`)
+  const labelAttribute = attributes.find(attribute => attribute.value.label === true)
+  if (labelAttribute === undefined) {
+    return undefined
+  }
+  return new InstanceElement(
+    name,
+    labelAttributeType,
+    {
+      labelAttribute: new ReferenceExpression(labelAttribute.elemID, labelAttribute),
+      objectType: new ReferenceExpression(objectType.elemID, objectType),
+    },
+    [...(objectType.path ?? []).slice(0, -1), 'attributes', pathNaclCase(name)],
+  )
+}
+
+/* Handles the object type Label attribute inside each objectType
+ * by creating an InstanceElement of the Label attribute.
+ */
+const filterCreator: FilterCreator = ({ config, fetchQuery, client }) => ({
+  name: 'dafaultAttributeFilter',
+  onFetch: async (elements: Element[]) => {
+    if (!config.fetch.enableJSM
+    || !config.fetch.enableJsmExperimental
+    || !fetchQuery.isTypeMatch(OBJECT_TYPE_ATTRIBUTE_TYPE)) {
+      return
+    }
+
+    const objectTypeAttributeInstances = elements.filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
+
+    const parentToObjectTypeAttributes = _.groupBy(
+      objectTypeAttributeInstances.filter(attribute => isReferenceExpression(attribute.value.objectType)),
+      attribute => attribute.value.objectType.elemID.getFullName()
+    )
+
+    const instanceNameToInstacne = _.keyBy(elements.filter(isInstanceElement)
+      .filter(e => e.elemID.typeName === OBJECT_TYPE_TYPE), inst => inst.elemID.getFullName())
+
+    const labelAttributeType = createLabelAttributeType()
+    elements.push(labelAttributeType)
+    Object.entries(parentToObjectTypeAttributes).forEach(([parentName, attributes]) => {
+      const labelAttributeInstance = createLabelAttributeInstance(
+        attributes,
+        labelAttributeType,
+        instanceNameToInstacne[parentName]
+      )
+      if (labelAttributeInstance === undefined) {
+        return
+      }
+      elements.push(labelAttributeInstance)
+    })
+    // Remove label field field from attributes
+    objectTypeAttributeInstances.forEach(attribute => {
+      delete attribute.value.label
+    })
+  },
+  deploy: async changes => {
+    const { jsmApiDefinitions } = config
+    if (!config.fetch.enableJSM || !config.fetch.enableJsmExperimental || jsmApiDefinitions === undefined) {
+      return {
+        deployResult: { appliedChanges: [], errors: [] },
+        leftoverChanges: changes,
+      }
+    }
+
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change => getChangeData(change).elemID.typeName === OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE
+    )
+    const workspaceId = await getWorkspaceId(client)
+    if (workspaceId === undefined) {
+      log.error(`Skip deployment of ${OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE} types because workspaceId is undefined`)
+      const errors = relevantChanges.map(change => createSaltoElementError({
+        message: `The following changes were not deployed, due to error with the workspaceId: ${relevantChanges.map(c => getChangeData(c).elemID.getFullName()).join(', ')}`,
+        severity: 'Error',
+        elemID: getChangeData(change).elemID,
+      }))
+      return {
+        deployResult: { appliedChanges: [], errors },
+        leftoverChanges,
+      }
+    }
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange),
+      async change => {
+        if (isRemovalChange(change)) {
+          return
+        }
+        const instance = getChangeData(change)
+        const attribute = isReferenceExpression(instance.value.labelAttribute)
+          ? instance.value.labelAttribute.value : undefined
+        if (attribute === undefined) {
+          return
+        }
+        await client.put({
+          url: `/gateway/api/jsm/assets/workspace/${workspaceId}/v1/objecttypeattribute/${attribute.value.id}/configure`,
+          data: {
+            label: true,
+          },
+        })
+      }
+    )
+
+    return { deployResult, leftoverChanges }
+  },
+})
+
+export default filterCreator

--- a/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
+++ b/packages/jira-adapter/src/filters/assets/label_object_type_attribute.ts
@@ -122,7 +122,7 @@ const filterCreator: FilterCreator = ({ config, fetchQuery, client }) => ({
     )
     const workspaceId = await getWorkspaceId(client)
     if (workspaceId === undefined) {
-      log.error(`Skip deployment of ${OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE} types because workspaceId is undefined`)
+      log.error(`Skipped deployment of ${OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE} type because its workspaceId is undefined`)
       const errors = relevantChanges.map(change => createSaltoElementError({
         message: `The following changes were not deployed, due to error with the workspaceId: ${relevantChanges.map(c => getChangeData(c).elemID.getFullName()).join(', ')}`,
         severity: 'Error',

--- a/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
@@ -141,22 +141,4 @@ describe('attributeValidator', () => {
     )
     expect(changeErrors).toHaveLength(0)
   })
-  it('should return error if trying to remove \'Name\' attribute', async () => {
-    attributeInstance = new InstanceElement(
-      'attribute1',
-      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
-      {
-        id: 22,
-        name: 'Name',
-        editable: true,
-        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
-      },
-    )
-    const validator = defaultAttributeValidator(config, client)
-    const changeErrors = await validator(
-      [toChange({ before: attributeInstance })],
-      elementsSource
-    )
-    expect(changeErrors).toHaveLength(1)
-  })
 })

--- a/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
@@ -68,7 +68,7 @@ describe('labelAttributeValidator', () => {
       elemID: attributeInstance.elemID,
       severity: 'Error',
       message: 'Cannot delete an objectType label attribute',
-      detailedMessage: 'Cannot delete this attribute, as it is the label attribute of it\'s objectType.',
+      detailedMessage: 'Cannot delete this attribute, as it is the label attribute of its objectType.',
     })
   })
   it('should not return error on addition change', async () => {

--- a/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
@@ -1,0 +1,119 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE, OBJECT_TYPE_TYPE } from '../../../src/constants'
+import { createEmptyType } from '../../utils'
+import { deleteLabelAtttributeValidator } from '../../../src/change_validators/assets/label_attribute_removal'
+import { JiraConfig, getDefaultConfig } from '../../../src/config/config'
+
+describe('labelAttributeValidator', () => {
+  let attributeInstance: InstanceElement
+  let config: JiraConfig
+  const objectTypeInstance = new InstanceElement(
+    'objectTypeInstance',
+    createEmptyType(OBJECT_TYPE_TYPE),
+    {
+      id: '1',
+      name: 'ObjectType',
+    },
+  )
+  let objectTypeLabelAttributeInstance: InstanceElement
+  beforeEach(async () => {
+    attributeInstance = new InstanceElement(
+      'attribute1',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 22,
+        name: 'Name',
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+        description: 'description',
+      },
+    )
+    objectTypeLabelAttributeInstance = new InstanceElement(
+      'ObjectTypeLabelAttributeInstance',
+      createEmptyType(OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE),
+      {
+        labelAttribute: new ReferenceExpression(attributeInstance.elemID, attributeInstance),
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+      },
+    )
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableJSM = true
+    config.fetch.enableJsmExperimental = true
+  })
+  it('should return error if trying to remove the label attribute', async () => {
+    const validator = deleteLabelAtttributeValidator(config)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance })],
+      buildElementsSourceFromElements([objectTypeLabelAttributeInstance])
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: attributeInstance.elemID,
+      severity: 'Error',
+      message: 'Cannot delete an objectType label attribute',
+      detailedMessage: 'Cannot delete this attribute, as it is the label attribute of it\'s objectType.',
+    })
+  })
+  it('should not return error on addition change', async () => {
+    const validator = deleteLabelAtttributeValidator(config)
+    const changeErrors = await validator(
+      [toChange({ after: attributeInstance })],
+      buildElementsSourceFromElements([objectTypeLabelAttributeInstance])
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return error on modification change', async () => {
+    const attributeAfter = attributeInstance.clone()
+    attributeAfter.value.description = 'new description'
+    const validator = deleteLabelAtttributeValidator(config)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance, after: attributeAfter })],
+      buildElementsSourceFromElements([objectTypeLabelAttributeInstance])
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return error on removal change of non label attribute', async () => {
+    const nonLbaelAttribute = new InstanceElement(
+      'attribute2',
+      createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+      {
+        id: 222,
+        name: 'Name',
+        objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+        description: 'description',
+      },
+    )
+    const validator = deleteLabelAtttributeValidator(config)
+    const changeErrors = await validator(
+      [toChange({ before: nonLbaelAttribute })],
+      buildElementsSourceFromElements([objectTypeLabelAttributeInstance])
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not do anything if enableJsmExperimental is false', async () => {
+    config.fetch.enableJsmExperimental = false
+    const validator = deleteLabelAtttributeValidator(config)
+    const changeErrors = await validator(
+      [toChange({ before: attributeInstance })],
+      buildElementsSourceFromElements([objectTypeLabelAttributeInstance])
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/label_attribute_removal.test.ts
@@ -67,7 +67,7 @@ describe('labelAttributeValidator', () => {
     expect(changeErrors[0]).toEqual({
       elemID: attributeInstance.elemID,
       severity: 'Error',
-      message: 'Cannot delete an objectType label attribute',
+      message: 'Cannot delete this attribute, as it is the label attribute of its Object Type.',
       detailedMessage: 'Cannot delete this attribute, as it is the label attribute of its objectType.',
     })
   })

--- a/packages/jira-adapter/test/filters/assets/label_object_type_attribute.test.ts
+++ b/packages/jira-adapter/test/filters/assets/label_object_type_attribute.test.ts
@@ -1,0 +1,192 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import { filterUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { InstanceElement, ReferenceExpression, isInstanceElement, isObjectType, toChange } from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import { getDefaultConfig } from '../../../src/config/config'
+import dafaultAttributeFilter from '../../../src/filters/assets/label_object_type_attribute'
+import { createEmptyType, getFilterParams, mockClient } from '../../utils'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE, JIRA, OBJECT_TYPE_ATTRIBUTE_TYPE, OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE } from '../../../src/constants'
+import JiraClient from '../../../src/client/client'
+
+const createAttributeInstance = (
+  id: number,
+  suffix: string,
+  objectType: InstanceElement,
+  isLabel: boolean,
+): InstanceElement => new InstanceElement(
+  `assetsObjectType${suffix}`,
+  createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
+  {
+    id,
+    name: `assetsObjectType${suffix}`,
+    objectType: new ReferenceExpression(objectType.elemID, objectType),
+    label: isLabel,
+  },
+  [JIRA, elementUtils.RECORDS_PATH, OBJECT_SCHEMA_TYPE, 'assetsSchema', 'assetsObjectTypes', 'parentObjectTypeInstance', 'attributes', `assetsObjectType${suffix}`],
+)
+describe('labelObjectTypeAttributeFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: FilterType
+  let client: JiraClient
+  const objectTypeInstance = new InstanceElement(
+    'parent_Object_Type_Instance@sss',
+    createEmptyType(OBJECT_TYPE_TYPE),
+    {
+      id: 'p1',
+      name: 'AssetsObjectTypeP1',
+    },
+    [JIRA, elementUtils.RECORDS_PATH, OBJECT_SCHEMA_TYPE, 'assetsSchema', 'assetsObjectTypes', 'parentObjectTypeInstance', 'parentObjectTypeInstance'],
+  )
+  const attributeInstanceOne = createAttributeInstance(1, 'One', objectTypeInstance, false)
+  const attributeInstanceTwo = createAttributeInstance(2, 'Two', objectTypeInstance, true)
+  describe('fetch', () => {
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      config.fetch.enableJsmExperimental = true
+      filter = dafaultAttributeFilter(getFilterParams({ config, client })) as typeof filter
+    })
+    it('should add labelAttributeInstance and type to the elements', async () => {
+      const elements = [
+        objectTypeInstance,
+        attributeInstanceOne,
+        attributeInstanceTwo,
+      ]
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(5)
+      const labelAttributeInstances = elements
+        .filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE)
+      expect(labelAttributeInstances[0]).toBeDefined()
+      expect(labelAttributeInstances[0].elemID.name).toEqual('parent_Object_Type_Instance_label_attribute@sssuu')
+      expect(labelAttributeInstances[0].value.labelAttribute).toEqual(
+        new ReferenceExpression(attributeInstanceTwo.elemID, attributeInstanceTwo),
+      )
+      const labelAttributeType = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE)
+      expect(labelAttributeType).toBeDefined()
+    })
+    it('should do nothing for instnaces without objectType references', async () => {
+      const elements = [
+        objectTypeInstance,
+        attributeInstanceOne,
+        attributeInstanceTwo,
+      ]
+      delete attributeInstanceTwo.value.objectType
+      await filter.onFetch(elements)
+      expect(elements).toHaveLength(4)
+    })
+  })
+  describe('deploy', () => {
+    let connection: MockInterface<clientUtils.APIConnection>
+    let labelAttributeInstance: InstanceElement
+    beforeEach(() => {
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+      config.fetch.enableJsmExperimental = true
+      const { client: cli, connection: conn } = mockClient(false)
+      client = cli
+      connection = conn
+      filter = dafaultAttributeFilter(getFilterParams({ config, client })) as typeof filter
+      labelAttributeInstance = new InstanceElement(
+        'labelAttributeInstance',
+        createEmptyType(OBJECT_TYPE_LABEL_ATTRIBUTE_TYPE),
+        {
+          objectType: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          labelAttribute: new ReferenceExpression(attributeInstanceTwo.elemID, attributeInstanceTwo),
+        },
+      )
+      connection.get.mockImplementation(async url => {
+        if (url === '/rest/servicedeskapi/assets/workspace') {
+          return {
+            status: 200,
+            data: {
+              values: [
+                {
+                  workspaceId: 'workspaceId',
+                },
+              ],
+            },
+          }
+        }
+        throw new Error('Unexpected url')
+      })
+      connection.put.mockResolvedValueOnce({ status: 200, data: {} })
+    })
+    it('should set label in addition change', async () => {
+      const changes = [
+        toChange({ after: labelAttributeInstance }),
+      ]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(1)
+    })
+    it('should set label in modifictaion change', async () => {
+      const labelAttributeInstanceAfter = labelAttributeInstance.clone()
+      labelAttributeInstanceAfter.value.labelAttribute = new ReferenceExpression(
+        attributeInstanceOne.elemID, attributeInstanceOne
+      )
+      const changes = [
+        toChange({ before: labelAttributeInstance, after: labelAttributeInstanceAfter }),
+      ]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(1)
+    })
+    it('should do nothing if labelAttribute is not a referenceExpression', async () => {
+      const labelAttributeInstanceAfter = labelAttributeInstance.clone()
+      labelAttributeInstanceAfter.value.labelAttribute = 'unexpected string'
+      const changes = [
+        toChange({ before: labelAttributeInstance, after: labelAttributeInstanceAfter }),
+      ]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+    it('should do nothing on removalChange', async () => {
+      const changes = [
+        toChange({ before: labelAttributeInstance }),
+      ]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+    it('should return error when workspaceId is undefined', async () => {
+      connection.get.mockResolvedValueOnce({ status: 200, data: {} })
+      const changes = [
+        toChange({ after: labelAttributeInstance }),
+      ]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0].message).toEqual(
+        'The following changes were not deployed, due to error with the workspaceId: jira.ObjectTypeLabelAttribute.instance.labelAttributeInstance'
+      )
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.post).toHaveBeenCalledTimes(0)
+    })
+  })
+})


### PR DESCRIPTION
In this PR:
1. Added CV that prevents the deletion of label attribute.
2. Added a filter that fetches and deploys the label attribute.
3. Modified the attribute deploy filter. 

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter_:
1. New instance element that holds for each objectType who its label attribute. 
2. New CV that prevents deletion of assets label attribute. 

---
_User Notifications_: 
_Jira Adapter_:
1. New instance element that holds for each objectType who its label attribute. 
2. New CV that prevents deletion of assets label attribute. 
