### PR TITLE
SALTO-5369 - Salesforce: Handle circular dependency of CPQ PriceRule/PriceCondition

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -476,6 +476,7 @@ export const CPQ_HIDDEN_SOURCE_OBJECT = 'SBQQ__HiddenSourceObject__c'
 export const CPQ_TARGET_FIELD = 'SBQQ__TargetField__c'
 export const CPQ_TARGET_OBJECT = 'SBQQ__TargetObject__c'
 export const CPQ_CONDITIONS_MET = 'SBQQ__ConditionsMet__c'
+export const CPQ_PRICE_CONDITION_RULE_FIELD = 'SBQQ__Rule__c'
 
 export const CPQ_QUOTE_NO_PRE = 'Quote__c'
 export const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -435,6 +435,7 @@ export const DATA_INSTANCES_CHANGED_AT_MAGIC = '__DataInstances__'
 export const CPQ_NAMESPACE = 'SBQQ'
 export const CPQ_PRODUCT_RULE = 'SBQQ__ProductRule__c'
 export const CPQ_PRICE_RULE = 'SBQQ__PriceRule__c'
+export const CPQ_PRICE_CONDITION = 'SBQQ__PriceCondition__c'
 export const CPQ_LOOKUP_QUERY = 'SBQQ__LookupQuery__c'
 export const CPQ_PRICE_ACTION = 'SBQQ__PriceAction__c'
 export const CPQ_FIELD_METADATA = 'SBQQ__FieldMetadata__c'
@@ -474,6 +475,7 @@ export const CPQ_HIDDEN_SOURCE_FIELD = 'SBQQ__HiddenSourceField__c'
 export const CPQ_HIDDEN_SOURCE_OBJECT = 'SBQQ__HiddenSourceObject__c'
 export const CPQ_TARGET_FIELD = 'SBQQ__TargetField__c'
 export const CPQ_TARGET_OBJECT = 'SBQQ__TargetObject__c'
+export const CPQ_CONDITIONS_MET = 'SBQQ__ConditionsMet__c'
 
 export const CPQ_QUOTE_NO_PRE = 'Quote__c'
 export const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'
@@ -524,7 +526,8 @@ export const groupIdForInstanceChangeGroup = (action: ActionName, typeName: stri
   }
   return `${_.capitalize(toVerbalNoun(action))} of data instances of type '${typeName}'`
 }
-export const ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP = groupIdForInstanceChangeGroup('add', 'Custom ApprovalRule and ApprovalCondition')
+export const ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP = groupIdForInstanceChangeGroup('add', 'Custom ApprovalRule and ApprovalCondition')
+export const ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP = groupIdForInstanceChangeGroup('add', 'Custom PriceRule and PriceCondition')
 export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
 
 

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -40,7 +40,7 @@ import {
   DEFAULT_CUSTOM_OBJECT_DEPLOY_RETRY_DELAY_MULTIPLIER, OWNER_ID, SBAA_APPROVAL_CONDITION,
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET, SYSTEM_FIELDS, ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP, CPQ_PRICE_RULE,
-  CPQ_PRICE_CONDITION, CPQ_CONDITIONS_MET,
+  CPQ_PRICE_CONDITION, CPQ_CONDITIONS_MET, CPQ_PRICE_CONDITION_RULE_FIELD,
 } from './constants'
 import { getIdFields, transformRecordToValues } from './filters/custom_objects_instances'
 import {
@@ -740,6 +740,7 @@ const deployRulesAndConditionsGroup = async (
   ruleTypeName: string,
   ruleConditionFieldName: string,
   conditionTypeName: string,
+  conditionRuleFieldName: string,
   changes: ReadonlyArray<Change<InstanceElement>>,
   changeGroupId: string,
   client: SalesforceClient,
@@ -791,9 +792,9 @@ const deployRulesAndConditionsGroup = async (
     conditionChanges,
     change => {
       const conditionInstance = getChangeData(change)
-      const ruleInstance = conditionInstance.value[ruleTypeName]
+      const ruleInstance = conditionInstance.value[conditionRuleFieldName]
       if (!isInstanceElement(ruleInstance)) {
-        log.error(`Expected ${conditionTypeName} with name %s to contain InstanceElement for the ${ruleTypeName} field`, conditionInstance.elemID.getFullName())
+        log.error(`Expected ${conditionTypeName} with name %s to contain InstanceElement for the ${conditionRuleFieldName} field`, conditionInstance.elemID.getFullName())
         return false
       }
       // Only successfully deployed Instances have Id
@@ -847,6 +848,7 @@ const deployAddCustomApprovalRulesAndConditions = async (
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
   SBAA_APPROVAL_CONDITION,
+  SBAA_APPROVAL_RULE,
   changes,
   ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
   client,
@@ -861,6 +863,7 @@ const deployAddCustomPriceRulesAndConditions = async (
   CPQ_PRICE_RULE,
   CPQ_CONDITIONS_MET,
   CPQ_PRICE_CONDITION,
+  CPQ_PRICE_CONDITION_RULE_FIELD,
   changes,
   ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
   client,

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -13,7 +13,6 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { collections } from '@salto-io/lowerdash'
 import {
   Change,
   ChangeGroupIdFunction,
@@ -27,8 +26,9 @@ import {
   AdditionChange,
 } from '@salto-io/adapter-api'
 import wu from 'wu'
-import { isInstanceOfCustomObjectChange } from './custom_object_instances_deploy'
-import { isInstanceOfTypeChange, safeApiName } from './filters/utils'
+import {
+  apiNameSync, isInstanceOfCustomObjectChangeSync, isInstanceOfTypeChangeSync,
+} from './filters/utils'
 import {
   ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, SBAA_APPROVAL_CONDITION,
   SBAA_APPROVAL_RULE,
@@ -37,52 +37,70 @@ import {
   groupIdForInstanceChangeGroup,
 } from './constants'
 
-const { awu } = collections.asynciterable
-
-const getGroupId = async (change: Change): Promise<string> => {
-  if (!isInstanceChange(change) || !(await isInstanceOfCustomObjectChange(change))) {
+const getGroupId = (change: Change): string => {
+  if (!isInstanceChange(change) || !(isInstanceOfCustomObjectChangeSync(change))) {
     return METADATA_CHANGE_GROUP
   }
-  const typeName = await safeApiName(await getChangeData(change).getType()) ?? 'UNKNOWN'
+  const typeName = apiNameSync(getChangeData(change).getTypeSync()) ?? 'UNKNOWN'
   return groupIdForInstanceChangeGroup(change.action, typeName)
+}
+
+
+/**
+ * Returns the changes that should be part of the special deploy group for adding Rule and Condition instances that
+ * contain a circular dependency.
+ *
+ * @ref deployRulesAndConditionsGroup
+ */
+const getAddCustomRuleAndConditionGroupChangeIds = (
+  changes: Map<ChangeId, Change>,
+  ruleTypeName: string,
+  ruleConditionFieldName: string,
+  conditionTypeName: string,
+): Set<ChangeId> => {
+  const addedInstancesChanges = wu(changes.entries())
+    .filter(([_changeId, change]) => isAdditionChange(change))
+    .filter(([_changeId, change]) => isInstanceChange(change))
+    .toArray() as [ChangeId, AdditionChange<InstanceElement>][]
+  const customApprovalRuleAdditions = addedInstancesChanges
+    .filter(([_changeId, change]) => isInstanceOfTypeChangeSync(ruleTypeName)(change))
+    .filter(([_changeId, change]) => getChangeData(change).value[ruleConditionFieldName] === 'Custom')
+  const customApprovalRuleElemIds = new Set(customApprovalRuleAdditions
+    .map(([_changeId, change]) => getChangeData(change).elemID.getFullName()))
+  const customApprovalConditionAdditions = addedInstancesChanges
+    .filter(([_changeId, change]) => isInstanceOfTypeChangeSync(conditionTypeName)(change))
+    .filter(([_changeId, change]) => {
+      const approvalRule = getChangeData(change).value[ruleTypeName]
+      return isReferenceExpression(approvalRule) && customApprovalRuleElemIds.has(approvalRule.elemID.getFullName())
+    })
+  return new Set(customApprovalRuleAdditions
+    .concat(customApprovalConditionAdditions)
+    .map(([changeId]) => changeId))
 }
 
 /**
  * Returns the changes that should be part of the special deploy group for adding sbaa__ApprovalRule
  * instances with sbaa__ConditionsMet = 'Custom' and their corresponding sbaa__ApprovalCondition instances.
  */
-const getAddCustomRuleAndConditionGroupChangeIds = async (
+const getAddSbaaCustomRuleAndConditionGroupChangeIds = (
   changes: Map<ChangeId, Change>
-): Promise<Set<ChangeId>> => {
-  const addedInstancesChanges = wu(changes.entries())
-    .filter(([_changeId, change]) => isAdditionChange(change))
-    .filter(([_changeId, change]) => isInstanceChange(change))
-    .toArray() as [ChangeId, AdditionChange<InstanceElement>][]
-  const customApprovalRuleAdditions = addedInstancesChanges
-    .filter(([_changeId, change]) => isInstanceOfTypeChange(SBAA_APPROVAL_RULE)(change))
-    .filter(([_changeId, change]) => getChangeData(change).value[SBAA_CONDITIONS_MET] === 'Custom')
-  const customApprovalRuleElemIds = new Set(customApprovalRuleAdditions
-    .map(([_changeId, change]) => getChangeData(change).elemID.getFullName()))
-  const customApprovalConditionAdditions = await awu(addedInstancesChanges)
-    .filter(([_changeId, change]) => isInstanceOfTypeChange(SBAA_APPROVAL_CONDITION)(change))
-    .filter(([_changeId, change]) => {
-      const approvalRule = getChangeData(change).value[SBAA_APPROVAL_RULE]
-      return isReferenceExpression(approvalRule) && customApprovalRuleElemIds.has(approvalRule.elemID.getFullName())
-    })
-    .toArray()
-  return new Set(customApprovalRuleAdditions
-    .concat(customApprovalConditionAdditions)
-    .map(([changeId]) => changeId))
-}
+): Set<ChangeId> => (
+  getAddCustomRuleAndConditionGroupChangeIds(
+    changes,
+    SBAA_APPROVAL_RULE,
+    SBAA_CONDITIONS_MET,
+    SBAA_APPROVAL_CONDITION,
+  )
+)
 
 export const getChangeGroupIds: ChangeGroupIdFunction = async changes => {
   const changeGroupIdMap = new Map<ChangeId, ChangeGroupId>()
-  const customApprovalRuleAndConditionChangeIds = await getAddCustomRuleAndConditionGroupChangeIds(changes)
-  await awu(changes.entries())
-    .forEach(async ([changeId, change]) => {
+  const customApprovalRuleAndConditionChangeIds = getAddSbaaCustomRuleAndConditionGroupChangeIds(changes)
+  wu(changes.entries())
+    .forEach(([changeId, change]) => {
       const groupId = customApprovalRuleAndConditionChangeIds.has(changeId)
         ? ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP
-        : await getGroupId(change)
+        : getGroupId(change)
       changeGroupIdMap.set(changeId, groupId)
     })
 

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -35,7 +35,7 @@ import {
   SBAA_CONDITIONS_MET,
   METADATA_CHANGE_GROUP,
   groupIdForInstanceChangeGroup, CPQ_PRICE_RULE, CPQ_CONDITIONS_MET, CPQ_PRICE_CONDITION,
-  ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
+  ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP, CPQ_PRICE_CONDITION_RULE_FIELD,
 } from './constants'
 
 const getGroupId = (change: Change): string => {
@@ -58,6 +58,7 @@ const getAddCustomRuleAndConditionGroupChangeIds = (
   ruleTypeName: string,
   ruleConditionFieldName: string,
   conditionTypeName: string,
+  conditionRuleFieldName: string,
 ): Set<ChangeId> => {
   const addedInstancesChanges = wu(changes.entries())
     .filter(([_changeId, change]) => isAdditionChange(change))
@@ -71,7 +72,7 @@ const getAddCustomRuleAndConditionGroupChangeIds = (
   const customConditionAdditions = addedInstancesChanges
     .filter(([_changeId, change]) => isInstanceOfTypeChangeSync(conditionTypeName)(change))
     .filter(([_changeId, change]) => {
-      const rule = getChangeData(change).value[ruleTypeName]
+      const rule = getChangeData(change).value[conditionRuleFieldName]
       return isReferenceExpression(rule) && customRuleElemIds.has(rule.elemID.getFullName())
     })
   return new Set(customRuleAdditions
@@ -91,6 +92,7 @@ const getAddSbaaCustomApprovalRuleAndConditionGroupChangeIds = (
     SBAA_APPROVAL_RULE,
     SBAA_CONDITIONS_MET,
     SBAA_APPROVAL_CONDITION,
+    SBAA_APPROVAL_RULE,
   )
 )
 
@@ -106,6 +108,7 @@ const getAddCpqCustomPriceRuleAndConditionGroupChangeIds = (
     CPQ_PRICE_RULE,
     CPQ_CONDITIONS_MET,
     CPQ_PRICE_CONDITION,
+    CPQ_PRICE_CONDITION_RULE_FIELD,
   )
 )
 

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -31,7 +31,8 @@ import { createCustomObjectType, nullProgressReporter } from './utils'
 import {
   ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CUSTOM_OBJECT_ID_FIELD,
   FIELD_ANNOTATIONS, OWNER_ID, SBAA_APPROVAL_CONDITION,
-  SBAA_APPROVAL_RULE, SBAA_CONDITIONS_MET, DefaultSoqlQueryLimits,
+  SBAA_APPROVAL_RULE, SBAA_CONDITIONS_MET, DefaultSoqlQueryLimits, CPQ_PRICE_RULE, CPQ_CONDITIONS_MET,
+  CPQ_PRICE_CONDITION, CPQ_PRICE_CONDITION_RULE_FIELD, ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
 } from '../src/constants'
 import { mockTypes } from './mock_elements'
 
@@ -295,6 +296,8 @@ describe('Custom Object Instances CRUD', () => {
                     { objectsRegex: 'TestType__c', idFields: ['Name'] },
                     { objectsRegex: 'sbaa__ApprovalRule__c', idFields: ['Id'] },
                     { objectsRegex: 'sbaa__ApprovalCondition__c', idFields: ['sbaa__ApprovalRule__c'] },
+                    { objectsRegex: CPQ_PRICE_RULE, idFields: ['Id'] },
+                    { objectsRegex: CPQ_PRICE_CONDITION, idFields: [CPQ_PRICE_CONDITION_RULE_FIELD] },
                   ],
                 },
               },
@@ -1496,6 +1499,177 @@ describe('Custom Object Instances CRUD', () => {
           changeGroup = {
             groupID: ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
             changes: [approvalRule, approvalCondition].map(instance => toChange({ after: instance })),
+          }
+        })
+        it('should throw an error', async () => {
+          await expect(adapter.deploy({ changeGroup, progressReporter: nullProgressReporter })).rejects.toThrow()
+        })
+      })
+    })
+
+    describe('when group is ADD_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP', () => {
+      describe('when no Errors occur during the deploy', () => {
+        beforeEach(async () => {
+          const priceRule = new InstanceElement(
+            'somePriceRule',
+            mockTypes[CPQ_PRICE_RULE],
+            {
+              [CPQ_CONDITIONS_MET]: 'Custom',
+            },
+          )
+          const priceCondition = new InstanceElement(
+            'somePriceCondition',
+            mockTypes[CPQ_PRICE_CONDITION],
+            {
+              [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(priceRule.elemID, priceRule),
+            }
+          )
+          const changeGroup = {
+            groupID: ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
+            changes: [priceRule, priceCondition].map(instance => toChange({ after: instance })),
+          }
+          result = await adapter.deploy({
+            changeGroup,
+            progressReporter: nullProgressReporter,
+          })
+        })
+        it('should deploy successfully', () => {
+          expect(result.errors).toBeEmpty()
+          expect(result.appliedChanges).toHaveLength(2)
+          const [appliedPriceRule, appliedPriceCondition] = result.appliedChanges
+            .map(getChangeData)
+            .filter(isInstanceElement)
+          expect(appliedPriceRule.value).toEqual({
+            [CUSTOM_OBJECT_ID_FIELD]: 'newId0',
+            [CPQ_CONDITIONS_MET]: 'Custom',
+          })
+          expect(appliedPriceCondition.value).toEqual({
+            [CUSTOM_OBJECT_ID_FIELD]: 'newId0',
+            [CPQ_PRICE_CONDITION_RULE_FIELD]: expect.objectContaining({ elemID: appliedPriceRule.elemID }),
+          })
+
+          expect(connection.bulk.load).toHaveBeenCalledTimes(3)
+          expect(connection.bulk.load).toHaveBeenCalledWith(
+            CPQ_PRICE_RULE, 'insert', expect.anything(), [
+              { Id: undefined, [CPQ_CONDITIONS_MET]: 'All' },
+            ]
+          )
+          expect(connection.bulk.load).toHaveBeenCalledWith(
+            CPQ_PRICE_CONDITION, 'insert', expect.anything(), [
+              { Id: undefined, [CPQ_PRICE_CONDITION_RULE_FIELD]: appliedPriceRule.value[CUSTOM_OBJECT_ID_FIELD] },
+            ]
+          )
+          expect(connection.bulk.load).toHaveBeenCalledWith(
+            CPQ_PRICE_RULE, 'update', expect.anything(), [
+              { Id: 'newId0', [CPQ_CONDITIONS_MET]: 'Custom', Name: null },
+            ]
+          )
+        })
+      })
+      describe('when some PriceRule instances fail to deploy', () => {
+        let priceRule: InstanceElement
+        let priceCondition: InstanceElement
+        let failPriceRule: InstanceElement
+        let failPriceCondition: InstanceElement
+        beforeEach(async () => {
+          priceRule = new InstanceElement(
+            '1',
+            mockTypes[CPQ_PRICE_RULE],
+            {
+              [CPQ_CONDITIONS_MET]: 'Custom',
+            },
+          )
+          priceCondition = new InstanceElement(
+            '1',
+            mockTypes[CPQ_PRICE_CONDITION],
+            {
+              [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(priceRule.elemID, priceRule),
+            }
+          )
+          failPriceRule = new InstanceElement(
+            '2',
+            mockTypes[CPQ_PRICE_RULE],
+            {
+              [CPQ_CONDITIONS_MET]: 'Custom',
+              Name: 'Fail', // Used to indicate which Record should fail in SF
+            },
+          )
+          failPriceCondition = new InstanceElement(
+            '2',
+            mockTypes[CPQ_PRICE_CONDITION],
+            {
+              [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(failPriceRule.elemID, failPriceRule),
+            }
+          )
+          const changeGroup = {
+            groupID: ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
+            changes: [
+              priceRule,
+              failPriceRule,
+              priceCondition,
+              failPriceCondition,
+            ].map(instance => toChange({ after: instance })),
+          }
+
+          connection.bulk.load = jest.fn().mockImplementation(
+            (_type: string, _operation: BulkLoadOperation, _opt?: BulkOptions, input?: SfRecord[]) => {
+              const loadEmitter = new EventEmitter()
+              loadEmitter.on('newListener', (_event, _listener) => {
+                // This is a workaround to call emit('close')
+                // that is really called as a side effect to load() inside
+                // jsforce *after* our code listens on.('close')
+                setTimeout(() => loadEmitter.emit('close'), 0)
+              })
+              return {
+                then: () => (Promise.resolve(input?.map((res, index) => ({
+                  id: res.Id || `newId${index}`,
+                  success: res.Name !== 'Fail',
+                  errors: res.Name === 'Fail' ? ['Failed to deploy ApprovalRule with Name Fail'] : [],
+                })))),
+                job: loadEmitter,
+              }
+            }
+          )
+
+          result = await adapter.deploy({
+            changeGroup,
+            progressReporter: nullProgressReporter,
+          })
+        })
+
+        it('should deploy partially', () => {
+          expect(result.errors).toEqual([
+            expect.objectContaining({ elemID: failPriceRule.elemID }),
+            expect.objectContaining({ elemID: failPriceCondition.elemID }),
+          ])
+          expect(result.appliedChanges).toHaveLength(2)
+          const [appliedPriceRule, appliedPriceCondition] = result.appliedChanges
+            .map(getChangeData)
+            .filter(isInstanceElement)
+          expect(appliedPriceRule.elemID).toEqual(priceRule.elemID)
+          expect(appliedPriceCondition.elemID).toEqual(priceCondition.elemID)
+        })
+      })
+      describe('when a PriceRule instance does not have SBQQ__ConditionsMet__c = Custom', () => {
+        let changeGroup: ChangeGroup
+        beforeEach(() => {
+          const priceRule = new InstanceElement(
+            '1',
+            mockTypes[CPQ_PRICE_RULE],
+            {
+              [CPQ_CONDITIONS_MET]: 'All',
+            },
+          )
+          const priceCondition = new InstanceElement(
+            '1',
+            mockTypes[CPQ_PRICE_CONDITION],
+            {
+              [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(priceRule.elemID, priceRule),
+            }
+          )
+          changeGroup = {
+            groupID: ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
+            changes: [priceRule, priceCondition].map(instance => toChange({ after: instance })),
           }
         })
         it('should throw an error', async () => {

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -1508,6 +1508,36 @@ describe('Custom Object Instances CRUD', () => {
     })
 
     describe('when group is ADD_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP', () => {
+      let mockQuery: jest.Mock
+      beforeEach(() => {
+        mockQuery = jest.fn()
+          .mockImplementationOnce(() => ({
+            // first insert of PriceRule with ConditionsMet='All'
+            totalSize: 0,
+            done: true,
+            records: [
+            ],
+          }))
+          .mockImplementationOnce(() => ({
+            // insert of PriceCondition
+            totalSize: 0,
+            done: true,
+            records: [
+            ],
+          }))
+          .mockImplementationOnce(() => ({
+            // second insert of PriceRule with ConditionsMet='Custom'
+            totalSize: 1,
+            done: true,
+            records: [
+              {
+                Id: 'newId0',
+                OwnerId: 'SomeOwnerId',
+              },
+            ],
+          }))
+        connection.query = mockQuery
+      })
       describe('when no Errors occur during the deploy', () => {
         beforeEach(async () => {
           const priceRule = new InstanceElement(
@@ -1542,6 +1572,7 @@ describe('Custom Object Instances CRUD', () => {
           expect(appliedPriceRule.value).toEqual({
             [CUSTOM_OBJECT_ID_FIELD]: 'newId0',
             [CPQ_CONDITIONS_MET]: 'Custom',
+            [OWNER_ID]: 'SomeOwnerId',
           })
           expect(appliedPriceCondition.value).toEqual({
             [CUSTOM_OBJECT_ID_FIELD]: 'newId0',
@@ -1561,7 +1592,7 @@ describe('Custom Object Instances CRUD', () => {
           )
           expect(connection.bulk.load).toHaveBeenCalledWith(
             CPQ_PRICE_RULE, 'update', expect.anything(), [
-              { Id: 'newId0', [CPQ_CONDITIONS_MET]: 'Custom', Name: null },
+              { Id: 'newId0', [OWNER_ID]: 'SomeOwnerId', [CPQ_CONDITIONS_MET]: 'Custom', Name: null },
             ]
           )
         })

--- a/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
+++ b/packages/salesforce-adapter/test/custom_object_instances.crud.test.ts
@@ -29,7 +29,7 @@ import Connection from '../src/client/jsforce'
 import mockAdapter from './adapter'
 import { createCustomObjectType, nullProgressReporter } from './utils'
 import {
-  ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CUSTOM_OBJECT_ID_FIELD,
+  ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CUSTOM_OBJECT_ID_FIELD,
   FIELD_ANNOTATIONS, OWNER_ID, SBAA_APPROVAL_CONDITION,
   SBAA_APPROVAL_RULE, SBAA_CONDITIONS_MET, DefaultSoqlQueryLimits,
 } from '../src/constants'
@@ -1353,7 +1353,7 @@ describe('Custom Object Instances CRUD', () => {
             }
           )
           const changeGroup = {
-            groupID: ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+            groupID: ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
             changes: [approvalRule, approvalCondition].map(instance => toChange({ after: instance })),
           }
           result = await adapter.deploy({
@@ -1428,7 +1428,7 @@ describe('Custom Object Instances CRUD', () => {
             }
           )
           const changeGroup = {
-            groupID: ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+            groupID: ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
             changes: [
               approvalRule,
               failApprovalRule,
@@ -1494,7 +1494,7 @@ describe('Custom Object Instances CRUD', () => {
             }
           )
           changeGroup = {
-            groupID: ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+            groupID: ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
             changes: [approvalRule, approvalCondition].map(instance => toChange({ after: instance })),
           }
         })

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -34,7 +34,8 @@ import {
   OBJECTS_PATH,
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
-  ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+  ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP, CPQ_PRICE_RULE, CPQ_CONDITIONS_MET, CPQ_PRICE_CONDITION,
+  CPQ_PRICE_CONDITION_RULE_FIELD, ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
 } from '../src/constants'
 import { getChangeGroupIds } from '../src/group_changes'
 import { createInstanceElement } from '../src/transformers/transformer'
@@ -236,6 +237,56 @@ describe('Group changes function', () => {
       expect(result.changeGroupIdMap.get('CustomApprovalCondition')).toEqual(ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
       expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('Addition of data instances of type \'sbaa__ApprovalRule__c\'')
       expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('Addition of data instances of type \'sbaa__ApprovalCondition__c\'')
+    })
+  })
+  describe('when changes are additions of SBQQ__PriceRule__c and SBQQ__PriceCondition__c', () => {
+    let result: ChangeGroupIdFunctionReturn
+    beforeEach(async () => {
+      const customPriceRule = new InstanceElement(
+        'CustomPriceRule',
+        mockTypes[CPQ_PRICE_RULE],
+        {
+          [CPQ_CONDITIONS_MET]: 'Custom',
+        }
+      )
+      const priceRule = new InstanceElement(
+        'PriceRule',
+        mockTypes[CPQ_PRICE_RULE],
+        {
+          [CPQ_CONDITIONS_MET]: 'All',
+        }
+      )
+      const customPriceCondition = new InstanceElement(
+        'CustomPriceCondition',
+        mockTypes[CPQ_PRICE_CONDITION],
+        {
+          [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(customPriceRule.elemID, customPriceRule),
+        }
+      )
+      const priceCondition = new InstanceElement(
+        'PriceCondition',
+        mockTypes[CPQ_PRICE_CONDITION],
+        {
+          [CPQ_PRICE_CONDITION_RULE_FIELD]: new ReferenceExpression(priceRule.elemID, priceRule),
+        }
+      )
+      const addedInstances = [
+        customPriceRule,
+        priceRule,
+        customPriceCondition,
+        priceCondition,
+      ]
+      const changeMap = new Map<string, Change>()
+      addedInstances.forEach(instance => {
+        changeMap.set(instance.elemID.name, toChange({ after: instance }))
+      })
+      result = await getChangeGroupIds(changeMap)
+    })
+    it('should create correct groups', () => {
+      expect(result.changeGroupIdMap.get('CustomPriceRule')).toEqual(ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP)
+      expect(result.changeGroupIdMap.get('CustomPriceCondition')).toEqual(ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP)
+      expect(result.changeGroupIdMap.get('PriceRule')).toEqual('Addition of data instances of type \'SBQQ__PriceRule__c\'')
+      expect(result.changeGroupIdMap.get('PriceCondition')).toEqual('Addition of data instances of type \'SBQQ__PriceCondition__c\'')
     })
   })
 })

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -34,7 +34,7 @@ import {
   OBJECTS_PATH,
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
-  ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
+  ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP,
 } from '../src/constants'
 import { getChangeGroupIds } from '../src/group_changes'
 import { createInstanceElement } from '../src/transformers/transformer'
@@ -232,8 +232,8 @@ describe('Group changes function', () => {
       result = await getChangeGroupIds(changeMap)
     })
     it('should create correct groups', () => {
-      expect(result.changeGroupIdMap.get('CustomApprovalRule')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
-      expect(result.changeGroupIdMap.get('CustomApprovalCondition')).toEqual(ADD_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
+      expect(result.changeGroupIdMap.get('CustomApprovalRule')).toEqual(ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
+      expect(result.changeGroupIdMap.get('CustomApprovalCondition')).toEqual(ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP)
       expect(result.changeGroupIdMap.get('ApprovalRule')).toEqual('Addition of data instances of type \'sbaa__ApprovalRule__c\'')
       expect(result.changeGroupIdMap.get('ApprovalCondition')).toEqual('Addition of data instances of type \'sbaa__ApprovalCondition__c\'')
     })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -28,7 +28,7 @@ import {
   API_NAME,
   ArtificialTypes,
   ASSIGNMENT_RULES_METADATA_TYPE,
-  CHANGED_AT_SINGLETON,
+  CHANGED_AT_SINGLETON, CPQ_CONDITIONS_MET, CPQ_PRICE_CONDITION, CPQ_PRICE_CONDITION_RULE_FIELD, CPQ_PRICE_RULE,
   CPQ_QUOTE,
   CUSTOM_METADATA,
   CUSTOM_OBJECT,
@@ -59,6 +59,19 @@ import { SORT_ORDER } from '../src/change_validators/duplicate_rules_sort_order'
 const SBAA_APPROVAL_RULE_TYPE = createCustomObjectType(SBAA_APPROVAL_RULE, {
   fields: {
     [SBAA_CONDITIONS_MET]: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [FIELD_ANNOTATIONS.CREATABLE]: true,
+        [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+      },
+    },
+  },
+})
+
+const CPQ_PRICE_RULE_TYPE = createCustomObjectType(CPQ_PRICE_RULE, {
+  fields: {
+    [CPQ_CONDITIONS_MET]: {
       refType: BuiltinTypes.STRING,
       annotations: {
         [FIELD_ANNOTATIONS.QUERYABLE]: true,
@@ -562,6 +575,22 @@ export const mockTypes = {
       metadataType: 'BusinessProcess',
     },
   }),
+  [CPQ_PRICE_RULE]: CPQ_PRICE_RULE_TYPE,
+  [CPQ_PRICE_CONDITION]: createCustomObjectType(
+    CPQ_PRICE_CONDITION,
+    {
+      fields: {
+        [CPQ_PRICE_CONDITION_RULE_FIELD]: {
+          refType: Types.primitiveDataTypes.Lookup,
+          annotations: {
+            [FIELD_ANNOTATIONS.QUERYABLE]: true,
+            [FIELD_ANNOTATIONS.CREATABLE]: true,
+            [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+          },
+        },
+      },
+    },
+  ),
 }
 
 export const lwcJsResourceContent = "import { LightningElement } from 'lwc';\nexport default class BikeCard extends LightningElement {\n   name = 'Electra X4';\n   description = 'A sweet bike built for comfort.';\n   category = 'Mountain';\n   material = 'Steel';\n   price = '$2,700';\n   pictureUrl = 'https://s3-us-west-1.amazonaws.com/sfdc-demo/ebikes/electrax4.jpg';\n }"

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -37,7 +37,7 @@ import {
   INSTALLED_PACKAGE_METADATA,
   INSTANCE_FULL_NAME_FIELD, LABEL,
   LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE,
-  METADATA_TYPE,
+  METADATA_TYPE, OWNER_ID,
   PATH_ASSISTANT_METADATA_TYPE,
   SALESFORCE,
   SBAA_APPROVAL_CONDITION,
@@ -54,6 +54,7 @@ import { API_VERSION } from '../src/client/client'
 import { WORKFLOW_FIELD_TO_TYPE } from '../src/filters/workflow'
 import { createCustomObjectType } from './utils'
 import { SORT_ORDER } from '../src/change_validators/duplicate_rules_sort_order'
+import * as constants from '../src/constants'
 
 
 const SBAA_APPROVAL_RULE_TYPE = createCustomObjectType(SBAA_APPROVAL_RULE, {
@@ -77,6 +78,15 @@ const CPQ_PRICE_RULE_TYPE = createCustomObjectType(CPQ_PRICE_RULE, {
         [FIELD_ANNOTATIONS.QUERYABLE]: true,
         [FIELD_ANNOTATIONS.CREATABLE]: true,
         [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+      },
+    },
+    [OWNER_ID]: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+        [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [constants.API_NAME]: OWNER_ID,
       },
     },
   },


### PR DESCRIPTION
Similar to the special handling we have for SBAA `ApprovalRule`/`ApprovalCondition`, we need to do the same thing for CPQ `PriceRule`/`PriceCondition`.

---

I made the existing code more generic and implemented two special cases for SBAA and CPQ

---
_Release Notes_: 
Salesforce: Can now deploy new CPQ PriceRule records with 'Custom' ConditionMet value that reference new PriceCondition records.

---
_User Notifications_: 
N/A
