### PR TITLE
SALTO-5326: log errored GQL responses

### DIFF
--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -117,12 +117,22 @@ describe('client', () => {
         },
       },
     }
-    mockAxios.onPost().replyOnce(200, { data: { data: innerData } })
+    mockAxios.onPost().replyOnce(200, { data: innerData })
     result = await client.gqlPost({ url: 'www.test.com', query: 'query' })
-    expect(result).toEqual({ data: { data: innerData } })
+    expect(result).toEqual({ data: innerData })
   })
   it('check if gqlpost throws an error if the response is not as expected', async () => {
     mockAxios.onPost().replyOnce(200, { response: 'not as expected' })
+    await expect(client.gqlPost({ url: 'www.test.com', query: 'query' })).rejects.toThrow()
+  })
+  it('check if gqlpost throws an error if the response has an error', async () => {
+    const error = {
+      message: 'Requested issue layout configuration is not found',
+      locations: [{ line: 65, column: 3 }],
+      path: ['issueLayoutConfiguration'],
+      extensions: { statusCode: 404, errorType: 'DataFetchingException', classification: 'DataFetchingException' },
+    }
+    mockAxios.onPost().reply(200, { data: { layoutConfiguration: null }, errors: [error] })
     await expect(client.gqlPost({ url: 'www.test.com', query: 'query' })).rejects.toThrow()
   })
 })


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
