### PR TITLE
SALTO-5357 - Salesforce: Log deployed data records

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -968,8 +968,10 @@ export default class SalesforceClient {
     type: string,
     operation: BulkLoadOperation,
     records: SalesforceRecord[]
-  ):
-  Promise<BatchResultInfo[]> {
+  ): Promise<BatchResultInfo[]> {
+    if (this.config?.additionalDebugging) {
+      log.trace('client.bulkLoadOperation: %s %d records of type %s: %o', operation, records.length, type, records)
+    }
     const batch = this.conn.bulk.load(
       type,
       operation,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -969,9 +969,7 @@ export default class SalesforceClient {
     operation: BulkLoadOperation,
     records: SalesforceRecord[]
   ): Promise<BatchResultInfo[]> {
-    if (this.config?.additionalDebugging) {
-      log.trace('client.bulkLoadOperation: %s %d records of type %s: %o', operation, records.length, type, records)
-    }
+    log.trace('client.bulkLoadOperation: %s %d records of type %s: %o', operation, records.length, type, records)
     const batch = this.conn.bulk.load(
       type,
       operation,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -392,6 +392,7 @@ export type SalesforceClientConfig = Partial<{
   retry: ClientRetryConfig
   dataRetry: CustomObjectsDeployRetryConfig
   readMetadataChunkSize: ReadMetadataChunkSizeConfig
+  additionalDebugging: boolean
 }>
 
 export type SalesforceConfig = {
@@ -680,6 +681,7 @@ const clientConfigType = new ObjectType({
     retry: { refType: clientRetryConfigType },
     maxConcurrentApiRequests: { refType: clientRateLimitConfigType },
     readMetadataChunkSize: { refType: readMetadataChunkSizeConfigType },
+    additionalDebugging: { refType: BuiltinTypes.BOOLEAN },
   } as Record<keyof SalesforceClientConfig, FieldDefinition>,
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -392,7 +392,6 @@ export type SalesforceClientConfig = Partial<{
   retry: ClientRetryConfig
   dataRetry: CustomObjectsDeployRetryConfig
   readMetadataChunkSize: ReadMetadataChunkSizeConfig
-  additionalDebugging: boolean
 }>
 
 export type SalesforceConfig = {
@@ -681,7 +680,6 @@ const clientConfigType = new ObjectType({
     retry: { refType: clientRetryConfigType },
     maxConcurrentApiRequests: { refType: clientRateLimitConfigType },
     readMetadataChunkSize: { refType: readMetadataChunkSizeConfigType },
-    additionalDebugging: { refType: BuiltinTypes.BOOLEAN },
   } as Record<keyof SalesforceClientConfig, FieldDefinition>,
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
~Introduce a new undocumented config `client.additionalDebugging`. When this config is set we~ log (at `trace` level) the parameters passed to `SalesforceClient.bulkLoadOperation`.

---
Test:
 - Deploy data records with the config set to `true`, observe trace-level logs
 - Deploy data records without the config, confirm no logs of data records

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A