### PR TITLE
SALTO-5352: Salesforce Quick Deploy Regression Fix

### DIFF
--- a/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
+++ b/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
@@ -35,6 +35,7 @@ describe('validation and quick deploy e2e', () => {
   let credLease: CredsLease<UsernamePasswordCredentials>
   let changeGroup: ChangeGroup
   let quickDeploySpy: jest.SpyInstance
+  let deploySpy: jest.SpyInstance
   let apexClassInstance: MetadataInstanceElement
   let apexTestInstance: MetadataInstanceElement
 
@@ -98,12 +99,15 @@ describe('validation and quick deploy e2e', () => {
     adapter = adapterQuickDeploy.adapter
 
     const { client } = adapterQuickDeploy
+    deploySpy = jest.spyOn(client, 'deploy')
     quickDeploySpy = jest.spyOn(client, 'quickDeploy')
   })
 
   it('should perform quick deploy', async () => {
     const deployResult = await adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })
     expect(deployResult.appliedChanges).toHaveLength(changeGroup.changes.length)
+    // Make sure we don't fallback to deploy, and the only deploy call was the validation
+    expect(deploySpy).not.toHaveBeenCalled()
     expect(quickDeploySpy).toHaveBeenCalledOnce()
   })
 

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -35,7 +35,7 @@
     "@salto-io/adapter-components": "0.3.53",
     "@salto-io/adapter-utils": "0.3.53",
     "@salto-io/file": "0.3.53",
-    "@salto-io/jsforce": "^1.9.3",
+    "@salto-io/jsforce": "^1.9.4",
     "@salto-io/logging": "0.3.53",
     "@salto-io/lowerdash": "0.3.53",
     "@salto-io/salesforce-formula-parser": "0.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,10 +3032,10 @@
   resolved "https://registry.yarnpkg.com/@salto-io/jsforce-types/-/jsforce-types-0.1.0.tgz#e1a6b1c8c8060dabee2055c39f0b1dd9655489f2"
   integrity sha512-fKC9EdrVoT+5nwjgFi/ybHqT2gWYpCYGBpQ9zfdqc4Qc7rNbWlsr6c1WVrrBxSHNBaoiLpVlrssj166MdOPSAw==
 
-"@salto-io/jsforce@^1.9.3":
-  version "1.9.3"
-  resolved "https://registry.yarnpkg.com/@salto-io/jsforce/-/jsforce-1.9.3.tgz#6a7e2bd818432c40c2b5417e0c438ec16777617e"
-  integrity sha512-346nzB3qt9ljAYSKE8SXi4tyBVvx/m5M81yL1qDpeOjZi/FDoSoEpZII/4srMlKoZil9sUW2PKJ+eRlO9Hf9/w==
+"@salto-io/jsforce@^1.9.4":
+  version "1.9.4"
+  resolved "https://registry.yarnpkg.com/@salto-io/jsforce/-/jsforce-1.9.4.tgz#3919bced17a07e3b363a8780b857fe6c2cabada9"
+  integrity sha512-JiHWhkeGq5pH2CvOyfWsF/2Af1BrQ7dwzAFNYpj9bOwj3PAoKHNQmXThKU2RMX4mK4LOa+LvyY6WtpaIHF8qfg==
   dependencies:
     base64-url "^2.2.0"
     co-prompt "^1.0.0"


### PR DESCRIPTION
Salesforce Quick Deploy Regression Fix

---

The previous salto-io/jsforce version didn't contain the `deployRecentValidation` method so we always failed back to regular deploy.

---
_Release Notes_: 
Salesforce Adapter:
- Fix Quick Metadata Deploy.

---
_User Notifications_: 
_None_
