### PR TITLE
SALTO-5247: [zendesk] Add a few MissingRefStrategy in workspace types

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -395,11 +395,13 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
   {
     src: { field: 'macro_id' },
     serializationStrategy: 'id',
+    zendeskMissingRefStrategy: 'typeAndValue',
     target: { type: 'macro' },
   },
   {
     src: { field: 'macro_ids' },
     serializationStrategy: 'id',
+    zendeskMissingRefStrategy: 'typeAndValue',
     target: { type: 'macro' },
   },
   {
@@ -491,6 +493,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'id', parentTypes: ['workspace__selected_macros'] },
     serializationStrategy: 'id',
     target: { type: 'macro' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'role_restrictions' },
@@ -798,6 +801,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     src: { field: 'id', parentTypes: ['workspace__apps'] },
     serializationStrategy: 'id',
     target: { type: 'app_installation' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
     src: { field: 'resource_id' },
@@ -886,6 +890,7 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
     },
     zendeskSerializationStrategy: 'idString',
     target: { typeContext: 'neighborField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
   // only one of these applies in a given instance
   {


### PR DESCRIPTION
In workspaces, there are a few dangling IDs that need to be replaced by missingRefs. This PR adds a MissingRefStrategy for most of those types

---

_Test Plan_:
Before:
![Screenshot 2024-02-05 at 13 46 18](https://github.com/salto-io/salto/assets/13694783/9cfcd29f-f258-4692-81a3-fc34ba5aeb14)

After:
![Screenshot 2024-02-05 at 14 00 43](https://github.com/salto-io/salto/assets/13694783/56420668-6a1f-4342-86cc-b7af555f892b)


---
_Release Notes_: 
Zendesk: Workspace fields now have MissingRefs instead of dangling IDs
