### PR TITLE
SALTO-5351: minor bundle updates

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -333,15 +333,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
         typeName: BUNDLE,
         values: { ...bundle, id: bundle.id.toString() },
       }))
-      // TODO: remove this log when SALTO-2602 is open for all customers
-      log.debug(
-        'The following bundle ids are missing in the bundle record: %o',
-        bundlesCustomInfo.map(bundle => [
-          bundle.values.id,
-          bundle.values.installedFrom?.toUpperCase(),
-          bundle.values.publisher,
-        ])
-      )
       const elementsToCreate = [
         ...customObjects,
         ...fileCabinetContent,

--- a/packages/netsuite-adapter/src/change_validators/bundle_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/bundle_changes.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { values, collections } from '@salto-io/lowerdash'
-import { Change, ChangeError, getChangeData, isAdditionChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { Change, ChangeError, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
 import { NetsuiteChangeValidator } from './types'
 import { getElementValueOrAnnotations, isBundleInstance } from '../types'
 
@@ -32,10 +32,10 @@ const getBundlesChangeError = (change: Change): ChangeError | undefined => {
     }
   } if (isBundleInstance(changeData)) {
     return {
-      message: 'Can\'t deploy bundle',
+      message: 'Cannot add, modify, or remove bundles',
       severity: 'Error',
       elemID: changeData.elemID,
-      detailedMessage: 'This bundle doesn\'t exist in the target account, and cannot be automatically deployed.\nIt may be required by some elements in your deployment.\nYou can manually install this bundle in the target account by following these steps: Customization > SuiteBundler > Search & Install Bundles',
+      detailedMessage: 'Cannot create, modify or remove bundles.To manage bundles, please manually install or update them in the target account. Follow these steps: Customization > SuiteBundler > Search & Install Bundles.',
     }
   }
   return undefined
@@ -43,7 +43,6 @@ const getBundlesChangeError = (change: Change): ChangeError | undefined => {
 
 const changeValidator: NetsuiteChangeValidator = async changes => (
   awu(changes)
-    .filter(isAdditionOrModificationChange)
     .map(getBundlesChangeError)
     .filter(isDefined)
     .toArray()

--- a/packages/netsuite-adapter/src/filters/bundle_ids.ts
+++ b/packages/netsuite-adapter/src/filters/bundle_ids.ts
@@ -81,7 +81,8 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
     const [bundleInstances, nonBundleElements] = _.partition(elements, isBundleInstance)
     const [existingBundles, missingBundles] = _.partition(bundleInstances, bundle =>
       bundle.value.id in BUNDLE_ID_TO_COMPONENTS)
-    log.debug('The following bundle ids are missing in the bundle record: %o', missingBundles.map(bundle => bundle.value.id))
+    log.debug('The following bundle ids are missing in the bundle record: %o',
+      missingBundles.map(bundle => [bundle.value.id, bundle.value.installedFrom.toUpperCase(), bundle.value.publisher]))
     existingBundles.forEach(bundle => {
       bundle.value.isPrivate = Object.keys(BUNDLE_ID_TO_COMPONENTS[bundle.value.id]).length === 0
     })

--- a/packages/netsuite-adapter/src/filters/bundle_ids.ts
+++ b/packages/netsuite-adapter/src/filters/bundle_ids.ts
@@ -81,8 +81,10 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
     const [bundleInstances, nonBundleElements] = _.partition(elements, isBundleInstance)
     const [existingBundles, missingBundles] = _.partition(bundleInstances, bundle =>
       bundle.value.id in BUNDLE_ID_TO_COMPONENTS)
-    log.debug('The following bundle ids are missing in the bundle record: %o',
-      missingBundles.map(bundle => [bundle.value.id, bundle.value.installedFrom.toUpperCase(), bundle.value.publisher]))
+    if (missingBundles) {
+      log.debug('The following bundle ids are missing in the bundle record: %o',
+        missingBundles.map(bundle => ({ bundleId: bundle.value.id, installedFrom: bundle.value.installedFrom.toUpperCase(), publisher: bundle.value.publisher })))
+    }
     existingBundles.forEach(bundle => {
       bundle.value.isPrivate = Object.keys(BUNDLE_ID_TO_COMPONENTS[bundle.value.id]).length === 0
     })

--- a/packages/netsuite-adapter/src/filters/bundle_ids.ts
+++ b/packages/netsuite-adapter/src/filters/bundle_ids.ts
@@ -83,7 +83,12 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
       bundle.value.id in BUNDLE_ID_TO_COMPONENTS)
     if (missingBundles) {
       log.debug('The following bundle ids are missing in the bundle record: %o',
-        missingBundles.map(bundle => ({ bundleId: bundle.value.id, installedFrom: bundle.value.installedFrom.toUpperCase(), publisher: bundle.value.publisher })))
+        missingBundles.map(bundle => (
+          {
+            bundleId: bundle.value.id,
+            installedFrom: bundle.value.installedFrom.toUpperCase(),
+            publisher: bundle.value.publisher,
+          })))
     }
     existingBundles.forEach(bundle => {
       bundle.value.isPrivate = Object.keys(BUNDLE_ID_TO_COMPONENTS[bundle.value.id]).length === 0

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -68,7 +68,7 @@ const getServiceIdFieldName = (type: ObjectType): string => {
   return isStandardType(type) ? SCRIPT_ID : PATH
 }
 
-const addBundlePrefix = (desiredName: string, type: ObjectType): string => (isBundleType(type) ? `${BUNDLE}_${desiredName}` : desiredName)
+const addBundlePrefix = (desiredName: string, type: ObjectType): string => (isBundleType(type) ? (`${BUNDLE}_${desiredName}`) : desiredName)
 
 export const createInstanceElement = async (
   customizationInfo: CustomizationInfo,
@@ -92,7 +92,7 @@ export const createInstanceElement = async (
     }
     const desiredName = naclCase(addBundlePrefix(transformedValues[serviceIdFieldName], type)
       .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
-    return getElemIdFunc ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
+    return getElemIdFunc && !isBundleType(type) ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
   }
 
   const getInstancePath = (instanceName: string): string[] => {

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -31,7 +31,7 @@ import _ from 'lodash'
 import {
   ADDRESS_FORM, ENTRY_FORM, TRANSACTION_FORM, IS_ATTRIBUTE, NETSUITE, RECORDS_PATH,
   SCRIPT_ID, ADDITIONAL_FILE_SUFFIX, FILE_CABINET_PATH, PATH, FILE_CABINET_PATH_SEPARATOR,
-  APPLICATION_ID, SETTINGS_PATH, CUSTOM_RECORD_TYPE, CONTENT, ID_FIELD,
+  APPLICATION_ID, SETTINGS_PATH, CUSTOM_RECORD_TYPE, CONTENT, ID_FIELD, BUNDLE,
 } from './constants'
 import { fieldTypes } from './types/field_types'
 import { isSDFConfigType, isStandardType, isFileCabinetType, isCustomRecordType, getTopLevelStandardTypes, metadataTypesToList, getMetadataTypes, isFileInstance, isBundleType } from './types'
@@ -68,6 +68,8 @@ const getServiceIdFieldName = (type: ObjectType): string => {
   return isStandardType(type) ? SCRIPT_ID : PATH
 }
 
+const addBundlePrefix = (desiredName: string, type: ObjectType): string => (isBundleType(type) ? BUNDLE.concat(`_${desiredName}`) : desiredName)
+
 export const createInstanceElement = async (
   customizationInfo: CustomizationInfo,
   type: ObjectType,
@@ -88,7 +90,7 @@ export const createInstanceElement = async (
         [OBJECT_NAME]: type.elemID.getFullName(),
       }),
     }
-    const desiredName = naclCase(transformedValues[serviceIdFieldName]
+    const desiredName = naclCase(addBundlePrefix(transformedValues[serviceIdFieldName], type)
       .replace(new RegExp(`^${FILE_CABINET_PATH_SEPARATOR}`), ''))
     return getElemIdFunc ? getElemIdFunc(NETSUITE, serviceIds, desiredName).name : desiredName
   }

--- a/packages/netsuite-adapter/src/transformer.ts
+++ b/packages/netsuite-adapter/src/transformer.ts
@@ -68,7 +68,7 @@ const getServiceIdFieldName = (type: ObjectType): string => {
   return isStandardType(type) ? SCRIPT_ID : PATH
 }
 
-const addBundlePrefix = (desiredName: string, type: ObjectType): string => (isBundleType(type) ? BUNDLE.concat(`_${desiredName}`) : desiredName)
+const addBundlePrefix = (desiredName: string, type: ObjectType): string => (isBundleType(type) ? `${BUNDLE}_${desiredName}` : desiredName)
 
 export const createInstanceElement = async (
   customizationInfo: CustomizationInfo,

--- a/packages/netsuite-adapter/test/change_validators/bundle_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/bundle_changes.test.ts
@@ -41,7 +41,7 @@ describe('bundle changes', () => {
       })
   })
 
-  it('should have changeError when trying to deploy a bundle instance', async () => {
+  it('should have changeError when trying to deploy a bundle instance change', async () => {
     bundleInstanceAfter.value.name = 'newName'
     const changeError = await bundleChangesValidation([
       toChange({ after: bundleInstanceAfter, before: bundleInstanceBefore }),
@@ -49,10 +49,10 @@ describe('bundle changes', () => {
     expect(changeError).toHaveLength(1)
     expect(changeError[0]).toEqual(
       {
-        message: 'Can\'t deploy bundle',
+        message: 'Cannot add, modify, or remove bundles',
         severity: 'Error',
         elemID: bundleInstanceAfter.elemID,
-        detailedMessage: 'This bundle doesn\'t exist in the target account, and cannot be automatically deployed.\nIt may be required by some elements in your deployment.\nYou can manually install this bundle in the target account by following these steps: Customization > SuiteBundler > Search & Install Bundles',
+        detailedMessage: 'Cannot create, modify or remove bundles.To manage bundles, please manually install or update them in the target account. Follow these steps: Customization > SuiteBundler > Search & Install Bundles.',
       }
     )
   })

--- a/packages/netsuite-adapter/test/filters/bundle_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/bundle_ids.test.ts
@@ -64,7 +64,7 @@ describe('bundle_ids filter', () => {
     })
 
     it('should not add bundle field in case the bundle doesn\'t exist in the record', async () => {
-      const notInRecordBundle = new InstanceElement('0', bundleType().type, { id: '0' })
+      const notInRecordBundle = new InstanceElement('0', bundleType().type, { id: '0', installedFrom: 'Production' })
       await filterCreator(filterOpts).onFetch?.([recordInstance, notInRecordBundle])
       expect(fileCabinetInstance.value.bundle).toBeUndefined()
     })

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -23,9 +23,9 @@ import _ from 'lodash'
 import { createInstanceElement, getLookUpName, toCustomizationInfo } from '../src/transformer'
 import {
   ENTITY_CUSTOM_FIELD, SCRIPT_ID, CUSTOM_RECORD_TYPE, METADATA_TYPE,
-  EMAIL_TEMPLATE, NETSUITE, RECORDS_PATH, FILE, FILE_CABINET_PATH, FOLDER, PATH, CONFIG_FEATURES, WORKFLOW,
+  EMAIL_TEMPLATE, NETSUITE, RECORDS_PATH, FILE, FILE_CABINET_PATH, FOLDER, PATH, CONFIG_FEATURES, WORKFLOW, BUNDLE,
 } from '../src/constants'
-import { CustomTypeInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../src/client/types'
+import { CustomTypeInfo, CustomizationInfo, FileCustomizationInfo, FolderCustomizationInfo, TemplateCustomTypeInfo } from '../src/client/types'
 import { isFileCustomizationInfo, isFolderCustomizationInfo } from '../src/client/utils'
 import { entitycustomfieldType } from '../src/autogen/types/standard_types/entitycustomfield'
 import { getFileCabinetTypes } from '../src/types/file_cabinet_types'
@@ -35,6 +35,7 @@ import { emailtemplateType } from '../src/autogen/types/standard_types/emailtemp
 import { addressFormType } from '../src/autogen/types/standard_types/addressForm'
 import { transactionFormType } from '../src/autogen/types/standard_types/transactionForm'
 import { workflowType } from '../src/autogen/types/standard_types/workflow'
+import { bundleType } from '../src/types/bundle_type'
 
 const NAME_FROM_GET_ELEM_ID = 'nameFromGetElemId'
 const mockGetElemIdFunc = (adapterName: string, _serviceIds: ServiceIds, name: string):
@@ -207,6 +208,7 @@ describe('Transformer', () => {
   const workflow = workflowType().type
   const { file, folder } = getFileCabinetTypes()
   const companyFeatures = featuresType()
+  const bundle = bundleType().type
 
   describe('createInstanceElement', () => {
     const mockElementsSource = buildElementsSourceFromElements([])
@@ -387,6 +389,24 @@ describe('Transformer', () => {
         [SCRIPT_ID]: 'custemailtmpl_my_script_id',
       })
     })
+
+    it('should create bundle instance name correctly', async () => {
+      const bundleCustomizationInfo = {
+        typeName: 'bundle',
+        values: {
+          name: 'bundle name',
+          id: '4321',
+        },
+      } as CustomizationInfo
+      const result = await createInstanceElement(
+        bundleCustomizationInfo,
+        bundle,
+        mockElementsSource,
+        mockGetElemIdFunc
+      )
+      expect(result.elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${BUNDLE}_${bundleCustomizationInfo.values.id}`)
+    })
+
 
     describe('file cabinet types', () => {
       const fileCustomizationInfo: FileCustomizationInfo = {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -404,7 +404,7 @@ describe('Transformer', () => {
         mockElementsSource,
         mockGetElemIdFunc
       )
-      expect(result.elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${BUNDLE}_${bundleCustomizationInfo.values.id}`)
+      expect(result.elemID.name).toEqual(`${BUNDLE}_${bundleCustomizationInfo.values.id}`)
     })
 
 


### PR DESCRIPTION
_A few bundles related updates_:
* bundles change validator updated to prevent all modifications on bundle elements and not only additions
* bundle elements renamed to have "bundle_" prefix and not only id

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* bundle elements will be renamed from `<bundleId>` to `bundle_<bundleId>`

---
_User Notifications_: 
_bundle elements will be renamed from `<bundleId>` to `bundle_<bundleId>`_
