### PR TITLE
SALTO-4536: Nest app schema and app logo under application type

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -367,7 +367,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
         },
         {
           type: 'AppUserSchema',
-          toField: 'appUserSchema',
+          toField: 'AppUserSchema',
           context: [{ name: 'appId', fromField: 'id' }],
         },
       ],
@@ -383,14 +383,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
         { fieldName: 'assignedGroups', fieldType: 'list<ApplicationGroupAssignment>' },
         { fieldName: 'profileEnrollment', fieldType: 'string' },
         { fieldName: 'accessPolicy', fieldType: 'string' },
-        { fieldName: 'appUserSchema', fieldType: 'list<AppUserSchema>' },
+        { fieldName: 'AppUserSchema', fieldType: 'list<AppUserSchema>' },
       ],
       idFields: ['label'],
       serviceIdField: 'id',
       fieldsToHide: [{ fieldName: CUSTOM_NAME_FIELD }, { fieldName: 'id' }, { fieldName: '_links' }],
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat({ fieldName: '_embedded' }),
       serviceUrl: '/admin/app/{name}/instance/{id}/#tab-general',
-      standaloneFields: [{ fieldName: 'appUserSchema' }],
+      standaloneFields: [{ fieldName: 'AppUserSchema' }],
     },
     deployRequests: {
       add: {
@@ -439,8 +439,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       url: '/api/v1/meta/schemas/apps/{appId}/default',
     },
     transformation: {
-      idFields: [],
-      extendsParentId: true,
+      idFields: [], // the parent name is being used
       dataField: '.',
       fieldsToOmit: DEFAULT_FIELDS_TO_OMIT.concat(
         { fieldName: '$schema' },

--- a/packages/okta-adapter/src/filters/app_logo.ts
+++ b/packages/okta-adapter/src/filters/app_logo.ts
@@ -99,6 +99,7 @@ const getAppLogo = async ({
 }): Promise<InstanceElement | Error> => {
   const appLogo = app.value[LINKS_FIELD].logo[0]
   const logoLink = appLogo.href
+
   const idFields = configUtils.getTypeTransformationConfig(
     APPLICATION_TYPE_NAME,
     config.apiDefinitions.types,
@@ -110,7 +111,15 @@ const getAppLogo = async ({
   if (contentType === undefined) {
     return new Error(`Failed to find content type for ${app.elemID.name}`)
   }
-  return getLogo({ client, parents: [app], logoType: appLogoType, contentType, logoName: name, link: logoLink })
+  return getLogo({
+    client,
+    parents: [app],
+    logoType: appLogoType,
+    contentType,
+    logoName: name,
+    link: logoLink,
+    nestedPath: app.path?.slice(2, app.path?.length - 1) ?? [],
+  })
 }
 
 /**

--- a/packages/okta-adapter/src/filters/delete_fields.ts
+++ b/packages/okta-adapter/src/filters/delete_fields.ts
@@ -25,7 +25,7 @@ import {
 
 const TYPES_TO_FIELDS: Record<string, string[]> = {
   [GROUP_TYPE_NAME]: ['roles'],
-  [APPLICATION_TYPE_NAME]: ['appUserSchema'],
+  [APPLICATION_TYPE_NAME]: ['AppUserSchema'],
   [AUTHORIZATION_POLICY]: ['policyRules'],
   [AUTOMATION_TYPE_NAME]: ['policyRules'],
   ...Object.fromEntries(POLICY_TYPE_NAMES.map(typeName => [typeName, ['policyRules']])),

--- a/packages/okta-adapter/src/logo.ts
+++ b/packages/okta-adapter/src/logo.ts
@@ -143,6 +143,7 @@ export const getLogo = async ({
   contentType,
   logoName,
   link,
+  nestedPath = [],
 }: {
   client: OktaClient
   parents: InstanceElement[]
@@ -150,6 +151,7 @@ export const getLogo = async ({
   contentType: string
   logoName: string
   link: string
+  nestedPath?: string[]
 }): Promise<InstanceElement | Error> => {
   const logoContent = await getLogoContent(link, client)
   if (logoContent instanceof Error) {
@@ -172,7 +174,7 @@ export const getLogo = async ({
         content: logoContent,
       }),
     },
-    [OKTA, RECORDS_PATH, logoType.elemID.typeName, pathName],
+    [OKTA, RECORDS_PATH, ...nestedPath, logoType.elemID.typeName, pathName],
     {
       [CORE_ANNOTATIONS.PARENT]: refParents,
     },

--- a/packages/okta-adapter/test/filters/delete_fields.test.ts
+++ b/packages/okta-adapter/test/filters/delete_fields.test.ts
@@ -39,7 +39,7 @@ describe('deleteFieldsFilter', () => {
       })
       const applicationInstance = new InstanceElement('application', applicationType, {
         label: 'app',
-        appUserSchema: { id: '123' },
+        AppUserSchema: { id: '123' },
       })
       const accessPolicy = new InstanceElement('access', accessType, {
         id: 'BBB',
@@ -48,7 +48,7 @@ describe('deleteFieldsFilter', () => {
       await filter.onFetch?.([groupType, groupInstance, applicationInstance, accessPolicy, accessType])
       expect(groupInstance.value.roles).toEqual(undefined)
       expect(groupInstance.value).toEqual({ id: 'AAA', profile: { name: 'everyone' } })
-      expect(applicationInstance.value.appUserSchema).toEqual(undefined)
+      expect(applicationInstance.value.AppUserSchema).toEqual(undefined)
       expect(applicationInstance.value).toEqual({ label: 'app' })
       expect(accessPolicy.value).toEqual({ id: 'BBB' })
     })


### PR DESCRIPTION
This pr nests app-related instances under app

---

The new file tree structure will be - 

```md
── Application
    └── appName
       └── AppUserSchema
            └── appUserSchemaName.nacl
       └──AppLogo
            └── appLogoName.nacl
       └──appName.nacl
```

We should have group push instances nested as well, but there's currently a bug with `referencedInstanceNames` blocking it

---
_Release Notes_: 

_Okta_adapter_:
- On the next fetch, AppLogo and AppUserSchema types will now be nested under Application type in the element tree

---
_User Notifications_: 
None