### PR TITLE
Fix custom record types with segments partial fetch

### DIFF
--- a/packages/netsuite-adapter/test/config/query.test.ts
+++ b/packages/netsuite-adapter/test/config/query.test.ts
@@ -24,6 +24,7 @@ describe('netsuite config query', () => {
           { name: 'advancedpdftemplate', ids: ['ccc.*', 'ddd.*'] },
           { name: 'account', ids: ['.*'] },
           { name: 'account', ids: ['.*'] },
+          { name: 'customrecordtype', ids: ['customrecord_cseg123'] },
         ],
         fileCabinet: ['eee.*', 'fff.*'],
         customRecords: [
@@ -40,6 +41,11 @@ describe('netsuite config query', () => {
 
         it('should not match types the were not received', () => {
           expect(query.isTypeMatch('wrongType')).toBeFalsy()
+        })
+
+        it('should match customsegment when customrecordtype match', () => {
+          expect(query.isTypeMatch('customrecordtype')).toBeTruthy()
+          expect(query.isTypeMatch('customsegment')).toBeTruthy()
         })
       })
 
@@ -74,6 +80,13 @@ describe('netsuite config query', () => {
         it('should not match objects that do not match the received regexes', () => {
           expect(query.isObjectMatch({ instanceId: 'aaaaaa', type: 'notExists' })).toBeFalsy()
           expect(query.isObjectMatch({ instanceId: 'cccccc', type: 'addressForm' })).toBeFalsy()
+        })
+
+        it('should match custom segment object with its custom record type object', () => {
+          expect(query.isObjectMatch({ instanceId: 'customrecord_cseg123', type: 'customrecordtype' })).toBeTruthy()
+          expect(query.isObjectMatch({ instanceId: 'cseg123', type: 'customsegment' })).toBeTruthy()
+
+          expect(query.isObjectMatch({ instanceId: 'cseg124', type: 'customsegment' })).toBeFalsy()
         })
       })
 


### PR DESCRIPTION
When running partial fetch for custom record types, the custom record types with custom segments were deleted.
It is because those custom record types are fetched by their custom segments, and since the custom segments weren't fetched we thought that the custom record types were deleted in the service and we marked them as "deleted elements".
The solution is to fetch the matching custom segments of those custom record types.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Fix custom record types with segments partial fetch

---
_User Notifications_: 
None