### PR TITLE
SALTO-5411: make get content of article_attachment use relative_path field

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1958,6 +1958,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
         { fieldName: 'content_url', fieldType: 'string' },
         { fieldName: 'size', fieldType: 'number' },
         { fieldName: 'hash', fieldType: 'string' },
+        { fieldName: 'relative_path', fieldType: 'string' },
       ),
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
@@ -1968,7 +1969,6 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldsToOmit: FIELDS_TO_OMIT.concat(
         { fieldName: 'article_id', fieldType: 'number' },
         { fieldName: 'display_file_name', fieldType: 'string' },
-        { fieldName: 'relative_path', fieldType: 'string' },
       ),
       extendsParentId: true,
       dataField: 'article_attachments',

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -130,11 +130,16 @@ const getAttachmentContent = async ({
     log.error(error)
     return contentWarning(error)
   }
+  if (attachment.value.relative_path === undefined) {
+    const error = `could not add attachment ${attachment.elemID.getFullName()}, as the relative_path is undefined`
+    log.error(error)
+    return contentWarning(error)
+  }
   const client = brandIdToClient[attachment.value.brand]
   let res
   try {
     res = await client.get({
-      url: `/hc/article_attachments/${attachment.value.id}/${attachment.value.file_name}`,
+      url: `${attachment.value.relative_path}`,
       responseType: 'arraybuffer',
     })
   } catch (e) {

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -132,7 +132,7 @@ const getAttachmentContent = async ({
   }
   if (attachment.value.relative_path === undefined) {
     const error = `could not add attachment ${attachment.elemID.getFullName()}, as the relative_path is undefined`
-    log.error(error)
+    log.warn(error)
     return contentWarning(error)
   }
   const client = brandIdToClient[attachment.value.brand]

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -138,6 +138,7 @@ describe('article filter', () => {
       inline: false,
       brand: brandInstance.value.id,
       content_url: 'https://someURL.com',
+      relative_path: '/hc/article_attachments/20222022/attachmentFileName.png',
     },
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [


### PR DESCRIPTION
make get content of article_attachment use relative_path field

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix fetch of attachments with non english characters

---
_User Notifications_: 
None
