### PR TITLE
SALTO-4861 - Salesforce: fix mapping of nested objects in deploy errors

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -79,16 +79,10 @@ const getTypeOfNestedElement = (changeElem: MetadataInstanceElement, fieldName: 
   return fieldType
 }
 
-const getNamesOfNestedElements = (element: MetadataInstanceElement, fieldName: string): string[] => {
-  if (_.isArray(element.value[fieldName])) {
-    return element.value[fieldName]
-      .map((fieldValue: Value) => [apiNameSync(element), fieldValue[INSTANCE_FULL_NAME_FIELD]].join(API_NAME_SEPARATOR))
-  }
-  if (_.isPlainObject(element.value[fieldName])) {
-    return makeArray(element.value[fieldName][INSTANCE_FULL_NAME_FIELD])
-  }
-  return []
-}
+const getNamesOfNestedElements = (element: MetadataInstanceElement, fieldName: string): string[] => (
+  makeArray(element.value[fieldName])
+    .map((fieldValue: Value) => [apiNameSync(element), fieldValue[INSTANCE_FULL_NAME_FIELD]].join(API_NAME_SEPARATOR))
+)
 
 const addNestedInstancesToPackageManifest = async (
   pkg: DeployPackage,

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -399,16 +399,6 @@ const quickDeployOrDeploy = async (
 const isQuickDeployable = (deployRes: SFDeployResult): boolean =>
   deployRes.id !== undefined && deployRes.checkOnly && deployRes.success && deployRes.numberTestsCompleted >= 1
 
-const isEmptyValue = (value: Value): boolean => {
-  if (_.isArray(value)) {
-    return value.length === 0
-  }
-  if (_.isPlainObject(value)) {
-    return Object.keys(value).length === 0
-  }
-  return value === undefined
-}
-
 const mapNestedNamesToElemIds = (nestedType: TypeElement, nestedNames: string[]): NameToElemIDMap => (
   Object.fromEntries(
     nestedNames
@@ -427,11 +417,11 @@ const getExistingNestedFields = (
   nestedNames: string[]
 }[] => (
   nestedTypeInfo.nestedInstanceFields
-    .filter(field => !isEmptyValue(instance.value[field]))
     .map(field => ({
       nestedType: getTypeOfNestedElement(instance, field),
       nestedNames: getNamesOfNestedElements(instance, field),
     }))
+    .filter(({ nestedNames }) => nestedNames.length > 0)
 )
 
 export const deployMetadata = async (

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -167,7 +167,13 @@ describe('SalesforceAdapter CRUD', () => {
             { [CORE_ANNOTATIONS.PARENT]:
               new ReferenceExpression(mockTypes.TestCustomObject__c.elemID, mockTypes.TestCustomObject__c) }
           )
-          workflowFieldUpdate = createInstanceElement(mockDefaultValues.WorkflowFieldUpdate, mockTypes.Workflow)
+          workflowFieldUpdate = createInstanceElement(
+            {
+              ...mockDefaultValues.WorkflowFieldUpdate,
+              [INSTANCE_FULL_NAME_FIELD]: 'TestCustomObject__c.TestWorkflowFieldUpdate',
+            },
+            mockTypes.WorkflowFieldUpdate
+          )
 
           connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
             success: false,
@@ -189,8 +195,8 @@ describe('SalesforceAdapter CRUD', () => {
               // WorkflowFieldUpdate failure
               {
                 componentType: 'WorkflowFieldUpdate',
-                fullName: 'ChangeRequest.Update_Status_to_Authorised',
-                problem: 'Some workflow task error',
+                fullName: 'TestCustomObject__c.TestWorkflowFieldUpdate',
+                problem: 'Some workflow field update error',
               },
             ],
           }))
@@ -225,11 +231,11 @@ describe('SalesforceAdapter CRUD', () => {
 
           expect(result.errors[1].severity).toEqual('Error' as SeverityLevel)
 
-          // WorkflowTask will not have an ElemID because on failure
-          //  we only return the sub-instance and not the wrapped instance
-          expect(result.errors[2].message).toContain('Some workflow task error')
-          expect(isSaltoElementError(result.errors[2])).toBeFalse()
-          expect(result.errors[2].severity).toEqual('Error' as SeverityLevel)
+          expect(result.errors[2]).toEqual({
+            message: expect.stringContaining('Some workflow field update error'),
+            severity: 'Error',
+            elemID: workflowFieldUpdate.elemID,
+          })
         })
       })
 

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -44,7 +44,7 @@ import {
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
   SETTINGS_METADATA_TYPE,
-  STATUS,
+  STATUS, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE,
 } from '../src/constants'
@@ -189,7 +189,7 @@ export const mockTypes = {
   }),
   WorkflowFieldUpdate: createMetadataObjectType({
     annotations: {
-      metadataType: WORKFLOW_TASK_METADATA_TYPE,
+      metadataType: WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
       dirName: 'workflows',
       suffix: 'workflow',
     },


### PR DESCRIPTION
We need to add the types and names of nested instances for when we get deploy errors that reference them

Note that there are still error conditions in which the error mapping will be wrong. See ticket for further details.
---
~Unit tests pending.~

Before the change:
<img width="335" alt="image" src="https://github.com/salto-io/salto/assets/117099820/ab3d8228-8d04-4840-9318-e5c5741135b0">

After the change:
<img width="836" alt="image" src="https://github.com/salto-io/salto/assets/117099820/93af9701-2f9b-470f-9a08-7f02857f5aa8">

---
_Release Notes_: 
Salesforce: Improved mapping of deploy errors to elements

---
_User Notifications_: 
N/A
