### PR TITLE
SALTO-5421 adjust adapter-components filters that only need user config so they will work with both versions of the system config

### DIFF
--- a/packages/adapter-components/src/definitions/system/references.ts
+++ b/packages/adapter-components/src/definitions/system/references.ts
@@ -16,6 +16,7 @@
 import { FieldReferenceDefinition } from '../../references'
 
 export type ReferenceDefinitions = {
-  // TODO use in filter
+  // rules for finding references - coverting values to references in fetch, and references to values in deploy.
+  // this is an array of arrays because rules can be run in multiple iterations during fetch,
   rules: FieldReferenceDefinition<never>[]
 }

--- a/packages/adapter-components/src/definitions/system/references.ts
+++ b/packages/adapter-components/src/definitions/system/references.ts
@@ -16,7 +16,7 @@
 import { FieldReferenceDefinition } from '../../references'
 
 export type ReferenceDefinitions = {
-  // rules for finding references - coverting values to references in fetch, and references to values in deploy.
-  // this is an array of arrays because rules can be run in multiple iterations during fetch,
+  // rules for finding references - converting values to references in fetch, and references to values in deploy.
+  // this is an array of arrays because rules can be run in multiple iterations during fetch
   rules: FieldReferenceDefinition<never>[]
 }

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -79,7 +79,7 @@ export const filterRunner = <
   onFetchAggregator: (results: TResult[]) => TResult | void = () => undefined,
 ): Required<Filter<TResult>> => filter.filtersRunner(opts, filterCreators, onFetchAggregator)
 
-// TODO deprecate when upgrading to new definitions
+// TODO deprecate when upgrading to new definitions SALTO-5538
 
 export type FilterOpts<TClient, TContext, TAdditional = {}> = {
   client: TClient

--- a/packages/adapter-components/src/filters/hide_types.ts
+++ b/packages/adapter-components/src/filters/hide_types.ts
@@ -16,17 +16,16 @@
 import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { UserFetchConfig } from '../definitions/user'
-import { FilterCreator } from '../filter_utils'
+import { UserConfigAdapterFilterCreator } from '../filter_utils'
 
 /**
  * Hide types if needed according to configuration.
  * Note: This should apply only to hard-coded types - it is the adapter's responsibility to ensure this.
  */
 export const hideTypesFilterCreator: <
-  TClient,
   TContext extends { fetch: Pick<UserFetchConfig, 'hideTypes'> },
   TResult extends void | filter.FilterResult = void,
->() => FilterCreator<TClient, TContext, TResult> =
+>() => UserConfigAdapterFilterCreator<TContext, TResult> =
   () =>
   ({ config }) => ({
     name: 'hideTypes',

--- a/packages/adapter-components/src/filters/query.ts
+++ b/packages/adapter-components/src/filters/query.ts
@@ -19,8 +19,7 @@ import { filter, getParents } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { AbstractNodeMap } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
-import { FilterCreator } from '../filter_utils'
-import { ElementQuery } from '../fetch/query'
+import { UserConfigAdapterFilterCreator } from '../filter_utils'
 
 const log = logger(module)
 
@@ -53,18 +52,13 @@ export const createParentChildGraph = (
 /**
  * A filter to filter out instances by the fetchQuery of the adapter
  */
-export const queryFilterCreator: <
-  TClient,
-  TContext,
-  TResult extends void | filter.FilterResult,
-  TAdditional extends { fetchQuery: ElementQuery },
->({
+export const queryFilterCreator: <TContext, TResult extends void | filter.FilterResult>({
   additionalParentFields,
   typesToKeep,
 }: {
   additionalParentFields?: Record<string, string[]>
   typesToKeep?: string[]
-}) => FilterCreator<TClient, TContext, TResult, TAdditional> =
+}) => UserConfigAdapterFilterCreator<TContext, TResult> =
   ({ additionalParentFields, typesToKeep }) =>
   ({ fetchQuery }) => ({
     name: 'queryFilter',

--- a/packages/adapter-components/test/filters/hide_types.test.ts
+++ b/packages/adapter-components/test/filters/hide_types.test.ts
@@ -15,7 +15,6 @@
  */
 import { ObjectType, ElemID, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter_utils'
-import { Paginator } from '../../src/client'
 import { hideTypesFilterCreator } from '../../src/filters/hide_types'
 import { createMockQuery } from '../../src/fetch/query'
 
@@ -30,8 +29,6 @@ describe('hide types filter', () => {
 
   const createFilter = (hideTypes: boolean): FilterType =>
     hideTypesFilterCreator()({
-      client: {} as unknown,
-      paginator: undefined as unknown as Paginator,
       fetchQuery: createMockQuery(),
       config: {
         fetch: {

--- a/packages/adapter-components/test/filters/query.test.ts
+++ b/packages/adapter-components/test/filters/query.test.ts
@@ -23,7 +23,6 @@ import {
 } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
 import { FilterWith } from '../../src/filter_utils'
-import { Paginator } from '../../src/client'
 import { queryFilterCreator } from '../../src/filters/query'
 import { createMockQuery, ElementQuery } from '../../src/fetch/query'
 
@@ -91,8 +90,6 @@ describe('query filter', () => {
         fetchQuery = createMockQuery()
         elements = generateElements()
         filter = queryFilterCreator({})({
-          client: {} as unknown,
-          paginator: undefined as unknown as Paginator,
           config: {},
           fetchQuery,
         }) as FilterWith<'onFetch'>
@@ -128,8 +125,6 @@ describe('query filter', () => {
             instance.elemID.typeName !== 'extra' && instance.elemID.getFullName() !== 'salto.folder.instance.folder2',
         )
         filter = queryFilterCreator({})({
-          client: {} as unknown,
-          paginator: undefined as unknown as Paginator,
           config: {},
           fetchQuery,
         }) as FilterWith<'onFetch'>
@@ -167,8 +162,6 @@ describe('query filter', () => {
           },
           typesToKeep: ['extra'],
         })({
-          client: {} as unknown,
-          paginator: undefined as unknown as Paginator,
           config: {},
           fetchQuery,
         }) as FilterWith<'onFetch'>


### PR DESCRIPTION
some of the other filters will need a "migration" from the relevant args of the old config to the new format, but these only rely on the user part so adjusting the types to have a reduced scope in order to avoid needing to support both formats. 

note this also contains some helper types + utils for filters using the new definitions.

---

this is technically ready, but I want to adjust some of the type names (used for now names that are very similar to the old format). if this is needed feel free to merge, or I'll adjust these before merging

---
_Release Notes_: 
None

---
_User Notifications_: 
None