### PR TITLE
SALTO-5243 - Salesforce: Create deploy warning when data instance may have been partially deployed due to non existing fields

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -192,7 +192,7 @@ export const createElement = async <T extends InstanceElement | ObjectType>(
   const errors = result.errors.filter(error => error.severity === 'Error')
   if (verify && errors.length > 0) {
     if (errors.length === 1) throw result.errors[0]
-    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${result.errors.map(error => safeJsonStringify(error))}`)
+    throw new Error(`Failed adding element ${element.elemID.getFullName()} with errors: ${errors.map(error => safeJsonStringify(error))}`)
   }
   if (verify && result.appliedChanges.length === 0) {
     throw new Error(`Failed adding element ${element.elemID.getFullName()}: no applied changes`)

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -26,7 +26,7 @@ import {
   SeverityLevel,
   isInstanceElement, isInstanceChange, toChange, isElement, getAllChangeData, ElemID, isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
-import { inspectValue, safeJsonStringify, getValuesChanges } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify, getValuesChanges, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { BatchResultInfo } from '@salto-io/jsforce-types'
 import { EOL } from 'os'
 import {
@@ -606,6 +606,25 @@ const isModificationChangeList = <T>(
     changes.every(isModificationChange)
   )
 
+const getMissingFields = (change: Change<InstanceElement>): string[] => {
+  const typeFields = new Set(Object.keys(getChangeData(change).getTypeSync().fields))
+  return Object.keys(getChangeData(change).value).filter(instanceField => !typeFields.has(instanceField))
+}
+
+const omitMissingFieldsValues = async (change: Change<InstanceElement>): Promise<Change<InstanceElement>> => (
+  applyFunctionToChangeData(change, instance => {
+    const instanceClone = instance.clone()
+    const typeFields = new Set(Object.keys(instanceClone.getTypeSync().fields))
+    Object.keys(instanceClone.value)
+      .forEach(instanceField => {
+        if (!typeFields.has(instanceField)) {
+          delete instanceClone.value[instanceField]
+        }
+      })
+    return instanceClone
+  })
+)
+
 const deploySingleTypeAndActionCustomObjectInstancesGroup = async (
   changes: ReadonlyArray<Change<InstanceElement>>,
   client: SalesforceClient,
@@ -620,8 +639,31 @@ const deploySingleTypeAndActionCustomObjectInstancesGroup = async (
       elemID: getChangeData(change).elemID,
     })),
   })
+  const [changesWithMissingFields, validChanges] = _.partition(
+    changes,
+    change => getMissingFields(change).length > 0,
+  )
+  const missingFieldValuesWarnings: SaltoElementError[] = changesWithMissingFields
+    .map(change => ({ change, missingFields: getMissingFields(change) }))
+    .map(({ change, missingFields }) => ({
+      severity: 'Warning',
+      elemID: getChangeData(change).elemID,
+      message: `The values of the following fields were not deployed since they are not defined in the type: [${missingFields.join(', ')}]`,
+    }))
+  const withMissingFieldValuesErrors = (deployResult: DeployResult): DeployResult => {
+    const appliedChangesElemIds = new Set(deployResult.appliedChanges
+      .map(change => getChangeData(change).elemID.getFullName()))
+    return {
+      ...deployResult,
+      errors: deployResult.errors
+        // We should omit warnings on non applied changes
+        .concat(missingFieldValuesWarnings.filter(warning => appliedChangesElemIds.has(warning.elemID.getFullName()))),
+    }
+  }
+  const changesToDeploy = validChanges
+    .concat(await awu(changesWithMissingFields).map(omitMissingFieldsValues).toArray())
   try {
-    const instances = changes.map(change => getChangeData(change))
+    const instances = changesToDeploy.map(change => getChangeData(change))
     const instanceTypes = [...new Set(await awu(instances)
       .map(async inst => apiName(await inst.getType())).toArray())]
     if (instanceTypes.length > 1) {
@@ -639,13 +681,13 @@ const deploySingleTypeAndActionCustomObjectInstancesGroup = async (
       if (invalidIdFields !== undefined && invalidIdFields.length > 0) {
         return customObjectInstancesDeployError(`Failed to add instances of type ${instanceTypes[0]} due to invalid SaltoIdFields - ${invalidIdFields}`)
       }
-      return await deployAddInstances(changes, idFields, client, groupId)
+      return withMissingFieldValuesErrors(await deployAddInstances(changes, idFields, client, groupId))
     }
     if (changes.every(isRemovalChange)) {
       return await deployRemoveInstances(instances, client, groupId)
     }
-    if (isModificationChangeList(changes)) {
-      return await deployModifyChanges(changes, client, groupId)
+    if (isModificationChangeList(changesToDeploy)) {
+      return withMissingFieldValuesErrors(await deployModifyChanges(changesToDeploy, client, groupId))
     }
     return customObjectInstancesDeployError('Custom Object Instances change group must have one action')
   } catch (error) {

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -579,13 +579,10 @@ describe('Custom Object Instances CRUD', () => {
           })
 
           it('Should not insert non-creatable fields', () => {
-            expect(result.errors).toEqual([
-              expect.objectContaining({
-                elemID: newInstanceWithNonCreatableField.elemID,
-                message: expect.stringContaining('Creatable'),
-                severity: 'Warning',
-              }),
-            ])
+            expect(result.errors).toSatisfyAny(error =>
+              error.elemID.isEqual(newInstanceWithNonCreatableField.elemID)
+              && error.message.includes('createable')
+              && error.severity === 'Warning')
             const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
               .map(getChangeData)
               .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement
@@ -666,13 +663,10 @@ describe('Custom Object Instances CRUD', () => {
               expect(anotherNewInstanceChangeData.value.Id).toEqual('newId1')
             })
             it('Should not insert non-creatable fields', () => {
-              expect(result.errors).toEqual([
-                expect.objectContaining({
-                  elemID: newInstanceWithNonCreatableField.elemID,
-                  message: expect.stringContaining('Creatable'),
-                  severity: 'Warning',
-                }),
-              ])
+              expect(result.errors).toSatisfyAny(error =>
+                error.elemID.isEqual(newInstanceWithNonCreatableField.elemID)
+                && error.message.includes('createable')
+                && error.severity === 'Warning')
               const newInstanceWithNonCreatableFieldChangeData = result.appliedChanges
                 .map(getChangeData)
                 .find(element => element.elemID.isEqual(newInstanceWithNonCreatableField.elemID)) as InstanceElement


### PR DESCRIPTION
Create Deploy Warning when attempting to deploy data instance with missing fields.

---
~Based on https://github.com/salto-io/salto/pull/5317~

Take 2 of https://github.com/salto-io/salto/pull/5277
When users attempt to deploy data instances with values to fields that do not exist in the CustomObject, we warn the users that the instance was most likely partially deployed in Salesforce.

The implementation does not intercept the applied changes, as we don't really know what was actually deployed to the service.
![image](https://github.com/salto-io/salto/assets/117099820/f106dd61-4c50-40dd-b745-4cf5a8ed1176)
<img width="1176" alt="image" src="https://github.com/salto-io/salto/assets/117099820/608190a1-9908-4d1d-a83b-d2ac15b309ed">



---
_Release Notes_: 
Salesforce Adapter:

Add Deploy Warning when attempting to deploy Data Instance with fields that do not exist on the CustomObject type.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
