### PR TITLE
SALTO-5332 keep additional properties from swagger as annotation and not field

### DIFF
--- a/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
@@ -58,7 +58,6 @@ const removeAdditionalPropertiesFlat = async (
   }
 }
 
-
 // TODO remove this
 // https://salto-io.atlassian.net/browse/SALTO-5332
 /**

--- a/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
@@ -58,6 +58,9 @@ const removeAdditionalPropertiesFlat = async (
   }
 }
 
+
+// TODO remove this
+// https://salto-io.atlassian.net/browse/SALTO-5332
 /**
  * Remove the additional properties value we added on fetch in normalizeElementValues before deploy
  * and add its values to the top level values if deployable

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -15,25 +15,14 @@
  */
 import _ from 'lodash'
 import {
-  InstanceElement,
-  Values,
-  ObjectType,
-  isObjectType,
-  ReferenceExpression,
-  isReferenceExpression,
-  isListType,
-  isMapType,
-  TypeElement,
-  PrimitiveType,
-  MapType,
-  ElemIdGetter,
-  SaltoError,
+  InstanceElement, Values, ObjectType, isObjectType, ReferenceExpression, isReferenceExpression,
+  isListType, ElemIdGetter, SaltoError, isMapType,
 } from '@salto-io/adapter-api'
-import { transformElement, TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
+import { TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { ADDITIONAL_PROPERTIES_FIELD, ARRAY_ITEMS_FIELD } from './type_elements/swagger_parser'
-import { InstanceCreationParams, shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
+import { shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
 import { UnauthorizedError, Paginator, PageEntriesExtractor, HTTPError } from '../../client'
 import {
   TypeSwaggerDefaultConfig,
@@ -159,60 +148,6 @@ const extractStandaloneFields = async (
   return allInstances
 }
 
-const getListDeepInnerType = async (type: TypeElement): Promise<ObjectType | PrimitiveType | MapType> => {
-  if (!isListType(type)) {
-    return type
-  }
-  return getListDeepInnerType(await type.getInnerType())
-}
-
-/**
- * Normalize the element's values, by nesting swagger additionalProperties under the
- * additionalProperties field in order to align with the type.
- *
- * Note: The reverse will need to be done pre-deploy (not implemented for fetch-only)
- */
-const normalizeElementValues = (instance: InstanceElement): Promise<InstanceElement> => {
-  const transformAdditionalProps: TransformFunc = async ({ value, field, path }) => {
-    if (!_.isPlainObject(value)) {
-      return value
-    }
-
-    const fieldType = path?.isEqual(instance.elemID) ? await instance.getType() : await field?.getType()
-
-    if (fieldType === undefined) {
-      return value
-    }
-    const fieldInnerType = await getListDeepInnerType(fieldType)
-    if (
-      !isObjectType(fieldInnerType) ||
-      fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD] === undefined ||
-      !isMapType(await fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD].getType())
-    ) {
-      return value
-    }
-
-    const additionalProps = _.merge(
-      _.pickBy(value, (_val, key) => !Object.keys(fieldInnerType.fields).includes(key)),
-      // if the value already has additional properties, give them precedence
-      value[ADDITIONAL_PROPERTIES_FIELD],
-    )
-    return {
-      ..._.omit(value, Object.keys(additionalProps)),
-      [ADDITIONAL_PROPERTIES_FIELD]: additionalProps,
-    }
-  }
-
-  return transformElement({
-    element: instance,
-    transformFunc: transformAdditionalProps,
-    strict: false,
-  })
-}
-
-const toInstance = async (args: InstanceCreationParams): Promise<InstanceElement> =>
-  args.normalized ? toBasicInstance(args) : normalizeElementValues(await toBasicInstance(args))
-
 /**
  * Generate instances for the specified types based on the entries from the API responses,
  * using the endpoint's specific config and the adapter's defaults.
@@ -240,21 +175,19 @@ const generateInstancesForType = ({
 }): Promise<InstanceElement[]> => {
   const standaloneFields = transformationConfigByType[objType.elemID.name]?.standaloneFields
   return awu(entries)
-    .map((entry, index) =>
-      toInstance({
-        entry,
-        type: objType,
-        nestName,
-        parent,
-        transformationConfigByType,
-        transformationDefaultConfig,
-        normalized,
-        nestedPath,
-        defaultName: `unnamed_${index}`, // TODO improve
-        getElemIdFunc,
-      }),
-    )
-    .flatMap(inst =>
+    .map((entry, index) => toBasicInstance({
+      entry,
+      type: objType,
+      nestName,
+      parent,
+      transformationConfigByType,
+      transformationDefaultConfig,
+      normalized,
+      nestedPath,
+      defaultName: `unnamed_${index}`, // TODO improve
+      getElemIdFunc,
+    }))
+    .flatMap(inst => (
       standaloneFields === undefined
         ? [inst]
         : extractStandaloneFields(inst, {
@@ -267,10 +200,13 @@ const generateInstancesForType = ({
     .toArray()
 }
 
-const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean =>
-  _.isEqual(Object.keys(type.fields), [ADDITIONAL_PROPERTIES_FIELD])
+const isItemsOnlyObjectType = (type: ObjectType): boolean => (
+  _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
+)
 
-const isItemsOnlyObjectType = (type: ObjectType): boolean => _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
+const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean => (
+  _.isEqual(Object.keys(type.fields), [ADDITIONAL_PROPERTIES_FIELD])
+)
 
 const normalizeType = async (type: ObjectType | undefined): Promise<ObjectType | undefined> => {
   if (type !== undefined && isItemsOnlyObjectType(type)) {

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -15,8 +15,16 @@
  */
 import _ from 'lodash'
 import {
-  InstanceElement, Values, ObjectType, isObjectType, ReferenceExpression, isReferenceExpression,
-  isListType, ElemIdGetter, SaltoError, isMapType,
+  InstanceElement,
+  Values,
+  ObjectType,
+  isObjectType,
+  ReferenceExpression,
+  isReferenceExpression,
+  isListType,
+  ElemIdGetter,
+  SaltoError,
+  isMapType,
 } from '@salto-io/adapter-api'
 import { TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -175,19 +183,21 @@ const generateInstancesForType = ({
 }): Promise<InstanceElement[]> => {
   const standaloneFields = transformationConfigByType[objType.elemID.name]?.standaloneFields
   return awu(entries)
-    .map((entry, index) => toBasicInstance({
-      entry,
-      type: objType,
-      nestName,
-      parent,
-      transformationConfigByType,
-      transformationDefaultConfig,
-      normalized,
-      nestedPath,
-      defaultName: `unnamed_${index}`, // TODO improve
-      getElemIdFunc,
-    }))
-    .flatMap(inst => (
+    .map((entry, index) =>
+      toBasicInstance({
+        entry,
+        type: objType,
+        nestName,
+        parent,
+        transformationConfigByType,
+        transformationDefaultConfig,
+        normalized,
+        nestedPath,
+        defaultName: `unnamed_${index}`, // TODO improve
+        getElemIdFunc,
+      }),
+    )
+    .flatMap(inst =>
       standaloneFields === undefined
         ? [inst]
         : extractStandaloneFields(inst, {
@@ -200,13 +210,10 @@ const generateInstancesForType = ({
     .toArray()
 }
 
-const isItemsOnlyObjectType = (type: ObjectType): boolean => (
-  _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
-)
+const isItemsOnlyObjectType = (type: ObjectType): boolean => _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
 
-const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean => (
+const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean =>
   _.isEqual(Object.keys(type.fields), [ADDITIONAL_PROPERTIES_FIELD])
-)
 
 const normalizeType = async (type: ObjectType | undefined): Promise<ObjectType | undefined> => {
   if (type !== undefined && isItemsOnlyObjectType(type)) {

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -171,9 +171,7 @@ const typeAdder = ({
         // fallback type name when no name is provided in the swagger def
         `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
       )
-      Object.assign(type.annotations, {
-        [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: { refType: additionalPropertiesType },
-      })
+      type.annotate({ [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: { refType: additionalPropertiesType } })
     }
 
     if (endpoints !== undefined && endpoints.length > 0) {

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -20,9 +20,9 @@ import {
   ElemID,
   BuiltinTypes,
   Field,
-  MapType,
   ListType,
   TypeMap,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { types as lowerdashTypes, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -165,36 +165,15 @@ const typeAdder = ({
         return new Field(type, fieldName, createNestedType(fieldSchema, toNestedTypeName(fieldSchema)))
       }),
     )
-
     if (additionalProperties !== undefined) {
-      if (type.fields[ADDITIONAL_PROPERTIES_FIELD] !== undefined) {
-        log.warn(
-          'type %s has both a standard %s field and allows additionalProperties - overriding with an additionalProperties field of type unknown',
-          type.elemID.name,
-          ADDITIONAL_PROPERTIES_FIELD,
-        )
-        Object.assign(type.fields, {
-          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
-            type,
-            ADDITIONAL_PROPERTIES_FIELD,
-            new MapType(BuiltinTypes.UNKNOWN),
-          ),
-        })
-      } else {
-        Object.assign(type.fields, {
-          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
-            type,
-            ADDITIONAL_PROPERTIES_FIELD,
-            new MapType(
-              createNestedType(
-                additionalProperties,
-                // fallback type name when no name is provided in the swagger def
-                `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
-              ),
-            ),
-          ),
-        })
-      }
+      const additionalPropertiesType = createNestedType(
+        additionalProperties,
+        // fallback type name when no name is provided in the swagger def
+        `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
+      )
+      Object.assign(type.annotations, {
+        [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: { refType: additionalPropertiesType },
+      })
     }
 
     if (endpoints !== undefined && endpoints.length > 0) {

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -289,17 +289,13 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
               primaryOwner: { name: 'primary' },
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -526,10 +522,8 @@ describe('swagger_instance_elements', () => {
             objectTypes.Owner,
             {
               name: 'o1',
-              additionalProperties: {
-                bla: 'BLA',
-                x: { nested: 'value' },
-              },
+              bla: 'BLA',
+              x: { nested: 'value' },
             },
             // path has no effect on equality
             [],
@@ -565,10 +559,8 @@ describe('swagger_instance_elements', () => {
               name: 'def',
               owners: [new ReferenceExpression(dogO1Inst.elemID)],
               primaryOwner: new ReferenceExpression(primaryOInst.elemID),
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             // path has no effect on equality
             [],
@@ -704,16 +696,12 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -796,10 +784,8 @@ describe('swagger_instance_elements', () => {
             objectTypes.Owner,
             {
               name: 'o1',
-              additionalProperties: {
-                bla: 'BLA',
-                x: { nested: 'value' },
-              },
+              bla: 'BLA',
+              x: { nested: 'value' },
             },
             [ADAPTER_NAME, 'Records', 'Owner', 'o1'],
           ),
@@ -940,17 +926,13 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
               primaryOwner: { name: 'primary' },
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -1060,9 +1042,7 @@ describe('swagger_instance_elements', () => {
             objectTypes.CustomObjectDefinition,
             {
               name: 'Pet',
-              additionalProperties: {
-                something: 'else',
-              },
+              something: 'else',
             },
             [ADAPTER_NAME, 'CustomObjectDefinition', 'Owner', 'Pet'],
           ),
@@ -1133,86 +1113,10 @@ describe('swagger_instance_elements', () => {
               primaryOwner: [
                 {
                   name: 'o3',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
-                },
-              ],
-            },
-            [ADAPTER_NAME, 'Records', 'Pet', 'mouse'],
-          ),
-        ),
-      ).toBeTruthy()
-    })
-
-    it('should not put existing field values under additionalProperties even if they unexpectedly contain single values', async () => {
-      const objectTypes = generateObjectTypes()
-
-      mockPaginator = mockFunction<Paginator>().mockImplementation(
-        async function* getAll(getParams, extractPageEntries) {
-          if (getParams.url === '/pet') {
-            yield [
-              {
-                id: 'mouse',
-                name: 'def',
-                owners: { name: 'o3', bla: 'BLA', x: { nested: 'value' } },
-              },
-            ].flatMap(extractPageEntries)
-          }
-        },
-      )
-      const res = await getAllInstances({
-        paginator: mockPaginator,
-        apiConfig: {
-          typeDefaults: {
-            transformation: {
-              idFields: ['id'],
-            },
-          },
-          types: {
-            Pet: {
-              request: {
-                url: '/pet',
-              },
-            },
-          },
-        },
-        fetchQuery: createElementQuery({
-          include: [{ type: 'Pet' }],
-          exclude: [],
-        }),
-        supportedTypes: {
-          Pet: ['Pet'],
-        },
-        objectTypes,
-        computeGetArgs: simpleGetArgs,
-        nestedFieldFinder: returnFullEntry,
-      })
-      expect(res.elements).toHaveLength(1)
-      const petInst = res.elements[0]
-      expect(petInst.elemID.getFullName()).toEqual(`${ADAPTER_NAME}.Pet.instance.mouse`)
-      expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith(
-        { url: '/pet', recursiveQueryParams: undefined, paginationField: undefined },
-        expect.anything(),
-      )
-
-      expect(
-        petInst.isEqual(
-          new InstanceElement(
-            'mouse',
-            objectTypes.Pet,
-            {
-              id: 'mouse',
-              name: 'def',
-              owners: {
-                name: 'o3',
-                additionalProperties: {
                   bla: 'BLA',
                   x: { nested: 'value' },
                 },
-              },
+              ],
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'mouse'],
           ),
@@ -1384,23 +1288,19 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')
         expect(fish.value).toHaveProperty('owners', [
-          { name: 'o1', additionalProperties: { info: { numOfPets: 2 } } },
-          { name: 'o2', additionalProperties: { info: { numOfPets: 2 } } },
+          { name: 'o1', info: { numOfPets: 2 } },
+          { name: 'o2', info: { numOfPets: 2 } },
         ])
       })
 
@@ -1440,17 +1340,13 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')
@@ -1496,17 +1392,13 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -100,7 +100,6 @@ describe('swagger_type_elements', () => {
         const pet = allTypes.Pet as ObjectType
         expect(pet).toBeInstanceOf(ObjectType)
         expect(_.mapValues(pet.fields, f => f.refType.elemID.getFullName())).toEqual({
-          additionalProperties: 'Map<unknown>',
           category: 'myAdapter.Category',
           id: 'number',
           name: 'serviceid',
@@ -138,19 +137,15 @@ describe('swagger_type_elements', () => {
           middleName: 'string',
           // ref to UserAdditional2 in swagger
           middleName2: 'string',
-          // additional properties
-          additionalProperties: 'Map<myAdapter.Order>',
         })
 
-        // additionalProperties explicit property combined with enabled additionalProperties
-        // should be undefined
         const food = allTypes.Food as ObjectType
         expect(food).toBeInstanceOf(ObjectType)
         expect(_.mapValues(food.fields, f => f.refType.elemID.getFullName())).toEqual({
           brand: 'string',
           id: 'number',
           storage: 'List<string>',
-          additionalProperties: 'Map<unknown>',
+          additionalProperties: 'myAdapter.Category',
         })
 
         return { allTypes, parsedConfigs }
@@ -189,7 +184,6 @@ describe('swagger_type_elements', () => {
         const location = allTypes.Location as ObjectType
         expect(location).toBeInstanceOf(ObjectType)
         expect(_.mapValues(location.fields, f => f.refType.elemID.name)).toEqual({
-          additionalProperties: 'Map<unknown>',
           name: 'serviceid',
           // address is defined as anyOf combining primitive and object - should use unknown
           address: 'unknown',
@@ -316,7 +310,6 @@ describe('swagger_type_elements', () => {
         // regular response type with reference
         const pet = allTypes.Pet__new
         expect(Object.keys((pet as ObjectType).fields).sort()).toEqual([
-          'additionalProperties',
           'category',
           'id',
           'name',

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1120,7 +1120,7 @@ export const getSubtypes = async (types: ObjectType[], validateUniqueness = fals
   const findSubtypes = async (type: ObjectType): Promise<void> => {
     const fieldsTypes = await Promise.all(Object.values(type.fields).map(field => field.getType()))
     const additionalPropertiesRefType = type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType
-    await awu(additionalPropertiesRefType ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes).forEach(
+    await awu(additionalPropertiesRefType !== undefined ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes).forEach(
       async refType => {
         const fieldType = isContainerType(refType) ? await refType.getInnerType() : refType
 

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1118,11 +1118,12 @@ export const getSubtypes = async (types: ObjectType[], validateUniqueness = fals
   const subtypes: Record<string, ObjectType> = {}
 
   const findSubtypes = async (type: ObjectType): Promise<void> => {
-    await awu(Object.values(type.fields)).forEach(async field => {
-      const fieldContainerOrType = await field.getType()
-      const fieldType = isContainerType(fieldContainerOrType)
-        ? await fieldContainerOrType.getInnerType()
-        : fieldContainerOrType
+    const fieldsTypes = await Promise.all(Object.values(type.fields).map(field => field.getType()))
+    const additionalPropertiesRefType = type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType
+    await awu(additionalPropertiesRefType ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes).forEach(async refType => {
+      const fieldType = isContainerType(refType)
+        ? await refType.getInnerType()
+        : refType
 
       if (!isObjectType(fieldType) || types.includes(fieldType)) {
         return

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1120,24 +1120,24 @@ export const getSubtypes = async (types: ObjectType[], validateUniqueness = fals
   const findSubtypes = async (type: ObjectType): Promise<void> => {
     const fieldsTypes = await Promise.all(Object.values(type.fields).map(field => field.getType()))
     const additionalPropertiesRefType = type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType
-    await awu(additionalPropertiesRefType ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes).forEach(async refType => {
-      const fieldType = isContainerType(refType)
-        ? await refType.getInnerType()
-        : refType
+    await awu(additionalPropertiesRefType ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes).forEach(
+      async refType => {
+        const fieldType = isContainerType(refType) ? await refType.getInnerType() : refType
 
-      if (!isObjectType(fieldType) || types.includes(fieldType)) {
-        return
-      }
-      if (fieldType.elemID.getFullName() in subtypes) {
-        if (validateUniqueness && !subtypes[fieldType.elemID.getFullName()].isEqual(fieldType)) {
-          log.warn(`duplicate ElemIDs of subtypes found. The duplicate is ${fieldType.elemID.getFullName()}`)
+        if (!isObjectType(fieldType) || types.includes(fieldType)) {
+          return
         }
-        return
-      }
+        if (fieldType.elemID.getFullName() in subtypes) {
+          if (validateUniqueness && !subtypes[fieldType.elemID.getFullName()].isEqual(fieldType)) {
+            log.warn(`duplicate ElemIDs of subtypes found. The duplicate is ${fieldType.elemID.getFullName()}`)
+          }
+          return
+        }
 
-      subtypes[fieldType.elemID.getFullName()] = fieldType
-      await findSubtypes(fieldType)
-    })
+        subtypes[fieldType.elemID.getFullName()] = fieldType
+        await findSubtypes(fieldType)
+      },
+    )
   }
 
   await awu(types).forEach(findSubtypes)

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -92,7 +92,9 @@ export const transformNotificationEvent = (notificationEvent: NotificationEvent)
   notificationEvent.notifications?.forEach((notification: Values) => {
     notification.type = notification.notificationType
     delete notification.notificationType
-    delete notification.additionalProperties
+    delete notification.recipient
+    delete notification.field
+    delete notification.projectRole
     delete notification.user
     delete notification.id
   })

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -40,7 +40,6 @@ const NOT_FETCHED_POST_FUNCTION_TYPES = ['GenerateChangeHistoryFunction', 'Issue
 const FETCHED_ONLY_INITIAL_POST_FUNCTION = ['UpdateIssueStatusFunction', 'CreateCommentFunction', 'IssueStoreFunction']
 
 const transformProperties = (item: Status | Transition): void => {
-  // item.properties = item.properties?.additionalProperties
   // This is not deployable and we get another property
   // of "jira.issue.editable" with the same value
   delete item.properties?.issueEditable

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -40,7 +40,7 @@ const NOT_FETCHED_POST_FUNCTION_TYPES = ['GenerateChangeHistoryFunction', 'Issue
 const FETCHED_ONLY_INITIAL_POST_FUNCTION = ['UpdateIssueStatusFunction', 'CreateCommentFunction', 'IssueStoreFunction']
 
 const transformProperties = (item: Status | Transition): void => {
-  item.properties = item.properties?.additionalProperties
+  // item.properties = item.properties?.additionalProperties
   // This is not deployable and we get another property
   // of "jira.issue.editable" with the same value
   delete item.properties?.issueEditable

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -355,8 +355,10 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
       .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE)
       .filter(instance => instance.value.issueTypeMappings !== undefined)
       .forEach(instance => {
-        instance.value.items = Object.entries(instance.value.issueTypeMappings
-           ?? {}).map(([issueType, workflow]) => ({ workflow, issueType }))
+        instance.value.items = Object.entries(instance.value.issueTypeMappings ?? {}).map(([issueType, workflow]) => ({
+          workflow,
+          issueType,
+        }))
         delete instance.value.issueTypeMappings
       })
   },

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -355,9 +355,8 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
       .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE)
       .filter(instance => instance.value.issueTypeMappings !== undefined)
       .forEach(instance => {
-        instance.value.items = Object.entries(instance.value.issueTypeMappings.additionalProperties ?? {}).map(
-          ([issueType, workflow]) => ({ workflow, issueType }),
-        )
+        instance.value.items = Object.entries(instance.value.issueTypeMappings
+           ?? {}).map(([issueType, workflow]) => ({ workflow, issueType }))
         delete instance.value.issueTypeMappings
       })
   },

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
@@ -50,7 +50,6 @@ describe('notificationSchemeStructureFilter', () => {
               notificationType: 'type',
               parameter: 'parameter',
               user: 'user',
-              additionalProperties: 'additionalProperties',
             },
           ],
         },

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -197,18 +197,14 @@ describe('workflowStructureFilter', () => {
         statuses: [
           {
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'true',
-                issueEditable: true,
-              },
+              'jira.issue.editable': 'true',
+              issueEditable: true,
             },
           },
           {
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'false',
-                issueEditable: false,
-              },
+              'jira.issue.editable': 'false',
+              issueEditable: false,
             },
           },
           {},
@@ -237,19 +233,15 @@ describe('workflowStructureFilter', () => {
           {
             name: 'tran1',
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'true',
-                issueEditable: true,
-              },
+              'jira.issue.editable': 'true',
+              issueEditable: true,
             },
           },
           {
             name: 'tran2',
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'false',
-                issueEditable: false,
-              },
+              'jira.issue.editable': 'false',
+              issueEditable: false,
             },
           },
           { name: 'tran3' },

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -113,9 +113,7 @@ describe('workflowScheme', () => {
     it('replace value of issueTypeMappings with items', async () => {
       const instance = new InstanceElement('instance', workflowSchemeType, {
         issueTypeMappings: {
-          additionalProperties: {
-            1234: 'workflow name',
-          },
+          1234: 'workflow name',
         },
       })
       await filter.onFetch?.([instance])

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -48,7 +48,6 @@ const orderPasswordPolicyRuleMethods = (instance: InstanceElement): void => {
   const methodsPath = instance.elemID.createNestedID(
     'actions',
     'selfServicePasswordReset',
-    'additionalProperties',
     'requirement',
     'primary',
     'methods',

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -42,7 +42,7 @@ const log = logger(module)
 const { getTransformationConfigByType } = configUtils
 const { toBasicInstance } = elementUtils
 const { isDefined } = values
-const LINK_PATH = [LINKS_FIELD, 'additionalProperties', 'schema', 'href']
+const LINK_PATH = [LINKS_FIELD, 'schema', 'href']
 
 const getUserSchemaId = (instance: InstanceElement): string | undefined => {
   const url = _.get(instance.value, LINK_PATH)

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -68,20 +68,21 @@ describe('unorderedListsFilter', () => {
         actions: {
           selfServicePasswordReset: {
             access: 'ALLOW',
-            additionalProperties: {
-              requirement: {
-                primary: {
-                  methods: ['push', 'email', 'voice', 'sms'],
-                },
+            requirement: {
+              primary: {
+                methods: ['push', 'email', 'voice', 'sms'],
               },
             },
           },
         },
       })
       await filter.onFetch([policyRuleType, policyRuleInstance])
-      expect(
-        policyRuleInstance.value.actions.selfServicePasswordReset.additionalProperties.requirement.primary.methods,
-      ).toEqual(['email', 'push', 'sms', 'voice'])
+      expect(policyRuleInstance.value.actions.selfServicePasswordReset.requirement.primary.methods).toEqual([
+        'email',
+        'push',
+        'sms',
+        'voice',
+      ])
     })
 
     it('should do nothing if there are no methods defined', async () => {

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -45,10 +45,8 @@ describe('userSchemaFilter', () => {
     id: 123,
     name: 'A',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/A123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/A123',
       },
     },
     default: false,
@@ -69,10 +67,8 @@ describe('userSchemaFilter', () => {
     id: 345,
     name: 'C',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/C123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/C123',
       },
     },
     default: true,

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -55,10 +55,8 @@ describe('userSchemaFilter', () => {
     id: 234,
     name: 'B',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/B123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/B123',
       },
     },
     default: false,


### PR DESCRIPTION
Keep additional properties annotation from swagger and stop creating a field `additionalProperties` 

---



---
_Release Notes_: 
_Jira_Adapter_:
Instances with `additionalProperties` map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

_Okta_Adapter_:
Instances with `additionalProperties` map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)


---
_User Notifications_: 

_Jira_Adapter_:
Instances with `additionalProperties` map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

_Okta_Adapter_:
Instances with `additionalProperties` map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)
