### PR TITLE
SALTO-5309: Jsm Types should be hidden

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -184,7 +184,7 @@ const {
 const { createPaginator } = clientUtils
 const log = logger(module)
 
-const { query: queryFilter, ...otherCommonFilters } = commonFilters
+const { query: queryFilter, hideTypes: hideTypesFilter, ...otherCommonFilters } = commonFilters
 
 export const DEFAULT_FILTERS = [
   accountInfoFilter,
@@ -357,6 +357,7 @@ export const DEFAULT_FILTERS = [
   deployAttributesFilter,
   deployJsmTypesFilter,
   // Must be last
+  hideTypesFilter,
   defaultInstancesDeployFilter,
 ]
 

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -356,8 +356,8 @@ export const DEFAULT_FILTERS = [
   assetsObjectTypeOrderFilter,
   deployAttributesFilter,
   deployJsmTypesFilter,
+  hideTypesFilter, // Must run after defaultAttributesFilter and assetsObjectTypeOrderFilter, which also create types.
   // Must be last
-  hideTypesFilter,
   defaultInstancesDeployFilter,
 ]
 


### PR DESCRIPTION
In this PR, I changed the filters order so the types I create in 
```
  defaultAttributesFilter,
  assetsObjectTypeOrderFilter,
```
Can be hide as well   

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
