### PR TITLE
SALTO-5458: Salesforce Metadata Important Values

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -45,7 +45,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   fixRetrieveFilePaths: true,
   extraDependenciesV2: true,
   extendedCustomFieldInformation: false,
-  importantValues: false,
+  importantValues: true,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2720,9 +2720,7 @@ public class LargeClass${index} {
         ...mockFetchOpts,
         withChangesDetection: true,
       })
-      expect(elements.filter(isMetadataObjectType)).toEqual([
-        mockTypes.ApexClass,
-      ])
+      expect(elements.filter(isMetadataObjectType).map(type => apiNameSync(type))).toEqual(['ApexClass'])
     })
     it('should get the ChangedAtSingleton from the ElementsSource when fetchWithChangesDetection is true', async () => {
       await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2720,7 +2720,9 @@ public class LargeClass${index} {
         ...mockFetchOpts,
         withChangesDetection: true,
       })
-      expect(elements.filter(isMetadataObjectType).map(type => apiNameSync(type))).toEqual(['ApexClass'])
+      expect(
+        elements.filter(isMetadataObjectType).map((type) => apiNameSync(type)),
+      ).toEqual(['ApexClass'])
     })
     it('should get the ChangedAtSingleton from the ElementsSource when fetchWithChangesDetection is true', async () => {
       await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })


### PR DESCRIPTION
Add important values for Salesforce Metadata Types.

---

Turned on the feature `importantValues` by default.

---
_Release Notes_: 
Salesforce Adapter:
- Add important values to Salesforce Metadata Types.

---
_User Notifications_: 
Salesforce:
- Upon your next fetch, expect changes to existing Metadata Types nacls.
