### PR TITLE
SALTO-5321: add guards in the deploy of themes

### DIFF
--- a/packages/zendesk-adapter/test/filters/guide_theme.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_theme.test.ts
@@ -260,6 +260,26 @@ describe('filterCreator', () => {
         expect(mockCreate).not.toHaveBeenCalled()
       })
     })
+    describe('with invalid elements', () => {
+      beforeEach(() => {
+        mockCreate.mockResolvedValue({ themeId: 'newId', errors: [] })
+        mockPublish.mockResolvedValue([])
+      })
+      it('should not fail', async () => {
+        const invalidTheme = new InstanceElement('invalidTheme', themeType,
+          {
+            name: 'SevenFlags',
+            brand_id: new ReferenceExpression(brand1.elemID, brand1),
+            root: {},
+          })
+        const changes = [toChange({ after: invalidTheme })]
+        expect(await filter.deploy?.(changes))
+          .toEqual({ deployResult: { appliedChanges: changes, errors: [] }, leftoverChanges: [] })
+        expect((changes[0] as AdditionChange<InstanceElement>).data.after.value.id).toEqual('newId')
+        expect(mockCreate).toHaveBeenCalled()
+        expect(mockPublish).not.toHaveBeenCalled()
+      })
+    })
 
     describe('create theme', () => {
       let changes: Change<InstanceElement>[]


### PR DESCRIPTION
add guards in the deploy of themes

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
