### PR TITLE
SALTO-3080 Log handlebar references

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -308,7 +308,7 @@ describe('Zendesk adapter E2E', () => {
 
     const createRootForTheme = async (buffer: Buffer, brandName: string, name: string)
       : Promise<ThemeDirectory> => {
-      const root = await unzipFolderToElements(buffer, brandName, name)
+      const root = await unzipFolderToElements({ buffer, brandName, name, idsToElements: {} })
       const { content } = root.files['manifest_json@v']
       expect(isStaticFile(content)).toBeTruthy()
       if (!isStaticFile(content)) {

--- a/packages/zendesk-adapter/package.json
+++ b/packages/zendesk-adapter/package.json
@@ -30,6 +30,7 @@
     "lint-fix": "yarn lint --fix"
   },
   "dependencies": {
+    "@handlebars/parser": "^2.1.0",
     "@salto-io/adapter-api": "0.3.53",
     "@salto-io/adapter-components": "0.3.53",
     "@salto-io/adapter-utils": "0.3.53",

--- a/packages/zendesk-adapter/src/filters/template_engines/handlebar_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/handlebar_parser.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { parse } from '@handlebars/parser'
+import { BlockStatement, MustacheStatement, Node, NumberLiteral, PathExpression, SubExpression } from '@handlebars/parser/types/ast'
+import { values } from '@salto-io/lowerdash'
+
+const RELEVANT_HELPERS = ['is', 'isnt']
+const isMustacheStatement = (node: Node): node is MustacheStatement => node.type === 'MustacheStatement'
+const isBlockStatement = (node: Node): node is BlockStatement => node.type === 'BlockStatement'
+const isSubExpression = (node: Node): node is SubExpression => node.type === 'SubExpression'
+const isPathExpression = (node: Node): node is PathExpression => node.type === 'PathExpression'
+const isNumberLiteral = (node: Node): node is NumberLiteral => node.type === 'NumberLiteral'
+
+const extractHelper = (node: MustacheStatement['path'] | BlockStatement['path']): string | undefined => {
+  if (isSubExpression(node)) {
+    return extractHelper(node.path)
+  }
+  if (isPathExpression(node)) {
+    return typeof node.head === 'string' ? node.head : extractHelper(node.head)
+  }
+  return undefined // When node is a Literal
+}
+
+/**
+ * Extracts all the number literals from a handlebar template that are used as arguments in relevant helper functions
+ * @example parseHandlebarReferences('Hello {{#is id 12345}}good name{{else}}bad name{{/is}}')
+ * // Returns [{ value: 12345, loc: { start: { line: 1, column: 18 }, end: { line: 1, column: 23 } } }]
+ */
+export const parseHandlebarReferences = (template: string): NumberLiteral[] => {
+  const ast = parse(template)
+  return ast.body.map(node => {
+    if (isMustacheStatement(node) || isBlockStatement(node)) {
+      const helper = extractHelper(node.path)
+      if (helper && RELEVANT_HELPERS.includes(helper)) {
+        return node.params.filter(isNumberLiteral)
+      }
+    }
+    return undefined
+  }).filter(values.isDefined).flat()
+}

--- a/packages/zendesk-adapter/test/filters/template_engines/handlebar_parser.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/handlebar_parser.test.ts
@@ -1,0 +1,38 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { parseHandlebarReferences } from '../../../src/filters/template_engines/handlebar_parser'
+
+describe('parse', () => {
+  it('should parse a template with a relevant helper function', () => {
+    const template = 'Hello {{#is id 12345}}good name{{else}}bad name{{/is}}'
+    const parsed = parseHandlebarReferences(template)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].value).toEqual(12345)
+  })
+
+  it('should parse a template with a relevant helper function and a sub expression', () => {
+    const template = 'Hello {{#is (lookup id) 12345}}good name{{else}}bad name{{/is}}'
+    const parsed = parseHandlebarReferences(template)
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].value).toEqual(12345)
+  })
+
+  it('should not parse a template with an irrelevant helper function', () => {
+    const template = 'Hello {{#if id 123456}}good name{{else}}bad name{{/if}}{{notBlock 1231}}'
+    const parsed = parseHandlebarReferences(template)
+    expect(parsed).toHaveLength(0)
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1733,6 +1733,11 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
+"@handlebars/parser@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@handlebars/parser/-/parser-2.1.0.tgz#100e625d53c339e2b571c91fa93a455e93670fe2"
+  integrity sha512-R14NuNaSKZ6eE9y4t0fg/1f8iKd5ZJtSOTIseGFzXINTV17XffhLG2Y0CvdKOgyVQ7+UnXi89YGzRo/xsgwHIA==
+
 "@hapi/hoek@^9.0.0":
   version "9.2.1"
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.2.1.tgz#9551142a1980503752536b5050fd99f4a7f13b17"


### PR DESCRIPTION
Extract references from handlebar templates. First stage, only log the results.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
