### PR TITLE
SALTO-2392 reduce employees queries

### DIFF
--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -17,7 +17,7 @@ import { types as lowerdashTypes } from '@salto-io/lowerdash'
 import { ElemID, ListType, BuiltinTypes, CORE_ANNOTATIONS, createRestriction, MapType, Values } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { definitions } from '@salto-io/adapter-components'
-import { BIN, CURRENCY, CUSTOM_RECORD_TYPE, DATASET, EXCHANGE_RATE, INACTIVE_FIELDS, NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK } from '../constants'
+import { BIN, CURRENCY, CUSTOM_RECORD_TYPE, DATASET, EMPLOYEE, EXCHANGE_RATE, INACTIVE_FIELDS, NETSUITE, PERMISSIONS, SAVED_SEARCH, WORKBOOK } from '../constants'
 import { netsuiteSupportedTypes } from '../types'
 import { ITEM_TYPE_TO_SEARCH_STRING } from '../data_elements/types'
 import { ALL_TYPES_REGEX, GROUPS_TO_DATA_FILE_TYPES, DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_COMMAND_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY, DEFAULT_FETCH_ALL_TYPES_AT_ONCE, DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB, DEFAULT_MAX_ITEMS_IN_IMPORT_OBJECTS_REQUEST, FILE_CABINET, FILE_TYPES_TO_EXCLUDE_REGEX, INCLUDE_ALL } from './constants'
@@ -460,7 +460,7 @@ export const fetchDefault: FetchParams = {
       { name: DATASET },
       { name: 'customer' },
       { name: 'accountingPeriod' },
-      { name: 'employee' },
+      { name: EMPLOYEE },
       { name: 'job' },
       { name: 'manufacturingCostTemplate' },
       { name: 'partner' },

--- a/packages/netsuite-adapter/src/data_elements/custom_fields.ts
+++ b/packages/netsuite-adapter/src/data_elements/custom_fields.ts
@@ -18,7 +18,7 @@ import { BuiltinTypes, Field, InstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { SOAP_FIELDS_TYPES } from '../client/suiteapp_client/soap_client/types'
 import { INTERNAL_ID_TO_TYPES } from './types'
-import { OTHER_CUSTOM_FIELD } from '../constants'
+import { EMPLOYEE, OTHER_CUSTOM_FIELD } from '../constants'
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?([+-]\d{2}:\d{2})?$/
 
@@ -26,7 +26,7 @@ const CUSTOM_FIELD_TO_TYPE: Record<string, Record<string, string[]>> = {
   entitycustomfield: {
     appliestocontact: ['contact'],
     appliestocustomer: ['customer'],
-    appliestoemployee: ['employee'],
+    appliestoemployee: [EMPLOYEE],
     appliestopartner: ['partner'],
     appliestovendor: ['vendor'],
     appliestopricelist: ['priceList'],

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -17,7 +17,7 @@ import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
 import { CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, TopLevelElement, createRefToElmWithValue } from '@salto-io/adapter-api'
 import NetsuiteClient from '../client/client'
-import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../constants'
+import { ALLOCATION_TYPE, EMPLOYEE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../constants'
 import { getLastServerTime } from '../server_time'
 import { toSuiteQLWhereDateString } from '../changes_detector/date_formats'
 import { SuiteQLTableName } from './types'
@@ -516,7 +516,8 @@ const getSuiteQLTableInstance = async (
   const instanceElemId = suiteQLTableType.elemID.createNestedID('instance', tableName)
   const existingInstance = await elementsSource.get(instanceElemId)
   fixExistingInstance(suiteQLTableType, existingInstance)
-  if (isPartial) {
+  // we want to query employees in partial fetch too, for _changed_by
+  if (isPartial && tableName !== EMPLOYEE) {
     return existingInstance
   }
   const instance = createOrGetExistingInstance(suiteQLTableType, tableName, existingInstance)

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -16,7 +16,7 @@
 import { BuiltinTypes, ElemID, Field, isContainerType, isObjectType, isPrimitiveType, ListType, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { NETSUITE, PARENT, RECORD_REF } from '../constants'
+import { EMPLOYEE, NETSUITE, PARENT, RECORD_REF } from '../constants'
 import { LocalFilterCreator } from '../filter'
 
 const { awu } = collections.asynciterable
@@ -141,7 +141,7 @@ const fieldNameToTypeName: Record<string, string | undefined> = {
   owner: undefined,
   attendee: undefined,
   resource: undefined,
-  employee: 'employee',
+  employee: EMPLOYEE,
   customer: 'customer',
   payrollItem: 'payrollItem',
   temporaryLocalJurisdiction: undefined,
@@ -221,7 +221,7 @@ const fieldNameToTypeName: Record<string, string | undefined> = {
   voidJournal: undefined,
   payeeAddressList: undefined,
   contactSource: undefined,
-  supervisor: 'employee',
+  supervisor: EMPLOYEE,
   assistant: undefined,
   role: 'role',
   entityStatus: undefined,

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -21,7 +21,7 @@ import { Element, ElemID, InstanceElement, ReadOnlyElementsSource, Value, Values
 import { WALK_NEXT_STEP, resolvePath, walkOnElement, walkOnValue } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../client/client'
 import { RemoteFilterCreator } from '../filter'
-import { ACCOUNT_SPECIFIC_VALUE, ALLOCATION_TYPE, INIT_CONDITION, NAME_FIELD, PROJECT_EXPENSE_TYPE, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
+import { ACCOUNT_SPECIFIC_VALUE, ALLOCATION_TYPE, EMPLOYEE, INIT_CONDITION, NAME_FIELD, PROJECT_EXPENSE_TYPE, SCRIPT_ID, SELECT_RECORD_TYPE, TAX_SCHEDULE, WORKFLOW } from '../constants'
 import { QUERY_RECORD_TYPES, QueryRecordType, QueryRecordResponse, QueryRecordSchema } from '../client/suiteapp_client/types'
 import { SUITEQL_TABLE, getSuiteQLTableInternalIdsMap } from '../data_elements/suiteql_table_elements'
 import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
@@ -124,12 +124,12 @@ const getSelectRecordType: GetFieldTypeIDFunc = params => {
 
 const GET_FIELD_TYPE_FUNCTIONS: Record<string, GetFieldTypeIDFunc> = {
   sender: ({ isFieldWithAccountSpecificValue }) => (
-    isFieldWithAccountSpecificValue ? 'employee' : undefined
+    isFieldWithAccountSpecificValue ? EMPLOYEE : undefined
   ),
   recipient: ({ isFieldWithAccountSpecificValue }) => (
     // there is no intersection between the internal ids of those types,
     // and no indication in the element which type should be used.
-    isFieldWithAccountSpecificValue ? ['employee', 'contact', 'customer', 'partner', 'vendor'] : undefined
+    isFieldWithAccountSpecificValue ? [EMPLOYEE, 'contact', 'customer', 'partner', 'vendor'] : undefined
   ),
   campaignevent: ({ isFieldWithAccountSpecificValue }) => (
     isFieldWithAccountSpecificValue ? 'campaignEvent' : undefined

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -276,9 +276,9 @@ describe('SuiteQL table elements', () => {
   describe('when isPartial=true', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockResolvedValue([
-        { id: '1', name: 'Some name' },
-        { id: '2', name: 'Some name 2' },
-        { id: '3', name: 'Some name 3' },
+        { id: '1', entityid: 'Some name' },
+        { id: '2', entityid: 'Some name 2' },
+        { id: '3', entityid: 'Some name 3' },
       ])
       const elementsSource = buildElementsSourceFromElements([
         suiteQLTableType,
@@ -289,8 +289,8 @@ describe('SuiteQL table elements', () => {
       elements = await getSuiteQLTableElements(client, elementsSource, true)
     })
 
-    it('should return only existing instances', () => {
-      expect(elements).toHaveLength(4)
+    it('should return only existing instances and employee instance', () => {
+      expect(elements).toHaveLength(5)
       const existingInstance = elements.filter(isInstanceElement)
         .find(element => element.elemID.name === 'currency')
       expect(existingInstance?.value).toEqual({
@@ -317,10 +317,21 @@ describe('SuiteQL table elements', () => {
         [INTERNAL_IDS_MAP]: {},
         version: 1,
       })
+      const employeeInstance = elements.filter(isInstanceElement)
+        .find(element => element.elemID.name === 'employee')
+      expect(employeeInstance?.value).toEqual({
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+        version: 1,
+      })
     })
 
     it('should not call runSuiteQL', () => {
-      expect(runSuiteQLMock).not.toHaveBeenCalled()
+      expect(runSuiteQLMock).toHaveBeenCalledTimes(1)
+      expect(runSuiteQLMock).toHaveBeenCalledWith(expect.stringContaining('FROM employee'))
     })
   })
 })


### PR DESCRIPTION
Use the existing "employee" suiteQLTable instance to populate the `_changed_by` annotation.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None