### PR TITLE
SALTO-5164: [Zendesk] Add check for content in article attachment validator

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
+++ b/packages/zendesk-adapter/src/change_validators/article_attachment_size.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceElement } from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceElement, isStaticFile } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { ARTICLE_ATTACHMENT_TYPE_NAME } from '../constants'
@@ -30,11 +30,21 @@ export const articleAttachmentSizeValidator: ChangeValidator = async changes => 
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME)
     .filter(async attachmentInstance => {
-      if (attachmentInstance.value.content === undefined) {
+      const { content } = attachmentInstance.value
+      if (content === undefined) {
         log.error(`the attachment ${attachmentInstance.elemID.getFullName()} does not have a content field`)
         return false
       }
-      const internalContentLength = Buffer.byteLength(await attachmentInstance.value.content.getContent())
+      if (isStaticFile(content) === false) {
+        log.error(`the attachment ${attachmentInstance.elemID.getFullName()} is not a static file`)
+        return false
+      }
+      const contentValue = await attachmentInstance.value.content.getContent()
+      if (contentValue) {
+        log.error(`the attachment ${attachmentInstance.elemID.getFullName()}'s content does not exist`)
+        return false
+      }
+      const internalContentLength = Buffer.byteLength(contentValue)
       return internalContentLength >= SIZE_20_MB
     })
     .toArray()

--- a/packages/zendesk-adapter/test/change_validators/article_attachment_size.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/article_attachment_size.test.ts
@@ -132,4 +132,22 @@ describe('articleAttachmentSizeValidator', () => {
     )
     expect(errors).toHaveLength(0)
   })
+  it('should not return an error when the content inside the attachment is not a static file', async () => {
+    const articleAttachmentLazyInstance = new InstanceElement(
+      'testArticle',
+      new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_ATTACHMENT_TYPE_NAME) }),
+      {
+        id: 20222022,
+        filename: 'filename.png',
+        contentType: 'image/png',
+        content: 'Hello',
+        inline: true,
+        brand: '1',
+      }
+    )
+    const errors = await articleAttachmentSizeValidator(
+      [toChange({ after: articleAttachmentLazyInstance })],
+    )
+    expect(errors).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
doing `getContent()` on anything that's not a static file throws, so add a check to elegantly leave if that is the case
Also added a test case

---
_Test Plan_:

Before:
![Screenshot 2024-02-05 at 16 01 30](https://github.com/salto-io/salto/assets/13694783/24a686c8-8d2d-4afd-aaf5-bd9742701ce1)
![Screenshot 2024-02-05 at 16 01 53](https://github.com/salto-io/salto/assets/13694783/fc927f1e-fa2b-42b0-a1e0-85117a9bdd19)

After:
![Screenshot 2024-02-05 at 16 02 07](https://github.com/salto-io/salto/assets/13694783/cccccd0a-f5f8-43fe-be03-9a73a67d66ce)
![Screenshot 2024-02-05 at 16 03 32](https://github.com/salto-io/salto/assets/13694783/0fba1afc-7ed9-4240-b50a-e8b388a5af08)

---
_Release Notes_: 
Zendesk: 
Add check in Article Attachment CV to prevent throws when content is not a static file
