### PR TITLE
Add generic ASV warning to workflows

### DIFF
--- a/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/account_specific_values.ts
@@ -33,7 +33,7 @@ export const toAccountSpecificValuesWarning = (element: Element): ChangeError =>
     'You can either edit the element in Salto and replace ACCOUNT_SPECIFIC_VALUE with the real value and deploy it or after a successful deploy, set the correct value directly in the NetSuite UI.',
 })
 
-const changeValidator: NetsuiteChangeValidator = async changes => (
+const changeValidator: NetsuiteChangeValidator = async changes =>
   awu(changes)
     .filter(isAdditionOrModificationChange)
     .map(async change => {
@@ -52,6 +52,5 @@ const changeValidator: NetsuiteChangeValidator = async changes => (
     })
     .filter(isDefined)
     .toArray()
-)
 
 export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -107,10 +107,10 @@ const getChangeErrorsOnAccountSpecificValues = (
         }
       }
       if (
-        typeof value === 'string'
-        && value.includes(ACCOUNT_SPECIFIC_VALUE)
-        && ![SENDER, RECIPIENT].includes(path.name)
-        && path.createParentID(2).name !== PARAMETER
+        typeof value === 'string' &&
+        value.includes(ACCOUNT_SPECIFIC_VALUE) &&
+        ![SENDER, RECIPIENT].includes(path.name) &&
+        path.createParentID(2).name !== PARAMETER
       ) {
         returnGenericAccountSpecificValuesWarning = true
       }

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -114,7 +114,7 @@ describe('workflow account specific values', () => {
     const changeErrors = await workflowAccountSpecificValidator(
       [toChange({ before: instance, after })],
       false,
-      buildElementsSourceFromElements([])
+      buildElementsSourceFromElements([]),
     )
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors[0].severity).toEqual('Warning')

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -108,6 +108,20 @@ describe('workflow account specific values', () => {
     expect(changeErrors).toHaveLength(0)
   })
 
+  it('should have a generic ASV warning when deploying an instance with ACCOUNT_SPECIFIC_VALUES', async () => {
+    const after = instance.clone()
+    after.value.valueselect = '[ACCOUNT_SPECIFIC_VALUE]|[ACCOUNT_SPECIFIC_VALUE]'
+    const changeErrors = await workflowAccountSpecificValidator(
+      [toChange({ before: instance, after })],
+      false,
+      buildElementsSourceFromElements([])
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0].severity).toEqual('Warning')
+    expect(changeErrors[0].elemID).toEqual(instance.elemID)
+    expect(changeErrors[0].message).toEqual('Values containing ACCOUNT_SPECIFIC_VALUE are ignored by NetSuite')
+  })
+
   describe('sender and recepient fields', () => {
     it('should have changeError when deploying an instance with sender = ACCOUNT_SPECIFIC_VALUES and sendertype = SPECIFIC', async () => {
       const after = instance.clone()


### PR DESCRIPTION
Workflow instances are ignored in the generic ASV change validator, but in case of `ACCOUNT_SPECIFIC_VALUE` in a workflow instance, that is not sender/recipient/parameters, we still should return the generic CV warning about ASV.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add generic ASV warning to workflows

---
_User Notifications_: 
None