### PR TITLE
Remove important values from Settings types

### DIFF
--- a/packages/netsuite-adapter/src/filters/add_important_values.ts
+++ b/packages/netsuite-adapter/src/filters/add_important_values.ts
@@ -70,7 +70,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
     )
 
     const netsuiteSupportedTypesSet = new Set(netsuiteSupportedTypes)
-    types.filter(type => netsuiteSupportedTypesSet.has(type.elemID.name)).forEach(type => {
+    types.filter(type => netsuiteSupportedTypesSet.has(type.elemID.name) && !type.isSettings).forEach(type => {
       const importantValues = getImportantValues(type)
       if (importantValues.length > 0) {
         type.annotations[IMPORTANT_VALUES] = importantValues


### PR DESCRIPTION
Settings types in NS should not have important values (at least not the scriptid/label/name/isInactive/bundle fields). The problem is that `companyInformation` has isinactive field, so we create `_important_values` annotation for `companyInformation`, although that it doesn't make sense to filter it by the `isInactive` field (because there's only one `companyInformation` instance).

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Remove important values from Settings types

---
_User Notifications_: 
Netsuite Adapter:
- The `_important_values` annotation will be removed from the `companyInformation` type
