### PR TITLE
SALTO-2392 fetch internal ids from SuiteQL tables

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -16,7 +16,7 @@
 import {
   FetchResult, AdapterOperations, DeployOptions, ElemIdGetter, ReadOnlyElementsSource, ProgressReporter,
   FetchOptions, DeployModifiers, getChangeData, isObjectType, isInstanceElement, ElemID, isSaltoElementError,
-  setPartialFetchData, InstanceElement, ObjectType, TypeElement,
+  setPartialFetchData, InstanceElement, ObjectType, TypeElement, ChangeDataType,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
@@ -80,6 +80,7 @@ import { cloneChange } from './change_validators/utils'
 import { getChangeGroupIdsFunc } from './group_changes'
 import { getCustomRecords } from './custom_records/custom_records'
 import { getDataElements } from './data_elements/data_elements'
+import { getSuiteQLTableElements } from './data_elements/suiteql_table_elements'
 import { getStandardTypesNames } from './autogen/types'
 import { getConfigTypes, toConfigElements } from './suiteapp_config_elements'
 import { ImportFileCabinetResult } from './client/types'
@@ -373,9 +374,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
         failures,
       },
       { elements: dataElements, requestedTypes: requestedDataTypes, largeTypesError: dataTypeError },
+      suiteQLTableElements,
     ] = await Promise.all([
       getStandardAndCustomElements(),
       getDataElements(this.client, fetchQuery, this.getElemIdFunc),
+      this.userConfig.fetch.addSuiteQLTables
+        ? getSuiteQLTableElements(this.client, this.elementsSource, isPartial) : [],
     ])
 
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
@@ -402,15 +406,15 @@ export default class NetsuiteAdapter implements AdapterOperations {
       ? await getOrCreateServerTimeElements(serverTime, this.elementsSource, isPartial)
       : []
 
-    const elements = [
-      ...standardInstances,
-      ...standardTypes,
-      ...customRecordTypes,
-      ...customRecords,
-      ...dataElements,
-      ...suiteAppConfigElements,
-      ...serverTimeElements,
-    ]
+    const elements = ([] as ChangeDataType[])
+      .concat(standardInstances)
+      .concat(standardTypes)
+      .concat(customRecordTypes)
+      .concat(customRecords)
+      .concat(dataElements)
+      .concat(suiteQLTableElements)
+      .concat(suiteAppConfigElements)
+      .concat(serverTimeElements)
 
     await this.createFiltersRunner({
       operation: 'fetch',

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -378,7 +378,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     ] = await Promise.all([
       getStandardAndCustomElements(),
       getDataElements(this.client, fetchQuery, this.getElemIdFunc),
-      this.userConfig.fetch.addSuiteQLTables
+      this.userConfig.fetch.resolveAccountSpecificValues
         ? getSuiteQLTableElements(this.client, this.elementsSource, isPartial) : [],
     ])
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -31,7 +31,7 @@ import { CustomRecordResponse, DeployListResults, GetAllResponse, GetResult, Get
 import { DEPLOY_LIST_SCHEMA, GET_ALL_RESPONSE_SCHEMA, GET_RESULTS_SCHEMA, GET_SELECT_VALUE_SCHEMA, SEARCH_RESPONSE_SCHEMA } from './schemas'
 import { InvalidSuiteAppCredentialsError } from '../../types'
 import { isCustomRecordType } from '../../../types'
-import { INTERNAL_ID_TO_TYPES, isItemType, ITEM_TYPE_ID, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
+import { isItemType, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
 import { XSI_TYPE } from '../../constants'
 import { InstanceLimiterFunc } from '../../../config/types'
 import { toError } from '../../utils'
@@ -44,7 +44,6 @@ export const { createClientAsync } = elementUtils.soap
 
 const log = logger(module)
 
-export const ITEMS_TYPES = INTERNAL_ID_TO_TYPES[ITEM_TYPE_ID]
 export const WSDL_PATH = `${__dirname}/client/suiteapp_client/soap_client/wsdl/netsuite_1.wsdl`
 const REQUEST_MAX_RETRIES = 5
 const REQUEST_RETRY_DELAY = 5000

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -84,6 +84,7 @@ export type FetchParams = {
   addAlias?: boolean
   addBundles?: boolean
   addImportantValues?: boolean
+  addSuiteQLTables?: boolean
 } & LockedElementsConfig['fetch']
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -96,6 +97,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   addAlias: 'addAlias',
   addBundles: 'addBundles',
   addImportantValues: 'addImportantValues',
+  addSuiteQLTables: 'addSuiteQLTables',
 }
 
 export type AdditionalSdfDeployDependencies = {
@@ -530,6 +532,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     addAlias: { refType: BuiltinTypes.BOOLEAN },
     addBundles: { refType: BuiltinTypes.BOOLEAN },
     addImportantValues: { refType: BuiltinTypes.BOOLEAN },
+    addSuiteQLTables: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -84,7 +84,7 @@ export type FetchParams = {
   addAlias?: boolean
   addBundles?: boolean
   addImportantValues?: boolean
-  addSuiteQLTables?: boolean
+  resolveAccountSpecificValues?: boolean
 } & LockedElementsConfig['fetch']
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -97,7 +97,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   addAlias: 'addAlias',
   addBundles: 'addBundles',
   addImportantValues: 'addImportantValues',
-  addSuiteQLTables: 'addSuiteQLTables',
+  resolveAccountSpecificValues: 'resolveAccountSpecificValues',
 }
 
 export type AdditionalSdfDeployDependencies = {
@@ -532,7 +532,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     addAlias: { refType: BuiltinTypes.BOOLEAN },
     addBundles: { refType: BuiltinTypes.BOOLEAN },
     addImportantValues: { refType: BuiltinTypes.BOOLEAN },
-    addSuiteQLTables: { refType: BuiltinTypes.BOOLEAN },
+    resolveAccountSpecificValues: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -1,0 +1,392 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { logger } from '@salto-io/logging'
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, TopLevelElement, createRefToElmWithValue } from '@salto-io/adapter-api'
+import NetsuiteClient from '../client/client'
+import { NETSUITE } from '../constants'
+import { getLastServerTime } from '../server_time'
+import { toSuiteQLWhereDateString } from '../changes_detector/date_formats'
+import { SuiteQLTableName } from './types'
+
+const log = logger(module)
+
+export const SUITEQL_TABLE = 'suiteql_table'
+export const INTERNAL_IDS_MAP = 'internalIdsMap'
+
+const VERSION_FIELD = 'version'
+const LATEST_VERSION = 1
+
+type QueryParams = {
+  internalIdField: 'id'
+  nameField: string
+  lastModifiedDateField?: 'lastmodifieddate'
+}
+
+export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undefined> = {
+  item: {
+    internalIdField: 'id',
+    nameField: 'itemid',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  transaction: {
+    internalIdField: 'id',
+    nameField: 'trandisplayname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  account: {
+    internalIdField: 'id',
+    nameField: 'accountsearchdisplayname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  customer: {
+    internalIdField: 'id',
+    nameField: 'companyname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  accountingPeriod: {
+    internalIdField: 'id',
+    nameField: 'periodname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  calendarEvent: {
+    internalIdField: 'id',
+    nameField: 'title',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  classification: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  contact: {
+    internalIdField: 'id',
+    nameField: 'entitytitle',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  currency: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  department: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  employee: {
+    internalIdField: 'id',
+    nameField: 'entityid',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  expenseCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  generalToken: {
+    internalIdField: 'id',
+    nameField: 'externalid',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  inventoryNumber: {
+    internalIdField: 'id',
+    nameField: 'inventorynumber',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  job: {
+    internalIdField: 'id',
+    nameField: 'companyname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  location: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  partner: {
+    internalIdField: 'id',
+    nameField: 'companyname',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  paymentCard: {
+    internalIdField: 'id',
+    nameField: 'nameoncard',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  paymentCardToken: {
+    internalIdField: 'id',
+    nameField: 'externalid',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  paymentMethod: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  phoneCall: {
+    internalIdField: 'id',
+    nameField: 'title',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  priceLevel: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  pricingGroup: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  subsidiary: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  task: {
+    internalIdField: 'id',
+    nameField: 'title',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  term: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  timeBill: {
+    internalIdField: 'id',
+    nameField: 'displayfield',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  unitsType: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  usage: {
+    internalIdField: 'id',
+    nameField: 'externalid',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  vendor: {
+    internalIdField: 'id',
+    nameField: 'entitytitle',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+  vendorCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+    lastModifiedDateField: 'lastmodifieddate',
+  },
+
+  // tables with no 'lastmodifieddate' field
+  billingSchedule: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  budgetCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  contactCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  contactRole: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  customerCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  customerMessage: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  jobType: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  nexus: {
+    internalIdField: 'id',
+    nameField: 'description',
+  },
+  otherNameCategory: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  payrollItem: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+
+  // could not find table
+  address: undefined,
+  billingAccount: undefined,
+  bin: undefined,
+  bom: undefined,
+  bomRevision: undefined,
+  campaign: undefined,
+  campaignAudience: undefined,
+  campaignCategory: undefined,
+  campaignChannel: undefined,
+  campaignFamily: undefined,
+  campaignOffer: undefined,
+  campaignResponse: undefined,
+  campaignSearchEngine: undefined,
+  campaignSubscription: undefined,
+  campaignVertical: undefined,
+  charge: undefined,
+  costCategory: undefined,
+  customerStatus: undefined,
+  fairValuePrice: undefined,
+  globalAccountMapping: undefined,
+  hcmJob: undefined,
+  inboundShipment: undefined,
+  inventoryDetail: undefined,
+  issue: undefined,
+  itemAccountMapping: undefined,
+  itemDemandPlan: undefined,
+  itemRevision: undefined,
+  itemSupplyPlan: undefined,
+  manufacturingCostTemplate: undefined,
+  manufacturingOperationTask: undefined,
+  manufacturingRouting: undefined,
+  noteType: undefined,
+  opportunity: undefined,
+  partnerCategory: undefined,
+  projectTask: undefined,
+  promotionCode: undefined,
+  resourceAllocation: undefined,
+  salesRole: undefined,
+  solution: undefined,
+  supportCase: undefined,
+  supportCaseIssue: undefined,
+  supportCaseOrigin: undefined,
+  supportCasePriority: undefined,
+  supportCaseStatus: undefined,
+  supportCaseType: undefined,
+  timeEntry: undefined,
+  timeSheet: undefined,
+  winLossReason: undefined,
+
+  // has table, but no relevant info
+  consolidatedExchangeRate: undefined,
+  note: undefined,
+  salesTaxItem: undefined,
+
+  // referenced by scriptid
+  customList: undefined,
+  customRecordType: undefined,
+  customfield: undefined,
+  script: undefined,
+  role: undefined,
+  workflow: undefined,
+  customrecordtype: undefined,
+}
+
+const getInternalIdsMap = async (
+  client: NetsuiteClient,
+  tableName: string,
+  { internalIdField, nameField, lastModifiedDateField }: QueryParams,
+  lastFetchTime: Date | undefined,
+): Promise<Record<string, { name: string }>> => {
+  const whereLastModified = lastModifiedDateField !== undefined && lastFetchTime !== undefined
+    ? `WHERE ${lastModifiedDateField} >= ${toSuiteQLWhereDateString(lastFetchTime)}` : ''
+  const queryString = `SELECT ${internalIdField}, ${nameField} FROM ${tableName} ${whereLastModified} ORDER BY ${internalIdField} ASC`
+  const results = await client.runSuiteQL(queryString)
+  if (results === undefined) {
+    log.warn('failed to query table %s', tableName)
+    return {}
+  }
+  const validResults = results.flatMap(res => {
+    const internalId = res[internalIdField]
+    const name = res[nameField]
+    if (typeof internalId === 'string' && internalId !== '' && typeof name === 'string' && name !== '') {
+      return { internalId, name }
+    }
+    log.warn('ignoring invalid result from table %s: %o', tableName, res)
+    return []
+  })
+  return Object.fromEntries(
+    validResults.map(({ internalId, name }) => [internalId, { name }])
+  )
+}
+
+const getSuiteQLTableInstance = async (
+  client: NetsuiteClient,
+  suiteQLTableType: ObjectType,
+  tableName: string,
+  queryParams: QueryParams,
+  existingInstance: InstanceElement | undefined,
+  lastFetchTime: Date | undefined,
+  isPartial: boolean,
+): Promise<InstanceElement | undefined> => {
+  if (existingInstance !== undefined) {
+    existingInstance.refType = createRefToElmWithValue(suiteQLTableType)
+  }
+  if (isPartial) {
+    return existingInstance
+  }
+  const instance = existingInstance ?? new InstanceElement(tableName, suiteQLTableType)
+  instance.annotate({ [CORE_ANNOTATIONS.HIDDEN]: true })
+  if (instance.value[INTERNAL_IDS_MAP] === undefined) {
+    instance.value[INTERNAL_IDS_MAP] = {}
+  }
+  Object.assign(
+    instance.value[INTERNAL_IDS_MAP],
+    await getInternalIdsMap(
+      client,
+      tableName,
+      queryParams,
+      instance.value[VERSION_FIELD] === LATEST_VERSION ? lastFetchTime : undefined
+    )
+  )
+  instance.value[VERSION_FIELD] = LATEST_VERSION
+  return instance
+}
+
+export const getSuiteQLTableElements = async (
+  client: NetsuiteClient,
+  elementsSource: ReadOnlyElementsSource,
+  isPartial: boolean
+): Promise<TopLevelElement[]> => {
+  const suiteQLTableType = new ObjectType({
+    elemID: new ElemID(NETSUITE, SUITEQL_TABLE),
+    annotations: { [CORE_ANNOTATIONS.HIDDEN]: true },
+  })
+
+  const lastFetchTime = await getLastServerTime(elementsSource)
+  const instances = await Promise.all(
+    Object.entries(QUERIES_BY_TABLE_NAME).map(async ([tableName, queryParams]) => {
+      if (queryParams === undefined) {
+        return undefined
+      }
+      return getSuiteQLTableInstance(
+        client,
+        suiteQLTableType,
+        tableName,
+        queryParams,
+        await elementsSource.get(suiteQLTableType.elemID.createNestedID('instance', tableName)),
+        lastFetchTime,
+        isPartial
+      )
+    })
+  ).then(res => res.flatMap(instance => instance ?? []))
+
+  return [suiteQLTableType, ...instances]
+}

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -16,35 +16,34 @@
 import { ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 
-export const ITEM_TYPE_ID = '-10'
-export const TRANSACTION_TYPE_ID = '-30'
-const FIELD_TYPE = '-124'
-const SCRIPT_TYPE = '-417'
+const ITEM_TYPES = [
+  'assemblyItem',
+  'lotNumberedAssemblyItem',
+  'serializedAssemblyItem',
+  'descriptionItem',
+  'discountItem',
+  'kitItem',
+  'markupItem',
+  'nonInventoryPurchaseItem',
+  'nonInventorySaleItem',
+  'nonInventoryResaleItem',
+  'otherChargeSaleItem',
+  'otherChargeResaleItem',
+  'otherChargePurchaseItem',
+  'paymentItem',
+  'serviceResaleItem',
+  'servicePurchaseItem',
+  'serviceSaleItem',
+  'subtotalItem',
+  'inventoryItem',
+  'lotNumberedInventoryItem',
+  'serializedInventoryItem',
+  'itemGroup',
+  'giftCertificateItem',
+  'downloadItem',
+] as const
 
-type ItemType = 'assemblyItem' |
-'lotNumberedAssemblyItem' |
-'serializedAssemblyItem' |
-'descriptionItem' |
-'discountItem' |
-'kitItem' |
-'markupItem' |
-'nonInventoryPurchaseItem' |
-'nonInventorySaleItem' |
-'nonInventoryResaleItem' |
-'otherChargeSaleItem' |
-'otherChargeResaleItem' |
-'otherChargePurchaseItem' |
-'paymentItem' |
-'serviceResaleItem' |
-'servicePurchaseItem' |
-'serviceSaleItem' |
-'subtotalItem' |
-'inventoryItem' |
-'lotNumberedInventoryItem' |
-'serializedInventoryItem' |
-'itemGroup' |
-'giftCertificateItem' |
-'downloadItem'
+type ItemType = typeof ITEM_TYPES[number]
 
 type TypeWithMultiFieldsIdentifier = 'accountingPeriod' |
 'nexus' |
@@ -66,19 +65,17 @@ type TypeWithSingleFieldIdentifier = 'subsidiary' |
 export type SupportedDataType = ItemType | TypeWithMultiFieldsIdentifier | TypeWithSingleFieldIdentifier
 
 // Was taken from https://<account_id>.app.netsuite.com/app/help/helpcenter.nl?fid=section_n3432681.html&whence=
-const ORIGINAL_TYPES_TO_INTERNAL_ID: Record<string, string> = {
+const TABLE_TO_INTERNAL_ID = {
+  item: '-10',
+  transaction: '-30',
+  customfield: '-124',
+  script: '-417',
   account: '-112',
   accountingPeriod: '-105',
   address: '-289',
-  advInterCompanyJournalEntry: TRANSACTION_TYPE_ID,
-  assemblyBuild: TRANSACTION_TYPE_ID,
-  assemblyItem: ITEM_TYPE_ID,
-  assemblyUnbuild: TRANSACTION_TYPE_ID,
   billingAccount: '-333',
   billingSchedule: '-141',
   bin: '-242',
-  binTransfer: TRANSACTION_TYPE_ID,
-  binWorksheet: TRANSACTION_TYPE_ID,
   bom: '-422',
   bomRevision: '-423',
   budgetCategory: '-396',
@@ -93,97 +90,50 @@ const ORIGINAL_TYPES_TO_INTERNAL_ID: Record<string, string> = {
   campaignSearchEngine: '-148',
   campaignSubscription: '-149',
   campaignVertical: '-150',
-  cashRefund: TRANSACTION_TYPE_ID,
-  cashSale: TRANSACTION_TYPE_ID,
   charge: '-290',
-  check: TRANSACTION_TYPE_ID,
   classification: '-101',
   consolidatedExchangeRate: '-322',
   contact: '-6',
   contactCategory: '-158',
   contactRole: '-157',
   costCategory: '-155',
-  creditMemo: TRANSACTION_TYPE_ID,
-  crmCustomField: FIELD_TYPE,
   currency: '-122',
   customer: '-2',
   customerCategory: '-109',
-  customerDeposit: TRANSACTION_TYPE_ID,
   customerMessage: '-161',
-  customerPayment: TRANSACTION_TYPE_ID,
-  customerRefund: TRANSACTION_TYPE_ID,
   customerStatus: '-104',
   customList: '-123',
-  customRecordCustomField: FIELD_TYPE,
   customRecordType: '-123',
-  customTransaction: TRANSACTION_TYPE_ID,
   department: '-102',
-  deposit: TRANSACTION_TYPE_ID,
-  depositApplication: TRANSACTION_TYPE_ID,
-  descriptionItem: ITEM_TYPE_ID,
-  discountItem: ITEM_TYPE_ID,
-  downloadItem: ITEM_TYPE_ID,
   employee: '-4',
-  entityCustomField: FIELD_TYPE,
-  estimate: TRANSACTION_TYPE_ID,
   expenseCategory: '-126',
-  expenseReport: TRANSACTION_TYPE_ID,
   fairValuePrice: '-332',
   generalToken: '-540',
-  giftCertificateItem: ITEM_TYPE_ID,
   globalAccountMapping: '-250',
   hcmJob: '-355',
   inboundShipment: '-427',
-  interCompanyJournalEntry: TRANSACTION_TYPE_ID,
-  interCompanyTransferOrder: TRANSACTION_TYPE_ID,
-  inventoryAdjustment: TRANSACTION_TYPE_ID,
-  inventoryCostRevaluation: TRANSACTION_TYPE_ID,
   inventoryDetail: '-260',
-  inventoryItem: ITEM_TYPE_ID,
   inventoryNumber: '-266',
-  inventoryTransfer: TRANSACTION_TYPE_ID,
-  invoice: TRANSACTION_TYPE_ID,
   issue: '-26',
   itemAccountMapping: '-251',
-  itemCustomField: FIELD_TYPE,
   itemDemandPlan: '-246',
-  itemFulfillment: TRANSACTION_TYPE_ID,
-  itemGroup: ITEM_TYPE_ID,
-  itemNumberCustomField: FIELD_TYPE,
-  itemOptionCustomField: FIELD_TYPE,
-  itemReceipt: TRANSACTION_TYPE_ID,
   itemRevision: '-269',
   itemSupplyPlan: '-247',
   job: '-7',
   jobType: '-177',
-  journalEntry: TRANSACTION_TYPE_ID,
-  kitItem: ITEM_TYPE_ID,
   location: '-103',
-  lotNumberedAssemblyItem: ITEM_TYPE_ID,
-  lotNumberedInventoryItem: ITEM_TYPE_ID,
   manufacturingCostTemplate: '-294',
   manufacturingOperationTask: '-36',
   manufacturingRouting: '-288',
-  markupItem: ITEM_TYPE_ID,
   nexus: '-400',
-  nonInventoryPurchaseItem: ITEM_TYPE_ID,
-  nonInventoryResaleItem: ITEM_TYPE_ID,
-  nonInventorySaleItem: ITEM_TYPE_ID,
   note: '-303',
   noteType: '-180',
   opportunity: '-31',
-  otherChargePurchaseItem: ITEM_TYPE_ID,
-  otherChargeResaleItem: ITEM_TYPE_ID,
-  otherChargeSaleItem: ITEM_TYPE_ID,
-  otherCustomField: FIELD_TYPE,
   otherNameCategory: '-181',
   partner: '-5',
   partnerCategory: '-182',
-  paycheck: TRANSACTION_TYPE_ID,
-  paycheckJournal: TRANSACTION_TYPE_ID,
   paymentCard: '-538',
   paymentCardToken: '-539',
-  paymentItem: ITEM_TYPE_ID,
   paymentMethod: '-183',
   payrollItem: '-265',
   phoneCall: '-22',
@@ -191,22 +141,11 @@ const ORIGINAL_TYPES_TO_INTERNAL_ID: Record<string, string> = {
   pricingGroup: '-187',
   projectTask: '-27',
   promotionCode: '-121',
-  purchaseOrder: TRANSACTION_TYPE_ID,
-  purchaseRequisition: TRANSACTION_TYPE_ID,
   resourceAllocation: '-28',
-  returnAuthorization: TRANSACTION_TYPE_ID,
-  salesOrder: TRANSACTION_TYPE_ID,
   salesRole: '-191',
   salesTaxItem: '-128',
-  serializedAssemblyItem: ITEM_TYPE_ID,
-  serializedInventoryItem: ITEM_TYPE_ID,
-  servicePurchaseItem: ITEM_TYPE_ID,
-  serviceResaleItem: ITEM_TYPE_ID,
-  serviceSaleItem: ITEM_TYPE_ID,
   solution: '-25',
-  statisticalJournalEntry: TRANSACTION_TYPE_ID,
   subsidiary: '-117',
-  subtotalItem: ITEM_TYPE_ID,
   supportCase: '-23',
   supportCaseIssue: '-151',
   supportCaseOrigin: '-152',
@@ -218,51 +157,109 @@ const ORIGINAL_TYPES_TO_INTERNAL_ID: Record<string, string> = {
   timeBill: '-256',
   timeEntry: '-295',
   timeSheet: '-292',
-  transactionBodyCustomField: FIELD_TYPE,
-  transactionColumnCustomField: FIELD_TYPE,
-  transferOrder: TRANSACTION_TYPE_ID,
   unitsType: '-201',
   usage: '-362',
   vendor: '-3',
-  vendorBill: TRANSACTION_TYPE_ID,
   vendorCategory: '-110',
-  vendorCredit: TRANSACTION_TYPE_ID,
-  vendorPayment: TRANSACTION_TYPE_ID,
-  vendorReturnAuthorization: TRANSACTION_TYPE_ID,
   winLossReason: '-203',
-  workOrder: TRANSACTION_TYPE_ID,
-  workOrderClose: TRANSACTION_TYPE_ID,
-  workOrderCompletion: TRANSACTION_TYPE_ID,
-  workOrderIssue: TRANSACTION_TYPE_ID,
-}
+} as const
 
-const MANUALLY_MAPPED_TYPES_TO_INTERNAL_IDS: Record<string, string> = {
+const MANUALLY_TABLE_TO_INTERNAL_ID = {
   // Some types from the original map were wrong and some were missing.
   // This map was manually added with corrected types to ids.
   role: '-264',
   workflow: '-129',
   vendor: '-9',
-  customrecordtype: '-123',
-  priceLevel: ITEM_TYPE_ID,
-  scheduledscript: SCRIPT_TYPE,
-  workflowactionscript: SCRIPT_TYPE,
-  clientscript: SCRIPT_TYPE,
-  suitelet: SCRIPT_TYPE,
-  portlet: SCRIPT_TYPE,
-  bundleinstallationscript: SCRIPT_TYPE,
-  restlet: SCRIPT_TYPE,
-  massupdatescript: SCRIPT_TYPE,
-  mapreducescript: SCRIPT_TYPE,
-  customSegment: FIELD_TYPE,
-  customsegment: FIELD_TYPE,
-  usereventscript: SCRIPT_TYPE,
-  sdfinstallationscript: SCRIPT_TYPE,
-}
+  customrecordtype: TABLE_TO_INTERNAL_ID.customRecordType,
+  priceLevel: TABLE_TO_INTERNAL_ID.item,
+} as const
 
+const ALL_TABLE_TO_INTERNAL_ID = {
+  ...TABLE_TO_INTERNAL_ID,
+  ...MANUALLY_TABLE_TO_INTERNAL_ID,
+} as const
+
+export type SuiteQLTableName = keyof typeof ALL_TABLE_TO_INTERNAL_ID
+
+const TRANSACTION_TYPES = [
+  'advInterCompanyJournalEntry',
+  'assemblyBuild',
+  'assemblyUnbuild',
+  'binTransfer',
+  'binWorksheet',
+  'cashRefund',
+  'cashSale',
+  'check',
+  'creditMemo',
+  'customerDeposit',
+  'customerPayment',
+  'customerRefund',
+  'customTransaction',
+  'deposit',
+  'depositApplication',
+  'estimate',
+  'expenseReport',
+  'interCompanyJournalEntry',
+  'interCompanyTransferOrder',
+  'inventoryAdjustment',
+  'inventoryCostRevaluation',
+  'inventoryTransfer',
+  'invoice',
+  'itemFulfillment',
+  'itemReceipt',
+  'journalEntry',
+  'paycheck',
+  'paycheckJournal',
+  'purchaseOrder',
+  'purchaseRequisition',
+  'returnAuthorization',
+  'salesOrder',
+  'statisticalJournalEntry',
+  'transferOrder',
+  'vendorBill',
+  'vendorCredit',
+  'vendorPayment',
+  'vendorReturnAuthorization',
+  'workOrder',
+  'workOrderClose',
+  'workOrderCompletion',
+  'workOrderIssue',
+]
+
+const FIELD_TYPES = [
+  'crmCustomField',
+  'customRecordCustomField',
+  'entityCustomField',
+  'itemCustomField',
+  'itemNumberCustomField',
+  'itemOptionCustomField',
+  'otherCustomField',
+  'transactionBodyCustomField',
+  'transactionColumnCustomField',
+  'customSegment',
+  'customsegment',
+]
+
+const SCRIPT_TYPES = [
+  'scheduledscript',
+  'workflowactionscript',
+  'clientscript',
+  'suitelet',
+  'portlet',
+  'bundleinstallationscript',
+  'restlet',
+  'massupdatescript',
+  'mapreducescript',
+  'usereventscript',
+  'sdfinstallationscript',
+]
 
 export const TYPES_TO_INTERNAL_ID: Record<string, string> = {
-  ...ORIGINAL_TYPES_TO_INTERNAL_ID,
-  ...MANUALLY_MAPPED_TYPES_TO_INTERNAL_IDS,
+  ...ALL_TABLE_TO_INTERNAL_ID,
+  ...Object.fromEntries(TRANSACTION_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.transaction])),
+  ...Object.fromEntries(FIELD_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.customfield])),
+  ...Object.fromEntries(SCRIPT_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.script])),
+  ...Object.fromEntries(ITEM_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.item])),
 }
 
 export const INTERNAL_ID_TO_TYPES: Record<string, string[]> = _(TYPES_TO_INTERNAL_ID)

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -1,0 +1,240 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, TopLevelElement, isInstanceElement } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import NetsuiteClient from '../../src/client/client'
+import { INTERNAL_IDS_MAP, QUERIES_BY_TABLE_NAME, SUITEQL_TABLE, getSuiteQLTableElements } from '../../src/data_elements/suiteql_table_elements'
+import { SuiteQLTableName } from '../../src/data_elements/types'
+import { NETSUITE } from '../../src/constants'
+import { SERVER_TIME_TYPE_NAME } from '../../src/server_time'
+
+const runSuiteQLMock = jest.fn()
+const client = {
+  runSuiteQL: runSuiteQLMock,
+} as unknown as NetsuiteClient
+
+describe('SuiteQL table elements', () => {
+  let serverTimeType: ObjectType
+  let serverTimeInstance: InstanceElement
+  let suiteQLTableType: ObjectType
+  let suiteQLTableInstance: InstanceElement
+  let oldSuiteQLTableInstance: InstanceElement
+  let emptySuiteQLTableInstance: InstanceElement
+  let elements: TopLevelElement[]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    serverTimeType = new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) })
+    serverTimeInstance = new InstanceElement(
+      ElemID.CONFIG_NAME,
+      serverTimeType,
+      { serverTime: '2024-01-01T00:00:00.000Z' }
+    )
+    suiteQLTableType = new ObjectType({ elemID: new ElemID(NETSUITE, SUITEQL_TABLE) })
+    suiteQLTableInstance = new InstanceElement(
+      'currency',
+      suiteQLTableType,
+      {
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 1,
+      }
+    )
+    oldSuiteQLTableInstance = new InstanceElement(
+      'department',
+      suiteQLTableType,
+      {
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 'old',
+      }
+    )
+    emptySuiteQLTableInstance = new InstanceElement(
+      'subsidiary',
+      suiteQLTableType,
+      {
+        version: 1,
+      }
+    )
+  })
+
+  describe('when there are no existing instances', () => {
+    const numOfInstances = Object.values(QUERIES_BY_TABLE_NAME).filter(query => query !== undefined).length
+
+    beforeEach(async () => {
+      runSuiteQLMock.mockResolvedValue([
+        { id: '1', name: 'Some name' },
+        { id: '2', name: 'Some name 2' },
+        { id: '3', name: 'Some name 3' },
+      ])
+      const elementsSource = buildElementsSourceFromElements([])
+      elements = await getSuiteQLTableElements(client, elementsSource, false)
+    })
+
+    it('should return all elements', () => {
+      expect(elements).toHaveLength(numOfInstances + 1)
+      expect(elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
+    })
+
+    it('should set instance values correctly', () => {
+      const instanceWithInternalIdsRecords = elements.filter(isInstanceElement)
+        .find(element => QUERIES_BY_TABLE_NAME[element.elemID.name as SuiteQLTableName]?.nameField === 'name')
+      expect(instanceWithInternalIdsRecords?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 1,
+      })
+    })
+
+    it('should not set values when name field do not match', () => {
+      const instanceWithoutInternalIdsRecords = elements.filter(isInstanceElement)
+        .find(element => QUERIES_BY_TABLE_NAME[element.elemID.name as SuiteQLTableName]?.nameField === 'title')
+      expect(instanceWithoutInternalIdsRecords?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {},
+        version: 1,
+      })
+    })
+  })
+
+  describe('when there are existing instances', () => {
+    beforeEach(async () => {
+      runSuiteQLMock.mockResolvedValue([
+        { id: '1', name: 'Updated name' },
+        { id: '4', name: 'New name 4' },
+        { id: '5', name: 'New name 5' },
+      ])
+      const elementsSource = buildElementsSourceFromElements([
+        serverTimeType,
+        serverTimeInstance,
+        suiteQLTableType,
+        suiteQLTableInstance,
+        oldSuiteQLTableInstance,
+        emptySuiteQLTableInstance,
+      ])
+      elements = await getSuiteQLTableElements(client, elementsSource, false)
+    })
+
+    it('should update existing instance values', () => {
+      const updatedInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'currency')
+      expect(updatedInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Updated name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+          4: { name: 'New name 4' },
+          5: { name: 'New name 5' },
+        },
+        version: 1,
+      })
+    })
+
+    it('should override existing values when instance version is not latest version', () => {
+      const updatedInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'department')
+      expect(updatedInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Updated name' },
+          4: { name: 'New name 4' },
+          5: { name: 'New name 5' },
+        },
+        version: 1,
+      })
+    })
+
+    it('should add values to empty instance', () => {
+      const updatedInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'subsidiary')
+      expect(updatedInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Updated name' },
+          4: { name: 'New name 4' },
+          5: { name: 'New name 5' },
+        },
+        version: 1,
+      })
+    })
+
+    it('should call runSuiteQL with right queries', () => {
+      // instance with latest version is called with lastmodifieddate
+      expect(runSuiteQLMock).toHaveBeenCalledWith('SELECT id, name FROM currency WHERE lastmodifieddate >= TO_DATE(\'2024-1-1\', \'YYYY-MM-DD\') ORDER BY id ASC')
+      // instance without latest version is called without lastmodifieddate
+      expect(runSuiteQLMock).toHaveBeenCalledWith('SELECT id, name FROM department  ORDER BY id ASC')
+      // empty instance with latest version is called with lastmodifieddate
+      expect(runSuiteQLMock).toHaveBeenCalledWith('SELECT id, name FROM subsidiary WHERE lastmodifieddate >= TO_DATE(\'2024-1-1\', \'YYYY-MM-DD\') ORDER BY id ASC')
+    })
+  })
+
+  describe('when isPartial=true', () => {
+    beforeEach(async () => {
+      runSuiteQLMock.mockResolvedValue([
+        { id: '1', name: 'Some name' },
+        { id: '2', name: 'Some name 2' },
+        { id: '3', name: 'Some name 3' },
+      ])
+      const elementsSource = buildElementsSourceFromElements([
+        suiteQLTableType,
+        suiteQLTableInstance,
+        oldSuiteQLTableInstance,
+        emptySuiteQLTableInstance,
+      ])
+      elements = await getSuiteQLTableElements(client, elementsSource, true)
+    })
+
+    it('should return only existing instances', () => {
+      expect(elements).toHaveLength(4)
+      const existingInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'currency')
+      expect(existingInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 1,
+      })
+      const oldExistingInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'department')
+      expect(oldExistingInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 'old',
+      })
+      const emptyExistingInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'subsidiary')
+      expect(emptyExistingInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {},
+        version: 1,
+      })
+    })
+
+    it('should not call runSuiteQL', () => {
+      expect(runSuiteQLMock).not.toHaveBeenCalled()
+    })
+  })
+})


### PR DESCRIPTION
Fetch the internal ids & names of lots of data objects from SuiteQL tables and save them in hidden instances.
This will be used in the future for finding the real value behind an ACCOUNT_SPECIFIC_VALUE, in workflows & data elements.
In case of partial/quick fetch no new data will be fetched.
This feature is behind an adapter config value - `fetch.addSuiteQLTables`

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
None

---
_User Notifications_: 
None