### PR TITLE
SALTO-5255: [Zendesk] Fix bug when deploying an article with a change to User Segment to "Everyone"

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -13,6 +13,9 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
+
+/* eslint-disable no-console */
+
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections, strings, promises } from '@salto-io/lowerdash'
@@ -104,13 +107,16 @@ const setupArticleUserSegmentId = (
   elements: Element[],
   articleInstances: InstanceElement[],
 ): void => {
+  console.log('h1i')
   const everyoneUserSegmentInstance = elements
     .filter(instance => instance.elemID.typeName === USER_SEGMENT_TYPE_NAME)
     .find(instance => instance.elemID.name === EVERYONE_USER_TYPE)
+  console.log('hi2', everyoneUserSegmentInstance)
   if (everyoneUserSegmentInstance === undefined) {
     log.info("Couldn't find Everyone user_segment instance.")
     return
   }
+  console.log('hi3')
   articleInstances
     .filter(article => article.value[USER_SEGMENT_ID_FIELD] === undefined)
     .forEach(article => {
@@ -127,10 +133,17 @@ const setUserSegmentIdForAdditionChanges = (
   changes: Change<InstanceElement>[]
 ): void => {
   changes
+    .map(getChangeData)
+    .forEach(articleInstance => {
+      console.log(articleInstance)
+    })
+
+  changes
     .filter(isAdditionChange)
     .map(getChangeData)
     .filter(articleInstance => articleInstance.value[USER_SEGMENT_ID_FIELD] === undefined)
     .forEach(articleInstance => {
+      console.log(articleInstance)
       articleInstance.value[USER_SEGMENT_ID_FIELD] = null
     })
 }
@@ -387,6 +400,7 @@ const calculateAndRemoveDeletedAttachments = ({
  */
 const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdToClient = {} }) => {
   const articleNameToAttachments: Record<string, number[]> = {}
+  console.log('hello?')
   return {
     name: 'articleFilter',
     onFetch: async (elements: Element[]) => {
@@ -465,6 +479,11 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource, brandIdT
       await handleArticleAttachmentsPreDeploy(
         { changes, client, elementsSource, articleNameToAttachments, config }
       )
+      changes
+        .map(getChangeData)
+        .forEach(articleInstance => {
+          console.log(articleInstance)
+        })
       await awu(changes)
         .filter(isAdditionChange)
         .filter(change => getChangeData(change).elemID.typeName === ARTICLE_TYPE_NAME)

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -720,4 +720,17 @@ describe('article filter', () => {
       expect(getChangeData(TranslationAddition)).toBe(clonedTranslation)
     })
   })
+  it('should have an empty user segment id when changing to Everyone', async () => {
+    const clonedArticle = anotherArticleInstance.clone()
+    // Changing user segment to "Everyone" completely removes the
+    // field from the article instance
+    delete clonedArticle.value.user_segment_id
+    const articleModification = toChange({ before: anotherArticleInstance, after: clonedArticle })
+
+    await filter.deploy([
+      articleModification,
+    ])
+    const filteredArticle = getChangeData(articleModification)
+    expect(filteredArticle.value.user_segment_id).toBeNull()
+  })
 })


### PR DESCRIPTION
TSIA

---

Since the "Everyone" instance is a Salto concept and Zendesk doesn't know it, changing the User Segment to "Everyone" would fail on deploy.

---
_Release Notes_: 
Zendesk:

Changing `User Segment` in `Article` to `Everyone` now deploys correctly

---
_User Notifications_: 

None