### PR TITLE
SALTO-5328: Omit condition's and trigger's ids in jiraWorkflow

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1240,6 +1240,20 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       },
     },
   },
+  WorkflowRuleConfiguration: {
+    transformation: {
+      fieldsToHide: [
+        { fieldName: 'id' },
+      ],
+    },
+  },
+  WorkflowTrigger: {
+    transformation: {
+      fieldsToHide: [
+        { fieldName: 'id' },
+      ],
+    },
+  },
   WorkflowRuleConfiguration_parameters: {
     transformation: {
       fieldTypeOverrides: [

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1242,14 +1242,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   },
   WorkflowRuleConfiguration: {
     transformation: {
-      fieldsToHide: [
+      fieldsToOmit: [
         { fieldName: 'id' },
       ],
     },
   },
   WorkflowTrigger: {
     transformation: {
-      fieldsToHide: [
+      fieldsToOmit: [
         { fieldName: 'id' },
       ],
     },


### PR DESCRIPTION
_Omit condition's and trigger's ids in jiraWorkflow_

---

_Additional context for reviewer_
* it does not affect any user - the jiraWorkflow is behind a config flag

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
