### PR TITLE
SALTO-5440: adjust empty validator cv and filter to the new Workflow structure

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -245,6 +245,7 @@ export const DEFAULT_FILTERS = [
   transitionIdsFilter,
   workflowDeployFilter,
   workflowModificationFilter,
+  // must run after workflowFilter
   emptyValidatorWorkflowFilter,
   // must run before fieldReferencesFilter
   groupNameFilter,

--- a/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
@@ -13,9 +13,11 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { ChangeError, ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange, SeverityLevel, Values } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
-import { isWorkflowV1Instance, WorkflowV1Instance } from '../../filters/workflow/types'
+import { isWorkflowV1Instance, Transition as TransitionV1, WorkflowV1Instance } from '../../filters/workflow/types'
+import { isWorkflowInstance, isWorkflowV2Instance, TransitionV2, WorkflowV2Instance } from '../../filters/workflowV2/types'
 
 const { isDefined } = values
 export const CONFIGURATION_VALIDATOR_TYPE = new Set([
@@ -30,34 +32,72 @@ export const CONFIGURATION_VALIDATOR_TYPE = new Set([
   'WindowsDateValidator',
 ])
 
-const workflowHasEmptyValidator = (instance: WorkflowV1Instance): Set<string> => {
-  const invalidValidators = new Set<string>()
-  Object.values(instance.value.transitions).forEach(transition => {
-    transition.rules?.validators?.forEach(validator => {
-      if (validator.type !== undefined && CONFIGURATION_VALIDATOR_TYPE.has(validator.type) && !('configuration' in validator)) {
-        invalidValidators.add(validator.type)
-      }
-    })
+const FIELD_VALIDATOR_TYPE = new Set([
+  'fieldHasSingleValue',
+  'fieldChanged',
+])
+
+export const isEmptyValidatorV2 = (validator: Values): boolean =>
+  validator.parameters?.ruleType !== undefined
+    && FIELD_VALIDATOR_TYPE.has(validator.parameters.ruleType)
+    && _.isEmpty(validator.parameters.fieldKey)
+
+export const isEmptyValidatorV1 = (validator: Values): boolean =>
+  validator.type !== undefined
+  && CONFIGURATION_VALIDATOR_TYPE.has(validator.type)
+  && !('configuration' in validator)
+
+const workflowV1HasEmptyValidator = (transition: TransitionV1, invalidValidators: Set<string>): void => {
+  transition.rules?.validators?.forEach(validator => {
+    if (validator.type !== undefined && isEmptyValidatorV1(validator)) {
+      invalidValidators.add(validator.type)
+    }
   })
+}
+
+const workflowV2HasEmptyValidator = (transition: TransitionV2, invalidValidators: Set<string>): void => {
+  transition.validators?.forEach(validator => {
+    if (isEmptyValidatorV2(validator)) {
+      invalidValidators.add(validator.parameters.ruleType)
+    }
+  })
+}
+
+const workflowHasEmptyValidator = (instance: WorkflowV1Instance | WorkflowV2Instance): Set<string> => {
+  const invalidValidators = new Set<string>()
+  if (isWorkflowV1Instance(instance)) {
+    Object.values(instance.value.transitions)
+      .forEach(transition => workflowV1HasEmptyValidator(transition, invalidValidators))
+  }
+  if (isWorkflowV2Instance(instance)) {
+    Object.values(instance.value.transitions)
+      .forEach(transition => workflowV2HasEmptyValidator(transition, invalidValidators))
+  }
   return invalidValidators
 }
 
 const createEmptyValidatorWorkflowError = (
-  instance: WorkflowV1Instance,
+  instance: WorkflowV1Instance | WorkflowV2Instance,
   validatorType: Set<string>,
-): ChangeError | undefined => (validatorType.size > 0 ? {
-  elemID: instance.elemID,
-  severity: 'Warning' as SeverityLevel,
-  message: 'Invalid workflow transition validator won’t be deployed',
-  detailedMessage: `This workflow has ${validatorType.size === 1 ? `a ${[...validatorType][0]} transition validator` : `the following transition validators ${[...validatorType].join(', ')}`}, which ${validatorType.size === 1 ? 'is' : 'are'} missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration`,
-} : undefined)
+): ChangeError | undefined => {
+  if (validatorType.size === 0) {
+    return undefined
+  }
+  const isWorkflowV1 = isWorkflowV1Instance(instance)
+  return {
+    elemID: instance.elemID,
+    severity: 'Warning' as SeverityLevel,
+    message: 'Invalid workflow transition validator won’t be deployed',
+    detailedMessage: `This workflow has ${validatorType.size === 1 ? `a ${[...validatorType][0]} transition validator` : `the following transition validators ${[...validatorType].join(', ')}`}, which ${validatorType.size === 1 ? 'is' : 'are'} missing ${isWorkflowV1 ? 'some configuration' : "'fieldKey' field"}. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its ${isWorkflowV1 ? 'configuration' : "'fieldKey' field"}`,
+  }
+}
 
 export const emptyValidatorWorkflowChangeValidator: ChangeValidator = async changes => (
   changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
-    .filter(isWorkflowV1Instance)
+    .filter(isWorkflowInstance)
     .map(instance => ({ instance, validatorTypes: workflowHasEmptyValidator(instance) }))
     .map(({ instance, validatorTypes }) => createEmptyValidatorWorkflowError(instance, validatorTypes))
     .filter(isDefined)

--- a/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/empty_validator_workflow.ts
@@ -17,7 +17,7 @@ import { ChangeError, ChangeValidator, getChangeData, isAdditionOrModificationCh
 import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
 import { isWorkflowV1Instance, Transition as TransitionV1, WorkflowV1Instance } from '../../filters/workflow/types'
-import { isWorkflowInstance, isWorkflowV2Instance, TransitionV2, WorkflowV2Instance } from '../../filters/workflowV2/types'
+import { isWorkflowInstance, isWorkflowV2Instance, WorkflowTransitionV2, WorkflowV2Instance } from '../../filters/workflowV2/types'
 
 const { isDefined } = values
 export const CONFIGURATION_VALIDATOR_TYPE = new Set([
@@ -55,7 +55,7 @@ const workflowV1HasEmptyValidator = (transition: TransitionV1, invalidValidators
   })
 }
 
-const workflowV2HasEmptyValidator = (transition: TransitionV2, invalidValidators: Set<string>): void => {
+const workflowV2HasEmptyValidator = (transition: WorkflowTransitionV2, invalidValidators: Set<string>): void => {
   transition.validators?.forEach(validator => {
     if (isEmptyValidatorV2(validator)) {
       invalidValidators.add(validator.parameters.ruleType)
@@ -68,8 +68,7 @@ const workflowHasEmptyValidator = (instance: WorkflowV1Instance | WorkflowV2Inst
   if (isWorkflowV1Instance(instance)) {
     Object.values(instance.value.transitions)
       .forEach(transition => workflowV1HasEmptyValidator(transition, invalidValidators))
-  }
-  if (isWorkflowV2Instance(instance)) {
+  } else if (isWorkflowV2Instance(instance)) {
     Object.values(instance.value.transitions)
       .forEach(transition => workflowV2HasEmptyValidator(transition, invalidValidators))
   }

--- a/packages/jira-adapter/src/filters/workflow/empty_validator_workflow.ts
+++ b/packages/jira-adapter/src/filters/workflow/empty_validator_workflow.ts
@@ -28,8 +28,7 @@ const removeEmptyValidators = (instance: WorkflowV1Instance | WorkflowV2Instance
         transition.rules.validators = transition.rules.validators
           .filter((validator: Value) => !isEmptyValidatorV1(validator))
       })
-  }
-  if (isWorkflowV2Instance(instance)) {
+  } else if (isWorkflowV2Instance(instance)) {
     Object.values(instance.value.transitions)
       .filter((transition: Value) => transition.validators !== undefined)
       .forEach((transition: Value) => {
@@ -47,9 +46,7 @@ const filter: FilterCreator = () => ({
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
       .filter(isWorkflowInstance)
-      .forEach(instance => {
-        removeEmptyValidators(instance)
-      })
+      .forEach(removeEmptyValidators)
   },
 })
 

--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -19,7 +19,7 @@ import { SaltoError, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { Status, Transition, WorkflowV1Instance } from './types'
 import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../script_runner/workflow/workflow_cloud'
-import { WorkflowTransition } from '../workflowV2/types'
+import { TransitionV2 } from '../workflowV2/types'
 
 export const TRANSITION_PARTS_SEPARATOR = '::'
 
@@ -132,7 +132,7 @@ export const walkOverTransitionIds = (transition: Transition, func: (value: Valu
     })
 }
 
-export const walkOverTransitionIdsV2 = (transition: WorkflowTransition, func: (value: Value) => void): void => {
+export const walkOverTransitionIdsV2 = (transition: TransitionV2, func: (value: Value) => void): void => {
   transition.actions
     ?.filter(action =>
       action.parameters?.appKey === SCRIPT_RUNNER_POST_FUNCTION_TYPE

--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -19,7 +19,7 @@ import { SaltoError, Value } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { Status, Transition, WorkflowV1Instance } from './types'
 import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../script_runner/workflow/workflow_cloud'
-import { TransitionV2 } from '../workflowV2/types'
+import { WorkflowTransitionV2 } from '../workflowV2/types'
 
 export const TRANSITION_PARTS_SEPARATOR = '::'
 
@@ -132,7 +132,7 @@ export const walkOverTransitionIds = (transition: Transition, func: (value: Valu
     })
 }
 
-export const walkOverTransitionIdsV2 = (transition: TransitionV2, func: (value: Value) => void): void => {
+export const walkOverTransitionIdsV2 = (transition: WorkflowTransitionV2, func: (value: Value) => void): void => {
   transition.actions
     ?.filter(action =>
       action.parameters?.appKey === SCRIPT_RUNNER_POST_FUNCTION_TYPE

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -46,7 +46,7 @@ export type WorkflowStatus = {
   name: string
 }
 
-export type WorkflowTransition = {
+export type TransitionV2 = {
   id: string
   actions?: Values[]
   conditions?: Values
@@ -79,7 +79,7 @@ export type Workflow = {
   statuses: Values[]
 }
 
-export type WorkflowV2Instance = InstanceElement & { value: InstanceElement['value'] & Omit<Workflow, 'transitions'> & { transitions: Record<string, WorkflowTransition> } }
+export type WorkflowV2Instance = InstanceElement & { value: InstanceElement['value'] & Omit<Workflow, 'transitions'> & { transitions: Record<string, TransitionV2> } }
 
 const WORKFLOW_SCHEMA = Joi.object({
   name: Joi.string().required(),
@@ -101,7 +101,7 @@ const WORKFLOW_SCHEMA = Joi.object({
   statuses: Joi.array().items(Joi.object()).required(),
 }).unknown(true).required()
 
-const isWorkflowValues = createSchemeGuard<Workflow & { transitions: Record<string, WorkflowTransition> }>(WORKFLOW_SCHEMA, 'Received an invalid workflow values')
+const isWorkflowValues = createSchemeGuard<Workflow & { transitions: Record<string, TransitionV2> }>(WORKFLOW_SCHEMA, 'Received an invalid workflow values')
 
 export const isWorkflowV2Instance = (instance: InstanceElement)
 : instance is WorkflowV2Instance =>

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -46,7 +46,7 @@ export type WorkflowStatus = {
   name: string
 }
 
-export type TransitionV2 = {
+export type WorkflowTransitionV2 = {
   id: string
   actions?: Values[]
   conditions?: Values
@@ -79,7 +79,7 @@ export type Workflow = {
   statuses: Values[]
 }
 
-export type WorkflowV2Instance = InstanceElement & { value: InstanceElement['value'] & Omit<Workflow, 'transitions'> & { transitions: Record<string, TransitionV2> } }
+export type WorkflowV2Instance = InstanceElement & { value: InstanceElement['value'] & Omit<Workflow, 'transitions'> & { transitions: Record<string, WorkflowTransitionV2> } }
 
 const WORKFLOW_SCHEMA = Joi.object({
   name: Joi.string().required(),
@@ -101,7 +101,7 @@ const WORKFLOW_SCHEMA = Joi.object({
   statuses: Joi.array().items(Joi.object()).required(),
 }).unknown(true).required()
 
-const isWorkflowValues = createSchemeGuard<Workflow & { transitions: Record<string, TransitionV2> }>(WORKFLOW_SCHEMA, 'Received an invalid workflow values')
+const isWorkflowValues = createSchemeGuard<Workflow & { transitions: Record<string, WorkflowTransitionV2> }>(WORKFLOW_SCHEMA, 'Received an invalid workflow values')
 
 export const isWorkflowV2Instance = (instance: InstanceElement)
 : instance is WorkflowV2Instance =>

--- a/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
@@ -163,7 +163,7 @@ describe('workflowPropertiesValidator', () => {
       expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
         {
           elemID: workflowV2Instance.elemID,
-          severity: 'Warning', // fix the error messages and finish the tests
+          severity: 'Warning',
           message: 'Invalid workflow transition validator won’t be deployed',
           detailedMessage: "This workflow has a fieldHasSingleValue transition validator, which is missing 'fieldKey' field. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its 'fieldKey' field",
         },

--- a/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
@@ -13,114 +13,210 @@
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
-import { toChange, ObjectType, ElemID, InstanceElement, ChangeDataType, Change } from '@salto-io/adapter-api'
+import { toChange, InstanceElement, ChangeDataType, Change } from '@salto-io/adapter-api'
 import { emptyValidatorWorkflowChangeValidator } from '../../../src/change_validators/workflows/empty_validator_workflow'
-import { JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { JIRA_WORKFLOW_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { createEmptyType } from '../../utils'
 
 describe('workflowPropertiesValidator', () => {
-  let type: ObjectType
-  let instance: InstanceElement
   let changes: ReadonlyArray<Change<ChangeDataType>>
+  describe('workflowV1', () => {
+    let instance: InstanceElement
+    beforeEach(() => {
+      instance = new InstanceElement(
+        'instance',
+        createEmptyType(WORKFLOW_TYPE_NAME),
+        {
+          transitions: {
+            tran1: {
+              name: 'tran1',
+              rules: {
+                validators: [
+                  {
+                    type: 'FieldChangedValidator',
+                    configuration: {
+                      key: 'value',
+                    },
+                  },
+                  {
+                    type: 'add_on_type_with_no_configuration',
+                  },
+                  {
+                    type: 'FieldHasSingleValueValidator',
+                  },
+                ],
+              },
+            },
+          },
+        },
+      )
+      changes = [toChange({ after: instance })]
+    })
+    it('should return an error if there are invalid validators', async () => {
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: instance.elemID,
+          severity: 'Warning',
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: 'This workflow has a FieldHasSingleValueValidator transition validator, which is missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
+        },
+      ])
+    })
+    it('should return a singular error if there are multiple invalid validators', async () => {
+      instance.value.transitions.tran1.rules.validators.push({
+        type: 'PreviousStatusValidator',
+      })
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: instance.elemID,
+          severity: 'Warning',
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: 'This workflow has the following transition validators FieldHasSingleValueValidator, PreviousStatusValidator, which are missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
+        },
+      ])
+    })
+    it('should return a singular error if there are multiple invalid validators but only one type', async () => {
+      instance.value.transitions.tran1.rules.validators.push({
+        type: 'FieldHasSingleValueValidator',
+      })
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: instance.elemID,
+          severity: 'Warning',
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: 'This workflow has a FieldHasSingleValueValidator transition validator, which is missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
+        },
+      ])
+    })
+    it('should not return an error if workflow has only valid validator', async () => {
+      instance.value.transitions.tran1.rules.validators.pop()
+      expect(await emptyValidatorWorkflowChangeValidator(changes))
+        .toEqual([])
+    })
 
-  beforeEach(() => {
-    type = new ObjectType({ elemID: new ElemID(JIRA, WORKFLOW_TYPE_NAME) })
-    instance = new InstanceElement(
-      'instance',
-      type,
-      {
-        transitions: {
-          tran1: {
-            name: 'tran1',
-            rules: {
+    it('should not return an error when there are no validators', async () => {
+      delete instance.value.transitions.tran1.rules.validators
+      expect(await emptyValidatorWorkflowChangeValidator(changes))
+        .toEqual([])
+    })
+
+    it('should not return an error when there are no rules', async () => {
+      delete instance.value.transitions.tran1.rules
+      expect(await emptyValidatorWorkflowChangeValidator(changes))
+        .toEqual([])
+    })
+
+    it('should not return an error when workflow is removed', async () => {
+      expect(await emptyValidatorWorkflowChangeValidator([
+        toChange({ before: instance }),
+      ]))
+        .toEqual([])
+    })
+  })
+  describe('workflowV2', () => {
+    let workflowV2Instance: InstanceElement
+    beforeEach(() => {
+      workflowV2Instance = new InstanceElement(
+        'workflowV2Instance',
+        createEmptyType(JIRA_WORKFLOW_TYPE),
+        {
+          name: 'workflowV2Instance',
+          version: {
+            versionNumber: 1,
+            id: 'id',
+          },
+          id: 'id',
+          scope: {
+            project: 'project',
+            type: 'type',
+          },
+          statuses: [],
+          transitions: {
+            tran1: {
+              name: 'tran1',
+              id: 'id',
               validators: [
                 {
-                  type: 'FieldChangedValidator',
-                  configuration: {
-                    key: 'value',
+                  parameters: {
+                    ruleType: 'fieldHasSingleValue',
+                    fieldKey: 'fieldKey',
                   },
                 },
                 {
-                  type: 'add_on_type_with_no_configuration',
+                  parameters: {
+                    ruleType: 'anotherType',
+                  },
                 },
                 {
-                  type: 'FieldHasSingleValueValidator',
+                  parameters: {
+                    ruleType: 'fieldHasSingleValue',
+                  },
                 },
               ],
             },
           },
         },
-      },
-    )
-    changes = [toChange({ after: instance })]
-  })
-  it('should return an error if there are invalid validators', async () => {
-    expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
-      {
-        elemID: instance.elemID,
-        severity: 'Warning',
-        message: 'Invalid workflow transition validator won’t be deployed',
-        detailedMessage: 'This workflow has a FieldHasSingleValueValidator transition validator, which is missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
-      },
-    ])
-  })
-  it('should return an plural error if there are multiple invalid validators', async () => {
-    instance.value.transitions.tran1.rules.validators.push({
-      type: 'PreviousStatusValidator',
+      )
+      changes = [toChange({ after: workflowV2Instance })]
     })
-    expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
-      {
-        elemID: instance.elemID,
-        severity: 'Warning',
-        message: 'Invalid workflow transition validator won’t be deployed',
-        detailedMessage: 'This workflow has the following transition validators FieldHasSingleValueValidator, PreviousStatusValidator, which are missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
-      },
-    ])
-  })
-  it('should return an plural error if there are multiple invalid validators but only once per type', async () => {
-    instance.value.transitions.tran1.rules.validators.push({
-      type: 'FieldHasSingleValueValidator',
+    it('should return an error if there are invalid validators', async () => {
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: workflowV2Instance.elemID,
+          severity: 'Warning', // fix the error messages and finish the tests
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: "This workflow has a fieldHasSingleValue transition validator, which is missing 'fieldKey' field. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its 'fieldKey' field",
+        },
+      ])
     })
-    expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
-      {
-        elemID: instance.elemID,
-        severity: 'Warning',
-        message: 'Invalid workflow transition validator won’t be deployed',
-        detailedMessage: 'This workflow has a FieldHasSingleValueValidator transition validator, which is missing some configuration. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its configuration',
-      },
-    ])
-  })
-  it('should not return an error if workflow has only valid validator', async () => {
-    instance.value.transitions.tran1.rules.validators.pop()
-    expect(await emptyValidatorWorkflowChangeValidator([
-      toChange({
-        after: instance,
-      }),
-    ])).toEqual([])
-  })
-
-  it('should not return an error when there are no validators', async () => {
-    delete instance.value.transitions.tran1.rules
-    expect(await emptyValidatorWorkflowChangeValidator([
-      toChange({
-        after: instance,
-      }),
-    ])).toEqual([])
-  })
-
-  it('should not return an error when there are no rules', async () => {
-    delete instance.value.transitions.tran1
-    expect(await emptyValidatorWorkflowChangeValidator([
-      toChange({
-        after: instance,
-      }),
-    ])).toEqual([])
-  })
-
-  it('should not return an error when workflow is removed', async () => {
-    expect(await emptyValidatorWorkflowChangeValidator([
-      toChange({
-        before: instance,
-      }),
-    ])).toEqual([])
+    it('should return an plural error if there are multiple invalid validators', async () => {
+      workflowV2Instance.value.transitions.tran1.validators.push(
+        {
+          parameters: {
+            ruleType: 'fieldChanged',
+          },
+        }
+      )
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: workflowV2Instance.elemID,
+          severity: 'Warning',
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: "This workflow has the following transition validators fieldHasSingleValue, fieldChanged, which are missing 'fieldKey' field. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its 'fieldKey' field",
+        },
+      ])
+    })
+    it('should return a singular error if there are multiple invalid validators but only from one type', async () => {
+      workflowV2Instance.value.transitions.tran1.validators.push(
+        {
+          parameters: {
+            ruleType: 'fieldHasSingleValue',
+          },
+        }
+      )
+      expect(await emptyValidatorWorkflowChangeValidator(changes)).toEqual([
+        {
+          elemID: workflowV2Instance.elemID,
+          severity: 'Warning',
+          message: 'Invalid workflow transition validator won’t be deployed',
+          detailedMessage: "This workflow has a fieldHasSingleValue transition validator, which is missing 'fieldKey' field. The workflow will be deployed without this transition validator. To fix this, go to your Jira instance and delete the validator, or fix its 'fieldKey' field",
+        },
+      ])
+    })
+    it('should not return an error if workflow has only valid validator', async () => {
+      workflowV2Instance.value.transitions.tran1.validators.pop()
+      expect(await emptyValidatorWorkflowChangeValidator(changes))
+        .toEqual([])
+    })
+    it('should not return an error when there are no validators', async () => {
+      delete workflowV2Instance.value.transitions.tran1.validators
+      expect(await emptyValidatorWorkflowChangeValidator(changes))
+        .toEqual([])
+    })
+    it('should not return an error when workflow is removed', async () => {
+      expect(await emptyValidatorWorkflowChangeValidator([
+        toChange({ before: workflowV2Instance }),
+      ])).toEqual([])
+    })
   })
 })


### PR DESCRIPTION
_adjust empty validator cv and filter to the new Workflow structure_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
