### PR TITLE
SALTO-4741 - Salesforce: don't allow deploying instances without their types

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -45,6 +45,7 @@ import installedPackages from './change_validators/installed_packages'
 import dataCategoryGroupValidator from './change_validators/data_category_group'
 import standardFieldOrObjectAdditionsOrDeletions from './change_validators/standard_field_or_object_additions_or_deletions'
 import deletedNonQueryableFields from './change_validators/deleted_non_queryable_fields'
+import instanceWithUnknownType from './change_validators/instance_with_unknown_type'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
@@ -98,6 +99,7 @@ export const changeValidators: Record<
   standardFieldOrObjectAdditionsOrDeletions: () =>
     standardFieldOrObjectAdditionsOrDeletions,
   deletedNonQueryableFields: () => deletedNonQueryableFields,
+  instanceWithUnknownType: () => instanceWithUnknownType,
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/instance_with_unknown_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/instance_with_unknown_type.ts
@@ -15,26 +15,29 @@
  */
 import {
   ChangeError,
-  ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange,
+  ChangeValidator,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
   isPlaceholderObjectType,
 } from '@salto-io/adapter-api'
 
-const createInstanceWithoutTypeError = (instance: InstanceElement): ChangeError => (
-  {
-    elemID: instance.elemID,
-    message: 'Instance added without its type',
-    detailedMessage: `The record ${instance.elemID.getFullName()} is being added, but its type (${instance.getTypeSync().elemID.getFullName()}) is not.`,
-    severity: 'Error',
-  }
-)
+const createInstanceWithoutTypeError = (
+  instance: InstanceElement,
+): ChangeError => ({
+  elemID: instance.elemID,
+  message: 'Instance added without its type',
+  detailedMessage: `The record ${instance.elemID.getFullName()} is being added, but its type (${instance.getTypeSync().elemID.getFullName()}) is not.`,
+  severity: 'Error',
+})
 
-const changeValidator: ChangeValidator = async changes => (
+const changeValidator: ChangeValidator = async (changes) =>
   changes
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)
     .map(getChangeData)
-    .filter(instance => isPlaceholderObjectType(instance.getTypeSync()))
+    .filter((instance) => isPlaceholderObjectType(instance.getTypeSync()))
     .map(createInstanceWithoutTypeError)
-)
 
 export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/instance_with_unknown_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/instance_with_unknown_type.ts
@@ -1,0 +1,40 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeError,
+  ChangeValidator, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceChange,
+  isPlaceholderObjectType,
+} from '@salto-io/adapter-api'
+
+const createInstanceWithoutTypeError = (instance: InstanceElement): ChangeError => (
+  {
+    elemID: instance.elemID,
+    message: 'Instance added without its type',
+    detailedMessage: `The record ${instance.elemID.getFullName()} is being added, but its type (${instance.getTypeSync().elemID.getFullName()}) is not.`,
+    severity: 'Error',
+  }
+)
+
+const changeValidator: ChangeValidator = async changes => (
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => isPlaceholderObjectType(instance.getTypeSync()))
+    .map(createInstanceWithoutTypeError)
+)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -158,6 +158,7 @@ export type ChangeValidatorName =
   | 'dataCategoryGroup'
   | 'standardFieldOrObjectAdditionsOrDeletions'
   | 'deletedNonQueryableFields'
+  | 'instanceWithUnknownType'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -868,6 +869,7 @@ const changeValidatorConfigType =
         refType: BuiltinTypes.BOOLEAN,
       },
       deletedNonQueryableFields: { refType: BuiltinTypes.BOOLEAN },
+      instanceWithUnknownType: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
@@ -23,10 +23,10 @@ import changeValidator from '../../src/change_validators/instance_with_unknown_t
 import { mockTypes } from '../mock_elements'
 
 describe('instanceWithUnknownType', () => {
-  let validationResult: ReadonlyArray<ChangeError>
+  let errors: ReadonlyArray<ChangeError>
   describe('When an instance is added along with its type', () => {
     beforeEach(async () => {
-      validationResult = await changeValidator([
+      errors = await changeValidator([
         toChange({ after: mockTypes.Account }),
         toChange({
           after: new InstanceElement('SomeAccount', mockTypes.Account),
@@ -34,23 +34,23 @@ describe('instanceWithUnknownType', () => {
       ])
     })
     it('Should not raise an error', () => {
-      expect(validationResult).toBeEmpty()
+      expect(errors).toBeEmpty()
     })
   })
   describe('When an instance is modified without its type', () => {
     const instance = new InstanceElement('SomeAccount', mockTypes.Account)
     beforeEach(async () => {
-      validationResult = await changeValidator([
+      errors = await changeValidator([
         toChange({ before: instance, after: instance }),
       ])
     })
     it('Should not raise an error', () => {
-      expect(validationResult).toBeEmpty()
+      expect(errors).toBeEmpty()
     })
   })
   describe('When an instance is added and its type is modified', () => {
     beforeEach(async () => {
-      validationResult = await changeValidator([
+      errors = await changeValidator([
         toChange({ before: mockTypes.Account, after: mockTypes.Account }),
         toChange({
           after: new InstanceElement('SomeAccount', mockTypes.Account),
@@ -58,7 +58,7 @@ describe('instanceWithUnknownType', () => {
       ])
     })
     it('Should not raise an error', () => {
-      expect(validationResult).toBeEmpty()
+      expect(errors).toBeEmpty()
     })
   })
   describe('When an instance is added without its type', () => {
@@ -67,11 +67,11 @@ describe('instanceWithUnknownType', () => {
       new TypeReference(mockTypes.Account.elemID),
     )
     beforeEach(async () => {
-      validationResult = await changeValidator([toChange({ after: instance })])
+      errors = await changeValidator([toChange({ after: instance })])
     })
     it('Should raise an error', () => {
-      expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll((error) =>
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toSatisfy((error) =>
         error.elemID.isEqual(instance.elemID),
       )
     })
@@ -82,14 +82,14 @@ describe('instanceWithUnknownType', () => {
       new TypeReference(mockTypes.Account.elemID),
     )
     beforeEach(async () => {
-      validationResult = await changeValidator([
+      errors = await changeValidator([
         toChange({ after: instance }),
         toChange({ before: mockTypes.Account }),
       ])
     })
     it('Should raise an error', () => {
-      expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll((error) =>
+      expect(errors).toHaveLength(1)
+      expect(errors).toSatisfyAll((error) =>
         error.elemID.isEqual(instance.elemID),
       )
     })
@@ -100,14 +100,14 @@ describe('instanceWithUnknownType', () => {
       new TypeReference(mockTypes.Account.elemID),
     )
     beforeEach(async () => {
-      validationResult = await changeValidator([
+      errors = await changeValidator([
         toChange({ before: instance, after: instance }),
         toChange({ before: mockTypes.Account }),
       ])
     })
     it('Should raise an error', () => {
-      expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll((error) =>
+      expect(errors).toHaveLength(1)
+      expect(errors).toSatisfyAll((error) =>
         error.elemID.isEqual(instance.elemID),
       )
     })

--- a/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
@@ -1,0 +1,93 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeError, InstanceElement, toChange, TypeReference } from '@salto-io/adapter-api'
+import changeValidator from '../../src/change_validators/instance_with_unknown_type'
+import { mockTypes } from '../mock_elements'
+
+describe('instanceWithUnknownType', () => {
+  let validationResult: ReadonlyArray<ChangeError>
+  describe('When an instance is added along with its type', () => {
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ after: mockTypes.Account }),
+        toChange({ after: new InstanceElement('SomeAccount', mockTypes.Account) }),
+      ])
+    })
+    it('Should not raise an error', () => {
+      expect(validationResult).toBeEmpty()
+    })
+  })
+  describe('When an instance is modified without its type', () => {
+    const instance = new InstanceElement('SomeAccount', mockTypes.Account)
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ before: instance, after: instance }),
+      ])
+    })
+    it('Should not raise an error', () => {
+      expect(validationResult).toBeEmpty()
+    })
+  })
+  describe('When an instance is added and its type is modified', () => {
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ before: mockTypes.Account, after: mockTypes.Account }),
+        toChange({ after: new InstanceElement('SomeAccount', mockTypes.Account) }),
+      ])
+    })
+    it('Should not raise an error', () => {
+      expect(validationResult).toBeEmpty()
+    })
+  })
+  describe('When an instance is added without its type', () => {
+    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ after: instance }),
+      ])
+    })
+    it('Should raise an error', () => {
+      expect(validationResult).toHaveLength(1)
+      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+    })
+  })
+  describe('When an instance is added and its type is deleted', () => {
+    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ after: instance }),
+        toChange({ before: mockTypes.Account }),
+      ])
+    })
+    it('Should raise an error', () => {
+      expect(validationResult).toHaveLength(1)
+      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+    })
+  })
+  describe('When an instance is modified and its type is deleted', () => {
+    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    beforeEach(async () => {
+      validationResult = await changeValidator([
+        toChange({ before: instance, after: instance }),
+        toChange({ before: mockTypes.Account }),
+      ])
+    })
+    it('Should raise an error', () => {
+      expect(validationResult).toHaveLength(1)
+      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/instance_with_unknown_type.test.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ChangeError, InstanceElement, toChange, TypeReference } from '@salto-io/adapter-api'
+import {
+  ChangeError,
+  InstanceElement,
+  toChange,
+  TypeReference,
+} from '@salto-io/adapter-api'
 import changeValidator from '../../src/change_validators/instance_with_unknown_type'
 import { mockTypes } from '../mock_elements'
 
@@ -23,7 +28,9 @@ describe('instanceWithUnknownType', () => {
     beforeEach(async () => {
       validationResult = await changeValidator([
         toChange({ after: mockTypes.Account }),
-        toChange({ after: new InstanceElement('SomeAccount', mockTypes.Account) }),
+        toChange({
+          after: new InstanceElement('SomeAccount', mockTypes.Account),
+        }),
       ])
     })
     it('Should not raise an error', () => {
@@ -45,7 +52,9 @@ describe('instanceWithUnknownType', () => {
     beforeEach(async () => {
       validationResult = await changeValidator([
         toChange({ before: mockTypes.Account, after: mockTypes.Account }),
-        toChange({ after: new InstanceElement('SomeAccount', mockTypes.Account) }),
+        toChange({
+          after: new InstanceElement('SomeAccount', mockTypes.Account),
+        }),
       ])
     })
     it('Should not raise an error', () => {
@@ -53,19 +62,25 @@ describe('instanceWithUnknownType', () => {
     })
   })
   describe('When an instance is added without its type', () => {
-    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    const instance = new InstanceElement(
+      'SomeAccount',
+      new TypeReference(mockTypes.Account.elemID),
+    )
     beforeEach(async () => {
-      validationResult = await changeValidator([
-        toChange({ after: instance }),
-      ])
+      validationResult = await changeValidator([toChange({ after: instance })])
     })
     it('Should raise an error', () => {
       expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+      expect(validationResult).toSatisfyAll((error) =>
+        error.elemID.isEqual(instance.elemID),
+      )
     })
   })
   describe('When an instance is added and its type is deleted', () => {
-    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    const instance = new InstanceElement(
+      'SomeAccount',
+      new TypeReference(mockTypes.Account.elemID),
+    )
     beforeEach(async () => {
       validationResult = await changeValidator([
         toChange({ after: instance }),
@@ -74,11 +89,16 @@ describe('instanceWithUnknownType', () => {
     })
     it('Should raise an error', () => {
       expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+      expect(validationResult).toSatisfyAll((error) =>
+        error.elemID.isEqual(instance.elemID),
+      )
     })
   })
   describe('When an instance is modified and its type is deleted', () => {
-    const instance = new InstanceElement('SomeAccount', new TypeReference(mockTypes.Account.elemID))
+    const instance = new InstanceElement(
+      'SomeAccount',
+      new TypeReference(mockTypes.Account.elemID),
+    )
     beforeEach(async () => {
       validationResult = await changeValidator([
         toChange({ before: instance, after: instance }),
@@ -87,7 +107,9 @@ describe('instanceWithUnknownType', () => {
     })
     it('Should raise an error', () => {
       expect(validationResult).toHaveLength(1)
-      expect(validationResult).toSatisfyAll(error => error.elemID.isEqual(instance.elemID))
+      expect(validationResult).toSatisfyAll((error) =>
+        error.elemID.isEqual(instance.elemID),
+      )
     })
   })
 })


### PR DESCRIPTION

In some "Compare and Deploy" cases there may be cases where instances are deployed to the new environment but their types are not.
Let's create an explicit warning in such cases.
---

Tests:
 - Delete the `Account` folder in a workspace, add an `Account` instance and deploy. Observe the CV warning.

---
_Release Notes_: 
Salesforce: Warn when attempting to add instances without their types

---
_User Notifications_: 
N/A
