### PR TITLE
SALTO-5303: Add validator to remind users to change tenant specific values when deploying application (Okta)

### DIFF
--- a/packages/okta-adapter/src/change_validators/app_urls.ts
+++ b/packages/okta-adapter/src/change_validators/app_urls.ts
@@ -1,0 +1,36 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { APPLICATION_TYPE_NAME } from '../constants'
+
+export const DEFAULT_APP_URLS_VALIDATOR_VALUE = false
+
+/**
+* Remind users to update environment-specific fields when moving applications between Okta tenants
+*/
+export const appUrlsValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === APPLICATION_TYPE_NAME)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Warning',
+      message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
+      detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+    }))
+)

--- a/packages/okta-adapter/src/change_validators/app_urls.ts
+++ b/packages/okta-adapter/src/change_validators/app_urls.ts
@@ -30,7 +30,7 @@ export const appUrlsValidator: ChangeValidator = async changes => (
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning',
-      message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
-      detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+      message: 'Update environment-specific values when deploying application elements between Okta tenants',
+      detailedMessage: 'Update environment-specific values, such as URLs and subdomains, when deploying application elements between Okta tenants. Adjust these values by editing the relevant element in Salto.',
     }))
 )

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -34,6 +34,7 @@ import { usersValidator } from './user'
 import { appWithGroupPushValidator } from './app_with_group_push'
 import { appUserSchemaWithInactiveAppValidator } from './app_schema_with_inactive_app'
 import { appGroupAssignmentValidator } from './app_group_assignments'
+import { appUrlsValidator } from './app_urls'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -79,6 +80,7 @@ export default ({
     appWithGroupPush: appWithGroupPushValidator,
     groupPushToApplicationUniqueness: groupPushToApplicationUniquenessValidator,
     appGroupAssignment: appGroupAssignmentValidator,
+    appUrls: appUrlsValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -19,6 +19,7 @@ import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { client as clientUtils, config as configUtils, elements } from '@salto-io/adapter-components'
 import { ACCESS_POLICY_TYPE_NAME, CUSTOM_NAME_FIELD, IDP_POLICY_TYPE_NAME, MFA_POLICY_TYPE_NAME, OKTA, PASSWORD_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, SIGN_ON_POLICY_TYPE_NAME, AUTOMATION_TYPE_NAME, AUTHENTICATOR_TYPE_NAME, DEVICE_ASSURANCE } from './constants'
 import { DEFAULT_CONVERT_USERS_IDS_VALUE, DEFAULT_GET_USERS_STRATEGY } from './user_utils'
+import { DEFAULT_APP_URLS_VALIDATOR_VALUE } from './change_validators/app_urls'
 
 type UserDeployConfig = configUtils.UserDeployConfig
 const {
@@ -1778,6 +1779,11 @@ export const DEFAULT_CONFIG: OktaConfig = {
   [CLIENT_CONFIG]: {
     usePrivateAPI: true,
   },
+  [DEPLOY_CONFIG]: {
+    changeValidators: {
+      appUrls: DEFAULT_APP_URLS_VALIDATOR_VALUE,
+    },
+  },
 }
 
 const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [DEVICE_ASSURANCE, AUTHENTICATOR_TYPE_NAME, ACCESS_POLICY_TYPE_NAME,
@@ -1812,6 +1818,7 @@ export type ChangeValidatorName = (
   | 'appWithGroupPush'
   | 'groupPushToApplicationUniqueness'
   | 'appGroupAssignment'
+  | 'appUrls'
   )
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
@@ -1838,6 +1845,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     appWithGroupPush: { refType: BuiltinTypes.BOOLEAN },
     groupPushToApplicationUniqueness: { refType: BuiltinTypes.BOOLEAN },
     appGroupAssignment: { refType: BuiltinTypes.BOOLEAN },
+    appUrls: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/test/change_validators/app_urls.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_urls.test.ts
@@ -46,14 +46,14 @@ describe('appUrlsValidator', () => {
       {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
-        detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+        message: 'Update environment-specific values when deploying application elements between Okta tenants',
+        detailedMessage: 'Update environment-specific values, such as URLs and subdomains, when deploying application elements between Okta tenants. Adjust these values by editing the relevant element in Salto.',
       },
       {
         elemID: instance.elemID,
         severity: 'Warning',
-        message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
-        detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+        message: 'Update environment-specific values when deploying application elements between Okta tenants',
+        detailedMessage: 'Update environment-specific values, such as URLs and subdomains, when deploying application elements between Okta tenants. Adjust these values by editing the relevant element in Salto.',
       },
     ])
   })

--- a/packages/okta-adapter/test/change_validators/app_urls.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_urls.test.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { appUrlsValidator } from '../../src/change_validators/app_urls'
+import { OKTA, APPLICATION_TYPE_NAME } from '../../src/constants'
+
+describe('appUrlsValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+    instance = new InstanceElement(
+      'bookmarkApp',
+      type,
+      {
+        label: 'bookmark app',
+        status: 'ACTIVE',
+        signOnMode: 'BOOKMARK',
+        settings: {
+          app: {
+            domain: 'my-domain',
+          },
+        },
+      },
+    )
+  })
+  it('should return warning when adding or modifying application', async () => {
+    expect(await appUrlsValidator([
+      toChange({ after: instance }),
+      toChange({ before: instance, after: instance }),
+    ])).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
+        detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+      },
+      {
+        elemID: instance.elemID,
+        severity: 'Warning',
+        message: 'Remember to update environment-specific fields when moving applications between Okta tenants',
+        detailedMessage: 'Ensure a smooth deployment by updating environment-specific fields, such as URLs and subdomains, when moving applications between Okta tenants. Easily adjust these fields by editing the relevant elements in Salto.',
+      },
+    ])
+  })
+  it('should not return warning when removing application', async () => {
+    expect(await appUrlsValidator([toChange({ before: instance })])).toEqual([])
+  })
+})


### PR DESCRIPTION
Add a validator to remind users to change tenant specific values

---

For more context see ticket details.
The validator is disabled by default and can be enabled from the adapter's config file

---
_Release Notes_: 

_Okta_adapter_:
- Add the ability to setup a reminder to change tenant specific values (such as URLs or subdomains) when deploying applications. To enable it, add the following config to the deploy section in adapter config: 

```
okta = {
  deploy = {
    changeValidators = {
      appUrls = true
    }
  }
}

```


---
_User Notifications_: 
None
