### PR TITLE
SALTO-5340 Support referencing custom status

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -122,6 +122,7 @@ const TICKET_FIELD_OPTION_TYPE_NAME = 'ticket_field__custom_field_options'
 const ORG_FIELD_OPTION_TYPE_NAME = 'organization_field__custom_field_options'
 const USER_FIELD_OPTION_TYPE_NAME = 'user_field__custom_field_options'
 const CUSTOM_OBJECT_PREFIX = 'zen:custom_object:'
+const CUSTOM_STATUS_FIELD_PREFIX = 'custom_status_'
 
 const customFieldOptionSerialization: GetLookupNameFunc = ({ ref }) => {
   const fieldName = ref.elemID.typeName === TICKET_FIELD_OPTION_TYPE_NAME ? 'value' : 'id'
@@ -199,6 +200,7 @@ type ZendeskReferenceSerializationStrategyName = 'ticketField'
   | 'locale'
   | 'idString'
   | 'customObjectKey'
+  | 'customStatusField'
 const ZendeskReferenceSerializationStrategyLookup: Record<
   ZendeskReferenceSerializationStrategyName
   | referenceUtils.ReferenceSerializationStrategyName,
@@ -250,6 +252,13 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
     lookup: val =>
       ((_.isString(val) && val.startsWith(CUSTOM_OBJECT_PREFIX)) ? val.slice(CUSTOM_OBJECT_PREFIX.length) : val),
     lookupIndexName: 'key',
+  },
+  customStatusField: {
+    serialize: ({ ref }) => (isInstanceElement(ref.value) ? `${CUSTOM_STATUS_FIELD_PREFIX}${ref.value.value.id}` : ref.value),
+    lookup: val => ((_.isString(val) && val.match(`${CUSTOM_STATUS_FIELD_PREFIX}\\d+`) !== null)
+      ? val.slice(CUSTOM_STATUS_FIELD_PREFIX.length)
+      : val),
+    lookupIndexName: 'id',
   },
 }
 
@@ -640,6 +649,14 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     },
     zendeskSerializationStrategy: 'userFieldAlternative',
     target: { type: USER_FIELD_TYPE_NAME },
+  },
+  {
+    src: {
+      field: 'field',
+    },
+    zendeskSerializationStrategy: 'customStatusField',
+    zendeskMissingRefStrategy: 'prefixAndNumber',
+    target: { type: CUSTOM_STATUS_TYPE_NAME },
   },
   {
     src: {

--- a/packages/zendesk-adapter/src/filters/references/missing_references.ts
+++ b/packages/zendesk-adapter/src/filters/references/missing_references.ts
@@ -18,12 +18,13 @@ import _ from 'lodash'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import {
   CUSTOM_OBJECT_FIELD_TYPE_NAME,
+  CUSTOM_STATUS_TYPE_NAME,
   ORG_FIELD_TYPE_NAME,
   TICKET_FIELD_TYPE_NAME,
   USER_FIELD_TYPE_NAME,
 } from '../../constants'
 
-export type ZendeskMissingReferenceStrategyName = referenceUtils.MissingReferenceStrategyName | 'startsWith'
+export type ZendeskMissingReferenceStrategyName = referenceUtils.MissingReferenceStrategyName | 'startsWith' | 'prefixAndNumber'
 
 export const VALUES_TO_SKIP_BY_TYPE: Record<string, string[]> = {
   group: ['current_groups', 'group_id'],
@@ -35,6 +36,7 @@ const VALUE_BY_TYPE: Record<string, string[]> = {
   [USER_FIELD_TYPE_NAME]: ['requester.custom_fields.'],
   [ORG_FIELD_TYPE_NAME]: ['organization.custom_fields.'],
   [CUSTOM_OBJECT_FIELD_TYPE_NAME]: ['zen:custom_object:'],
+  [CUSTOM_STATUS_TYPE_NAME]: ['custom_status_'],
 }
 
 export const ZendeskMissingReferenceStrategyLookup: Record<
@@ -54,6 +56,18 @@ ZendeskMissingReferenceStrategyName, referenceUtils.MissingReferenceStrategy
         && value
         && !VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)
         && (VALUE_BY_TYPE[typeName] ?? []).some(prefix => value.startsWith(prefix))
+      ) {
+        return referenceUtils.createMissingInstance(adapter, typeName, value)
+      }
+      return undefined
+    },
+  },
+  prefixAndNumber: {
+    create: ({ value, adapter, typeName }) => {
+      if (_.isString(typeName)
+        && value
+        && !VALUES_TO_SKIP_BY_TYPE[typeName]?.includes(value)
+        && (VALUE_BY_TYPE[typeName] ?? []).some(prefix => value.match(`${prefix}\\d+`) !== null)
       ) {
         return referenceUtils.createMissingInstance(adapter, typeName, value)
       }

--- a/packages/zendesk-adapter/test/filters/field_references.test.ts
+++ b/packages/zendesk-adapter/test/filters/field_references.test.ts
@@ -18,7 +18,7 @@ import { ElemID, InstanceElement, ObjectType, ReferenceExpression, Element,
 import { filterUtils } from '@salto-io/adapter-components'
 import filterCreator from '../../src/filters/field_references'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
-import { ROUTING_ATTRIBUTE_VALUE_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { CUSTOM_STATUS_TYPE_NAME, ROUTING_ATTRIBUTE_VALUE_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { createFilterCreatorParams } from '../utils'
 
 describe('References by id filter', () => {
@@ -225,6 +225,12 @@ describe('References by id filter', () => {
       },
     },
   })
+  const customStatusType = new ObjectType({
+    elemID: new ElemID(ZENDESK, CUSTOM_STATUS_TYPE_NAME),
+    fields: {
+      id: { refType: BuiltinTypes.NUMBER },
+    },
+  })
 
   const generateElements = (
   ): Element[] => ([
@@ -307,6 +313,7 @@ describe('References by id filter', () => {
       }
     ),
     new InstanceElement('customField2', ticketFieldType, { id: 6005, type: 'text' }),
+    new InstanceElement('customStatus', customStatusType, { id: 2001, type: 'text' }),
     new InstanceElement('userField1', userFieldType, { id: 6002, key: 'key_uf1', type: 'dropdown' }),
     new InstanceElement('orgField1', orgFieldType, { id: 6003, key: 'key_of1', type: 'dropdown' }),
     new InstanceElement('orgField2', orgFieldType, { id: 6003, key: 'key_of2', type: 'text' }),
@@ -368,6 +375,8 @@ describe('References by id filter', () => {
             { field: 'organization.custom_fields.key_of1', value: '9003' },
             { field: 'organization.custom_fields.key_of2', value: '9004' },
             { field: 'custom_fields_6005', operator: 'is', value: 'v11' },
+            { field: 'custom_status_2001', operator: 'is', value: '48' },
+            { field: 'custom_status_id', operator: 'is', value: 2001 },
           ],
         },
       },
@@ -385,6 +394,7 @@ describe('References by id filter', () => {
             { field: 'group_id', operator: 'is', value: 'a_thing' },
             { field: 'schedule_id', operator: 'is', value: 'someone_you_love' },
             { field: 'group_id', operator: 'is', value: 'current_groups' },
+            { field: 'custom_status_2002', operator: 'is', value: '48' },
           ],
         },
       },
@@ -501,6 +511,9 @@ describe('References by id filter', () => {
       expect(trigger.value.conditions.all[4].field.elemID.getFullName())
         .toEqual('zendesk.ticket_field.instance.customField2')
       expect(trigger.value.conditions.all[4].value).not.toBeInstanceOf(ReferenceExpression)
+      expect(trigger.value.conditions.all[5].field).toBeInstanceOf(ReferenceExpression)
+      expect(trigger.value.conditions.all[5].field.elemID.getFullName())
+        .toEqual('zendesk.custom_status.instance.customStatus')
 
       const userLookup = elements.filter(
         e => isInstanceElement(e) && e.elemID.name === 'userLookup1'
@@ -535,6 +548,9 @@ describe('References by id filter', () => {
           .toEqual('missing_someone_you_love')
         expect(brokenTrigger.value.conditions.all[5].value).not.toBeInstanceOf(ReferenceExpression)
         expect(brokenTrigger.value.conditions.all[5].value).toEqual('current_groups')
+        expect(brokenTrigger.value.conditions.all[6].field).toBeInstanceOf(ReferenceExpression)
+        expect(brokenTrigger.value.conditions.all[6].field.elemID.name)
+          .toEqual('missing_custom_status_2002')
       })
       it('should create valid missing reference for routing_attribute_value', async () => {
         const brokenAttribute = elements.filter(


### PR DESCRIPTION
Support referencing a custom status, add missing reference if is a valid number and does not exist.

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter:__
* Support referencing a custom status, add missing reference if is a valid number and does not exist.

---
_User Notifications_: 
Field values that are of the type `custom_status_####` will be converted to references to the relevant custom status.