### PR TITLE
SALTO-4056: Allow configuring idFields that only exist in some elements

### DIFF
--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -49,9 +49,8 @@ export const joinInstanceNameParts = (
   // if nameParts is empty, we assume it is intentional
   (nameParts.length === 0 || nameParts.some(part => part !== undefined && part !== ''))
     ? nameParts
-      .map(part => (part === undefined ? '' : part))
+      .filter(part => part !== undefined)
       .map(String)
-      .filter((part, idx) => part !== '' || idx !== nameParts.length - 1) // if the last part is empty, avoid adding an extra '_'
       .join('_')
     : undefined
 )

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -49,7 +49,7 @@ export const joinInstanceNameParts = (
   // if nameParts is empty, we assume it is intentional
   (nameParts.length === 0 || nameParts.some(part => part !== undefined && part !== ''))
     ? nameParts
-      .filter(part => part !== undefined)
+      .filter(part => part !== undefined && part !== '')
       .map(String)
       .join('_')
     : undefined

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -44,8 +44,17 @@ export type InstanceCreationParams = {
 }
 
 export const joinInstanceNameParts = (
-  nameParts: string[],
-): string | undefined => (nameParts.every(part => part !== undefined && part !== '') ? nameParts.map(String).join('_') : undefined)
+  nameParts: unknown[],
+): string | undefined => (
+  // if nameParts is empty, we assume it is intentional
+  (nameParts.length === 0 || nameParts.some(part => part !== undefined && part !== ''))
+    ? nameParts
+      .map(part => (part === undefined ? '' : part))
+      .map(String)
+      .filter((part, idx) => part !== '' || idx !== nameParts.length - 1) // if the last part is empty, avoid adding an extra '_'
+      .join('_')
+    : undefined
+)
 
 export const getInstanceName = (
   instanceValues: Values,
@@ -53,11 +62,12 @@ export const getInstanceName = (
   typeName: string,
 ): string | undefined => {
   const nameParts = idFields
-    .map(fieldName => _.get(instanceValues, dereferenceFieldName(fieldName)))
-  if (nameParts.includes(undefined)) {
-    log.warn(`could not find id for entry in type ${typeName} - expected id fields ${idFields}, available fields ${Object.keys(instanceValues)}`)
+    .map(fieldName => ({ fieldName, value: _.get(instanceValues, dereferenceFieldName(fieldName)) }))
+  const missingFieldNames = nameParts.filter(part => part.value === undefined).map(part => part.fieldName)
+  if (missingFieldNames.length > 0) {
+    log.debug(`Some instances of type ${typeName} did not contain the following id fields: ${missingFieldNames}`)
   }
-  return joinInstanceNameParts(nameParts)
+  return joinInstanceNameParts(nameParts.map(part => part.value))
 }
 
 export const getInstanceFilePath = ({
@@ -151,8 +161,8 @@ export const getInstanceNaclName = ({
   nameMapping?: NameMappingOptions
 }): string => {
   // If the name is empty, there is no reason to add the ID_SEPARATOR
-  const parentNameSuffix = !isEmpty(name) ? `${ID_SEPARATOR}${name}` : ''
-  const newName = parentName ? `${parentName}${parentNameSuffix}` : String(name)
+  const nameWithSeparator = !isEmpty(name) ? `${ID_SEPARATOR}${name}` : ''
+  const newName = parentName ? `${parentName}${nameWithSeparator}` : String(name)
   const naclName = naclCase(newName)
 
   const desiredName = nameMapping

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -50,10 +50,8 @@ const getFirstParentElemId = (instance: InstanceElement): ElemID | undefined => 
   return parentsElemIds.length > 0 ? parentsElemIds[0] : undefined
 }
 
-const createInstanceReferencedNameParts = (
-  instance: InstanceElement,
-  idFields: string[],
-): unknown[] => idFields.map(
+const createInstanceReferencedNameParts = (instance: InstanceElement, idFields: string[]):
+ (string | undefined)[] => idFields.map(
   fieldName => {
     if (!isReferencedIdField(fieldName)) {
       return _.get(instance.value, fieldName)

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -53,7 +53,7 @@ const getFirstParentElemId = (instance: InstanceElement): ElemID | undefined => 
 const createInstanceReferencedNameParts = (
   instance: InstanceElement,
   idFields: string[],
-): string[] => idFields.map(
+): unknown[] => idFields.map(
   fieldName => {
     if (!isReferencedIdField(fieldName)) {
       return _.get(instance.value, fieldName)
@@ -71,8 +71,8 @@ const createInstanceReferencedNameParts = (
       return fieldValue.parts.map(part => (isReferenceExpression(part) ? dereferenceFieldValue(part) : _.toString(part))).join('')
     }
     if (fieldValue === undefined) {
-      log.warn(`In instance: ${instance.elemID.getFullName()}, could not find idField: ${fieldName}, returning ''`)
-      return _.toString(fieldValue)
+      log.debug(`In instance: ${instance.elemID.getFullName()}, could not find idField: ${fieldName}`)
+      return undefined
     }
     log.warn(`In instance: ${instance.elemID.getFullName()}, could not find reference for referenced idField: ${fieldName}, falling back to original value`)
     return _.toString(fieldValue)

--- a/packages/adapter-components/test/elements/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/instance_elements.test.ts
@@ -15,7 +15,7 @@
 */
 
 import { ElemID } from '@salto-io/adapter-api'
-import { generateInstanceNameFromConfig, getInstanceNaclName } from '../../src/elements/instance_elements'
+import { generateInstanceNameFromConfig, getInstanceNaclName, getInstanceName } from '../../src/elements/instance_elements'
 import { NameMappingOptions } from '../../src/definitions'
 
 describe('generateInstanceNameFromConfig', () => {
@@ -135,5 +135,49 @@ describe('getInstanceNaclName', () => {
     })
     expect(naclNameEmptyName).toBe('parent')
     expect(naclNameRegular).toBe('parent__name')
+  })
+})
+
+describe('getInstanceName', () => {
+  it('should return the correct name based on the idFields', () => {
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['name'],
+      'test'
+    )).toBe('name')
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['name', 'type'],
+      'test'
+    )).toBe('name_A')
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      [],
+      'test'
+    )).toBe('')
+  })
+  it('should return undefined if all idFields doesnt exist in entry', () => {
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['foo', 'bar'],
+      'test'
+    )).toBe(undefined)
+  })
+  it('should ignore undefined fields when there is at least one defined field', () => {
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['name', 'foo', 'type'],
+      'test'
+    )).toBe('name_A')
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['foo', 'name', 'type'],
+      'test'
+    )).toBe('name_A')
+    expect(getInstanceName(
+      { name: 'name', type: 'A' },
+      ['name', 'foo'],
+      'test'
+    )).toBe('name')
   })
 })

--- a/packages/adapter-components/test/filters/referenced_instance_name.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_name.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-
+import _ from 'lodash'
 import {
   ElemID,
   InstanceElement,
@@ -229,7 +229,7 @@ describe('referenced instances', () => {
         }
       ),
     ]
-    const noIdFieldsParent = new InstanceElement('no_idFieldsParent', noIdFieldsType)
+    const noIdFieldsParent = new InstanceElement('no_idFieldsParent', bookType)
     const noIdFieldsWithParent = new InstanceElement(
       'no_idFieldsWithParent',
       noIdFieldsType,
@@ -239,7 +239,8 @@ describe('referenced instances', () => {
     )
     return [recipeType, bookType, ...recipes, anotherBook, rootBook,
       sameRecipeOne, sameRecipeTwo, lastRecipe, groupType, ...groups,
-      folderType, folderOne, folderTwo, statusType, status, ...emailsWithTemplates, noIdFieldsWithParent]
+      folderType, folderOne, folderTwo, statusType, status, ...emailsWithTemplates,
+      noIdFieldsParent, noIdFieldsWithParent]
   }
   const lowercaseName : NameMappingOptions = 'lowercase'
   const config = {
@@ -316,16 +317,17 @@ describe('referenced instances', () => {
         .map(e => e.elemID.getFullName()).sort())
         .toEqual(['myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
+          'myAdapter.book.instance.no_idFieldsParent',
           'myAdapter.email.instance.aaa_username_group1@um',
           'myAdapter.email.instance.aaa_username_group1_x_y@umvv',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
           'myAdapter.group.instance.group3',
           'myAdapter.noIdFields.instance.no_idFieldsParent',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
           'myAdapter.recipe.instance.sameRecipe',
           'myAdapter.recipe.instance.sameRecipe',
@@ -357,14 +359,15 @@ describe('referenced instances', () => {
       expect(sortedResult)
         .toEqual(['myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.book.instance.no_idFieldsParent',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.group.instance.group1',
           'myAdapter.group.instance.group2',
           'myAdapter.group.instance.group3',
           'myAdapter.noIdFields.instance.no_idFieldsWithParent',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
         ])
     })
@@ -413,19 +416,20 @@ describe('referenced instances', () => {
         transformationConfigByType,
         transformationDefaultConfig
       )
-      expect(result.length).toEqual(13)
+      expect(result.length).toEqual(14)
       expect(result
         .map(e => e.elemID.getFullName()).sort())
         .toEqual(['myAdapter.book',
           'myAdapter.book.instance.123_ROOT',
           'myAdapter.book.instance.456_123_ROOT',
+          'myAdapter.book.instance.no_idFieldsParent',
           'myAdapter.folder',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Desktop',
-          'myAdapter.folder.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Desktop',
+          'myAdapter.folder.instance.lastRecipe_456_123_ROOT__Documents',
           'myAdapter.noIdFields.instance.no_idFieldsWithParent',
           'myAdapter.recipe',
+          'myAdapter.recipe.instance.lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe123_123_ROOT',
-          'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
           'myAdapter.recipe.instance.recipe456_456_123_ROOT',
           'myAdapter.recipe.instance.sameRecipe',
           'myAdapter.recipe.instance.sameRecipe',
@@ -438,15 +442,14 @@ describe('referenced instances', () => {
         .map(i => i.elemID.getFullName())
       const allIns = elements.filter(isInstanceElement)
       const res = createReferenceIndex(allIns, new Set(bookOrRecipeIns))
-      expect(Object.keys(res)).toEqual([
-        'myAdapter.book.instance.rootBook',
-        'myAdapter.book.instance.book',
-        'myAdapter.recipe.instance.recipe123',
-        'myAdapter.recipe.instance.recipe456',
-        'myAdapter.recipe.instance.last',
-      ])
-      expect(Object.values(res).map(n => n.length))
-        .toEqual([4, 3, 6, 2, 2])
+      expect(_.mapValues(res, val => val.length)).toEqual({
+        'myAdapter.book.instance.rootBook': 4,
+        'myAdapter.book.instance.book': 3,
+        'myAdapter.book.instance.no_idFieldsParent': 1,
+        'myAdapter.recipe.instance.recipe123': 6,
+        'myAdapter.recipe.instance.last': 2,
+        'myAdapter.recipe.instance.recipe456': 1,
+      })
     })
     it('should not have different results on the second fetch', async () => {
       elements = generateElements()

--- a/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
@@ -200,9 +200,9 @@ describe('referenced id fields filter', () => {
     const instances = elements.filter(isInstanceElement)
     expect(instances.map(e => e.elemID.getFullName()).sort()).toEqual([
       'workato.folder.instance.Root',
-      'workato.folder.instance.folder11_55',
-      'workato.folder.instance.folder22_11',
-      'workato.folder.instance.folder33_55',
+      'workato.folder.instance.folder11',
+      'workato.folder.instance.folder22',
+      'workato.folder.instance.folder33',
       'workato.recipe.instance.recipe123',
       'workato.recipe__code.instance.recipe123_',
     ])


### PR DESCRIPTION
We now allow configuring idFields that might be null in some elements. 

---

_Additional context for reviewer_

This continues - https://github.com/salto-io/salto/pull/4056

---
_Release Notes_: 
None 

---
_User Notifications_: 
None
