### PR TITLE
SALTO-2392 resolve account specific values in workflows

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -67,6 +67,7 @@ import addImportantValuesFilter from './filters/add_important_values'
 import addBundleReferences from './filters/bundle_ids'
 import excludeCustomRecordTypes from './filters/exclude_by_criteria/exclude_custom_record_types'
 import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
+import workflowAccountSpecificValues from './filters/workflow_account_specific_values'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
 import { getLastServerTime, getOrCreateServerTimeElements, getLastServiceIdToFetchTime } from './server_time'
 import { getChangedObjects } from './changes_detector/changes_detector'
@@ -137,6 +138,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: savedSearchesAuthorInformation, addsNewInformation: true },
   { creator: translationConverter },
   { creator: accountSpecificValues },
+  // the preDeploy of workflowAccountSpecificValues should run before accountSpecificValues
+  { creator: workflowAccountSpecificValues, addsNewInformation: true },
   { creator: suiteAppConfigElementsFilter },
   { creator: configFeaturesFilter },
   { creator: customRecordsFilter },

--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -16,7 +16,7 @@
 import { values, collections } from '@salto-io/lowerdash'
 import { ChangeError, getChangeData, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { isStandardInstanceOrCustomRecordType } from '../types'
-import { ACCOUNT_SPECIFIC_VALUE } from '../constants'
+import { ACCOUNT_SPECIFIC_VALUE, WORKFLOW } from '../constants'
 import { isElementContainsStringValue } from './utils'
 import { NetsuiteChangeValidator } from './types'
 
@@ -30,6 +30,10 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
     .map(async change => {
       const element = getChangeData(change)
       if (!isStandardInstanceOrCustomRecordType(element)) {
+        return undefined
+      }
+      // workflow account specific values are handled in another CV
+      if (element.elemID.typeName === WORKFLOW) {
         return undefined
       }
       if (!isElementContainsStringValue(element, ACCOUNT_SPECIFIC_VALUE)) {

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -16,7 +16,7 @@
 import { AdditionChange, ChangeError, ElemID, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, ModificationChange, toChange, Value } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP, resolvePath } from '@salto-io/adapter-utils'
 import { ACCOUNT_SPECIFIC_VALUE, INIT_CONDITION, WORKFLOW } from '../constants'
-import { handleWorkflowAccountSpecificValuesOnDeploy } from '../filters/workflow_account_specific_values'
+import { resolveWorkflowsAccountSpecificValues } from '../filters/workflow_account_specific_values'
 import { NetsuiteChangeValidator } from './types'
 
 const SEND_EMAIL_ACTION = 'sendemailaction'
@@ -123,7 +123,7 @@ const changeValidator: NetsuiteChangeValidator = async (
     after: change.data.after.clone(),
   }) as AdditionChange<InstanceElement> | ModificationChange<InstanceElement>)
 
-  const resolveWarnings = await handleWorkflowAccountSpecificValuesOnDeploy(
+  const resolveWarnings = await resolveWorkflowsAccountSpecificValues(
     clonedWorkflowChanges.map(getChangeData),
     elementsSource
   )

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -13,9 +13,10 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { AdditionChange, ChangeError, ElemID, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, ModificationChange, Value } from '@salto-io/adapter-api'
+import { AdditionChange, ChangeError, ElemID, getChangeData, InstanceElement, isAdditionChange, isAdditionOrModificationChange, isEqualValues, isInstanceChange, ModificationChange, ReadOnlyElementsSource, toChange, Value } from '@salto-io/adapter-api'
 import { walkOnElement, WALK_NEXT_STEP, resolvePath } from '@salto-io/adapter-utils'
-import { ACCOUNT_SPECIFIC_VALUE, WORKFLOW } from '../constants'
+import { ACCOUNT_SPECIFIC_VALUE, INIT_CONDITION, WORKFLOW } from '../constants'
+import { handleWorkflowAccountSpecificValuesOnDeploy } from '../filters/workflow_account_specific_values'
 import { NetsuiteChangeValidator } from './types'
 
 const SEND_EMAIL_ACTION = 'sendemailaction'
@@ -24,7 +25,6 @@ const RECIPIENT = 'recipient'
 const SPECIFIC = 'SPECIFIC'
 
 const PARAMETER = 'parameter'
-const INIT_CONDITION = 'initcondition'
 
 const toValidationError = (instance: InstanceElement, probField: string): ChangeError => ({
   elemID: instance.elemID,
@@ -60,56 +60,111 @@ const isNestedValueChanged = (
   resolvePath(change.data.before, nestedElemId)
 )
 
-const changeValidator: NetsuiteChangeValidator = async changes => (
-  changes
-    .filter(isAdditionOrModificationChange)
-    .filter(isInstanceChange)
-    .flatMap(change => {
-      const instance = getChangeData(change)
-      if (instance.elemID.typeName !== WORKFLOW) {
-        return []
+const getChangeErrorsOnAccountSpecificValues = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>,
+): ChangeError[] => {
+  const instance = getChangeData(change)
+  const sendEmailActionFieldsWithAccountSpecificValues = new Set<string>()
+  const conditionsWithAccountSpecificValues = new Set<string>()
+
+  walkOnElement({
+    element: instance,
+    func: ({ value, path }) => {
+      if (path.isAttrID()) {
+        return WALK_NEXT_STEP.SKIP
       }
+      if (path.createParentID().name === SEND_EMAIL_ACTION) {
+        if (value?.[SENDER] === ACCOUNT_SPECIFIC_VALUE && value?.sendertype === SPECIFIC) {
+          sendEmailActionFieldsWithAccountSpecificValues.add(SENDER)
+        }
+        if (value?.[RECIPIENT] === ACCOUNT_SPECIFIC_VALUE && value?.recipienttype === SPECIFIC) {
+          sendEmailActionFieldsWithAccountSpecificValues.add(RECIPIENT)
+        }
+      }
+      if (path.name === PARAMETER) {
+        const conditionElemId = findClosestInitConditionAncestorElemID(path) ?? path
+        if (
+          !conditionsWithAccountSpecificValues.has(conditionElemId.getFullName())
+          && Object.values(value).some((val: Value) => val?.value === ACCOUNT_SPECIFIC_VALUE)
+          && isNestedValueChanged(change, conditionElemId)
+        ) {
+          conditionsWithAccountSpecificValues.add(conditionElemId.getFullName())
+        }
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
 
-      const sendEmailActionFieldsWithAccountSpecificValues = new Set<string>()
-      const conditionsWithAccountSpecificValues = new Set<string>()
+  const sendEmailActionErrors = Array.from(sendEmailActionFieldsWithAccountSpecificValues)
+    .map(fieldName => toValidationError(instance, fieldName))
 
-      walkOnElement({
-        element: instance,
-        func: ({ value, path }) => {
-          if (path.isAttrID()) {
-            return WALK_NEXT_STEP.SKIP
-          }
-          if (path.createParentID().name === SEND_EMAIL_ACTION) {
-            if (value?.[SENDER] === ACCOUNT_SPECIFIC_VALUE && value?.sendertype === SPECIFIC) {
-              sendEmailActionFieldsWithAccountSpecificValues.add(SENDER)
-            }
-            if (value?.[RECIPIENT] === ACCOUNT_SPECIFIC_VALUE && value?.recipienttype === SPECIFIC) {
-              sendEmailActionFieldsWithAccountSpecificValues.add(RECIPIENT)
-            }
-          }
-          if (path.name === PARAMETER) {
-            const conditionElemId = findClosestInitConditionAncestorElemID(path) ?? path
-            if (
-              !conditionsWithAccountSpecificValues.has(conditionElemId.getFullName())
-              && Object.values(value).some((val: Value) => val?.value === ACCOUNT_SPECIFIC_VALUE)
-              && isNestedValueChanged(change, conditionElemId)
-            ) {
-              conditionsWithAccountSpecificValues.add(conditionElemId.getFullName())
-            }
-          }
-          return WALK_NEXT_STEP.RECURSE
-        },
-      })
+  const conditionWarnings = Array.from(conditionsWithAccountSpecificValues)
+    .map(ElemID.fromFullName)
+    .map(toConditionParametersWarning)
 
-      const sendEmailActionErrors = Array.from(sendEmailActionFieldsWithAccountSpecificValues)
-        .map(fieldName => toValidationError(instance, fieldName))
+  return sendEmailActionErrors.concat(conditionWarnings)
+}
 
-      const conditionWarnings = Array.from(conditionsWithAccountSpecificValues)
-        .map(ElemID.fromFullName)
-        .map(toConditionParametersWarning)
+const resolveAcountSpecificValues = async (
+  instances: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource
+): Promise<ChangeError[]> => {
+  const warnings: ChangeError[] = []
+  await handleWorkflowAccountSpecificValuesOnDeploy(
+    instances,
+    elementsSource,
+    {
+      onMissingInternalId: ({ path, value, field, name }) => {
+        warnings.push({
+          elemID: path,
+          severity: 'Warning',
+          message: 'Could not identify value in workflow',
+          detailedMessage: `Could not find object "${name}" for field "${field}". Setting ACCOUNT_SPECIFIC_VALUE instead.`,
+        })
+        value[field] = ACCOUNT_SPECIFIC_VALUE
+      },
+      onSingleInternalId: ({ value, field, internalId }) => {
+        value[field] = internalId
+      },
+      onMultipleInternalIds: ({ path, value, field, name, internalIds: [internalId] }) => {
+        warnings.push({
+          elemID: path,
+          severity: 'Warning',
+          message: 'Multiple objects with the same name',
+          detailedMessage: `There are multiple objects with the name "${name}". Using the first one (internal id: ${internalId}).`,
+        })
+        value[field] = internalId
+      },
+    }
+  )
+  return warnings
+}
 
-      return sendEmailActionErrors.concat(conditionWarnings)
-    })
-)
+const changeValidator: NetsuiteChangeValidator = async (
+  changes,
+  _deployReferencedElements,
+  elementsSource,
+) => {
+  const workflowChanges = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => change.data.after.elemID.typeName === WORKFLOW)
+
+  if (elementsSource === undefined || workflowChanges.length === 0) {
+    return []
+  }
+  const clonedWorkflowChanges = workflowChanges.map(change => toChange({
+    ...change.data,
+    after: change.data.after.clone(),
+  }) as AdditionChange<InstanceElement> | ModificationChange<InstanceElement>)
+
+  const resolveWarnings = await resolveAcountSpecificValues(
+    clonedWorkflowChanges.map(getChangeData),
+    elementsSource
+  )
+  const accountSpecificValuesErrors = clonedWorkflowChanges
+    .flatMap(getChangeErrorsOnAccountSpecificValues)
+  return resolveWarnings.concat(accountSpecificValuesErrors)
+}
 
 export default changeValidator

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -23,9 +23,9 @@ import { captureServiceIdInfo } from '../service_id_info'
 import { NetsuiteFetchQueries, NetsuiteQuery } from '../config/query'
 import { Credentials, isSuiteAppCredentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
-import SuiteAppClient, { SuiteAppType } from './suiteapp_client/suiteapp_client'
+import SuiteAppClient from './suiteapp_client/suiteapp_client'
 import { createSuiteAppFileCabinetOperations, SuiteAppFileCabinetOperations, DeployType } from './suiteapp_client/suiteapp_file_cabinet'
-import { ConfigRecord, EnvType, HasElemIDFunc, SavedSearchQuery, SystemInformation } from './suiteapp_client/types'
+import { ConfigRecord, EnvType, HasElemIDFunc, QueryRecordSchema, QueryRecordResponse, SavedSearchQuery, SystemInformation, SuiteAppType } from './suiteapp_client/types'
 import { CustomRecordResponse, RecordResponse } from './suiteapp_client/soap_client/types'
 import { DeployableChange, FeaturesMap, getChangeNodeId, GetCustomObjectsResult, getDeployableChanges, getNodeId, getOrTransformCustomRecordTypeToInstance, ImportFileCabinetResult, InvalidSuiteAppCredentialsError, ManifestDependencies, SDFObjectNode } from './types'
 import { toCustomizationInfo } from '../transformer'
@@ -534,6 +534,13 @@ export default class NetsuiteClient {
   public async runSavedSearchQuery(query: SavedSearchQuery):
     Promise<Record<string, unknown>[] | undefined> {
     return this.suiteAppClient?.runSavedSearchQuery(query)
+  }
+
+  public async runRecordsQuery(
+    ids: string[],
+    schema: QueryRecordSchema
+  ): Promise<QueryRecordResponse[] | undefined> {
+    return this.suiteAppClient?.runRecordsQuery(ids, schema)
   }
 
   public async getSystemInformation(): Promise<SystemInformation | undefined> {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -209,7 +209,7 @@ type ReadFailure = {
 
 export type ReadResults = (ReadSuccess | ReadFailure)[]
 
-export type RestletOperation = 'search' | 'sysInfo' | 'readFile' | 'config' | 'listBundles' | 'listSuiteApps'
+export type RestletOperation = 'search' | 'sysInfo' | 'readFile' | 'config' | 'record' | 'listBundles' | 'listSuiteApps'
 
 export type CallsLimiter = <T>(fn: () => Promise<T>) => Promise<T>
 
@@ -377,6 +377,20 @@ export const SET_CONFIG_RESULT_SCHEMA = {
   },
 }
 
+export type SuiteAppType = {
+  appId: string
+  name: string
+  version: string
+  description: string
+  dateInstalled: Date
+  dateLastUpdated: Date
+  publisherId: string
+  installedBy: {
+    id: number
+    name: string
+  }
+}
+
 export const GET_BUNDLES_RESULT_SCHEMA = {
   type: 'array',
   items: {
@@ -425,3 +439,47 @@ export const GET_SUITEAPPS_RESULT_SCHEMA = {
 }
 
 export type SetConfigRecordsValuesResult = { errorMessage: string } | SetConfigResult
+
+export const QUERY_RECORD_TYPES = {
+  workflow: 'workflow',
+  workflowstate: 'workflowstate',
+  workflowtransition: 'workflowtransition',
+  actiontype: 'actiontype',
+  workflowstatecustomfield: 'workflowstatecustomfield',
+  workflowcustomfield: 'workflowcustomfield',
+} as const
+
+export type QueryRecordType = keyof typeof QUERY_RECORD_TYPES
+
+export type QueryRecordSchema = {
+  type: QueryRecordType
+  sublistId?: string
+  idAlias?: string
+  typeSuffix?: string
+  customTypes?: Record<string, string>
+  fields: string[]
+  filter: {
+    fieldId: string
+    in: string[]
+  }
+  sublists?: QueryRecordSchema[]
+}
+
+export type QueryRecordResponse = {
+  body: Record<string, unknown>
+  sublists: QueryRecordResponse[]
+  errors?: string[]
+}
+
+export const QUERY_RECORDS_RESPONSE_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    required: ['body', 'sublists'],
+    properties: {
+      body: { type: 'object' },
+      sublists: { type: 'array' },
+      errors: { type: 'array', items: { type: 'string' } },
+    },
+  },
+}

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -64,6 +64,7 @@ export const REPORT_DEFINITION = 'reportdefinition'
 export const FINANCIAL_LAYOUT = 'financiallayout'
 export const BUNDLE = 'bundle'
 export const BIN = 'bin'
+export const TAX_SCHEDULE = 'taxSchedule'
 
 // Type Annotations
 export const SOURCE = 'source'
@@ -87,6 +88,8 @@ export const PERMISSIONS = 'permissions'
 export const CUSTOM_FIELD = 'customField'
 export const CUSTOM_FIELD_LIST = 'customFieldList'
 export const CONTENT = 'content'
+export const INIT_CONDITION = 'initcondition'
+export const SELECT_RECORD_TYPE = 'selectrecordtype'
 
 type InactiveFields = 'isinactive' | 'inactive' | 'isInactive'
 export const INACTIVE_FIELDS: { [K in InactiveFields]: K } = {

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -21,7 +21,7 @@ import { getElementValueOrAnnotations, isCustomRecordType } from '../types'
 import { ElementsSourceIndexes, LazyElementsSourceIndexes, ServiceIdRecords } from './types'
 import { getFieldInstanceTypes } from '../data_elements/custom_fields'
 import { extractCustomRecordFields, getElementServiceIdRecords } from '../filters/element_references'
-import { CUSTOM_LIST, CUSTOM_RECORD_TYPE, INTERNAL_ID, IS_SUB_INSTANCE } from '../constants'
+import { CUSTOM_LIST, CUSTOM_RECORD_TYPE, INTERNAL_ID, IS_SUB_INSTANCE, SELECT_RECORD_TYPE } from '../constants'
 import { TYPES_TO_INTERNAL_ID } from '../data_elements/types'
 
 const { awu } = collections.asynciterable
@@ -82,6 +82,21 @@ export const assignToInternalIdsIndex = async (
   }
 }
 
+export const assignToCustomFieldsSelectRecordTypeIndex = (
+  element: Element,
+  index: Record<string, unknown>
+): void => {
+  if (isInstanceElement(element) && element.value[SELECT_RECORD_TYPE] !== undefined) {
+    index[element.elemID.getFullName()] = element.value[SELECT_RECORD_TYPE]
+  } else if (isObjectType(element) && isCustomRecordType(element)) {
+    Object.values(element.fields).forEach(field => {
+      if (field.annotations[SELECT_RECORD_TYPE] !== undefined) {
+        index[field.elemID.getFullName()] = field.annotations[SELECT_RECORD_TYPE]
+      }
+    })
+  }
+}
+
 const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: boolean, deletedElements: ElemID[]):
   Promise<ElementsSourceIndexes> => {
   const serviceIdRecordsIndex: ServiceIdRecords = {}
@@ -90,6 +105,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
   const elemIdToChangeByIndex: Record<string, string> = {}
   const elemIdToChangeAtIndex: Record<string, string> = {}
   const customRecordFieldsServiceIdRecordsIndex: ServiceIdRecords = {}
+  const customFieldsSelectRecordTypeIndex: Record<string, unknown> = {}
 
   const updateInternalIdsIndex = async (element: Element): Promise<void> => {
     await assignToInternalIdsIndex(element, internalIdsIndex, elementsSource)
@@ -129,6 +145,10 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
     _.assign(customRecordFieldsServiceIdRecordsIndex, serviceIdRecords)
   }
 
+  const updateCustomFieldsSelectRecordTypeIndex = (element: Element): void => {
+    assignToCustomFieldsSelectRecordTypeIndex(element, customFieldsSelectRecordTypeIndex)
+  }
+
   const deletedElementSet = new Set(deletedElements.map(elemId => elemId.getFullName()))
   const elements = await elementsSource.getAll()
   await awu(elements)
@@ -141,6 +161,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
       if (isPartial) {
         await updateServiceIdRecordsIndex(element)
         await updateInternalIdsIndex(element)
+        updateCustomFieldsSelectRecordTypeIndex(element)
         if (isInstanceElement(element)) {
           updateCustomFieldsIndex(element)
         } else if (isObjectType(element) && isCustomRecordType(element)) {
@@ -156,6 +177,7 @@ const createIndexes = async (elementsSource: ReadOnlyElementsSource, isPartial: 
     elemIdToChangeByIndex,
     elemIdToChangeAtIndex,
     customRecordFieldsServiceIdRecordsIndex,
+    customFieldsSelectRecordTypeIndex,
   }
 }
 

--- a/packages/netsuite-adapter/src/elements_source_index/types.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/types.ts
@@ -29,6 +29,7 @@ export type ElementsSourceIndexes = {
   elemIdToChangeByIndex: Record<string, string>
   elemIdToChangeAtIndex: Record<string, string>
   customRecordFieldsServiceIdRecordsIndex: ServiceIdRecords
+  customFieldsSelectRecordTypeIndex: Record<string, unknown>
 }
 
 export type LazyElementsSourceIndexes = {

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -206,11 +206,11 @@ const replaceReferenceValues = async (
 const createElementsSourceServiceIdToElemID = async (
   elementsSourceIndex: LazyElementsSourceIndexes,
   isPartial: boolean,
-): Promise<ServiceIdRecords> => (
-  isPartial
+): Promise<ServiceIdRecords> => ({
+  ...isPartial
     ? (await elementsSourceIndex.getIndexes()).serviceIdRecordsIndex
-    : {}
-)
+    : {},
+})
 
 const applyValuesAndAnnotationsToElement = (element: Element, newElement: Element): void => {
   if (isInstanceElement(element) && isInstanceElement(newElement)) {
@@ -266,8 +266,8 @@ const filterCreator: LocalFilterCreator = ({
   name: 'replaceElementReferences',
   onFetch: async elements => {
     const serviceIdToElemID = Object.assign(
+      await createElementsSourceServiceIdToElemID(elementsSourceIndex, isPartial),
       await generateServiceIdToElemID(elements),
-      await createElementsSourceServiceIdToElemID(elementsSourceIndex, isPartial)
     )
     const customRecordFieldsToServiceIds = Object.assign(
       createCustomRecordFieldsToElemID(elements),

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -1,0 +1,784 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import Ajv from 'ajv'
+import { logger } from '@salto-io/logging'
+import { strings, collections } from '@salto-io/lowerdash'
+import { Element, ElemID, InstanceElement, ReadOnlyElementsSource, Value, Values, getChangeData, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isReferenceExpression, ReferenceExpression } from '@salto-io/adapter-api'
+import { WALK_NEXT_STEP, resolvePath, walkOnElement, walkOnValue } from '@salto-io/adapter-utils'
+import NetsuiteClient from '../client/client'
+import { RemoteFilterCreator } from '../filter'
+import { ACCOUNT_SPECIFIC_VALUE, INIT_CONDITION, NAME_FIELD, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
+import { QUERY_RECORD_TYPES, QueryRecordType, QueryRecordResponse, QueryRecordSchema } from '../client/suiteapp_client/types'
+import { INTERNAL_IDS_MAP, InternalIdsMap, SUITEQL_TABLE } from '../data_elements/suiteql_table_elements'
+import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
+import { captureServiceIdInfo } from '../service_id_info'
+import { LazyElementsSourceIndexes } from '../elements_source_index/types'
+import { assignToCustomFieldsSelectRecordTypeIndex } from '../elements_source_index/elements_source_index'
+
+const log = logger(module)
+const { isNumberStr, matchAll } = strings
+const { makeArray } = collections.array
+const { awu } = collections.asynciterable
+
+const RECORDS_PER_QUERY = 10
+
+const FORMULA = 'formula'
+const FORMULA_PARAMS = 'formulaParams'
+
+const RESOLVED_ACCOUNT_SPECIFIC_VALUE_PREFIX = `${ACCOUNT_SPECIFIC_VALUE} (`
+const RESOLVED_ACCOUNT_SPECIFIC_VALUE_SUFFIX = ')'
+
+type QueryRecordField = {
+  name: string
+  type: string | string[]
+}
+
+type QueryRecord = {
+  type: QueryRecordType
+  serviceId: string
+  fields: QueryRecordField[]
+  elemID: ElemID
+  path: string[]
+}
+
+type InstanceWithQueryRecords = {
+  instance: InstanceElement
+  records: QueryRecord[]
+}
+
+type WorkflowInternalID = {
+  internalid: [{
+    value: string
+  }]
+}
+
+type GetFieldTypeIDFunc = (
+  params: {
+    fieldValue: unknown
+    instance: InstanceElement
+    isFieldWithAccountSpecificValue: boolean
+    selectRecordTypeMap: Record<string, unknown>
+  }
+) => string | string[] | undefined
+
+type AccountSpecificValueHandlerParams = {
+  path: ElemID
+  value: Values
+  field: string
+  name: string
+}
+
+type AccountSpecificValueHandlers = {
+  onMissingInternalId: (params: AccountSpecificValueHandlerParams) => void
+  onSingleInternalId: (params: AccountSpecificValueHandlerParams & { internalId: string }) => void
+  onMultipleInternalIds: (params: AccountSpecificValueHandlerParams & { internalIds: string[] }) => void
+}
+
+const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, string> = {
+  STDITEMTAXSCHEDULE: TAX_SCHEDULE,
+  STDBODYACCOUNT: 'account',
+}
+
+const getSelectRecordTypeFromReference = (
+  ref: ReferenceExpression,
+  selectRecordTypeMap: Record<string, unknown>
+): unknown => {
+  const baseId = ref.elemID.createBaseID().parent
+  if (baseId.idType === 'type') {
+    return `[${SCRIPT_ID}=${baseId.name}]`
+  }
+  if (selectRecordTypeMap[baseId.getFullName()] !== undefined) {
+    return selectRecordTypeMap[baseId.getFullName()]
+  }
+  // on deploy the reference's top level parent is resolved
+  if (ref.topLevelParent !== undefined) {
+    return resolvePath(ref.topLevelParent, baseId.createNestedID(SELECT_RECORD_TYPE))
+  }
+  return undefined
+}
+
+const getSelectRecordType: GetFieldTypeIDFunc = params => {
+  const { fieldValue, selectRecordTypeMap } = params
+  if (typeof fieldValue === 'string') {
+    if (isNumberStr(fieldValue)) {
+      return fieldValue
+    }
+    const serviceIdInfos = captureServiceIdInfo(fieldValue)
+    if (serviceIdInfos.length === 1 && serviceIdInfos[0].isFullMatch) {
+      return serviceIdInfos[0].serviceId
+    }
+  }
+  if (isReferenceExpression(fieldValue)) {
+    return getSelectRecordType({
+      ...params,
+      fieldValue: getSelectRecordTypeFromReference(fieldValue, selectRecordTypeMap),
+    })
+  }
+  log.warn('could not get field type from selectrecordtype: %o', fieldValue)
+  return undefined
+}
+
+const GET_FIELD_TYPE_FUNCTIONS: Record<string, GetFieldTypeIDFunc> = {
+  sender: ({ isFieldWithAccountSpecificValue }) => (
+    isFieldWithAccountSpecificValue ? 'employee' : undefined
+  ),
+  recipient: ({ isFieldWithAccountSpecificValue }) => (
+    // there is no intersection between the internal ids of those types,
+    // and no indication in the element which type should be used.
+    isFieldWithAccountSpecificValue ? ['employee', 'contact', 'customer', 'partner', 'vendor'] : undefined
+  ),
+  selectrecordtype: getSelectRecordType,
+  resultfield: params => {
+    const { fieldValue, instance } = params
+    if (isReferenceExpression(fieldValue)) {
+      const refField = resolvePath(instance, fieldValue.elemID.createParentID())
+      if (_.isPlainObject(refField) && refField[SELECT_RECORD_TYPE] !== undefined) {
+        return getSelectRecordType({ ...params, fieldValue: refField[SELECT_RECORD_TYPE] })
+      }
+    }
+    log.warn('could not get field type from resultfield: %o', fieldValue)
+    return undefined
+  },
+  field: params => {
+    const { fieldValue, selectRecordTypeMap } = params
+    if (typeof fieldValue === 'string') {
+      const recordType = STANDARD_FIELDS_TO_RECORD_TYPE[fieldValue]
+      if (recordType !== undefined) {
+        return recordType
+      }
+    }
+    if (isReferenceExpression(fieldValue)) {
+      return getSelectRecordType({
+        ...params,
+        fieldValue: getSelectRecordTypeFromReference(fieldValue, selectRecordTypeMap),
+      })
+    }
+    log.warn('could not get field type from field: %o', fieldValue)
+    return undefined
+  },
+}
+
+const WORKFLOW_INTERNAL_IDS_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    required: ['internalid'],
+    properties: {
+      internalid: {
+        type: 'array',
+        maxItems: 1,
+        minItems: 1,
+        items: {
+          type: 'object',
+          required: ['value'],
+          properties: {
+            value: {
+              type: 'string',
+            },
+          },
+        },
+      },
+    },
+  },
+}
+
+const getFieldsToQuery = (records: QueryRecord[]): string[] =>
+  _.uniq([SCRIPT_ID, ...records.flatMap(row => row.fields).map(field => field.name)])
+
+const createQuerySchema = (records: QueryRecord[]): QueryRecordSchema => {
+  const {
+    [QUERY_RECORD_TYPES.workflow]: workflows = [],
+    [QUERY_RECORD_TYPES.workflowstate]: workflowstates = [],
+    [QUERY_RECORD_TYPES.workflowtransition]: workflowtransitions = [],
+    [QUERY_RECORD_TYPES.actiontype]: workflowactions = [],
+    [QUERY_RECORD_TYPES.workflowstatecustomfield]: workflowstatecustomfields = [],
+    [QUERY_RECORD_TYPES.workflowcustomfield]: workflowcustomfields = [],
+  } = _.groupBy(records, record => record.type)
+
+  const workflowTransitionSchema: QueryRecordSchema | undefined = workflowtransitions.length > 0
+    ? {
+      type: 'workflowtransition',
+      sublistId: 'transitions',
+      idAlias: 'transitionid',
+      fields: getFieldsToQuery(workflowtransitions),
+      filter: {
+        fieldId: SCRIPT_ID,
+        in: _.uniq(workflowtransitions.map(row => row.serviceId)),
+      },
+    }
+    : undefined
+
+  const workflowActionSchema: QueryRecordSchema | undefined = workflowactions.length > 0
+    ? {
+      type: 'actiontype',
+      sublistId: 'actions',
+      idAlias: 'actionid',
+      typeSuffix: 'action',
+      fields: getFieldsToQuery(workflowactions),
+      filter: {
+        fieldId: SCRIPT_ID,
+        in: _.uniq(workflowactions.map(row => row.serviceId)),
+      },
+      customTypes: {
+        customactionaction: 'customaction',
+      },
+    }
+    : undefined
+
+  const workflowStateCustomFieldSchema: QueryRecordSchema | undefined = workflowstatecustomfields.length > 0
+    ? {
+      type: 'workflowstatecustomfield',
+      sublistId: 'fields',
+      idAlias: 'id',
+      fields: getFieldsToQuery(workflowstatecustomfields),
+      filter: {
+        fieldId: SCRIPT_ID,
+        in: _.uniq(workflowstatecustomfields.map(row => row.serviceId)),
+      },
+    }
+    : undefined
+
+  const workflowStateSchema: QueryRecordSchema | undefined = workflowstates.length > 0
+    ? {
+      type: 'workflowstate',
+      sublistId: 'states',
+      idAlias: 'stateid',
+      fields: getFieldsToQuery(workflowstates),
+      filter: {
+        fieldId: SCRIPT_ID,
+        in: _.uniq(workflowstates.map(row => row.serviceId)),
+      },
+      sublists: [
+        workflowTransitionSchema ?? [],
+        workflowActionSchema ?? [],
+        workflowStateCustomFieldSchema ?? [],
+      ].flat(),
+    }
+    : undefined
+
+  const workflowCustomFieldSchema: QueryRecordSchema | undefined = workflowcustomfields.length > 0
+    ? {
+      type: 'workflowcustomfield',
+      sublistId: 'fields',
+      idAlias: 'id',
+      fields: getFieldsToQuery(workflowcustomfields),
+      filter: {
+        fieldId: SCRIPT_ID,
+        in: _.uniq(workflowcustomfields.map(row => row.serviceId)),
+      },
+    }
+    : undefined
+
+  return {
+    type: 'workflow',
+    fields: getFieldsToQuery(workflows),
+    filter: {
+      fieldId: SCRIPT_ID,
+      in: _.uniq(workflows.map(row => row.serviceId)),
+    },
+    sublists: [
+      workflowStateSchema ?? [],
+      workflowCustomFieldSchema ?? [],
+    ].flat(),
+  }
+}
+
+const getQueryRecordType = (path: ElemID): QueryRecordType | undefined => {
+  if (path.isTopLevel()) {
+    return 'workflow'
+  }
+  if (path.createParentID(3).name === 'workflowactions') {
+    return 'actiontype'
+  }
+  return QUERY_RECORD_TYPES[path.createParentID().name as QueryRecordType]
+}
+
+const getQueryRecordFieldType = (
+  instance: InstanceElement,
+  value: Values,
+  field: string,
+  suiteQLTablesMap: Record<string, unknown>,
+  selectRecordTypeMap: Record<string, unknown>
+): string | string[] | undefined => {
+  // a field type by the field itself should be the first option ([field, value[field]])
+  const fieldType = [[field, value[field]]].concat(Object.entries(value))
+    .filter(([key]) => GET_FIELD_TYPE_FUNCTIONS[key] !== undefined)
+    .map(([key, fieldValue]) => GET_FIELD_TYPE_FUNCTIONS[key]({
+      fieldValue,
+      instance,
+      selectRecordTypeMap,
+      isFieldWithAccountSpecificValue: field === key,
+    }))
+    .find(res => res !== undefined)
+
+  if (fieldType === undefined) {
+    log.warn('could not find field type id of %s from value: %o', field, value)
+    return undefined
+  }
+
+  if (Array.isArray(fieldType)) {
+    const [suiteQLTableNames, nonExistingNames] = _.partition(
+      fieldType,
+      typeName => suiteQLTablesMap[typeName] !== undefined
+    )
+    if (nonExistingNames.length > 0) {
+      log.warn('could not find SuiteQL table instances %s', nonExistingNames)
+    }
+    return suiteQLTableNames.length > 0 ? suiteQLTableNames : undefined
+  }
+
+  const suiteQLTableName = suiteQLTablesMap[fieldType] !== undefined
+    ? fieldType
+    : (INTERNAL_ID_TO_TYPES[fieldType] ?? [])
+      .find(typeName => suiteQLTablesMap[typeName] !== undefined)
+
+  if (suiteQLTableName === undefined) {
+    log.warn('could not find SuiteQL table instance %s', fieldType)
+    return undefined
+  }
+  return suiteQLTableName
+}
+
+const getConditionParameters = (value: Value): Values[] =>
+  Object.values(value?.parameters?.parameter ?? {})
+
+const getFieldsWithAccountSpecificValue = (
+  instance: InstanceElement,
+  value: Values,
+  path: ElemID,
+  suiteQLTablesMap: Record<string, InstanceElement>,
+  selectRecordTypeMap: Record<string, unknown>
+): QueryRecordField[] =>
+  Object.entries(value)
+    .flatMap(([field, fieldValue]) => {
+      if (fieldValue === ACCOUNT_SPECIFIC_VALUE) {
+        const fieldType = getQueryRecordFieldType(
+          instance,
+          value,
+          field,
+          suiteQLTablesMap,
+          selectRecordTypeMap,
+        )
+        if (fieldType !== undefined) {
+          return { name: field, type: fieldType }
+        }
+      }
+      if (field === INIT_CONDITION) {
+        const parameters = getConditionParameters(fieldValue)
+        if (parameters.some(param => param?.value === ACCOUNT_SPECIFIC_VALUE && getQueryRecordFieldType(
+          instance, param, 'value', suiteQLTablesMap, selectRecordTypeMap
+        ) !== undefined)) {
+          if (typeof fieldValue[FORMULA] !== 'string') {
+            log.warn('formula of initcondition in %s is not string: %o', path.getFullName(), fieldValue[FORMULA])
+            return []
+          }
+          return {
+            type: FORMULA_PARAMS,
+            name: path.isTopLevel() ? 'initconditionformula' : 'conditionformula',
+          }
+        }
+      }
+      return []
+    })
+
+const getQueryRecords = (
+  instance: InstanceElement,
+  suiteQLTablesMap: Record<string, InstanceElement>,
+  selectRecordTypeMap: Record<string, unknown>
+): InstanceWithQueryRecords => {
+  const allQueryRecords: Record<string, Omit<QueryRecord, 'path'>> = {}
+
+  walkOnValue({
+    elemId: instance.elemID,
+    value: instance.value,
+    func: ({ path: elemID, value }) => {
+      if (!_.isPlainObject(value) || value[SCRIPT_ID] === undefined) {
+        return WALK_NEXT_STEP.RECURSE
+      }
+      const type = getQueryRecordType(elemID)
+      if (type !== undefined) {
+        const fields = getFieldsWithAccountSpecificValue(
+          instance,
+          value,
+          elemID,
+          suiteQLTablesMap,
+          selectRecordTypeMap,
+        )
+        allQueryRecords[elemID.getFullName()] = {
+          type,
+          serviceId: value[SCRIPT_ID],
+          fields,
+          elemID,
+        }
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+
+  const getPath = (elemId: ElemID): string[] => {
+    const fullName = elemId.getFullName()
+    if (elemId.isTopLevel()) {
+      return [allQueryRecords[fullName].serviceId]
+    }
+    const serviceId = allQueryRecords[fullName]?.serviceId ?? []
+    return getPath(elemId.createParentID()).concat(serviceId)
+  }
+
+  const queryRecordsToReturn = _.uniq(
+    Object.values(allQueryRecords)
+      .filter(record => record.fields.length > 0)
+      .flatMap(record => record.elemID.createAllElemIdParents())
+      .map(elemId => elemId.getFullName())
+      .filter(fullName => allQueryRecords[fullName] !== undefined)
+  )
+
+  const records = queryRecordsToReturn.map(fullName => ({
+    ...allQueryRecords[fullName],
+    path: getPath(allQueryRecords[fullName].elemID),
+  }))
+
+  return { instance, records }
+}
+
+const getWorkflowIdsToQuery = async (
+  client: NetsuiteClient,
+  instances: InstanceElement[],
+  queryRecords: QueryRecord[]
+): Promise<string[]> => {
+  const workflowScriptIds = new Set(
+    queryRecords
+      .filter(record => record.type === 'workflow')
+      .map(record => record.serviceId)
+  )
+  const workflowNames = _.uniq(
+    instances
+      .filter(instance => workflowScriptIds.has(instance.value[SCRIPT_ID]))
+      .map(instance => instance.value[NAME_FIELD])
+  )
+  const result = await client.runSavedSearchQuery({
+    type: 'workflow',
+    columns: ['internalid'],
+    filters: workflowNames
+      .map(name => ['name', 'is', name])
+      .reduce((filter, curr, i) => (
+        i < workflowNames.length - 1
+          ? [...filter, curr, 'OR']
+          : [...filter, curr]
+      ), []),
+  })
+  const ajv = new Ajv({ allErrors: true, strict: false })
+  if (!ajv.validate<WorkflowInternalID[]>(WORKFLOW_INTERNAL_IDS_SCHEMA, result)) {
+    log.error('Got invalid results from workflow internal ids search: %s', ajv.errorsText())
+    return []
+  }
+  return _.uniq(result.map(row => row.internalid[0].value))
+}
+
+const query = async (
+  client: NetsuiteClient,
+  instances: InstanceElement[],
+  queryRecords: QueryRecord[]
+): Promise<QueryRecordResponse[] | undefined> => {
+  const schema = createQuerySchema(queryRecords)
+  const ids = await getWorkflowIdsToQuery(client, instances, queryRecords)
+  return client.runRecordsQuery(ids, schema)
+}
+
+const getInnerResult = (
+  results: QueryRecordResponse[],
+  path: string[]
+): QueryRecordResponse | undefined => {
+  const [nextScriptId, ...restOfPath] = path
+  const result = results.find(res => res.body[SCRIPT_ID] === nextScriptId)
+  if (result === undefined || restOfPath.length === 0) {
+    return result
+  }
+  return getInnerResult(result.sublists, restOfPath)
+}
+
+const toResolvedAccountSpecificValue = (name: string): string =>
+  `${RESOLVED_ACCOUNT_SPECIFIC_VALUE_PREFIX}${name}${RESOLVED_ACCOUNT_SPECIFIC_VALUE_SUFFIX}`
+
+const isResolvedAccountSpecificValue = (name: string): boolean =>
+  name.startsWith(RESOLVED_ACCOUNT_SPECIFIC_VALUE_PREFIX)
+  && name.endsWith(RESOLVED_ACCOUNT_SPECIFIC_VALUE_SUFFIX)
+
+const getResolvedAccountSpecificValue = (name: string): string =>
+  name.slice(
+    RESOLVED_ACCOUNT_SPECIFIC_VALUE_PREFIX.length,
+    name.length - RESOLVED_ACCOUNT_SPECIFIC_VALUE_SUFFIX.length
+  )
+
+const setFieldValue = (
+  field: QueryRecordField,
+  value: Values,
+  internalId: string,
+  suiteQLTablesMap: Record<string, InstanceElement>
+): void => {
+  const { name } = makeArray(field.type)
+    .map(typeName => suiteQLTablesMap[typeName].value[INTERNAL_IDS_MAP][internalId])
+    .find(res => res !== undefined) ?? {}
+  if (name === undefined) {
+    log.warn('could not find internal id %s of type %s', internalId, field.type)
+    return
+  }
+  value[field.name] = toResolvedAccountSpecificValue(name)
+}
+
+const setParametersValues = (
+  instance: InstanceElement,
+  value: Values,
+  formulaWithInternalIds: string,
+  suiteQLTablesMap: Record<string, InstanceElement>,
+  selectRecordTypeMap: Record<string, unknown>
+): void => {
+  const params = getConditionParameters(value[INIT_CONDITION])
+    // not only params with ACCOUNT_SPECIFIC_VALUE are represented with internalid in the formula (e.g roles)
+    // but only params that have selectrecordtype are represented with internalid in the formula
+    .filter(param => param?.[SELECT_RECORD_TYPE] !== undefined)
+  const internalIds = Array.from(matchAll(formulaWithInternalIds, /-?\d+/g))
+    .map(res => res[0])
+    // 0 (zero) can be used in a formula (e.g 'arrayIndexOf(...) < 0'), but it's not an internalid
+    .filter(internalId => internalId !== '0')
+  if (params.length !== internalIds.length) {
+    log.warn(
+      'params length %d do not match the internal ids extracted from the formula: %s',
+      params.length,
+      formulaWithInternalIds
+    )
+    return
+  }
+  _.sortBy(params, param => value[INIT_CONDITION][FORMULA].indexOf(`"${param.name}"`))
+    .forEach((param, index) => {
+      if (param.value === ACCOUNT_SPECIFIC_VALUE) {
+        const internalId = internalIds[index]
+        const paramType = getQueryRecordFieldType(
+          instance,
+          param,
+          'value',
+          suiteQLTablesMap,
+          selectRecordTypeMap,
+        )
+        if (paramType !== undefined) {
+          setFieldValue({ name: 'value', type: paramType }, param, internalId, suiteQLTablesMap)
+        }
+      }
+    })
+}
+
+const setValuesInInstance = (
+  instance: InstanceElement,
+  record: QueryRecord,
+  results: QueryRecordResponse[],
+  suiteQLTablesMap: Record<string, InstanceElement>,
+  selectRecordTypeMap: Record<string, unknown>
+): void => {
+  const innerValue = record.elemID.isTopLevel()
+    ? instance.value
+    : resolvePath(instance, record.elemID)
+  const innerResult = getInnerResult(results, record.path)
+  if (innerResult === undefined) {
+    log.warn('missing record %s in path %s: %o', record.serviceId, record.path.join('.'), results)
+    return
+  }
+  record.fields.forEach(field => {
+    const internalId = innerResult.body[field.name]
+    if (internalId === undefined || internalId === '') {
+      log.warn('missing field %s in record %s: %o', field.name, record.serviceId, innerResult.body)
+      return
+    }
+    if (typeof internalId !== 'string') {
+      log.warn('field %s in record %s is not a string: %o', field.name, record.serviceId, internalId)
+      return
+    }
+    if (field.type === FORMULA_PARAMS) {
+      setParametersValues(instance, innerValue, internalId, suiteQLTablesMap, selectRecordTypeMap)
+    } else {
+      setFieldValue(field, innerValue, internalId, suiteQLTablesMap)
+    }
+  })
+}
+
+const getSuiteQLNameToInternalIdsMap = async (
+  elementsSource: ReadOnlyElementsSource
+): Promise<Record<string, Record<string, string[]>>> => {
+  const suiteQLTableInstances = await awu(await elementsSource.list())
+    .filter(elemId => elemId.idType === 'instance' && elemId.typeName === SUITEQL_TABLE)
+    .map(elemId => elementsSource.get(elemId))
+    .filter(isInstanceElement)
+    .toArray()
+
+  return _(suiteQLTableInstances)
+    .keyBy(instance => instance.elemID.name)
+    .mapValues(instance => instance.value[INTERNAL_IDS_MAP] as InternalIdsMap)
+    .mapValues(
+      internalIdsMap => _(internalIdsMap)
+        .entries()
+        .groupBy(row => row[1].name)
+        .mapValues(rows => rows.map(row => row[0]))
+        .value()
+    )
+    .value()
+}
+
+const resolveAccountSpecificValues = (
+  instance: InstanceElement,
+  suiteQLTablesMap: Record<string, Record<string, string[]>>,
+  handlers: AccountSpecificValueHandlers
+): void => {
+  const resolveAccountSpecificValueForField = (
+    path: ElemID,
+    value: Values,
+    field: string,
+    fieldValue: unknown,
+  ): void => {
+    if (typeof fieldValue !== 'string' || !isResolvedAccountSpecificValue(fieldValue)) {
+      return
+    }
+    const name = getResolvedAccountSpecificValue(fieldValue)
+    const fieldType = getQueryRecordFieldType(instance, value, field, suiteQLTablesMap, {})
+    const internalIds = _.uniq(makeArray(fieldType).flatMap(type => suiteQLTablesMap[type][name] ?? []))
+    if (internalIds.length === 0) {
+      handlers.onMissingInternalId({ path, value, field, name })
+    } else if (internalIds.length > 1) {
+      handlers.onMultipleInternalIds({ path, value, field, name, internalIds })
+    } else {
+      handlers.onSingleInternalId({ path, value, field, name, internalId: internalIds[0] })
+    }
+  }
+
+  walkOnElement({
+    element: instance,
+    func: ({ value, path }) => {
+      if (!_.isPlainObject(value)) {
+        return WALK_NEXT_STEP.RECURSE
+      }
+      Object.entries(value).forEach(([field, fieldValue]) => {
+        resolveAccountSpecificValueForField(path, value, field, fieldValue)
+      })
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+}
+
+export const handleWorkflowAccountSpecificValuesOnDeploy = async (
+  instances: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+  handlers: AccountSpecificValueHandlers
+): Promise<void> => {
+  const suiteQLNameToInternalIdsMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
+  instances.forEach(instance => resolveAccountSpecificValues(
+    instance,
+    suiteQLNameToInternalIdsMap,
+    handlers,
+  ))
+}
+
+const accountSpecificValueHandlers: AccountSpecificValueHandlers = {
+  onMissingInternalId: ({ path, value, field, name }) => {
+    log.warn(
+      'could not find internal id of "%s" in field %s from value: %o',
+      name,
+      path.createNestedID(field).getFullName(),
+      value,
+    )
+    value[field] = ACCOUNT_SPECIFIC_VALUE
+  },
+  onSingleInternalId: ({ value, field, internalId }) => {
+    value[field] = internalId
+  },
+  onMultipleInternalIds: ({ value, field, name, internalIds: [internalId] }) => {
+    log.warn('there are several internal ids for name %s - using the first: %d', name, internalId)
+    value[field] = internalId
+  },
+}
+
+const getSelectRecordTypeMap = async (
+  elements: Element[],
+  elementsSourceIndex: LazyElementsSourceIndexes,
+  isPartial: boolean,
+): Promise<Record<string, unknown>> => {
+  const selectRecordTypeMap = {
+    ...isPartial
+      ? (await elementsSourceIndex.getIndexes()).customFieldsSelectRecordTypeIndex
+      : {},
+  }
+  elements.forEach(element => {
+    assignToCustomFieldsSelectRecordTypeIndex(element, selectRecordTypeMap)
+  })
+  return selectRecordTypeMap
+}
+
+const filterCreator: RemoteFilterCreator = ({ client, elementsSource, elementsSourceIndex, isPartial }) => ({
+  name: 'workflowAccountSpecificValues',
+  remote: true,
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    const suiteQLTablesMap = _.keyBy(
+      instances.filter(instance => instance.elemID.typeName === SUITEQL_TABLE),
+      instance => instance.elemID.name
+    )
+    if (_.isEmpty(suiteQLTablesMap)) {
+      log.debug('there are no suiteql tables instances - skipping setting workflow account specific values')
+      return
+    }
+    const selectRecordTypeMap = await getSelectRecordTypeMap(elements, elementsSourceIndex, isPartial)
+    const workflowInstances = instances.filter(instance => instance.elemID.typeName === WORKFLOW)
+    const queryRecords = workflowInstances
+      .map(instance => getQueryRecords(instance, suiteQLTablesMap, selectRecordTypeMap))
+      .filter(({ records }) => records.length > 0)
+
+    if (queryRecords.length === 0) {
+      return
+    }
+
+    await Promise.all(
+      _.chunk(queryRecords, RECORDS_PER_QUERY).map(
+        async (chunk: InstanceWithQueryRecords[]): Promise<void> => {
+          const chunkRecords = chunk.flatMap(item => item.records)
+          const results = await query(client, workflowInstances, chunkRecords) ?? []
+          if (results.length === 0) {
+            log.warn('skipping setting values due to empty result of query records: %o', chunkRecords)
+            return
+          }
+          chunk.forEach(({ instance, records }) => {
+            records.forEach(record => {
+              setValuesInInstance(instance, record, results, suiteQLTablesMap, selectRecordTypeMap)
+            })
+          })
+        }
+      )
+    )
+  },
+  preDeploy: async changes => {
+    const workflowInstances = changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(instance => instance.elemID.typeName === WORKFLOW)
+    if (workflowInstances.length === 0) {
+      return
+    }
+    await handleWorkflowAccountSpecificValuesOnDeploy(
+      workflowInstances,
+      elementsSource,
+      accountSpecificValueHandlers,
+    )
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -243,10 +243,10 @@ const createQuerySchema = (records: QueryRecord[]): QueryRecordSchema => {
       fields: getFieldsToQuery(workflowstates),
       filter: getQueryFilter(workflowstates),
       sublists: [
-        workflowTransitionSchema ?? [],
-        workflowActionSchema ?? [],
-        workflowStateCustomFieldSchema ?? [],
-      ].flat(),
+        workflowTransitionSchema,
+        workflowActionSchema,
+        workflowStateCustomFieldSchema,
+      ].flatMap(schema => schema ?? []),
     }
     : undefined
 
@@ -265,9 +265,9 @@ const createQuerySchema = (records: QueryRecord[]): QueryRecordSchema => {
     fields: getFieldsToQuery(workflows),
     filter: getQueryFilter(workflows),
     sublists: [
-      workflowStateSchema ?? [],
-      workflowCustomFieldSchema ?? [],
-    ].flat(),
+      workflowStateSchema,
+      workflowCustomFieldSchema,
+    ].flatMap(schema => schema ?? []),
   }
 }
 
@@ -469,6 +469,10 @@ const query = async (
 ): Promise<QueryRecordResponse[] | undefined> => {
   const schema = createQuerySchema(queryRecords)
   const ids = await getWorkflowIdsToQuery(client, instances, queryRecords)
+  if (ids.length === 0) {
+    log.warn('received an empty list workflow internal ids - skipping records query')
+    return []
+  }
   return client.runRecordsQuery(ids, schema)
 }
 

--- a/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/account_specific_values.test.ts
@@ -15,7 +15,7 @@
 */
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import { fileType } from '../../src/types/file_cabinet_types'
-import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+import { usereventscriptType } from '../../src/autogen/types/standard_types/usereventscript'
 import accountSpecificValueValidator from '../../src/change_validators/account_specific_values'
 import { ACCOUNT_SPECIFIC_VALUE, PATH, SCRIPT_ID } from '../../src/constants'
 
@@ -23,11 +23,11 @@ import { ACCOUNT_SPECIFIC_VALUE, PATH, SCRIPT_ID } from '../../src/constants'
 describe('account specific value validator', () => {
   const origInstance = new InstanceElement(
     'instance',
-    workflowType().type,
+    usereventscriptType().type,
     {
       isinactive: false,
-      [SCRIPT_ID]: 'customworkflow1',
-      name: 'WokrflowName',
+      [SCRIPT_ID]: 'customscript1',
+      name: 'ScriptName',
     }
   )
   let instance: InstanceElement

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -212,7 +212,7 @@ describe('workflow account specific values', () => {
           elemID: ElemID.fromFullName('netsuite.workflow.instance.instance.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction'),
           severity: 'Warning',
           message: 'Could not identify value in workflow',
-          detailedMessage: 'Could not find object "Unknown Salto user" for field "recipient". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "recipient". Setting it to ACCOUNT_SPECIFIC_VALUE instead.',
         },
         {
           elemID: instance.elemID,
@@ -224,7 +224,7 @@ describe('workflow account specific values', () => {
           elemID: ElemID.fromFullName('netsuite.workflow.instance.instance.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction'),
           severity: 'Warning',
           message: 'Could not identify value in workflow',
-          detailedMessage: 'Could not find object "Unknown Salto user" for field "sender". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "sender". Setting it to ACCOUNT_SPECIFIC_VALUE instead.',
         },
         {
           elemID: instance.elemID,
@@ -354,7 +354,7 @@ describe('workflow account specific values', () => {
           elemID: instance.elemID.createNestedID('initcondition', 'parameters', 'parameter', 'Account1'),
           severity: 'Warning',
           message: 'Could not identify value in workflow',
-          detailedMessage: 'Could not find object "Unknown Salto user" for field "value". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "value". Setting it to ACCOUNT_SPECIFIC_VALUE instead.',
         },
         {
           elemID: instance.elemID.createNestedID('initcondition'),

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -13,13 +13,16 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 import workflowAccountSpecificValidator from '../../src/change_validators/workflow_account_specific_values'
-import { SCRIPT_ID } from '../../src/constants'
+import { NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { INTERNAL_IDS_MAP, SUITEQL_TABLE } from '../../src/data_elements/suiteql_table_elements'
 
 describe('workflow account specific values', () => {
   let instance: InstanceElement
+  let suiteqlTableInstance: InstanceElement
   beforeEach(() => {
     instance = new InstanceElement(
       'instance',
@@ -88,12 +91,27 @@ describe('workflow account specific values', () => {
         },
       }
     )
+    const suiteqlTableType = new ObjectType({ elemID: new ElemID(NETSUITE, SUITEQL_TABLE) })
+    suiteqlTableInstance = new InstanceElement(
+      'employee',
+      suiteqlTableType,
+      {
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Salto user 1' },
+          2: { name: 'Salto user 2' },
+          3: { name: 'Salto user 3' },
+          4: { name: 'Salto user 3' },
+        },
+      },
+    )
   })
 
   it('should not have changeError when deploying an instance without ACCOUNT_SPECIFIC_VALUES', async () => {
     const after = instance.clone()
     const changeErrors = await workflowAccountSpecificValidator(
-      [toChange({ before: instance, after })]
+      [toChange({ before: instance, after })],
+      false,
+      buildElementsSourceFromElements([])
     )
     expect(changeErrors).toHaveLength(0)
   })
@@ -104,7 +122,9 @@ describe('workflow account specific values', () => {
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE]'
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
@@ -116,7 +136,9 @@ describe('workflow account specific values', () => {
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE]'
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Error')
@@ -130,7 +152,9 @@ describe('workflow account specific values', () => {
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE]'
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(2)
       expect(changeErrors).toEqual(expect.arrayContaining([
@@ -150,11 +174,65 @@ describe('workflow account specific values', () => {
     })
     it('should not have changeError when sendertype is not SPECIFIC', async () => {
       const after = instance.clone()
-      after.value.sender = '[ACCOUNT_SPECIFIC_VALUE]'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE]'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(0)
+    })
+    it('should not have changeErrors when the account specific values are resolved', async () => {
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE] (Salto user 1)'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE] (Salto user 1)'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([suiteqlTableInstance])
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should have changeErrors when the account specific values cannot be resolved', async () => {
+      const after = instance.clone()
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sender = '[ACCOUNT_SPECIFIC_VALUE] (Unknown Salto user)'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.sendertype = 'SPECIFIC'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipient = '[ACCOUNT_SPECIFIC_VALUE] (Unknown Salto user)'
+      after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.recipienttype = 'SPECIFIC'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([suiteqlTableInstance])
+      )
+      expect(changeErrors).toHaveLength(4)
+      expect(changeErrors).toEqual(expect.arrayContaining([
+        {
+          elemID: ElemID.fromFullName('netsuite.workflow.instance.instance.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction'),
+          severity: 'Warning',
+          message: 'Could not identify value in workflow',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "recipient". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+        },
+        {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Workflow contains fields which cannot be deployed',
+          detailedMessage: expect.stringContaining('The Workflow contains a \'recipient\' field with an ACCOUNT_SPECIFIC_VALUE'),
+        },
+        {
+          elemID: ElemID.fromFullName('netsuite.workflow.instance.instance.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction'),
+          severity: 'Warning',
+          message: 'Could not identify value in workflow',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "sender". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+        },
+        {
+          elemID: instance.elemID,
+          severity: 'Error',
+          message: 'Workflow contains fields which cannot be deployed',
+          detailedMessage: expect.stringContaining('The Workflow contains a \'sender\' field with an ACCOUNT_SPECIFIC_VALUE'),
+        },
+      ]))
     })
   })
 
@@ -163,7 +241,9 @@ describe('workflow account specific values', () => {
       const after = instance.clone()
       after.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors).toEqual([
@@ -184,7 +264,9 @@ describe('workflow account specific values', () => {
       after.value.another.parameters.parameter.Account2.value = '[ACCOUNT_SPECIFIC_VALUE]'
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.initcondition.parameters.parameter.Account2.value = '[ACCOUNT_SPECIFIC_VALUE]'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(3)
       expect(changeErrors).toEqual(expect.arrayContaining([
@@ -196,7 +278,9 @@ describe('workflow account specific values', () => {
     it('should return warning on an addition change', async () => {
       instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE]'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ after: instance })]
+        [toChange({ after: instance })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors).toEqual([
@@ -215,7 +299,9 @@ describe('workflow account specific values', () => {
       const after = instance.clone()
       after.value.initcondition.formula = '"Account1" EQUALS "Account2"'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors).toEqual([
@@ -234,9 +320,71 @@ describe('workflow account specific values', () => {
       const after = instance.clone()
       after.value.workflowstates.workflowstate.workflowstate1.workflowactions.sendemailaction.workflowaction.initcondition.formula = '"Account1" EQUALS "Account2"'
       const changeErrors = await workflowAccountSpecificValidator(
-        [toChange({ before: instance, after })]
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([])
       )
       expect(changeErrors).toHaveLength(0)
+    })
+    it('should not return warning when the account specific value is resolved', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE] (Salto user 1)'
+      instance.value.initcondition.parameters.parameter.Account1.selectrecordtype = '-4'
+      const after = instance.clone()
+      after.value.initcondition.formula = '"Account1" EQUALS "Account2"'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([suiteqlTableInstance])
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should return warnings when the account specific value cannot be resolved', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE] (Unknown Salto user)'
+      instance.value.initcondition.parameters.parameter.Account1.selectrecordtype = '-4'
+      const after = instance.clone()
+      after.value.initcondition.formula = '"Account1" EQUALS "Account2"'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([suiteqlTableInstance])
+      )
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors).toEqual(expect.arrayContaining([
+        {
+          elemID: instance.elemID.createNestedID('initcondition', 'parameters', 'parameter', 'Account1'),
+          severity: 'Warning',
+          message: 'Could not identify value in workflow',
+          detailedMessage: 'Could not find object "Unknown Salto user" for field "value". Setting ACCOUNT_SPECIFIC_VALUE instead.',
+        },
+        {
+          elemID: instance.elemID.createNestedID('initcondition'),
+          severity: 'Warning',
+          message: 'Workflow Condition won\'t be deployed',
+          detailedMessage: 'This Workflow Condition includes an ACCOUNT_SPECIFIC_VALUE, which, due to NetSuite limitations, cannot be deployed.'
+          + ' To ensure a smooth deployment, please edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value.'
+          + ' Other non-restricted aspects of the Workflow will be deployed as usual.',
+        },
+      ]))
+    })
+    it('should return warning when the account specific value name is not unique', async () => {
+      instance.value.initcondition.parameters.parameter.Account1.value = '[ACCOUNT_SPECIFIC_VALUE] (Salto user 3)'
+      instance.value.initcondition.parameters.parameter.Account1.selectrecordtype = '-4'
+      const after = instance.clone()
+      after.value.initcondition.formula = '"Account1" EQUALS "Account2"'
+      const changeErrors = await workflowAccountSpecificValidator(
+        [toChange({ before: instance, after })],
+        false,
+        buildElementsSourceFromElements([suiteqlTableInstance])
+      )
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors).toEqual(expect.arrayContaining([
+        {
+          elemID: instance.elemID.createNestedID('initcondition', 'parameters', 'parameter', 'Account1'),
+          severity: 'Warning',
+          message: 'Multiple objects with the same name',
+          detailedMessage: 'There are multiple objects with the name "Salto user 3". Using the first one (internal id: 3).',
+        },
+      ]))
     })
   })
 })

--- a/packages/netsuite-adapter/test/elements_source_index.test.ts
+++ b/packages/netsuite-adapter/test/elements_source_index.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { CUSTOM_RECORD_TYPE, INTERNAL_ID, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../src/constants'
@@ -251,6 +251,35 @@ describe('createElementsSourceIndex', () => {
     expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).customRecordFieldsServiceIdRecordsIndex)
       .toEqual({
         custom_field: { elemID: custRecordField.elemID.createNestedID(SCRIPT_ID), serviceID: 'custom_field' },
+      })
+  })
+  it('should create the correct customFieldsSelectRecordType index', async () => {
+    const customFieldInstance = new InstanceElement(
+      'customentityfield123',
+      entitycustomfield,
+      {
+        selectrecordtype: '-4',
+      }
+    )
+    const custRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1'),
+      fields: {
+        custom_field: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            selectrecordtype: new ReferenceExpression(customFieldInstance.elemID.createNestedID(SCRIPT_ID)),
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    getAllMock.mockImplementation(buildElementsSourceFromElements([custRecordType, customFieldInstance]).getAll)
+    expect((await createElementsSourceIndex(elementsSource, true).getIndexes()).customFieldsSelectRecordTypeIndex)
+      .toEqual({
+        [customFieldInstance.elemID.getFullName()]: '-4',
+        [custRecordType.elemID.createNestedID('field', 'custom_field').getFullName()]: new ReferenceExpression(customFieldInstance.elemID.createNestedID(SCRIPT_ID)),
       })
   })
 })

--- a/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
@@ -1,0 +1,1070 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, Element, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import NetsuiteClient from '../../src/client/client'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
+import { ACCOUNT_SPECIFIC_VALUE, CUSTOM_RECORD_TYPE, INIT_CONDITION, METADATA_TYPE, NAME_FIELD, NETSUITE, SCRIPT_ID, SELECT_RECORD_TYPE } from '../../src/constants'
+import { INTERNAL_IDS_MAP, SUITEQL_TABLE } from '../../src/data_elements/suiteql_table_elements'
+import filterCreator from '../../src/filters/workflow_account_specific_values'
+import { RemoteFilterOpts } from '../../src/filter'
+import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+
+const runSavedSearchQueryMock = jest.fn()
+const runRecordsQueryMock = jest.fn()
+const client = {
+  runSavedSearchQuery: runSavedSearchQueryMock,
+  runRecordsQuery: runRecordsQueryMock,
+} as unknown as NetsuiteClient
+
+describe('workflow account specific values filter', () => {
+  const { type: workflow } = workflowType()
+  const { type: entitycustomfield } = entitycustomfieldType()
+  const suiteQLTableType = new ObjectType({ elemID: new ElemID(NETSUITE, SUITEQL_TABLE) })
+
+  let filterOpts: RemoteFilterOpts
+  let workflowInstance1: InstanceElement
+  let workflowInstance2: InstanceElement
+  let suiteQLInstances: InstanceElement[]
+  let customFieldInstance: InstanceElement
+  let customRecordType: ObjectType
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    customFieldInstance = new InstanceElement(
+      'entitycustomfield123',
+      entitycustomfield,
+      {
+        [SCRIPT_ID]: 'entitycustomfield123',
+        [SELECT_RECORD_TYPE]: '-4',
+      }
+    )
+    suiteQLInstances = [
+      new InstanceElement(
+        'employee',
+        suiteQLTableType,
+        {
+          [INTERNAL_IDS_MAP]: {
+            '-1': { name: 'Salto user 1' },
+            '-2': { name: 'Salto user 2' },
+            '-3': { name: 'Salto user 3' },
+            '-4': { name: 'Salto user 4' },
+          },
+        }
+      ),
+      new InstanceElement(
+        'account',
+        suiteQLTableType,
+        {
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Account 1' },
+            2: { name: 'Account 2' },
+            3: { name: 'Account 3' },
+            4: { name: 'Account 4' },
+            5: { name: 'Account 5' },
+            15: { name: 'Account 5' },
+          },
+        }
+      ),
+    ]
+    customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord123'),
+      fields: {
+        custom_field: {
+          refType: BuiltinTypes.STRING,
+          annotations: {
+            [SCRIPT_ID]: 'custom_field',
+            [SELECT_RECORD_TYPE]: '-112',
+          },
+        },
+      },
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    filterOpts = {
+      client,
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve({
+          ...createEmptyElementsSourceIndexes(),
+          customFieldsSelectRecordTypeIndex: {
+            [customFieldInstance.elemID.getFullName()]: '-4',
+          },
+        }),
+      },
+      elementsSource: buildElementsSourceFromElements(suiteQLInstances),
+      isPartial: true,
+      config: await getDefaultAdapterConfig(),
+    }
+  })
+
+  describe('on fetch', () => {
+    let elements: Element[]
+
+    beforeEach(() => {
+      workflowInstance1 = new InstanceElement(
+        'customworkflow1',
+        workflow,
+        {
+          [SCRIPT_ID]: 'customworkflow1',
+          [NAME_FIELD]: 'Custom workflow 1',
+          [INIT_CONDITION]: {
+            formula: '"Subsidiary (Main):Default Account for Corporate Card Expenses" IN ("Account1","Account2","Account3","Account4","Account5","Account6") AND "Employee" IN ("Employee1") OR "User Role" IN ("Role1")',
+            parameters: {
+              parameter: {
+                'Subsidiary__Main__Default_Account_for_Corporate_Card_Expenses@sjkfsssss': {
+                  name: 'Subsidiary (Main):Default Account for Corporate Card Expenses',
+                  value: 'STDBODYSUBSIDIARY:STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
+                },
+                Account1: {
+                  name: 'Account1',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Account2: {
+                  name: 'Account2',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Account3: {
+                  name: 'Account3',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Account4: {
+                  name: 'Account4',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Account5: {
+                  name: 'Account5',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Account6: {
+                  name: 'Account6',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Employee: {
+                  name: 'Employee',
+                  value: 'STDBODYEMPLOYEE',
+                },
+                Employee1: {
+                  name: 'Employee1',
+                  [SELECT_RECORD_TYPE]: '-4',
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                'User_Role@s': {
+                  name: 'User Role',
+                  value: 'STDUSERROLE',
+                },
+                Role1: {
+                  name: 'Role1',
+                  [SELECT_RECORD_TYPE]: '-118',
+                  value: '[scriptid=customrole123]',
+                },
+              },
+            },
+          },
+          workflowcustomfields: {
+            workflowcustomfield: {
+              custworkflow1: {
+                [SCRIPT_ID]: 'custworkflow1',
+                [SELECT_RECORD_TYPE]: new ReferenceExpression(customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID)),
+                defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+              },
+            },
+          },
+          workflowstates: {
+            workflowstate: {
+              workflowstate118: {
+                [SCRIPT_ID]: 'workflowstate118',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction166: {
+                        [SCRIPT_ID]: 'workflowaction166',
+                        [SELECT_RECORD_TYPE]: new ReferenceExpression(customRecordType.elemID.createNestedID('attr', SCRIPT_ID)),
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                      },
+                      workflowaction167: {
+                        [SCRIPT_ID]: 'workflowaction167',
+                        resultfield: new ReferenceExpression(new ElemID(NETSUITE, 'workflow', 'instance', 'customworkflow1', 'workflowcustomfields', 'workflowcustomfield', 'custworkflow1', SCRIPT_ID)),
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction224: {
+                        [SCRIPT_ID]: 'workflowaction224',
+                        field: 'UNKNOWN',
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                        [INIT_CONDITION]: {
+                          formula: '"User Role" IN ("Role1")',
+                          parameters: {
+                            parameter: {
+                              'User_Role@s': {
+                                name: 'User Role',
+                                value: 'STDUSERROLE',
+                              },
+                              Role1: {
+                                name: 'Role1',
+                                [SELECT_RECORD_TYPE]: '-118',
+                                value: '[scriptid=customrole123]',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+      workflowInstance2 = new InstanceElement(
+        'customworkflow2',
+        workflow,
+        {
+          [SCRIPT_ID]: 'customworkflow2',
+          [NAME_FIELD]: 'Custom workflow 2',
+          workflowstates: {
+            workflowstate: {
+              workflowstate18: {
+                [SCRIPT_ID]: 'workflowstate18',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction66: {
+                        [SCRIPT_ID]: 'workflowaction66',
+                        [INIT_CONDITION]: {
+                          formula: '"Employee" IN ("Employee2")',
+                          parameters: {
+                            parameter: {
+                              Employee: {
+                                name: 'Employee',
+                                value: 'STDBODYEMPLOYEE',
+                              },
+                              Employee2: {
+                                name: 'Employee2',
+                                [SELECT_RECORD_TYPE]: '-4',
+                                value: ACCOUNT_SPECIFIC_VALUE,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction124: {
+                        [SCRIPT_ID]: 'workflowaction124',
+                        field: 'STDBODYACCOUNT',
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                        recipient: ACCOUNT_SPECIFIC_VALUE,
+                        sender: ACCOUNT_SPECIFIC_VALUE,
+                      },
+                    },
+                  },
+                },
+                workflowstatecustomfields: {
+                  workflowstatecustomfield: {
+                    custwfstate2: {
+                      [SCRIPT_ID]: 'custwfstate2',
+                      field: new ReferenceExpression(customFieldInstance.elemID.createNestedID(SCRIPT_ID)),
+                      defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+      elements = [
+        workflowInstance1,
+        workflowInstance2,
+        ...suiteQLInstances,
+        customRecordType,
+      ]
+    })
+    describe('successful call', () => {
+      beforeEach(async () => {
+        runSavedSearchQueryMock.mockResolvedValue([
+          { internalid: [{ value: '3' }] },
+          { internalid: [{ value: '5' }] },
+        ])
+        runRecordsQueryMock.mockResolvedValue([
+          {
+            body: {
+              [SCRIPT_ID]: 'customworkflow1',
+              initconditionformula: '{subsidiary} in (1,2,3,4,5,6) AND {employee}=-1 or {role}=4',
+            },
+            sublists: [
+              {
+                body: {
+                  [SCRIPT_ID]: 'custworkflow1',
+                  defaultvalue: '5',
+                },
+                sublists: [],
+              },
+              {
+                body: {
+                  [SCRIPT_ID]: 'workflowstate118',
+                },
+                sublists: [
+                  {
+                    body: {
+                      [SCRIPT_ID]: 'workflowaction167',
+                      defaultvalue: '3',
+                    },
+                    sublists: [],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            body: {
+              [SCRIPT_ID]: 'customworkflow2',
+              initconditionformula: '',
+            },
+            sublists: [
+              {
+                body: {
+                  [SCRIPT_ID]: 'workflowstate18',
+                },
+                sublists: [
+                  {
+                    body: {
+                      [SCRIPT_ID]: 'workflowaction66',
+                      conditionformula: '{employee}=-2',
+                    },
+                    sublists: [],
+                  },
+                  {
+                    body: {
+                      [SCRIPT_ID]: 'workflowaction124',
+                      conditionformula: '',
+                      defaultvalue: '5',
+                      sender: '-3',
+                      recipient: '-4',
+                    },
+                    sublists: [],
+                  },
+                  {
+                    body: {
+                      [SCRIPT_ID]: 'custwfstate2',
+                      defaultvalue: '-1',
+                    },
+                    sublists: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ])
+        await filterCreator(filterOpts).onFetch?.(elements)
+      })
+      it('should call runSavedSearchQuery with right params', () => {
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
+          type: 'workflow',
+          columns: ['internalid'],
+          filters: [['name', 'is', 'Custom workflow 1'], 'OR', ['name', 'is', 'Custom workflow 2']],
+        })
+      })
+      it('should call runRecordsQuery with right params', () => {
+        expect(runRecordsQueryMock).toHaveBeenCalledWith(
+          ['3', '5'],
+          {
+            type: 'workflow',
+            fields: ['scriptid', 'initconditionformula'],
+            filter: {
+              fieldId: 'scriptid',
+              in: ['customworkflow1', 'customworkflow2'],
+            },
+            sublists: [
+              {
+                type: 'workflowstate',
+                fields: ['scriptid'],
+                filter: {
+                  fieldId: 'scriptid',
+                  in: ['workflowstate118', 'workflowstate18'],
+                },
+                idAlias: 'stateid',
+                sublistId: 'states',
+                sublists: [
+                  {
+                    type: 'actiontype',
+                    idAlias: 'actionid',
+                    sublistId: 'actions',
+                    typeSuffix: 'action',
+                    customTypes: { customactionaction: 'customaction' },
+                    fields: ['scriptid', 'defaultvalue', 'conditionformula', 'recipient', 'sender'],
+                    filter: {
+                      fieldId: 'scriptid',
+                      in: ['workflowaction167', 'workflowaction66', 'workflowaction124'],
+                    },
+                  },
+                  {
+                    type: 'workflowstatecustomfield',
+                    sublistId: 'fields',
+                    idAlias: 'id',
+                    fields: ['scriptid', 'defaultvalue'],
+                    filter: {
+                      fieldId: 'scriptid',
+                      in: ['custwfstate2'],
+                    },
+                  },
+                ],
+              },
+              {
+                type: 'workflowcustomfield',
+                sublistId: 'fields',
+                idAlias: 'id',
+                fields: ['scriptid', 'defaultvalue'],
+                filter: {
+                  fieldId: 'scriptid',
+                  in: ['custworkflow1'],
+                },
+              },
+            ],
+          }
+        )
+      })
+      it('should resolve account specific values', () => {
+        expect(workflowInstance1.value).toEqual({
+          [SCRIPT_ID]: 'customworkflow1',
+          [NAME_FIELD]: 'Custom workflow 1',
+          [INIT_CONDITION]: {
+            formula: '"Subsidiary (Main):Default Account for Corporate Card Expenses" IN ("Account1","Account2","Account3","Account4","Account5","Account6") AND "Employee" IN ("Employee1") OR "User Role" IN ("Role1")',
+            parameters: {
+              parameter: {
+                'Subsidiary__Main__Default_Account_for_Corporate_Card_Expenses@sjkfsssss': {
+                  name: 'Subsidiary (Main):Default Account for Corporate Card Expenses',
+                  value: 'STDBODYSUBSIDIARY:STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
+                },
+                Account1: {
+                  name: 'Account1',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 1)`,
+                },
+                Account2: {
+                  name: 'Account2',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 2)`,
+                },
+                Account3: {
+                  name: 'Account3',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 3)`,
+                },
+                Account4: {
+                  name: 'Account4',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 4)`,
+                },
+                Account5: {
+                  name: 'Account5',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+                },
+                Account6: {
+                  name: 'Account6',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  // should not be resolved - no internal id is 6
+                  value: ACCOUNT_SPECIFIC_VALUE,
+                },
+                Employee: {
+                  name: 'Employee',
+                  value: 'STDBODYEMPLOYEE',
+                },
+                Employee1: {
+                  name: 'Employee1',
+                  [SELECT_RECORD_TYPE]: '-4',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 1)`,
+                },
+                'User_Role@s': {
+                  name: 'User Role',
+                  value: 'STDUSERROLE',
+                },
+                Role1: {
+                  name: 'Role1',
+                  [SELECT_RECORD_TYPE]: '-118',
+                  value: '[scriptid=customrole123]',
+                },
+              },
+            },
+          },
+          workflowcustomfields: {
+            workflowcustomfield: {
+              custworkflow1: {
+                [SCRIPT_ID]: 'custworkflow1',
+                [SELECT_RECORD_TYPE]: new ReferenceExpression(customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID)),
+                defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+              },
+            },
+          },
+          workflowstates: {
+            workflowstate: {
+              workflowstate118: {
+                [SCRIPT_ID]: 'workflowstate118',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction166: {
+                        [SCRIPT_ID]: 'workflowaction166',
+                        [SELECT_RECORD_TYPE]: new ReferenceExpression(customRecordType.elemID.createNestedID('attr', SCRIPT_ID)),
+                        // should not resolve - there is no suiteql table instnace for custom record types
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                      },
+                      workflowaction167: {
+                        [SCRIPT_ID]: 'workflowaction167',
+                        resultfield: new ReferenceExpression(workflowInstance1.elemID.createNestedID('workflowcustomfields', 'workflowcustomfield', 'custworkflow1', SCRIPT_ID)),
+                        defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 3)`,
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction224: {
+                        [SCRIPT_ID]: 'workflowaction224',
+                        field: 'UNKNOWN',
+                        // should not resolve - field is UNKNOWN
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                        [INIT_CONDITION]: {
+                          formula: '"User Role" IN ("Role1")',
+                          parameters: {
+                            parameter: {
+                              'User_Role@s': {
+                                name: 'User Role',
+                                value: 'STDUSERROLE',
+                              },
+                              Role1: {
+                                name: 'Role1',
+                                [SELECT_RECORD_TYPE]: '-118',
+                                value: '[scriptid=customrole123]',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+        expect(workflowInstance2.value).toEqual({
+          [SCRIPT_ID]: 'customworkflow2',
+          [NAME_FIELD]: 'Custom workflow 2',
+          workflowstates: {
+            workflowstate: {
+              workflowstate18: {
+                [SCRIPT_ID]: 'workflowstate18',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction66: {
+                        [SCRIPT_ID]: 'workflowaction66',
+                        [INIT_CONDITION]: {
+                          formula: '"Employee" IN ("Employee2")',
+                          parameters: {
+                            parameter: {
+                              Employee: {
+                                name: 'Employee',
+                                value: 'STDBODYEMPLOYEE',
+                              },
+                              Employee2: {
+                                name: 'Employee2',
+                                [SELECT_RECORD_TYPE]: '-4',
+                                value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 2)`,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction124: {
+                        [SCRIPT_ID]: 'workflowaction124',
+                        field: 'STDBODYACCOUNT',
+                        defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+                        recipient: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 4)`,
+                        sender: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 3)`,
+                      },
+                    },
+                  },
+                },
+                workflowstatecustomfields: {
+                  workflowstatecustomfield: {
+                    custwfstate2: {
+                      [SCRIPT_ID]: 'custwfstate2',
+                      field: new ReferenceExpression(customFieldInstance.elemID.createNestedID(SCRIPT_ID)),
+                      defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 1)`,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        })
+      })
+    })
+    describe('with errors', () => {
+      let originalWorkflowInstance1: InstanceElement
+      let originalWorkflowInstance2: InstanceElement
+      beforeEach(() => {
+        originalWorkflowInstance1 = workflowInstance1.clone()
+        originalWorkflowInstance2 = workflowInstance2.clone()
+      })
+      it('should not run records query when internal ids query fail', async () => {
+        runSavedSearchQueryMock.mockResolvedValue(undefined)
+        await filterCreator(filterOpts).onFetch?.(elements)
+        expect(runRecordsQueryMock).not.toHaveBeenCalled()
+        expect(workflowInstance1.value).toEqual(originalWorkflowInstance1.value)
+        expect(workflowInstance2.value).toEqual(originalWorkflowInstance2.value)
+      })
+      it('should not resolve account specific values when record query result has no data', async () => {
+        runSavedSearchQueryMock.mockResolvedValue([
+          { internalid: [{ value: '3' }] },
+          { internalid: [{ value: '5' }] },
+        ])
+        runRecordsQueryMock.mockResolvedValue([
+          {
+            body: {
+              [SCRIPT_ID]: 'customworkflow1',
+              initconditionformula: '',
+            },
+            sublists: [],
+          },
+        ])
+        await filterCreator(filterOpts).onFetch?.(elements)
+        expect(workflowInstance1.value).toEqual(originalWorkflowInstance1.value)
+        expect(workflowInstance2.value).toEqual(originalWorkflowInstance2.value)
+      })
+      it('should not run filter when there are no suiteql instances', async () => {
+        await filterCreator(filterOpts).onFetch?.(elements.filter(e => e.elemID.typeName !== SUITEQL_TABLE))
+        expect(runSavedSearchQueryMock).not.toHaveBeenCalled()
+        expect(runRecordsQueryMock).not.toHaveBeenCalled()
+      })
+      it('should not run filter when there are no unresolved workflows', async () => {
+        workflowInstance1.value = {
+          [SCRIPT_ID]: 'customworkflow1',
+        }
+        workflowInstance2.value = {
+          [SCRIPT_ID]: 'customworkflow2',
+        }
+        await filterCreator(filterOpts).onFetch?.(elements)
+        expect(runSavedSearchQueryMock).not.toHaveBeenCalled()
+        expect(runRecordsQueryMock).not.toHaveBeenCalled()
+      })
+    })
+  })
+
+  describe('pre deploy', () => {
+    beforeEach(async () => {
+      workflowInstance1 = new InstanceElement(
+        'customworkflow1',
+        workflow,
+        {
+          [SCRIPT_ID]: 'customworkflow1',
+          [NAME_FIELD]: 'Custom workflow 1',
+          [INIT_CONDITION]: {
+            formula: '"Subsidiary (Main):Default Account for Corporate Card Expenses" IN ("Account1","Account2","Account3","Account4","Account5","Account6") AND "Employee" IN ("Employee1") OR "User Role" IN ("Role1")',
+            parameters: {
+              parameter: {
+                'Subsidiary__Main__Default_Account_for_Corporate_Card_Expenses@sjkfsssss': {
+                  name: 'Subsidiary (Main):Default Account for Corporate Card Expenses',
+                  value: 'STDBODYSUBSIDIARY:STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
+                },
+                Account1: {
+                  name: 'Account1',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 1)`,
+                },
+                Account2: {
+                  name: 'Account2',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 2)`,
+                },
+                Account3: {
+                  name: 'Account3',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 3)`,
+                },
+                Account4: {
+                  name: 'Account4',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 4)`,
+                },
+                Account5: {
+                  name: 'Account5',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+                },
+                Account6: {
+                  name: 'Account6',
+                  [SELECT_RECORD_TYPE]: '-112',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Account 6)`,
+                },
+                Employee: {
+                  name: 'Employee',
+                  value: 'STDBODYEMPLOYEE',
+                },
+                Employee1: {
+                  name: 'Employee1',
+                  [SELECT_RECORD_TYPE]: '-4',
+                  value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 1)`,
+                },
+                'User_Role@s': {
+                  name: 'User Role',
+                  value: 'STDUSERROLE',
+                },
+                Role1: {
+                  name: 'Role1',
+                  [SELECT_RECORD_TYPE]: '-118',
+                  value: '[scriptid=customrole123]',
+                },
+              },
+            },
+          },
+          workflowcustomfields: {
+            workflowcustomfield: {
+              custworkflow1: {
+                [SCRIPT_ID]: 'custworkflow1',
+                [SELECT_RECORD_TYPE]: new ReferenceExpression(
+                  customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID),
+                  customRecordType.fields.custom_field.annotations[SCRIPT_ID],
+                  customRecordType,
+                ),
+                defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+              },
+            },
+          },
+          workflowstates: {
+            workflowstate: {
+              workflowstate118: {
+                [SCRIPT_ID]: 'workflowstate118',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction166: {
+                        [SCRIPT_ID]: 'workflowaction166',
+                        [SELECT_RECORD_TYPE]: new ReferenceExpression(
+                          customRecordType.elemID.createNestedID('attr', SCRIPT_ID),
+                          customRecordType.annotations[SCRIPT_ID],
+                          customRecordType,
+                        ),
+                        // should not resolve - there is no suiteql table instnace for custom record types
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                      },
+                      workflowaction167: {
+                        [SCRIPT_ID]: 'workflowaction167',
+                        resultfield: new ReferenceExpression(workflowInstance1.elemID.createNestedID('workflowcustomfields', 'workflowcustomfield', 'custworkflow1', SCRIPT_ID)),
+                        defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 3)`,
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction224: {
+                        [SCRIPT_ID]: 'workflowaction224',
+                        field: 'UNKNOWN',
+                        // should not resolve - field is UNKNOWN
+                        defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                        [INIT_CONDITION]: {
+                          formula: '"User Role" IN ("Role1")',
+                          parameters: {
+                            parameter: {
+                              'User_Role@s': {
+                                name: 'User Role',
+                                value: 'STDUSERROLE',
+                              },
+                              Role1: {
+                                name: 'Role1',
+                                [SELECT_RECORD_TYPE]: '-118',
+                                value: '[scriptid=customrole123]',
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+      workflowInstance2 = new InstanceElement(
+        'customworkflow2',
+        workflow,
+        {
+          [SCRIPT_ID]: 'customworkflow2',
+          [NAME_FIELD]: 'Custom workflow 2',
+          workflowstates: {
+            workflowstate: {
+              workflowstate18: {
+                [SCRIPT_ID]: 'workflowstate18',
+                workflowactions: {
+                  ONENTRY: {
+                    setfieldvalueaction: {
+                      workflowaction66: {
+                        [SCRIPT_ID]: 'workflowaction66',
+                        [INIT_CONDITION]: {
+                          formula: '"Employee" IN ("Employee2")',
+                          parameters: {
+                            parameter: {
+                              Employee: {
+                                name: 'Employee',
+                                value: 'STDBODYEMPLOYEE',
+                              },
+                              Employee2: {
+                                name: 'Employee2',
+                                [SELECT_RECORD_TYPE]: '-4',
+                                value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 2)`,
+                              },
+                            },
+                          },
+                        },
+                      },
+                    },
+                    sendemailaction: {
+                      workflowaction124: {
+                        [SCRIPT_ID]: 'workflowaction124',
+                        field: 'STDBODYACCOUNT',
+                        defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+                        recipient: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 4)`,
+                        sender: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 3)`,
+                      },
+                    },
+                  },
+                },
+                workflowstatecustomfields: {
+                  workflowstatecustomfield: {
+                    custwfstate2: {
+                      [SCRIPT_ID]: 'custwfstate2',
+                      field: new ReferenceExpression(
+                        customFieldInstance.elemID.createNestedID(SCRIPT_ID),
+                        customFieldInstance.value[SCRIPT_ID],
+                        customFieldInstance,
+                      ),
+                      defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 1)`,
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }
+      )
+      await filterCreator(filterOpts).preDeploy?.([
+        toChange({ after: workflowInstance1 }),
+        toChange({ after: workflowInstance2 }),
+      ])
+    })
+    it('should resolve account specific values', () => {
+      expect(workflowInstance1.value).toEqual({
+        [SCRIPT_ID]: 'customworkflow1',
+        [NAME_FIELD]: 'Custom workflow 1',
+        [INIT_CONDITION]: {
+          formula: '"Subsidiary (Main):Default Account for Corporate Card Expenses" IN ("Account1","Account2","Account3","Account4","Account5","Account6") AND "Employee" IN ("Employee1") OR "User Role" IN ("Role1")',
+          parameters: {
+            parameter: {
+              'Subsidiary__Main__Default_Account_for_Corporate_Card_Expenses@sjkfsssss': {
+                name: 'Subsidiary (Main):Default Account for Corporate Card Expenses',
+                value: 'STDBODYSUBSIDIARY:STDRECORDSUBSIDIARYDEFAULTACCTCORPCARDEXP',
+              },
+              Account1: {
+                name: 'Account1',
+                [SELECT_RECORD_TYPE]: '-112',
+                value: '1',
+              },
+              Account2: {
+                name: 'Account2',
+                [SELECT_RECORD_TYPE]: '-112',
+                value: '2',
+              },
+              Account3: {
+                name: 'Account3',
+                [SELECT_RECORD_TYPE]: '-112',
+                value: '3',
+              },
+              Account4: {
+                name: 'Account4',
+                [SELECT_RECORD_TYPE]: '-112',
+                value: '4',
+              },
+              Account5: {
+                name: 'Account5',
+                [SELECT_RECORD_TYPE]: '-112',
+                value: '5',
+              },
+              Account6: {
+                name: 'Account6',
+                [SELECT_RECORD_TYPE]: '-112',
+                // should not be resolved - no internal id match "Account 6"
+                value: ACCOUNT_SPECIFIC_VALUE,
+              },
+              Employee: {
+                name: 'Employee',
+                value: 'STDBODYEMPLOYEE',
+              },
+              Employee1: {
+                name: 'Employee1',
+                [SELECT_RECORD_TYPE]: '-4',
+                value: '-1',
+              },
+              'User_Role@s': {
+                name: 'User Role',
+                value: 'STDUSERROLE',
+              },
+              Role1: {
+                name: 'Role1',
+                [SELECT_RECORD_TYPE]: '-118',
+                value: '[scriptid=customrole123]',
+              },
+            },
+          },
+        },
+        workflowcustomfields: {
+          workflowcustomfield: {
+            custworkflow1: {
+              [SCRIPT_ID]: 'custworkflow1',
+              [SELECT_RECORD_TYPE]: new ReferenceExpression(
+                customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID),
+                customRecordType.fields.custom_field.annotations[SCRIPT_ID],
+                customRecordType,
+              ),
+              defaultvalue: '5',
+            },
+          },
+        },
+        workflowstates: {
+          workflowstate: {
+            workflowstate118: {
+              [SCRIPT_ID]: 'workflowstate118',
+              workflowactions: {
+                ONENTRY: {
+                  setfieldvalueaction: {
+                    workflowaction166: {
+                      [SCRIPT_ID]: 'workflowaction166',
+                      [SELECT_RECORD_TYPE]: new ReferenceExpression(
+                        customRecordType.elemID.createNestedID('attr', SCRIPT_ID),
+                        customRecordType.annotations[SCRIPT_ID],
+                        customRecordType,
+                      ),
+                      // should not resolve - there is no suiteql table instnace for custom record types
+                      defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                    },
+                    workflowaction167: {
+                      [SCRIPT_ID]: 'workflowaction167',
+                      resultfield: new ReferenceExpression(workflowInstance1.elemID.createNestedID('workflowcustomfields', 'workflowcustomfield', 'custworkflow1', SCRIPT_ID)),
+                      defaultvalue: '3',
+                    },
+                  },
+                  sendemailaction: {
+                    workflowaction224: {
+                      [SCRIPT_ID]: 'workflowaction224',
+                      field: 'UNKNOWN',
+                      // should not resolve - field is UNKNOWN
+                      defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+                      [INIT_CONDITION]: {
+                        formula: '"User Role" IN ("Role1")',
+                        parameters: {
+                          parameter: {
+                            'User_Role@s': {
+                              name: 'User Role',
+                              value: 'STDUSERROLE',
+                            },
+                            Role1: {
+                              name: 'Role1',
+                              [SELECT_RECORD_TYPE]: '-118',
+                              value: '[scriptid=customrole123]',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+      expect(workflowInstance2.value).toEqual({
+        [SCRIPT_ID]: 'customworkflow2',
+        [NAME_FIELD]: 'Custom workflow 2',
+        workflowstates: {
+          workflowstate: {
+            workflowstate18: {
+              [SCRIPT_ID]: 'workflowstate18',
+              workflowactions: {
+                ONENTRY: {
+                  setfieldvalueaction: {
+                    workflowaction66: {
+                      [SCRIPT_ID]: 'workflowaction66',
+                      [INIT_CONDITION]: {
+                        formula: '"Employee" IN ("Employee2")',
+                        parameters: {
+                          parameter: {
+                            Employee: {
+                              name: 'Employee',
+                              value: 'STDBODYEMPLOYEE',
+                            },
+                            Employee2: {
+                              name: 'Employee2',
+                              [SELECT_RECORD_TYPE]: '-4',
+                              value: '-2',
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                  sendemailaction: {
+                    workflowaction124: {
+                      [SCRIPT_ID]: 'workflowaction124',
+                      field: 'STDBODYACCOUNT',
+                      defaultvalue: '5',
+                      recipient: '-4',
+                      sender: '-3',
+                    },
+                  },
+                },
+              },
+              workflowstatecustomfields: {
+                workflowstatecustomfield: {
+                  custwfstate2: {
+                    [SCRIPT_ID]: 'custwfstate2',
+                    field: new ReferenceExpression(
+                      customFieldInstance.elemID.createNestedID(SCRIPT_ID),
+                      customFieldInstance.value[SCRIPT_ID],
+                      customFieldInstance,
+                    ),
+                    defaultvalue: '-1',
+                  },
+                },
+              },
+            },
+          },
+        },
+      })
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/utils.ts
+++ b/packages/netsuite-adapter/test/utils.ts
@@ -34,4 +34,5 @@ export const createEmptyElementsSourceIndexes = (): ElementsSourceIndexes => ({
   elemIdToChangeByIndex: {},
   elemIdToChangeAtIndex: {},
   customRecordFieldsServiceIdRecordsIndex: {},
+  customFieldsSelectRecordTypeIndex: {},
 })


### PR DESCRIPTION
Use queried internal ids maps from SuiteQL and the "record" SuiteApp operation to get the value behind ASV in workflows.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- resolve account specific values in workflows (behind config value `fetch.resolveAccountSpecificValues`)

---
_User Notifications_: 
None