### PR TITLE
SALTO-5067: [Zendesk] Remove Article label ordering from the deployment changeset

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -228,15 +228,14 @@ const orderViewCustomFields = (instances: InstanceElement[]): void => {
 }
 
 /*
-* label names are unordered in an article, sort them alphabetically to keep them consistent
-*/
+ * label names are unordered in an article, sort them alphabetically to keep them consistent
+ */
 const orderArticleLabelNames = (instances: InstanceElement[]): void => {
-  instances.filter(e => e.refType.elemID.name === ARTICLE_TYPE_NAME)
+  instances
+    .filter(e => e.refType.elemID.name === ARTICLE_TYPE_NAME)
     .forEach(article => {
       if (Array.isArray(article.value.label_names)) {
-        article.value.label_names = _.sortBy(
-          article.value.label_names,
-        )
+        article.value.label_names = _.sortBy(article.value.label_names)
       }
     })
 }

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -25,6 +25,7 @@ import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from './dynamic_content'
 import {
+  ARTICLE_TYPE_NAME,
   GROUP_TYPE_NAME,
   MACRO_TYPE_NAME,
   TICKET_FIELD_CUSTOM_FIELD_OPTION,
@@ -226,6 +227,20 @@ const orderViewCustomFields = (instances: InstanceElement[]): void => {
     })
 }
 
+/*
+* label names are unordered in an article, sort them alphabetically to keep them consistent
+*/
+const orderArticleLabelNames = (instances: InstanceElement[]): void => {
+  instances.filter(e => e.refType.elemID.name === ARTICLE_TYPE_NAME)
+    .forEach(article => {
+      if (Array.isArray(article.value.label_names)) {
+        article.value.label_names = _.sortBy(
+          article.value.label_names,
+        )
+      }
+    })
+}
+
 /**
  * Sort lists whose order changes between fetches, to avoid unneeded noise.
  */
@@ -238,6 +253,7 @@ const filterCreator: FilterCreator = () => ({
     orderMacroAndViewRestrictions(instances)
     orderFormCondition(instances)
     orderViewCustomFields(instances)
+    orderArticleLabelNames(instances)
   },
 })
 


### PR DESCRIPTION
Article labels are unordered, so add them to the unordered_list to make sure they don't show up in changesets while deploying

---
_Test Plan_: 
Before:
![Screenshot 2024-02-05 at 15 04 14](https://github.com/salto-io/salto/assets/13694783/8a2b46e3-1d81-4f79-9a6e-80f31f62d6e0)
After:
![Screenshot 2024-02-05 at 15 04 24](https://github.com/salto-io/salto/assets/13694783/17230399-a39e-456f-a7c6-09172d109a3c)

---
_Release Notes_: 

Zendesk:
Stop showing Article Label ordering in deployment changesets

---
_User Notifications_: 

Zendesk:
Stop showing Article Label ordering in deployment changesets