### PR TITLE
SALTO-4927: Allow using parent in serviceUrl

### DIFF
--- a/packages/adapter-components/src/fetch/request/utils.ts
+++ b/packages/adapter-components/src/fetch/request/utils.ts
@@ -18,7 +18,7 @@ import _ from 'lodash'
 import { Values, isPrimitiveValue } from '@salto-io/adapter-api'
 import { ContextParams } from '../../definitions'
 
-export const ARG_PLACEHOLDER_MATCHER = /\{([\w_]+)\}/g
+export const ARG_PLACEHOLDER_MATCHER = /\{([\w_.]+)\}/g
 
 export const findUnresolvedArgs = (value: string, definedParams: Set<string> = new Set()): string[] => {
   const urlParams = value.match(ARG_PLACEHOLDER_MATCHER)?.map(m => m.slice(1, -1)) ?? []

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -1,68 +1,71 @@
 /*
- *                      Copyright 2024 Salto Labs Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-import {
-  Change,
-  CORE_ANNOTATIONS,
-  Element,
-  getChangeData,
-  InstanceElement,
-  isAdditionChange,
-  isInstanceChange,
-  isInstanceElement,
-} from '@salto-io/adapter-api'
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { Change, CORE_ANNOTATIONS, Element, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement, isReferenceExpression, Values } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter_utils'
 import { AdapterApiConfig } from '../config'
 import { createUrl } from '../fetch/resource'
 
-export const addUrlToInstance = <TContext extends { apiDefinitions: AdapterApiConfig }>(
-  instance: InstanceElement,
-  baseUrl: string,
-  config: TContext,
-  otherApiDefinitions?: AdapterApiConfig,
+
+export const addUrlToInstance = (
+  instance: InstanceElement, baseUrl: string, apiDefs: AdapterApiConfig
 ): void => {
-  const definitions = otherApiDefinitions ?? config.apiDefinitions
-  const serviceUrl = definitions.types[instance.elemID.typeName]?.transformation?.serviceUrl
+  const serviceUrl = apiDefs
+    .types[instance.elemID.typeName]?.transformation?.serviceUrl
   if (serviceUrl === undefined) {
     return
   }
-  const url = createUrl({ instance, baseUrl: serviceUrl })
-  instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(url, baseUrl).href
+  // parent is ReferenceExpression during fetch, and serialized into full value during deploy
+  const parentValues = instance.annotations[CORE_ANNOTATIONS.PARENT]?.map(
+    (parent: unknown) => (isReferenceExpression(parent) ? parent.value.value : parent)
+  )
+  const parentContext = parentValues?.reduce((
+    result: Values, parentVal: Values, idx: number
+  ) => {
+    Object.entries(parentVal).forEach(([key, value]) => { result[`_parent.${idx}.${key}`] = value })
+    return result
+  }, {})
+  const url = createUrl({ instance, baseUrl: serviceUrl, additionalUrlVars: parentContext })
+  instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, baseUrl)).href
 }
 
 export const serviceUrlFilterCreator: <
   TClient,
   TContext extends { apiDefinitions: AdapterApiConfig },
-  TResult extends void | filter.FilterResult = void,
->(
-  baseUrl: string,
-  otherApiDefinitions?: AdapterApiConfig,
-) => FilterCreator<TClient, TContext, TResult> =
-  (baseUrl, otherApiDefinitions) =>
-  ({ config }) => ({
-    name: 'serviceUrlFilter',
-    onFetch: async (elements: Element[]) => {
-      elements
-        .filter(isInstanceElement)
-        .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherApiDefinitions))
-    },
-    onDeploy: async (changes: Change<InstanceElement>[]) => {
-      const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
-      relevantChanges
-        .map(getChangeData)
-        .forEach(instance => addUrlToInstance(instance, baseUrl, config, otherApiDefinitions))
-    },
-  })
+  TResult extends void | filter.FilterResult = void
+>(baseUrl: string, additionalApiDefinitions?: AdapterApiConfig)
+=> FilterCreator<TClient, TContext, TResult> = (baseUrl, additionalApiDefinitions) => ({ config }) => ({
+  name: 'serviceUrlFilter',
+  onFetch: async (elements: Element[]) => {
+    elements
+      .filter(isInstanceElement)
+      .forEach(instance => {
+        const apiDefinitions = additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
+          ? additionalApiDefinitions : config.apiDefinitions
+        addUrlToInstance(instance, baseUrl, apiDefinitions)
+      })
+  },
+  onDeploy: async (changes: Change<InstanceElement>[]) => {
+    const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
+    relevantChanges
+      .map(getChangeData)
+      .forEach(instance => {
+        const apiDefinitions = additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
+          ? additionalApiDefinitions : config.apiDefinitions
+        addUrlToInstance(instance, baseUrl, apiDefinitions)
+      })
+  },
+})

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -1,71 +1,82 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-import { Change, CORE_ANNOTATIONS, Element, getChangeData, InstanceElement, isAdditionChange, isInstanceChange, isInstanceElement, isReferenceExpression, Values } from '@salto-io/adapter-api'
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Change,
+  CORE_ANNOTATIONS,
+  Element,
+  getChangeData,
+  InstanceElement,
+  isAdditionChange,
+  isInstanceChange,
+  isInstanceElement,
+  isReferenceExpression,
+  Values,
+} from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter_utils'
 import { AdapterApiConfig } from '../config'
 import { createUrl } from '../fetch/resource'
 
-
-export const addUrlToInstance = (
-  instance: InstanceElement, baseUrl: string, apiDefs: AdapterApiConfig
-): void => {
-  const serviceUrl = apiDefs
-    .types[instance.elemID.typeName]?.transformation?.serviceUrl
+export const addUrlToInstance = (instance: InstanceElement, baseUrl: string, apiDefs: AdapterApiConfig): void => {
+  const serviceUrl = apiDefs.types[instance.elemID.typeName]?.transformation?.serviceUrl
   if (serviceUrl === undefined) {
     return
   }
   // parent is ReferenceExpression during fetch, and serialized into full value during deploy
-  const parentValues = instance.annotations[CORE_ANNOTATIONS.PARENT]?.map(
-    (parent: unknown) => (isReferenceExpression(parent) ? parent.value.value : parent)
+  const parentValues = instance.annotations[CORE_ANNOTATIONS.PARENT]?.map((parent: unknown) =>
+    isReferenceExpression(parent) ? parent.value.value : parent,
   )
-  const parentContext = parentValues?.reduce((
-    result: Values, parentVal: Values, idx: number
-  ) => {
-    Object.entries(parentVal).forEach(([key, value]) => { result[`_parent.${idx}.${key}`] = value })
+  const parentContext = parentValues?.reduce((result: Values, parentVal: Values, idx: number) => {
+    Object.entries(parentVal).forEach(([key, value]) => {
+      result[`_parent.${idx}.${key}`] = value
+    })
     return result
   }, {})
   const url = createUrl({ instance, baseUrl: serviceUrl, additionalUrlVars: parentContext })
-  instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = (new URL(url, baseUrl)).href
+  instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(url, baseUrl).href
 }
 
 export const serviceUrlFilterCreator: <
   TClient,
   TContext extends { apiDefinitions: AdapterApiConfig },
-  TResult extends void | filter.FilterResult = void
->(baseUrl: string, additionalApiDefinitions?: AdapterApiConfig)
-=> FilterCreator<TClient, TContext, TResult> = (baseUrl, additionalApiDefinitions) => ({ config }) => ({
-  name: 'serviceUrlFilter',
-  onFetch: async (elements: Element[]) => {
-    elements
-      .filter(isInstanceElement)
-      .forEach(instance => {
-        const apiDefinitions = additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
-          ? additionalApiDefinitions : config.apiDefinitions
+  TResult extends void | filter.FilterResult = void,
+>(
+  baseUrl: string,
+  additionalApiDefinitions?: AdapterApiConfig,
+) => FilterCreator<TClient, TContext, TResult> =
+  (baseUrl, additionalApiDefinitions) =>
+  ({ config }) => ({
+    name: 'serviceUrlFilter',
+    onFetch: async (elements: Element[]) => {
+      elements.filter(isInstanceElement).forEach(instance => {
+        const apiDefinitions =
+          additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
+            ? additionalApiDefinitions
+            : config.apiDefinitions
         addUrlToInstance(instance, baseUrl, apiDefinitions)
       })
-  },
-  onDeploy: async (changes: Change<InstanceElement>[]) => {
-    const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
-    relevantChanges
-      .map(getChangeData)
-      .forEach(instance => {
-        const apiDefinitions = additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
-          ? additionalApiDefinitions : config.apiDefinitions
+    },
+    onDeploy: async (changes: Change<InstanceElement>[]) => {
+      const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
+      relevantChanges.map(getChangeData).forEach(instance => {
+        const apiDefinitions =
+          additionalApiDefinitions?.types[instance.elemID.typeName] !== undefined
+            ? additionalApiDefinitions
+            : config.apiDefinitions
         addUrlToInstance(instance, baseUrl, apiDefinitions)
       })
-  },
-})
+    },
+  })

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -1,19 +1,19 @@
 /*
- *                      Copyright 2024 Salto Labs Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData } from '@salto-io/adapter-api'
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
 import { serviceUrlFilterCreator } from '../../src/filters/service_url'
@@ -27,6 +27,14 @@ describe('service url filter', () => {
   const testObjType = new ObjectType({ elemID: new ElemID('adapter', 'test') })
   const testInst = new InstanceElement('test', testObjType, { id: 11, name: 'test' })
   const baseUrl = 'https://www.example.com'
+  const objectType = new ObjectType({ elemID: new ElemID('adapter', 'foo') })
+  const instWithParent = new InstanceElement(
+    'instWithParent',
+    objectType,
+    { id: 'ab', name: 'instWithParent' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(roleInst.elemID, roleInst)] }
+  )
 
   beforeEach(async () => {
     jest.clearAllMocks()
@@ -42,6 +50,9 @@ describe('service url filter', () => {
                 serviceUrl: '/roles/{id}',
               },
             },
+            foo: {
+              transformation: { serviceUrl: 'roles/{_parent.0.id}/foo/{id}' },
+            },
           },
           typeDefaults: {
             transformation: { idFields: ['id'] },
@@ -54,13 +65,15 @@ describe('service url filter', () => {
 
   describe('onFetch', () => {
     it('should add service url annotation if it is exist in the config', async () => {
-      const elements = [roleInst].map(e => e.clone())
+      const elements = [roleInst, instWithParent].map(e => e.clone())
       await filter.onFetch(elements)
-      expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual(['adapter.role.instance.role'])
-      const [instance] = elements
-      expect(instance.annotations).toEqual({
+      expect(elements.map(e => e.elemID.getFullName()).sort())
+        .toEqual(['adapter.foo.instance.instWithParent', 'adapter.role.instance.role'])
+      const [role, withParent] = elements
+      expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/ab')
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const elements = [testInst].map(e => e.clone())
@@ -72,18 +85,17 @@ describe('service url filter', () => {
   })
   describe('onDeploy', () => {
     it('should add service url annotation if it is exist in the config', async () => {
-      const changes = [roleInst].map(e => e.clone()).map(inst => toChange({ after: inst }))
+      const instWithResolvedParent = instWithParent.clone()
+      instWithResolvedParent.annotations[CORE_ANNOTATIONS.PARENT] = [roleInst.clone().value]
+      const changes = [roleInst, instWithResolvedParent].map(e => e.clone()).map(inst => toChange({ after: inst }))
       await filter.onDeploy(changes)
-      expect(
-        changes
-          .map(getChangeData)
-          .map(e => e.elemID.getFullName())
-          .sort(),
-      ).toEqual(['adapter.role.instance.role'])
-      const instance = getChangeData(changes[0])
-      expect(instance.annotations).toEqual({
+      expect(changes.map(getChangeData).map(e => e.elemID.getFullName()).sort())
+        .toEqual(['adapter.foo.instance.instWithParent', 'adapter.role.instance.role'])
+      const [role, withParent] = changes.map(getChangeData)
+      expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/ab')
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const changes = [testInst].map(e => e.clone()).map(inst => toChange({ after: inst }))

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -1,19 +1,27 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
-import { ObjectType, ElemID, InstanceElement, CORE_ANNOTATIONS, toChange, getChangeData, ReferenceExpression } from '@salto-io/adapter-api'
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  CORE_ANNOTATIONS,
+  toChange,
+  getChangeData,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
 import { serviceUrlFilterCreator } from '../../src/filters/service_url'
@@ -33,7 +41,7 @@ describe('service url filter', () => {
     objectType,
     { id: 'ab', name: 'instWithParent' },
     undefined,
-    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(roleInst.elemID, roleInst)] }
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(roleInst.elemID, roleInst)] },
   )
 
   beforeEach(async () => {
@@ -67,8 +75,10 @@ describe('service url filter', () => {
     it('should add service url annotation if it is exist in the config', async () => {
       const elements = [roleInst, instWithParent].map(e => e.clone())
       await filter.onFetch(elements)
-      expect(elements.map(e => e.elemID.getFullName()).sort())
-        .toEqual(['adapter.foo.instance.instWithParent', 'adapter.role.instance.role'])
+      expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+        'adapter.foo.instance.instWithParent',
+        'adapter.role.instance.role',
+      ])
       const [role, withParent] = elements
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
@@ -89,8 +99,12 @@ describe('service url filter', () => {
       instWithResolvedParent.annotations[CORE_ANNOTATIONS.PARENT] = [roleInst.clone().value]
       const changes = [roleInst, instWithResolvedParent].map(e => e.clone()).map(inst => toChange({ after: inst }))
       await filter.onDeploy(changes)
-      expect(changes.map(getChangeData).map(e => e.elemID.getFullName()).sort())
-        .toEqual(['adapter.foo.instance.instWithParent', 'adapter.role.instance.role'])
+      expect(
+        changes
+          .map(getChangeData)
+          .map(e => e.elemID.getFullName())
+          .sort(),
+      ).toEqual(['adapter.foo.instance.instWithParent', 'adapter.role.instance.role'])
       const [role, withParent] = changes.map(getChangeData)
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -259,7 +259,7 @@ export const workflowSchemeMigrationValidator =
       .map(async change => {
         await updateSchemeId(change, client, paginator, config)
         const instance = getChangeData(change)
-        addUrlToInstance(instance, client.baseUrl, config)
+        addUrlToInstance(instance, client.baseUrl, config.apiDefinitions)
         const changedItems = await getChangedItemsFromChange(
           change,
           workflowSchemesToProjects[getChangeData(change).elemID.getFullName()],

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -448,6 +448,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
         { fieldName: 'properties' },
       ),
       fieldsToHide: [{ fieldName: 'id' }, { fieldName: 'name' }],
+      serviceUrl: '/admin/universaldirectory#app/{_parent.0.id}',
     },
     deployRequests: {
       modify: {
@@ -555,7 +556,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
         { fieldName: 'properties' },
       ),
       fieldsToHide: [{ fieldName: 'id' }, { fieldName: 'name' }],
-      // serviceUrl is created in service_url filter
+      serviceUrl: '/admin/universaldirectory#okta/{_parent.0.id}',
     },
     deployRequests: {
       add: {
@@ -1678,6 +1679,7 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
       idFields: ['&userGroupId'],
       serviceIdField: 'mappingId',
       extendsParentId: true,
+      serviceUrl: '/admin/app/{_parent.0.name}/instance/{_parent.0.id}/#tab-group-push',
     },
     deployRequests: {
       add: {
@@ -1703,6 +1705,7 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
       idFields: ['name'],
       serviceIdField: 'mappingRuleId',
       extendsParentId: true,
+      serviceUrl: '/admin/app/{_parent.0.name}/instance/{_parent.0.id}/#tab-group-push',
     },
     deployRequests: {
       add: {

--- a/packages/okta-adapter/src/filters/service_url.ts
+++ b/packages/okta-adapter/src/filters/service_url.ts
@@ -1,102 +1,28 @@
 /*
- *                      Copyright 2024 Salto Labs Ltd.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
-import {
-  isInstanceElement,
-  CORE_ANNOTATIONS,
-  Element,
-  InstanceElement,
-  Change,
-  isInstanceChange,
-  isAdditionChange,
-  getChangeData,
-} from '@salto-io/adapter-api'
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
 import { filters } from '@salto-io/adapter-components'
-import { getParent } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
-import { FilterCreator } from '../filter'
-import {
-  APP_USER_SCHEMA_TYPE_NAME,
-  USER_SCHEMA_TYPE_NAME,
-  GROUP_PUSH_TYPE_NAME,
-  GROUP_PUSH_RULE_TYPE_NAME,
-} from '../constants'
+import { FilterContext, PRIVATE_API_DEFINITIONS_CONFIG } from '../config'
+import { FilterCreator, FilterResult } from '../filter'
+import OktaClient from '../client/client'
 import { getAdminUrl } from '../client/admin'
 
-const log = logger(module)
-const { addUrlToInstance } = filters
+const filter: FilterCreator = params =>
+  filters.serviceUrlFilterCreator<OktaClient, FilterContext, FilterResult>(
+    getAdminUrl(params.client.baseUrl) ?? params.client.baseUrl,
+    params.config[PRIVATE_API_DEFINITIONS_CONFIG]
+  )(params)
 
-const SUPPORTED_TYPES = new Set([
-  USER_SCHEMA_TYPE_NAME,
-  APP_USER_SCHEMA_TYPE_NAME,
-  GROUP_PUSH_TYPE_NAME,
-  GROUP_PUSH_RULE_TYPE_NAME,
-])
-
-const createSuffixUrL = (instance: InstanceElement): string => {
-  const parent = getParent(instance)
-  if (instance.elemID.typeName === USER_SCHEMA_TYPE_NAME) {
-    return `/admin/universaldirectory#okta/${parent.value.id}`
-  }
-  if (instance.elemID.typeName === GROUP_PUSH_TYPE_NAME || instance.elemID.typeName === GROUP_PUSH_RULE_TYPE_NAME) {
-    return `/admin/app/${parent.value.name}/instance/${parent.value.id}/#tab-group-push`
-  }
-  return `/api/v1/meta/schemas/apps/${parent.value.id}/default`
-}
-
-const createServiceUrl = (instance: InstanceElement, baseUrl: string): void => {
-  try {
-    const suffixUrl = createSuffixUrL(instance)
-    instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = new URL(suffixUrl, baseUrl).href
-  } catch (error) {
-    log.warn(`Failed to create serviceUrl for ${instance.elemID.getFullName()}. Error: ${error.message}}`)
-  }
-}
-
-const serviceUrlFilter: FilterCreator = ({ client, config }) => ({
-  name: 'serviceUrlFilter',
-  onFetch: async (elements: Element[]) => {
-    const baseUrl = getAdminUrl(client.baseUrl)
-    if (baseUrl === undefined) {
-      log.warn('Failed to run serviceUrlFilter, because baseUrl could not be found')
-      return
-    }
-    elements.filter(isInstanceElement).forEach(instance => {
-      if (SUPPORTED_TYPES.has(instance.elemID.typeName)) {
-        createServiceUrl(instance, baseUrl)
-        return
-      }
-      addUrlToInstance(instance, baseUrl, config)
-    })
-  },
-  onDeploy: async (changes: Change<InstanceElement>[]) => {
-    const baseUrl = getAdminUrl(client.baseUrl)
-    if (baseUrl === undefined) {
-      log.warn('Failed to run serviceUrlFilter, because baseUrl could not be found')
-      return
-    }
-    const relevantChanges = changes.filter(isInstanceChange).filter(isAdditionChange)
-    relevantChanges.map(getChangeData).forEach(instance => {
-      if (SUPPORTED_TYPES.has(instance.elemID.typeName)) {
-        createServiceUrl(instance, baseUrl)
-        return
-      }
-      addUrlToInstance(instance, baseUrl, config)
-    })
-  },
-})
-
-export default serviceUrlFilter
+export default filter

--- a/packages/okta-adapter/src/filters/service_url.ts
+++ b/packages/okta-adapter/src/filters/service_url.ts
@@ -1,18 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import { filters } from '@salto-io/adapter-components'
 import { FilterContext, PRIVATE_API_DEFINITIONS_CONFIG } from '../config'
 import { FilterCreator, FilterResult } from '../filter'
@@ -22,7 +22,7 @@ import { getAdminUrl } from '../client/admin'
 const filter: FilterCreator = params =>
   filters.serviceUrlFilterCreator<OktaClient, FilterContext, FilterResult>(
     getAdminUrl(params.client.baseUrl) ?? params.client.baseUrl,
-    params.config[PRIVATE_API_DEFINITIONS_CONFIG]
+    params.config[PRIVATE_API_DEFINITIONS_CONFIG],
   )(params)
 
 export default filter

--- a/packages/okta-adapter/test/filters/service_url.test.ts
+++ b/packages/okta-adapter/test/filters/service_url.test.ts
@@ -44,25 +44,12 @@ describe('serviceUrlFilter', () => {
 
   const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
   const userTypeType = new ObjectType({ elemID: new ElemID(OKTA, USERTYPE_TYPE_NAME) })
-  const userTypeInstance = new InstanceElement(
-    'user1',
-    userTypeType,
-    { id: 11, name: 'user1' }
-  )
-  const userSchemaInstance = new InstanceElement(
-    'schema',
-    userSchemaType,
-    { id: 12 },
-    undefined,
-    { [CORE_ANNOTATIONS.PARENT]: [
-      new ReferenceExpression(userTypeInstance.elemID, userTypeInstance)] },
-  )
+  const userTypeInstance = new InstanceElement('user1', userTypeType, { id: 11, name: 'user1' })
+  const userSchemaInstance = new InstanceElement('schema', userSchemaType, { id: 12 }, undefined, {
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(userTypeInstance.elemID, userTypeInstance)],
+  })
   const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
-  const appInstance = new InstanceElement(
-    'app1',
-    appType,
-    { id: 11, name: 'app1' },
-  )
+  const appInstance = new InstanceElement('app1', appType, { id: 11, name: 'app1' })
 
   describe('onFetch', () => {
     it('should add service url annotation for application if it is exist in the config', async () => {

--- a/packages/okta-adapter/test/filters/service_url.test.ts
+++ b/packages/okta-adapter/test/filters/service_url.test.ts
@@ -42,67 +42,53 @@ describe('serviceUrlFilter', () => {
     filter = serviceUrlFilter(getFilterParams({ client })) as typeof filter
   })
 
-  describe('types using serviceUrl config', () => {
-    const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
-    const appInstance = new InstanceElement('app1', appType, { id: 11, name: 'app1' })
+  const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
+  const userTypeType = new ObjectType({ elemID: new ElemID(OKTA, USERTYPE_TYPE_NAME) })
+  const userTypeInstance = new InstanceElement(
+    'user1',
+    userTypeType,
+    { id: 11, name: 'user1' }
+  )
+  const userSchemaInstance = new InstanceElement(
+    'schema',
+    userSchemaType,
+    { id: 12 },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [
+      new ReferenceExpression(userTypeInstance.elemID, userTypeInstance)] },
+  )
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const appInstance = new InstanceElement(
+    'app1',
+    appType,
+    { id: 11, name: 'app1' },
+  )
 
-    describe('onFetch', () => {
-      it('should add service url annotation for application if it is exist in the config', async () => {
-        const elements = [appInstance].map(e => e.clone())
-        await filter.onFetch(elements)
-        const [instance] = elements
-        expect(instance.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
-          `${getAdminUrl(client.baseUrl)}/admin/app/${appInstance.value.name}/instance/${appInstance.value.id}/#tab-general`,
-        )
-      })
-    })
-    describe('onDeploy', () => {
-      it('should add service url annotation for application if it is exist in the config', async () => {
-        const changes = [appInstance].map(e => e.clone()).map(inst => toChange({ after: inst }))
-        await filter.onDeploy(changes)
-        const instance = getChangeData(changes[0])
-        expect(instance.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
-          `${getAdminUrl(client.baseUrl)}/admin/app/${appInstance.value.name}/instance/${appInstance.value.id}/#tab-general`,
-        )
-      })
+  describe('onFetch', () => {
+    it('should add service url annotation for application if it is exist in the config', async () => {
+      const elements = [appInstance, userSchemaInstance].map(e => e.clone())
+      await filter.onFetch(elements)
+      const [appInst, schemaInst] = elements
+      expect(appInst.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        `${getAdminUrl(client.baseUrl)}/admin/app/${appInstance.value.name}/instance/${appInstance.value.id}/#tab-general`,
+      )
+      expect(schemaInst.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        `${getAdminUrl(client.baseUrl)}/admin/universaldirectory#okta/${userTypeInstance.value.id}`,
+      )
     })
   })
-  describe('additionalServiceUrlFilter', () => {
-    describe('checking UserSchema type', () => {
-      const userSchemaType = new ObjectType({ elemID: new ElemID(OKTA, USER_SCHEMA_TYPE_NAME) })
-      const userTypeType = new ObjectType({ elemID: new ElemID(OKTA, USERTYPE_TYPE_NAME) })
-      const userTypeInstance = new InstanceElement('user1', userTypeType, { id: 11, name: 'user1' })
-      const userSchemaInstance = new InstanceElement('schema', userSchemaType, { id: 12 }, undefined, {
-        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(userTypeInstance.elemID, userTypeInstance)],
-      })
-      const userSchemaInstaceWithoutParents = new InstanceElement('schema', userSchemaType, { id: 12 }, undefined, {})
-      describe('onFetch', () => {
-        it('should add service url annotation for userSchema if it has userType as reference expression', async () => {
-          const elements = [userSchemaInstance].map(e => e.clone())
-          await filter.onFetch(elements)
-          const [instance] = elements
-          expect(instance.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
-            `${getAdminUrl(client.baseUrl)}/admin/universaldirectory#okta/${userTypeInstance.value.id}`,
-          )
-        })
-        it('should not add service url annotation for userSchema if it has no parents annotation', async () => {
-          const elements = [userSchemaInstaceWithoutParents.clone()]
-          delete elements[0].annotations[CORE_ANNOTATIONS.PARENT]
-          await filter.onFetch(elements)
-          const [instance] = elements
-          expect(instance.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
-        })
-      })
-      describe('onDeploy', () => {
-        it('should add service url annotation for userSchema if it has userType as parent', async () => {
-          const changes = [userSchemaInstance].map(e => e.clone()).map(inst => toChange({ after: inst }))
-          await filter.onDeploy(changes)
-          const instance = getChangeData(changes[0])
-          expect(instance.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
-            `${getAdminUrl(client.baseUrl)}/admin/universaldirectory#okta/${userTypeInstance.value.id}`,
-          )
-        })
-      })
+  describe('onDeploy', () => {
+    it('should add service url annotation for application if it is exist in the config', async () => {
+      const changes = [appInstance, userSchemaInstance].map(e => e.clone()).map(inst => toChange({ after: inst }))
+      await filter.onDeploy(changes)
+      const appInst = getChangeData(changes[0])
+      expect(appInst.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        `${getAdminUrl(client.baseUrl)}/admin/app/${appInstance.value.name}/instance/${appInstance.value.id}/#tab-general`,
+      )
+      const schemaInse = getChangeData(changes[1])
+      expect(schemaInse.annotations?.[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        `${getAdminUrl(client.baseUrl)}/admin/universaldirectory#okta/${userTypeInstance.value.id}`,
+      )
     })
   })
 })


### PR DESCRIPTION
Allow using parent values with service url through the config.
The format is similar to the one being used with `urlParamsToFields`, for example `api/v1/apps/{_parent.0.id}/schema/{id}`

---

I also change serviceId Filter to use the definitions according to type to avoid creating filter for each config

---
_Release Notes_: 
None

---
_User Notifications_: 
None
