### PR TITLE
SALTO-5325: Omit priority field from policies when not relevant

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -20,7 +20,6 @@ export const mockDefaultValues: Record<string, Values> = {
   [ACCESS_POLICY_TYPE_NAME]: {
     status: 'ACTIVE',
     name: 'authentication policy',
-    priority: 1,
     system: false,
     type: 'ACCESS_POLICY',
   },
@@ -134,7 +133,6 @@ export const mockDefaultValues: Record<string, Values> = {
   [PROFILE_ENROLLMENT_POLICY_TYPE_NAME]: {
     status: 'ACTIVE',
     name: 'profile',
-    priority: 1,
     system: false,
     type: 'PROFILE_ENROLLMENT',
   },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -130,6 +130,7 @@ const POLICY_TYPE_NAME_TO_PARAMS: Record<PolicyTypeNames, PolicyParams> = {
 const getPolicyItemsName = (policyName: string): string => (policyName === AUTOMATION_TYPE_NAME ? 'Automations' : `${(policyName).slice(0, -1)}ies`)
 const getPolicyRuleItemsName = (policyRuleName: string): string => (`${policyRuleName}s`)
 const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
+  const policiesToOmitPriorities = [ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, IDP_POLICY_TYPE_NAME]
   const policiesConfig = Object.entries(POLICY_TYPE_NAME_TO_PARAMS).map(([typeName, details]) => {
     const policyRuleConfig = {
       transformation: {
@@ -260,7 +261,11 @@ const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
         transformation: {
           serviceIdField: 'id',
           fieldsToHide: [{ fieldName: 'id' }],
-          fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_links' }),
+          fieldsToOmit: [
+            ...DEFAULT_FIELDS_TO_OMIT,
+            { fieldName: '_links' },
+            ...(policiesToOmitPriorities.includes(typeName) ? [{ fieldName: 'priority', fieldType: 'number' }] : []),
+          ],
           fieldTypeOverrides: [{ fieldName: 'policyRules', fieldType: `list<${details.ruleName}>` }],
           standaloneFields: [{ fieldName: 'policyRules' }],
           serviceUrl: details.policyServiceUrl,


### PR DESCRIPTION
I omitted `priority` field from policies that has no order and can't be deployed (it returned by default the API as other types of policies supports this)

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 

_Okta_adapter_:
- In AccessPolicy, ProfileEnrollment Policy and IDP policy instances, 'priority' field will be omitted
