### PR TITLE
SALTO-3483 return detailed change with base change

### DIFF
--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -94,12 +94,10 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
       after?: ElemID
     }
     path?: ReadonlyArray<string>
+    baseChange?: Change<Element>
   }
 
-export type DetailedChangeWithBaseChange<T = ChangeDataType | Values | Value> =
-  DetailedChange<T> & {
-    baseChange: Change<Element>
-  }
+export type DetailedChangeWithBaseChange = DetailedChange & Required<Pick<DetailedChange, 'baseChange'>>
 
 export type ChangeParams<T> = { before?: T; after?: T }
 

--- a/packages/adapter-api/src/change.ts
+++ b/packages/adapter-api/src/change.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/dag'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import {
-  ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TopLevelElement,
+  ObjectType, InstanceElement, Field, isInstanceElement, isObjectType, isField, TopLevelElement, Element,
 } from './elements'
 import { ElemID } from './element_id'
 import { Values, Value } from './values'
@@ -94,6 +94,11 @@ export type DetailedChange<T = ChangeDataType | Values | Value> =
       after?: ElemID
     }
     path?: ReadonlyArray<string>
+  }
+
+export type DetailedChangeWithBaseChange<T = ChangeDataType | Values | Value> =
+  DetailedChange<T> & {
+    baseChange: Change<Element>
   }
 
 export type ChangeParams<T> = { before?: T; after?: T }

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -225,7 +225,7 @@ const getAnnotationTypeChanges = ({
   return []
 }
 
-export const toDetailedChangeWithBaseChange = (
+export const toDetailedChangeFromBaseChange = (
   baseChange: Change<Element>,
   elemIDs?: DetailedChangeWithBaseChange['elemIDs']
 ): DetailedChangeWithBaseChange => ({
@@ -281,7 +281,7 @@ export const detailedCompare = (
   // A special case to handle type changes in fields, we have to modify the whole field
   if (isField(before) && isField(after) && !before.refType.elemID.isEqual(after.refType.elemID)) {
     return [
-      toDetailedChangeWithBaseChange(
+      toDetailedChangeFromBaseChange(
         baseChange,
         { before: before.elemID, after: after.elemID }
       ),
@@ -332,7 +332,7 @@ export const detailedCompare = (
 
 export const getDetailedChanges = (change: Change, compareOptions?: CompareOptions): DetailedChangeWithBaseChange[] => {
   if (change.action !== 'modify') {
-    return [toDetailedChangeWithBaseChange(change)]
+    return [toDetailedChangeFromBaseChange(change)]
   }
   return detailedCompare(
     change.data.before,

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -28,6 +28,7 @@ import {
   ReferenceExpression,
   isAdditionChange,
   toChange,
+  Change,
 } from '@salto-io/adapter-api'
 import { detailedCompare, applyDetailedChanges, getRelevantNamesFromChange } from '../src/compare'
 
@@ -98,11 +99,13 @@ describe('detailedCompare', () => {
       let beforeInst: InstanceElement
       let afterInst: InstanceElement
       let listID: ElemID
+      let baseChange: Change<InstanceElement>
 
       beforeEach(() => {
         beforeInst = new InstanceElement('inst', instType, { list: [] })
         afterInst = new InstanceElement('inst', instType, { list: [] })
         listID = beforeInst.elemID.createNestedID('list')
+        baseChange = toChange({ before: beforeInst, after: afterInst })
       })
 
       it('should detect removals', () => {
@@ -117,6 +120,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -126,6 +130,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('2'),
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
         ])
       })
@@ -142,6 +147,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -151,6 +157,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('1'),
               after: listID.createNestedID('2'),
             },
+            baseChange,
           },
         ])
       })
@@ -167,6 +174,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               after: listID.createNestedID('0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('1'),
@@ -175,6 +183,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -184,6 +193,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('0'),
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('3'),
@@ -193,6 +203,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('2'),
               after: listID.createNestedID('2'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('4'),
@@ -201,6 +212,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               after: listID.createNestedID('3'),
             },
+            baseChange,
           },
         ])
       })
@@ -217,6 +229,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               after: listID.createNestedID('0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('1'),
@@ -226,6 +239,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('0'),
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -235,6 +249,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('1'),
               after: listID.createNestedID('2'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('3'),
@@ -244,6 +259,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('2'),
               after: listID.createNestedID('3'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('4'),
@@ -253,6 +269,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('3'),
               after: listID.createNestedID('4'),
             },
+            baseChange,
           },
         ])
       })
@@ -269,6 +286,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('1'),
@@ -278,6 +296,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('1'),
               after: listID.createNestedID('0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -286,6 +305,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('3'),
@@ -294,6 +314,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('3'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('4'),
@@ -303,6 +324,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('2'),
               after: listID.createNestedID('2'),
             },
+            baseChange,
           },
         ])
       })
@@ -339,6 +361,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('1', 'value2', '0'),
               after: listID.createNestedID('0', 'value2', '0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('0'),
@@ -351,6 +374,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('1'),
               after: listID.createNestedID('0'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('1'),
@@ -363,6 +387,7 @@ describe('detailedCompare', () => {
               before: listID.createNestedID('0'),
               after: listID.createNestedID('1'),
             },
+            baseChange,
           },
         ])
       })
@@ -390,6 +415,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('1'),
             },
+            baseChange,
           },
           {
             id: listID.createNestedID('2'),
@@ -398,6 +424,7 @@ describe('detailedCompare', () => {
             elemIDs: {
               before: listID.createNestedID('2'),
             },
+            baseChange,
           },
         ])
       })
@@ -432,6 +459,10 @@ describe('detailedCompare', () => {
     })
 
     const changes = detailedCompare(before, after)
+    it('should add the right baseChange', () => {
+      const baseChange = toChange({ before, after })
+      changes.forEach(change => expect(change.baseChange).toEqual(baseChange))
+    })
     it('should create add changes for values that were only present in the after type', () => {
       expect(hasChange(
         changes,
@@ -528,6 +559,10 @@ describe('detailedCompare', () => {
 
     describe('without field changes', () => {
       const changes = detailedCompare(before, after)
+      it('should add the right baseChange', () => {
+        const baseChange = toChange({ before, after })
+        changes.forEach(change => expect(change.baseChange).toEqual(baseChange))
+      })
       it('should create add changes for values that were only present in the after object', () => {
         expect(hasChange(
           changes,
@@ -567,6 +602,10 @@ describe('detailedCompare', () => {
     })
     describe('with field changes', () => {
       const changes = detailedCompare(before, after, { createFieldChanges: true })
+      it('should add the right baseChange', () => {
+        const baseChange = toChange({ before, after })
+        changes.forEach(change => expect(change.baseChange).toEqual(baseChange))
+      })
       it('should identify field changes, and create changes with the field id', () => {
         expect(hasChange(
           changes,
@@ -598,6 +637,10 @@ describe('detailedCompare', () => {
       modify: 'After',
     })
     const changes = detailedCompare(before, after)
+    it('should add the right baseChange', () => {
+      const baseChange = toChange({ before, after })
+      changes.forEach(change => expect(change.baseChange).toEqual(baseChange))
+    })
     it('should create add changes for values that were only present in the after field', () => {
       expect(hasChange(
         changes,

--- a/packages/cli/test/commands/apply_patch.test.ts
+++ b/packages/cli/test/commands/apply_patch.test.ts
@@ -13,7 +13,7 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { DetailedChange, Element, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { Element, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { detailedCompare } from '@salto-io/adapter-utils'
 import { calculatePatch } from '@salto-io/core'
 import { merger, updateElementsWithAlternativeAccount } from '@salto-io/workspace'
@@ -65,10 +65,12 @@ describe('apply-patch command', () => {
         originalInstance,
         updatedInstance,
       )
+      const baseChange = toChange({ after: newInstance })
       const additionChange = {
-        ...toChange({ after: newInstance }),
+        ...baseChange,
         id: newInstance.elemID,
-      } as DetailedChange
+        baseChange,
+      }
       mockCalculatePatch.mockResolvedValue({
         changes: [
           ...modifyInstanceChanges.map(c => ({ change: c, serviceChanges: [c] })),

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -14,9 +14,8 @@
 * limitations under the License.
 */
 import { EventEmitter } from 'pietile-eventemitter'
-import { InstanceElement, DetailedChange } from '@salto-io/adapter-api'
-import { fetch, fetchFromWorkspace, FetchChange, FetchProgressEvents, StepEmitter, FetchFunc,
-  loadLocalWorkspace } from '@salto-io/core'
+import { InstanceElement } from '@salto-io/adapter-api'
+import { fetch, fetchFromWorkspace, FetchProgressEvents, StepEmitter, FetchFunc, loadLocalWorkspace } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { CliExitCode, CliTelemetry, CliError } from '../../src/types'
@@ -273,7 +272,7 @@ describe('fetch command', () => {
       })
       describe('with upstream changes', () => {
         const changes = mocks.dummyChanges.map(
-          (change: DetailedChange): FetchChange => ({ change, serviceChanges: [change] })
+          change => ({ change, serviceChanges: [change] })
         )
         const mockFetchWithChanges = jest.fn().mockResolvedValue(
           {

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -15,7 +15,7 @@
 */
 import { restore, restorePaths } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
-import { DetailedChange, ElemID, ModificationChange, StaticFile, Values } from '@salto-io/adapter-api'
+import { DetailedChangeWithBaseChange, ElemID, ModificationChange, StaticFile, Values } from '@salto-io/adapter-api'
 import { getUserBooleanInput } from '../../src/callbacks'
 import { CliExitCode } from '../../src/types'
 import { action } from '../../src/commands/restore'
@@ -439,7 +439,7 @@ describe('restore command', () => {
 
     it('should warn of inner unrestoring modified static files without content', async () => {
       const workspace = mocks.mockWorkspace({})
-      const change: ModificationChange<Values> & DetailedChange = {
+      const change: ModificationChange<Values> & DetailedChangeWithBaseChange = {
         data: {
           before: {
             file: new StaticFile({
@@ -456,6 +456,7 @@ describe('restore command', () => {
         },
         action: 'modify',
         id: new ElemID('adapter', 'type', 'instance', 'inst', 'value'),
+        baseChange: mocks.baseChange('modify'),
       }
       mockRestore.mockResolvedValueOnce([
         {

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import { logger } from '@salto-io/logging'
-import { DetailedChange, ElemID, isRemovalChange } from '@salto-io/adapter-api'
+import { DetailedChange, DetailedChangeWithBaseChange, ElemID, isRemovalChange } from '@salto-io/adapter-api'
 import { ElementSelector, selectElementIdsByTraversal, elementSource, Workspace, remoteMap } from '@salto-io/workspace'
 import wu from 'wu'
 import { collections, values } from '@salto-io/lowerdash'
@@ -132,7 +132,7 @@ export function createDiffChanges(
   elementSelectors?: ElementSelector[],
   topLevelFilters?: IDFilter[],
   resultType?: 'detailedChanges'
-): Promise<DetailedChange[]>
+): Promise<DetailedChangeWithBaseChange[]>
 export async function createDiffChanges(
   toElementsSrc: elementSource.ElementsSource,
   fromElementsSrc: elementSource.ElementsSource,
@@ -140,7 +140,7 @@ export async function createDiffChanges(
   elementSelectors: ElementSelector[] = [],
   topLevelFilters: IDFilter[] = [],
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges'
-): Promise<DetailedChange[] | ChangeWithDetails[]> {
+): Promise<DetailedChangeWithBaseChange[] | ChangeWithDetails[]> {
   if (elementSelectors.length > 0) {
     const matchers = await createMatchers(
       toElementsSrc,

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -63,7 +63,7 @@ import {
   resolvePath,
   safeJsonStringify,
   setPath,
-  toDetailedChangeWithBaseChange,
+  toDetailedChangeFromBaseChange,
   WALK_NEXT_STEP,
   walkOnElement,
   WalkOnFunc,
@@ -113,7 +113,7 @@ const getFetchChangeMetadata = (changedElement: Element | undefined): FetchChang
   getAuthorInformation(changedElement)
 
 export const toAddFetchChange = (elem: Element): FetchChange => {
-  const change = toDetailedChangeWithBaseChange(toChange({ after: elem }))
+  const change = toDetailedChangeFromBaseChange(toChange({ after: elem }))
   return { change, serviceChanges: [change], metadata: getFetchChangeMetadata(elem) }
 }
 

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -20,7 +20,6 @@ import {
   AdapterOperations,
   AdapterOperationsContext,
   AdditionChange,
-  Change,
   CORE_ANNOTATIONS,
   DetailedChange,
   DetailedChangeWithBaseChange,
@@ -64,6 +63,7 @@ import {
   resolvePath,
   safeJsonStringify,
   setPath,
+  toDetailedChangeWithBaseChange,
   WALK_NEXT_STEP,
   walkOnElement,
   WalkOnFunc,
@@ -113,15 +113,7 @@ const getFetchChangeMetadata = (changedElement: Element | undefined): FetchChang
   getAuthorInformation(changedElement)
 
 export const toAddFetchChange = (elem: Element): FetchChange => {
-  const baseChange: Change<Element> = {
-    action: 'add',
-    data: { after: elem },
-  }
-  const change: DetailedChangeWithBaseChange = {
-    ...baseChange,
-    id: elem.elemID,
-    baseChange,
-  }
+  const change = toDetailedChangeWithBaseChange(toChange({ after: elem }))
   return { change, serviceChanges: [change], metadata: getFetchChangeMetadata(elem) }
 }
 

--- a/packages/core/src/core/plan/plan_item.ts
+++ b/packages/core/src/core/plan/plan_item.ts
@@ -16,18 +16,18 @@
 import wu from 'wu'
 
 import { NodeId, Group, ActionName } from '@salto-io/dag'
-import { Change, getChangeData, DetailedChange, CompareOptions } from '@salto-io/adapter-api'
+import { Change, getChangeData, CompareOptions, DetailedChangeWithBaseChange } from '@salto-io/adapter-api'
 import { getDetailedChanges } from '@salto-io/adapter-utils'
 
 export type PlanItemId = NodeId
 export type ChangeWithDetails = Change & {
-  detailedChanges: () => DetailedChange[]
+  detailedChanges: () => DetailedChangeWithBaseChange[]
 }
 export type PlanItem = Group<Change> & {
   action: ActionName
   account: string
   changes: () => Iterable<ChangeWithDetails>
-  detailedChanges: () => Iterable<DetailedChange>
+  detailedChanges: () => Iterable<DetailedChangeWithBaseChange>
 }
 
 const getGroupAction = (group: Group<Change>): ActionName => {

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 import _ from 'lodash'
-import { ElemID, DetailedChange, isRemovalChange, toChange, getChangeData, Element } from '@salto-io/adapter-api'
+import { ElemID, isRemovalChange, toChange, getChangeData, Element, DetailedChangeWithBaseChange } from '@salto-io/adapter-api'
 import { filterByID, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { pathIndex, filterByPathHint, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
@@ -24,9 +24,9 @@ import { ChangeWithDetails } from './plan/plan_item'
 const { awu } = collections.asynciterable
 
 const splitDetailedChangeByPath = async (
-  change: DetailedChange,
+  change: DetailedChangeWithBaseChange,
   index: pathIndex.PathIndex
-): Promise<DetailedChange[]> => {
+): Promise<DetailedChangeWithBaseChange[]> => {
   const changeHints = await pathIndex.getFromPathIndex(change.id, index)
   if (_.isEmpty(changeHints) || isRemovalChange(change)) {
     return [change]
@@ -66,7 +66,7 @@ export function createRestoreChanges(
   elementSelectors?: ElementSelector[],
   accounts?: readonly string[],
   resultType?: 'detailedChanges'
-): Promise<DetailedChange[]>
+): Promise<DetailedChangeWithBaseChange[]>
 export async function createRestoreChanges(
   workspaceElements: elementSource.ElementsSource,
   state: elementSource.ElementsSource,
@@ -75,7 +75,7 @@ export async function createRestoreChanges(
   elementSelectors: ElementSelector[] = [],
   accounts?: readonly string[],
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges'
-): Promise<DetailedChange[] | ChangeWithDetails[]> {
+): Promise<DetailedChangeWithBaseChange[] | ChangeWithDetails[]> {
   if (resultType === 'changes') {
     const changes = await createDiffChanges(
       workspaceElements,
@@ -113,20 +113,25 @@ export const createRestorePathChanges = async (
   elements: Element[],
   index: remoteMap.RemoteMap<pathIndex.Path[]>,
   accounts?: string[],
-): Promise<DetailedChange[]> => {
+): Promise<DetailedChangeWithBaseChange[]> => {
   const relevantElements = elements
     .filter(element => accounts === undefined || accounts.includes(element.elemID.adapter))
-  const removalChanges = relevantElements.map(element => ({
-    ...toChange({ before: element }),
-    id: element.elemID,
-  }))
+  const removalChanges = relevantElements.map(element => {
+    const baseChange = toChange({ before: element })
+    return {
+      ...baseChange,
+      id: element.elemID,
+      baseChange,
+    }
+  })
 
   const additionChanges = await awu(relevantElements)
     .map(element => toChange({ after: element }))
-    .flatMap(change => splitDetailedChangeByPath(
+    .flatMap(baseChange => splitDetailedChangeByPath(
       {
-        ...change,
-        id: getChangeData(change).elemID,
+        ...baseChange,
+        id: getChangeData(baseChange).elemID,
+        baseChange,
       },
       index
     ))

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -15,7 +15,7 @@
 */
 import _ from 'lodash'
 import { ElemID, isRemovalChange, toChange, Element, DetailedChangeWithBaseChange } from '@salto-io/adapter-api'
-import { filterByID, applyFunctionToChangeData, toDetailedChangeWithBaseChange } from '@salto-io/adapter-utils'
+import { filterByID, applyFunctionToChangeData, toDetailedChangeFromBaseChange } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { pathIndex, filterByPathHint, ElementSelector, elementSource, remoteMap } from '@salto-io/workspace'
 import { createDiffChanges } from './diff'
@@ -119,12 +119,12 @@ export const createRestorePathChanges = async (
 
   const removalChanges = relevantElements
     .map(element => toChange({ before: element }))
-    .map(change => toDetailedChangeWithBaseChange(change))
+    .map(change => toDetailedChangeFromBaseChange(change))
 
   const additionChanges = await awu(relevantElements)
     .map(element => toChange({ after: element }))
     .flatMap(change => splitDetailedChangeByPath(
-      toDetailedChangeWithBaseChange(change),
+      toDetailedChangeFromBaseChange(change),
       index
     ))
     .toArray()

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -17,7 +17,7 @@ import {
   AdapterGroupProperties,
   AuthorInformation,
   Change,
-  DetailedChange,
+  DetailedChangeWithBaseChange,
   SaltoElementError,
   SaltoError,
 } from '@salto-io/adapter-api'
@@ -25,11 +25,11 @@ import {
 export type FetchChangeMetadata = AuthorInformation
 export type FetchChange = {
   // The actual change to apply to the workspace
-  change: DetailedChange
+  change: DetailedChangeWithBaseChange
   // The change that happened in the service
-  serviceChanges: DetailedChange[]
+  serviceChanges: DetailedChangeWithBaseChange[]
   // The change between the working copy and the state
-  pendingChanges?: DetailedChange[]
+  pendingChanges?: DetailedChangeWithBaseChange[]
   // Metadata information about the change.
   metadata?: FetchChangeMetadata
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1424,7 +1424,10 @@ describe('api.ts', () => {
       const res = await api.fixElements(ws, [
         workspace.createElementSelector(type.elemID.getFullName()),
       ])
-
+      const typeBefore = type.clone()
+      const typeAfter = type.clone()
+      typeAfter.annotate({ a: 1, b: 2 })
+      const baseChange = toChange({ before: typeBefore, after: typeAfter })
       expect(res).toEqual({
         changes: [
           {
@@ -1437,6 +1440,7 @@ describe('api.ts', () => {
               before: new ElemID('test1', 'test', 'attr', 'a'),
               after: new ElemID('test1', 'test', 'attr', 'a'),
             },
+            baseChange,
           },
           {
             action: 'add',
@@ -1448,6 +1452,7 @@ describe('api.ts', () => {
               before: new ElemID('test1', 'test', 'attr', 'b'),
               after: new ElemID('test1', 'test', 'attr', 'b'),
             },
+            baseChange,
           },
         ],
         errors: [


### PR DESCRIPTION
Create `DetailedChangeWithBaseChange` that is a `DetailedChange` with `baseChange: Change<Element>` in it, and return it in `PlanItem` & `FetchChange`

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Create `DetailedChangeWithBaseChange` and return it in `PlanItem` & `FetchChange`

---
_User Notifications_: 
None