### PR TITLE
SALTO-5381: Salesforce Data Deploy with wrong applied changes bugfix

### DIFF
--- a/packages/salesforce-adapter/src/filters/cpq/referencable_field_references.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/referencable_field_references.ts
@@ -177,6 +177,7 @@ const filter: LocalFilterCreator = () => {
         changes.filter(isInstanceChange),
         change => getChangeData(change).elemID.getFullName(),
       )
+      const appliedChangesFullNames = new Set(Object.keys(appliedChangesByFullName))
       const relatedAppliedChanges = _.pick(appliedChangesByFullName, Object.keys(originalChangesByFullName))
       // Enrich the original changes with any extra data from the applied changes (e.g. Id, OwnerId etc...)
       Object.entries(originalChangesByFullName)
@@ -195,8 +196,11 @@ const filter: LocalFilterCreator = () => {
             ..._.pick(originalInstanceValue, _.flatten(Object.entries(REFERENCABLE_FIELD_NAME_TO_CONTROLLING_FIELD))),
           }
         })
+      // Revert the changes from preDeploy and use the original changes for the applied changes
       _.pullAll(changes, Object.values(relatedAppliedChanges))
-      Object.values(originalChangesByFullName).forEach(change => changes.push(change))
+      Object.entries(originalChangesByFullName)
+        .filter(([elemIdFullName, _originalChange]) => appliedChangesFullNames.has(elemIdFullName))
+        .forEach(([_elemIdFullName, originalChange]) => changes.push(originalChange))
     },
   }
 }

--- a/packages/salesforce-adapter/test/filters/cpq/referencable_field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/referencable_field_references.test.ts
@@ -147,5 +147,12 @@ describe('cpqReferencableFieldReferences', () => {
         [CUSTOM_OBJECT_ID_FIELD]: CUSTOM_OBJECT_ID,
       })
     })
+    it('should only handle applied changes', async () => {
+      const afterPreDeployChanges = [change]
+      await filter.preDeploy(afterPreDeployChanges)
+      const onDeployChanges: Change[] = []
+      await filter.onDeploy(onDeployChanges)
+      expect(onDeployChanges).toBeEmpty()
+    })
   })
 })


### PR DESCRIPTION
Fixed a bug where the cpqReferencableFieldReferencesFilter returned incorrect appliedChanges

---

This filter would push all the related changes that were manipulated on `preDeploy` and pushed them to the `appliedChanges` regardless if they were successful or not.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
