### PR TITLE
SALTO-5187: Add validate creds func (Jira)

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.ts
+++ b/packages/jira-adapter/e2e_test/adapter.ts
@@ -43,7 +43,7 @@ export const realAdapter = (
   jiraConfig?: JiraConfig
 ): Reals => {
   const client = (adapterParams && adapterParams.client)
-    || new JiraClient({ credentials, isDataCenter })
+    || new JiraClient({ credentials: { ...credentials, isDataCenter }, isDataCenter })
   const scriptRunnerClient = new ScriptRunnerClient(
     {
       jiraClient: client,

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -164,7 +164,7 @@ export const adapter: Adapter = {
 
     return validateCredentials({
       connection: productSettings.wrapConnection(await connection.login(creds)),
-      isDataCenter: Boolean(creds.isDataCenter),
+      credentials: creds,
     })
   },
   authenticationMethods: {

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -25,7 +25,6 @@ import { Credentials, basicAuthCredentialsType } from './auth'
 import { configType, JiraConfig, getApiDefinitions, getDefaultConfig, validateJiraFetchConfig } from './config/config'
 import { createConnection, validateCredentials } from './client/connection'
 import { AUTOMATION_TYPE, SCRIPT_RUNNER_API_DEFINITIONS, WEBHOOK_TYPE } from './constants'
-import { getProductSettings } from './product_settings'
 import { configCreator } from './config_creator'
 import ScriptRunnerClient from './client/script_runner_client'
 import { weakReferenceHandlers } from './weak_references'
@@ -160,10 +159,9 @@ export const adapter: Adapter = {
   validateCredentials: async config => {
     const connection = createConnection(createRetryOptions(DEFAULT_RETRY_OPTS, DEFAULT_TIMEOUT_OPTS))
     const creds = credentialsFromConfig(config)
-    const productSettings = getProductSettings({ isDataCenter: Boolean(creds.isDataCenter) })
 
     return validateCredentials({
-      connection: productSettings.wrapConnection(await connection.login(creds)),
+      connection: await connection.login(creds),
       credentials: creds,
     })
   },

--- a/packages/jira-adapter/src/client/connection.ts
+++ b/packages/jira-adapter/src/client/connection.ts
@@ -53,7 +53,7 @@ Based on the current implementation of the Jira API, we can't know if the accoun
 account, but in some cases we can know that it's not a production account.
 */
 export const validateCredentials = async (
-  { connection, isDataCenter }: { connection: clientUtils.APIConnection; isDataCenter: boolean },
+  { connection, credentials }: { connection: clientUtils.APIConnection; credentials: Credentials },
 ): Promise<AccountInfo> => {
   if (await isAuthorized(connection)) {
     const accountId = await getBaseUrl(connection)
@@ -61,7 +61,7 @@ export const validateCredentials = async (
       return { accountId, isProduction: false, accountType: 'Sandbox' }
     }
 
-    if (isDataCenter) {
+    if (credentials.isDataCenter) {
       return { accountId }
     }
     const response = await connection.get('/rest/api/3/instance/license')
@@ -86,7 +86,7 @@ export const createConnection: clientUtils.ConnectionCreator<Credentials> = (ret
       }
     ),
     baseURLFunc: async ({ baseUrl }) => baseUrl,
-    credValidateFunc: async () => ({ accountId: '' }), // There is no login endpoint to call
+    credValidateFunc: validateCredentials,
     timeout,
   })
 )

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -444,8 +444,12 @@ describe('adapter', () => {
         (loadSwagger as jest.MockedFunction<typeof loadSwagger>)
           .mockResolvedValue({ document: {}, parser: {} } as elements.swagger.LoadedSwagger)
         mockAxiosAdapter = new MockAdapter(axios)
-        // mock as there are gets of license during fetch
-        mockAxiosAdapter.onGet().reply(200, { })
+        mockAxiosAdapter
+          // first three requests are for login assertion
+          .onGet('/rest/api/3/configuration').replyOnce(200)
+          .onGet('/rest/api/3/serverInfo').replyOnce(200, { baseUrl: 'a' })
+          .onGet('/rest/api/3/instance/license')
+          .replyOnce(200, { applications: [{ plan: 'FREE' }] })
         // mock as we call getCloudId in the forms filter.
         mockAxiosAdapter.onPost().reply(200, {
           unparsedData: {

--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -25,6 +25,12 @@ describe('client', () => {
   beforeEach(() => {
     mockAxios = new MockAdapter(axios)
     client = new JiraClient({ credentials: { baseUrl: 'http://myjira.net', user: 'me', token: 'tok' }, isDataCenter: false })
+    mockAxios
+      // first three requests are for login assertion
+      .onGet('/rest/api/3/configuration').replyOnce(200)
+      .onGet('/rest/api/3/serverInfo').replyOnce(200, { baseUrl: 'a' })
+      .onGet('/rest/api/3/instance/license')
+      .replyOnce(200, { applications: [{ plan: 'FREE' }] })
   })
   afterEach(() => {
     mockAxios.restore()
@@ -41,17 +47,15 @@ describe('client', () => {
 
   describe('getSinglePage', () => {
     beforeEach(async () => {
-      mockAxios.onGet().reply(200, { response: 'asd' })
+      mockAxios.onGet('/myPath').reply(200, { response: 'asd' })
       result = await client.getSinglePage({ url: '/myPath' })
     })
-    it('should not try to call a login endpoint', () => {
-      expect(mockAxios.history.get).toHaveLength(1)
-    })
     it('should request the correct path with auth headers', () => {
-      const request = mockAxios.history.get[0]
-      expect(request.auth).toEqual({ username: 'me', password: 'tok' })
-      expect(request.baseURL).toEqual('http://myjira.net')
-      expect(request.url).toEqual('/myPath')
+      const request = mockAxios.history.get.find(r => r.url === '/myPath')
+      expect(request).toBeDefined()
+      expect(request?.auth).toEqual({ username: 'me', password: 'tok' })
+      expect(request?.baseURL).toEqual('http://myjira.net')
+      expect(request?.url).toEqual('/myPath')
     })
     it('should return the response', () => {
       expect(result).toEqual({ status: 200, data: { response: 'asd' } })
@@ -60,7 +64,7 @@ describe('client', () => {
   it('should preserve headers', async () => {
     mockAxios.onPatch().reply(200, { response: 'asd' })
     mockAxios.onPost().reply(200, { response: 'asd' })
-    mockAxios.onGet().reply(200, { response: 'asd' })
+    mockAxios.onGet('/myPath').reply(200, { response: 'asd' })
     mockAxios.onPut().reply(200, { response: 'asd' })
     mockAxios.onDelete().reply(200, { response: 'asd' })
     await client.patchPrivate({ url: '/myPath', headers: { 'x-atlassian-force-account-id': '1234' }, data: { a: 'b' } })
@@ -70,7 +74,7 @@ describe('client', () => {
     await client.getPrivate({ url: '/myPath', headers: { 'x-atlassian-force-account-id': '1234' } })
     await client.deletePrivate({ url: '/myPath', headers: { 'x-atlassian-force-account-id': '1234' } })
     expect(mockAxios.history.patch[0].headers?.['x-atlassian-force-account-id']).toEqual('1234')
-    expect(mockAxios.history.get[0].headers?.['x-atlassian-force-account-id']).toEqual('1234')
+    expect(mockAxios.history.get.find(r => r.url === '/myPath')?.headers?.['x-atlassian-force-account-id']).toEqual('1234')
     expect(mockAxios.history.post[0].headers?.['x-atlassian-force-account-id']).toEqual('1234')
     expect(mockAxios.history.post[1].headers?.['x-atlassian-force-account-id']).toEqual('1234')
     expect(mockAxios.history.delete[0].headers?.['x-atlassian-force-account-id']).toEqual('1234')

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -18,19 +18,20 @@ import MockAdapter from 'axios-mock-adapter'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { createConnection, validateCredentials } from '../../src/client/connection'
 import { FORCE_ACCEPT_LANGUAGE_HEADERS } from '../../src/client/headers'
+import { Credentials } from '../../src/auth'
 
 describe('connection', () => {
   describe('validateCredentials', () => {
     let mockAxios: MockAdapter
     let connection: clientUtils.APIConnection
+    let credentials: Credentials
     beforeEach(async () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
-      )
+      credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
+      connection = await createConnection({ retries: 1 }).login(credentials)
     })
     afterEach(() => {
       mockAxios.restore()
@@ -42,7 +43,7 @@ describe('connection', () => {
       beforeEach(async () => {
         ({ accountId } = await validateCredentials({
           connection,
-          isDataCenter: false,
+          credentials,
         }))
       })
 
@@ -62,12 +63,12 @@ describe('connection', () => {
     describe('when unauthorized', () => {
       it('should throw Invalid Credentials Error', async () => {
         mockAxios.onGet('/rest/api/3/configuration').reply(401)
-        await expect(validateCredentials({ connection, isDataCenter: false })).rejects.toThrow(new Error('Invalid Credentials'))
+        await expect(validateCredentials({ connection, credentials })).rejects.toThrow(new Error('Invalid Credentials'))
       })
 
       it('should rethrow unrelated Network Error', async () => {
         mockAxios.onGet('/rest/api/3/configuration').networkError()
-        await expect(validateCredentials({ connection, isDataCenter: false })).rejects.toThrow(new Error('Network Error'))
+        await expect(validateCredentials({ connection, credentials })).rejects.toThrow(new Error('Network Error'))
       })
     })
   })
@@ -75,18 +76,18 @@ describe('connection', () => {
   describe('validateHeaders Cloud', () => {
     let mockAxios: MockAdapter
     let connection: clientUtils.APIConnection
+    let credentials: Credentials
 
     beforeEach(async () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
-      )
+      credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: false }
+      connection = await createConnection({ retries: 1 }).login(credentials)
       await validateCredentials({
         connection,
-        isDataCenter: false,
+        credentials,
       })
     })
     afterEach(() => {
@@ -102,17 +103,17 @@ describe('connection', () => {
   describe('validateHeaders DC', () => {
     let mockAxios: MockAdapter
     let connection: clientUtils.APIConnection
+    let credentials: Credentials
     beforeEach(async () => {
       mockAxios = new MockAdapter(axios)
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
-      )
+      credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
+      connection = await createConnection({ retries: 1 }).login(credentials)
       await validateCredentials({
         connection,
-        isDataCenter: true,
+        credentials,
       })
     })
     afterEach(() => {
@@ -131,61 +132,63 @@ describe('connection', () => {
     let mockAxios: MockAdapter
     let connection: clientUtils.APIConnection
     beforeEach(async () => {
+      jest.clearAllMocks()
       mockAxios = new MockAdapter(axios)
+      // initial calls as part of login func
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
+      mockAxios.onGet('/rest/api/3/serverInfo').replyOnce(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/3/instance/license').replyOnce(200, { applications: [] })
     })
     afterEach(() => {
       mockAxios.restore()
     })
     it('should return isProduction undefined and accountType = undefined when account id does not include -sandbox- and has paid app', async () => {
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
-      )
+      const credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
+      connection = await createConnection({ retries: 1 }).login(credentials)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ id: 'software', plan: 'PAID' }, { id: 'serviceDesk', plan: 'FREE' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
-        isDataCenter: false,
+        credentials,
       })
       expect(isProduction).toEqual(undefined)
       expect(accountType).toEqual(undefined)
     })
     it('should return isProduction false and accountType = "Sandbox" when account id includes -sandbox-', async () => {
+      const credentials = { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: false }
       connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
+        credentials
       )
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test-sandbox-999.atlassian.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'PAID' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
-        isDataCenter: false,
+        credentials,
       })
       expect(isProduction).toEqual(false)
       expect(accountType).toEqual('Sandbox')
     })
     it('should return isProduction false and accountType = undefined when account id does not include -sandbox- but has no paid app', async () => {
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
-      )
+      const credentials = { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: false }
+      connection = await createConnection({ retries: 1 }).login(credentials)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
-        isDataCenter: false,
+        credentials,
       })
       expect(accountType).toEqual(undefined)
       expect(isProduction).toEqual(false)
     })
 
     it('should return isProduction undefined and accountType = undefined', async () => {
-      connection = await createConnection({ retries: 1 }).login(
-        { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
-      )
+      const credentials = { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
+      connection = await createConnection({ retries: 1 }).login(credentials)
       mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
       mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
-        isDataCenter: true,
+        credentials,
       })
       expect(accountType).toEqual(undefined)
       expect(isProduction).toEqual(undefined)

--- a/packages/jira-adapter/test/client/connection.test.ts
+++ b/packages/jira-adapter/test/client/connection.test.ts
@@ -106,9 +106,9 @@ describe('connection', () => {
     let credentials: Credentials
     beforeEach(async () => {
       mockAxios = new MockAdapter(axios)
-      mockAxios.onGet('/rest/api/3/configuration').reply(200)
-      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
-      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
+      mockAxios.onGet('/rest/api/2/configuration').reply(200)
+      mockAxios.onGet('/rest/api/2/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/2/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       connection = await createConnection({ retries: 1 }).login(credentials)
       await validateCredentials({
@@ -121,8 +121,8 @@ describe('connection', () => {
     })
 
     it('should not have force accept language headers when calling Jira DC', async () => {
-      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
-      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
+      mockAxios.onGet('/rest/api/2/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/2/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       expect(mockAxios.history.get).toContainEqual(expect.objectContaining({
         headers: expect.not.objectContaining(FORCE_ACCEPT_LANGUAGE_HEADERS),
       }))
@@ -134,10 +134,14 @@ describe('connection', () => {
     beforeEach(async () => {
       jest.clearAllMocks()
       mockAxios = new MockAdapter(axios)
-      // initial calls as part of login func
+      // initial calls as part of login func, for regular Jira
       mockAxios.onGet('/rest/api/3/configuration').reply(200)
       mockAxios.onGet('/rest/api/3/serverInfo').replyOnce(200, { baseUrl: 'http://my.jira.net' })
       mockAxios.onGet('/rest/api/3/instance/license').replyOnce(200, { applications: [] })
+      // initial calls as part of login func, for DC
+      mockAxios.onGet('/rest/api/2/configuration').reply(200)
+      mockAxios.onGet('/rest/api/2/serverInfo').replyOnce(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/2/instance/license').replyOnce(200, { applications: [] })
     })
     afterEach(() => {
       mockAxios.restore()
@@ -145,8 +149,8 @@ describe('connection', () => {
     it('should return isProduction undefined and accountType = undefined when account id does not include -sandbox- and has paid app', async () => {
       const credentials = { baseUrl: 'http://myJira.net', user: 'me', token: 'tok', isDataCenter: true }
       connection = await createConnection({ retries: 1 }).login(credentials)
-      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
-      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ id: 'software', plan: 'PAID' }, { id: 'serviceDesk', plan: 'FREE' }] })
+      mockAxios.onGet('/rest/api/2/serverInfo').reply(200, { baseUrl: 'http://my.jira.net' })
+      mockAxios.onGet('/rest/api/2/instance/license').reply(200, { applications: [{ id: 'software', plan: 'PAID' }, { id: 'serviceDesk', plan: 'FREE' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
         credentials,
@@ -184,8 +188,8 @@ describe('connection', () => {
     it('should return isProduction undefined and accountType = undefined', async () => {
       const credentials = { baseUrl: 'https://test-sandbox-999.atlassian.net', user: 'me', token: 'tok', isDataCenter: true }
       connection = await createConnection({ retries: 1 }).login(credentials)
-      mockAxios.onGet('/rest/api/3/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
-      mockAxios.onGet('/rest/api/3/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
+      mockAxios.onGet('/rest/api/2/serverInfo').reply(200, { baseUrl: 'https://test.atlassian.net' })
+      mockAxios.onGet('/rest/api/2/instance/license').reply(200, { applications: [{ plan: 'FREE' }] })
       const { isProduction, accountType } = await validateCredentials({
         connection,
         credentials,

--- a/packages/jira-adapter/test/client/pagination.test.ts
+++ b/packages/jira-adapter/test/client/pagination.test.ts
@@ -30,6 +30,12 @@ describe('pageByOffset', () => {
   beforeEach(() => {
     mockAxios = new MockAdapter(axios)
     client = new JiraClient({ credentials: { baseUrl: 'http://myjira.net', user: 'me', token: 'tok' }, isDataCenter: false })
+    mockAxios
+      // first three requests are for login assertion
+      .onGet('/rest/api/3/configuration').replyOnce(200)
+      .onGet('/rest/api/3/serverInfo').replyOnce(200, { baseUrl: 'a' })
+      .onGet('/rest/api/3/instance/license')
+      .replyOnce(200, { applications: [{ plan: 'FREE' }] })
   })
   afterEach(() => {
     mockAxios.restore()


### PR DESCRIPTION
add validate creds func as we have in other adapters

---

_Additional context for reviewer_

we will call validateCredentials for each function with `@requiresLogin()` decorator.
This way user will get unauthorized error when credentials are invalid

---
_Release Notes_: 

_Jira adapter_:
- When trying to deploy with invalid credentials, user will get unauthorized error.

---
_User Notifications_: 

None