### PR TITLE
SALTO-5304: sort password policy rule methods (Okta)

### DIFF
--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -18,7 +18,7 @@ import { Element, InstanceElement, isInstanceElement, isReferenceExpression, Ref
 import { setPath, resolvePath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { GROUP_RULE_TYPE_NAME } from '../constants'
+import { GROUP_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME } from '../constants'
 
 const log = logger(module)
 
@@ -34,6 +34,15 @@ const orderTargetGroupsInRule = (instance: InstanceElement): void => {
   setPath(instance, targetGroupsPath, _.sortBy(targetGroups, group => group.elemID.getFullName()))
 }
 
+const orderPasswordPolicyRuleMethods = (instance: InstanceElement): void => {
+  const methodsPath = instance.elemID
+    .createNestedID('actions', 'selfServicePasswordReset', 'additionalProperties', 'requirement', 'primary', 'methods')
+  const methods = resolvePath(instance, methodsPath)
+  if (_.isArray(methods)) {
+    setPath(instance, methodsPath, methods.sort())
+  }
+}
+
 /**
  * Sort lists whose order changes between fetches, to avoid unneeded noise.
  */
@@ -45,6 +54,10 @@ const filterCreator: FilterCreator = () => ({
     instances
       .filter(instance => instance.elemID.typeName === GROUP_RULE_TYPE_NAME)
       .forEach(instance => orderTargetGroupsInRule(instance))
+
+    instances
+      .filter(instance => instance.elemID.typeName === PASSWORD_RULE_TYPE_NAME)
+      .forEach(instance => orderPasswordPolicyRuleMethods(instance))
   },
 })
 

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -16,46 +16,106 @@
 
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA } from '../../src/constants'
+import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, PASSWORD_RULE_TYPE_NAME } from '../../src/constants'
 import unorderedListsFilter from '../../src/filters/unordered_lists'
 import { getFilterParams } from '../utils'
 
 describe('unorderedListsFilter', () => {
   let filter: filterUtils.FilterWith<'onFetch'>
-  const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
-  const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
-
   beforeEach(() => {
     filter = unorderedListsFilter(getFilterParams()) as typeof filter
   })
 
-  it('should order group rule target group list', async () => {
-    const groupA = new InstanceElement('A', groupType, { id: 'A1', profile: { name: 'A' } })
-    const groupB = new InstanceElement('B', groupType, { id: 'B2', profile: { name: 'B' } })
-    const groupC = new InstanceElement('C', groupType, { id: 'C3', profile: { name: 'C' } })
-    const groupRule = new InstanceElement(
-      'rulez',
-      groupRuleType,
-      {
+  describe('GroupRule instances', () => {
+    const groupType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_TYPE_NAME) })
+    const groupRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_RULE_TYPE_NAME) })
+
+    it('should order group rule target group list', async () => {
+      const groupA = new InstanceElement('A', groupType, { id: 'A1', profile: { name: 'A' } })
+      const groupB = new InstanceElement('B', groupType, { id: 'B2', profile: { name: 'B' } })
+      const groupC = new InstanceElement('C', groupType, { id: 'C3', profile: { name: 'C' } })
+      const groupRule = new InstanceElement(
+        'rulez',
+        groupRuleType,
+        {
+          name: 'rule',
+          status: 'ACTIVE',
+          conditions: {},
+          actions: {
+            assignUserToGroups: {
+              groupIds: [
+                new ReferenceExpression(groupB.elemID, groupB),
+                new ReferenceExpression(groupC.elemID, groupC),
+                new ReferenceExpression(groupA.elemID, groupA),
+              ],
+            },
+          },
+        },
+      )
+      await filter.onFetch([groupType, groupRuleType, groupA, groupB, groupC, groupRule])
+      expect(groupRule.value.actions.assignUserToGroups.groupIds).toEqual([
+        new ReferenceExpression(groupA.elemID, groupA),
+        new ReferenceExpression(groupB.elemID, groupB),
+        new ReferenceExpression(groupC.elemID, groupC),
+      ])
+    })
+  })
+
+  describe('PasswordPolicyRule instances', () => {
+    const policyRuleType = new ObjectType({ elemID: new ElemID(OKTA, PASSWORD_RULE_TYPE_NAME) })
+
+    it('should order password policy rule methods list', async () => {
+      const policyRuleInstance = new InstanceElement(
+        'rulesA',
+        policyRuleType,
+        {
+          name: 'rule',
+          status: 'ACTIVE',
+          conditions: {},
+          actions: {
+            selfServicePasswordReset: {
+              access: 'ALLOW',
+              additionalProperties: {
+                requirement: {
+                  primary: {
+                    methods: ['push', 'email', 'voice', 'sms'],
+                  },
+                },
+              },
+            },
+          },
+        },
+      )
+      await filter.onFetch([policyRuleType, policyRuleInstance])
+      expect(policyRuleInstance.value
+        .actions.selfServicePasswordReset.additionalProperties.requirement.primary.methods)
+        .toEqual(['email', 'push', 'sms', 'voice'])
+    })
+
+    it('should do nothing if there are no methods defined', async () => {
+      const policyRuleInstance = new InstanceElement(
+        'rulesA',
+        policyRuleType,
+        {
+          name: 'rule',
+          status: 'ACTIVE',
+          conditions: {},
+          actions: {
+            selfServicePasswordReset: { access: 'ALLOW' },
+            selfServiceUnlock: { access: 'DENY' },
+          },
+        },
+      )
+      await filter.onFetch([policyRuleType, policyRuleInstance])
+      expect(policyRuleInstance.value).toEqual({
         name: 'rule',
         status: 'ACTIVE',
         conditions: {},
         actions: {
-          assignUserToGroups: {
-            groupIds: [
-              new ReferenceExpression(groupB.elemID, groupB),
-              new ReferenceExpression(groupC.elemID, groupC),
-              new ReferenceExpression(groupA.elemID, groupA),
-            ],
-          },
+          selfServicePasswordReset: { access: 'ALLOW' },
+          selfServiceUnlock: { access: 'DENY' },
         },
-      },
-    )
-    await filter.onFetch([groupType, groupRuleType, groupA, groupB, groupC, groupRule])
-    expect(groupRule.value.actions.assignUserToGroups.groupIds).toEqual([
-      new ReferenceExpression(groupA.elemID, groupA),
-      new ReferenceExpression(groupB.elemID, groupB),
-      new ReferenceExpression(groupC.elemID, groupC),
-    ])
+      })
+    })
   })
 })


### PR DESCRIPTION
Sort unordered list password policy rule to avoid noise in subsequent fetches

---

there are no notifications enabled for this type, so no need of noise reduction

---

_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 

_Okta_adapter_:
- In password policy rules with more then one method used for password reset, the list of methods will be sorted. 
