### PR TITLE
Make fix-order-problems-in-workbooks run generically on XMLs

### DIFF
--- a/packages/netsuite-adapter/src/filters/fix_order_problems_in_workbooks.ts
+++ b/packages/netsuite-adapter/src/filters/fix_order_problems_in_workbooks.ts
@@ -19,7 +19,14 @@ import { parse } from 'fast-xml-parser'
 import { decode } from 'he'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import { Change, getChangeData, InstanceElement, isAdditionOrModificationChange, isInstanceElement, Values } from '@salto-io/adapter-api'
+import {
+  Change,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  Values,
+} from '@salto-io/adapter-api'
 import { TransformFunc, resolvePath, transformValuesSync } from '@salto-io/adapter-utils'
 import { DATASET, SCRIPT_ID, WORKBOOK } from '../constants'
 import { LocalFilterCreator } from '../filter'

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
@@ -195,17 +195,6 @@ export type EmptyObject = {
 }
 
 // containers of special fields
-export const TValuesToIgnore = new Set([
-  'workbook',
-  'dataSet',
-  'formula',
-])
-export const fieldsToOmitFromDefinition = [
-  NAME,
-]
-export const fieldsToOmitFromOriginal = [
-  DEFINITION,
-  TABLES,
-  CHARTS,
-  PIVOTS,
-]
+export const TValuesToIgnore = new Set(['workbook', 'dataSet', 'formula'])
+export const fieldsToOmitFromDefinition = [NAME]
+export const fieldsToOmitFromOriginal = [DEFINITION, TABLES, CHARTS, PIVOTS]

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
@@ -195,10 +195,17 @@ export type EmptyObject = {
 }
 
 // containers of special fields
-export const TValuesToIgnore = new Set(['workbook', 'dataSet', 'formula'])
-export const fieldsToOmitFromDefinition = [NAME]
-export const fieldsToOmitFromOriginal = [DEFINITION, TABLES, CHARTS, PIVOTS]
-
-export const INNER_ARRAY_NAMES = [PIVOTS, CHARTS, DATASET_LINKS]
-
-export const INNER_XML_TITLES = [DEFINITION, MAPPING]
+export const TValuesToIgnore = new Set([
+  'workbook',
+  'dataSet',
+  'formula',
+])
+export const fieldsToOmitFromDefinition = [
+  NAME,
+]
+export const fieldsToOmitFromOriginal = [
+  DEFINITION,
+  TABLES,
+  CHARTS,
+  PIVOTS,
+]


### PR DESCRIPTION
Instead of checking for unrelevant changes in XMLs only in specific paths, it would be better to check for XMLs all over the instance, and then compare the XML content with the XML content in the existing instance.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None