### PR TITLE
SALTO-4690 - Salesforce: CV for modification/deletion of CurrencyIsoCode instance

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -46,6 +46,7 @@ import dataCategoryGroupValidator from './change_validators/data_category_group'
 import standardFieldOrObjectAdditionsOrDeletions from './change_validators/standard_field_or_object_additions_or_deletions'
 import deletedNonQueryableFields from './change_validators/deleted_non_queryable_fields'
 import instanceWithUnknownType from './change_validators/instance_with_unknown_type'
+import artificialTypes from './change_validators/artifical_types'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
@@ -100,6 +101,7 @@ export const changeValidators: Record<
     standardFieldOrObjectAdditionsOrDeletions,
   deletedNonQueryableFields: () => deletedNonQueryableFields,
   instanceWithUnknownType: () => instanceWithUnknownType,
+  artificialTypes: () => artificialTypes,
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/artifical_types.ts
+++ b/packages/salesforce-adapter/src/change_validators/artifical_types.ts
@@ -23,9 +23,9 @@ import { CURRENCY_CODE_TYPE_NAME } from '../constants'
 
 const createCurrencyIsoCodeError = (element: Element): ChangeError => ({
   elemID: element.elemID,
-  message: "The list of supported currency codes can't be changed via Salto.",
+  message: "The list of currency codes can't be changed via Salto.",
   detailedMessage:
-    'To add or remove supported currency codes, follow the instructions at https://help.salesforce.com/s/articleView?id=sf.admin_currency.htm',
+    'To add or remove currency codes, follow the instructions at https://help.salesforce.com/s/articleView?id=sf.admin_currency.htm',
   severity: 'Error',
 })
 

--- a/packages/salesforce-adapter/src/change_validators/artifical_types.ts
+++ b/packages/salesforce-adapter/src/change_validators/artifical_types.ts
@@ -1,0 +1,38 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeError,
+  ChangeValidator,
+  Element,
+  getChangeData,
+} from '@salto-io/adapter-api'
+import { CURRENCY_CODE_TYPE_NAME } from '../constants'
+
+const createCurrencyIsoCodeError = (element: Element): ChangeError => ({
+  elemID: element.elemID,
+  message: "The list of supported currency codes can't be changed via Salto.",
+  detailedMessage:
+    'To add or remove supported currency codes, follow the instructions at https://help.salesforce.com/s/articleView?id=sf.admin_currency.htm',
+  severity: 'Error',
+})
+
+const changeValidator: ChangeValidator = async (changes) =>
+  changes
+    .map(getChangeData)
+    .filter((element) => element.elemID.typeName === CURRENCY_CODE_TYPE_NAME)
+    .map(createCurrencyIsoCodeError)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -158,6 +158,7 @@ export type ChangeValidatorName =
   | 'standardFieldOrObjectAdditionsOrDeletions'
   | 'deletedNonQueryableFields'
   | 'instanceWithUnknownType'
+  | 'artificialTypes'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -871,6 +872,7 @@ const changeValidatorConfigType =
       },
       deletedNonQueryableFields: { refType: BuiltinTypes.BOOLEAN },
       instanceWithUnknownType: { refType: BuiltinTypes.BOOLEAN },
+      artificialTypes: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/artificial_types.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/artificial_types.test.ts
@@ -1,0 +1,92 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ChangeError,
+  toChange,
+} from '@salto-io/adapter-api'
+import {
+  CURRENCY_CODE_TYPE_NAME,
+  CURRENCY_ISO_CODE,
+  INSTANCE_FULL_NAME_FIELD,
+  METADATA_TYPE,
+  SALESFORCE,
+} from '../../src/constants'
+import validator from '../../src/change_validators/artifical_types'
+
+describe('artificialTypes', () => {
+  let errors: ReadonlyArray<ChangeError>
+  describe('when modifying artificial types', () => {
+    describe('when modifying CurrencyIsoCode', () => {
+      const currencyIsoCodeType = new ObjectType({
+        elemID: new ElemID(SALESFORCE, CURRENCY_CODE_TYPE_NAME),
+        annotations: {
+          [METADATA_TYPE]: CURRENCY_CODE_TYPE_NAME,
+        },
+      })
+      describe('when modifying the type', () => {
+        beforeEach(async () => {
+          errors = await validator([
+            toChange({
+              before: currencyIsoCodeType,
+              after: currencyIsoCodeType,
+            }),
+          ])
+        })
+        it('should fail to deploy', () => {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toSatisfy(
+            (error) =>
+              error.elemID.isEqual(currencyIsoCodeType.elemID) &&
+              error.message ===
+                "The list of currency codes can't be changed via Salto." &&
+              error.severity === 'Error',
+          )
+        })
+      })
+      describe('when modifying the instance', () => {
+        const currencyIsoCodeInstance = new InstanceElement(
+          'currencyIsoCodeInstance',
+          currencyIsoCodeType,
+          {
+            [INSTANCE_FULL_NAME_FIELD]: CURRENCY_ISO_CODE,
+          },
+        )
+        beforeEach(async () => {
+          errors = await validator([
+            toChange({
+              before: currencyIsoCodeInstance,
+              after: currencyIsoCodeInstance,
+            }),
+          ])
+        })
+
+        it('should fail to deploy', () => {
+          expect(errors).toHaveLength(1)
+          expect(errors[0]).toSatisfy(
+            (error) =>
+              error.elemID.isEqual(currencyIsoCodeInstance.elemID) &&
+              error.message ===
+                "The list of currency codes can't be changed via Salto." &&
+              error.severity === 'Error',
+          )
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
`CurrencyIsoCodes` is a synthetic type we create. The type (and its instances) can't be deployed because they don't exist on the service.

---

<img width="1046" alt="image" src="https://github.com/salto-io/salto/assets/117099820/7d5a3283-2c87-40c9-b685-e2cc07fe6047">

---
_Release Notes_: 
Salesforce: Warn when attempting to modify the list of supported currencies.

---
_User Notifications_: 
N/A