### PR TITLE
PROD-232 enable features

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -46,13 +46,10 @@ import { createCustomRecordTypes } from '../src/custom_records/custom_record_typ
 import { savedsearchType } from '../src/type_parsers/saved_search_parsing/parsed_saved_search'
 import { reportdefinitionType } from '../src/type_parsers/report_definition_parsing/parsed_report_definition'
 import { financiallayoutType } from '../src/type_parsers/financial_layout_parsing/parsed_financial_layout'
-import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import { ProjectInfo, createAdditionalFiles, createSdfExecutor } from './sdf_executor'
 import { parsedDatasetType } from '../src/type_parsers/analytics_parsers/parsed_dataset'
 import { parsedWorkbookType } from '../src/type_parsers/analytics_parsers/parsed_workbook'
 import { UNKNOWN_TYPE_REFERENCES_ELEM_ID } from '../src/filters/data_account_specific_values'
-import { SUITEQL_TABLE } from '../src/data_elements/suiteql_table_elements'
-import { NUM_OF_SUITEQL_ELEMENTS } from '../test/data_elements/suiteql_table_elements.test'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -673,13 +670,7 @@ describe('Netsuite adapter E2E with real account', () => {
           // some sub-instances don't have alias
           .filter(element => getElementValueOrAnnotations(element)[IS_SUB_INSTANCE] !== true)
 
-        if (withSuiteApp) {
-          expect(elementsWithoutAlias).toHaveLength(1 + NUM_OF_SUITEQL_ELEMENTS)
-          expect(elementsWithoutAlias.every(e =>
-            [SERVER_TIME_TYPE_NAME, SUITEQL_TABLE].includes(e.elemID.typeName))).toBeTruthy()
-        } else {
-          expect(elementsWithoutAlias).toHaveLength(0)
-        }
+        expect(elementsWithoutAlias.every(elem => elem.annotations[CORE_ANNOTATIONS.HIDDEN])).toBeTruthy()
       })
 
       it('should fetch the created entityCustomField and its special chars', async () => {

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -50,6 +50,9 @@ import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import { ProjectInfo, createAdditionalFiles, createSdfExecutor } from './sdf_executor'
 import { parsedDatasetType } from '../src/type_parsers/analytics_parsers/parsed_dataset'
 import { parsedWorkbookType } from '../src/type_parsers/analytics_parsers/parsed_workbook'
+import { UNKNOWN_TYPE_REFERENCES_ELEM_ID } from '../src/filters/data_account_specific_values'
+import { SUITEQL_TABLE } from '../src/data_elements/suiteql_table_elements'
+import { NUM_OF_SUITEQL_ELEMENTS } from '../test/data_elements/suiteql_table_elements.test'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -671,8 +674,9 @@ describe('Netsuite adapter E2E with real account', () => {
           .filter(element => getElementValueOrAnnotations(element)[IS_SUB_INSTANCE] !== true)
 
         if (withSuiteApp) {
-          expect(elementsWithoutAlias).toHaveLength(1)
-          expect(elementsWithoutAlias[0].elemID.typeName).toEqual(SERVER_TIME_TYPE_NAME)
+          expect(elementsWithoutAlias).toHaveLength(1 + NUM_OF_SUITEQL_ELEMENTS)
+          expect(elementsWithoutAlias.every(e =>
+            [SERVER_TIME_TYPE_NAME, SUITEQL_TABLE].includes(e.elemID.typeName))).toBeTruthy()
         } else {
           expect(elementsWithoutAlias).toHaveLength(0)
         }
@@ -996,6 +1000,8 @@ describe('Netsuite adapter E2E with real account', () => {
           .concat(filesToImport)
           .concat(existingFileCabinetInstances)
           .concat(newFileCabinetInstancesElemIds)
+          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID })
+          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID.createNestedID('instance', ElemID.CONFIG_NAME) })
 
         const expectedElements = _.uniq(
           allTypes

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -338,7 +338,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       const elementsToCreate = [
         ...customObjects,
         ...fileCabinetContent,
-        ...(this.userConfig.fetch.addBundles ? bundlesCustomInfo : []),
+        ...(this.userConfig.fetch.addBundles !== false ? bundlesCustomInfo : []),
       ]
       const elements = await createElements(elementsToCreate, this.elementsSource, this.getElemIdFunc)
       const [standardInstances, types] = _.partition(elements, isInstanceElement)

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -82,7 +82,7 @@ const changeValidator: NetsuiteChangeValidator = async (
     return []
   }
 
-  if (config?.fetch.resolveAccountSpecificValues && elementsSource !== undefined) {
+  if (config?.fetch.resolveAccountSpecificValues !== false && elementsSource !== undefined) {
     const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
     const suiteQLTablesMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
     return relevantChangedInstances

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -668,7 +668,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean
 ): Promise<TopLevelElement[]> => {
-  if (!config.fetch.resolveAccountSpecificValues) {
+  if (config.fetch.resolveAccountSpecificValues === false) {
     return []
   }
   const suiteQLTableType = new ObjectType({

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -668,7 +668,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean
 ): Promise<TopLevelElement[]> => {
-  if (config.fetch.resolveAccountSpecificValues === false) {
+  if (config.fetch.resolveAccountSpecificValues === false || !client.isSuiteAppConfigured()) {
     return []
   }
   const suiteQLTableType = new ObjectType({

--- a/packages/netsuite-adapter/src/filters/bundle_ids.ts
+++ b/packages/netsuite-adapter/src/filters/bundle_ids.ts
@@ -75,7 +75,7 @@ const addBundleToRecords = (
 const filterCreator: LocalFilterCreator = ({ config }) => ({
   name: 'bundleIds',
   onFetch: async elements => {
-    if (!config.fetch.addBundles) {
+    if (config.fetch.addBundles === false) {
       return
     }
     const [bundleInstances, nonBundleElements] = _.partition(elements, isBundleInstance)

--- a/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
@@ -354,7 +354,7 @@ const resolveAccountSpecificValues = ({
 const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }) => ({
   name: 'dataAccountSpecificValues',
   onFetch: async elements => {
-    if (!config.fetch.resolveAccountSpecificValues) {
+    if (config.fetch.resolveAccountSpecificValues === false) {
       return
     }
     const instances = elements.filter(isInstanceElement)
@@ -377,7 +377,7 @@ const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }
     addReferenceTypes(elements)
   },
   preDeploy: async changes => {
-    if (!config.fetch.resolveAccountSpecificValues) {
+    if (config.fetch.resolveAccountSpecificValues === false) {
       return
     }
     const relevantChangedInstances = changes

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -51,7 +51,7 @@ const isNestedPath = (path: ElemID | undefined): path is ElemID =>
 const filterCreator: LocalFilterCreator = ({ config }) => ({
   name: 'dataInstancesInternalId',
   onFetch: async elements => {
-    if (config.fetch.resolveAccountSpecificValues) {
+    if (config.fetch.resolveAccountSpecificValues !== false) {
       return
     }
     const newInstancesMap: Record<string, InstanceElement> = {}
@@ -113,7 +113,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
   },
 
   preDeploy: async changes => {
-    if (config.fetch.resolveAccountSpecificValues) {
+    if (config.fetch.resolveAccountSpecificValues !== false) {
       return
     }
     await awu(changes).forEach(async change => {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -50,6 +50,7 @@ import { getDataElements } from '../src/data_elements/data_elements'
 import * as elementsSourceIndexModule from '../src/elements_source_index/elements_source_index'
 import { fullQueryParams, fullFetchConfig } from '../src/config/config_creator'
 import { FetchByQueryFunc } from '../src/config/query'
+import { NUM_OF_SUITEQL_ELEMENTS } from './data_elements/suiteql_table_elements.test'
 
 const DEFAULT_SDF_DEPLOY_PARAMS = {
   manifestDependencies: {
@@ -232,7 +233,7 @@ describe('Adapter', () => {
       expect(fileCabinetQuery.isFileMatch('Some/anotherFile/Regex')).toBeTruthy()
 
       // metadataTypes + folderInstance + fileInstance + featuresInstance + customTypeInstance
-      expect(elements).toHaveLength(metadataTypes.length + 4)
+      expect(elements).toHaveLength(metadataTypes.length + NUM_OF_SUITEQL_ELEMENTS + 4)
 
       const customFieldType = elements.find(element =>
         element.elemID.isEqual(new ElemID(NETSUITE, ENTITY_CUSTOM_FIELD)))
@@ -496,7 +497,7 @@ describe('Adapter', () => {
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         })
       const { elements } = await netsuiteAdapter.fetch(mockFetchOpts)
-      expect(elements).toHaveLength(metadataTypes.length)
+      expect(elements).toHaveLength(metadataTypes.length + NUM_OF_SUITEQL_ELEMENTS)
     })
 
     it('should call filters by their order', async () => {
@@ -1212,6 +1213,8 @@ describe('Adapter', () => {
         getSystemInformation: getSystemInformationMock,
         getNetsuiteWsdl: () => undefined,
         getConfigRecords: () => [],
+        runSavedSearchQuery: () => [],
+        runSuiteQL: () => [],
         getInstalledBundles: () => [],
         getCustomRecords: getCustomRecordsMock,
       } as unknown as SuiteAppClient
@@ -1276,6 +1279,7 @@ describe('Adapter', () => {
           ),
           getInstalledBundles: () => [],
           getCustomRecords: getCustomRecordsMock,
+          runSuiteQL: () => [],
         } as unknown as SuiteAppClient
 
         adapter = new NetsuiteAdapter({

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -50,7 +50,6 @@ import { getDataElements } from '../src/data_elements/data_elements'
 import * as elementsSourceIndexModule from '../src/elements_source_index/elements_source_index'
 import { fullQueryParams, fullFetchConfig } from '../src/config/config_creator'
 import { FetchByQueryFunc } from '../src/config/query'
-import { NUM_OF_SUITEQL_ELEMENTS } from './data_elements/suiteql_table_elements.test'
 
 const DEFAULT_SDF_DEPLOY_PARAMS = {
   manifestDependencies: {
@@ -233,7 +232,7 @@ describe('Adapter', () => {
       expect(fileCabinetQuery.isFileMatch('Some/anotherFile/Regex')).toBeTruthy()
 
       // metadataTypes + folderInstance + fileInstance + featuresInstance + customTypeInstance
-      expect(elements).toHaveLength(metadataTypes.length + NUM_OF_SUITEQL_ELEMENTS + 4)
+      expect(elements).toHaveLength(metadataTypes.length + 4)
 
       const customFieldType = elements.find(element =>
         element.elemID.isEqual(new ElemID(NETSUITE, ENTITY_CUSTOM_FIELD)))
@@ -497,7 +496,7 @@ describe('Adapter', () => {
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         })
       const { elements } = await netsuiteAdapter.fetch(mockFetchOpts)
-      expect(elements).toHaveLength(metadataTypes.length + NUM_OF_SUITEQL_ELEMENTS)
+      expect(elements).toHaveLength(metadataTypes.length)
     })
 
     it('should call filters by their order', async () => {

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -24,6 +24,10 @@ import { SERVER_TIME_TYPE_NAME } from '../../src/server_time'
 import { NetsuiteConfig } from '../../src/config/types'
 import { fullFetchConfig } from '../../src/config/config_creator'
 
+export const NUM_OF_SUITEQL_ELEMENTS = Object.values(QUERIES_BY_TABLE_NAME).filter(query => query !== undefined).length
+  // additional elements are the type, and instances from getAdditionalInstances
+  + 4
+
 const runSuiteQLMock = jest.fn()
 const runSavedSearchQueryMock = jest.fn()
 const client = {
@@ -91,8 +95,6 @@ describe('SuiteQL table elements', () => {
   })
 
   describe('when there are no existing instances', () => {
-    const numOfInstances = Object.values(QUERIES_BY_TABLE_NAME).filter(query => query !== undefined).length
-
     beforeEach(async () => {
       runSuiteQLMock.mockResolvedValue([
         { id: '1', name: 'Some name' },
@@ -127,9 +129,8 @@ describe('SuiteQL table elements', () => {
     })
 
     it('should return all elements', () => {
-      // additional elements are the type, and instances from getAdditionalInstances
       // minus 1 for the skipped vendor table
-      expect(elements).toHaveLength(numOfInstances + 4 - 1)
+      expect(elements).toHaveLength(NUM_OF_SUITEQL_ELEMENTS - 1)
       expect(elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
     })
 

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -33,6 +33,7 @@ const runSavedSearchQueryMock = jest.fn()
 const client = {
   runSuiteQL: runSuiteQLMock,
   runSavedSearchQuery: runSavedSearchQueryMock,
+  isSuiteAppConfigured: () => true,
 } as unknown as NetsuiteClient
 
 describe('SuiteQL table elements', () => {

--- a/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_internal_id.test.ts
@@ -49,6 +49,7 @@ describe('data_instances_internal_id', () => {
       isPartial: false,
       config: await getDefaultAdapterConfig(),
     }
+    defaultOpts.config.fetch.resolveAccountSpecificValues = false
   })
   describe('onFetch', () => {
     it('should add account specific value to record refs', async () => {


### PR DESCRIPTION
Enable the "fetch bundles" and "resolve account specific values" features by default.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Enable the "fetch bundles" and "resolve account specific values" features by default

---
_User Notifications_: 
Netsuite Adapter:
- `bundle` instances will be fetched
- `bundle` field will be added to instances that are part of a bundle
- `ACCOUNT_SPECIFIC_VALUE` will be resolved in workflows & data elements, on fetch & deploy