### PR TITLE
SALTO-2392 more account specific values resolving in workflows

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -531,9 +531,9 @@ export default class NetsuiteClient {
     return this.suiteAppClient?.runSuiteQL(query)
   }
 
-  public async runSavedSearchQuery(query: SavedSearchQuery):
+  public async runSavedSearchQuery(query: SavedSearchQuery, limit?: number):
     Promise<Record<string, unknown>[] | undefined> {
-    return this.suiteAppClient?.runSavedSearchQuery(query)
+    return this.suiteAppClient?.runSavedSearchQuery(query, limit)
   }
 
   public async runRecordsQuery(

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -193,16 +193,19 @@ export default class SuiteAppClient {
     return items
   }
 
-  public async runSavedSearchQuery(query: SavedSearchQuery):
-    Promise<Record<string, unknown>[] | undefined> {
+  public async runSavedSearchQuery(
+    query: SavedSearchQuery,
+    limit = Infinity
+  ): Promise<Record<string, unknown>[] | undefined> {
     let hasMore = true
     const items: Record<string, unknown>[] = []
-    for (let offset = 0; hasMore; offset += PAGE_SIZE) {
+    const pageSize = Math.min(limit, PAGE_SIZE)
+    for (let offset = 0; hasMore; offset += pageSize) {
       try {
         // eslint-disable-next-line no-await-in-loop
-        const results = await this.sendSavedSearchRequest(query, offset, PAGE_SIZE)
+        const results = await this.sendSavedSearchRequest(query, offset, pageSize)
         items.push(...results)
-        hasMore = results.length === PAGE_SIZE
+        hasMore = results.length === pageSize && items.length < limit
       } catch (error) {
         log.error('Saved search query error', { error })
         return undefined

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -65,6 +65,8 @@ export const FINANCIAL_LAYOUT = 'financiallayout'
 export const BUNDLE = 'bundle'
 export const BIN = 'bin'
 export const TAX_SCHEDULE = 'taxSchedule'
+export const PROJECT_EXPENSE_TYPE = 'projectExpenseType'
+export const ALLOCATION_TYPE = 'allocationType'
 
 // Type Annotations
 export const SOURCE = 'source'

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -179,7 +179,12 @@ const ALL_TABLE_TO_INTERNAL_ID = {
   ...MANUALLY_TABLE_TO_INTERNAL_ID,
 } as const
 
-export type SuiteQLTableName = keyof typeof ALL_TABLE_TO_INTERNAL_ID
+const ADDITIONAL_TABLES = [
+  'entityStatus',
+  'campaignEvent',
+] as const
+
+export type SuiteQLTableName = keyof typeof ALL_TABLE_TO_INTERNAL_ID | typeof ADDITIONAL_TABLES[number]
 
 const TRANSACTION_TYPES = [
   'advInterCompanyJournalEntry',

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -21,7 +21,7 @@ import { Element, ElemID, InstanceElement, ReadOnlyElementsSource, Value, Values
 import { WALK_NEXT_STEP, resolvePath, walkOnElement, walkOnValue } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../client/client'
 import { RemoteFilterCreator } from '../filter'
-import { ACCOUNT_SPECIFIC_VALUE, INIT_CONDITION, NAME_FIELD, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
+import { ACCOUNT_SPECIFIC_VALUE, ALLOCATION_TYPE, INIT_CONDITION, NAME_FIELD, PROJECT_EXPENSE_TYPE, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
 import { QUERY_RECORD_TYPES, QueryRecordType, QueryRecordResponse, QueryRecordSchema } from '../client/suiteapp_client/types'
 import { INTERNAL_IDS_MAP, InternalIdsMap, SUITEQL_TABLE } from '../data_elements/suiteql_table_elements'
 import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
@@ -78,6 +78,9 @@ type GetFieldTypeIDFunc = (
 const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, string> = {
   STDITEMTAXSCHEDULE: TAX_SCHEDULE,
   STDBODYACCOUNT: 'account',
+  STDEVENTALLOCATIONTYPE: ALLOCATION_TYPE,
+  STDENTITYPROJECTEXPENSETYPE: PROJECT_EXPENSE_TYPE,
+  STDENTITYSTATUS: 'entityStatus',
 }
 
 const getSelectRecordTypeFromReference = (
@@ -127,6 +130,9 @@ const GET_FIELD_TYPE_FUNCTIONS: Record<string, GetFieldTypeIDFunc> = {
     // there is no intersection between the internal ids of those types,
     // and no indication in the element which type should be used.
     isFieldWithAccountSpecificValue ? ['employee', 'contact', 'customer', 'partner', 'vendor'] : undefined
+  ),
+  campaignevent: ({ isFieldWithAccountSpecificValue }) => (
+    isFieldWithAccountSpecificValue ? 'campaignEvent' : undefined
   ),
   selectrecordtype: getSelectRecordType,
   resultfield: params => {

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -109,7 +109,7 @@ describe('role', () => {
         type: 'role',
         columns: ['internalid', 'permchangedate'],
         filters: [['permchangedate', 'within', '2021-01-11 6:55 pm', '2021-02-22 6:56 pm']],
-      })
+      }, undefined)
     })
   })
 

--- a/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/savedsearch.test.ts
@@ -55,7 +55,7 @@ describe('savedsearch', () => {
         type: 'savedsearch',
         columns: ['id', 'datemodified'],
         filters: [['datemodified', 'within', '2021-01-11 6:55 pm', '2021-02-22 6:56 pm']],
-      })
+      }, undefined)
     })
   })
 

--- a/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/workflow.test.ts
@@ -55,7 +55,7 @@ describe('workflow', () => {
             ['date', 'within', '2021-01-11 6:55 pm', '2021-02-22 6:56 am'],
           ],
           columns: ['recordid'],
-        })
+        }, undefined)
       })
     })
 

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -98,8 +98,8 @@ describe('SuiteQL table elements', () => {
     })
 
     it('should return all elements', () => {
-      // additional elements are the type and taxSchedule instance that is fetched with runSavedSearchQuery
-      expect(elements).toHaveLength(numOfInstances + 2)
+      // additional elements are the type, and instances from getAdditionalInstances
+      expect(elements).toHaveLength(numOfInstances + 4)
       expect(elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
     })
 

--- a/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/saved_searches.test.ts
@@ -71,7 +71,7 @@ describe('netsuite saved searches author information tests', () => {
       type: 'savedsearch',
       columns: ['modifiedby', 'id', 'datemodified'],
       filters: [],
-    })
+    }, undefined)
     expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -192,7 +192,7 @@ describe('sdf internal ids tests', () => {
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, 'SELECT scriptid, internalid FROM customfield ORDER BY internalid ASC')
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, 'SELECT scriptid, internalid FROM customrecordtype ORDER BY internalid ASC')
       expect(runSuiteQLMock).toHaveBeenCalledTimes(3)
-      expect(runSavedSearchQueryMock).toHaveBeenCalledWith({ type: 'savedsearch', filters: [], columns: ['id', 'internalid'] })
+      expect(runSavedSearchQueryMock).toHaveBeenCalledWith({ type: 'savedsearch', filters: [], columns: ['id', 'internalid'] }, undefined)
       expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(1)
     })
     it('should add internal ids to elements', () => {
@@ -252,7 +252,7 @@ describe('sdf internal ids tests', () => {
         expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, 'SELECT scriptid, id FROM clientscript ORDER BY id ASC')
         expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, 'SELECT scriptid, internalid FROM customrecordtype ORDER BY internalid ASC')
         expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
-        expect(runSavedSearchQueryMock).toHaveBeenCalledWith({ type: 'savedsearch', filters: [], columns: ['id', 'internalid'] })
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith({ type: 'savedsearch', filters: [], columns: ['id', 'internalid'] }, undefined)
         expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(1)
       })
       it('should add internal ids to new elements', () => {


### PR DESCRIPTION
- map more fields with ASV to the data types they are referring
- fetch more SuiteQL tables
- fetch internal id maps from saved search too
- add option to limit saveSearch query results

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- More account specific values resolving in workflows

---
_User Notifications_: 
Netsuite Adapter:
- When `fetch.resolveAccountSpecificValues` is `true`, more `ACCOUNT_SPECIFIC_VALUE` values in workflows will be resolved.