### PR TITLE
SALTO-5376: Fix bug in recreation of elemIds for trusted users group

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -245,6 +245,7 @@ export const DEFAULT_FILTERS = [
   workflowDeployFilter,
   workflowModificationFilter,
   emptyValidatorWorkflowFilter,
+  // must run before fieldReferencesFilter
   groupNameFilter,
   workflowGroupsFilter,
   workflowSchemeFilter,

--- a/packages/jira-adapter/src/filters/group_name.ts
+++ b/packages/jira-adapter/src/filters/group_name.ts
@@ -16,10 +16,12 @@
 import { Element, ElemIdGetter, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { elements as elementUtils, config as configUtils } from '@salto-io/adapter-components'
-import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { GROUP_TYPE_NAME, JIRA } from '../constants'
+import { GROUP_TYPE_NAME } from '../constants'
 import { JiraConfig } from '../config/config'
+
+const log = logger(module)
 
 const UUID_REGEX = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
 const GROUP_NAME = 'trusted-users'
@@ -31,54 +33,28 @@ const isGroupElement = (element: Element): boolean =>
 const isTrustedGroupInstance = (instance: InstanceElement): boolean =>
   TRUSTED_GROUP_NAME_REGEX.exec(instance.value.name) !== null
 
-const getInstanceName = (
-  instance: InstanceElement,
-  config: JiraConfig,
-  getElemIdFunc?: ElemIdGetter
-): string => {
-  if (!isTrustedGroupInstance(instance)) {
-    return instance.elemID.name
-  }
-  const defaultName = naclCase(GROUP_NAME)
-  const { serviceIdField } = configUtils.getConfigWithDefault(
-    config.apiDefinitions.types[instance.elemID.typeName].transformation,
-    config.apiDefinitions.typeDefaults.transformation
-  )
-  if (serviceIdField === undefined || getElemIdFunc === undefined) {
-    return instance.elemID.name
-  }
-
-  const serviceIds = elementUtils.createServiceIds({
-    entry: instance.value,
-    serviceIdFields: [serviceIdField],
-    typeID: instance.refType.elemID,
-  })
-
-  return getElemIdFunc(JIRA, serviceIds, defaultName).name
-}
-
 const getGroupName = (instance: InstanceElement): string => (
   isTrustedGroupInstance(instance)
     ? GROUP_NAME
     : instance.value.name
 )
 
-const getRenamedInstance = (
+const createRenamedTrustedGroupInstance = async (
   instance: InstanceElement,
   config: JiraConfig,
   getElemIdFunc?: ElemIdGetter,
-): InstanceElement => {
-  const elementName = getInstanceName(instance, config, getElemIdFunc)
-  const originalName = instance.value.name
+): Promise<InstanceElement> => {
   const newName = getGroupName(instance)
-  const newPath = [...(instance.path ?? []).slice(0, -1), pathNaclCase(elementName)]
-  return new InstanceElement(
-    elementName,
-    instance.refType,
-    { ...instance.value, name: newName, originalName },
-    newPath,
-    instance.annotations,
-  )
+  const originalName = instance.value.name
+  const newInstance = await elementUtils.toBasicInstance({
+    entry: { ...instance.value, name: newName, originalName },
+    type: await instance.getType(),
+    transformationConfigByType: configUtils.getTransformationConfigByType(config.apiDefinitions.types),
+    transformationDefaultConfig: config.apiDefinitions.typeDefaults.transformation,
+    defaultName: newName,
+    getElemIdFunc,
+  })
+  return newInstance
 }
 
 /**
@@ -87,12 +63,19 @@ const getRenamedInstance = (
 const filter: FilterCreator = ({ config, getElemIdFunc }) => ({
   name: 'groupNameFilter',
   onFetch: async (elements: Element[]) => {
-    const instances = _.remove(elements,
-      element => isGroupElement(element) && isInstanceElement(element))
-    const newInstances = instances
-      .filter(isInstanceElement)
-      .map(e => getRenamedInstance(e, config, getElemIdFunc))
-    newInstances.forEach(instance => elements.push(instance))
+    const trustedUsersGroup = elements
+      .filter(isInstanceElement).filter(instance => isGroupElement(instance) && isTrustedGroupInstance(instance))
+    if (trustedUsersGroup.length > 1) {
+      log.error('Found more than one trusted users group instances %s. Skipping renaming groups', trustedUsersGroup.map(e => e.elemID.getFullName()).join(', '))
+      return
+    }
+    if (trustedUsersGroup.length === 0) {
+      return
+    }
+    const trustedGroup = trustedUsersGroup[0]
+    _.pull(elements, trustedGroup)
+    const renamedTrustedGroupInstance = await createRenamedTrustedGroupInstance(trustedGroup, config, getElemIdFunc)
+    elements.push(renamedTrustedGroupInstance)
   },
   onDeploy: async changes => {
     changes

--- a/packages/jira-adapter/src/filters/group_name.ts
+++ b/packages/jira-adapter/src/filters/group_name.ts
@@ -58,13 +58,17 @@ const createRenamedTrustedGroupInstance = async (
 }
 
 /**
- * Remove uuid suffix from group names.
+ * Remove uuid suffix from the trusted-users group name
+ * The filter also update original name field for all instances because references are curretnly based on this field
  */
 const filter: FilterCreator = ({ config, getElemIdFunc }) => ({
   name: 'groupNameFilter',
   onFetch: async (elements: Element[]) => {
-    const trustedUsersGroup = elements
-      .filter(isInstanceElement).filter(instance => isGroupElement(instance) && isTrustedGroupInstance(instance))
+    const groupInstances = elements.filter(isInstanceElement).filter(isGroupElement)
+    // this is needed inorder for groupStrategyByOriginalName serialization strategy will work
+    groupInstances.forEach(instance => { instance.value.originalName = instance.value.name })
+
+    const trustedUsersGroup = groupInstances.filter(isTrustedGroupInstance)
     if (trustedUsersGroup.length > 1) {
       log.error('Found more than one trusted users group instances %s. Skipping renaming groups', trustedUsersGroup.map(e => e.elemID.getFullName()).join(', '))
       return

--- a/packages/jira-adapter/test/filters/group_name.test.ts
+++ b/packages/jira-adapter/test/filters/group_name.test.ts
@@ -99,6 +99,12 @@ describe('group name filter', () => {
     await filter.onFetch(elements)
     expect(elements[0].path).toEqual(['jira', 'Records', 'Group', 'trusted_users'])
   })
+  it('should update original name field for all group instances', async () => {
+    const elements = [withUUIDInstance, withoutUUIDInstance]
+    await filter.onFetch(elements)
+    expect(elements[0].value.originalName).toEqual('normal')
+    expect(elements[1].value.originalName).toEqual('trusted-users-128baddc-c238-4857-b249-cfc84bd10c4b')
+  })
 
   it('onDeploy should add originalName when addition', async () => {
     await filter.onDeploy([toChange({ after: withUUIDInstance })])


### PR DESCRIPTION
Fix bug in recreation of elemIds for trusted users group

---

The bug was that in every fetch after the first fetch ran with `--regenerate-salto-ids`, we didn't rename the `trusted-users` group in Jira (because `elemIdGetter` wasn't provided so we returned original name).

This pr fixes this issue. In addition, instead of recreating all group instances, we'll only recreate the group we'd want to rename

---
_Release Notes_: 

_Jira_adapter_:
- Fix issue with the elemId of trusted-users group in Jira. If the elemId for the trusted-users group contains uuid, fetch with `regenerate salto ids` to resolve the issue.

---
_User Notifications_: 
None