### PR TITLE
SALTO-5313: Salesforce Post Deploy Retrieve Zip Artifact

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -51,6 +51,7 @@ import {
 } from '../constants'
 import { CompleteSaveResult, SalesforceRecord, SfError } from './types'
 import {
+  ClientDeployConfig,
   ClientPollingConfig,
   ClientRateLimitConfig,
   ClientRetryConfig,
@@ -849,7 +850,7 @@ export default class SalesforceClient {
     this.setDeployPollingTimeout()
     const defaultDeployOptions = { rollbackOnError: true, ignoreWarnings: true }
     const { checkOnly = false } = deployOptions ?? {}
-    const optionsToSend = ['rollbackOnError', 'ignoreWarnings', 'purgeOnDelete', 'testLevel', 'runTests']
+    const optionsToSend: (keyof ClientDeployConfig)[] = ['rollbackOnError', 'ignoreWarnings', 'purgeOnDelete', 'testLevel', 'runTests', 'performRetrieve']
     const deployStatus = this.conn.metadata.deploy(
       zip,
       {

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -600,4 +600,5 @@ export const isSalesforceError = (error: Error): error is SalesforceError => {
 // Artifacts
 export const SalesforceArtifacts = {
   DeployPackageXml: 'package.xml',
+  PostDeployRetrieveZip: 'post-deploy-retrieve-zip.zip',
 } as const

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -348,7 +348,7 @@ export type QuickDeployParams = {
   hash: string
 }
 
-type ClientDeployConfig = Partial<{
+export type ClientDeployConfig = Partial<{
   rollbackOnError: boolean
   ignoreWarnings: boolean
   purgeOnDelete: boolean
@@ -357,6 +357,7 @@ type ClientDeployConfig = Partial<{
   runTests: string[]
   deleteBeforeUpdate: boolean
   quickDeployParams: QuickDeployParams
+  performRetrieve: boolean
 }>
 
 export enum RetryStrategyName {
@@ -612,6 +613,7 @@ const clientDeployConfigType = new ObjectType({
     runTests: { refType: new ListType(BuiltinTypes.STRING) },
     deleteBeforeUpdate: { refType: BuiltinTypes.BOOLEAN },
     quickDeployParams: { refType: QuickDeployParamsType },
+    performRetrieve: { refType: BuiltinTypes.BOOLEAN },
   } as Record<keyof ClientDeployConfig, FieldDefinition>,
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -33,7 +33,7 @@ import mockAdapter from './adapter'
 import { createValueSetEntry, createCustomObjectType, nullProgressReporter } from './utils'
 import { createElement, removeElement } from '../e2e_test/utils'
 import { mockTypes, mockDefaultValues } from './mock_elements'
-import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete } from './connection'
+import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete, mockRetrieveResult } from './connection'
 import { MAPPABLE_PROBLEM_TO_USER_FRIENDLY_MESSAGE, MappableSalesforceProblem } from '../src/client/user_facing_errors'
 import { GLOBAL_VALUE_SET } from '../src/filters/global_value_sets'
 import { apiNameSync, metadataTypeSync } from '../src/filters/utils'
@@ -1149,6 +1149,7 @@ describe('SalesforceAdapter CRUD', () => {
               fullName: mockDefaultValues.Profile.fullName,
               componentType: constants.PROFILE_METADATA_TYPE,
             }],
+            retrieveResult: await mockRetrieveResult({}),
           }))
           result = await adapter.deploy({
             changeGroup: {
@@ -1178,9 +1179,9 @@ describe('SalesforceAdapter CRUD', () => {
         it('should return correct artifacts', () => {
           const groups = result.extraProperties?.groups ?? []
           expect(groups).toHaveLength(1)
-          const artifacts = groups[0].artifacts ?? []
-          expect(artifacts).toHaveLength(1)
-          expect(artifacts[0]).toSatisfy(artifact => artifact.name === SalesforceArtifacts.DeployPackageXml)
+          const artifactNames = makeArray(groups[0].artifacts).map(artifact => artifact.name)
+          expect(artifactNames)
+            .toIncludeSameMembers([SalesforceArtifacts.DeployPackageXml, SalesforceArtifacts.PostDeployRetrieveZip])
         })
       })
 

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -166,6 +166,7 @@ type GetDeployResultParams = {
   testCompleted?: number
   testErrors?: number
   errorMessage?: string
+  retrieveResult?: RetrieveResult
 }
 
 type MockDeployResultParams = GetDeployResultParams & Required<Pick<GetDeployResultParams, 'id'>>
@@ -182,6 +183,7 @@ export const mockDeployResultComplete = ({
   checkOnly = false,
   testCompleted = 0,
   testErrors = 0,
+  retrieveResult,
 }: MockDeployResultParams): DeployResult => ({
   id,
   checkOnly,
@@ -192,6 +194,7 @@ export const mockDeployResultComplete = ({
     componentFailures: componentFailure.map(mockDeployMessage),
     componentSuccesses: componentSuccess.map(mockDeployMessage),
     runTestResult: mockRunTestResult(runTestResult),
+    retrieveResult,
   }],
   ignoreWarnings,
   lastModifiedDate: '2020-05-01T14:31:36.000Z',


### PR DESCRIPTION
Add Salesforce Post Deploy Retrieve Zip Artifact for metadata deploys with the option `performRetrieve` enabled.

---

Here's an example of the retrieved zip for modification on `salesforce.Role.instance.CEO`:

<img width="805" alt="Screen Shot 2024-01-22 at 18 38 30" src="https://github.com/salto-io/salto/assets/92912659/0a4b8ca0-0b4d-421e-8591-d47ba7d44fc1">


---
_Release Notes_: 
Salesforce Adapter:
- Add Salesforce Post Deploy Retrieve Zip Artifact for metadata deploys with the option `performRetrieve` enabled. 

---
_User Notifications_: 
_None_
