### PR TITLE
SALTO-5186: [Zendesk] Hide title field in view and fix the raw_title deployment bug

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -391,7 +391,7 @@ describe('Zendesk adapter E2E', () => {
       })
       const viewInstance = createInstanceElement({
         type: 'view',
-        valuesOverride: { title: createName('view') },
+        valuesOverride: { title: createName('view'), raw_title: createName('view') },
       })
       const ticketFieldInstance = createInstanceElement({
         type: 'ticket_field',

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -216,8 +216,8 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   view: {
     transformation: {
       sourceTypeName: 'views__views',
-      idFields: ['&title'],
-      fileNameFields: ['&title'],
+      idFields: ['title'],
+      fileNameFields: ['title'],
       fieldsToHide: FIELDS_TO_HIDE.concat([
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'title', fieldType: 'string' },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -216,9 +216,12 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   view: {
     transformation: {
       sourceTypeName: 'views__views',
-      idFields: ['title'],
-      fileNameFields: ['title'],
-      fieldsToHide: FIELDS_TO_HIDE.concat({ fieldName: 'id', fieldType: 'number' }),
+      idFields: ['&title'],
+      fileNameFields: ['&title'],
+      fieldsToHide: FIELDS_TO_HIDE.concat([
+        { fieldName: 'id', fieldType: 'number' },
+        { fieldName: 'title', fieldType: 'string' },
+      ]),
       fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'number' }],
       serviceUrl: '/admin/workspaces/agent-workspace/views/{id}',
     },

--- a/packages/zendesk-adapter/src/filters/view.ts
+++ b/packages/zendesk-adapter/src/filters/view.ts
@@ -46,6 +46,9 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
             columns: instance.value.execution.columns?.filter(_.isPlainObject)
               .map((c: Values) => c.id).filter(values.isDefined) ?? [],
           },
+          // copying raw_title to title means that title might now be a dynamic content token
+          // and not a raw string. Since the title field is hidden, this should be safe
+          title: instance.value.raw_title,
         }
         return instance
       }

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -184,6 +184,9 @@ describe('views filter', () => {
       expect(anotherClonedView.value.any).toBeDefined()
       expect(anotherClonedView.value.any).toHaveLength(0)
     })
+    it('should copy raw_title to title', async () => {
+      expect(clonedView.value.raw_title).toEqual(clonedView.value.title)
+    })
   })
 
   describe('onDeploy', () => {


### PR DESCRIPTION
When deploying a view, if raw_title was a `dynamic content` token if used to get swapped into a raw string (specifically, the resolved dynamic token)

Now, it no longer happens, and we've hidden the title field so that users don't edit it and create conflicts with changes to the raw_title field

---

_Test plan_:
Before:

1. apply a dynamic content name to a view - {{dc.dynamic_content}}, who's value is "blip bloop"
2. `salto fetch`
3. Observe that in the instance, the following fields show up:
```
  title = "blip bloop"
  raw_title = "{{${ zendesk.dynamic_content_item.instance.dynamic_content }}}"
```
4. Change anything in the view (changed the description text, for example)
5. `salto deploy`
6. `salto fetch`
7. Observe that in the instance, the title fields are now as follows:
```
  title = "blip bloop"
  raw_title = "blip bloop"
```
=> Title changed even though it shouldn't have changed, because the string value of the dynamic content is applied as both the title and raw_title

After:
1. apply a dynamic content name to a view - {{dc.dynamic_content}}, who's value is "blip bloop"
2. `salto fetch`
3. Observe that in the instance, the following field show up:
```
  raw_title = "{{${ zendesk.dynamic_content_item.instance.dynamic_content }}}"
```
    There is no `title` field, it is now hidden
4. Change anything in the view (changed the description text, for example)
5. `salto deploy`
6. `salto fetch`
6. Observe that in the instance, the title field is the same as before:
```
  raw_title = "{{${ zendesk.dynamic_content_item.instance.dynamic_content }}}"
```
=> Title remains unchanged, `raw_title` remains unchanged, as expected


Also ran the `adapter.test.ts` to make sure that elementIDs remain consistent

---
_Release Notes_: 
Zendesk:
Fix `raw_title` deployment issue and hide the `title` field in `views`

---
_User Notifications_: 
Zendesk: 
`title` field in `views` is now hidden

