### PR TITLE
SALTO-5388 allow omitting the user fetch config elem id field

### DIFF
--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -33,6 +33,7 @@ export type ConfigTypeCreator = (args: {
   additionalDeployFields?: Record<string, FieldDefinition>
   additionalClientFields?: Record<string, FieldDefinition>
   changeValidatorNames?: string[]
+  omitElemID?: boolean
 }) => ObjectType
 
 export const createUserConfigType: ConfigTypeCreator = ({
@@ -43,6 +44,7 @@ export const createUserConfigType: ConfigTypeCreator = ({
   additionalFetchFields,
   additionalDeployFields,
   additionalClientFields,
+  omitElemID,
 }) => createMatchingObjectType<Partial<UserConfig>>({
   elemID: new ElemID(adapterName),
   fields: {
@@ -50,10 +52,11 @@ export const createUserConfigType: ConfigTypeCreator = ({
       refType: createClientConfigType(adapterName, undefined, additionalClientFields),
     },
     fetch: {
-      refType: createUserFetchConfigType(
+      refType: createUserFetchConfigType({
         adapterName,
-        additionalFetchFields,
-      ),
+        additionalFields: additionalFetchFields,
+        omitElemID,
+      }),
     },
     deploy: {
       refType: createUserDeployConfigType(

--- a/packages/adapter-components/test/definitions/user/fetch_config.test.ts
+++ b/packages/adapter-components/test/definitions/user/fetch_config.test.ts
@@ -18,13 +18,21 @@ import { createUserFetchConfigType } from '../../../src/definitions/user'
 describe('config_shared', () => {
   describe('createUserFetchConfigType', () => {
     it('should return default type when no custom fields were added', () => {
-      const type = createUserFetchConfigType('myAdapter')
+      const type = createUserFetchConfigType({ adapterName: 'myAdapter' })
       expect(Object.keys(type.fields)).toHaveLength(5)
       expect(type.fields.include).toBeDefined()
       expect(type.fields.exclude).toBeDefined()
       expect(type.fields.hideTypes).toBeDefined()
       expect(type.fields.asyncPagination).toBeDefined()
       expect(type.fields.elemID).toBeDefined()
+    })
+    it('should not add elem id when flag is set', () => {
+      const type = createUserFetchConfigType({ adapterName: 'myAdapter', omitElemID: true })
+      expect(Object.keys(type.fields)).toHaveLength(4)
+      expect(type.fields.include).toBeDefined()
+      expect(type.fields.exclude).toBeDefined()
+      expect(type.fields.hideTypes).toBeDefined()
+      expect(type.fields.asyncPagination).toBeDefined()
     })
   })
 })

--- a/packages/adapter-components/test/definitions/user/user_config.test.ts
+++ b/packages/adapter-components/test/definitions/user/user_config.test.ts
@@ -17,7 +17,7 @@ import { BuiltinTypes } from '@salto-io/adapter-api'
 import { createUserConfigType } from '../../../src/definitions/user'
 
 describe('config_shared', () => {
-  describe('createUserFetchConfigType', () => {
+  describe('createUserConfigType', () => {
     it('should return default type when no custom fields were added', () => {
       const type = createUserConfigType({ adapterName: 'myAdapter' })
       expect(Object.keys(type.fields)).toHaveLength(3)

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -328,9 +328,9 @@ const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
   },
 })
 
-const fetchConfigType = definitions.createUserFetchConfigType(
-  JIRA,
-  {
+const fetchConfigType = definitions.createUserFetchConfigType({
+  adapterName: JIRA,
+  additionalFields: {
     fallbackToInternalId: { refType: BuiltinTypes.BOOLEAN },
     addTypeToFieldName: { refType: BuiltinTypes.BOOLEAN },
     showUserDisplayNames: { refType: BuiltinTypes.BOOLEAN },
@@ -346,8 +346,9 @@ const fetchConfigType = definitions.createUserFetchConfigType(
     enableIssueLayouts: { refType: BuiltinTypes.BOOLEAN },
     enableNewWorkflowAPI: { refType: BuiltinTypes.BOOLEAN },
   },
-  fetchFiltersType,
-)
+  fetchCriteriaType: fetchFiltersType,
+  omitElemID: true,
+})
 
 const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
   elemID: new ElemID(JIRA, 'MaskingConfig'),

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1879,9 +1879,9 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
       refType: createClientConfigType(),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(
-        OKTA,
-        {
+      refType: definitions.createUserFetchConfigType({
+        adapterName: OKTA,
+        additionalFields: {
           convertUsersIds: { refType: BuiltinTypes.BOOLEAN },
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           includeGroupMemberships: { refType: BuiltinTypes.BOOLEAN },
@@ -1893,8 +1893,9 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
             },
           },
           isClassicOrg: { refType: BuiltinTypes.BOOLEAN },
-        }
-      ),
+        },
+        omitElemID: true,
+      }),
     },
     [DEPLOY_CONFIG]: {
       refType: definitions.createUserDeployConfigType(

--- a/packages/sap-adapter/src/config.ts
+++ b/packages/sap-adapter/src/config.ts
@@ -137,9 +137,10 @@ export const configType = createMatchingObjectType<Partial<SAPConfig>>({
       refType: createClientConfigType(SAP),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(
-        SAP,
-      ),
+      refType: definitions.createUserFetchConfigType({
+        adapterName: SAP,
+        omitElemID: true,
+      }),
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createSwaggerAdapterApiConfigType({ adapter: SAP }),

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -144,7 +144,7 @@ export const configType = createMatchingObjectType<Partial<StripeConfig>>({
       refType: createClientConfigType(STRIPE),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(STRIPE),
+      refType: definitions.createUserFetchConfigType({ adapterName: STRIPE, omitElemID: true }),
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createSwaggerAdapterApiConfigType({

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -250,14 +250,15 @@ export const configType = new ObjectType({
       refType: createClientConfigType(WORKATO),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(
-        WORKATO,
-        {
+      refType: definitions.createUserFetchConfigType({
+        adapterName: WORKATO,
+        additionalFields: {
           serviceConnectionNames: {
             refType: new MapType(new ListType(BuiltinTypes.STRING)),
           },
         },
-      ),
+        omitElemID: true,
+      }),
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createDucktypeAdapterApiConfigType({ adapter: WORKATO }),

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -3044,9 +3044,9 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       refType: createClientConfigType(ZENDESK),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(
-        ZENDESK,
-        {
+      refType: definitions.createUserFetchConfigType({
+        adapterName: ZENDESK,
+        additionalFields: {
           enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
           resolveUserIDs: { refType: BuiltinTypes.BOOLEAN },
           includeAuditDetails: { refType: BuiltinTypes.BOOLEAN },
@@ -3059,7 +3059,8 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           extractReferencesFromFreeText: { refType: BuiltinTypes.BOOLEAN },
           convertJsonIdsToReferences: { refType: BuiltinTypes.BOOLEAN },
         },
-      ),
+        omitElemID: true,
+      }),
     },
     [DEPLOY_CONFIG]: {
       refType: definitions.createUserDeployConfigType(

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -810,9 +810,7 @@ export const configType = createMatchingObjectType<Partial<ZuoraConfig>>({
       refType: createClientConfigType(ZUORA_BILLING),
     },
     [FETCH_CONFIG]: {
-      refType: definitions.createUserFetchConfigType(
-        ZUORA_BILLING,
-      ),
+      refType: definitions.createUserFetchConfigType({ adapterName: ZUORA_BILLING, omitElemID: true }),
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createSwaggerAdapterApiConfigType({


### PR DESCRIPTION
the new elem id field was added in https://github.com/salto-io/salto/pull/5411 as optional - I think it's safer to allow the adapter to not support it until we allow users to control the flow via that (forgot to add this in the previous PR).
also using this opportunity to switch the function to named parameters.

---
_Release Notes_: 
None

---
_User Notifications_: 
None