### PR TITLE
Add config option to SuiteQL queries limitation

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -192,7 +192,7 @@ export default class SuiteAppClient {
     throwOnErrors: Record<string, string> = {},
   ): Promise<Record<string, unknown>[] | undefined> {
     log.debug('Running SuiteQL query: %s', query)
-    if (!/ORDER BY .* (ASC|DESC)/.test(query)) {
+    if (!/ORDER BY .* (ASC|DESC)/.test(query) && !/count\(\*\)/i.test(query)) {
       log.warn(
         `SuiteQL ${query} does not contain ORDER BY <unique identifier> ASC/DESC, which can cause the response to not contain all the results`,
       )

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -198,11 +198,13 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
   httpTimeoutLimitInMinutes?: number
+  maxRecordsPerSuiteQLTable?: MaxInstancesPerType[]
 }
 
 export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
   suiteAppConcurrencyLimit: 'suiteAppConcurrencyLimit',
   httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
+  maxRecordsPerSuiteQLTable: 'maxRecordsPerSuiteQLTable',
 }
 
 export type NetsuiteConfig = {
@@ -383,6 +385,7 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
         }),
       },
     },
+    maxRecordsPerSuiteQLTable: { refType: new ListType(maxInstancesPerConfigType) },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Add the `suiteAppClient.maxRecordsPerSuiteQLTable` config to allow defining the max allowed records of a suiteql table query

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Add config option to SuiteQL queries limitation: `suiteAppClient.maxRecordsPerSuiteQLTable`

---
_User Notifications_: 
None