### PR TITLE
SALTO-5316 fix IssueLayout id

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -139,6 +139,7 @@ const deployLayoutChange = async (
     }
     const response = await getLayoutResponse({ variables, client, typeName })
     if (!isIssueLayoutResponse(response.data)) {
+      log.error('received invalid response from jira', response)
       throw Error('Failed to deploy issue layout changes due to bad response from jira service')
     }
     const issueLayoutId = response.data.issueLayoutConfiguration.issueLayoutResult.id

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { CORE_ANNOTATIONS, Change, Element, InstanceElement, ReferenceExpression, getChangeData, isAdditionChange, isInstanceChange, isInstanceElement, isRemovalChange } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, Change, Element, InstanceElement, ReferenceExpression, getChangeData, isInstanceChange, isInstanceElement, isRemovalChange } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { getParent, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -119,18 +119,16 @@ const deployLayoutChange = async (
         items,
       },
     }
-    if (isAdditionChange(change)) {
-      const variables = {
-        projectId: parentProject.value.id,
-        extraDefinerId: layout.value.extraDefinerId.value.value.id,
-      }
-      const response = await getLayoutResponse({ variables, client, typeName })
-      if (!isIssueLayoutResponse(response.data)) {
-        throw Error('Failed to deploy issue layout changes due to bad response from jira service')
-      }
-      layout.value.id = response.data.issueLayoutConfiguration.issueLayoutResult.id
+    const variables = {
+      projectId: parentProject.value.id,
+      extraDefinerId: layout.value.extraDefinerId.value.value.id,
     }
-    const url = `/rest/internal/1.0/issueLayouts/${layout.value.id}`
+    const response = await getLayoutResponse({ variables, client, typeName })
+    if (!isIssueLayoutResponse(response.data)) {
+      throw Error('Failed to deploy issue layout changes due to bad response from jira service')
+    }
+    const issueLayoutId = response.data.issueLayoutConfiguration.issueLayoutResult.id
+    const url = `/rest/internal/1.0/issueLayouts/${issueLayoutId}`
     await client.put({ url, data })
     return
   }

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -15,7 +15,18 @@
 */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { CORE_ANNOTATIONS, Change, Element, InstanceElement, ReferenceExpression, getChangeData, isInstanceChange, isInstanceElement, isRemovalChange } from '@salto-io/adapter-api'
+import {
+  CORE_ANNOTATIONS,
+  Change,
+  Element,
+  InstanceElement,
+  ReferenceExpression,
+  getChangeData,
+  isInstanceChange,
+  isInstanceElement,
+  isRemovalChange,
+  isAdditionChange,
+} from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { getParent, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -23,7 +34,7 @@ import { ISSUE_LAYOUT_TYPE, PROJECT_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { createLayoutType, LayoutConfigItem } from './layout_types'
 import { addAnnotationRecursively, setTypeDeploymentAnnotations } from '../../utils'
-import { getLayout, getLayoutResponse, isIssueLayoutResponse } from './layout_service_operations'
+import { generateLayoutId, getLayout, getLayoutResponse, isIssueLayoutResponse } from './layout_service_operations'
 import { deployChanges } from '../../deployment/standard_deployment'
 import JiraClient from '../../client/client'
 
@@ -122,6 +133,9 @@ const deployLayoutChange = async (
     const variables = {
       projectId: parentProject.value.id,
       extraDefinerId: layout.value.extraDefinerId.value.value.id,
+    }
+    if (isAdditionChange(change)) {
+      layout.value.id = generateLayoutId(variables.projectId, variables.extraDefinerId)
     }
     const response = await getLayoutResponse({ variables, client, typeName })
     if (!isIssueLayoutResponse(response.data)) {

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -119,7 +119,7 @@ const fromLayoutConfigRespToLayoutConfig = (
   return { items }
 }
 
-const generateLayoutId = (
+export const generateLayoutId = (
   projectId: string, extraDefinerId: string | number
 ): string => projectId.concat('_').concat(extraDefinerId.toString())
 

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -45,7 +45,7 @@ type QueryVariables = {
     projectId: string | number
     extraDefinerId: string | number
     layoutType?: string
-  }
+}
 
 export type LayoutTypeName = 'RequestForm' | 'IssueView' | 'IssueLayout'
 export const LAYOUT_TYPE_NAME_TO_DETAILS: Record<LayoutTypeName, LayoutTypeDetails> = {
@@ -86,12 +86,11 @@ export const getLayoutResponse = async ({
     if (query === undefined) {
       log.error(`Failed to get issue layout for project ${variables.projectId} and screen ${variables.extraDefinerId}: query is undefined`)
     }
-    const response = await client.gqlPost({
+    return await client.gqlPost({
       url: baseUrl,
       query,
       variables,
     })
-    return response
   } catch (e) {
     log.error(`Failed to get issue layout for project ${variables.projectId} and screen ${variables.extraDefinerId}: ${e}`)
   }
@@ -120,6 +119,10 @@ const fromLayoutConfigRespToLayoutConfig = (
   return { items }
 }
 
+const generateLayoutId = (
+  projectId: string, extraDefinerId: string | number
+): string => projectId.concat(extraDefinerId.toString())
+
 export const getLayout = async ({
   extraDefinerId,
   response,
@@ -138,7 +141,7 @@ export const getLayout = async ({
   if (!Array.isArray(response.data) && isIssueLayoutResponse(response.data) && instance.path !== undefined) {
     const { issueLayoutResult } = response.data.issueLayoutConfiguration
     const value = {
-      id: issueLayoutResult.id,
+      id: generateLayoutId(instance.value.id, extraDefinerId),
       extraDefinerId,
       issueLayoutConfig: fromLayoutConfigRespToLayoutConfig(response.data.issueLayoutConfiguration),
     }

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -121,7 +121,7 @@ const fromLayoutConfigRespToLayoutConfig = (
 
 const generateLayoutId = (
   projectId: string, extraDefinerId: string | number
-): string => projectId.concat(extraDefinerId.toString())
+): string => projectId.concat('_').concat(extraDefinerId.toString())
 
 export const getLayout = async ({
   extraDefinerId,

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -54,88 +54,107 @@ describe('issue layout filter', () => {
     const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
     config.fetch.enableIssueLayouts = true
     filter = issueLayoutFilter(getFilterParams({ client, config })) as typeof filter
+    screenType = new ObjectType({ elemID: new ElemID(JIRA, 'Screen'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+      } })
+    screenInstance = new InstanceElement(
+      'screen1',
+      screenType,
+      {
+        id: 11,
+      }
+    )
+    fieldType = new ObjectType({ elemID: new ElemID(JIRA, 'Field') })
+    fieldInstance1 = new InstanceElement(
+      'testField1',
+      fieldType,
+      {
+        id: 'testField1',
+        name: 'TestField1',
+        type: 'testField1',
+      }
+    )
+    fieldInstance2 = new InstanceElement(
+      'testField2',
+      fieldType,
+      {
+        id: 'testField2',
+        name: 'TestField2',
+        schema: {
+          system: 'testField2',
+        },
+      }
+    )
+    screenSchemeType = new ObjectType({
+      elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        screens: { refType: screenType },
+      },
+    })
+    issueTypeScreenSchemeItemType = new ObjectType({
+      elemID: new ElemID(JIRA, 'IssueTypeScreenSchemeItem'),
+      fields: {
+        issueTypeId: { refType: BuiltinTypes.STRING },
+        screenSchemeId: { refType: screenSchemeType },
+      },
+    })
+    issueTypeScreenSchemeType = new ObjectType({
+      elemID: new ElemID(JIRA, 'IssueTypeScreenScheme'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        issueTypeMappings: { refType: new ListType(issueTypeScreenSchemeItemType) },
+      },
+    })
+    projectType = new ObjectType({
+      elemID: new ElemID(JIRA, PROJECT_TYPE),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        simplified: { refType: BuiltinTypes.BOOLEAN },
+        issueTypeScreenScheme: { refType: issueTypeScreenSchemeType },
+        key: { refType: BuiltinTypes.STRING },
+      },
+    })
+    screenSchemeInstance = new InstanceElement(
+      'screenScheme1',
+      screenSchemeType,
+      {
+        id: 111,
+        screens: { default: new ReferenceExpression(screenInstance.elemID, screenInstance) },
+      }
+    )
+    issueTypeScreenSchemeInstance = new InstanceElement(
+      'issueTypeScreenScheme1',
+      issueTypeScreenSchemeType,
+      {
+        id: 1111,
+        issueTypeMappings: [
+          {
+            issueTypeId: 1,
+            screenSchemeId: new ReferenceExpression(screenSchemeInstance.elemID, screenSchemeInstance),
+          },
+        ],
+      }
+    )
+    projectInstance = new InstanceElement(
+      'project1',
+      projectType,
+      {
+        id: '11111',
+        key: 'projKey',
+        name: 'project1',
+        simplified: false,
+        projectTypeKey: 'software',
+        issueTypeScreenScheme:
+          new ReferenceExpression(issueTypeScreenSchemeInstance.elemID, issueTypeScreenSchemeInstance),
+      },
+      [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1']
+    )
   })
   describe('on fetch', () => {
     beforeEach(async () => {
       client = mockCli.client
-      screenType = new ObjectType({ elemID: new ElemID(JIRA, 'Screen'),
-        fields: {
-          id: { refType: BuiltinTypes.NUMBER },
-        } })
-      screenInstance = new InstanceElement(
-        'screen1',
-        screenType,
-        {
-          id: 11,
-        }
-      )
-
-      screenSchemeType = new ObjectType({
-        elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE),
-        fields: {
-          id: { refType: BuiltinTypes.NUMBER },
-          screens: { refType: screenType },
-        },
-      })
-      screenSchemeInstance = new InstanceElement(
-        'screenScheme1',
-        screenSchemeType,
-        {
-          id: 111,
-          screens: { default: new ReferenceExpression(screenInstance.elemID, screenInstance) },
-        }
-      )
-
-      issueTypeScreenSchemeItemType = new ObjectType({
-        elemID: new ElemID(JIRA, 'IssueTypeScreenSchemeItem'),
-        fields: {
-          issueTypeId: { refType: BuiltinTypes.STRING },
-          screenSchemeId: { refType: screenSchemeType },
-        },
-      })
-      issueTypeScreenSchemeType = new ObjectType({
-        elemID: new ElemID(JIRA, 'IssueTypeScreenScheme'),
-        fields: {
-          id: { refType: BuiltinTypes.NUMBER },
-          issueTypeMappings: { refType: new ListType(issueTypeScreenSchemeItemType) },
-        },
-      })
-      issueTypeScreenSchemeInstance = new InstanceElement(
-        'issueTypeScreenScheme1',
-        issueTypeScreenSchemeType,
-        {
-          id: 1111,
-          issueTypeMappings: [
-            {
-              issueTypeId: 1,
-              screenSchemeId: new ReferenceExpression(screenSchemeInstance.elemID, screenSchemeInstance),
-            },
-          ],
-        }
-      )
-      projectType = new ObjectType({
-        elemID: new ElemID(JIRA, PROJECT_TYPE),
-        fields: {
-          id: { refType: BuiltinTypes.NUMBER },
-          simplified: { refType: BuiltinTypes.BOOLEAN },
-          issueTypeScreenScheme: { refType: issueTypeScreenSchemeType },
-          key: { refType: BuiltinTypes.STRING },
-        },
-      })
-      projectInstance = new InstanceElement(
-        'project1',
-        projectType,
-        {
-          id: '11111',
-          key: 'projKey',
-          name: 'project1',
-          simplified: false,
-          projectTypeKey: 'software',
-          issueTypeScreenScheme:
-          new ReferenceExpression(issueTypeScreenSchemeInstance.elemID, issueTypeScreenSchemeInstance),
-        },
-        [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1']
-      )
       issueTypeType = new ObjectType({ elemID: new ElemID(JIRA, 'IssueType') })
       issueTypeInstance = new InstanceElement(
         'issueType1',
@@ -145,28 +164,6 @@ describe('issue layout filter', () => {
           name: 'OwnerTest',
         }
       )
-      fieldType = new ObjectType({ elemID: new ElemID(JIRA, 'Field') })
-      fieldInstance1 = new InstanceElement(
-        'testField1',
-        fieldType,
-        {
-          id: 'testField1',
-          name: 'TestField1',
-          type: 'testField1',
-        }
-      )
-      fieldInstance2 = new InstanceElement(
-        'testField2',
-        fieldType,
-        {
-          id: 'testField2',
-          name: 'TestField2',
-          schema: {
-            system: 'testField2',
-          },
-        }
-      )
-
       mockGet = jest.spyOn(client, 'gqlPost')
       mockGet.mockImplementation(params => {
         if (params.url === '/rest/gira/1') {

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -23,6 +23,7 @@ import issueLayoutFilter from '../../../src/filters/layouts/issue_layout'
 import { getFilterParams, mockClient } from '../../utils'
 import { ISSUE_LAYOUT_TYPE, JIRA, PROJECT_TYPE, SCREEN_SCHEME_TYPE } from '../../../src/constants'
 import { createLayoutType } from '../../../src/filters/layouts/layout_types'
+import { generateLayoutId } from '../../../src/filters/layouts/layout_service_operations'
 
 describe('issue layout filter', () => {
   let connection: MockInterface<clientUtils.APIConnection>
@@ -407,7 +408,7 @@ describe('issue layout filter', () => {
         'issueLayout',
         issueLayoutType,
         {
-          id: '2',
+          id: generateLayoutId(projectInstance.value.id, screenInstance.value.id),
           extraDefinerId: new ReferenceExpression(screenInstance.elemID, screenInstance),
           issueLayoutConfig: {
             items: [


### PR DESCRIPTION
In some cases, IssueLayout ids are being changed over and over, causing fetches to be very big.
We need to replace the id of IssueLayouts with a combination of screenId and projectId

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
