### PR TITLE
SALTO-5367 fix undefined internalIdsMap bug in workflow ASV resolving

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -32,7 +32,7 @@ const LATEST_VERSION = 1
 
 const ALLOCATION_TYPE_QUERY_LIMIT = 50
 
-export type InternalIdsMap = Record<string, { name: string }>
+type InternalIdsMap = Record<string, { name: string }>
 
 type QueryParams = {
   internalIdField: 'id' | 'key'
@@ -443,6 +443,10 @@ export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undef
   workflow: undefined,
   customrecordtype: undefined,
 }
+
+export const getSuiteQLTableInternalIdsMap = (instance: InstanceElement): InternalIdsMap =>
+  // value[INTERNAL_IDS_MAP] can be undefined because transformElement transform empty objects to undefined
+  instance.value[INTERNAL_IDS_MAP] ?? {}
 
 const getInternalIdsMap = async (
   client: NetsuiteClient,

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -23,7 +23,7 @@ import NetsuiteClient from '../client/client'
 import { RemoteFilterCreator } from '../filter'
 import { ACCOUNT_SPECIFIC_VALUE, ALLOCATION_TYPE, INIT_CONDITION, NAME_FIELD, PROJECT_EXPENSE_TYPE, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
 import { QUERY_RECORD_TYPES, QueryRecordType, QueryRecordResponse, QueryRecordSchema } from '../client/suiteapp_client/types'
-import { INTERNAL_IDS_MAP, InternalIdsMap, SUITEQL_TABLE } from '../data_elements/suiteql_table_elements'
+import { SUITEQL_TABLE, getSuiteQLTableInternalIdsMap } from '../data_elements/suiteql_table_elements'
 import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
 import { captureServiceIdInfo } from '../service_id_info'
 import { LazyElementsSourceIndexes } from '../elements_source_index/types'
@@ -514,7 +514,7 @@ const setFieldValue = (
   suiteQLTablesMap: Record<string, InstanceElement>
 ): void => {
   const { name } = makeArray(field.type)
-    .map(typeName => suiteQLTablesMap[typeName].value[INTERNAL_IDS_MAP][internalId])
+    .map(typeName => getSuiteQLTableInternalIdsMap(suiteQLTablesMap[typeName])[internalId])
     .find(res => res !== undefined) ?? {}
   if (name === undefined) {
     log.warn('could not find internal id %s of type %s', internalId, field.type)
@@ -608,7 +608,7 @@ const getSuiteQLNameToInternalIdsMap = async (
 
   return _(suiteQLTableInstances)
     .keyBy(instance => instance.elemID.name)
-    .mapValues(instance => instance.value[INTERNAL_IDS_MAP] as InternalIdsMap)
+    .mapValues(getSuiteQLTableInternalIdsMap)
     .mapValues(
       internalIdsMap => _(internalIdsMap)
         .entries()

--- a/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
@@ -80,6 +80,10 @@ describe('workflow account specific values filter', () => {
           },
         }
       ),
+      new InstanceElement(
+        'partner',
+        suiteQLTableType,
+      ),
     ]
     customRecordType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'customrecord123'),


### PR DESCRIPTION
`instance.value[INTERNAL_IDS_MAP]` can be undefined because transformElement transform empty objects to undefined

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix `undefined` internalIdsMap bug in workflow ASV resolving

---
_User Notifications_: 
None