### PR TITLE
SALTO-4956 Validate group has no default members before deletion.

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -154,7 +154,7 @@ export default ({
     helpCenterActivation: helpCenterActivationValidator,
     helpCenterCreationOrRemoval: helpCenterCreationOrRemovalValidator(client, apiConfig),
     externalSourceWebhook: externalSourceWebhookValidator,
-    defaultGroupChange: defaultGroupChangeValidator,
+    defaultGroupChange: defaultGroupChangeValidator(client),
     organizationExistence: organizationExistenceValidator(client, fetchConfig, deployConfig),
     badFormatWebhookAction: badFormatWebhookActionValidator,
     guideDisabled: guideDisabledValidator(fetchConfig),

--- a/packages/zendesk-adapter/src/change_validators/default_group_change.ts
+++ b/packages/zendesk-adapter/src/change_validators/default_group_change.ts
@@ -17,7 +17,15 @@ import {
   ChangeError, ChangeValidator, getChangeData, InstanceElement, isAdditionChange,
   isInstanceChange, isModificationChange, isRemovalChange,
 } from '@salto-io/adapter-api'
+import { createSchemeGuard, safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { values } from '@salto-io/lowerdash'
+import Joi from 'joi'
+import _ from 'lodash'
+import ZendeskClient from '../client/client'
 import { GROUP_TYPE_NAME } from '../constants'
+
+const log = logger(module)
 
 const API_ERROR_MESSAGE = 'Changing the default group is not supported via the Zendesk API'
 
@@ -43,17 +51,65 @@ const defaultGroupModificationError = (group: InstanceElement): ChangeError => (
   detailedMessage: `${API_ERROR_MESSAGE}, therefore, you will need to do it directly via Zendesk and fetch.`,
 })
 
+const EXPECTED_GROUP_MEMBERSHIP_RESPONSE_SCHEMA = Joi.object({
+  group_memberships: Joi.array().items(Joi.object({
+    created_at: Joi.string(),
+    default: Joi.boolean().required(),
+    group_id: Joi.number(),
+    id: Joi.number(),
+    updated_at: Joi.string(),
+    url: Joi.string(),
+    user_id: Joi.number().required(),
+  })).required(),
+  next_page: Joi.string().allow(null),
+  previous_page: Joi.string().allow(null),
+  count: Joi.number(),
+})
+
+// eslint-disable-next-line camelcase
+const groupMembershipSchema = createSchemeGuard<{ group_memberships: { user_id: string; default: boolean }[] }>(
+  EXPECTED_GROUP_MEMBERSHIP_RESPONSE_SCHEMA, 'Invalid group membership response'
+)
+
+const fetchDefaultGroupMembershipRemovals = async (
+  client: ZendeskClient, groups: InstanceElement[]
+): Promise<ChangeError[]> => {
+  const errorsWithUndefined = await Promise.all(groups.map(async group => {
+    const response = await client.getSinglePage({ url: `/api/v2/groups/${group.value.id}/memberships` })
+    if (!groupMembershipSchema(response.data)) {
+      log.warn(`Got an invalid response for group membership for group ${group.value.id}, skipping this validation. Response: ${safeJsonStringify(response.data)}`)
+      return undefined
+    }
+    const groupMemberships = response.data.group_memberships
+    const usersWithDefaultGroup = groupMemberships.filter(membership => membership.default === true)
+    if (usersWithDefaultGroup.length > 0) {
+      return {
+        elemID: group.elemID,
+        severity: 'Error' as const,
+        message: 'Cannot remove the group, it is set as default for some users',
+        detailedMessage: `This group (${group.elemID.name}) is currently set as default for the following user ids: ${usersWithDefaultGroup.map(user => user.user_id).join(', ')}.`,
+      }
+    }
+    return undefined
+  }))
+  return errorsWithUndefined.filter(values.isDefined)
+}
+
 /**
- * Validates that the default group was not changed, and tell the user what to do
+ * Validates that the default group was not changed, and tell the user what to do.
+ * Also validates if the group is a default group for a user, and if so, tell the user what to do.
  */
-export const defaultGroupChangeValidator: ChangeValidator = async changes => {
+export const defaultGroupChangeValidator: (client: ZendeskClient) => ChangeValidator = client => async changes => {
   const groupChanges = changes.filter(isInstanceChange)
     .filter(change => getChangeData(change).elemID.typeName === GROUP_TYPE_NAME)
 
   const defaultGroupAddition = groupChanges.filter(isAdditionChange).map(getChangeData)
     .filter(group => group.value.default === true)
-  const defaultGroupRemoval = groupChanges.filter(isRemovalChange).map(getChangeData)
-    .filter(group => group.value.default === true)
+  const [defaultGroupRemoval, nonDefaultGroupRemoval] = _.partition(
+    groupChanges.filter(isRemovalChange).map(getChangeData),
+    group => group.value.default === true
+  )
+  const defaultGroupMembershipRemoval = await fetchDefaultGroupMembershipRemovals(client, nonDefaultGroupRemoval)
   const defaultGroupModification = groupChanges.filter(isModificationChange)
     .filter(change => change.data.before.value.default !== change.data.after.value.default).map(getChangeData)
 
@@ -61,5 +117,6 @@ export const defaultGroupChangeValidator: ChangeValidator = async changes => {
     defaultGroupAddition.map(defaultGroupAdditionError),
     defaultGroupRemoval.map(defaultGroupRemovalError),
     defaultGroupModification.map(defaultGroupModificationError),
+    defaultGroupMembershipRemoval,
   ].flat()
 }

--- a/packages/zendesk-adapter/test/change_validators/default_group_change.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/default_group_change.test.ts
@@ -16,6 +16,7 @@
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { GROUP_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { defaultGroupChangeValidator } from '../../src/change_validators'
+import ZendeskClient from '../../src/client/client'
 
 const createGroup = (elemName: string, isDefault: boolean): InstanceElement => new InstanceElement(
   elemName,
@@ -32,6 +33,22 @@ describe('defaultGroupDeletion', () => {
   const afterDefaultGroup = createGroup('afterDefaultGroup', true)
   const defaultGroup = createGroup('notChangingDefaultGroup', true)
   const notDefaultGroup = createGroup('notChangingNotDefaultGroup', false)
+
+  let client: ZendeskClient
+  let mockGet: jest.SpyInstance
+  beforeEach(() => {
+    jest.clearAllMocks()
+    client = new ZendeskClient({ credentials: { username: 'a', password: 'b', subdomain: 'ignore' } })
+    mockGet = jest.spyOn(client, 'getSinglePage')
+    mockGet.mockImplementation(() => (
+      {
+        status: 200,
+        data: {
+        },
+      }
+    ))
+  })
+
   it('should not allow the user to make a change of the default group', async () => {
     const changes = [
       toChange({ after: newDefaultGroup }), // New group that is default
@@ -44,7 +61,7 @@ describe('defaultGroupDeletion', () => {
       toChange({ after: notDefaultGroup }), // Should do nothing because it is not a default group
     ]
 
-    const errors = await defaultGroupChangeValidator(changes)
+    const errors = await defaultGroupChangeValidator(client)(changes)
     expect(errors).toHaveLength(4)
     expect(errors).toEqual([
       {
@@ -58,7 +75,7 @@ describe('defaultGroupDeletion', () => {
         severity: 'Error',
         message: 'Cannot delete the default group',
         detailedMessage: `This group (${removedDefaultGroup.elemID.name}) is currently set as default in Zendesk and therefore cannot be deleted.\n`
-            + 'Changing the default group is not supported via the Zendesk API, therefore, you will need to configure a new default group directly via Zendesk and fetch.',
+          + 'Changing the default group is not supported via the Zendesk API, therefore, you will need to configure a new default group directly via Zendesk and fetch.',
       },
       {
         elemID: afterNotDefaultGroup.elemID,
@@ -71,6 +88,31 @@ describe('defaultGroupDeletion', () => {
         severity: 'Error',
         message: 'Cannot change the default group',
         detailedMessage: 'Changing the default group is not supported via the Zendesk API, therefore, you will need to do it directly via Zendesk and fetch.',
+      },
+    ])
+  })
+
+  it('does not allow deletion of groups that have members with default group', async () => {
+    const group = createGroup('nonDefaultWithDefaultUser', false)
+    const changes = [toChange({ before: group })]
+    mockGet.mockImplementation(() => (
+      {
+        status: 200,
+        data: {
+          group_memberships: [
+            { user_id: '1', default: true },
+          ],
+        },
+      }
+    ))
+    const errors = await defaultGroupChangeValidator(client)(changes)
+    expect(errors).toHaveLength(1)
+    expect(errors).toEqual([
+      {
+        elemID: group.elemID,
+        severity: 'Error',
+        message: 'Cannot remove the group, it is set as default for some users',
+        detailedMessage: 'This group (nonDefaultWithDefaultUser) is currently set as default for the following user ids: 1.',
       },
     ])
   })


### PR DESCRIPTION
Do not allow deletion of groups where one of the group's members has it set as default.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
