### PR TITLE
SALTO-5331: Fixed jql in queue

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/queue.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/queue.ts
@@ -21,14 +21,6 @@ import { JIRA } from '../../../../src/constants'
 export const createQueueValues = (name: string, allElements: Element[]): Values => ({
   name,
   jql: new TemplateExpression({ parts: [
-    createReference(new ElemID(JIRA, 'Field', 'instance', 'Project__project'), allElements),
-    ' = ',
-    createReference(new ElemID(JIRA, 'Project', 'instance', 'Support'), allElements, ['key']),
-    ' AND ',
-    createReference(new ElemID(JIRA, 'Field', 'instance', 'Project__project'), allElements),
-    ' = ',
-    createReference(new ElemID(JIRA, 'Project', 'instance', 'Support'), allElements, ['key']),
-    ' AND ',
     createReference(new ElemID(JIRA, 'Field', 'instance', 'Resolution__resolution'), allElements),
     ' = UNRESOLVED',
   ] }),

--- a/packages/jira-adapter/src/filters/queue_fetch.ts
+++ b/packages/jira-adapter/src/filters/queue_fetch.ts
@@ -54,7 +54,10 @@ const QUEUES_CATAGORIES_RESPONSE_SCHEME = Joi.object({
 
 const isQueuesCatagoriesResponse = createSchemeGuard<QueuesCatagoriesResponse>(QUEUES_CATAGORIES_RESPONSE_SCHEME)
 
-const replaceTypeWithIssueType = (input: string): string => input.replace(/\btype\b/g, 'issuetype')
+const fixJql = (input: string): string => {
+  const firstProjectKeyPattern = /^project\s*=\s*\w+\s*AND\s*/i
+  return input.replace(firstProjectKeyPattern, '').replace(/\btype\b/g, 'issuetype')
+}
 
 const addQueueStarAndPriority = async (
   projectKeysToQueues: Record<string, InstanceElement[]>,
@@ -93,7 +96,7 @@ const filter: FilterCreator = ({ config, client }) => ({
         instance.value.columns = instance.value.fields
         delete instance.value.fields
         if (instance.value.jql) {
-          instance.value.jql = replaceTypeWithIssueType(instance.value.jql)
+          instance.value.jql = fixJql(instance.value.jql)
         }
       })
 

--- a/packages/jira-adapter/test/filters/queue_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/queue_fetch.test.ts
@@ -43,6 +43,7 @@ describe('queueFetch filter', () => {
             name: 'queue1',
             fields: ['Summary'],
             projectKey: 'PROJ1',
+            jql: 'project = ICP56 AND type = Bug',
           },
         )
         mockGet.mockImplementation(async params => {
@@ -117,6 +118,20 @@ describe('queueFetch filter', () => {
         expect(queueInstance.value.columns).toEqual(['Summary'])
         expect(queueInstance.value.canBeHidden).toBeUndefined()
         expect(queueInstance.value.favourite).toBeUndefined()
+      })
+      it('should fix jql', async () => {
+        await filter.onFetch([queueInstance])
+        expect(queueInstance.value.jql).toEqual('issuetype = Bug')
+      })
+      it('should remove only the first project key', async () => {
+        queueInstance.value.jql = 'project = ICP56 AND project = ICP56 AND type = Bug'
+        await filter.onFetch([queueInstance])
+        expect(queueInstance.value.jql).toEqual('project = ICP56 AND issuetype = Bug')
+      })
+      it('should do nothing if regex is not match', async () => {
+        queueInstance.value.jql = 'assignee = currentUser() AND resolution = Unresolved'
+        await filter.onFetch([queueInstance])
+        expect(queueInstance.value.jql).toEqual('assignee = currentUser() AND resolution = Unresolved')
       })
     })
 })


### PR DESCRIPTION
When fetching a queue, the API adds 'project = <ProjectKey>' at the beginning of the JQL. This doesn't appear to have any functional impact, but it is causing a lot of unnecessary noise

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter:_
The JQL for queues will no longer include an unnecessary 'project = <projectKey>' at the beginning.

---
_User Notifications_: 
_Jira Adapter:_
The JQL for queues will no longer include an unnecessary 'project = <projectKey>' at the beginning.
