### PR TITLE
SALTO-5409: Fix Jsm Permissons Validator

### DIFF
--- a/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
+++ b/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { Change, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { Change, ChangeValidator, getChangeData, isAdditionChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -30,8 +30,9 @@ const SUPPORTED_TYPES = new Set(
   [REQUEST_TYPE_NAME, QUEUE_TYPE, PORTAL_GROUP_TYPE, CALENDAR_TYPE, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, FORM_TYPE]
 )
 
-const getProjectChangesNames = (changes: ReadonlyArray<Change>): string[] => changes
+const getAdditionChangedProjectsNames = (changes: ReadonlyArray<Change>): string[] => changes
   .filter(isInstanceChange)
+  .filter(isAdditionChange)
   .map(getChangeData)
   .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
   .map(instance => instance.elemID.getFullName())
@@ -66,7 +67,7 @@ export const jsmPermissionsValidator: (
       .filter(instance => SUPPORTED_TYPES.has(instance.elemID.typeName))
       .filter(instance => hasValidParent(instance))
       // We don't need to check for permissions if we are also deploying the project itself
-      .filter(instance => !getProjectChangesNames(changes).includes(getParent(instance).elemID.getFullName()))
+      .filter(instance => !getAdditionChangedProjectsNames(changes).includes(getParent(instance).elemID.getFullName()))
       .filter(instance => !serviceDeskProjectIds.includes(getParent(instance).value.id))
       .map(instance => ({
         elemID: instance.elemID,

--- a/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
+++ b/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
@@ -13,20 +13,29 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeValidator, getChangeData, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { Change, ChangeValidator, getChangeData, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import JiraClient from '../../client/client'
 import { JiraConfig } from '../../config/config'
-import { JSM_DUCKTYPE_SUPPORTED_TYPES } from '../../config/api_config'
+import { REQUEST_TYPE_NAME, QUEUE_TYPE, PORTAL_GROUP_TYPE, CALENDAR_TYPE, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, FORM_TYPE, PROJECT_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
 const { createPaginator, getWithCursorPagination } = clientUtils
 const { toArrayAsync } = collections.asynciterable
 const { makeArray } = collections.array
 
-const SUPPORTED_TYPES = new Set(Object.keys(JSM_DUCKTYPE_SUPPORTED_TYPES))
+const SUPPORTED_TYPES = new Set(
+  [REQUEST_TYPE_NAME, QUEUE_TYPE, PORTAL_GROUP_TYPE, CALENDAR_TYPE, PORTAL_SETTINGS_TYPE_NAME, SLA_TYPE_NAME, FORM_TYPE]
+)
+
+const getProjectChangesNames = (changes: ReadonlyArray<Change>): string[] => changes
+  .filter(isInstanceChange)
+  .map(getChangeData)
+  .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
+  .map(instance => instance.elemID.getFullName())
+
 /*
 * This validator prevents deployment of jsm types when user has no jsm permissions.
 */
@@ -56,6 +65,8 @@ export const jsmPermissionsValidator: (
       .map(getChangeData)
       .filter(instance => SUPPORTED_TYPES.has(instance.elemID.typeName))
       .filter(instance => hasValidParent(instance))
+      // We don't need to check for permissions if we are also deploying the project itself
+      .filter(instance => !getProjectChangesNames(changes).includes(getParent(instance).elemID.getFullName()))
       .filter(instance => !serviceDeskProjectIds.includes(getParent(instance).value.id))
       .map(instance => ({
         elemID: instance.elemID,

--- a/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
+++ b/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
@@ -115,4 +115,12 @@ describe('jsmPermissionsValidator', () => {
     )
     expect(changeErrors).toHaveLength(0)
   })
+  it('should not return error if trying to deploy Jsm type with its associated project', async () => {
+    const validator = jsmPermissionsValidator(config, client)
+    projectInstance.value.id = '44'
+    const changeErrors = await validator(
+      [toChange({ after: queueInstance }), toChange({ after: projectInstance })],
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
 })


### PR DESCRIPTION
In this PR I fixed the jsmPermissionsValidator

---

_Additional context for reviewer_
This PR fixes two bugs that can be found in [this thread](https://salto-io.slack.com/archives/C02A0C56GGL/p1707304806010629?thread_ts=1707227425.893209&cid=C02A0C56GGL) and [this thread](https://salto-io.slack.com/archives/C05R7BP89RA/p1707320341823179) about JSM Permissions validator.

Bug 1 - Admins are encountering "Lacking permissions" errors despite they have permissions. 
The problem was that we are checking for the permission of the associated project even if the project itself is an addition change, and therefore doesn't locate in the system yet.
I filtered out all the changes that are connected to a project that being added as well. 

Bug 2 - unnecessary types are being validate. 
I removed the Assets type and kept just the JSM types that are associated to a project. 


---
_Release Notes_: 
_JIra Adapter_:
Fixed jsmPermissionsValidator.

---
_User Notifications_: 
None
