### PR TITLE
SALTO-5283: convert requestForm properties to list - Jira

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -21,7 +21,7 @@ import { getParent, isResolvedReferenceExpression } from '@salto-io/adapter-util
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { ISSUE_LAYOUT_TYPE, PROJECT_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
-import { createLayoutType, layoutConfigItem } from './layout_types'
+import { createLayoutType, LayoutConfigItem } from './layout_types'
 import { addAnnotationRecursively, setTypeDeploymentAnnotations } from '../../utils'
 import { getLayout, getLayoutResponse, isIssueLayoutResponse } from './layout_service_operations'
 import { deployChanges } from '../../deployment/standard_deployment'
@@ -90,7 +90,7 @@ const deployLayoutChange = async (
     // TODO SALTO-5205 - suppress removals of IssueLayout when associated Screen is deleted from IssueTypeScreenScheme
     throw new Error('Could not remove IssueLayout')
   }
-  const items = layout.value.issueLayoutConfig?.items.map((item: layoutConfigItem) => {
+  const items = layout.value.issueLayoutConfig?.items.map((item: LayoutConfigItem) => {
     if (isResolvedReferenceExpression(item.key)) {
       const key = item.key.value.value.id
       return {

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -105,10 +105,7 @@ const fromLayoutConfigRespToLayoutConfig = (
   const fieldItemIdToMetaData: Record<string, Value> = Object.fromEntries(
     (layoutConfig.metadata?.configuration.items.nodes ?? [])
       .filter(node => !_.isEmpty(node))
-      .map(node => {
-        const { fieldItemId, ...nodeWithoutItemId } = node
-        return [fieldItemId, nodeWithoutItemId]
-      })
+      .map(node => [node.fieldItemId, _.omit(node, 'fieldItemId')])
   )
   const items = containers
     .flatMap(container => container.items.nodes

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -25,7 +25,7 @@ import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../../ut
 import { JiraConfig } from '../../config/config'
 import JiraClient, { graphQLResponseType } from '../../client/client'
 import { QUERY, QUERY_JSM } from './layout_queries'
-import { ISSUE_LAYOUT_CONFIG_ITEM_SCHEME, ISSUE_LAYOUT_RESPONSE_SCHEME, issueLayoutConfig, layoutConfigItem, IssueLayoutResponse, createLayoutType, IssueLayoutConfiguration } from './layout_types'
+import { ISSUE_LAYOUT_CONFIG_ITEM_SCHEME, ISSUE_LAYOUT_RESPONSE_SCHEME, LayoutConfigItem, IssueLayoutResponse, createLayoutType, IssueLayoutConfiguration, IssueLayoutConfig } from './layout_types'
 import { ISSUE_LAYOUT_TYPE, ISSUE_VIEW_TYPE, JIRA, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../constants'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
 
@@ -69,7 +69,7 @@ export const LAYOUT_TYPE_NAME_TO_DETAILS: Record<LayoutTypeName, LayoutTypeDetai
 }
 
 export const isIssueLayoutResponse = createSchemeGuard<IssueLayoutResponse>(ISSUE_LAYOUT_RESPONSE_SCHEME)
-const isLayoutConfigItem = createSchemeGuard<layoutConfigItem>(ISSUE_LAYOUT_CONFIG_ITEM_SCHEME)
+const isLayoutConfigItem = createSchemeGuard<LayoutConfigItem>(ISSUE_LAYOUT_CONFIG_ITEM_SCHEME)
 
 export const getLayoutResponse = async ({
   variables,
@@ -100,7 +100,7 @@ export const getLayoutResponse = async ({
 
 const fromLayoutConfigRespToLayoutConfig = (
   layoutConfig: IssueLayoutConfiguration
-): issueLayoutConfig => {
+): IssueLayoutConfig => {
   const { containers } = layoutConfig.issueLayoutResult
   const fieldItemIdToMetaData = Object.fromEntries((layoutConfig.metadata?.configuration.items.nodes ?? [])
     .filter(node => !_.isEmpty(node))
@@ -114,7 +114,7 @@ const fromLayoutConfigRespToLayoutConfig = (
         key: node.fieldItemId,
         data: fieldItemIdToMetaData[node.fieldItemId],
       })))
-    .filter(isLayoutConfigItem)
+    .filter(isLayoutConfigItem) as LayoutConfigItem[]
 
   return { items }
 }

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -15,7 +15,7 @@
 */
 
 import { logger } from '@salto-io/logging'
-import { ElemIdGetter, InstanceElement, ObjectType, Element, isInstanceElement, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { ElemIdGetter, InstanceElement, ObjectType, Element, isInstanceElement, CORE_ANNOTATIONS, Value } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { createSchemeGuard, getParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { elements as adapterElements, config as configUtils } from '@salto-io/adapter-components'
@@ -102,10 +102,14 @@ const fromLayoutConfigRespToLayoutConfig = (
   layoutConfig: IssueLayoutConfiguration
 ): IssueLayoutConfig => {
   const { containers } = layoutConfig.issueLayoutResult
-  const fieldItemIdToMetaData = Object.fromEntries((layoutConfig.metadata?.configuration.items.nodes ?? [])
-    .filter(node => !_.isEmpty(node))
-    .map(node => [node.fieldItemId, _.omit(node, 'fieldItemId')]))
-
+  const fieldItemIdToMetaData: Record<string, Value> = Object.fromEntries(
+    (layoutConfig.metadata?.configuration.items.nodes ?? [])
+      .filter(node => !_.isEmpty(node))
+      .map(node => {
+        const { fieldItemId, ...nodeWithoutItemId } = node
+        return [fieldItemId, nodeWithoutItemId]
+      })
+  )
   const items = containers
     .flatMap(container => container.items.nodes
       .map(node => ({
@@ -114,7 +118,7 @@ const fromLayoutConfigRespToLayoutConfig = (
         key: node.fieldItemId,
         data: fieldItemIdToMetaData[node.fieldItemId],
       })))
-    .filter(isLayoutConfigItem) as LayoutConfigItem[]
+    .filter(isLayoutConfigItem)
 
   return { items }
 }

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -122,7 +122,7 @@ export type LayoutConfigItem = {
   sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
   data: {
-    properties?: Value
+    properties?: Value | null
   } | undefined
 }
 
@@ -131,7 +131,7 @@ export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
   sectionType: Joi.string().valid('PRIMARY', 'SECONDARY', 'CONTENT', 'REQUEST').required(),
   key: Joi.string().required(),
   data: Joi.object({
-    properties: Joi.object().unknown(true),
+    properties: Joi.object().unknown(true).allow(null),
   }).unknown(true),
 }).unknown(true).required()
 

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -15,7 +15,7 @@
 */
 
 import Joi from 'joi'
-import { ObjectType, ElemID, BuiltinTypes, ListType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, ListType, CORE_ANNOTATIONS, Value, InstanceElement } from '@salto-io/adapter-api'
 import { elements as adapterElements } from '@salto-io/adapter-components'
 import { JIRA } from '../../constants'
 
@@ -68,7 +68,7 @@ export const createLayoutType = (typeName: string): {
   }
 }
 
-export type screenScheme = {
+export type ScreenScheme = {
   id: string
   name: string
   description: string
@@ -76,7 +76,7 @@ export type screenScheme = {
   }
 }
 
-export type containerIssueLayoutResponse = {
+export type ContainerIssueLayoutResponse = {
   containerType: string
   items: {
     nodes: {
@@ -100,7 +100,7 @@ export type IssueLayoutConfiguration = {
   issueLayoutResult: {
     id: string
     name: string
-    containers: containerIssueLayoutResponse[]
+    containers: ContainerIssueLayoutResponse[]
   }
   metadata?: {
     configuration: {
@@ -115,23 +115,28 @@ export type IssueLayoutConfiguration = {
 
 export type IssueLayoutResponse = {
   issueLayoutConfiguration: IssueLayoutConfiguration
-  }
+}
 
-export type layoutConfigItem = {
+export type LayoutConfigItem = {
   type: string
   sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
-  data: {}
+  data?: {
+    properties?: Value
+  }
 }
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
   type: Joi.string().required(),
   sectionType: Joi.string().valid('PRIMARY', 'SECONDARY', 'CONTENT', 'REQUEST').required(),
   key: Joi.string().required(),
+  data: Joi.object({
+    properties: Joi.object().unknown(true),
+  }).unknown(true),
 }).unknown(true).required()
 
-export type issueLayoutConfig = {
-    items: layoutConfigItem[]
+export type IssueLayoutConfig = {
+    items: LayoutConfigItem[]
 }
 
 export const ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
@@ -148,3 +153,13 @@ export const ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
     }).unknown(true).allow(null).required(),
   }).unknown(true).required(),
 }).unknown(true).required()
+
+type RequestType = {
+  requestForm: {
+    issueLayoutConfig: IssueLayoutConfig
+  }
+}
+
+export type RequestTypeWithIssueLayoutConfigInstance = InstanceElement & {
+  value: InstanceElement['value'] & RequestType
+}

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -121,9 +121,9 @@ export type LayoutConfigItem = {
   type: string
   sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
-  data?: {
+  data: {
     properties?: Value
-  }
+  } | undefined
 }
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({

--- a/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 
-import { CORE_ANNOTATIONS, Field, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Field, InstanceElement, Values, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../../filter'
@@ -22,6 +22,15 @@ import { ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../con
 
 const log = logger(module)
 const LAYOUT_TYPES_TO_ADJUST = [REQUEST_FORM_TYPE, ISSUE_VIEW_TYPE]
+
+const convertPropertiesToList = (instance: InstanceElement): void => {
+  instance.value.issueLayoutConfig.items.forEach((item: Values) => {
+    if (item.data?.properties !== undefined) {
+      item.data.properties = Object.entries(item.data.properties)
+        .map(([key, value]) => ({ key, value }))
+    }
+  })
+}
 
 /*
 * This filter is responsible for adding the requestForm and issueView fields to the requestType
@@ -62,6 +71,10 @@ const filter: FilterCreator = ({ config }) => ({
       delete layout.value.extraDefinerId
       delete layout.value.projectId
       if (layout.elemID.typeName === REQUEST_FORM_TYPE) {
+        if (layout.value.issueLayoutConfig?.items !== undefined
+          && _.isArray(layout.value.issueLayoutConfig.items)) {
+          convertPropertiesToList(layout)
+        }
         requestType.value.requestForm = layout.value
       } else {
         requestType.value.issueView = layout.value

--- a/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
@@ -25,14 +25,14 @@ const log = logger(module)
 const LAYOUT_TYPES_TO_ADJUST = [REQUEST_FORM_TYPE, ISSUE_VIEW_TYPE]
 
 const convertPropertiesToList = (item: LayoutConfigItem): void => {
-  if (item.data?.properties !== undefined) {
+  if (item.data?.properties != null) {
     item.data.properties = Object.entries(item.data.properties)
       .map(([key, value]) => ({ key, value }))
   }
 }
 
 const convertPropertiesToMap = (item: LayoutConfigItem): void => {
-  if (item.data?.properties !== undefined) {
+  if (item.data?.properties != null) {
     item.data.properties = Object.fromEntries(
       item.data.properties.map(({ key, value }: Values) => [key, value])
     )

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -24,7 +24,7 @@ import { FilterCreator } from '../filter'
 import { ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../constants'
 import { deployChanges, defaultDeployChange } from '../deployment/standard_deployment'
 import JiraClient from '../client/client'
-import { layoutConfigItem } from './layouts/layout_types'
+import { LayoutConfigItem } from './layouts/layout_types'
 import { LayoutTypeName, getLayoutResponse, isIssueLayoutResponse, LAYOUT_TYPE_NAME_TO_DETAILS } from './layouts/layout_service_operations'
 
 const { isDefined } = lowerDashValues
@@ -100,7 +100,7 @@ const deployRequestTypeLayout = async (
     return undefined
   }
   const layout = requestType.value[fieldName]
-  const items = layout.issueLayoutConfig.items.map((item: layoutConfigItem) => {
+  const items = layout.issueLayoutConfig.items.map((item: LayoutConfigItem) => {
     if (!isResolvedReferenceExpression(item.key)) {
       log.error(`Failed to deploy request type: ${requestType.elemID.getFullName()}'s ${fieldName} due to bad reference expression`)
       throw new Error(`Failed to deploy requestType ${fieldName} due to a bad item key: ${item.key}`)

--- a/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { filterUtils, elements as adapterElements } from '@salto-io/adapter-components'
-import { InstanceElement, ReferenceExpression, Element, ObjectType, ElemID, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { InstanceElement, ReferenceExpression, Element, ObjectType, ElemID, CORE_ANNOTATIONS, Value, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { getDefaultConfig } from '../../../src/config/config'
 import requestTypelayoutsToValuesFilter from '../../../src/filters/layouts/request_types_layouts_to_values'
@@ -22,7 +22,7 @@ import { createEmptyType, getFilterParams } from '../../utils'
 import { ISSUE_VIEW_TYPE, JIRA, PROJECT_TYPE, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../../src/constants'
 
 describe('requestTypelayoutsToValuesFilter', () => {
-  type FilterType = filterUtils.FilterWith<'onFetch'>
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   let elements: Element[]
   let projectInstance: InstanceElement
@@ -31,6 +31,7 @@ describe('requestTypelayoutsToValuesFilter', () => {
   let fieldInstance2: InstanceElement
   let requestFormInstance: InstanceElement
   let issueViewInstance: InstanceElement
+  let requestFormValue: Value
 
   describe('on fetch', () => {
     let requestTypeType: ObjectType
@@ -213,6 +214,113 @@ describe('requestTypelayoutsToValuesFilter', () => {
         const requestType = elements.find(e => e.elemID.isEqual(requestTypeInstance.elemID)) as InstanceElement
         expect(requestType.value.requestForm.issueLayoutConfig).toBeUndefined()
       })
+    })
+  })
+
+  describe('preDeploy', () => {
+    beforeEach(async () => {
+      requestFormValue = {
+        issueLayoutConfig: {
+          items: [{
+            type: 'FIELD',
+            data: {
+              properties: [
+                {
+                  key: 'jsd.field.displayName',
+                  value: 'Quack',
+                },
+                {
+                  key: 'jsd.field.helpText',
+                  value: 'Quack Quack',
+                },
+              ],
+            },
+          },
+          {
+            type: 'FIELD',
+          },
+          ],
+        },
+      }
+      requestTypeInstance = new InstanceElement(
+        'requestType',
+        createEmptyType(REQUEST_TYPE_NAME),
+        {
+          requestForm: requestFormValue,
+        },
+        [JIRA, adapterElements.RECORDS_PATH, REQUEST_TYPE_NAME, 'requestTypeTest']
+      )
+    })
+    it('should convert requestForm properties to a map', async () => {
+      await filter.preDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[0].data.properties).toEqual({
+        'jsd.field.displayName': 'Quack',
+        'jsd.field.helpText': 'Quack Quack',
+      })
+    })
+    it('should do nothing when requestForm data or properties are undefined', async () => {
+      requestFormValue.issueLayoutConfig.items[0].data.properties = undefined
+      await filter.preDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[0].data.properties).toBeUndefined()
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[1].data).toBeUndefined()
+    })
+    it('should do nothing when issueLayoutConfig is undefined', async () => {
+      requestFormValue.issueLayoutConfig = undefined
+      await filter.preDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig).toBeUndefined()
+    })
+  })
+  describe('onDeploy', () => {
+    beforeEach(async () => {
+      requestFormValue = {
+        issueLayoutConfig: {
+          items: [{
+            type: 'FIELD',
+            data: {
+              properties: {
+                'jsd.field.displayName': 'Quack',
+                'jsd.field.helpText': 'Quack Quack',
+              },
+            },
+          },
+          {
+            type: 'FIELD',
+          },
+          ],
+        },
+      }
+      requestTypeInstance = new InstanceElement(
+        'requestType',
+        createEmptyType(REQUEST_TYPE_NAME),
+        {
+          requestForm: requestFormValue,
+        },
+        [JIRA, adapterElements.RECORDS_PATH, REQUEST_TYPE_NAME, 'requestTypeTest']
+      )
+    })
+    it('should convert requestForm properties to a list', async () => {
+      await filter.onDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[0].data.properties).toEqual([
+        {
+          key: 'jsd.field.displayName',
+          value: 'Quack',
+        },
+        {
+          key: 'jsd.field.helpText',
+          value: 'Quack Quack',
+        },
+      ])
+    })
+    it('should do nothing when requestForm data or properties are undefined', async () => {
+      requestFormValue.issueLayoutConfig.items[0].data.properties = undefined
+      await filter.onDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[0].data.properties).toBeUndefined()
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig.items[1].data).toBeUndefined()
+    })
+    it('should do nothing when issueLayoutConfig is undefined', async () => {
+      requestFormValue.issueLayoutConfig = undefined
+      await filter.onDeploy([toChange({ after: requestTypeInstance })])
+      expect(requestTypeInstance.value.requestForm.issueLayoutConfig).toBeUndefined()
     })
   })
 })

--- a/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_types_layouts_to_values.test.ts
@@ -100,6 +100,12 @@ describe('requestTypelayoutsToValuesFilter', () => {
                 type: 'FIELD',
                 sectionType: 'PRIMARY',
                 key: new ReferenceExpression(fieldInstance1.elemID, fieldInstance1),
+                data: {
+                  properties: {
+                    'jsd.field.displayName': 'Quack',
+                    'jsd.field.helpText': 'Quack Quack',
+                  },
+                },
               },
               {
                 type: 'FIELD',
@@ -177,6 +183,35 @@ describe('requestTypelayoutsToValuesFilter', () => {
       expect(requestTypeType.fields.issueView.annotations).toEqual({
         [CORE_ANNOTATIONS.UPDATABLE]: true,
         [CORE_ANNOTATIONS.CREATABLE]: true,
+      })
+    })
+    describe('requestForm properties', () => {
+      it('should convert requestForm properties to a list', async () => {
+        await filter.onFetch(elements)
+        const requestType = elements.find(e => e.elemID.isEqual(requestTypeInstance.elemID)) as InstanceElement
+        expect(requestType.value.requestForm.issueLayoutConfig.items[0].data.properties).toEqual([
+          {
+            key: 'jsd.field.displayName',
+            value: 'Quack',
+          },
+          {
+            key: 'jsd.field.helpText',
+            value: 'Quack Quack',
+          },
+        ])
+      })
+      it('should do nothing when requestForm data or properties are undefined', async () => {
+        requestFormInstance.value.issueLayoutConfig.items[0].data.properties = undefined
+        await filter.onFetch(elements)
+        const requestType = elements.find(e => e.elemID.isEqual(requestTypeInstance.elemID)) as InstanceElement
+        expect(requestType.value.requestForm.issueLayoutConfig.items[1].data).toBeUndefined()
+        expect(requestType.value.requestForm.issueLayoutConfig.items[0].data.properties).toBeUndefined()
+      })
+      it('should do nothing when issueLayoutConfig is undefined', async () => {
+        requestFormInstance.value.issueLayoutConfig = undefined
+        await filter.onFetch(elements)
+        const requestType = elements.find(e => e.elemID.isEqual(requestTypeInstance.elemID)) as InstanceElement
+        expect(requestType.value.requestForm.issueLayoutConfig).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
_convert requestForm properties to list_

---

_Additional context for reviewer_

requestForm properties can have an invalid field name as you can see in the attached image, the solution is to convert the field to a list in which each entry contains key and value (same as we do in [other places](https://github.com/salto-io/salto/blob/main/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts#L92) in Jira).

before: 
<img width="997" alt="Screen Shot 2024-01-15 at 16 35 01" src="https://github.com/salto-io/salto/assets/77064001/1e4166f4-7216-40e6-9f6a-5d6845667710">
after: 
<img width="1004" alt="Screen Shot 2024-01-15 at 16 33 50" src="https://github.com/salto-io/salto/assets/77064001/0341d97f-3f98-4f37-9e11-f050f323bc4a">


---
_Release Notes_: 
None

---
_User Notifications_: 
Jira Adapter:
the properties of requestForm instances will be a list in which each entry will contain key and value

