### PR TITLE
SALTO-5434: Fix default attribute CV

### DIFF
--- a/packages/jira-adapter/src/change_validators/assets/default_attribute.ts
+++ b/packages/jira-adapter/src/change_validators/assets/default_attribute.ts
@@ -43,6 +43,7 @@ export const defaultAttributeValidator: (
 
   return awu(changes)
     .filter(isInstanceChange)
+    .filter(isRemovalChange)
     .filter(change => getChangeData(change).elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
     .filter(async change => {
       const instance = getChangeData(change)
@@ -61,8 +62,8 @@ export const defaultAttributeValidator: (
     .map(async change => ({
       elemID: getChangeData(change).elemID,
       severity: 'Error' as SeverityLevel,
-      message: 'Cannot deploy a system non editable attribute.',
-      detailedMessage: `Cannot deploy this attribute ${getChangeData(change).elemID.name}, as it is a system non deployable attribute.`,
+      message: 'Cannot remove a system non removable attribute.',
+      detailedMessage: `Cannot deploy this attribute ${getChangeData(change).elemID.name}, as it is a system non removable attribute.`,
     }))
     .toArray()
 }

--- a/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
+++ b/packages/jira-adapter/test/change_validators/assets/default_attribute.test.ts
@@ -69,7 +69,7 @@ describe('attributeValidator', () => {
     config.fetch.enableJSM = true
     config.fetch.enableJsmExperimental = true
   })
-  it('should return error if trying to add non editable defult attribute', async () => {
+  it('should not return error if trying to add non editable defult attribute', async () => {
     attributeInstance = new InstanceElement(
       'attribute1',
       createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
@@ -82,12 +82,12 @@ describe('attributeValidator', () => {
     )
     const validator = defaultAttributeValidator(config, client)
     const changeErrors = await validator(
-      [toChange({ before: attributeInstance })],
+      [toChange({ after: attributeInstance })],
       elementsSource
     )
-    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toHaveLength(0)
   })
-  it('should return error if trying to modify non editable defult attribute', async () => {
+  it('should not return error if trying to modify non editable defult attribute', async () => {
     attributeInstance = new InstanceElement(
       'attribute1',
       createEmptyType(OBJECT_TYPE_ATTRIBUTE_TYPE),
@@ -103,7 +103,7 @@ describe('attributeValidator', () => {
       [toChange({ before: attributeInstance, after: attributeInstance })],
       elementsSource
     )
-    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toHaveLength(0)
   })
   it('should return error if trying to remove non editable defult attribute', async () => {
     attributeInstance = new InstanceElement(


### PR DESCRIPTION
I fixed the default attribute CV to refer only to removal changes and not refers to all changes.

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira Adapter:_
Fixed bug in default attribute CV. 

---
_User Notifications_: 
None
