### PR TITLE
SALTO-5287: Netsuite too many instances type exclusion description is not containing the type name

### DIFF
--- a/packages/netsuite-adapter/src/config/suggestions.ts
+++ b/packages/netsuite-adapter/src/config/suggestions.ts
@@ -193,7 +193,7 @@ const updateConfigFromLargeTypes = (
       ...config.fetch,
       exclude: combineQueryParams(config.fetch.exclude, typesExcludeQuery),
     }
-    return excludedTypes
+    return excludedTypes.concat(failedCustomRecords)
   }
   return []
 }

--- a/packages/netsuite-adapter/src/config/suggestions.ts
+++ b/packages/netsuite-adapter/src/config/suggestions.ts
@@ -25,10 +25,10 @@ import { emptyQueryParams, fullFetchConfig } from './config_creator'
 export const STOP_MANAGING_ITEMS_MSG = 'Salto failed to fetch some items from NetSuite.'
   + ' Failed items must be excluded from the fetch.'
 
-export const LARGE_FOLDERS_EXCLUDED_MESSAGE = 'Some File Cabinet folders exceed File Cabinet\'s size limitation.'
+export const toLargeFoldersExcludedMessage = (updatedLargeFolders: NetsuiteFilePathsQueryParams): string => `The following File Cabinet folders exceed File Cabinet's size limitation: ${updatedLargeFolders.join(', ')}.`
  + ' To include them, increase the File Cabinet\'s size limitation and remove their exclusion rules from the configuration file.'
 
-export const LARGE_TYPES_EXCLUDED_MESSAGE = 'Some types were excluded from the fetch as the elements of that type were too numerous.'
+export const toLargeTypesExcludedMessage = (updatedLargeTypes: string[]): string => `The following types were excluded from the fetch as the elements of that type were too numerous: ${updatedLargeTypes.join(', ')}.`
  + ' To include them, increase the types elements\' size limitations and remove their exclusion rules.'
 
 const createFolderExclude = (folderPaths: NetsuiteFilePathsQueryParams): string[] =>
@@ -162,22 +162,25 @@ const updateConfigFromFailedFetch = (config: NetsuiteConfig, failures: FetchByQu
   return true
 }
 
-const updateConfigFromLargeFolders = (config: NetsuiteConfig, { largeFolderError }: FailedFiles): boolean => {
+const updateConfigFromLargeFolders = (
+  config: NetsuiteConfig,
+  { largeFolderError }: FailedFiles,
+): NetsuiteFilePathsQueryParams => {
   if (largeFolderError && !_.isEmpty(largeFolderError)) {
     const largeFoldersToExclude = convertToQueryParams({ filePaths: createFolderExclude(largeFolderError) })
     config.fetch = {
       ...config.fetch,
       exclude: combineQueryParams(config.fetch.exclude, largeFoldersToExclude),
     }
-    return true
+    return largeFolderError
   }
-  return false
+  return []
 }
 
 const updateConfigFromLargeTypes = (
   config: NetsuiteConfig,
   { failedTypes, failedCustomRecords }: FetchByQueryFailures
-): boolean => {
+): string[] => {
   const { excludedTypes } = failedTypes
   if (!_.isEmpty(excludedTypes) || !_.isEmpty(failedCustomRecords)) {
     const customRecords = failedCustomRecords.map(type => ({ name: type }))
@@ -190,9 +193,9 @@ const updateConfigFromLargeTypes = (
       ...config.fetch,
       exclude: combineQueryParams(config.fetch.exclude, typesExcludeQuery),
     }
-    return true
+    return excludedTypes
   }
-  return false
+  return []
 }
 
 const toConfigInstance = (config: NetsuiteConfig): InstanceElement =>
@@ -229,18 +232,18 @@ export const getConfigFromConfigChanges = (
 ): { config: InstanceElement[]; message: string } | undefined => {
   const config = _.cloneDeep(currentConfig)
   const didUpdateFromFailures = updateConfigFromFailedFetch(config, failures)
-  const didUpdateLargeFolders = updateConfigFromLargeFolders(config, failures.failedFilePaths)
-  const didUpdateLargeTypes = updateConfigFromLargeTypes(config, failures)
+  const updatedLargeFolders = updateConfigFromLargeFolders(config, failures.failedFilePaths)
+  const updatedLargeTypes = updateConfigFromLargeTypes(config, failures)
 
   const messages = [
     didUpdateFromFailures
       ? STOP_MANAGING_ITEMS_MSG
       : undefined,
-    didUpdateLargeFolders
-      ? LARGE_FOLDERS_EXCLUDED_MESSAGE
+    updatedLargeFolders.length > 0
+      ? toLargeFoldersExcludedMessage(updatedLargeFolders)
       : undefined,
-    didUpdateLargeTypes
-      ? LARGE_TYPES_EXCLUDED_MESSAGE
+    updatedLargeTypes.length > 0
+      ? toLargeTypesExcludedMessage(updatedLargeTypes)
       : undefined,
   ].filter(values.isDefined)
 

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { InstanceElement, ElemID } from '@salto-io/adapter-api'
 import { formatConfigSuggestionsReasons } from '@salto-io/adapter-utils'
 import { fullFetchConfig, fullQueryParams } from '../../src/config/config_creator'
-import { LARGE_FOLDERS_EXCLUDED_MESSAGE, LARGE_TYPES_EXCLUDED_MESSAGE, STOP_MANAGING_ITEMS_MSG, getConfigFromConfigChanges } from '../../src/config/suggestions'
+import { toLargeFoldersExcludedMessage, toLargeTypesExcludedMessage, STOP_MANAGING_ITEMS_MSG, getConfigFromConfigChanges } from '../../src/config/suggestions'
 import { NetsuiteQueryParameters, fetchDefault, configType } from '../../src/config/types'
 
 describe('netsuite config suggestions', () => {
@@ -162,7 +162,7 @@ describe('netsuite config suggestions', () => {
       ))).toBe(true)
 
     expect(configChange?.message).toBe(formatConfigSuggestionsReasons([
-      STOP_MANAGING_ITEMS_MSG, LARGE_FOLDERS_EXCLUDED_MESSAGE, LARGE_TYPES_EXCLUDED_MESSAGE,
+      STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath]), toLargeTypesExcludedMessage(['excludedTypeTest']),
     ]))
   })
 
@@ -190,7 +190,8 @@ describe('netsuite config suggestions', () => {
       config,
     )
 
-    expect(configChange?.message)
-      .toBe(formatConfigSuggestionsReasons([STOP_MANAGING_ITEMS_MSG, LARGE_FOLDERS_EXCLUDED_MESSAGE]))
+    expect(configChange?.message).toBe(
+      formatConfigSuggestionsReasons([STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath])])
+    )
   })
 })

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -162,7 +162,7 @@ describe('netsuite config suggestions', () => {
       ))).toBe(true)
 
     expect(configChange?.message).toBe(formatConfigSuggestionsReasons([
-      STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath]), toLargeTypesExcludedMessage(['excludedTypeTest']),
+      STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath]), toLargeTypesExcludedMessage(['excludedTypeTest', 'excludedCustomRecord']),
     ]))
   })
 


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
SALTO-5287: Netsuite too many instances type exclusion description is not containing the type name

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
