### PR TITLE
SALTO-5389 utils and DefaultWithCustomization, ArgsWithCustomizer, OptionsWithDefault

### DIFF
--- a/packages/adapter-components/src/definitions/index.ts
+++ b/packages/adapter-components/src/definitions/index.ts
@@ -1,0 +1,17 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export * from './system'

--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -1,0 +1,18 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export * from './utils'
+export { DefaultWithCustomizations, ArgsWithCustomizer, OptionsWithDefault } from './shared'

--- a/packages/adapter-components/src/definitions/system/shared/index.ts
+++ b/packages/adapter-components/src/definitions/system/shared/index.ts
@@ -1,0 +1,17 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+export * from './types'

--- a/packages/adapter-components/src/definitions/system/shared/types.ts
+++ b/packages/adapter-components/src/definitions/system/shared/types.ts
@@ -29,8 +29,8 @@ export type DefaultWithCustomizations<T, K extends string = string> = {
   customizations: string extends K ? Record<K, T> : Partial<Record<K, T>>
 }
 
-export type ArgsWithCustomizer<ResponseType, Args, Input = unknown, AdditionalArgs = {}> = Args & {
-  custom?: ((args: Partial<Args> & AdditionalArgs) => (input: Input) => ResponseType)
+export type ArgsWithCustomizer<ResultType, Args, Input = unknown, AdditionalArgs = {}> = Args & {
+  custom?: ((args: Partial<Args> & AdditionalArgs) => (input: Input) => ResultType)
 }
 
 export type OptionsWithDefault<T, K extends string> = {

--- a/packages/adapter-components/src/definitions/system/shared/types.ts
+++ b/packages/adapter-components/src/definitions/system/shared/types.ts
@@ -1,0 +1,39 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { types } from '@salto-io/lowerdash'
+
+/**
+ * Use this type to specify a default with customizations by key (usually type).
+ * This should be supplemented with merge logic - specifically, the final definition for a key
+ * is the customization if available, and otherwise it is the default.
+ * Note that there are some edge cases - merging should be done based on mergeSingleDefWithDefault.
+ */
+export type DefaultWithCustomizations<T, K extends string = string> = {
+  // if the customization is an array, the default will be applied to each array item
+  // (if the customization is empty, it will not be used)
+  default?: types.RecursivePartial<T extends (infer U)[] ? U : T>
+  // hack to avoid requiring all keys of an enum
+  customizations: string extends K ? Record<K, T> : Partial<Record<K, T>>
+}
+
+export type ArgsWithCustomizer<ResponseType, Args, Input = unknown, AdditionalArgs = {}> = Args & {
+  custom?: ((args: Partial<Args> & AdditionalArgs) => (input: Input) => ResponseType)
+}
+
+export type OptionsWithDefault<T, K extends string> = {
+  options: Record<K, T>
+  default: K
+}

--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -20,6 +20,16 @@ import { DefaultWithCustomizations } from './shared/types'
 
 const log = logger(module)
 
+/**
+ * merge a single custom definition with a default, assuming they came from a DefaultWithCustomizations definition.
+ * the merge is done as follows:
+ * - customization takes precedence over default
+ * - if the customization is an array, the default is expected to be a single item with the same structure,
+ *   and the default is applied to each item in the customization array
+ * - special case (TODO generalize): if the definition specifies ignoreDefaultFieldCustomizations=true, then
+ *   the corresponding fieldCustomizations field, if exists, will not be merged with the default.
+ *   the ignoreDefaultFieldCustomizations value itself is omitted from the returned result.
+ */
 export const mergeSingleDefWithDefault = <T, K extends string>(
   defaultDef: DefaultWithCustomizations<T, K>['default'] | undefined,
   def: T | undefined,
@@ -28,9 +38,6 @@ export const mergeSingleDefWithDefault = <T, K extends string>(
     return def
   }
   if (Array.isArray(def)) {
-    if (defaultDef === undefined) {
-      return def
-    }
     if (Array.isArray(defaultDef)) {
       // shouldn't happen
       log.warn('found array in custom and default definitions, ignoring default')

--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -1,0 +1,115 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { types, values as lowerdashValues } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { DefaultWithCustomizations } from './shared/types'
+
+const log = logger(module)
+
+export const mergeSingleDefWithDefault = <T, K extends string>(
+  defaultDef: DefaultWithCustomizations<T, K>['default'] | undefined,
+  def: T | undefined,
+): T | undefined => {
+  if (defaultDef === undefined) {
+    return def
+  }
+  if (Array.isArray(def)) {
+    if (defaultDef === undefined) {
+      return def
+    }
+    if (Array.isArray(defaultDef)) {
+      // shouldn't happen
+      log.warn('found array in custom and default definitions, ignoring default')
+      return def
+    }
+    // TODO improve casting
+    return def.map(item => mergeSingleDefWithDefault(defaultDef, item)) as unknown as T
+  }
+  // we add a fake nesting level called "value" in order for ignoreDefaultFieldCustomizations to be caught even
+  // if it directly under the root.
+  return _.mergeWith(
+    { value: _.cloneDeep(defaultDef) },
+    { value: def },
+    (first, second) => {
+      if (lowerdashValues.isPlainObject(second) && _.get(second, 'ignoreDefaultFieldCustomizations') !== undefined) {
+        const updatedSecond = _.omit(second, 'ignoreDefaultFieldCustomizations')
+        if (_.get(second, 'ignoreDefaultFieldCustomizations')) {
+          return mergeSingleDefWithDefault(
+            _.omit(first, 'fieldCustomizations'),
+            updatedSecond,
+          )
+        }
+        return mergeSingleDefWithDefault(first, updatedSecond)
+      }
+      if (Array.isArray(second)) {
+        return mergeSingleDefWithDefault(first, second)
+      }
+      return undefined
+    }
+  ).value
+}
+
+export type DefQuery<T> = {
+  query: (key: string) => T | undefined
+  allKeys: () => string[]
+  getAll: () => Record<string, T>
+}
+
+export const queryWithDefault = <T>(
+  defsWithDefault: types.PickyRequired<DefaultWithCustomizations<T, string>, 'customizations'>,
+): DefQuery<T> => {
+  const query: DefQuery<T>['query'] = key => mergeSingleDefWithDefault(
+    defsWithDefault.default,
+    defsWithDefault.customizations[key],
+  )
+  return {
+    query,
+    allKeys: () => Object.keys(defsWithDefault.customizations),
+    getAll: () => _.pickBy(
+      _.mapValues(defsWithDefault.customizations, (_def, k) => query(k)),
+      lowerdashValues.isDefined,
+    ),
+  }
+}
+
+export function mergeWithDefault<T, K extends string = string>(
+  defsWithDefault: DefaultWithCustomizations<T, K>
+): Record<K, T>
+export function mergeWithDefault<T>(
+  defsWithDefault: DefaultWithCustomizations<T, string>
+): Record<string, T> {
+  const query = queryWithDefault<T>(defsWithDefault)
+  return _.pickBy(
+    _.mapValues(
+      defsWithDefault.customizations,
+      (_val, k) => query.query(k)
+    ),
+    lowerdashValues.isDefined,
+  )
+}
+
+export const mergeNestedWithDefault = <T, TNested, K extends string>(
+  defsWithDefault: DefaultWithCustomizations<T, K>,
+  path: string
+): DefaultWithCustomizations<TNested, K> => mergeWithDefault({
+  default: _.get(defsWithDefault.default, path),
+  customizations: _.mapValues(
+    defsWithDefault.customizations,
+    (def: T) => _.get(def, path)
+  ),
+// TODO see if can avoid the cast
+}) as unknown as DefaultWithCustomizations<TNested, K>

--- a/packages/adapter-components/test/definitions/system/utils.test.ts
+++ b/packages/adapter-components/test/definitions/system/utils.test.ts
@@ -1,0 +1,213 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { DefaultWithCustomizations, mergeSingleDefWithDefault, queryWithDefault, mergeWithDefault, mergeNestedWithDefault, DefQuery } from '../../../src/definitions/system'
+
+describe('system definitions utils', () => {
+  let defs: DefaultWithCustomizations<unknown>
+  beforeEach(() => {
+    defs = {
+      default: {
+        a: 'a',
+        b: { c: 'd' },
+        arr: { x: 1, y: 2 },
+      },
+      customizations: {
+        k1: {
+          a: 'override',
+          arr: [
+            { a: 'a' },
+            { b: 'b', x: 7 },
+          ],
+        },
+        k2: {
+          b: 'different type',
+          arr: [],
+        },
+      },
+    }
+  })
+
+  describe('mergeSingleDefWithDefault', () => {
+    it('should return the default when no custom definition is provided', () => {
+      expect(mergeSingleDefWithDefault(defs.default, undefined)).toEqual(defs.default)
+    })
+    it('should return the custom definition when no default is provided', () => {
+      expect(mergeSingleDefWithDefault(undefined, defs.customizations.k1)).toEqual(defs.customizations.k1)
+    })
+    it('should give precedence to the custom definition', () => {
+      expect(_.get(mergeSingleDefWithDefault(defs.default, defs.customizations.k1), 'a')).toEqual('override')
+    })
+    it('should apply default to all array items', () => {
+      expect(_.get(mergeSingleDefWithDefault(defs.default, defs.customizations.k1), 'arr')).toEqual([
+        { a: 'a', x: 1, y: 2 },
+        { b: 'b', x: 7, y: 2 },
+      ])
+      expect(_.get(mergeSingleDefWithDefault(defs.default, defs.customizations.k2), 'arr')).toEqual([])
+    })
+    it('should not crash on type conflict', () => {
+      expect(mergeSingleDefWithDefault(defs.default, defs.customizations.k2)).toEqual({
+        a: 'a',
+        b: 'different type',
+        arr: [],
+      })
+    })
+    it('should ignore default for fieldCustomizations if ignoreDefaultFieldCustomizations=true', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeSingleDefWithDefault<any, string>(
+        {
+          fieldCustomizations: {
+            a: { hide: true },
+          },
+        },
+        {
+          fieldCustomizations: {
+            a: { omit: true },
+          },
+          ignoreDefaultFieldCustomizations: true,
+        },
+      )).toEqual({
+        fieldCustomizations: {
+          a: { omit: true },
+        },
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeSingleDefWithDefault<any, string>(
+        {
+          nested: {
+            fieldCustomizations: {
+              a: { hide: true },
+            },
+          },
+        },
+        {
+          nested: {
+            fieldCustomizations: {
+              a: { omit: true },
+            },
+            ignoreDefaultFieldCustomizations: true,
+          },
+        },
+      )).toEqual({
+        nested: {
+          fieldCustomizations: {
+            a: { omit: true },
+          },
+        },
+      })
+    })
+    it('should not ignore default for fieldCustomizations if ignoreDefaultFieldCustomizations=false', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeSingleDefWithDefault<any, string>(
+        {
+          fieldCustomizations: {
+            a: { hide: true },
+          },
+        },
+        {
+          fieldCustomizations: {
+            a: { omit: true },
+          },
+          ignoreDefaultFieldCustomizations: false,
+        },
+      )).toEqual({
+        fieldCustomizations: {
+          a: { hide: true, omit: true },
+        },
+      })
+    })
+  })
+
+  describe('mergeWithDefault', () => {
+    it('should merge definitions like mergeSingleDefWithDefault would on each key', () => {
+      expect(mergeWithDefault(defs)).toEqual({
+        k1: {
+          a: 'override',
+          b: { c: 'd' },
+          arr: [
+            { a: 'a', x: 1, y: 2 },
+            { b: 'b', x: 7, y: 2 },
+          ],
+        },
+        k2: {
+          a: 'a',
+          b: 'different type',
+          arr: [],
+        },
+      })
+    })
+  })
+
+  describe('mergeNestedWithDefault', () => {
+    it('should return the merged value in nested paths', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeNestedWithDefault<any, any, string>(defs, 'a')).toEqual({
+        k1: 'override',
+        k2: 'a',
+      })
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeNestedWithDefault<any, any, string>(defs, 'b.c')).toEqual({
+        k1: 'd',
+        k2: 'd',
+      })
+    })
+    it('should return undefined when path is missing', () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect(mergeNestedWithDefault<any, any, string>(defs, 'nonexistent')).toEqual({
+        k1: undefined,
+        k2: undefined,
+      })
+    })
+  })
+
+  describe('queryWithDefault', () => {
+    let query: DefQuery<unknown>
+    beforeEach(() => {
+      query = queryWithDefault(defs)
+    })
+
+    describe('allKeys', () => {
+      it('should get all keys correctly', () => {
+        expect(_.sortBy(query.allKeys())).toEqual(['k1', 'k2'])
+      })
+      it('should return empty list when there are no customizations', () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        expect(queryWithDefault<any>({ default: {}, customizations: {} }).allKeys()).toEqual([])
+      })
+    })
+    describe('getAll', () => {
+      it('should be identical to mergeWithDefault', () => {
+        expect(query.getAll()).toEqual(mergeWithDefault(defs))
+      })
+    })
+    describe('query', () => {
+      it('should merge correctly when queried on an existing key', () => {
+        expect(query.query('k1')).toEqual({
+          a: 'override',
+          b: { c: 'd' },
+
+          arr: [
+            { a: 'a', x: 1, y: 2 },
+            { b: 'b', x: 7, y: 2 },
+          ],
+        })
+      })
+      it('should return default when queried on a non-existing key', () => {
+        expect(query.query('missing')).toEqual(defs.default)
+      })
+    })
+  })
+})

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -109,3 +109,10 @@ export type AllowOnly<T, K extends keyof T> = Pick<T, K> & { [P in keyof Omit<T,
 export type OneOf<T, K = keyof T> = K extends keyof T ? AllowOnly<T, K> : never
 export type XOR<A, B> = AllowOnly<A & B, keyof A> | AllowOnly<A & B, keyof B>
 export type NonPromise<T> = T extends Promise<unknown> ? never : T
+
+export type RecursivePartial<T> = {
+  [P in keyof T]?:
+    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+    T[P] extends object | undefined ? RecursivePartial<T[P]> :
+    T[P];
+};


### PR DESCRIPTION
Add a few utility types and helper functions that will be used in the new infra.
See https://github.com/salto-io/salto/pull/5409/files for more context.
Merging this now because we want to start using `DefaultWithCustomization` and its utilities soon.

---
_Release Notes_: 
None

---
_User Notifications_: 
None