### PR TITLE
INCIDENT-12941 Change to more accurate API call

### DIFF
--- a/packages/zendesk-adapter/src/filters/organizations.ts
+++ b/packages/zendesk-adapter/src/filters/organizations.ts
@@ -138,10 +138,9 @@ export const getOrCreateOrganizationsByNames = async ({
   paginator: clientUtils.Paginator
   createMissingOrganizations?: boolean
   client?: ZendeskClient
- }
-): Promise<Organization[]> => {
+ }): Promise<Organization[]> => {
   const paginationArgs = {
-    url: '/api/v2/organizations/autocomplete',
+    url: '/api/v2/organizations/search',
     paginationField: 'next_page',
   }
   const organizations = (await Promise.all(


### PR DESCRIPTION
Change from `organizations/autocomplete` to `organizations/search` for more accurate searching (first one does not find organizations like "⭐⭐ INCIDENT-12941 ⭐⭐"

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter__
* Fix references to organizations starting with non alphanumeric characters, e.g. ⭐⭐ My Org ⭐⭐

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
