### PR TITLE
SALTO-5343: convert statuses and transitions properties to a list

### DIFF
--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType, getDeepInnerType, InstanceElement, ReadOnlyElementsSource, isInstanceElement, Value } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ObjectType, Element, isObjectType, getDeepInnerType, InstanceElement, ReadOnlyElementsSource, isInstanceElement, Value, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
@@ -196,4 +196,22 @@ Promise<boolean> => {
     log.error(`Failed to get server info: ${e}`)
   }
   return true
+}
+
+export const convertPropertiesToList = (fields: Values[]): void => {
+  fields.forEach(field => {
+    if (field.properties != null) {
+      field.properties = Object.entries(field.properties)
+        .map(([key, value]) => ({ key, value }))
+    }
+  })
+}
+export const convertPropertiesToMap = (fields: Values[]): void => {
+  fields.forEach(field => {
+    if (field.properties != null) {
+      field.properties = Object.fromEntries(
+        field.properties.map(({ key, value }: Values) => [key, value])
+      )
+    }
+  })
 }

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -94,7 +94,23 @@ describe('jiraWorkflowFilter', () => {
               scope: {
                 type: 'global',
               },
-              transitions: [{ type: 'INITIAL' }],
+              transitions: [
+                {
+                  type: 'INITIAL',
+                  properties:
+                    {
+                      'jira.issue.editable': 'true',
+                    },
+                },
+              ],
+              statuses: [
+                {
+                  id: '1',
+                  properties: {
+                    'jira.issue.editable': 'true',
+                  },
+                },
+              ],
             },
             {
               id: '2',
@@ -128,7 +144,28 @@ describe('jiraWorkflowFilter', () => {
         scope: {
           type: 'global',
         },
-        transitions: [{ type: 'INITIAL' }],
+        transitions: [
+          {
+            type: 'INITIAL',
+            properties: [
+              {
+                key: 'jira.issue.editable',
+                value: 'true',
+              },
+            ],
+          },
+        ],
+        statuses: [
+          {
+            id: '1',
+            properties: [
+              {
+                key: 'jira.issue.editable',
+                value: 'true',
+              },
+            ],
+          },
+        ],
       })
       const secondWorkflow = elements[2] as unknown as InstanceElement
       expect(secondWorkflow.elemID.name).toEqual('secondWorkflow')
@@ -406,6 +443,9 @@ describe('jiraWorkflowFilter', () => {
                 y: 34,
               },
               statusReference: 'uuid1',
+              properties: {
+                'jira.issue.editable': 'true',
+              },
             },
             {
               layout: {
@@ -426,6 +466,9 @@ describe('jiraWorkflowFilter', () => {
               conditions: {
                 operation: 'ALL',
                 conditionGroups: [],
+              },
+              properties: {
+                'jira.issue.editable': 'true',
               },
             },
             {
@@ -621,6 +664,12 @@ describe('jiraWorkflowFilter', () => {
               x: 12,
               y: 34,
             },
+            properties: [
+              {
+                key: 'jira.issue.editable',
+                value: 'true',
+              },
+            ],
           },
           {
             statusReference: new ReferenceExpression(status2.elemID, status2),
@@ -641,6 +690,12 @@ describe('jiraWorkflowFilter', () => {
             conditions: {
               operation: 'ALL',
             },
+            properties: [
+              {
+                key: 'jira.issue.editable',
+                value: 'true',
+              },
+            ],
           },
           {
             id: '2',


### PR DESCRIPTION
_convert statuses and transitions properties to a list_

---

_Additional context for reviewer_
* We use the same logic in other places in the adapter so I took it out as a more generic function

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
