### PR TITLE
Fix NS item types limiter exclusion

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -109,8 +109,13 @@ export type SearchResponse = {
 
 export type SoapSearchType = {
   type: string
-  subtypes?: string[]
-}
+} & ({
+  subtypes: string[]
+  originalTypes: string[]
+} | {
+  subtypes?: never
+  originalTypes?: never
+})
 
 export type SearchPageResponse = {
   records: RecordValue[]

--- a/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
@@ -637,9 +637,9 @@ describe('soap_client', () => {
         (_type: string, count: number) => count > 1,
         defaultSoapTimeOut
       )
-      await expect(client.getAllRecords(['subsidiary'])).resolves.toMatchObject({
+      await expect(client.getAllRecords(['subsidiary', 'assemblyItem', 'descriptionItem'])).resolves.toMatchObject({
         records: [],
-        largeTypesError: ['subsidiary'],
+        largeTypesError: ['subsidiary', 'assemblyItem', 'descriptionItem'],
       })
     })
 


### PR DESCRIPTION
when `item` types reach the limit of max allowed instances, we should return the correct types names for the exclusion.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix NS item types limiter exclusion

---
_User Notifications_: 
None