### PR TITLE
SALTO-5401 Improve handling publish workflowScheme draft

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -164,7 +164,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
   },
   deploy: {
     forceDelete: false,
-    taskMaxRetries: 120,
+    taskMaxRetries: 180,
     taskRetryDelay: 1000,
   },
   masking: {

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -49,7 +49,7 @@ class InvalidResponseError extends PublishDraftError {
 
 class TooManyRetriesError extends PublishDraftError {
   constructor() {
-    super('Failed to publish workflow scheme draft after too many retries')
+    super('Could not verify successful deployment of workflow scheme. Check your Jira instance to see whether it was deployed')
   }
 }
 


### PR DESCRIPTION
Increase number of retries in checking workflowScheme draft change, and instead of sending a failure error, state that we run out of retries but don't know wether this was successful

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
