### PR TITLE
SALTO-5382 - Don't skip deploy groups if a dependency had a recoverable error

### DIFF
--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -170,17 +170,10 @@ export const deployActions = async (
             item.groupKey,
             nonFatalErrors.map(err => err.message).join('\n\n'),
           )
-          accumulatedNonFatalErrors.push(
-            ...nonFatalErrors
-              .map(err => ({ ...err, groupId: item.groupKey }))
-          )
+          accumulatedNonFatalErrors.push(...nonFatalErrors.map(err => ({ ...err, groupId: item.groupKey })))
         }
         if (fatalErrors.length > 0) {
-          log.warn(
-            'Failed to deploy %s, errors: %s',
-            item.groupKey,
-            fatalErrors.map(err => err.message).join('\n\n'),
-          )
+          log.warn('Failed to deploy %s, errors: %s', item.groupKey, fatalErrors.map(err => err.message).join('\n\n'))
           throw new WalkDeployError(fatalErrors)
         }
         reportProgress(item, 'finished')

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -137,6 +137,7 @@ export const deployActions = async (
 ): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
   const groups: GroupProperties[] = []
+  const accumulatedNonFatalErrors: DeployError[] = []
   try {
     await deployPlan.walkAsync(async (itemId: PlanItemId): Promise<void> => {
       const item = deployPlan.getItem(itemId) as PlanItem
@@ -162,9 +163,26 @@ export const deployActions = async (
         // will have an updated version throughout the deploy plan
         updatePlanElement(item, result.appliedChanges)
         await postDeployAction(result.appliedChanges)
-        if (result.errors.length > 0) {
-          log.warn('Failed to deploy %s, errors: %s', item.groupKey, result.errors.map(err => err.message).join('\n\n'))
-          throw new WalkDeployError(result.errors)
+        const [fatalErrors, nonFatalErrors] = _.partition(result.errors, error => error.severity === 'Error')
+        if (nonFatalErrors.length > 0) {
+          log.warn(
+            'Deploy of %s encountered non-fatal issues: %s',
+            item.groupKey,
+            nonFatalErrors.map(err => err.message).join('\n\n'),
+          )
+          accumulatedNonFatalErrors.push(
+            ...nonFatalErrors
+              .map(err => ({ ...err, groupId: item.groupKey }))
+          )
+        }
+        if (fatalErrors.length > 0) {
+          log.warn(
+            'Failed to deploy %s, fatal errors: %s, non-fatal errors: %s',
+            item.groupKey,
+            fatalErrors.map(err => err.message).join('\n\n'),
+            nonFatalErrors.map(err => err.message).join('\n\n'),
+          )
+          throw new WalkDeployError(fatalErrors)
         }
         reportProgress(item, 'finished')
       } catch (error) {
@@ -208,6 +226,6 @@ export const deployActions = async (
         })
       }
     }
-    return { errors: deployErrors, appliedChanges, extraProperties: { groups } }
+    return { errors: deployErrors.concat(accumulatedNonFatalErrors), appliedChanges, extraProperties: { groups } }
   }
 }

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -191,7 +191,7 @@ export const deployActions = async (
         throw error
       }
     })
-    return { errors: [], appliedChanges, extraProperties: { groups } }
+    return { errors: accumulatedNonFatalErrors, appliedChanges, extraProperties: { groups } }
   } catch (error) {
     const deployErrors: DeployError[] = []
     if (error instanceof WalkError) {

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -177,10 +177,9 @@ export const deployActions = async (
         }
         if (fatalErrors.length > 0) {
           log.warn(
-            'Failed to deploy %s, fatal errors: %s, non-fatal errors: %s',
+            'Failed to deploy %s, errors: %s',
             item.groupKey,
             fatalErrors.map(err => err.message).join('\n\n'),
-            nonFatalErrors.map(err => err.message).join('\n\n'),
           )
           throw new WalkDeployError(fatalErrors)
         }

--- a/packages/core/test/core/deploy/deploy_actions.test.ts
+++ b/packages/core/test/core/deploy/deploy_actions.test.ts
@@ -1,0 +1,158 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import {
+  AdapterOperations, Change, DependencyChanger, Element, ElemID, InstanceElement, isInstanceChange,
+  isObjectTypeChange,
+  ObjectType,
+} from '@salto-io/adapter-api'
+import { deployActions } from '../../../src/core/deploy'
+import { Plan, getPlan } from '../../../src/core/plan'
+import { DeployError } from '../../../src/types'
+
+const ADAPTER_NAME = 'adapter'
+
+const createDeployPlanFromElements = async (elements: Element[]): Promise<Plan> => {
+  const dependencyChanger: DependencyChanger = async changes => {
+    const typeChangeId = Array.from(changes.entries())
+      .filter(([, change]) => isObjectTypeChange(change))
+      .map(([changeId]) => changeId)[0]
+    return Array.from(changes.entries())
+      .filter(([, change]) => isInstanceChange(change))
+      .map(([changeId]) => ({
+        action: 'add',
+        dependency: {
+          source: changeId,
+          target: typeChangeId,
+        },
+      }))
+  }
+  return getPlan({
+    before: buildElementsSourceFromElements([]),
+    after: buildElementsSourceFromElements(elements),
+    customGroupIdFunctions: {
+      [ADAPTER_NAME]: async changes => ({
+        changeGroupIdMap: new Map(
+          Array.from(changes.keys())
+            .map(changeId => [changeId, changeId as string])
+        ),
+      }),
+    },
+    dependencyChangers: [dependencyChanger],
+  })
+}
+
+describe('deployActions', () => {
+  let deployResult: {
+    errors: DeployError[]
+    appliedChanges: Change[]
+  }
+  describe('Dependent group behavior on errors', () => {
+    const objectType = new ObjectType({
+      elemID: new ElemID(ADAPTER_NAME, 'SomeType'),
+    })
+    describe('When a group has an error with `info` severity', () => {
+      beforeEach(async () => {
+        const instance = new InstanceElement('Instance1', objectType)
+        const deployPlan: Plan = await createDeployPlanFromElements([objectType, instance])
+        const mockAdapterOperations: AdapterOperations = {
+          fetch: jest.fn().mockResolvedValue({}),
+          deploy: jest.fn().mockImplementation(async deployParams => ({
+            errors: [{
+              message: 'Test message',
+              severity: 'Info' as const,
+            }],
+            appliedChanges: deployParams.changeGroup.changes,
+          })),
+        }
+        deployResult = await deployActions(
+          deployPlan,
+          {
+            [ADAPTER_NAME]: mockAdapterOperations,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          () => {},
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          async () => {},
+          false,
+        )
+      })
+      it('Should produce the correct errors', () => {
+        expect(deployResult.errors).toHaveLength(2)
+        expect(deployResult.errors).toSatisfyAll(error => error.severity === 'Info')
+      })
+      it('Should still deploy the dependant group', () => {
+        expect(deployResult.appliedChanges).toHaveLength(2)
+      })
+    })
+    describe('When a group has an error with `error` severity', () => {
+      beforeEach(async () => {
+        const instance1 = new InstanceElement('Instance1', objectType)
+        const instance2 = new InstanceElement('Instance2', objectType)
+        const deployPlan: Plan = await createDeployPlanFromElements([objectType, instance1, instance2])
+        const mockAdapterOperations: AdapterOperations = {
+          fetch: jest.fn().mockResolvedValue({}),
+          deploy: jest.fn().mockImplementation(async deployParams => {
+            if (deployParams.changeGroup.groupID.includes('instance')) {
+              return {
+                errors: [],
+                appliedChanges: deployParams.changeGroup.changes,
+              }
+            }
+            return {
+              errors: [
+                {
+                  message: 'Test message',
+                  severity: 'Error' as const,
+                },
+              ],
+              appliedChanges: [],
+            }
+          }),
+        }
+        deployResult = await deployActions(
+          deployPlan,
+          {
+            [ADAPTER_NAME]: mockAdapterOperations,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          () => {},
+          // eslint-disable-next-line @typescript-eslint/no-empty-function
+          async () => {},
+          false,
+        )
+      })
+      it('Should produce the correct error', () => {
+        expect(deployResult.errors).toHaveLength(3)
+        expect(deployResult.errors).toSatisfyAll(error => error.severity === 'Error')
+        expect(deployResult.errors).toEqual([
+          expect.objectContaining({
+            message: 'Test message',
+          }),
+          expect.objectContaining({
+            message: 'Element was not deployed, as it depends on adapter.SomeType/add which failed to deploy',
+          }),
+          expect.objectContaining({
+            message: 'Element was not deployed, as it depends on adapter.SomeType/add which failed to deploy',
+          }),
+        ])
+      })
+      it('Should not deploy dependant groups', () => {
+        expect(deployResult.appliedChanges).toBeEmpty()
+      })
+    })
+  })
+})

--- a/packages/core/test/core/deploy/deploy_actions.test.ts
+++ b/packages/core/test/core/deploy/deploy_actions.test.ts
@@ -1,21 +1,27 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import {
-  AdapterOperations, Change, DependencyChanger, Element, ElemID, InstanceElement, isInstanceChange,
+  AdapterOperations,
+  Change,
+  DependencyChanger,
+  Element,
+  ElemID,
+  InstanceElement,
+  isInstanceChange,
   isObjectTypeChange,
   ObjectType,
 } from '@salto-io/adapter-api'
@@ -45,10 +51,7 @@ const createDeployPlanFromElements = async (elements: Element[]): Promise<Plan> 
     after: buildElementsSourceFromElements(elements),
     customGroupIdFunctions: {
       [ADAPTER_NAME]: async changes => ({
-        changeGroupIdMap: new Map(
-          Array.from(changes.keys())
-            .map(changeId => [changeId, changeId as string])
-        ),
+        changeGroupIdMap: new Map(Array.from(changes.keys()).map(changeId => [changeId, changeId as string])),
       }),
     },
     dependencyChangers: [dependencyChanger],
@@ -71,10 +74,12 @@ describe('deployActions', () => {
         const mockAdapterOperations: AdapterOperations = {
           fetch: jest.fn().mockResolvedValue({}),
           deploy: jest.fn().mockImplementation(async deployParams => ({
-            errors: [{
-              message: 'Test message',
-              severity: 'Info' as const,
-            }],
+            errors: [
+              {
+                message: 'Test message',
+                severity: 'Info' as const,
+              },
+            ],
             appliedChanges: deployParams.changeGroup.changes,
           })),
         }


### PR DESCRIPTION
No reason to skip the dependencies of a change group with e.g. 'Info' level warnings.

---

---
_Release Notes_: 
Dependencies of change groups that have low-severity errors will now be deployed.

---
_User Notifications_: 
N/A