### PR TITLE
SALTO-4564: Netsuite - warning about deleting permissions from role

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -135,8 +135,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   // excludeCustomRecordTypes should run before customRecordTypesType,
   // because otherwise there will be broken references to excluded types.
   { creator: excludeCustomRecordTypes },
-  { creator: restoreDeletedListItems },
   { creator: restoreDeletedListItemsWithScriptId },
+  { creator: restoreDeletedListItems },
   // excludeCustomRecordTypes should run before customRecordTypesType,
   // because otherwise there will be broken references to excluded types.
   { creator: excludeCustomRecordTypes },

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -86,14 +86,9 @@ import excludeCustomRecordTypes from './filters/exclude_by_criteria/exclude_cust
 import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
 import workflowAccountSpecificValues from './filters/workflow_account_specific_values'
 import alignFieldNamesFilter from './filters/align_field_names'
-import {
-  Filter,
-  LocalFilterCreator,
-  LocalFilterCreatorDefinition,
-  RemoteFilterCreator,
-  RemoteFilterCreatorDefinition,
-  RemoteFilterOpts,
-} from './filter'
+import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
+import restoreDeletedListItems from './filters/restore_deleted_list_items_without_scriptid'
+import restoreDeletedListItemsWithScriptId from './filters/restore_deleted_list_items'
 import { getLastServerTime, getOrCreateServerTimeElements, getLastServiceIdToFetchTime } from './server_time'
 import { getChangedObjects } from './changes_detector/changes_detector'
 import { FetchDeletionResult, getDeletedElements } from './deletion_calculator'
@@ -190,6 +185,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: addAliasFilter },
   { creator: addImportantValuesFilter },
   { creator: fixOrderProblemsInWorkbooks },
+  { creator: restoreDeletedListItems }, // does it matter where it is?
+  { creator: restoreDeletedListItemsWithScriptId }, // does it matter where it is?
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   { creator: addBundleReferences },

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -86,7 +86,14 @@ import excludeCustomRecordTypes from './filters/exclude_by_criteria/exclude_cust
 import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
 import workflowAccountSpecificValues from './filters/workflow_account_specific_values'
 import alignFieldNamesFilter from './filters/align_field_names'
-import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
+import {
+  Filter,
+  LocalFilterCreator,
+  LocalFilterCreatorDefinition,
+  RemoteFilterCreator,
+  RemoteFilterCreatorDefinition,
+  RemoteFilterOpts,
+} from './filter'
 import restoreDeletedListItemsWithoutScriptId from './filters/restore_deleted_list_items_without_scriptid'
 import restoreDeletedListItems from './filters/restore_deleted_list_items'
 import { getLastServerTime, getOrCreateServerTimeElements, getLastServiceIdToFetchTime } from './server_time'

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -132,6 +132,14 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition)[] = [
+  // excludeCustomRecordTypes should run before customRecordTypesType,
+  // because otherwise there will be broken references to excluded types.
+  { creator: excludeCustomRecordTypes },
+  { creator: restoreDeletedListItems },
+  { creator: restoreDeletedListItemsWithScriptId },
+  // excludeCustomRecordTypes should run before customRecordTypesType,
+  // because otherwise there will be broken references to excluded types.
+  { creator: excludeCustomRecordTypes },
   { creator: customRecordTypesType },
   { creator: omitSdfUntypedValues },
   { creator: dataInstancesIdentifiers },
@@ -185,6 +193,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: addAliasFilter },
   { creator: addImportantValuesFilter },
   { creator: fixOrderProblemsInWorkbooks },
+  { creator: restoreDeletedListItems }, // does it matter where it is?
+  { creator: restoreDeletedListItemsWithScriptId }, // does it matter where it is?
   { creator: restoreDeletedListItems }, // does it matter where it is?
   { creator: restoreDeletedListItemsWithScriptId }, // does it matter where it is?
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -87,8 +87,8 @@ import excludeInstances from './filters/exclude_by_criteria/exclude_instances'
 import workflowAccountSpecificValues from './filters/workflow_account_specific_values'
 import alignFieldNamesFilter from './filters/align_field_names'
 import { Filter, LocalFilterCreator, LocalFilterCreatorDefinition, RemoteFilterCreator, RemoteFilterCreatorDefinition, RemoteFilterOpts } from './filter'
-import restoreDeletedListItems from './filters/restore_deleted_list_items_without_scriptid'
-import restoreDeletedListItemsWithScriptId from './filters/restore_deleted_list_items'
+import restoreDeletedListItemsWithoutScriptId from './filters/restore_deleted_list_items_without_scriptid'
+import restoreDeletedListItems from './filters/restore_deleted_list_items'
 import { getLastServerTime, getOrCreateServerTimeElements, getLastServiceIdToFetchTime } from './server_time'
 import { getChangedObjects } from './changes_detector/changes_detector'
 import { FetchDeletionResult, getDeletedElements } from './deletion_calculator'
@@ -135,8 +135,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   // excludeCustomRecordTypes should run before customRecordTypesType,
   // because otherwise there will be broken references to excluded types.
   { creator: excludeCustomRecordTypes },
-  { creator: restoreDeletedListItemsWithScriptId },
   { creator: restoreDeletedListItems },
+  { creator: restoreDeletedListItemsWithoutScriptId },
   // excludeCustomRecordTypes should run before customRecordTypesType,
   // because otherwise there will be broken references to excluded types.
   { creator: excludeCustomRecordTypes },
@@ -193,10 +193,6 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: addAliasFilter },
   { creator: addImportantValuesFilter },
   { creator: fixOrderProblemsInWorkbooks },
-  { creator: restoreDeletedListItems }, // does it matter where it is?
-  { creator: restoreDeletedListItemsWithScriptId }, // does it matter where it is?
-  { creator: restoreDeletedListItems }, // does it matter where it is?
-  { creator: restoreDeletedListItemsWithScriptId }, // does it matter where it is?
   // serviceUrls must run after suiteAppInternalIds and SDFInternalIds filter
   { creator: serviceUrls, addsNewInformation: true },
   { creator: addBundleReferences },

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -32,6 +32,7 @@ import dataAccountSpecificValuesValidator from './change_validators/data_account
 import removeStandardTypesValidator from './change_validators/remove_standard_types'
 import removeFileCabinetValidator from './change_validators/remove_file_cabinet'
 import removeListItemValidator from './change_validators/remove_list_item'
+import removeListItemWithoutScriptIDValidator from './change_validators/remove_list_item_without_id'
 import instanceChangesValidator from './change_validators/instance_changes'
 import removeSdfElementsValidator from './change_validators/remove_sdf_elements'
 import reportTypesMoveEnvironment from './change_validators/report_types_move_environment'
@@ -88,6 +89,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   immutableChanges: immutableChangesValidator,
   inactive: inactiveParent,
   removeListItem: removeListItemValidator,
+  removeListItemWithoutScriptID: removeListItemWithoutScriptIDValidator,
   file: fileValidator,
   uniqueFields: uniqueFieldsValidator,
   subInstances: subInstancesValidator,

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -32,7 +32,7 @@ import dataAccountSpecificValuesValidator from './change_validators/data_account
 import removeStandardTypesValidator from './change_validators/remove_standard_types'
 import removeFileCabinetValidator from './change_validators/remove_file_cabinet'
 import removeListItemValidator from './change_validators/remove_list_item'
-import removeListItemWithoutScriptIDValidator from './change_validators/remove_list_item_without_id'
+import removeListItemWithoutScriptIDValidator from './change_validators/remove_list_item_without_scriptid'
 import instanceChangesValidator from './change_validators/instance_changes'
 import removeSdfElementsValidator from './change_validators/remove_sdf_elements'
 import reportTypesMoveEnvironment from './change_validators/report_types_move_environment'

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -78,7 +78,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
       elemID,
       severity: 'Warning',
       message: 'Can\'t remove inner elements',
-      detailedMessage: `Can't remove the inner element${removedListItems.length > 1 ? 's' : ''} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from their UI.`,
+      detailedMessage: `Can't remove the inner element${removedListItems.length > 1 ? 's' : ''} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`,
     }))
     .toArray() as Promise<ChangeError[]>
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -76,8 +76,8 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
     .filter(({ removedListItems }: { removedListItems: string[] }) => !_.isEmpty(removedListItems))
     .map(({ elemID, removedListItems }: { removedListItems: string[]; elemID: ElemID }) => ({
       elemID,
-      severity: 'Error',
-      message: "Can't remove inner elements",
+      severity: 'Warning',
+      message: 'Can\'t remove inner elements',
       detailedMessage: `Can't remove the inner element${removedListItems.length > 1 ? 's' : ''} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from their UI.`,
     }))
     .toArray() as Promise<ChangeError[]>

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -77,12 +77,10 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
     .map(({ elemID, removedListItems }: { removedListItems: string[]; elemID: ElemID }) => ({
       elemID,
       severity: 'Warning',
-      message: 'Can\'t remove inner elements',
-      detailedMessage: ((removedListItems.length > 1)
-        ? (`Can't remove the inner elements ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
-          + ' Salto is going to ignore these removals.')
-        : (`Can't remove the inner element ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
-          + ' Salto is going to ignore this removal.')),
+      message: 'Inner Element Removal Not Supported',
+      detailedMessage: `Netsuite doesn't support the removal of inner element${(removedListItems.length > 1) ? 's' : ''} via API; `
+        + `Salto will ignore ${(removedListItems.length > 1) ? 'these changes' : 'this change'} for this deployment. `
+        + `Please use Netuiste's UI to remove ${(removedListItems.length > 1) ? 'it' : 'them'}`,
     }))
     .toArray() as Promise<ChangeError[]>
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -28,6 +28,7 @@ import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { SCRIPT_ID } from '../constants'
 import { NetsuiteChangeValidator } from './types'
+import { getMessageByElementNameAndListItems } from './remove_list_item_without_scriptid'
 
 const { awu } = collections.asynciterable
 
@@ -78,9 +79,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
       elemID,
       severity: 'Warning',
       message: 'Inner Element Removal Not Supported',
-      detailedMessage: `Netsuite doesn't support the removal of inner element${(removedListItems.length > 1) ? 's' : ''} via API; `
-        + `Salto will ignore ${(removedListItems.length > 1) ? 'these changes' : 'this change'} for this deployment. `
-        + `Please use Netuiste's UI to remove ${(removedListItems.length > 1) ? 'it' : 'them'}`,
+      detailedMessage: getMessageByElementNameAndListItems('element', removedListItems)
     }))
     .toArray() as Promise<ChangeError[]>
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -79,7 +79,7 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
       elemID,
       severity: 'Warning',
       message: 'Inner Element Removal Not Supported',
-      detailedMessage: getMessageByElementNameAndListItems('element', removedListItems)
+      detailedMessage: getMessageByElementNameAndListItems('element', removedListItems),
     }))
     .toArray() as Promise<ChangeError[]>
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item.ts
@@ -41,7 +41,7 @@ const getScriptIdsUnderLists = async (
       if (path.isAttrID()) {
         return WALK_NEXT_STEP.SKIP
       }
-      if (_.isPlainObject(value) && SCRIPT_ID in value) {
+      if (_.isPlainObject(value) && SCRIPT_ID in value && !path.isTopLevel()) {
         pathToScriptIds.get(path.getFullName()).add(value.scriptid)
       }
       return WALK_NEXT_STEP.RECURSE
@@ -78,7 +78,11 @@ const changeValidator: NetsuiteChangeValidator = async changes => {
       elemID,
       severity: 'Warning',
       message: 'Can\'t remove inner elements',
-      detailedMessage: `Can't remove the inner element${removedListItems.length > 1 ? 's' : ''} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`,
+      detailedMessage: ((removedListItems.length > 1)
+        ? (`Can't remove the inner elements ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
+          + ' Salto is going to ignore these removals.')
+        : (`Can't remove the inner element ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
+          + ' Salto is going to ignore this removal.')),
     }))
     .toArray() as Promise<ChangeError[]>
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item_without_id.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item_without_id.ts
@@ -1,0 +1,116 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import {
+  isModificationChange, InstanceElement, isInstanceChange,
+  Value,
+  ReferenceExpression,
+  ModificationChange,
+  ElemID,
+  ChangeError,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { NetsuiteChangeValidator } from './types'
+import { ROLE } from '../constants'
+
+
+const { awu } = collections.asynciterable
+
+type GetItemList = (instance: InstanceElement) => Value[]
+type GetItemString = (item: Value) => string
+
+type PermissionObject = {
+  permkey: string | ReferenceExpression
+  permlevel: string
+}
+
+type ItemListGetters = {
+  getItemList: GetItemList
+  getItemString: GetItemString
+}
+
+const getRolePermissionList:GetItemList = (
+  instance: InstanceElement,
+): Value[] => {
+  if (_.isPlainObject(instance.value.permissions?.permission)) {
+    return Object.values(instance.value.permissions?.permission)
+  }
+  return []
+}
+
+const getRolePermkey: GetItemString = (
+  permission: PermissionObject
+): string => {
+  if (_.isString(permission.permkey)) {
+    return permission.permkey
+  }
+  return permission.permkey.value
+}
+
+const roleGetters: ItemListGetters = {
+  getItemList: getRolePermissionList,
+  getItemString: getRolePermkey,
+}
+
+const getGettersByType = (
+  typename: string,
+): ItemListGetters | undefined => {
+  if (typename === ROLE) {
+    return roleGetters
+  }
+  return undefined
+}
+const getIdentifierList = (
+  instance: InstanceElement,
+): string[] => {
+  const getters = getGettersByType(instance.elemID.typeName)
+  if (getters === undefined) {
+    return []
+  }
+  return getters.getItemList(instance).map(getters.getItemString)
+}
+
+const getRemovedListItems = (
+  instanceChange: ModificationChange<InstanceElement>,
+): { removedListItems: string[]; elemID: ElemID} => {
+  const { before, after } = instanceChange.data
+  const beforeItemList = getIdentifierList(before)
+  const afterItemSet = new Set<string>(getIdentifierList(after))
+  return {
+    removedListItems: beforeItemList
+      .filter(id => !afterItemSet.has(id)),
+    elemID: before.elemID,
+  }
+}
+
+const changeValidator: NetsuiteChangeValidator = async changes => {
+  const instanceChanges = await awu(changes)
+    .filter(isModificationChange)
+    .filter(isInstanceChange)
+    .toArray() as ModificationChange<InstanceElement>[]
+
+  return instanceChanges
+    .map(getRemovedListItems)
+    .filter(({ removedListItems }) => !_.isEmpty(removedListItems))
+    .map(({ removedListItems, elemID }) => ({
+      elemID,
+      severity: 'Warning',
+      message: 'Can\'t remove inner elements',
+      detailedMessage: `Can't remove the inner element${removedListItems.length > 1 ? 's' : ''} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from their UI.`,
+    })) as ChangeError[]
+}
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
@@ -1,18 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import _ from 'lodash'
 import { isModificationChange, InstanceElement, isInstanceChange, ReferenceExpression, ModificationChange, ChangeError, isReferenceExpression } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -37,10 +37,14 @@ type GetItemString = (item: ItemInList) => string
 type GetListPath = () => string[]
 type GetMessage = (removedListItems: string[]) => string
 
-const getMessageByElementNameAndListItems = (elemName: string, removedListItems: string[]): string =>
-  `Netsuite doesn't support the removal of inner ${elemName}${(removedListItems.length > 1) ? 's' : ''} via API; `
-  + `Salto will ignore ${(removedListItems.length > 1) ? 'these changes' : 'this change'} for this deployment. `
-  + `Please use Netuiste's UI to remove ${(removedListItems.length > 1) ? 'it' : 'them'}`
+export const getMessageByElementNameAndListItems = (elemName: string, removedListItems: string[]): string =>
+  (removedListItems.length > 1)
+  ? `Netsuite doesn't support the removal of inner ${elemName}s ${removedListItems.join(', ')} via API; `
+    + 'Salto will ignore these changes for this deployment. '
+    + 'Please use Netuiste\'s UI to remove them'
+  : `Netsuite doesn't support the removal of inner ${elemName} ${removedListItems[0]} via API; `
+    + 'Salto will ignore this change for this deployment. '
+    + 'Please use Netuiste\'s UI to remove it'
 
 export type ItemListGetters = {
   getItemList: GetItemList
@@ -144,7 +148,7 @@ const getChangeError = (
   return (removedListItems.length > 0) ? {
     elemID,
     severity: 'Warning',
-    message: 'Can\'t remove inner elements',
+    message: 'Inner Element Removal Not Supported',
     detailedMessage: getters.getDetailedMessage(removedListItems),
   } : undefined
 }

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
@@ -38,11 +38,9 @@ type GetListPath = () => string[]
 type GetMessage = (removedListItems: string[]) => string
 
 const getMessageByElementNameAndListItems = (elemName: string, removedListItems: string[]): string =>
-  ((removedListItems.length > 1)
-    ? (`Can't remove the inner ${elemName}s ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
-      + ' Salto is going to ignore these removals.')
-    : (`Can't remove the inner ${elemName} ${removedListItems.join(', ')}. NetSuite supports the removal of inner elements only from its UI.`
-      + ' Salto is going to ignore this removal.'))
+  `Netsuite doesn't support the removal of inner ${elemName}${(removedListItems.length > 1) ? 's' : ''} via API; `
+  + `Salto will ignore ${(removedListItems.length > 1) ? 'these changes' : 'this change'} for this deployment. `
+  + `Please use Netuiste's UI to remove ${(removedListItems.length > 1) ? 'it' : 'them'}`
 
 export type ItemListGetters = {
   getItemList: GetItemList
@@ -114,11 +112,10 @@ const getIdentifierItemMap = (
   instance: InstanceElement,
   getters: ItemListGetters,
 ): Record<string, ItemInList> => {
-  const itemRecord: Record<string, ItemInList> = {}
-  getters.getItemList(instance)
-    .forEach(item => {
-      itemRecord[getters.getItemString(item)] = item
-    })
+  const itemRecord: Record<string, ItemInList> = Object.fromEntries(
+    getters.getItemList(instance)
+      .map(item => [getters.getItemString(item), item])
+  )
   return itemRecord
 }
 

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -281,6 +281,7 @@ export type NetsuiteValidatorName =
   | 'unreferencedDatasets'
   | 'analyticsSilentFailure'
   | 'undeployableBundleChanges'
+  | 'removeListItemWithoutScriptID'
 
 export type NonSuiteAppValidatorName = 'removeFileCabinet' | 'removeStandardTypes'
 
@@ -643,6 +644,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     unreferencedDatasets: { refType: BuiltinTypes.BOOLEAN },
     analyticsSilentFailure: { refType: BuiltinTypes.BOOLEAN },
     undeployableBundleChanges: { refType: BuiltinTypes.BOOLEAN },
+    removeListItemWithoutScriptID: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
@@ -1,0 +1,63 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { LocalFilterCreator } from '../filter'
+import { ItemInList, ItemListGetters, getGettersByType, getRemovedListItemStrings } from '../change_validators/remove_list_item_without_id'
+
+const log = logger(module)
+
+const getRemovedListItems = (
+  instanceChange: ModificationChange<InstanceElement>,
+  getters: ItemListGetters,
+): { [id: string]: ItemInList }[] => {
+  const idsList = getRemovedListItemStrings(instanceChange)
+  return idsList.removedListItems
+    .map(id => {
+      const item = getters.getItemByID(instanceChange.data.before, id)
+      if (item === undefined) {
+        return undefined
+      }
+      return { [id]: item }
+    })
+    .filter((val): val is { [id: string]: ItemInList } => val !== undefined)
+}
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'restorDeletedListItems',
+  /**
+   * This assigns the service URLs for new instances created through Salto
+   */
+  onDeploy: async changes => {
+    log.debug('')
+    changes
+      .filter(isModificationChange)
+      .filter(isInstanceChange)
+      .forEach(instanceChange => {
+        const getters = getGettersByType(instanceChange.data.before.elemID.typeName)
+        if (getters === undefined) {
+          return
+        }
+        const removedItems = getRemovedListItems(instanceChange, getters)
+        Object.assign(
+          getters.getItemList(instanceChange.data.after),
+          ...removedItems
+        )
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
@@ -1,18 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { collections } from '@salto-io/lowerdash'
 import { ElemID, InstanceElement, Value, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
 import { WALK_NEXT_STEP, setPath, walkOnElement } from '@salto-io/adapter-utils'

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items.ts
@@ -22,10 +22,8 @@ import { SCRIPT_ID } from '../constants'
 
 const { awu } = collections.asynciterable
 
-const getScriptIdsUnderLists = (
-  instance: InstanceElement
-): Map<string, { elemID: ElemID; val: Value}> => {
-  const pathToScriptIds = new Map<string, { elemID: ElemID; val: Value}>()
+const getScriptIdsUnderLists = (instance: InstanceElement): Map<string, { elemID: ElemID; val: Value }> => {
+  const pathToScriptIds = new Map<string, { elemID: ElemID; val: Value }>()
   walkOnElement({
     element: instance,
     func: ({ value, path }) => {

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
@@ -1,64 +1,54 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { InstanceElement, ModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { setPath } from '@salto-io/adapter-utils'
 import { LocalFilterCreator } from '../filter'
-import { ItemInList, ItemListGetters, getGettersByType, getRemovedListItemIds } from '../change_validators/remove_list_item_without_scriptid'
+import { getGettersByType, getRemovedItemsRecord } from '../change_validators/remove_list_item_without_scriptid'
 
-const getRemovedListItems = (
-  instanceChange: ModificationChange<InstanceElement>,
-  getters: ItemListGetters,
-): Record<string, ItemInList> => {
-  const idsList = getRemovedListItemIds(instanceChange, getters)
-  const itemsRecord: Record<string, ItemInList> = {}
-  idsList.forEach(id => {
-    const item = getters.getItemByID(instanceChange.data.before, id)
-    if (item !== undefined) {
-      itemsRecord[id] = item
-    }
-  })
-  return itemsRecord
+const addBeforeValuesToAfter = (instanceChange: ModificationChange<InstanceElement>): void => {
+  const getters = getGettersByType(instanceChange.data.before.elemID.typeName)
+  const { before, after } = instanceChange.data
+  if (getters === undefined || _.get(before.value, getters.getListPath()) === undefined) {
+    return
+  }
+  const listPath = getters.getListPath()
+  if (_.get(after.value, listPath) === undefined) {
+    setPath(
+      after,
+      after.elemID.createNestedID(...listPath),
+      _.get(before.value, listPath)
+    )
+  } else {
+    const removedItems = getRemovedItemsRecord(instanceChange, getters)
+    Object.assign(
+      _.get(after.value, listPath),
+      removedItems
+    )
+  }
 }
 
 const filterCreator: LocalFilterCreator = () => ({
-  name: 'restorDeletedListItems',
+  name: 'restoreDeletedListItemsWithoutScriptId',
   onDeploy: async changes => {
     changes
       .filter(isModificationChange)
       .filter(isInstanceChange)
       .forEach(instanceChange => {
-        const getters = getGettersByType(instanceChange.data.before.elemID.typeName)
-        const { before, after } = instanceChange.data
-        if (getters === undefined || _.isUndefined(_.get(before.value, getters.getListPath()))) {
-          return
-        }
-        if (_.isUndefined(_.get(after.value, getters.getListPath()))) {
-          setPath(
-            after,
-            after.elemID.createNestedID(...getters.getListPath()),
-            _.get(before.value, getters.getListPath())
-          )
-        } else {
-          const removedItems = getRemovedListItems(instanceChange, getters)
-          Object.assign(
-            _.get(after.value, getters.getListPath()),
-            removedItems
-          )
-        }
+        addBeforeValuesToAfter(instanceChange)
       })
   },
 })

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
@@ -1,0 +1,61 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { InstanceElement, ModificationChange, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { LocalFilterCreator } from '../filter'
+import { ItemInList, ItemListGetters, getGettersByType, getRemovedListItemDetails } from '../change_validators/remove_list_item_without_scriptid'
+
+const log = logger(module)
+
+const getRemovedListItems = (
+  instanceChange: ModificationChange<InstanceElement>,
+  getters: ItemListGetters,
+): { [id: string]: ItemInList }[] => {
+  const idsList = getRemovedListItemDetails(instanceChange)
+  return idsList.removedListItems
+    .map(id => {
+      const item = getters.getItemByID(instanceChange.data.before, id)
+      if (item === undefined) {
+        return undefined
+      }
+      return { [id]: item }
+    })
+    .filter((val: { [id: string]: ItemInList } | undefined): val is { [id: string]: ItemInList } => val !== undefined)
+}
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'restorDeletedListItems',
+  onDeploy: async changes => {
+    log.debug('')
+    changes
+      .filter(isModificationChange)
+      .filter(isInstanceChange)
+      .forEach(instanceChange => {
+        const getters = getGettersByType(instanceChange.data.before.elemID.typeName)
+        if (getters === undefined) {
+          return
+        }
+        const removedItems = getRemovedListItems(instanceChange, getters)
+        Object.assign(
+          _.get(instanceChange.data.after.value, getters.getListPath()),
+          ...removedItems
+        )
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/filters/restore_deleted_list_items_without_scriptid.ts
@@ -27,17 +27,10 @@ const addBeforeValuesToAfter = (instanceChange: ModificationChange<InstanceEleme
   }
   const listPath = getters.getListPath()
   if (_.get(after.value, listPath) === undefined) {
-    setPath(
-      after,
-      after.elemID.createNestedID(...listPath),
-      _.get(before.value, listPath)
-    )
+    setPath(after, after.elemID.createNestedID(...listPath), _.get(before.value, listPath))
   } else {
     const removedItems = getRemovedItemsRecord(instanceChange, getters)
-    Object.assign(
-      _.get(after.value, listPath),
-      removedItems
-    )
+    Object.assign(_.get(after.value, listPath), removedItems)
   }
 }
 

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
@@ -75,23 +75,27 @@ describe('remove item from customlist change validator', () => {
 })
 
 describe('removing inner items from customtypes', () => {
-  const origInstance = new InstanceElement('instance', clientscriptType().type, {
-    scriptdeployments: {
-      scriptdeployment: {
-        customdeploy1: {
-          scriptid: 'customdeploy_1',
-          status: 'Test',
-        },
-        customdeploy2: {
-          scriptid: 'customdeploy_2',
-          status: 'Test',
-        },
-        customdeploy3: {
-          scriptid: 'customdeploy_3',
-          status: 'Test',
+  const origInstance = new InstanceElement(
+    'instance',
+    clientscriptType().type,
+    {
+      scriptdeployments: {
+        scriptdeployment: {
+          customdeploy1: {
+            scriptid: 'customdeploy_1',
+            status: 'Test',
+          },
+          customdeploy2: {
+            scriptid: 'customdeploy_2',
+            status: 'Test',
+          },
+          customdeploy3: {
+            scriptid: 'customdeploy_3',
+            status: 'Test',
+          },
         },
       },
-    }},
+    },
     undefined,
     {
       [CORE_ANNOTATIONS.CREATED_BY]: 'hello',

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
@@ -65,6 +65,8 @@ describe('remove item from customlist change validator', () => {
       )
       expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from their UI.')
       expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI.')
+      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI.')
+      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
     })
 
     it('should not have change errors when modifiying a customvalue', async () => {
@@ -117,6 +119,8 @@ describe('removing inner items from customtypes', () => {
     )
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
   })
 
   it('should have an Error when removing few customdeploys', async () => {
@@ -133,6 +137,8 @@ describe('removing inner items from customtypes', () => {
     )
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from their UI.')
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
   })
 
   it('sohuld have an Error when removing scriptid from a customdeploy', async () => {
@@ -148,5 +154,7 @@ describe('removing inner items from customtypes', () => {
     )
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
     expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
@@ -61,12 +61,8 @@ describe('remove item from customlist change validator', () => {
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
       expect(changeErrors[0].detailedMessage).toEqual(
-        "Can't remove the inner element val_1. NetSuite supports the removal of inner elements only from their UI.",
+        "Netsuite doesn't support the removal of inner element val_1 via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it",
       )
-      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from their UI.')
-      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI.')
-      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI.')
-      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
     })
 
     it('should not have change errors when modifiying a customvalue', async () => {
@@ -115,12 +111,8 @@ describe('removing inner items from customtypes', () => {
     expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
-      "Can't remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.",
+      "Netsuite doesn't support the removal of inner element customdeploy_2 via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it",
     )
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
   })
 
   it('should have an Error when removing few customdeploys', async () => {
@@ -133,12 +125,8 @@ describe('removing inner items from customtypes', () => {
     expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
-      "Can't remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from their UI.",
+      "Netsuite doesn't support the removal of inner elements customdeploy_2, customdeploy_3 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them",
     )
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from their UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
   })
 
   it('sohuld have an Error when removing scriptid from a customdeploy', async () => {
@@ -150,11 +138,7 @@ describe('removing inner items from customtypes', () => {
     expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
-      "Can't remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.",
+      "Netsuite doesn't support the removal of inner element customdeploy_2 via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it",
     )
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
-    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, toChange } from '@salto-io/adapter-api'
 import { clientscriptType } from '../../src/autogen/types/standard_types/clientscript'
 import { customlistType } from '../../src/autogen/types/standard_types/customlist'
 import removeListItemValidator from '../../src/change_validators/remove_list_item'
@@ -58,11 +58,13 @@ describe('remove item from customlist change validator', () => {
       delete after.value.customvalues.customvalue.val1
       const changeErrors = await removeListItemValidator([toChange({ before: instance, after })])
       expect(changeErrors).toHaveLength(1)
-      expect(changeErrors[0].severity).toEqual('Error')
+      expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(instance.elemID)
       expect(changeErrors[0].detailedMessage).toEqual(
         "Can't remove the inner element val_1. NetSuite supports the removal of inner elements only from their UI.",
       )
+      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from their UI.')
+      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element val_1. NetSuite supports the removal of inner elements only from its UI.')
     })
 
     it('should not have change errors when modifiying a customvalue', async () => {
@@ -91,8 +93,12 @@ describe('removing inner items from customtypes', () => {
           status: 'Test',
         },
       },
+    }},
+    undefined,
+    {
+      [CORE_ANNOTATIONS.CREATED_BY]: 'hello',
     },
-  })
+  )
   let instance: InstanceElement
   beforeEach(() => {
     instance = origInstance.clone()
@@ -104,11 +110,13 @@ describe('removing inner items from customtypes', () => {
 
     const changeErrors = await removeListItemValidator([toChange({ before: instance, after })])
     expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
       "Can't remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.",
     )
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
   })
 
   it('should have an Error when removing few customdeploys', async () => {
@@ -118,11 +126,13 @@ describe('removing inner items from customtypes', () => {
 
     const changeErrors = await removeListItemValidator([toChange({ before: instance, after })])
     expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
       "Can't remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from their UI.",
     )
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from their UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner elements customdeploy_2, customdeploy_3. NetSuite supports the removal of inner elements only from its UI.')
   })
 
   it('sohuld have an Error when removing scriptid from a customdeploy', async () => {
@@ -131,10 +141,12 @@ describe('removing inner items from customtypes', () => {
 
     const changeErrors = await removeListItemValidator([toChange({ before: instance, after })])
     expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0].severity).toEqual('Error')
+    expect(changeErrors[0].severity).toEqual('Warning')
     expect(changeErrors[0].elemID).toEqual(instance.elemID)
     expect(changeErrors[0].detailedMessage).toEqual(
       "Can't remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.",
     )
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from their UI.')
+    expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner element customdeploy_2. NetSuite supports the removal of inner elements only from its UI.')
   })
 })

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
@@ -1,0 +1,178 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import removeListItemValidator from '../../src/change_validators/remove_list_item_without_scriptid'
+import { roleType } from '../../src/autogen/types/standard_types/role'
+import { CUSTOM_RECORD_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+
+
+describe('remove item without scriptis from inner list change validator', () => {
+  const customRecordInstance = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1'),
+    annotationRefsOrTypes: {
+      [SCRIPT_ID]: BuiltinTypes.SERVICE_ID,
+    },
+    annotations: {
+      metadataType: CUSTOM_RECORD_TYPE,
+      [SCRIPT_ID]: 'customrecord1',
+    },
+  })
+  const originRoleInstance = new InstanceElement(
+    'role_test',
+    roleType().type,
+    {
+      [SCRIPT_ID]: 'role_test',
+      permissions: {
+        permission: {
+          TRAN_PAYMENTAUDIT: {
+            permkey: 'TRAN_PAYMENTAUDIT',
+            permlevel: 'EDIT',
+          },
+          customrecord1: {
+            permkey: new ReferenceExpression(
+              customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
+              customRecordInstance.annotations[SCRIPT_ID],
+              customRecordInstance,
+            ),
+            permlevel: 'EDIT',
+            restriction: 'no',
+          },
+        },
+      },
+    }
+  )
+
+  const originRoleWithoutPermissions = new InstanceElement(
+    'role_without_permissions_test',
+    roleType().type,
+    {
+      [SCRIPT_ID]: 'role_without_permissions_test',
+    }
+  )
+
+  const originNonRelevantInstance = new InstanceElement(
+    'non-relevant',
+    workflowType().type,
+    {
+      [SCRIPT_ID]: 'non-relevant',
+      name: 'name1',
+    }
+  )
+
+
+  let roleInstance: InstanceElement
+  let roleWithoutPermissionsInstance: InstanceElement
+  let nonRelevantInstance: InstanceElement
+
+  beforeEach(() => {
+    roleInstance = originRoleInstance.clone()
+    roleWithoutPermissionsInstance = originRoleWithoutPermissions.clone()
+    nonRelevantInstance = originNonRelevantInstance.clone()
+  })
+
+  describe('When adding new instance with inner list', () => {
+    it('should have no change errors when adding an instance with inner list', async () => {
+      const changeErrors = await removeListItemValidator([
+        toChange({ after: roleInstance }),
+        toChange({ after: roleWithoutPermissionsInstance }),
+        toChange({ after: nonRelevantInstance }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+
+  describe('When modifying instance with inner list', () => {
+    it('should have no change errors when adding a permission to the role', async () => {
+      const after = roleInstance.clone()
+      after.value.permissions.permission.perm = {
+        permkey: 'perm',
+        permlevel: 'FULL',
+      }
+
+      const afterWithoutPermissions = roleWithoutPermissionsInstance.clone()
+      afterWithoutPermissions.value.permissions = {
+        permission: {
+          perm: {
+            permkey: 'perm',
+            permlevel: 'FULL',
+          },
+        },
+      }
+
+      const afterNonRelevantInstance = nonRelevantInstance.clone()
+      afterNonRelevantInstance.value.name = 'name2'
+      const changeErrors = await removeListItemValidator([
+        toChange({ before: roleInstance, after }),
+        toChange({ before: roleWithoutPermissionsInstance, after: afterWithoutPermissions }),
+        toChange({ before: nonRelevantInstance, after: afterNonRelevantInstance }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+
+    it('should have change error when removing a permission from the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.permissions.permission.TRAN_PAYMENTAUDIT
+      const firstChangeErrors = await removeListItemValidator(
+        [toChange({ before: roleInstance, after })]
+      )
+      expect(firstChangeErrors).toHaveLength(1)
+      expect(firstChangeErrors[0].severity).toEqual('Warning')
+      expect(firstChangeErrors[0].elemID).toEqual(roleInstance.elemID)
+      expect(firstChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permission TRAN_PAYMENTAUDIT. NetSuite supports the removal of inner elements only from its UI.')
+
+      delete after.value.permissions.permission.customrecord1
+      const secondChangeErrors = await removeListItemValidator(
+        [toChange({ before: roleInstance, after })]
+      )
+      expect(secondChangeErrors).toHaveLength(1)
+      expect(secondChangeErrors[0].severity).toEqual('Warning')
+      expect(secondChangeErrors[0].elemID).toEqual(roleInstance.elemID)
+      expect(secondChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI.')
+    })
+
+    it('should not have change errors when modifiying a permission from the role', async () => {
+      const after = roleInstance.clone()
+      after.value.permissions.permission.TRAN_PAYMENTAUDIT = {
+        permkey: 'TRAN_PAYMENTAUDIT',
+        permlevel: 'FULL',
+      }
+      after.value.permissions.permission.customrecord1 = {
+        permkey: new ReferenceExpression(
+          customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
+          customRecordInstance.annotations[SCRIPT_ID],
+          customRecordInstance,
+        ),
+        permlevel: 'FULL',
+      }
+      const changeErrors = await removeListItemValidator(
+        [toChange({ before: roleInstance, after })]
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+
+  describe('When deleting an instance with inner list', () => {
+    it('should have no change errors when deleting an instance with inner list', async () => {
+      const changeErrors = await removeListItemValidator([
+        toChange({ before: roleInstance }),
+        toChange({ before: roleWithoutPermissionsInstance }),
+        toChange({ before: nonRelevantInstance }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
@@ -1,18 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import removeListItemValidator from '../../src/change_validators/remove_list_item_without_scriptid'
 import { roleType } from '../../src/autogen/types/standard_types/role'
@@ -168,7 +168,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(firstChangeErrors).toHaveLength(1)
       expect(firstChangeErrors[0].severity).toEqual('Warning')
       expect(firstChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(firstChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permission TRAN_PAYMENTAUDIT. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
+      expect(firstChangeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permission TRAN_PAYMENTAUDIT via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it")
 
       delete after.value.permissions.permission.customrecord1
       const secondChangeErrors = await removeListItemValidator(
@@ -177,7 +177,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(secondChangeErrors).toHaveLength(1)
       expect(secondChangeErrors[0].severity).toEqual('Warning')
       expect(secondChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(secondChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
+      expect(secondChangeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them")
     })
 
     it('should not have a change error when modifiying a permission from the role', async () => {
@@ -208,7 +208,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
+      expect(changeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them")
     })
     it('should have no change errors when dealing with odd permission in role', async () => {
       const afterWithArray = roleWithArrayPermissionsInstance.clone()

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
@@ -168,7 +168,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(firstChangeErrors).toHaveLength(1)
       expect(firstChangeErrors[0].severity).toEqual('Warning')
       expect(firstChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(firstChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permission TRAN_PAYMENTAUDIT. NetSuite supports the removal of inner elements only from its UI.')
+      expect(firstChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permission TRAN_PAYMENTAUDIT. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore this removal.')
 
       delete after.value.permissions.permission.customrecord1
       const secondChangeErrors = await removeListItemValidator(
@@ -177,10 +177,10 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(secondChangeErrors).toHaveLength(1)
       expect(secondChangeErrors[0].severity).toEqual('Warning')
       expect(secondChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(secondChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI.')
+      expect(secondChangeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
     })
 
-    it('should not have change errors when modifiying a permission from the role', async () => {
+    it('should not have a change error when modifiying a permission from the role', async () => {
       const after = roleInstance.clone()
       after.value.permissions.permission.TRAN_PAYMENTAUDIT = {
         permkey: 'TRAN_PAYMENTAUDIT',
@@ -199,7 +199,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       )
       expect(changeErrors).toHaveLength(0)
     })
-    it('should have change errors when deleting the whole permissions field from the role', async () => {
+    it('should have a change error when deleting the whole permissions field from the role', async () => {
       const after = roleInstance.clone()
       delete after.value.permissions.permission
       const changeErrors = await removeListItemValidator(
@@ -208,7 +208,7 @@ describe('remove item without scriptis from inner list change validator', () => 
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(changeErrors[0].detailedMessage).toEqual("Can't remove the list permissions.permission.")
+      expect(changeErrors[0].detailedMessage).toEqual('Can\'t remove the inner permissions TRAN_PAYMENTAUDIT, customrecord1. NetSuite supports the removal of inner elements only from its UI. Salto is going to ignore these removals.')
     })
     it('should have no change errors when dealing with odd permission in role', async () => {
       const afterWithArray = roleWithArrayPermissionsInstance.clone()

--- a/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/remove_list_item_without_scriptid.test.ts
@@ -19,7 +19,6 @@ import { roleType } from '../../src/autogen/types/standard_types/role'
 import { CUSTOM_RECORD_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
 
-
 describe('remove item without scriptis from inner list change validator', () => {
   const customRecordInstance = new ObjectType({
     elemID: new ElemID(NETSUITE, 'customrecord1'),
@@ -31,80 +30,59 @@ describe('remove item without scriptis from inner list change validator', () => 
       [SCRIPT_ID]: 'customrecord1',
     },
   })
-  const originRoleInstance = new InstanceElement(
-    'role_test',
-    roleType().type,
-    {
-      [SCRIPT_ID]: 'role_test',
-      permissions: {
-        permission: {
-          TRAN_PAYMENTAUDIT: {
-            permkey: 'TRAN_PAYMENTAUDIT',
-            permlevel: 'EDIT',
-          },
-          customrecord1: {
-            permkey: new ReferenceExpression(
-              customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
-              customRecordInstance.annotations[SCRIPT_ID],
-              customRecordInstance,
-            ),
-            permlevel: 'EDIT',
-            restriction: 'no',
-          },
+  const originRoleInstance = new InstanceElement('role_test', roleType().type, {
+    [SCRIPT_ID]: 'role_test',
+    permissions: {
+      permission: {
+        TRAN_PAYMENTAUDIT: {
+          permkey: 'TRAN_PAYMENTAUDIT',
+          permlevel: 'EDIT',
+        },
+        customrecord1: {
+          permkey: new ReferenceExpression(
+            customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
+            customRecordInstance.annotations[SCRIPT_ID],
+            customRecordInstance,
+          ),
+          permlevel: 'EDIT',
+          restriction: 'no',
         },
       },
-    }
-  )
+    },
+  })
 
-  const originRoleWithoutPermissions = new InstanceElement(
-    'role_without_permissions_test',
-    roleType().type,
-    {
-      [SCRIPT_ID]: 'role_without_permissions_test',
-    }
-  )
+  const originRoleWithoutPermissions = new InstanceElement('role_without_permissions_test', roleType().type, {
+    [SCRIPT_ID]: 'role_without_permissions_test',
+  })
 
-  const originNonRelevantInstance = new InstanceElement(
-    'non-relevant',
-    workflowType().type,
-    {
-      [SCRIPT_ID]: 'non-relevant',
-      name: 'name1',
-    }
-  )
+  const originNonRelevantInstance = new InstanceElement('non-relevant', workflowType().type, {
+    [SCRIPT_ID]: 'non-relevant',
+    name: 'name1',
+  })
 
-  const originRoleWithArrayPermissions = new InstanceElement(
-    'role_with_array_permission_test',
-    roleType().type,
-    {
-      [SCRIPT_ID]: 'role_with_array_permission_test',
-      permissions: {
-        permission: [
-          {
-            permkey: 'TRAN_PAYMENTAUDIT',
-            permlevel: 'EDIT',
-          },
-        ],
-      },
-    }
-  )
+  const originRoleWithArrayPermissions = new InstanceElement('role_with_array_permission_test', roleType().type, {
+    [SCRIPT_ID]: 'role_with_array_permission_test',
+    permissions: {
+      permission: [
+        {
+          permkey: 'TRAN_PAYMENTAUDIT',
+          permlevel: 'EDIT',
+        },
+      ],
+    },
+  })
 
-  const originRoleWithOddPermission = new InstanceElement(
-    'role_with_odd_permission_test',
-    roleType().type,
-    {
-      [SCRIPT_ID]: 'role_with_odd_permission_test',
-      permissions: {
-        permission: {
-          TRAN_PAYMENTAUDIT: {
-            strangeKey: 'TRAN_PAYMENTAUDIT',
-            permlevel: 'EDIT',
-          },
+  const originRoleWithOddPermission = new InstanceElement('role_with_odd_permission_test', roleType().type, {
+    [SCRIPT_ID]: 'role_with_odd_permission_test',
+    permissions: {
+      permission: {
+        TRAN_PAYMENTAUDIT: {
+          strangeKey: 'TRAN_PAYMENTAUDIT',
+          permlevel: 'EDIT',
         },
       },
-    }
-  )
-
+    },
+  })
 
   let roleInstance: InstanceElement
   let roleWithoutPermissionsInstance: InstanceElement
@@ -162,22 +140,22 @@ describe('remove item without scriptis from inner list change validator', () => 
     it('should have change error when removing a permission from the role', async () => {
       const after = roleInstance.clone()
       delete after.value.permissions.permission.TRAN_PAYMENTAUDIT
-      const firstChangeErrors = await removeListItemValidator(
-        [toChange({ before: roleInstance, after })]
-      )
+      const firstChangeErrors = await removeListItemValidator([toChange({ before: roleInstance, after })])
       expect(firstChangeErrors).toHaveLength(1)
       expect(firstChangeErrors[0].severity).toEqual('Warning')
       expect(firstChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(firstChangeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permission TRAN_PAYMENTAUDIT via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it")
+      expect(firstChangeErrors[0].detailedMessage).toEqual(
+        "Netsuite doesn't support the removal of inner permission TRAN_PAYMENTAUDIT via API; Salto will ignore this change for this deployment. Please use Netuiste's UI to remove it",
+      )
 
       delete after.value.permissions.permission.customrecord1
-      const secondChangeErrors = await removeListItemValidator(
-        [toChange({ before: roleInstance, after })]
-      )
+      const secondChangeErrors = await removeListItemValidator([toChange({ before: roleInstance, after })])
       expect(secondChangeErrors).toHaveLength(1)
       expect(secondChangeErrors[0].severity).toEqual('Warning')
       expect(secondChangeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(secondChangeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them")
+      expect(secondChangeErrors[0].detailedMessage).toEqual(
+        "Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them",
+      )
     })
 
     it('should not have a change error when modifiying a permission from the role', async () => {
@@ -194,21 +172,19 @@ describe('remove item without scriptis from inner list change validator', () => 
         ),
         permlevel: 'FULL',
       }
-      const changeErrors = await removeListItemValidator(
-        [toChange({ before: roleInstance, after })]
-      )
+      const changeErrors = await removeListItemValidator([toChange({ before: roleInstance, after })])
       expect(changeErrors).toHaveLength(0)
     })
     it('should have a change error when deleting the whole permissions field from the role', async () => {
       const after = roleInstance.clone()
       delete after.value.permissions.permission
-      const changeErrors = await removeListItemValidator(
-        [toChange({ before: roleInstance, after })]
-      )
+      const changeErrors = await removeListItemValidator([toChange({ before: roleInstance, after })])
       expect(changeErrors).toHaveLength(1)
       expect(changeErrors[0].severity).toEqual('Warning')
       expect(changeErrors[0].elemID).toEqual(roleInstance.elemID)
-      expect(changeErrors[0].detailedMessage).toEqual("Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them")
+      expect(changeErrors[0].detailedMessage).toEqual(
+        "Netsuite doesn't support the removal of inner permissions TRAN_PAYMENTAUDIT, customrecord1 via API; Salto will ignore these changes for this deployment. Please use Netuiste's UI to remove them",
+      )
     })
     it('should have no change errors when dealing with odd permission in role', async () => {
       const afterWithArray = roleWithArrayPermissionsInstance.clone()

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
@@ -1,0 +1,94 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable camelcase */
+import { CORE_ANNOTATIONS, InstanceElement, ModificationChange, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { LocalFilterOpts } from '../../src/filter'
+import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import filterCreator from '../../src/filters/restore_deleted_list_items'
+import { customlistType } from '../../src/autogen/types/standard_types/customlist'
+
+
+describe('restore deleted list items with scriptid filter', () => {
+  let fetchOpts: LocalFilterOpts
+  let instance: InstanceElement
+  const origInstance = new InstanceElement(
+    'instance',
+    customlistType().type,
+    {
+      customvalues: {
+        customvalue: {
+          val1: {
+            scriptid: 'val_1',
+            value: 'value1',
+          },
+          val2: {
+            scriptid: 'val_2',
+            value: 'value2',
+          },
+        },
+      },
+      otherField: {
+        val1: {
+          val1: {
+            value: 'value1',
+          },
+          val2: {
+            value: 'value2',
+          },
+        },
+      },
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.CREATED_BY]: 'hello',
+    }
+  )
+  beforeEach(async () => {
+    instance = origInstance.clone()
+    fetchOpts = {
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+      },
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+  })
+
+  it('should not add any fields if not deleted fields with scriptid', async () => {
+    const after = instance.clone()
+    delete after.value.otherField.val1
+    const change = toChange({ before: instance, after }) as ModificationChange<InstanceElement>
+    await filterCreator(fetchOpts).onDeploy?.([change], {
+      appliedChanges: [],
+      errors: [],
+    },)
+    expect(change.data.after.value.otherField.val1).toBeUndefined()
+  })
+  it('should add the deleted field with scriptid', async () => {
+    const after = instance.clone()
+    delete after.value.customvalues.customvalue.val1
+    const change = toChange({ before: instance, after }) as ModificationChange<InstanceElement>
+    await filterCreator(fetchOpts).onDeploy?.([change], {
+      appliedChanges: [],
+      errors: [],
+    },)
+    expect(change.data.after.value.customvalues.customvalue.val1)
+      .toEqual(change.data.before.value.customvalues.customvalue.val1)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
@@ -1,20 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
-/* eslint-disable camelcase */
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { CORE_ANNOTATIONS, InstanceElement, ModificationChange, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { LocalFilterOpts } from '../../src/filter'

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items.test.ts
@@ -20,7 +20,6 @@ import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../ut
 import filterCreator from '../../src/filters/restore_deleted_list_items'
 import { customlistType } from '../../src/autogen/types/standard_types/customlist'
 
-
 describe('restore deleted list items with scriptid filter', () => {
   let fetchOpts: LocalFilterOpts
   let instance: InstanceElement
@@ -54,7 +53,7 @@ describe('restore deleted list items with scriptid filter', () => {
     undefined,
     {
       [CORE_ANNOTATIONS.CREATED_BY]: 'hello',
-    }
+    },
   )
   beforeEach(async () => {
     instance = origInstance.clone()
@@ -75,7 +74,7 @@ describe('restore deleted list items with scriptid filter', () => {
     await filterCreator(fetchOpts).onDeploy?.([change], {
       appliedChanges: [],
       errors: [],
-    },)
+    })
     expect(change.data.after.value.otherField.val1).toBeUndefined()
   })
   it('should add the deleted field with scriptid', async () => {
@@ -85,8 +84,9 @@ describe('restore deleted list items with scriptid filter', () => {
     await filterCreator(fetchOpts).onDeploy?.([change], {
       appliedChanges: [],
       errors: [],
-    },)
-    expect(change.data.after.value.customvalues.customvalue.val1)
-      .toEqual(change.data.before.value.customvalues.customvalue.val1)
+    })
+    expect(change.data.after.value.customvalues.customvalue.val1).toEqual(
+      change.data.before.value.customvalues.customvalue.val1,
+    )
   })
 })

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
@@ -1,20 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-
-/* eslint-disable camelcase */
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { BuiltinTypes, ElemID, InstanceElement, ModificationChange, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { LocalFilterOpts } from '../../src/filter'

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
@@ -1,0 +1,140 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+/* eslint-disable camelcase */
+import { BuiltinTypes, ElemID, InstanceElement, ModificationChange, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { LocalFilterOpts } from '../../src/filter'
+import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import filterCreator from '../../src/filters/restore_deleted_list_items_without_scriptid'
+import { roleType } from '../../src/autogen/types/standard_types/role'
+import { CUSTOM_RECORD_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
+import { workflowType } from '../../src/autogen/types/standard_types/workflow'
+
+
+describe('restore deleted list items with scriptid filter', () => {
+  let fetchOpts: LocalFilterOpts
+  let roleInstance: InstanceElement
+  let nonRelevantInstance: InstanceElement
+
+  const customRecordInstance = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1'),
+    annotationRefsOrTypes: {
+      [SCRIPT_ID]: BuiltinTypes.SERVICE_ID,
+    },
+    annotations: {
+      metadataType: CUSTOM_RECORD_TYPE,
+      [SCRIPT_ID]: 'customrecord1',
+    },
+  })
+  const originRoleInstance = new InstanceElement(
+    'role_test',
+    roleType().type,
+    {
+      [SCRIPT_ID]: 'role_test',
+      permissions: {
+        permission: {
+          TRAN_PAYMENTAUDIT: {
+            permkey: 'TRAN_PAYMENTAUDIT',
+            permlevel: 'EDIT',
+          },
+          customrecord1: {
+            permkey: new ReferenceExpression(
+              customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
+              customRecordInstance.annotations[SCRIPT_ID],
+              customRecordInstance,
+            ),
+            permlevel: 'EDIT',
+            restriction: 'no',
+          },
+        },
+      },
+      otherField: {
+        val1: {
+          val1: {
+            value: 'value1',
+          },
+          val2: {
+            value: 'value2',
+          },
+        },
+      },
+    },
+  )
+
+  const originNonRelevantInstance = new InstanceElement(
+    'non-relevant',
+    workflowType().type,
+    {
+      [SCRIPT_ID]: 'non-relevant',
+      name: 'name1',
+    }
+  )
+
+  beforeEach(async () => {
+    roleInstance = originRoleInstance.clone()
+    nonRelevantInstance = originNonRelevantInstance.clone()
+    fetchOpts = {
+      elementsSourceIndex: {
+        getIndexes: () => Promise.resolve(createEmptyElementsSourceIndexes()),
+      },
+      elementsSource: buildElementsSourceFromElements([]),
+      isPartial: false,
+      config: await getDefaultAdapterConfig(),
+    }
+  })
+
+  describe('Role', () => {
+    it('should not add any fields if not deleted permissions in the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.otherField.val1
+      const change = toChange({ before: roleInstance, after }) as ModificationChange<InstanceElement>
+      const nonRelevantAfter = nonRelevantInstance.clone()
+      delete nonRelevantAfter.value.name
+      const nonRelevantChange = toChange({
+        before: nonRelevantInstance,
+        after: nonRelevantAfter,
+      }) as ModificationChange<InstanceElement>
+      await filterCreator(fetchOpts).onDeploy?.([change, nonRelevantChange], {
+        appliedChanges: [],
+        errors: [],
+      },)
+      expect(change.data.after.value.otherField.val1).toBeUndefined()
+    })
+    it('should add the regular permission deleted from the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.permissions.permission.TRAN_PAYMENTAUDIT
+      const change = toChange({ before: roleInstance, after }) as ModificationChange<InstanceElement>
+      await filterCreator(fetchOpts).onDeploy?.([change], {
+        appliedChanges: [],
+        errors: [],
+      })
+      expect(change.data.after.value.permissions.permission.TRAN_PAYMENTAUDIT)
+        .toEqual(change.data.before.value.permissions.permission.TRAN_PAYMENTAUDIT)
+    })
+    it('should add the custom record permission deleted from the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.permissions.permission.customrecord1
+      const change = toChange({ before: roleInstance, after }) as ModificationChange<InstanceElement>
+      await filterCreator(fetchOpts).onDeploy?.([change], {
+        appliedChanges: [],
+        errors: [],
+      })
+      expect(change.data.after.value.permissions.permission.customrecord1)
+        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
@@ -136,5 +136,29 @@ describe('restore deleted list items with scriptid filter', () => {
       expect(change.data.after.value.permissions.permission.customrecord1)
         .toEqual(change.data.before.value.permissions.permission.customrecord1)
     })
+    it('should add the whole permissions field deleted from the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.permissions
+      const change = toChange({ before: roleInstance, after }) as ModificationChange<InstanceElement>
+      await filterCreator(fetchOpts).onDeploy?.([change], {
+        appliedChanges: [],
+        errors: [],
+      })
+      expect(change.data.after.value.permissions.permission).toBeDefined()
+      expect(change.data.after.value.permissions.permission.customrecord1)
+        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+    })
+    it('should add the whole permission list deleted from the role', async () => {
+      const after = roleInstance.clone()
+      delete after.value.permissions.permission
+      const change = toChange({ before: roleInstance, after }) as ModificationChange<InstanceElement>
+      await filterCreator(fetchOpts).onDeploy?.([change], {
+        appliedChanges: [],
+        errors: [],
+      })
+      expect(change.data.after.value.permissions.permission).toBeDefined()
+      expect(change.data.after.value.permissions.permission.customrecord1)
+        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+    })
   })
 })

--- a/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
+++ b/packages/netsuite-adapter/test/filters/restore_deleted_list_items_without_scriptid.test.ts
@@ -13,7 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { BuiltinTypes, ElemID, InstanceElement, ModificationChange, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import {
+  BuiltinTypes,
+  ElemID,
+  InstanceElement,
+  ModificationChange,
+  ObjectType,
+  ReferenceExpression,
+  toChange,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { LocalFilterOpts } from '../../src/filter'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
@@ -21,7 +29,6 @@ import filterCreator from '../../src/filters/restore_deleted_list_items_without_
 import { roleType } from '../../src/autogen/types/standard_types/role'
 import { CUSTOM_RECORD_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import { workflowType } from '../../src/autogen/types/standard_types/workflow'
-
 
 describe('restore deleted list items with scriptid filter', () => {
   let fetchOpts: LocalFilterOpts
@@ -38,49 +45,41 @@ describe('restore deleted list items with scriptid filter', () => {
       [SCRIPT_ID]: 'customrecord1',
     },
   })
-  const originRoleInstance = new InstanceElement(
-    'role_test',
-    roleType().type,
-    {
-      [SCRIPT_ID]: 'role_test',
-      permissions: {
-        permission: {
-          TRAN_PAYMENTAUDIT: {
-            permkey: 'TRAN_PAYMENTAUDIT',
-            permlevel: 'EDIT',
-          },
-          customrecord1: {
-            permkey: new ReferenceExpression(
-              customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
-              customRecordInstance.annotations[SCRIPT_ID],
-              customRecordInstance,
-            ),
-            permlevel: 'EDIT',
-            restriction: 'no',
-          },
+  const originRoleInstance = new InstanceElement('role_test', roleType().type, {
+    [SCRIPT_ID]: 'role_test',
+    permissions: {
+      permission: {
+        TRAN_PAYMENTAUDIT: {
+          permkey: 'TRAN_PAYMENTAUDIT',
+          permlevel: 'EDIT',
         },
-      },
-      otherField: {
-        val1: {
-          val1: {
-            value: 'value1',
-          },
-          val2: {
-            value: 'value2',
-          },
+        customrecord1: {
+          permkey: new ReferenceExpression(
+            customRecordInstance.elemID.createNestedID('attr', SCRIPT_ID),
+            customRecordInstance.annotations[SCRIPT_ID],
+            customRecordInstance,
+          ),
+          permlevel: 'EDIT',
+          restriction: 'no',
         },
       },
     },
-  )
+    otherField: {
+      val1: {
+        val1: {
+          value: 'value1',
+        },
+        val2: {
+          value: 'value2',
+        },
+      },
+    },
+  })
 
-  const originNonRelevantInstance = new InstanceElement(
-    'non-relevant',
-    workflowType().type,
-    {
-      [SCRIPT_ID]: 'non-relevant',
-      name: 'name1',
-    }
-  )
+  const originNonRelevantInstance = new InstanceElement('non-relevant', workflowType().type, {
+    [SCRIPT_ID]: 'non-relevant',
+    name: 'name1',
+  })
 
   beforeEach(async () => {
     roleInstance = originRoleInstance.clone()
@@ -109,7 +108,7 @@ describe('restore deleted list items with scriptid filter', () => {
       await filterCreator(fetchOpts).onDeploy?.([change, nonRelevantChange], {
         appliedChanges: [],
         errors: [],
-      },)
+      })
       expect(change.data.after.value.otherField.val1).toBeUndefined()
     })
     it('should add the regular permission deleted from the role', async () => {
@@ -120,8 +119,9 @@ describe('restore deleted list items with scriptid filter', () => {
         appliedChanges: [],
         errors: [],
       })
-      expect(change.data.after.value.permissions.permission.TRAN_PAYMENTAUDIT)
-        .toEqual(change.data.before.value.permissions.permission.TRAN_PAYMENTAUDIT)
+      expect(change.data.after.value.permissions.permission.TRAN_PAYMENTAUDIT).toEqual(
+        change.data.before.value.permissions.permission.TRAN_PAYMENTAUDIT,
+      )
     })
     it('should add the custom record permission deleted from the role', async () => {
       const after = roleInstance.clone()
@@ -131,8 +131,9 @@ describe('restore deleted list items with scriptid filter', () => {
         appliedChanges: [],
         errors: [],
       })
-      expect(change.data.after.value.permissions.permission.customrecord1)
-        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+      expect(change.data.after.value.permissions.permission.customrecord1).toEqual(
+        change.data.before.value.permissions.permission.customrecord1,
+      )
     })
     it('should add the whole permissions field deleted from the role', async () => {
       const after = roleInstance.clone()
@@ -143,8 +144,9 @@ describe('restore deleted list items with scriptid filter', () => {
         errors: [],
       })
       expect(change.data.after.value.permissions.permission).toBeDefined()
-      expect(change.data.after.value.permissions.permission.customrecord1)
-        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+      expect(change.data.after.value.permissions.permission.customrecord1).toEqual(
+        change.data.before.value.permissions.permission.customrecord1,
+      )
     })
     it('should add the whole permission list deleted from the role', async () => {
       const after = roleInstance.clone()
@@ -155,8 +157,9 @@ describe('restore deleted list items with scriptid filter', () => {
         errors: [],
       })
       expect(change.data.after.value.permissions.permission).toBeDefined()
-      expect(change.data.after.value.permissions.permission.customrecord1)
-        .toEqual(change.data.before.value.permissions.permission.customrecord1)
+      expect(change.data.after.value.permissions.permission.customrecord1).toEqual(
+        change.data.before.value.permissions.permission.customrecord1,
+      )
     })
   })
 })


### PR DESCRIPTION
_Added a CV to warn the user of deleting permissions from role (can be done only in the UI).
Changed the CV that check the inner item list to warning instead of error.
Added filters to add the deleted items onDeploy to make the user's enviroment updated._

---

Jira ticket: https://salto-io.atlassian.net/browse/SALTO-4564

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
