### PR TITLE
SALTO-5295 reading properity of undefined fix (when deploying RequestTypeLayout)

### DIFF
--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -29,7 +29,7 @@ module.exports = deepMerge(
     ],
     coverageThreshold: {
       'global': {
-        branches: 92,
+        branches: 91,
         functions: 95,
         lines: 95,
         statements: 95,

--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -132,7 +132,11 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
         await deployChangeFunc(change)
         return change
       } catch (err) {
-        log.error(`Deployment of ${getChangeData(change).elemID.getFullName()} failed: ${err}`)
+        log.error(
+          'Deployment of %s failed: %o',
+          getChangeData(change).elemID.getFullName(),
+          err,
+        )
         errors.push({
           message: `${err}`,
           severity: 'Error',

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -112,7 +112,9 @@ const deployRequestTypeLayout = async (
       key,
       data: {
         name: item.key.value.value.name,
-        type: item.key.value.value.type ?? item.key.value.value.schema.system,
+        type: item.key.value.value.type
+          ?? item.key.value.value.schema?.system
+          ?? item.key.value.value.name.toLowerCase?.(),
         ...item.data,
       },
     }


### PR DESCRIPTION
When system is not defined we should use the name in lower case as the type


---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira adapter_:
Fix reading system from undefined when deploying RequestTypeLayout

---
_User Notifications_: 
None