### PR TITLE
new Dependency Flow - changing removal depencdency 

### DIFF
--- a/packages/core/test/core/plan/dependency.test.ts
+++ b/packages/core/test/core/plan/dependency.test.ts
@@ -454,5 +454,25 @@ describe('dependency changers', () => {
         expect(dependencyChanges).toHaveLength(0)
       })
     })
+    describe('when reference changed and old referenced element removed', () => {
+      beforeEach(async () => {
+        const testInstanceAfter = testInstance.clone()
+        const firstTestReferenceInstance = new InstanceElement('first_ref', testType)
+        const secondTestReferenceInstance = new InstanceElement('second_ref', testType)
+        testInstance.value.ref = new ReferenceExpression(firstTestReferenceInstance.elemID)
+        testInstanceAfter.value.ref = new ReferenceExpression(secondTestReferenceInstance.elemID)
+        const inputChanges = new Map<number, Change>([
+          [0, toChange({ before: firstTestReferenceInstance })],
+          [1, toChange({ before: testInstance, after: testInstanceAfter })],
+        ])
+        dependencyChanges = [...await addReferencesDependency(inputChanges, new Map())]
+      })
+
+      it('should add dependency to the removed referenced element', () => {
+        expect(dependencyChanges).toEqual([
+          { action: 'add', dependency: { source: 0, target: 1 } },
+        ])
+      })
+    })
   })
 })


### PR DESCRIPTION
bugfix - add new dependency flow.
From now on - if A has reference to B and A modified and B removed, A would be dependency of B. so A would change before B removed.

---

_Additional context for reviewer_
see https://salto-io.atlassian.net/browse/SALTO-5402

---
_Release Notes_: 
Zendesk adapter - fix bug of getting Service error while removing trigger_category and changing trigger to be depend on other category simultaneously 

---
_User Notifications_: 

None