### PR TITLE
SALTO-5264: Add check for unresolved reference in translation cv

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
+++ b/packages/zendesk-adapter/src/change_validators/translation_for_default_locale.ts
@@ -16,10 +16,10 @@
 import {
   ChangeValidator,
   getChangeData, InstanceElement,
-  isAdditionOrModificationChange, isInstanceElement, isReferenceExpression,
+  isAdditionOrModificationChange, isInstanceElement,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
-import { createSchemeGuardForInstance, resolveValues } from '@salto-io/adapter-utils'
+import { createSchemeGuardForInstance, isResolvedReferenceExpression, resolveValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { isTranslation, TranslationType } from '../filters/guide_section_and_category'
 import { lookupFunc } from '../filters/field_references'
@@ -53,7 +53,7 @@ const noTranslationForDefaultLocale = (instance: InstanceElement): boolean => {
   const sourceLocale = instance.value.source_locale
   const translation = instance.value.translations
     .filter(isTranslation)
-    .find(tran => (isReferenceExpression(tran.locale)
+    .find(tran => (isResolvedReferenceExpression(tran.locale)
       ? tran.locale.value.value.locale === sourceLocale
       : tran.locale === sourceLocale)) // locale is a string
   return (translation === undefined) // no translation for the source_locale

--- a/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/translation_for_default_locale.test.ts
@@ -82,6 +82,15 @@ describe('translationForDefaultLocaleValidator',
         body: 'description',
       }
     )
+    const enArticleTranslationInstanceUnresolvedReferenceLocale = new InstanceElement(
+      'instance',
+      articleTranslationType,
+      {
+        locale: new ReferenceExpression(guideLanguageSettingsInstance.elemID.createNestedID('instance', 'Test1')),
+        title: 'name',
+        body: 'description',
+      }
+    )
     const enArticleTranslationInstanceReferenceLocale = new InstanceElement(
       'instance',
       articleTranslationType,
@@ -196,6 +205,37 @@ describe('translationForDefaultLocaleValidator',
         )
         expect(errors).toHaveLength(0)
       })
+    it('should return an error when a locale reference is unresolved',
+      async () => {
+        const validArticleInstance = replaceInstanceTypeForDeploy({
+          instance: new InstanceElement(
+            'instance',
+            articleType,
+            {
+              id: 1,
+              name: 'name',
+              description: 'description',
+              source_locale: new ReferenceExpression(
+                guideLanguageSettingsInstance.elemID.createNestedID('instance', 'Test1'),
+                guideLanguageSettingsInstance
+              ),
+              translations:
+          [
+            new ReferenceExpression(
+              enArticleTranslationInstanceUnresolvedReferenceLocale.elemID.createNestedID('instance', 'Test2'),
+              enArticleTranslationInstanceUnresolvedReferenceLocale
+            ),
+          ],
+            }
+          ),
+          config: DEFAULT_CONFIG.apiDefinitions,
+        })
+        const errors = await translationForDefaultLocaleValidator(
+          [toChange({ after: validArticleInstance })]
+        )
+        expect(errors).toHaveLength(1)
+      })
+
     it('should not return an error when article has translation for source_locale, locale is a reference expression',
       async () => {
         const validArticleInstance = replaceInstanceTypeForDeploy({


### PR DESCRIPTION
Return Change Validator error instead of crashing when a locale is unresolved while checking for translations.
Also added a test case to make sure we return an error elegantly.

---

_Test plan_:
Before applying the fix:
![Screenshot 2024-02-04 at 16 49 51](https://github.com/salto-io/salto/assets/13694783/1a8a1838-808b-4c04-be48-c3303177d1e4)

After applying the fix:
![Screenshot 2024-02-04 at 16 50 05](https://github.com/salto-io/salto/assets/13694783/5681a634-0aa4-4415-b056-ce7920cb601f)

---
_Release Notes_: 

Zendesk: 
Return Change Validator error instead of crashing when a locale is unresolved while checking for translations

