### PR TITLE
SALTO-5374: fix statusMappings CV bug

### DIFF
--- a/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
@@ -221,8 +221,8 @@ describe('status mappings', () => {
     )).toEqual([{
       elemID: workflowInstance.elemID,
       severity: 'Error',
-      message: 'Workflow status mappings has invalid format',
-      detailedMessage: 'The status mapping validation failed because of the following error: Expected issueTypeId to be ReferenceExpression. Learn more at https://help.salto.io/en/articles/8851200-migrating-issues-when-modifying-workflows.',
+      message: 'Invalid workflow status mapping',
+      detailedMessage: 'Error while validating the user-provided status mapping: Expected issueTypeId to be ReferenceExpression. Learn more at https://help.salto.io/en/articles/8851200-migrating-issues-when-modifying-workflows',
     }])
   })
   it('should not return an error when there is a removed status from an inactive workflow', async () => {

--- a/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
@@ -16,7 +16,7 @@
 
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { InstanceElement, ReadOnlyElementsSource, ReferenceExpression, toChange } from '@salto-io/adapter-api'
-import { ISSUE_TYPE_NAME, JIRA_WORKFLOW_TYPE, PROJECT_TYPE, STATUS_TYPE_NAME } from '../../../src/constants'
+import { ISSUE_TYPE_NAME, ISSUE_TYPE_SCHEMA_NAME, JIRA_WORKFLOW_TYPE, PROJECT_TYPE, STATUS_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType } from '../../utils'
 import { workflowStatusMappingsValidator } from '../../../src/change_validators/workflowsV2/status_mappings'
 
@@ -25,9 +25,11 @@ describe('status mappings', () => {
   let defaultWorkflowInstance: InstanceElement
   let workflowSchemeInstance: InstanceElement
   let projectInstance: InstanceElement
+  let issueTypeSchemeInstance: InstanceElement
   let issueType1: InstanceElement
   let issueType2: InstanceElement
   let issueType3: InstanceElement
+  let issueType4: InstanceElement
   let status1: InstanceElement
   let status2: InstanceElement
   let status3: InstanceElement
@@ -86,6 +88,10 @@ describe('status mappings', () => {
       'issueType3',
       createEmptyType(ISSUE_TYPE_NAME),
     )
+    issueType4 = new InstanceElement(
+      'issueType4',
+      createEmptyType(ISSUE_TYPE_NAME),
+    )
     workflowInstance = new InstanceElement(
       'workflowInstance',
       createEmptyType(JIRA_WORKFLOW_TYPE),
@@ -134,8 +140,23 @@ describe('status mappings', () => {
             workflow: new ReferenceExpression(workflowInstance.elemID, workflowInstance),
             issueType: new ReferenceExpression(issueType2.elemID, issueType2),
           },
+          {
+            workflow: new ReferenceExpression(workflowInstance.elemID, workflowInstance),
+            issueType: new ReferenceExpression(issueType4.elemID, issueType4),
+          },
         ],
       }
+    )
+    issueTypeSchemeInstance = new InstanceElement(
+      'issueTypeSchemeInstance',
+      createEmptyType(ISSUE_TYPE_SCHEMA_NAME),
+      {
+        issueTypeIds: [
+          new ReferenceExpression(issueType1.elemID, issueType1),
+          new ReferenceExpression(issueType2.elemID, issueType2),
+          new ReferenceExpression(issueType3.elemID, issueType3),
+        ],
+      },
     )
     projectInstance = new InstanceElement(
       'projectInstance',
@@ -143,6 +164,7 @@ describe('status mappings', () => {
       {
         name: 'projectInstance',
         workflowScheme: new ReferenceExpression(workflowSchemeInstance.elemID, workflowSchemeInstance),
+        issueTypeScheme: new ReferenceExpression(issueTypeSchemeInstance.elemID, issueTypeSchemeInstance),
       }
     )
     elementsSource = buildElementsSourceFromElements([
@@ -152,6 +174,7 @@ describe('status mappings', () => {
       issueType1,
       issueType2,
       issueType3,
+      issueTypeSchemeInstance,
       workflowInstance,
       defaultWorkflowInstance,
       workflowSchemeInstance,


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_
* statusMappings CV should suggest migrating only issueTypes that exist in the Project and not all the issueTypes that the workflowScheme contains.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
