### PR TITLE
SALTO-4861 - Salesforce: Revert the revert of mapping deploy errors to sub-instances

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -16,8 +16,9 @@
 import _ from 'lodash'
 import util from 'util'
 import { collections, values, hash as hashUtils } from '@salto-io/lowerdash'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { SaltoError,
+import { safeJsonStringify, naclCase } from '@salto-io/adapter-utils'
+import {
+  SaltoError,
   DeployResult,
   Change,
   getChangeData,
@@ -30,7 +31,10 @@ import { SaltoError,
   SeverityLevel,
   Artifact,
   ProgressReporter,
-  ElemID } from '@salto-io/adapter-api'
+  ElemID,
+  TypeElement,
+  Value,
+} from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 
 
@@ -39,8 +43,8 @@ import { DeployResult as SFDeployResult, DeployMessage } from '@salto-io/jsforce
 import SalesforceClient from './client/client'
 import { createDeployPackage, DeployPackage } from './transformers/xml_transformer'
 import { isMetadataInstanceElement, apiName, metadataType, isMetadataObjectType, MetadataInstanceElement, assertMetadataObjectType } from './transformers/transformer'
-import { fullApiName } from './filters/utils'
-import { GLOBAL_VALUE_SET_SUFFIX, INSTANCE_FULL_NAME_FIELD, SalesforceArtifacts } from './constants'
+import { apiNameSync, fullApiName } from './filters/utils'
+import { API_NAME_SEPARATOR, GLOBAL_VALUE_SET_SUFFIX, INSTANCE_FULL_NAME_FIELD, SalesforceArtifacts } from './constants'
 import { RunTestsResult } from './client/jsforce'
 import { getUserFriendlyDeployMessage } from './client/user_facing_errors'
 import { QuickDeployParams } from './types'
@@ -66,6 +70,20 @@ export type NestedMetadataTypeInfo = {
   isNestedApiNameRelative: boolean
 }
 
+const getTypeOfNestedElement = (changeElem: MetadataInstanceElement, fieldName: string): TypeElement => {
+  const rawFieldType = changeElem.getTypeSync().fields[fieldName]?.getTypeSync()
+  // We generally expect these to be lists, handling non list types just in case of a bug
+  const fieldType = isContainerType(rawFieldType)
+    ? rawFieldType.getInnerTypeSync()
+    : rawFieldType
+  return fieldType
+}
+
+const getNamesOfNestedElements = (element: MetadataInstanceElement, fieldName: string): string[] => (
+  makeArray(element.value[fieldName])
+    .map((fieldValue: Value) => [apiNameSync(element), fieldValue[INSTANCE_FULL_NAME_FIELD]].join(API_NAME_SEPARATOR))
+)
+
 const addNestedInstancesToPackageManifest = async (
   pkg: DeployPackage,
   nestedTypeInfo: NestedMetadataTypeInfo,
@@ -81,11 +99,7 @@ const addNestedInstancesToPackageManifest = async (
   )
 
   const addNestedInstancesFromField = async (fieldName: string): Promise<MetadataIdsMap> => {
-    const rawFieldType = await (await changeElem.getType()).fields[fieldName]?.getType()
-    // We generally expect these to be lists, handling non list types just in case of a bug
-    const fieldType = isContainerType(rawFieldType)
-      ? await rawFieldType.getInnerType()
-      : rawFieldType
+    const fieldType = getTypeOfNestedElement(changeElem, fieldName)
     if (!isMetadataObjectType(fieldType)) {
       log.error(
         'cannot deploy nested instances in %s field %s because the field type %s is not a metadata type',
@@ -385,6 +399,31 @@ const quickDeployOrDeploy = async (
 const isQuickDeployable = (deployRes: SFDeployResult): boolean =>
   deployRes.id !== undefined && deployRes.checkOnly && deployRes.success && deployRes.numberTestsCompleted >= 1
 
+const mapNestedNamesToElemIds = (nestedType: TypeElement, nestedNames: string[]): NameToElemIDMap => (
+  Object.fromEntries(
+    nestedNames
+      .map(nestedName => [
+        nestedName,
+        nestedType.elemID.createNestedID('instance', naclCase(nestedName)),
+      ])
+  )
+)
+
+const getExistingNestedFields = (
+  instance: MetadataInstanceElement,
+  nestedTypeInfo: NestedMetadataTypeInfo
+): {
+  nestedType: TypeElement
+  nestedNames: string[]
+}[] => (
+  nestedTypeInfo.nestedInstanceFields
+    .map(field => ({
+      nestedType: getTypeOfNestedElement(instance, field),
+      nestedNames: getNamesOfNestedElements(instance, field),
+    }))
+    .filter(({ nestedNames }) => nestedNames.length > 0)
+)
+
 export const deployMetadata = async (
   changes: ReadonlyArray<Change>,
   client: SalesforceClient,
@@ -394,6 +433,51 @@ export const deployMetadata = async (
   checkOnly?: boolean,
   quickDeployParams?: QuickDeployParams,
 ): Promise<DeployResult> => {
+  const updateTypeToElemIdMapping = (
+    deployedComponentsElemIdsByType: Record<string, NameToElemIDMap>,
+    deployedIds: Record<string, Set<string>>,
+    instance: MetadataInstanceElement
+  ): void => {
+    const appendToTypeElemIdMapping = (
+      typeName: ReturnType<typeof apiNameSync>,
+      nameToElemIdMapping: NameToElemIDMap
+    ): void => {
+      if (typeName === undefined) {
+        return
+      }
+
+      // doing it in a slightly more convoluted way because deployedComponentsElemIdsByType[type] may be undefined
+      deployedComponentsElemIdsByType[typeName] = _.assign(
+        {},
+        deployedComponentsElemIdsByType[typeName],
+        nameToElemIdMapping
+      )
+    }
+
+    const updateTypeElemIdMappingWithNestedType = (nestedTypeInfo: NestedMetadataTypeInfo): void => {
+      const existingNestedFields = getExistingNestedFields(instance, nestedTypeInfo)
+      existingNestedFields
+        .forEach(({ nestedType, nestedNames }) => {
+          appendToTypeElemIdMapping(
+            apiNameSync(nestedType),
+            mapNestedNamesToElemIds(nestedType, nestedNames),
+          )
+        })
+    }
+
+    Object.entries(deployedIds).forEach(([type, names]) => {
+      const nameToElemId: NameToElemIDMap = {}
+      const nestedTypeInfo = nestedMetadataTypes[type]
+      if (nestedTypeInfo) {
+        updateTypeElemIdMappingWithNestedType(nestedTypeInfo)
+      }
+      names.forEach(name => {
+        nameToElemId[name] = instance.elemID
+      })
+      appendToTypeElemIdMapping(type, nameToElemId)
+    })
+  }
+
   const pkg = createDeployPackage(deleteBeforeUpdate)
 
   const { validChanges, errors: validationErrors } = await validateChanges(changes)
@@ -404,20 +488,13 @@ export const deployMetadata = async (
   const changeToDeployedIds: Record<string, MetadataIdsMap> = {}
   const deployedComponentsElemIdsByType: Record<string, NameToElemIDMap> = {}
 
-  await awu(validChanges).forEach(async change => {
-    const deployedIds = await addChangeToPackage(pkg, change, nestedMetadataTypes)
-    const { elemID } = getChangeData(change)
-    changeToDeployedIds[elemID.getFullName()] = deployedIds
-
-    Object.entries(deployedIds).forEach(([type, names]) => {
-      const nameToElemId: NameToElemIDMap = {}
-      names.forEach(name => {
-        nameToElemId[name] = elemID
-      })
-      // doing it in a slightly more convoluted way because deployedComponentsElemIdsByType[type] may be udefined
-      deployedComponentsElemIdsByType[type] = _.assign({}, deployedComponentsElemIdsByType[type], nameToElemId)
+  await awu(validChanges)
+    .forEach(async change => {
+      const deployedIds = await addChangeToPackage(pkg, change, nestedMetadataTypes)
+      const { elemID } = getChangeData(change)
+      changeToDeployedIds[elemID.getFullName()] = deployedIds
+      updateTypeToElemIdMapping(deployedComponentsElemIdsByType, deployedIds, getChangeData(change))
     })
-  })
 
   const pkgData = await pkg.getZip()
   const planHash = hashUtils.toMD5(pkgData)

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -167,7 +167,13 @@ describe('SalesforceAdapter CRUD', () => {
             { [CORE_ANNOTATIONS.PARENT]:
               new ReferenceExpression(mockTypes.TestCustomObject__c.elemID, mockTypes.TestCustomObject__c) }
           )
-          workflowFieldUpdate = createInstanceElement(mockDefaultValues.WorkflowFieldUpdate, mockTypes.Workflow)
+          workflowFieldUpdate = createInstanceElement(
+            {
+              ...mockDefaultValues.WorkflowFieldUpdate,
+              [INSTANCE_FULL_NAME_FIELD]: 'TestCustomObject__c.TestWorkflowFieldUpdate',
+            },
+            mockTypes.WorkflowFieldUpdate
+          )
 
           connection.metadata.deploy.mockReturnValueOnce(mockDeployResult({
             success: false,
@@ -189,8 +195,8 @@ describe('SalesforceAdapter CRUD', () => {
               // WorkflowFieldUpdate failure
               {
                 componentType: 'WorkflowFieldUpdate',
-                fullName: 'ChangeRequest.Update_Status_to_Authorised',
-                problem: 'Some workflow task error',
+                fullName: 'TestCustomObject__c.TestWorkflowFieldUpdate',
+                problem: 'Some workflow field update error',
               },
             ],
           }))
@@ -225,11 +231,11 @@ describe('SalesforceAdapter CRUD', () => {
 
           expect(result.errors[1].severity).toEqual('Error' as SeverityLevel)
 
-          // WorkflowTask will not have an ElemID because on failure
-          //  we only return the sub-instance and not the wrapped instance
-          expect(result.errors[2].message).toContain('Some workflow task error')
-          expect(isSaltoElementError(result.errors[2])).toBeFalse()
-          expect(result.errors[2].severity).toEqual('Error' as SeverityLevel)
+          expect(result.errors[2]).toEqual({
+            message: expect.stringContaining('Some workflow field update error'),
+            severity: 'Error',
+            elemID: workflowFieldUpdate.elemID,
+          })
         })
       })
 

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -44,7 +44,7 @@ import {
   SBAA_APPROVAL_RULE,
   SBAA_CONDITIONS_MET,
   SETTINGS_METADATA_TYPE,
-  STATUS,
+  STATUS, WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE,
 } from '../src/constants'
@@ -189,7 +189,7 @@ export const mockTypes = {
   }),
   WorkflowFieldUpdate: createMetadataObjectType({
     annotations: {
-      metadataType: WORKFLOW_TASK_METADATA_TYPE,
+      metadataType: WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
       dirName: 'workflows',
       suffix: 'workflow',
     },


### PR DESCRIPTION
Revert the revert of this code, because the issue we thought was caused by it is still there after the revert.

---

_Additional context for reviewer_

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A