### PR TITLE
SALTO-2343 zendesk: move the omit inactive logic to the user facing part of the config #5404

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -22,6 +22,7 @@ import {
   TypeConfig,
   TypeDefaultsConfig,
   validateSupportedTypes,
+  validateCustomizationsTypes,
 } from './shared'
 import {
   TransformationConfig,
@@ -30,8 +31,10 @@ import {
   validateTransoformationConfig,
   getTransformationConfigByType,
 } from './transformation'
+
 import { validateRequestConfig } from './request'
 import { UserFetchConfig } from '../definitions/user'
+import { DefaultWithCustomizations } from '../definitions'
 
 const { isDefined } = lowerDashValues
 
@@ -111,4 +114,13 @@ export const validateFetchConfig = (
 ): void => {
   validateSupportedTypes(fetchConfigPath, userFetchConfig, Object.keys(adapterApiConfig.supportedTypes))
   validateSupportedTypes(fetchConfigPath, userFetchConfig, Object.keys(adapterApiConfig.types))
+}
+
+export const validateDefaultWithCustomizations = (
+  customizationName: string,
+  config: DefaultWithCustomizations<boolean>,
+  adapterApiConfig: AdapterApiConfig,
+): void => {
+  validateCustomizationsTypes(customizationName, config.customizations, Object.keys(adapterApiConfig.supportedTypes))
+  validateCustomizationsTypes(customizationName, config.customizations, Object.keys(adapterApiConfig.types))
 }

--- a/packages/adapter-components/src/config/index.ts
+++ b/packages/adapter-components/src/config/index.ts
@@ -22,6 +22,7 @@ export {
   TypeDuckTypeDefaultsConfig,
   validateApiDefinitionConfig as validateDuckTypeApiDefinitionConfig,
   validateFetchConfig as validateDuckTypeFetchConfig,
+  validateDefaultWithCustomizations,
 } from './ducktype'
 export {
   createRequestConfigs,

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -172,3 +172,16 @@ export const validateSupportedTypes = (
     )
   }
 }
+
+export const validateCustomizationsTypes = (
+  customizationName: string,
+  customization: Record<string, boolean>,
+  supportedTypesNames: string[],
+): void => {
+  const invalidCustomizations = Object.keys(customization).filter(
+    typeName => !supportedTypesNames.includes(typeName)
+  )
+  if (invalidCustomizations.length > 0) {
+    throw Error(`Invalid type names in ${customizationName}: ${invalidCustomizations} does not match any of the supported types.`)
+  }
+}

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -33,6 +33,12 @@ zendesk {
     }
     includeAuditDetails = true
     handleIdenticalAttachmentConflicts = true
+    omitInactive = {
+      default = true
+      customizations = {
+        group = false
+      }
+    }
   }
   deploy = {
     defaultMissingUserFallback = "##DEPLOYER##"
@@ -93,6 +99,8 @@ zendesk {
 | handleIdenticalAttachmentConflicts | false                              | When enabled, one attachment will be kept from each set of identical attachments (having the same hash) associated with the same article |
 | extractReferencesFromFreeText      | false                              | When enabled, convert ids in zendesk links in string values to salto references                                                          |
 | convertJsonIdsToReferences         | false                              | When enabled, If a field is a json with an 'id' field, convert its value to a reference                                                  |
+| omitInactive                       | true                               | When enabled, Inactive instances will be omitted from the fetch. This option support default value and specific types can be overridden using the customizations field |
+
 
 ## Fetch entry options
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -66,6 +66,7 @@ import {
   isGuideEnabled,
   isGuideThemesEnabled,
   ZendeskConfig,
+  migrateOmitInactiveConfig,
 } from './config'
 import {
   ARTICLE_ATTACHMENT_TYPE_NAME,
@@ -720,11 +721,15 @@ export default class ZendeskAdapter implements AdapterOperations {
           })
         : undefined
 
+    // TODO SALTO-5420 remove the omitInactive migration
+    const configWithOmitInactive = this.configInstance
+      ? migrateOmitInactiveConfig(this.configInstance, updatedConfig)
+      : undefined
     const fetchErrors = (errors ?? []).concat(result.errors ?? []).concat(localeError ?? [])
     if (this.logIdsFunc !== undefined) {
       this.logIdsFunc()
     }
-    return { elements, errors: fetchErrors, updatedConfig }
+    return { elements, errors: fetchErrors, updatedConfig: configWithOmitInactive }
   }
 
   private getBrandsFromElementsSource(): Promise<InstanceElement[]> {

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -42,6 +42,7 @@ import {
   CLIENT_CONFIG,
   FETCH_CONFIG,
   validateFetchConfig,
+  validateOmitInactiveConfig,
   API_DEFINITIONS_CONFIG,
   DEFAULT_CONFIG,
   ZendeskFetchConfig,
@@ -135,6 +136,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   validateFetchConfig(FETCH_CONFIG, adapterConfig.fetch, apiDefinitions)
   validateDuckTypeApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
   validateGuideTypesConfig(apiDefinitions)
+  validateOmitInactiveConfig(adapterConfig.fetch.omitInactive, apiDefinitions)
   if (adapterConfig.deploy !== undefined) {
     validateDefaultMissingUserFallbackConfig(DEPLOY_CONFIG, adapterConfig.deploy, isValidUser)
   }

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -176,7 +176,7 @@ export default ({
     defaultAutomationRemoval: defaultAutomationRemovalValidator,
     attachmentWithoutContent: attachmentWithoutContentValidator,
     duplicateRoutingAttributeValue: duplicateRoutingAttributeValueValidator,
-    triggerCategoryRemoval: triggerCategoryRemovalValidator(apiConfig),
+    triggerCategoryRemoval: triggerCategoryRemovalValidator(apiConfig, fetchConfig),
     duplicateIdFieldValues: duplicateIdFieldValuesValidator(apiConfig),
     notEnabledMissingReferences: notEnabledMissingReferencesValidator(config),
     conditionalTicketFields: conditionalTicketFieldsValidator,
@@ -188,7 +188,7 @@ export default ({
     childrenReferences: childrenReferencesValidator,
     orderChildrenParent: orderChildrenParentValidator,
     guideOrderDeletion: orderDeletionValidator,
-    ticketFieldDeactivation: ticketFieldDeactivationValidator(apiConfig),
+    ticketFieldDeactivation: ticketFieldDeactivationValidator,
     // ******************************
   }
 

--- a/packages/zendesk-adapter/src/change_validators/ticket_field_deactivation.ts
+++ b/packages/zendesk-adapter/src/change_validators/ticket_field_deactivation.ts
@@ -27,10 +27,8 @@ import {
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
-import { config as configUtils } from '@salto-io/adapter-components'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME } from '../constants'
-import { ZendeskApiConfig } from '../config'
 
 const { isDefined } = lowerdashValues
 const log = logger(module)
@@ -57,99 +55,83 @@ export const isTicketFormCondition = (value: Value): value is TicketFormConditio
 
 const TICKET_FORM_CONDITION_FIELDS = ['agent_conditions', 'end_user_conditions']
 
+// At the moment we do not omit inactive ticket_form instances because we need all the instance in order to reorder them
+// if we decide to enable this in the inactive.ts file
+// we will need to add the warning that is removed
 /**
  * Prevent deactivation of a ticket_field that is used as a condition in a ticket form
  */
-export const ticketFieldDeactivationValidator: (apiConfig: ZendeskApiConfig) => ChangeValidator =
-  apiConfig => async (changes, elementSource) => {
-    if (elementSource === undefined) {
-      log.error('Failed to run ticketFieldDeactivationValidator because element source is undefined')
-      return []
-    }
-
-    const deactivatedTicketFields = changes
-      .filter(isInstanceChange)
-      .filter(isRemovalOrModificationChange)
-      .filter(change => getChangeData(change).elemID.typeName === TICKET_FIELD_TYPE_NAME)
-      .filter(change => change.data.before.value.active === true)
-      // Removal also counts as deactivation
-      .filter(change => isRemovalChange(change) || change.data.after.value.active === false)
-      .map(getChangeData)
-
-    if (deactivatedTicketFields.length === 0) {
-      return []
-    }
-
-    const ticketForms = await getInstancesFromElementSource(elementSource, [TICKET_FORM_TYPE_NAME])
-    const ticketFieldIdToTicketForm: Record<string, string[]> = {}
-    // TICKET_FORM_CONDITION_FIELDS has 'parent_field_id' in them
-    // Each condition also may (or must?) have 'child_fields' with 'id' in them
-    ticketForms.forEach(ticketForm =>
-      TICKET_FORM_CONDITION_FIELDS.forEach(field => {
-        const conditions = ticketForm.value[field]
-        if (conditions === undefined) {
-          return
-        }
-
-        if (!_.isArray(conditions)) {
-          log.error(`${field} is not an array in ${ticketForm.elemID.getFullName()}`)
-          return
-        }
-
-        conditions.forEach((condition: Value) => {
-          if (!isTicketFormCondition(condition)) {
-            log.error(`${field} has an invalid format in ${ticketForm.elemID.getFullName()}}`)
-            return
-          }
-          // Support both options of resolved and unresolved values
-          const parentFieldId = _.isNumber(condition.parent_field_id)
-            ? condition.parent_field_id.toString()
-            : condition.parent_field_id.elemID.getFullName()
-          const childFields = (condition.child_fields ?? []).map(child =>
-            _.isNumber(child.id) ? child.id.toString() : child.id.elemID.getFullName(),
-          )
-          const ticketFieldIds = new Set<string>(childFields.concat(parentFieldId))
-          ticketFieldIds.forEach(id => {
-            ticketFieldIdToTicketForm[id] = (ticketFieldIdToTicketForm[id] ?? []).concat(ticketForm.elemID.name)
-          })
-        })
-      }),
-    )
-
-    const inactiveTicketFormsOmitted =
-      configUtils.getConfigWithDefault(
-        apiConfig.types?.[TICKET_FORM_TYPE_NAME]?.transformation,
-        apiConfig.typeDefaults?.transformation,
-      ).omitInactive === true
-
-    // Even inactive ticket form prevents deactivation of a ticket field
-    // If they are omitted, we can only warn about the deactivation
-    const warnings: ChangeError[] = inactiveTicketFormsOmitted
-      ? deactivatedTicketFields.map(ticketField => ({
-          elemID: ticketField.elemID,
-          severity: 'Warning',
-          message: 'Deactivation of a ticket field',
-          detailedMessage:
-            'This may be a conditional ticket field of a deactivated ticket form, if true, the deployment will fail',
-        }))
-      : []
-
-    const errors = deactivatedTicketFields
-      .map((ticketField): ChangeError | undefined => {
-        const usingTicketForms = (ticketFieldIdToTicketForm[ticketField.value.id] ?? []).concat(
-          ticketFieldIdToTicketForm[ticketField.elemID.getFullName()] ?? [],
-        )
-        if (usingTicketForms.length === 0) {
-          return undefined
-        }
-        return {
-          elemID: ticketField.elemID,
-          severity: 'Error',
-          message: 'Deactivation of a conditional ticket field',
-          detailedMessage: `Cannot remove this ticket field because it is configured as a conditional field in the following ticket forms: ${usingTicketForms.join(', ')}`,
-        }
-      })
-      .filter(isDefined)
-
-    return errors.concat(warnings)
+export const ticketFieldDeactivationValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run ticketFieldDeactivationValidator because element source is undefined')
+    return []
   }
+
+  const deactivatedTicketFields = changes
+    .filter(isInstanceChange)
+    .filter(isRemovalOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === TICKET_FIELD_TYPE_NAME)
+    .filter(change => change.data.before.value.active === true)
+    // Removal also counts as deactivation
+    .filter(change => isRemovalChange(change) || change.data.after.value.active === false)
+    .map(getChangeData)
+
+  if (deactivatedTicketFields.length === 0) {
+    return []
+  }
+
+  const ticketForms = await getInstancesFromElementSource(elementSource, [TICKET_FORM_TYPE_NAME])
+  const ticketFieldIdToTicketForm: Record<string, string[]> = {}
+  // TICKET_FORM_CONDITION_FIELDS has 'parent_field_id' in them
+  // Each condition also may (or must?) have 'child_fields' with 'id' in them
+  ticketForms.forEach(ticketForm =>
+    TICKET_FORM_CONDITION_FIELDS.forEach(field => {
+      const conditions = ticketForm.value[field]
+      if (conditions === undefined) {
+        return
+      }
+
+      if (!_.isArray(conditions)) {
+        log.error(`${field} is not an array in ${ticketForm.elemID.getFullName()}`)
+        return
+      }
+
+      conditions.forEach((condition: Value) => {
+        if (!isTicketFormCondition(condition)) {
+          log.error(`${field} has an invalid format in ${ticketForm.elemID.getFullName()}}`)
+          return
+        }
+        // Support both options of resolved and unresolved values
+        const parentFieldId = _.isNumber(condition.parent_field_id)
+          ? condition.parent_field_id.toString()
+          : condition.parent_field_id.elemID.getFullName()
+        const childFields = (condition.child_fields ?? []).map(child =>
+          _.isNumber(child.id) ? child.id.toString() : child.id.elemID.getFullName(),
+        )
+        const ticketFieldIds = new Set<string>(childFields.concat(parentFieldId))
+        ticketFieldIds.forEach(id => {
+          ticketFieldIdToTicketForm[id] = (ticketFieldIdToTicketForm[id] ?? []).concat(ticketForm.elemID.name)
+        })
+      })
+    }),
+  )
+
+  const errors = deactivatedTicketFields
+    .map((ticketField): ChangeError | undefined => {
+      const usingTicketForms = (ticketFieldIdToTicketForm[ticketField.value.id] ?? []).concat(
+        ticketFieldIdToTicketForm[ticketField.elemID.getFullName()] ?? [],
+      )
+      if (usingTicketForms.length === 0) {
+        return undefined
+      }
+      return {
+        elemID: ticketField.elemID,
+        severity: 'Error',
+        message: 'Deactivation of a conditional ticket field',
+        detailedMessage: `Cannot remove this ticket field because it is configured as a conditional field in the following ticket forms: ${usingTicketForms.join(', ')}`,
+      }
+    })
+    .filter(isDefined)
+
+  return errors
+}

--- a/packages/zendesk-adapter/src/change_validators/trigger_category_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/trigger_category_removal.ts
@@ -25,10 +25,10 @@ import {
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
-import { config as configUtils } from '@salto-io/adapter-components'
+import { config as configUtils, definitions } from '@salto-io/adapter-components'
 import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
 import { TRIGGER_CATEGORY_TYPE_NAME, TRIGGER_TYPE_NAME } from '../constants'
-import { ZendeskApiConfig } from '../config'
+import { ZendeskApiConfig, ZendeskFetchConfig } from '../config'
 
 const { isDefined } = lowerDashValues
 const log = logger(module)
@@ -38,83 +38,92 @@ const log = logger(module)
  * Warns about removal of a trigger category that is used by an inactive trigger
  * Warns about removal of a trigger category if omitInactive is true for triggers
  */
-export const triggerCategoryRemovalValidator: (apiConfig: ZendeskApiConfig) => ChangeValidator =
-  apiConfig => async (changes, elementSource) => {
-    if (elementSource === undefined) {
-      log.error('Failed to run triggerCategoryRemovalValidator because element source is undefined')
-      return []
+export const triggerCategoryRemovalValidator: (
+  apiConfig: ZendeskApiConfig,
+  fetchConfig: ZendeskFetchConfig,
+) => ChangeValidator = (apiConfig, fetchConfig) => async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run triggerCategoryRemovalValidator because element source is undefined')
+    return []
+  }
+
+  const removedTriggerCategories = changes
+    .filter(isInstanceChange)
+    .filter(isRemovalChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === TRIGGER_CATEGORY_TYPE_NAME)
+
+  if (removedTriggerCategories.length === 0) {
+    return []
+  }
+
+  const elementSourceTriggers = await getInstancesFromElementSource(elementSource, [TRIGGER_TYPE_NAME])
+
+  const triggersByRemovedTriggerCategory: Record<string, InstanceElement[]> = _.fromPairs(
+    removedTriggerCategories.map(instance => instance.elemID.name).map(name => [name, []]),
+  )
+
+  elementSourceTriggers.forEach(trigger => {
+    const triggerCategory = trigger.value.category_id
+    const triggerCategoryName = isReferenceExpression(triggerCategory) ? triggerCategory.elemID.name : triggerCategory
+    // If this trigger's category wasn't removed, we don't care about it
+    if (triggersByRemovedTriggerCategory[triggerCategoryName] === undefined) {
+      return
     }
+    triggersByRemovedTriggerCategory[triggerCategoryName].push(trigger)
+  })
 
-    const removedTriggerCategories = changes
-      .filter(isInstanceChange)
-      .filter(isRemovalChange)
-      .map(getChangeData)
-      .filter(instance => instance.elemID.typeName === TRIGGER_CATEGORY_TYPE_NAME)
+  const removalErrors = removedTriggerCategories.map((removedTriggerCategory): ChangeError | undefined => {
+    const triggerCategoryActiveTriggers = triggersByRemovedTriggerCategory[removedTriggerCategory.elemID.name]
+      .filter(trigger => trigger.value.active)
+      .map(trigger => trigger.elemID.name)
 
-    if (removedTriggerCategories.length === 0) {
-      return []
-    }
-
-    const elementSourceTriggers = await getInstancesFromElementSource(elementSource, [TRIGGER_TYPE_NAME])
-
-    const triggersByRemovedTriggerCategory: Record<string, InstanceElement[]> = _.fromPairs(
-      removedTriggerCategories.map(instance => instance.elemID.name).map(name => [name, []]),
-    )
-
-    elementSourceTriggers.forEach(trigger => {
-      const triggerCategory = trigger.value.category_id
-      const triggerCategoryName = isReferenceExpression(triggerCategory) ? triggerCategory.elemID.name : triggerCategory
-      // If this trigger's category wasn't removed, we don't care about it
-      if (triggersByRemovedTriggerCategory[triggerCategoryName] === undefined) {
-        return
-      }
-      triggersByRemovedTriggerCategory[triggerCategoryName].push(trigger)
-    })
-
-    const removalErrors = removedTriggerCategories.map((removedTriggerCategory): ChangeError | undefined => {
-      const triggerCategoryActiveTriggers = triggersByRemovedTriggerCategory[removedTriggerCategory.elemID.name]
-        .filter(trigger => trigger.value.active)
-        .map(trigger => trigger.elemID.name)
-
-      return triggerCategoryActiveTriggers.length > 0
-        ? {
-            elemID: removedTriggerCategory.elemID,
-            severity: 'Error',
-            message: 'Cannot remove a trigger category with active triggers',
-            detailedMessage: `Trigger category is used by the following active triggers: [${triggerCategoryActiveTriggers.join(', ')}], please deactivate or remove them before removing this category`,
-          }
-        : undefined
-    })
-
-    const inactiveTriggersOmitted =
+    return triggerCategoryActiveTriggers.length > 0
+      ? {
+          elemID: removedTriggerCategory.elemID,
+          severity: 'Error',
+          message: 'Cannot remove a trigger category with active triggers',
+          detailedMessage: `Trigger category is used by the following active triggers: [${triggerCategoryActiveTriggers.join(', ')}], please deactivate or remove them before removing this category`,
+        }
+      : undefined
+  })
+  // TODO SALTO-5420 remove the omitInactive migration
+  const oldOmitInactive =
+    _.get(
       configUtils.getConfigWithDefault(
         apiConfig.types?.[TRIGGER_TYPE_NAME]?.transformation,
         apiConfig.typeDefaults.transformation,
-      ).omitInactive === true
-    const removalWarnings = removedTriggerCategories.map((removedTriggerCategory): ChangeError | undefined => {
-      // If we omitted inactive triggers, we can't warn about them specifically, so we return a general warning
-      if (inactiveTriggersOmitted) {
-        return {
+      ),
+      'omitInactive',
+    ) === true
+  const omitInactiveConfig = fetchConfig.omitInactive
+  const newOmitInactive = omitInactiveConfig
+    ? definitions.queryWithDefault(omitInactiveConfig).query(TRIGGER_CATEGORY_TYPE_NAME)
+    : false
+  const inactiveTriggersOmitted = newOmitInactive || oldOmitInactive
+  const removalWarnings = removedTriggerCategories.map((removedTriggerCategory): ChangeError | undefined => {
+    // If we omitted inactive triggers, we can't warn about them specifically, so we return a general warning
+    if (inactiveTriggersOmitted) {
+      return {
+        elemID: removedTriggerCategory.elemID,
+        severity: 'Warning',
+        message: 'Removal of trigger category',
+        detailedMessage: 'Any inactive triggers of this category will be automatically removed',
+      }
+    }
+    const triggerCategoryInactiveTriggers = triggersByRemovedTriggerCategory[removedTriggerCategory.elemID.name]
+      .filter(trigger => !trigger.value.active)
+      .map(trigger => trigger.elemID.name)
+
+    return triggerCategoryInactiveTriggers.length > 0
+      ? {
           elemID: removedTriggerCategory.elemID,
           severity: 'Warning',
-          message: 'Removal of trigger category',
-          detailedMessage: 'Any inactive triggers of this category will be automatically removed',
+          message: 'Removal of trigger category with inactive triggers',
+          detailedMessage: `Trigger category is used by the following inactive triggers: [${triggerCategoryInactiveTriggers.join(', ')}], and they will be automatically removed with the removal of this category`,
         }
-      }
+      : undefined
+  })
 
-      const triggerCategoryInactiveTriggers = triggersByRemovedTriggerCategory[removedTriggerCategory.elemID.name]
-        .filter(trigger => !trigger.value.active)
-        .map(trigger => trigger.elemID.name)
-
-      return triggerCategoryInactiveTriggers.length > 0
-        ? {
-            elemID: removedTriggerCategory.elemID,
-            severity: 'Warning',
-            message: 'Removal of trigger category with inactive triggers',
-            detailedMessage: `Trigger category is used by the following inactive triggers: [${triggerCategoryInactiveTriggers.join(', ')}], and they will be automatically removed with the removal of this category`,
-          }
-        : undefined
-    })
-
-    return [...removalErrors, ...removalWarnings].filter(isDefined)
-  }
+  return [...removalErrors, ...removalWarnings].filter(isDefined)
+}

--- a/packages/zendesk-adapter/src/inactive.ts
+++ b/packages/zendesk-adapter/src/inactive.ts
@@ -13,9 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from 'lodash'
 import { InstanceElement } from '@salto-io/adapter-api'
-import { config as configUtils } from '@salto-io/adapter-components'
-import { ZendeskConfig, API_DEFINITIONS_CONFIG } from './config'
+import { config as configUtils, definitions } from '@salto-io/adapter-components'
+import { ZendeskConfig, API_DEFINITIONS_CONFIG, FETCH_CONFIG } from './config'
 import { TICKET_FORM_TYPE_NAME, WEBHOOK_TYPE_NAME } from './constants'
 
 /**
@@ -27,6 +28,8 @@ export const filterOutInactiveInstancesForType = (
   config: ZendeskConfig,
 ): ((instances: InstanceElement[]) => InstanceElement[]) => {
   const apiDefinitions = config[API_DEFINITIONS_CONFIG]
+  const omitInactiveConfig = config[FETCH_CONFIG]?.omitInactive
+  const newOmitInactiveQuery = omitInactiveConfig ? definitions.queryWithDefault(omitInactiveConfig) : undefined
   return instances => {
     if (instances.length === 0) {
       return instances
@@ -34,12 +37,21 @@ export const filterOutInactiveInstancesForType = (
     const { typeName } = instances[0].elemID
 
     // We can't omit inactive ticket_form instances because we need all the instance in order to reorder them
-    if (
-      typeName === TICKET_FORM_TYPE_NAME ||
-      !configUtils.getConfigWithDefault(
+    // if we decide to omit inactive ticket_form
+    // we will need to add warning in the ticket_field_deactivation change validator
+    // TODO SALTO-5420 remove the omitInactive migration
+    const oldOmitInactive = _.get(
+      configUtils.getConfigWithDefault(
         apiDefinitions.types?.[typeName]?.transformation,
         apiDefinitions.typeDefaults.transformation,
-      ).omitInactive
+      ),
+      'omitInactive',
+    )
+    const newOmitInactive = newOmitInactiveQuery ? newOmitInactiveQuery.query(typeName) : false
+    if (
+      typeName === TICKET_FORM_TYPE_NAME ||
+      (oldOmitInactive === undefined && !newOmitInactive) ||
+      oldOmitInactive === false
     ) {
       return instances
     }

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -142,13 +142,9 @@ describe('adapter', () => {
                 guide: {
                   brands: ['.*'],
                 },
-              },
-              [API_DEFINITIONS_CONFIG]: {
-                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-                typeDefaults: {
-                  transformation: {
-                    omitInactive: false,
-                  },
+                omitInactive: {
+                  default: false,
+                  customizations: {},
                 },
               },
             }),
@@ -701,13 +697,9 @@ describe('adapter', () => {
                 guide: {
                   brands: ['.*'],
                 },
-              },
-              [API_DEFINITIONS_CONFIG]: {
-                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-                typeDefaults: {
-                  transformation: {
-                    omitInactive: false,
-                  },
+                omitInactive: {
+                  default: false,
+                  customizations: {},
                 },
               },
             }),
@@ -1254,12 +1246,9 @@ describe('adapter', () => {
                 guide: {
                   brands: ['.*'],
                 },
-              },
-              [API_DEFINITIONS_CONFIG]: {
-                typeDefaults: {
-                  transformation: {
-                    omitInactive: true,
-                  },
+                omitInactive: {
+                  default: true,
+                  customizations: {},
                 },
               },
             }),
@@ -1804,13 +1793,9 @@ describe('adapter', () => {
                 guide: {
                   brands: ['.*'],
                 },
-              },
-              [API_DEFINITIONS_CONFIG]: {
-                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-                typeDefaults: {
-                  transformation: {
-                    omitInactive: false,
-                  },
+                omitInactive: {
+                  default: false,
+                  customizations: {},
                 },
               },
             }),
@@ -1862,13 +1847,9 @@ describe('adapter', () => {
                 guide: {
                   brands: ['.*'],
                 },
-              },
-              [API_DEFINITIONS_CONFIG]: {
-                ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-                typeDefaults: {
-                  transformation: {
-                    omitInactive: false,
-                  },
+                omitInactive: {
+                  default: false,
+                  customizations: {},
                 },
               },
             }),
@@ -1990,13 +1971,9 @@ describe('adapter', () => {
             guide: {
               brands: ['BestBrand'],
             },
-          },
-          [API_DEFINITIONS_CONFIG]: {
-            ...DEFAULT_CONFIG[API_DEFINITIONS_CONFIG],
-            typeDefaults: {
-              transformation: {
-                omitInactive: false,
-              },
+            omitInactive: {
+              default: false,
+              customizations: {},
             },
           },
         })

--- a/packages/zendesk-adapter/test/change_validators/ticket_field_deactivation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/ticket_field_deactivation.test.ts
@@ -17,7 +17,6 @@ import { InstanceElement, ObjectType, ElemID, toChange, ReferenceExpression } fr
 import { elementSource as elementSourceUtils } from '@salto-io/workspace'
 import { TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { ticketFieldDeactivationValidator } from '../../src/change_validators'
-import { ZendeskApiConfig } from '../../src/config'
 
 const { createInMemoryElementSource } = elementSourceUtils
 
@@ -46,7 +45,7 @@ describe('ticketFieldDeactivationValidator', () => {
     const changes = [toChange({ before: ticketField, after: ticketField })]
 
     const elementSource = createInMemoryElementSource([ticketField, ticketForm])
-    const errors = await ticketFieldDeactivationValidator({} as ZendeskApiConfig)(changes, elementSource)
+    const errors = await ticketFieldDeactivationValidator(changes, elementSource)
     expect(errors).toEqual([])
   })
 
@@ -58,7 +57,7 @@ describe('ticketFieldDeactivationValidator', () => {
     const changes = [toChange({ before: ticketField1, after: ticketField1 }), toChange({ before: ticketField2 })]
 
     const elementSource = createInMemoryElementSource([ticketField1, ticketField2, ticketForm])
-    const errors = await ticketFieldDeactivationValidator({} as ZendeskApiConfig)(changes, elementSource)
+    const errors = await ticketFieldDeactivationValidator(changes, elementSource)
     expect(errors).toEqual([])
   })
 
@@ -79,7 +78,7 @@ describe('ticketFieldDeactivationValidator', () => {
     ]
 
     const elementSource = createInMemoryElementSource([ticketField1, ticketField2, ticketForm1, ticketForm2])
-    const errors = await ticketFieldDeactivationValidator({} as ZendeskApiConfig)(changes, elementSource)
+    const errors = await ticketFieldDeactivationValidator(changes, elementSource)
     expect(errors).toMatchObject([
       {
         elemID: ticketField1.elemID,
@@ -94,37 +93,6 @@ describe('ticketFieldDeactivationValidator', () => {
         message: 'Deactivation of a conditional ticket field',
         detailedMessage:
           'Cannot remove this ticket field because it is configured as a conditional field in the following ticket forms: ticketForm1, ticketForm2',
-      },
-    ])
-  })
-
-  it('should return a warning when a ticket field is deactivated and inactive ticket forms are omitted', async () => {
-    const ticketField1 = createTicketFieldInstance('ticketField1', 1)
-    const ticketField2 = createTicketFieldInstance('ticketField2', 2)
-    const ticketField1Deactivated = ticketField1.clone()
-    ticketField1Deactivated.value.active = false
-    const changes = [
-      toChange({ before: ticketField1, after: ticketField1Deactivated }),
-      toChange({ before: ticketField2 }),
-    ]
-
-    const elementSource = createInMemoryElementSource([ticketField1, ticketField2])
-    const config = { typeDefaults: { transformation: { omitInactive: true } } } as ZendeskApiConfig
-    const errors = await ticketFieldDeactivationValidator(config)(changes, elementSource)
-    expect(errors).toMatchObject([
-      {
-        elemID: ticketField1.elemID,
-        severity: 'Warning',
-        message: 'Deactivation of a ticket field',
-        detailedMessage:
-          'This may be a conditional ticket field of a deactivated ticket form, if true, the deployment will fail',
-      },
-      {
-        elemID: ticketField2.elemID,
-        severity: 'Warning',
-        message: 'Deactivation of a ticket field',
-        detailedMessage:
-          'This may be a conditional ticket field of a deactivated ticket form, if true, the deployment will fail',
       },
     ])
   })

--- a/packages/zendesk-adapter/test/config.test.ts
+++ b/packages/zendesk-adapter/test/config.test.ts
@@ -1,0 +1,77 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InstanceElement } from '@salto-io/adapter-api'
+import {
+  API_DEFINITIONS_CONFIG,
+  configType,
+  DEFAULT_CONFIG,
+  FETCH_CONFIG,
+  migrateOmitInactiveConfig,
+} from '../src/config'
+
+describe('config', () => {
+  const baseConfig = new InstanceElement('config', configType, {
+    ...DEFAULT_CONFIG,
+    [FETCH_CONFIG]: {
+      include: [
+        {
+          type: '.*',
+        },
+      ],
+      exclude: [],
+    },
+  })
+  describe('migrateOmitInactiveConfig', () => {
+    describe('when the omitInactive is already exists in the new format', () => {
+      it('should not change the config', () => {
+        const config = baseConfig.clone()
+        config.value[FETCH_CONFIG].omitInactive = {
+          default: true,
+          customizations: {},
+        }
+        const updatedConfig = migrateOmitInactiveConfig(config, { config: [config], message: 'test' })
+        expect(updatedConfig?.config[0]).toEqual(config)
+      })
+    })
+    describe('when there is no omitInactive in the api definitions', () => {
+      it('should not change the config', () => {
+        const updatedConfig = migrateOmitInactiveConfig(baseConfig, { config: [baseConfig], message: 'test' })
+        expect(updatedConfig?.config[0]).toEqual(baseConfig)
+      })
+    })
+    describe('when we migrate the omitInactive from the api definitions to the fetch config', () => {
+      let updatedConfig: { config: InstanceElement[]; message: string } | undefined
+      beforeAll(() => {
+        const config = baseConfig.clone()
+        config.value[API_DEFINITIONS_CONFIG].typeDefaults.transformation = { omitInactive: false }
+        updatedConfig = migrateOmitInactiveConfig(config, { config: [config], message: 'test' })
+      })
+      it('should add the omitInactive to the fetch config', () => {
+        const fetchConfig = updatedConfig?.config[0].value[FETCH_CONFIG]
+        expect(fetchConfig.omitInactive).toEqual({
+          default: false,
+          customizations: {},
+        })
+      })
+      it('should remove the omitInactive from the api definitions', () => {
+        expect(
+          updatedConfig?.config[0].value[API_DEFINITIONS_CONFIG].typeDefaults.transformation.omitInactive,
+        ).toBeUndefined()
+      })
+    })
+  })
+})


### PR DESCRIPTION
SALTO-2343 zendesk: move the omit inactive logic to the user facing part of the config #5404

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
