### PR TITLE
SALTO-5353: Fix CV for Automation to assets

### DIFF
--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -48,7 +48,7 @@ const isComponentChanged = (beforeComponents: Component[], afterComponents: Comp
 }
 
 export const automationToAssetsValidator: (config: JiraConfig) => ChangeValidator = config => async changes => {
-  if (config.fetch.enableJSM) {
+  if (config.fetch.enableJSM && config.fetch.enableJsmExperimental) {
     return []
   }
   return changes
@@ -66,7 +66,7 @@ export const automationToAssetsValidator: (config: JiraConfig) => ChangeValidato
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning' as SeverityLevel,
-      message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
-      detailedMessage: `The automation '${instance.annotations[CORE_ANNOTATIONS.ALIAS]}', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.`,
+      message: 'Missing Assets support for Automation Linked to Assets Elements.',
+      detailedMessage: `The automation '${instance.annotations[CORE_ANNOTATIONS.ALIAS]}', linked to the Assets object, requires the Assets support in Salto. This automation currently uses internal IDs but does not have the Assets support. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the Assets support, could lead to deployment issues.`,
     }))
 }

--- a/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automation_to_assets.test.ts
@@ -57,13 +57,14 @@ describe('automationsToAssetsValidator', () => {
         {
           elemID: automationInstance.elemID,
           severity: 'Warning',
-          message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
-          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.',
+          message: 'Missing Assets support for Automation Linked to Assets Elements.',
+          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the Assets support in Salto. This automation currently uses internal IDs but does not have the Assets support. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the Assets support, could lead to deployment issues.',
         },
       ])
   })
   it('should not return a warning when its addition change and automation has workspaceId and enableJSM is true', async () => {
     config.fetch.enableJSM = true
+    config.fetch.enableJsmExperimental = true
     const validator = automationToAssetsValidator(config)
     expect(await validator([toChange({ after: automationInstance })]))
       .toEqual([])
@@ -84,8 +85,8 @@ describe('automationsToAssetsValidator', () => {
         {
           elemID: automationInstance.elemID,
           severity: 'Warning',
-          message: 'Missing JSM Add-On for Automation Linked to Assets Elements.',
-          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the JSM Add-On in Salto. This automation currently uses internal IDs but does not have the JSM Add-On. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the JSM Add-On, could lead to deployment issues.',
+          message: 'Missing Assets support for Automation Linked to Assets Elements.',
+          detailedMessage: 'The automation \'automation alias\', linked to the Assets object, requires the Assets support in Salto. This automation currently uses internal IDs but does not have the Assets support. If you have modified internal IDs, ensure they are accurate in the target environment. Incorrect IDs, without the Assets support, could lead to deployment issues.',
         },
       ])
   })


### PR DESCRIPTION
In this PR I fix the CV that warn when customer has automation to assets without assets support

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter:_
* Fixed automationToAssetsValidator validator in jira to warn when customer doesn't have assets support.

---
_User Notifications_: 
None
