### PR TITLE
SALTO-5364: remove omitRequestBody from calendar remove endpoint

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2123,7 +2123,6 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       remove: {
         url: '/rest/workinghours/1/api/calendar/{id}',
         method: 'delete',
-        omitRequestBody: true,
       },
     },
   },


### PR DESCRIPTION
_remove omitRequestBody from calendar remove endpoint_

---

_Additional context for reviewer_
* fix jira e2e

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
