### PR TITLE
SALTO-5206 - Salesforce: Warn when inaccessible fields are dropped from deploy

### DIFF
--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -24,9 +24,9 @@ import {
   SaltoElementError,
   SaltoError,
   SeverityLevel,
-  isInstanceElement, isInstanceChange, toChange, isElement, getAllChangeData,
+  isInstanceElement, isInstanceChange, toChange, isElement, getAllChangeData, ElemID, isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
-import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify, getValuesChanges } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from '@salto-io/jsforce-types'
 import { EOL } from 'os'
 import {
@@ -304,39 +304,59 @@ const removeFieldsWithNoPermission = async (
     if (isHiddenField(fieldDef) || SYSTEM_FIELDS.includes(fieldName)) {
       return false
     }
-    if (fieldValue === undefined
-      || !fieldDef.annotations[permissionAnnotation]) {
-      log.debug(
-        'Would have removed field %s because %s=%s. Field def: %o',
-        fieldDef.elemID.getFullName(),
-        permissionAnnotation,
-        fieldDef.annotations[permissionAnnotation],
-        _.omit(fieldDef, 'parent'),
-      )
-      return true
+    return (fieldValue === undefined
+      || !type.fields[fieldName].annotations[permissionAnnotation])
+  }
+  const createRemovedFieldWarning = (
+    type: ObjectType,
+    instanceId: ElemID,
+    fieldValue: Value,
+    fieldName: string
+  ): SaltoElementError => {
+    log.info('Removing field %s from %s: %s=%s, value=%s',
+      fieldName,
+      instanceId.getFullName(),
+      permissionAnnotation,
+      type.fields[fieldName]?.annotations[permissionAnnotation],
+      fieldValue)
+    return {
+      message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,
+      severity: 'Warning',
+      elemID: instanceId,
     }
-    return false
   }
   let namesOfFieldsThatChanged = Object.keys(getChangeData(instanceChange).value)
   if (isModificationChange(instanceChange)) {
     const [instanceBefore, instanceAfter] = getAllChangeData(instanceChange)
-    namesOfFieldsThatChanged = namesOfFieldsThatChanged
-      .filter(fieldName => instanceBefore.value[fieldName] !== instanceAfter.value[fieldName])
+    const detailedChanges = getValuesChanges({
+      id: instanceBefore.elemID,
+      before: instanceBefore.value,
+      after: instanceAfter.value,
+      beforeId: instanceBefore.elemID,
+      afterId: instanceAfter.elemID,
+    })
+    namesOfFieldsThatChanged = detailedChanges
+      .filter(detailedChange => isAdditionOrModificationChange(detailedChange))
+      .map(detailedChange => detailedChange.id.name)
   }
   const instanceAfter = getChangeData(instanceChange)
   const instanceType = instanceAfter.getTypeSync()
   const fieldsToRemove = namesOfFieldsThatChanged
     .filter(fieldName => shouldRemoveField(instanceType, fieldName, instanceAfter.value[fieldName]))
 
-  if (fieldsToRemove.length > 0) {
-    log.debug(
-      'Would have removed fields %s from %s change of %s',
-      fieldsToRemove.join(', '),
-      instanceChange.action,
-      instanceAfter.elemID.getFullName()
-    )
-  }
-  return []
+  const warnings = fieldsToRemove
+    .map(fieldName => createRemovedFieldWarning(
+      instanceType,
+      instanceAfter.elemID,
+      instanceAfter.value[fieldName],
+      fieldName
+    ))
+
+  instanceAfter.value = _.omit(
+    instanceAfter.value,
+    fieldsToRemove,
+  )
+  return warnings
 }
 
 const insertInstances: CrudFn = async (

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -568,6 +568,21 @@ describe('Custom Object Instances CRUD', () => {
 
             // newInstanceWithNonCreatableFieldChangeData has its own test case
           })
+
+          it('Should not insert non-creatable fields', () => {
+            expect(result.errors).toEqual([
+              expect.objectContaining({
+                elemID: newInstanceWithNonCreatableField.elemID,
+                message: expect.stringContaining('Creatable'),
+                severity: 'Warning',
+              }),
+            ])
+            const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
+              .map(getChangeData)
+              .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
+
+            expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
+          })
         })
         describe('When called with only new instances', () => {
           beforeEach(async () => {
@@ -632,6 +647,20 @@ describe('Custom Object Instances CRUD', () => {
               // Should add result Id
               expect(anotherNewInstanceChangeData.value.Id).toBeDefined()
               expect(anotherNewInstanceChangeData.value.Id).toEqual('newId1')
+            })
+            it('Should not insert non-creatable fields', () => {
+              expect(result.errors).toEqual([
+                expect.objectContaining({
+                  elemID: newInstanceWithNonCreatableField.elemID,
+                  message: expect.stringContaining('Creatable'),
+                  severity: 'Warning',
+                }),
+              ])
+              const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
+                .map(getChangeData)
+                .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
+
+              expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
             })
           })
           describe('when group has circular dependencies', () => {
@@ -957,7 +986,13 @@ describe('Custom Object Instances CRUD', () => {
         })
 
         it('should return one error and 3 fitting applied changes', async () => {
-          expect(result.errors).toBeEmpty()
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: instanceWithNonUpdateableFieldAfter.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
+            }),
+          ])
           expect(result.appliedChanges).toHaveLength(3)
           expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
           const changeData = getChangeData(result.appliedChanges[0])
@@ -970,6 +1005,7 @@ describe('Custom Object Instances CRUD', () => {
           const thirdChangeData = getChangeData(result.appliedChanges[2])
           expect(thirdChangeData).toBeDefined()
           expect(isInstanceElement(thirdChangeData)).toBeTruthy()
+          expect((thirdChangeData as InstanceElement).value).not.toHaveProperty('NotUpdateable')
         })
       })
 
@@ -1000,6 +1036,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 
@@ -1048,6 +1089,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 


### PR DESCRIPTION
Take 2 of https://github.com/salto-io/salto/pull/5239.

If the user doesn't have access to a field (i.e. it's not creatable for add or updateable for modify), remove it from the instance during deploy.
Only apply the logic for fields whose values changed, and that are neither hidden nor system fields.

---
Note that this logic is not identical to the code that removes fields in `toRecord`, because it is more selective in the fields it removes.

---
_Release Notes_: 
Salesforce: When deploying data instances with fields that are not creatable (for addition) or updateable (for modification) by the fetching user, the fields will now be deleted from the workspace and a warning will be issued.

---
_User Notifications_: 
N/A
