### PR TITLE
SALTO-5360 align inactive fields

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -95,6 +95,9 @@ describe('Netsuite adapter E2E with real account', () => {
     )
   }
 
+  // the hardcoded types have "isinactive"/"inactive" fields and there's a filter
+  // that replace them with "isInactive", so we should do that too here in order
+  // to compare a fetched instance and a hardcoded instance
   const alignInactiveFields = (instance: InstanceElement): InstanceElement => {
     const cloned = instance.clone()
     const type = cloned.getTypeSync().clone()

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -94,9 +94,9 @@ const includeCustomRecords = (config: NetsuiteConfig): FetchTypeQueryParams[] =>
   return [{ name: config.includeCustomRecords.join('|') }]
 }
 
-const excludeInactiveRecords = (config: NetsuiteConfig): CriteriaQuery[] => {
+const excludeInactiveRecords = (config: NetsuiteConfig): CriteriaQuery | undefined => {
   if (config.includeInactiveRecords === undefined || config.includeInactiveRecords.includes(INCLUDE_ALL)) {
-    return []
+    return undefined
   }
 
   const typesToInclude = config.includeInactiveRecords
@@ -107,12 +107,12 @@ const excludeInactiveRecords = (config: NetsuiteConfig): CriteriaQuery[] => {
     // match all except for the exact strings in typesToInclude
     : `(?!(${typesToInclude.join('|')})$).*`
 
-  return Object.values(INACTIVE_FIELDS).map(fieldName => ({
+  return {
     name: inactiveRecordsToExcludeRegex,
     criteria: {
-      [fieldName]: true,
+      [INACTIVE_FIELDS.isInactive]: true,
     },
-  }))
+  }
 }
 
 const excludeDataFileTypes = (config: NetsuiteConfig): string[] => {
@@ -142,7 +142,7 @@ const updatedFetchInclude = (config: NetsuiteConfig): QueryParams => ({
 
 const updatedFetchExclude = (config: NetsuiteConfig): QueryParams => ({
   ...config.fetch.exclude,
-  types: config.fetch.exclude.types.concat(excludeInactiveRecords(config)),
+  types: config.fetch.exclude.types.concat(excludeInactiveRecords(config) ?? []),
   fileCabinet: config.fetch.exclude.fileCabinet.concat(excludeDataFileTypes(config)),
 })
 

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -474,13 +474,12 @@ export const fetchDefault: FetchParams = {
           .filter(itemTypeName => !['giftCertificateItem', 'downloadItem'].includes(itemTypeName))
           .join('|'),
       }, // may be a lot of data that takes a lot of time to fetch
-      ...Object.values(INACTIVE_FIELDS)
-        .map((fieldName): CriteriaQuery => ({
-          name: ALL_TYPES_REGEX,
-          criteria: {
-            [fieldName]: true,
-          },
-        })),
+      {
+        name: ALL_TYPES_REGEX,
+        criteria: {
+          [INACTIVE_FIELDS.isInactive]: true,
+        },
+      },
       {
         name: SAVED_SEARCH,
         criteria: {

--- a/packages/netsuite-adapter/src/filters/align_field_names.ts
+++ b/packages/netsuite-adapter/src/filters/align_field_names.ts
@@ -1,0 +1,194 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
+import { AdditionChange, Field, InstanceElement, ModificationChange, ObjectType, Values, isAdditionOrModificationChange, isInstanceChange, isInstanceElement, isObjectType, isObjectTypeChange } from '@salto-io/adapter-api'
+import { customrecordtypeType } from '../autogen/types/standard_types/customrecordtype'
+import { INACTIVE_FIELDS } from '../constants'
+import { LocalFilterCreator } from '../filter'
+import { isCustomRecordType, isDataObjectType } from '../types'
+
+const log = logger(module)
+
+const ORIGINAL_NAME = 'originalName'
+
+const FIELDS_TO_ALIGN = [
+  { from: INACTIVE_FIELDS.isinactive, to: INACTIVE_FIELDS.isInactive },
+  { from: INACTIVE_FIELDS.inactive, to: INACTIVE_FIELDS.isInactive },
+]
+
+const CUSTOM_RECORD_TYPE_ANNOTATIONS_TO_ALIGN = [
+  { from: customrecordtypeType().type.fields.isinactive.name, to: INACTIVE_FIELDS.isInactive },
+]
+
+const runFuncOnFieldType = (
+  func: (fieldType: ObjectType, value: Values) => void
+): TransformFuncSync =>
+  ({ field, value }) => {
+    const fieldType = field?.getTypeSync()
+    if (isObjectType(fieldType) && _.isPlainObject(value)) {
+      func(fieldType, value)
+    }
+    return value
+  }
+
+const runFuncOnCustomRecordTypeNestedAnnotations = (
+  type: ObjectType,
+  func: (fieldType: ObjectType, values: Values) => void
+): void => {
+  Object.entries(type.annotationRefTypes).forEach(([anno, annoRefType]) => {
+    const annoType = annoRefType.getResolvedValueSync()
+    if (isObjectType(annoType) && _.isPlainObject(type.annotations[anno])) {
+      func(annoType, type.annotations[anno])
+      transformValuesSync({
+        values: type.annotations[anno],
+        type: annoType,
+        strict: false,
+        pathID: type.elemID.createNestedID('attr', anno),
+        transformFunc: runFuncOnFieldType(func),
+      })
+    }
+  })
+}
+
+const runFuncOnInstance = (
+  instance: InstanceElement,
+  func: (fieldType: ObjectType, values: Values) => void
+): void => {
+  const type = instance.getTypeSync()
+  func(type, instance.value)
+  transformValuesSync({
+    values: instance.value,
+    type,
+    strict: false,
+    pathID: instance.elemID,
+    transformFunc: runFuncOnFieldType(func),
+  })
+}
+
+const alignFieldNamesInType = (type: ObjectType): void => {
+  FIELDS_TO_ALIGN.forEach(field => {
+    if (type.fields[field.from] === undefined) {
+      return
+    }
+    if (type.fields[field.to] !== undefined) {
+      log.warn('cannot align field %s in type %s - field %s already exist', field.from, type.elemID.name, field.to)
+      return
+    }
+    const { refType, annotations } = type.fields[field.from]
+    const newAnnotations = { ...annotations, [ORIGINAL_NAME]: field.from }
+    type.fields[field.to] = new Field(type, field.to, refType, newAnnotations)
+    delete type.fields[field.from]
+  })
+}
+
+const alignFieldNamesInValue = (type: ObjectType, value: Values): void => {
+  Object.values(type.fields).forEach(field => {
+    if (field.annotations[ORIGINAL_NAME] !== undefined) {
+      value[field.name] = value[field.annotations[ORIGINAL_NAME]]
+      delete value[field.annotations[ORIGINAL_NAME]]
+    }
+  })
+}
+
+const restoreFieldNamesInValue = (type: ObjectType, value: Values): void => {
+  Object.values(type.fields).forEach(field => {
+    const originalName = field.annotations[ORIGINAL_NAME]
+    if (originalName === undefined) {
+      return
+    }
+    if (type.fields[originalName] === undefined) {
+      const annotations = _.omit(field.annotations, ORIGINAL_NAME)
+      type.fields[originalName] = new Field(type, originalName, field.refType, annotations)
+    }
+    value[originalName] = value[field.name]
+    delete value[field.name]
+  })
+}
+
+const alignFieldNamesInCustomRecordType = (type: ObjectType): void => {
+  CUSTOM_RECORD_TYPE_ANNOTATIONS_TO_ALIGN.forEach(anno => {
+    type.annotationRefTypes[anno.to] = type.annotationRefTypes[anno.from]
+    delete type.annotationRefTypes[anno.from]
+    type.annotations[anno.to] = type.annotations[anno.from]
+    delete type.annotations[anno.from]
+  })
+  runFuncOnCustomRecordTypeNestedAnnotations(type, alignFieldNamesInValue)
+}
+
+const alignFieldNamesInInstance = (instance: InstanceElement): void =>
+  runFuncOnInstance(instance, alignFieldNamesInValue)
+
+const restoreFieldNamesInCustomRecordType = (type: ObjectType): void => {
+  CUSTOM_RECORD_TYPE_ANNOTATIONS_TO_ALIGN.forEach(anno => {
+    type.annotationRefTypes[anno.from] = type.annotationRefTypes[anno.to]
+    delete type.annotationRefTypes[anno.to]
+    type.annotations[anno.from] = type.annotations[anno.to]
+    delete type.annotations[anno.to]
+  })
+  runFuncOnCustomRecordTypeNestedAnnotations(type, restoreFieldNamesInValue)
+}
+
+const restoreFieldNamesInInstance = (instance: InstanceElement): void =>
+  runFuncOnInstance(instance, restoreFieldNamesInValue)
+
+const restoreFieldNamesInInstanceChange = (
+  change: AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
+): void => {
+  const type = change.data.after.getTypeSync()
+  if (isCustomRecordType(type)) {
+    return
+  }
+  const changeData = isDataObjectType(type)
+    // in data instances we should transform also the before
+    ? Object.values(change.data)
+    : [change.data.after]
+
+  changeData.forEach(restoreFieldNamesInInstance)
+}
+
+const filterCreator: LocalFilterCreator = () => ({
+  name: 'alignFieldNames',
+  onFetch: async elements => {
+    const [customRecordTypes, types] = _.partition(
+      elements.filter(isObjectType),
+      isCustomRecordType
+    )
+
+    types.forEach(alignFieldNamesInType)
+    customRecordTypes.forEach(alignFieldNamesInCustomRecordType)
+
+    elements.filter(isInstanceElement)
+      // custom record instances don't have field names to align ATM
+      .filter(instance => !isCustomRecordType(instance.getTypeSync()))
+      .forEach(alignFieldNamesInInstance)
+  },
+  preDeploy: async changes => {
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .forEach(restoreFieldNamesInInstanceChange)
+
+    changes
+      .filter(isAdditionOrModificationChange)
+      .filter(isObjectTypeChange)
+      .filter(change => isCustomRecordType(change.data.after))
+      .forEach(change => restoreFieldNamesInCustomRecordType(change.data.after))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/align_field_names.ts
+++ b/packages/netsuite-adapter/src/filters/align_field_names.ts
@@ -122,10 +122,14 @@ const restoreFieldNamesInValue = (type: ObjectType, value: Values): void => {
 
 const alignFieldNamesInCustomRecordType = (type: ObjectType): void => {
   CUSTOM_RECORD_TYPE_ANNOTATIONS_TO_ALIGN.forEach(anno => {
-    type.annotationRefTypes[anno.to] = type.annotationRefTypes[anno.from]
-    delete type.annotationRefTypes[anno.from]
-    type.annotations[anno.to] = type.annotations[anno.from]
-    delete type.annotations[anno.from]
+    if (type.annotationRefTypes[anno.from] !== undefined) {
+      type.annotationRefTypes[anno.to] = type.annotationRefTypes[anno.from]
+      delete type.annotationRefTypes[anno.from]
+    }
+    if (type.annotations[anno.from] !== undefined) {
+      type.annotations[anno.to] = type.annotations[anno.from]
+      delete type.annotations[anno.from]
+    }
   })
   runFuncOnCustomRecordTypeNestedAnnotations(type, alignFieldNamesInValue)
 }
@@ -135,10 +139,14 @@ const alignFieldNamesInInstance = (instance: InstanceElement): void =>
 
 const restoreFieldNamesInCustomRecordType = (type: ObjectType): void => {
   CUSTOM_RECORD_TYPE_ANNOTATIONS_TO_ALIGN.forEach(anno => {
-    type.annotationRefTypes[anno.from] = type.annotationRefTypes[anno.to]
-    delete type.annotationRefTypes[anno.to]
-    type.annotations[anno.from] = type.annotations[anno.to]
-    delete type.annotations[anno.to]
+    if (type.annotationRefTypes[anno.to] !== undefined) {
+      type.annotationRefTypes[anno.from] = type.annotationRefTypes[anno.to]
+      delete type.annotationRefTypes[anno.to]
+    }
+    if (type.annotations[anno.to] !== undefined) {
+      type.annotations[anno.from] = type.annotations[anno.to]
+      delete type.annotations[anno.to]
+    }
   })
   runFuncOnCustomRecordTypeNestedAnnotations(type, restoreFieldNamesInValue)
 }

--- a/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/exclude_by_criteria/exclude_custom_record_types.ts
@@ -16,10 +16,10 @@
 import _ from 'lodash'
 import { regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { isInstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, createRefToElmWithValue, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
 import { isCriteriaQuery } from '../../config/query'
 import { LocalFilterCreator } from '../../filter'
-import { isCustomRecordType } from '../../types'
+import { isCustomFieldName, isCustomRecordType } from '../../types'
 import { CUSTOM_RECORD_TYPE } from '../../constants'
 import { shouldExcludeElement } from './exclude_instances'
 
@@ -45,6 +45,16 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
       removedCustomRecordInstances.length,
       removedCustomRecordTypes.map(elem => elem.elemID.getFullName())
     )
+
+    elements
+      .filter(isObjectType)
+      .filter(isCustomRecordType)
+      .flatMap(type => Object.values(type.fields))
+      .filter(field => isCustomFieldName(field.name))
+      .filter(field => removedCustomRecordTypeNames.has(field.refType.elemID.name))
+      .forEach(field => {
+        field.refType = createRefToElmWithValue(BuiltinTypes.UNKNOWN)
+      })
   },
 })
 

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -149,8 +149,6 @@ describe('netsuite config creator', () => {
       config.value.includeInactiveRecords = []
       expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual([
         ...config.value.fetch.exclude.types,
-        { name: '.*', criteria: { isinactive: true } },
-        { name: '.*', criteria: { inactive: true } },
         { name: '.*', criteria: { isInactive: true } },
       ])
     })
@@ -159,8 +157,6 @@ describe('netsuite config creator', () => {
       const allExceptRegex = '(?!(workflow|file|folder)$).*'
       expect(netsuiteConfigFromConfig(config).fetch.exclude.types).toEqual([
         ...config.value.fetch.exclude.types,
-        { name: allExceptRegex, criteria: { isinactive: true } },
-        { name: allExceptRegex, criteria: { inactive: true } },
         { name: allExceptRegex, criteria: { isInactive: true } },
       ])
       expect(regex.isFullRegexMatch('workflow', allExceptRegex)).toBeFalsy()

--- a/packages/netsuite-adapter/test/filters/align_field_names.test.ts
+++ b/packages/netsuite-adapter/test/filters/align_field_names.test.ts
@@ -1,0 +1,332 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { BuiltinTypes, Change, ElemID, Element, InstanceElement, ObjectType, createRefToElmWithValue, getChangeData, isModificationChange, toChange } from '@salto-io/adapter-api'
+import { fileType as fileTypeCreator } from '../../src/types/file_cabinet_types'
+import { entryFormType } from '../../src/autogen/types/standard_types/entryForm'
+import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
+import { workflowType as workflowTypeCreator } from '../../src/autogen/types/standard_types/workflow'
+import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SOAP, SOURCE } from '../../src/constants'
+import { LocalFilterOpts } from '../../src/filter'
+import { TypeAndInnerTypes } from '../../src/types/object_types'
+import filterCreator from '../../src/filters/align_field_names'
+
+describe('align field names filter', () => {
+  let formType: ObjectType
+  let fileType: ObjectType
+  let workflowType: ObjectType
+  let workflowInnerTypes: ObjectType[]
+  let dataType: ObjectType
+  let standardCustomRecordType: TypeAndInnerTypes
+  let customRecordType: ObjectType
+  let formInstance: InstanceElement
+  let fileInstance: InstanceElement
+  let workflowInstance: InstanceElement
+  let dataInstance: InstanceElement
+  let elements: Element[]
+
+  beforeEach(() => {
+    formType = entryFormType().type
+    fileType = fileTypeCreator()
+    const workflowTypeAndInnerTypes = workflowTypeCreator()
+    workflowType = workflowTypeAndInnerTypes.type
+    workflowInnerTypes = Object.values(workflowTypeAndInnerTypes.innerTypes)
+    dataType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'account'),
+      fields: {
+        isinactive: {
+          refType: BuiltinTypes.BOOLEAN,
+          annotations: { someAnno: 'test' },
+        },
+      },
+      annotations: {
+        [SOURCE]: SOAP,
+      },
+    })
+    standardCustomRecordType = customrecordtypeType()
+    customRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord123'),
+      annotationRefsOrTypes: {
+        isinactive: BuiltinTypes.BOOLEAN,
+        instances: standardCustomRecordType.innerTypes.customrecordtype_instances,
+      },
+      annotations: {
+        scriptid: 'customrecord123',
+        isinactive: false,
+        instances: {
+          instance: [
+            {
+              scriptid: 'val123',
+              isinactive: true,
+            },
+            {
+              scriptid: 'val456',
+              isinactive: false,
+            },
+          ],
+        },
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
+    formInstance = new InstanceElement(
+      'form123',
+      formType,
+      {
+        scriptid: 'form123',
+        inactive: true,
+      },
+    )
+    fileInstance = new InstanceElement(
+      'file123',
+      fileType,
+      {
+        path: '/file123',
+        isinactive: false,
+      },
+    )
+    workflowInstance = new InstanceElement(
+      'workflow123',
+      workflowType,
+      {
+        scriptid: 'workflow123',
+        isinactive: false,
+        workflowstates: {
+          workflowstate: [
+            {
+              scriptid: 'workflowstate6',
+              workflowactions: [
+                {
+                  triggertype: 'ONENTRY',
+                  setfieldvalueaction: [
+                    {
+                      scriptid: 'workflowaction23',
+                      isinactive: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      },
+    )
+    dataInstance = new InstanceElement(
+      'data123',
+      dataType,
+      {
+        name: 'data123',
+        isinactive: false,
+      }
+    )
+    elements = [
+      formType,
+      fileType,
+      workflowType,
+      ...workflowInnerTypes,
+      dataType,
+      standardCustomRecordType.innerTypes.customrecordtype_instances_instance,
+      customRecordType,
+      formInstance,
+      fileInstance,
+      workflowInstance,
+      dataInstance,
+    ]
+  })
+
+  describe('on fetch', () => {
+    beforeEach(async () => {
+      await filterCreator({} as LocalFilterOpts).onFetch?.(elements)
+    })
+    it('should align fields in types', () => {
+      expect(formType.fields.isInactive).toBeDefined()
+      expect(formType.fields.isInactive.annotations).toEqual({ originalName: 'inactive' })
+      expect(fileType.fields.isInactive).toBeDefined()
+      expect(fileType.fields.isInactive.annotations).toEqual({ originalName: 'isinactive' })
+      expect(workflowType.fields.isInactive).toBeDefined()
+      expect(workflowType.fields.isInactive.annotations).toEqual({ originalName: 'isinactive' })
+      const innerWorkflowType = workflowInnerTypes.find(type => type.elemID.name === 'workflow_workflowstates_workflowstate_workflowactions_setfieldvalueaction')
+      expect(innerWorkflowType?.fields.isInactive).toBeDefined()
+      expect(innerWorkflowType?.fields.isInactive.annotations).toEqual({ originalName: 'isinactive' })
+      expect(dataType.fields.isInactive).toBeDefined()
+      expect(dataType.fields.isInactive.annotations).toEqual({ originalName: 'isinactive', someAnno: 'test' })
+      expect(standardCustomRecordType.innerTypes.customrecordtype_instances_instance.fields.isInactive).toBeDefined()
+      expect(standardCustomRecordType.innerTypes.customrecordtype_instances_instance.fields.isInactive.annotations).toEqual({ originalName: 'isinactive' })
+    })
+    it('should align fields in instances', () => {
+      expect(formInstance.value).toEqual({
+        scriptid: 'form123',
+        isInactive: true,
+      })
+      expect(fileInstance.value).toEqual({
+        path: '/file123',
+        isInactive: false,
+      })
+      expect(workflowInstance.value).toEqual({
+        scriptid: 'workflow123',
+        isInactive: false,
+        workflowstates: {
+          workflowstate: [
+            {
+              scriptid: 'workflowstate6',
+              workflowactions: [
+                {
+                  triggertype: 'ONENTRY',
+                  setfieldvalueaction: [
+                    {
+                      scriptid: 'workflowaction23',
+                      isInactive: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+      expect(dataInstance.value).toEqual({
+        name: 'data123',
+        isInactive: false,
+      })
+    })
+    it('should align custom record type annotations', () => {
+      expect(customRecordType.annotationRefTypes).toEqual({
+        isInactive: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
+        instances: createRefToElmWithValue(standardCustomRecordType.innerTypes.customrecordtype_instances),
+      })
+      expect(customRecordType.annotations).toEqual({
+        scriptid: 'customrecord123',
+        isInactive: false,
+        instances: {
+          instance: [
+            {
+              scriptid: 'val123',
+              isInactive: true,
+            },
+            {
+              scriptid: 'val456',
+              isInactive: false,
+            },
+          ],
+        },
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      })
+    })
+  })
+
+  describe('pre deploy', () => {
+    let customRecordTypeChange: Change<ObjectType>
+    let formInstanceChange: Change<InstanceElement>
+    let fileInstanceChange: Change<InstanceElement>
+    let workflowInstanceChange: Change<InstanceElement>
+    let dataInstanceChange: Change<InstanceElement>
+    let changes: Change[]
+    beforeEach(async () => {
+      await filterCreator({} as LocalFilterOpts).onFetch?.(elements)
+      customRecordTypeChange = toChange({
+        before: customRecordType.clone(),
+        after: customRecordType.clone(),
+      })
+      formInstanceChange = toChange({
+        before: formInstance.clone(),
+        after: formInstance.clone(),
+      })
+      fileInstanceChange = toChange({
+        before: fileInstance.clone(),
+        after: fileInstance.clone(),
+      })
+      workflowInstanceChange = toChange({
+        before: workflowInstance.clone(),
+        after: workflowInstance.clone(),
+      })
+      dataInstanceChange = toChange({
+        before: dataInstance.clone(),
+        after: dataInstance.clone(),
+      })
+      changes = [
+        customRecordTypeChange,
+        formInstanceChange,
+        fileInstanceChange,
+        workflowInstanceChange,
+        dataInstanceChange,
+      ]
+      await filterCreator({} as LocalFilterOpts).preDeploy?.(changes)
+    })
+    it('should restore field names in instances', () => {
+      expect(getChangeData(formInstanceChange).value).toEqual({
+        scriptid: 'form123',
+        inactive: true,
+      })
+      expect(getChangeData(fileInstanceChange).value).toEqual({
+        path: '/file123',
+        isinactive: false,
+      })
+      expect(getChangeData(workflowInstanceChange).value).toEqual({
+        scriptid: 'workflow123',
+        isinactive: false,
+        workflowstates: {
+          workflowstate: [
+            {
+              scriptid: 'workflowstate6',
+              workflowactions: [
+                {
+                  triggertype: 'ONENTRY',
+                  setfieldvalueaction: [
+                    {
+                      scriptid: 'workflowaction23',
+                      isinactive: true,
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      })
+      expect(getChangeData(dataInstanceChange).value).toEqual({
+        name: 'data123',
+        isinactive: false,
+      })
+    })
+    it('should restore annotations in custom record type', () => {
+      expect(getChangeData(customRecordTypeChange).annotationRefTypes).toEqual({
+        isinactive: createRefToElmWithValue(BuiltinTypes.BOOLEAN),
+        instances: createRefToElmWithValue(standardCustomRecordType.innerTypes.customrecordtype_instances),
+      })
+      expect(getChangeData(customRecordTypeChange).annotations).toEqual({
+        scriptid: 'customrecord123',
+        isinactive: false,
+        instances: {
+          instance: [
+            {
+              scriptid: 'val123',
+              isinactive: true,
+            },
+            {
+              scriptid: 'val456',
+              isinactive: false,
+            },
+          ],
+        },
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      })
+    })
+    it('should restore also before of data instances', () => {
+      expect(isModificationChange(dataInstanceChange) && dataInstanceChange.data.before.value).toEqual({
+        name: 'data123',
+        isinactive: false,
+      })
+    })
+  })
+})


### PR DESCRIPTION
Align isinactive/inactive/isInactive fields to be all "isInactive", in top level & nested values.
In addition, changed the order of some filters and added removal of refTypes to excluded custom record types.

---

_Additional context for reviewer_
TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- align inactive fields

---
_User Notifications_: 
Netsuite Adapter:
- all isinactive/inactive fields will be replaced with "isInactive" field - in types, instances, and important values