### PR TITLE
SALTO-5206 - Salesforce: Log when inaccessible fields are dropped from deploy

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -18,7 +18,7 @@ import {
   Value, ObjectType, ElemID, InstanceElement, Element, isObjectType, ChangeGroup, getChangeData, DeployResult,
   ProgressReporter,
 } from '@salto-io/adapter-api'
-import { filter, findElement } from '@salto-io/adapter-utils'
+import { filter, findElement, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { MetadataInfo } from '@salto-io/jsforce'
 import { SalesforceRecord } from '../src/client/types'
@@ -191,7 +191,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
   if (verify && result.errors.length > 0) {
     if (result.errors.length === 1) throw result.errors[0]
-    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors}`)
+    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)
   }
   if (verify && result.appliedChanges.length === 0) {
     throw new Error(`Failed adding element ${element.elemID.getFullName()}: no applied changes`)

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -189,8 +189,9 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
     changes: [{ action: 'add', data: { after: element } }],
   }
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
-  if (verify && result.errors.length > 0) {
-    if (result.errors.length === 1) throw result.errors[0]
+  const errors = result.errors.filter(error => error.severity !== 'Warning')
+  if (verify && errors.length > 0) {
+    if (errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)
   }
   if (verify && result.appliedChanges.length === 0) {

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -189,7 +189,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
     changes: [{ action: 'add', data: { after: element } }],
   }
   const result = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
-  const errors = result.errors.filter(error => error.severity !== 'Warning')
+  const errors = result.errors.filter(error => error.severity === 'Error')
   if (verify && errors.length > 0) {
     if (errors.length === 1) throw result.errors[0]
     throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -117,8 +117,9 @@ import {
   CUSTOM_OBJECT,
   FLOW_DEFINITION_METADATA_TYPE,
   FLOW_METADATA_TYPE,
-  OWNER_ID,
   PROFILE_METADATA_TYPE,
+  SYSTEM_FIELDS,
+  UNSUPPORTED_SYSTEM_FIELDS,
 } from './constants'
 import { buildMetadataQuery, buildMetadataQueryForFetchWithChangesDetection } from './fetch_profile/metadata_query'
 
@@ -297,30 +298,6 @@ const METADATA_TO_RETRIEVE = [
   'Workflow',
 ]
 
-// See: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_custom_object__c.htm
-export const SYSTEM_FIELDS = [
-  'ConnectionReceivedId',
-  'ConnectionSentId',
-  'CreatedById',
-  'CreatedDate',
-  'Id',
-  'IsDeleted',
-  'LastActivityDate',
-  'LastModifiedDate',
-  'LastModifiedById',
-  'LastReferencedDate',
-  'LastViewedDate',
-  'Name',
-  'RecordTypeId',
-  'SystemModstamp',
-  OWNER_ID,
-  'SetupOwnerId',
-]
-
-export const UNSUPPORTED_SYSTEM_FIELDS = [
-  'LastReferencedDate',
-  'LastViewedDate',
-]
 
 const getMetadataTypesFromElementsSource = async (
   elementsSource: ReadOnlyElementsSource

--- a/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/custom_field_type.ts
@@ -18,9 +18,8 @@ import {
   ChangeValidator, Change, isAdditionChange, isFieldChange,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES } from '../constants'
+import { CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES, SYSTEM_FIELDS } from '../constants'
 import { isFieldOfCustomObject, fieldTypeName } from '../transformers/transformer'
-import { SYSTEM_FIELDS } from '../adapter'
 
 const { awu } = collections.asynciterable
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -529,6 +529,32 @@ export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
 
 export const UNLIMITED_INSTANCES_VALUE = -1
 
+
+// See: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_custom_object__c.htm
+export const SYSTEM_FIELDS = [
+  'ConnectionReceivedId',
+  'ConnectionSentId',
+  'CreatedById',
+  'CreatedDate',
+  'Id',
+  'IsDeleted',
+  'LastActivityDate',
+  'LastModifiedDate',
+  'LastModifiedById',
+  'LastReferencedDate',
+  'LastViewedDate',
+  'Name',
+  'RecordTypeId',
+  'SystemModstamp',
+  OWNER_ID,
+  'SetupOwnerId',
+]
+
+export const UNSUPPORTED_SYSTEM_FIELDS = [
+  'LastReferencedDate',
+  'LastViewedDate',
+]
+
 // Errors
 export const SOCKET_TIMEOUT = 'ESOCKETTIMEDOUT'
 export const INVALID_GRANT = 'invalid_grant'

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -294,11 +294,22 @@ const removeFieldsWithNoPermission = async (
   instance: InstanceElement,
   permissionAnnotation: string
 ): Promise<SaltoElementError[]> => {
-  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => (
-    fieldName !== CUSTOM_OBJECT_ID_FIELD
+  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => {
+    const shouldRemove = fieldName !== CUSTOM_OBJECT_ID_FIELD
     && (fieldValue === undefined
       || !type.fields[fieldName]?.annotations[permissionAnnotation])
-  )
+
+    if (shouldRemove) {
+      log.debug('Removing field %s from %s: %s=%s, value=%s',
+        fieldName,
+        instance.elemID.getFullName(),
+        permissionAnnotation,
+        type.fields[fieldName]?.annotations[permissionAnnotation],
+        fieldValue)
+    }
+
+    return shouldRemove
+  }
   const createRemovedFieldWarning = (fieldName: string): SaltoElementError => (
     {
       message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -294,35 +294,30 @@ const removeFieldsWithNoPermission = async (
   instance: InstanceElement,
   permissionAnnotation: string
 ): Promise<SaltoElementError[]> => {
-  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => {
-    const shouldRemove = fieldName !== CUSTOM_OBJECT_ID_FIELD
+  const shouldRemoveField = (type: ObjectType, fieldName: string, fieldValue: Value): boolean => (
+    fieldName !== CUSTOM_OBJECT_ID_FIELD
     && (fieldValue === undefined
       || !type.fields[fieldName]?.annotations[permissionAnnotation])
-
-    if (shouldRemove) {
-      log.debug('Removing field %s from %s: %s=%s, value=%s',
-        fieldName,
-        instance.elemID.getFullName(),
-        permissionAnnotation,
-        type.fields[fieldName]?.annotations[permissionAnnotation],
-        fieldValue)
-    }
-
-    return shouldRemove
-  }
-  const createRemovedFieldWarning = (fieldName: string): SaltoElementError => (
-    {
+  )
+  const createRemovedFieldWarning = (type: ObjectType, fieldValue: Value, fieldName: string): SaltoElementError => {
+    log.info('Removing field %s from %s: %s=%s, value=%s',
+      fieldName,
+      instance.elemID.getFullName(),
+      permissionAnnotation,
+      type.fields[fieldName]?.annotations[permissionAnnotation],
+      fieldValue)
+    return {
       message: `The field ${fieldName} will not be deployed because it lacks the '${permissionAnnotation}' permission`,
       severity: 'Warning',
       elemID: instance.elemID,
     }
-  )
+  }
   const instanceType = await instance.getType()
   const fieldsToRemove = Object.entries(instance.value)
     .filter(([fieldName, fieldValue]) => shouldRemoveField(instanceType, fieldName, fieldValue))
     .map(([fieldName]) => fieldName)
   const warnings = fieldsToRemove
-    .map(fieldName => createRemovedFieldWarning(fieldName))
+    .map(fieldName => createRemovedFieldWarning(instanceType, instance.value[fieldName], fieldName))
 
   instance.value = _.omit(
     instance.value,

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -21,11 +21,11 @@ import { collections, promises } from '@salto-io/lowerdash'
 import { filter } from '@salto-io/adapter-utils'
 import { ObjectType, StaticFile, isObjectType, ReadOnlyElementsSource, ElemID, Element, FetchResult, LoadElementsFromFolderArgs } from '@salto-io/adapter-api'
 import { readTextFile, readFile } from '@salto-io/file'
-import { SYSTEM_FIELDS, allFilters, UNSUPPORTED_SYSTEM_FIELDS } from '../adapter'
+import { allFilters } from '../adapter'
 import { xmlToValues, isComplexType, complexTypesMap, PACKAGE } from '../transformers/xml_transformer'
 import { METADATA_TYPES_TO_RENAME, createInstanceElement, createMetadataObjectType, MetadataValues } from '../transformers/transformer'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
-import { CUSTOM_OBJECT, METADATA_CONTENT_FIELD, SALESFORCE, RECORDS_PATH } from '../constants'
+import { CUSTOM_OBJECT, METADATA_CONTENT_FIELD, SALESFORCE, RECORDS_PATH, SYSTEM_FIELDS, UNSUPPORTED_SYSTEM_FIELDS } from '../constants'
 import { sfdxFilters } from './filters'
 
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -568,21 +568,6 @@ describe('Custom Object Instances CRUD', () => {
 
             // newInstanceWithNonCreatableFieldChangeData has its own test case
           })
-
-          it('Should not insert non-creatable fields', () => {
-            expect(result.errors).toEqual([
-              expect.objectContaining({
-                elemID: newInstanceWithNonCreatableField.elemID,
-                message: expect.stringContaining('Creatable'),
-                severity: 'Warning',
-              }),
-            ])
-            const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
-              .map(getChangeData)
-              .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
-
-            expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
-          })
         })
         describe('When called with only new instances', () => {
           beforeEach(async () => {
@@ -647,20 +632,6 @@ describe('Custom Object Instances CRUD', () => {
               // Should add result Id
               expect(anotherNewInstanceChangeData.value.Id).toBeDefined()
               expect(anotherNewInstanceChangeData.value.Id).toEqual('newId1')
-            })
-            it('Should not insert non-creatable fields', () => {
-              expect(result.errors).toEqual([
-                expect.objectContaining({
-                  elemID: newInstanceWithNonCreatableField.elemID,
-                  message: expect.stringContaining('Creatable'),
-                  severity: 'Warning',
-                }),
-              ])
-              const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
-                .map(getChangeData)
-                .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
-
-              expect(newInstanceWithNonCreatableFieldChangeData.value).not.toHaveProperty('NotCreatable')
             })
           })
           describe('when group has circular dependencies', () => {
@@ -986,13 +957,7 @@ describe('Custom Object Instances CRUD', () => {
         })
 
         it('should return one error and 3 fitting applied changes', async () => {
-          expect(result.errors).toEqual([
-            expect.objectContaining({
-              elemID: instanceWithNonUpdateableFieldAfter.elemID,
-              message: expect.stringContaining('updateable'),
-              severity: 'Warning',
-            }),
-          ])
+          expect(result.errors).toBeEmpty()
           expect(result.appliedChanges).toHaveLength(3)
           expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
           const changeData = getChangeData(result.appliedChanges[0])
@@ -1005,7 +970,6 @@ describe('Custom Object Instances CRUD', () => {
           const thirdChangeData = getChangeData(result.appliedChanges[2])
           expect(thirdChangeData).toBeDefined()
           expect(isInstanceElement(thirdChangeData)).toBeTruthy()
-          expect((thirdChangeData as InstanceElement).value).not.toHaveProperty('NotUpdateable')
         })
       })
 
@@ -1036,11 +1000,6 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
-            }),
-            expect.objectContaining({
-              elemID: existingInstanceWithNonUpdateableField.elemID,
-              message: expect.stringContaining('updateable'),
-              severity: 'Warning',
             }),
           ])
 
@@ -1089,11 +1048,6 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
-            }),
-            expect.objectContaining({
-              elemID: existingInstanceWithNonUpdateableField.elemID,
-              message: expect.stringContaining('updateable'),
-              severity: 'Warning',
             }),
           ])
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -537,7 +537,6 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('Should have result with 2 applied changes, add 3 instances with new Id', async () => {
-            expect(result.errors).toHaveLength(0)
             expect(result.appliedChanges).toHaveLength(3)
 
             // existingInstance appliedChange
@@ -570,6 +569,13 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('Should not insert non-creatable fields', () => {
+            expect(result.errors).toEqual([
+              expect.objectContaining({
+                elemID: newInstanceWithNonCreatableField.elemID,
+                message: expect.stringContaining('Creatable'),
+                severity: 'Warning',
+              }),
+            ])
             const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
               .map(getChangeData)
               .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
@@ -614,7 +620,6 @@ describe('Custom Object Instances CRUD', () => {
             })
 
             it('Should have result with 3 applied changes, add 3 instances with insert Id', async () => {
-              expect(result.errors).toHaveLength(0)
               expect(result.appliedChanges).toHaveLength(3)
               // newInstance appliedChange
               const newInstanceChangeData = result.appliedChanges
@@ -643,6 +648,13 @@ describe('Custom Object Instances CRUD', () => {
               expect(anotherNewInstanceChangeData.value.Id).toEqual('newId1')
             })
             it('Should not insert non-creatable fields', () => {
+              expect(result.errors).toEqual([
+                expect.objectContaining({
+                  elemID: newInstanceWithNonCreatableField.elemID,
+                  message: expect.stringContaining('Creatable'),
+                  severity: 'Warning',
+                }),
+              ])
               const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
                 .map(getChangeData)
                 .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
@@ -970,8 +982,14 @@ describe('Custom Object Instances CRUD', () => {
           result = await adapter.deploy({ changeGroup: modifyDeployGroup, progressReporter: nullProgressReporter })
         })
 
-        it('should return no errors and 3 fitting applied changes', async () => {
-          expect(result.errors).toHaveLength(0)
+        it('should return one error and 3 fitting applied changes', async () => {
+          expect(result.errors).toEqual([
+            expect.objectContaining({
+              elemID: instanceWithNonUpdateableFieldToModify.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
+            }),
+          ])
           expect(result.appliedChanges).toHaveLength(3)
           expect(isModificationChange(result.appliedChanges[0])).toBeTruthy()
           const changeData = getChangeData(result.appliedChanges[0])
@@ -1015,6 +1033,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 
@@ -1063,6 +1086,11 @@ describe('Custom Object Instances CRUD', () => {
               elemID: existingInstanceWithNonUpdateableField.elemID,
               message: expect.stringContaining(errorMsgs[1]),
               severity: 'Error',
+            }),
+            expect.objectContaining({
+              elemID: existingInstanceWithNonUpdateableField.elemID,
+              message: expect.stringContaining('updateable'),
+              severity: 'Warning',
             }),
           ])
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -42,6 +42,7 @@ describe('Custom Object Instances CRUD', () => {
   const mockElemID = new ElemID(constants.SALESFORCE, 'Test')
   const instanceName = 'Instance'
   const anotherInstanceName = 'AnotherInstance'
+  const nameOfInstanceWithNonUpdateableField = 'NotUpdatable'
 
   const customObject = new ObjectType({
     elemID: mockElemID,
@@ -97,7 +98,7 @@ describe('Custom Object Instances CRUD', () => {
           [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
           [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
           [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-          [constants.API_NAME]: 'NotCreatable',
+          [constants.API_NAME]: 'NotUpdateable',
         },
       },
       AnotherField: {
@@ -196,11 +197,11 @@ describe('Custom Object Instances CRUD', () => {
     NumField: null,
   }
   const existingInstanceWithNonUpdateableField = new InstanceElement(
-    anotherInstanceName,
+    nameOfInstanceWithNonUpdateableField,
     customObject,
     {
       SaltoName: 'existingInstanceWithNonUpdateableField',
-      NotUpdatable: 'DontSendMeOnUpdate',
+      NotUpdateable: 'DontSendMeOnUpdate',
     }
   )
   const newInstanceWithRefName = 'newInstanceWithRef'
@@ -967,14 +968,16 @@ describe('Custom Object Instances CRUD', () => {
       instanceToModify.value.Id = 'modifyId'
       const anotherInstanceToModify = anotherExistingInstance.clone()
       anotherInstanceToModify.value.Id = 'anotherModifyId'
-      const instanceWithNonUpdateableFieldToModify = existingInstanceWithNonUpdateableField.clone()
-      instanceWithNonUpdateableFieldToModify.value.Id = 'yetAnotherModifyId'
+      const instanceWithNonUpdateableFieldBefore = existingInstanceWithNonUpdateableField.clone()
+      instanceWithNonUpdateableFieldBefore.value.Id = 'yetAnotherModifyId'
+      const instanceWithNonUpdateableFieldAfter = instanceWithNonUpdateableFieldBefore.clone()
+      instanceWithNonUpdateableFieldAfter.value.NotUpdateable = 'PleaseDontUpdate'
       const modifyDeployGroup = {
         groupID: 'modify__Test__c',
         changes: [
           { action: 'modify', data: { before: instanceToModify, after: instanceToModify } },
           { action: 'modify', data: { before: anotherInstanceToModify, after: anotherInstanceToModify } },
-          { action: 'modify', data: { before: instanceWithNonUpdateableFieldToModify, after: instanceWithNonUpdateableFieldToModify } },
+          { action: 'modify', data: { before: instanceWithNonUpdateableFieldBefore, after: instanceWithNonUpdateableFieldAfter } },
         ],
       } as ChangeGroup
       describe('when loadBulk succeeds for all', () => {
@@ -985,7 +988,7 @@ describe('Custom Object Instances CRUD', () => {
         it('should return one error and 3 fitting applied changes', async () => {
           expect(result.errors).toEqual([
             expect.objectContaining({
-              elemID: instanceWithNonUpdateableFieldToModify.elemID,
+              elemID: instanceWithNonUpdateableFieldAfter.elemID,
               message: expect.stringContaining('updateable'),
               severity: 'Warning',
             }),

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -288,6 +288,8 @@ describe('Custom Object Instances CRUD', () => {
           refType: idType,
           label: 'id',
           annotations: {
+            [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: false,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
             [CORE_ANNOTATIONS.REQUIRED]: false,
             [constants.LABEL]: 'Record ID',
@@ -302,6 +304,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'Name',
             [constants.API_NAME]: 'Name',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
         },
@@ -313,6 +316,7 @@ describe('Custom Object Instances CRUD', () => {
             [constants.LABEL]: 'TestField',
             [constants.API_NAME]: 'Type.TestField__c',
             [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+            [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
             [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
           },
           annotationRefsOrTypes: {

--- a/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances_deploy.test.ts
@@ -198,7 +198,7 @@ describe('Custom Object Deploy', () => {
       expect(clientBulkOpSpy).toHaveBeenCalledTimes(3)
     })
 
-    it('should retry1 on recoverable error(s), failed because of max-retries', async () => {
+    it('should retry on recoverable error(s), failed because of max-retries', async () => {
       clientBulkOpSpy.mockImplementation(
         async (_1: string,
           _2: BulkLoadOperation,

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -31,10 +31,9 @@ import {
 import { buildElementsSourceFromElements, findElements as findElementsByID } from '@salto-io/adapter-utils'
 import JSZip from 'jszip'
 import * as constants from '../src/constants'
-import { FIELD_ANNOTATIONS } from '../src/constants'
+import { FIELD_ANNOTATIONS, SYSTEM_FIELDS } from '../src/constants'
 import { annotationsFileName, customFieldsFileName, standardFieldsFileName } from '../src/filters/custom_type_split'
 import { FilterContext } from '../src/filter'
-import { SYSTEM_FIELDS } from '../src/adapter'
 import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
 
 export const findElements = (


### PR DESCRIPTION
This is a de-fanged version of https://github.com/salto-io/salto/pull/5317 where we only log the fields we would have removed.

---

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A