### PR TITLE
SALTO-5456: hide workflow transitionId and add it in the deployment

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -88,6 +88,7 @@ import projectComponentFilter from './filters/project_component'
 import archivedProjectComponentsFilter from './filters/archived_project_components'
 import defaultInstancesDeployFilter from './filters/default_instances_deploy'
 import workflowFilter from './filters/workflowV2/workflow_filter'
+import workflowTransitionIdsFilter from './filters/workflowV2/transition_ids'
 import workflowStructureFilter from './filters/workflow/workflow_structure_filter'
 import workflowDiagramFilter from './filters/workflow/workflow_diagrams'
 import resolutionPropertyFilter from './filters/workflow/resolution_property_filter'
@@ -260,6 +261,8 @@ export const DEFAULT_FILTERS = [
   workflowPropertiesFilter,
   // must run after scriptRunnerWorkflowListsFilter and workflowPropertiesFilter
   scriptRunnerWorkflowReferencesFilter,
+  // must run after scriptRunnerWorkflowReferencesFilter
+  workflowTransitionIdsFilter,
   transitionIdsFilter,
   workflowDeployFilter,
   workflowModificationFilter,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1215,6 +1215,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
       fieldsToOmit: [{ fieldName: 'id' }],
     },
   },
+  WorkflowTransitions: {
+    transformation: {
+      // transitionId is not multi-env friendly
+      fieldsToHide: [
+        { fieldName: 'id' },
+      ],
+    },
+  },
   WorkflowTrigger: {
     transformation: {
       fieldsToOmit: [{ fieldName: 'id' }],

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1218,9 +1218,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
   WorkflowTransitions: {
     transformation: {
       // transitionId is not multi-env friendly
-      fieldsToHide: [
-        { fieldName: 'id' },
-      ],
+      fieldsToHide: [{ fieldName: 'id' }],
     },
   },
   WorkflowTrigger: {

--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
@@ -120,10 +120,10 @@ const filter: FilterCreator = ({ config, client }) => {
       workflows.filter(isWorkflowV2Instance).forEach(workflow => {
         Object.values(workflow.value.transitions).forEach(transition => {
           walkOverTransitionIdsV2(transition, scriptRunner => {
-              const { transitionId } = scriptRunner
+            const { transitionId } = scriptRunner
             scriptRunner.transitionId = isResolvedReferenceExpression(transitionId)
-              // because the reference value has been changed in transition_ids filter
-              ? resolvePath(workflow, transitionId.elemID.createNestedID('id'))
+              ? // because the reference value has been changed in transition_ids filter
+                resolvePath(workflow, transitionId.elemID.createNestedID('id'))
               : scriptRunner.transitionId
           })
         })

--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_references.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { isResolvedReferenceExpression, resolveValues, restoreValues } from '@salto-io/adapter-utils'
+import { isResolvedReferenceExpression, resolvePath, resolveValues, restoreValues } from '@salto-io/adapter-utils'
 import {
   isAdditionOrModificationChange,
   getChangeData,
@@ -120,8 +120,10 @@ const filter: FilterCreator = ({ config, client }) => {
       workflows.filter(isWorkflowV2Instance).forEach(workflow => {
         Object.values(workflow.value.transitions).forEach(transition => {
           walkOverTransitionIdsV2(transition, scriptRunner => {
-            scriptRunner.transitionId = isResolvedReferenceExpression(scriptRunner.transitionId)
-              ? scriptRunner.transitionId.value.id
+              const { transitionId } = scriptRunner
+            scriptRunner.transitionId = isResolvedReferenceExpression(transitionId)
+              // because the reference value has been changed in transition_ids filter
+              ? resolvePath(workflow, transitionId.elemID.createNestedID('id'))
               : scriptRunner.transitionId
           })
         })

--- a/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
@@ -1,31 +1,27 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import _ from 'lodash'
 import { getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
 import { FilterCreator } from '../../filter'
 import { isWorkflowV2Instance, WorkflowV2Instance } from './types'
 
-
-const getMaxTransitionId = (workflowInstance: WorkflowV2Instance): number => (
+const getMaxTransitionId = (workflowInstance: WorkflowV2Instance): number =>
   _.toSafeInteger(
-      _.maxBy(
-        Object.values(workflowInstance.value.transitions),
-        transition => _.toSafeInteger(transition.id)
-      )?.id
-  ))
+    _.maxBy(Object.values(workflowInstance.value.transitions), transition => _.toSafeInteger(transition.id))?.id,
+  )
 
 const addTransitionIds = (workflowInstance: WorkflowV2Instance): void => {
   let maxTransitionId = 0

--- a/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
@@ -1,0 +1,53 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { FilterCreator } from '../../filter'
+import { isWorkflowV2Instance, WorkflowV2Instance } from './types'
+
+
+const getMaxTransitionId = (workflowInstance: WorkflowV2Instance): number => (
+  _.toSafeInteger(
+      _.maxBy(
+        Object.values(workflowInstance.value.transitions),
+        transition => _.toSafeInteger(transition.id)
+      )?.id
+  ))
+
+const addTransitionIds = (workflowInstance: WorkflowV2Instance): void => {
+  let maxTransitionId = 0
+  maxTransitionId = getMaxTransitionId(workflowInstance)
+  Object.values(workflowInstance.value.transitions).forEach(transition => {
+    if (transition.id === undefined) {
+      transition.id = _.toString(maxTransitionId + 1)
+      maxTransitionId += 1
+    }
+  })
+}
+
+const filter: FilterCreator = () => ({
+  name: 'transitionIdsFilter',
+  preDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isWorkflowV2Instance)
+      .forEach(addTransitionIds)
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/transition_ids.ts
@@ -24,8 +24,7 @@ const getMaxTransitionId = (workflowInstance: WorkflowV2Instance): number =>
   )
 
 const addTransitionIds = (workflowInstance: WorkflowV2Instance): void => {
-  let maxTransitionId = 0
-  maxTransitionId = getMaxTransitionId(workflowInstance)
+  let maxTransitionId = getMaxTransitionId(workflowInstance)
   Object.values(workflowInstance.value.transitions).forEach(transition => {
     if (transition.id === undefined) {
       transition.id = _.toString(maxTransitionId + 1)

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -60,7 +60,7 @@ export type WorkflowStatus = {
 }
 
 export type WorkflowTransitionV2 = {
-  id: string
+  id?: string
   actions?: Values[]
   conditions?: Values
   validators?: Values[]
@@ -85,9 +85,9 @@ type WorkflowScope = {
 
 export type Workflow = {
   name: string
-  version: WorkflowVersion
+  version?: WorkflowVersion
   scope: WorkflowScope
-  id: string
+  id?: string
   transitions: Values[]
   statuses: Values[]
 }
@@ -103,20 +103,19 @@ const WORKFLOW_SCHEMA = Joi.object({
     versionNumber: Joi.number().required(),
     id: Joi.string().required(),
   })
-    .unknown(true)
-    .required(),
+    .unknown(true),
   scope: Joi.object({
     project: Joi.string(),
     type: Joi.string().required(),
   })
     .unknown(true)
     .required(),
-  id: Joi.string().required(),
+  id: Joi.string(),
   transitions: Joi.object()
     .pattern(
       Joi.string(),
       Joi.object({
-        id: Joi.string().required(),
+        id: Joi.string(),
         actions: Joi.array().items(Joi.object()),
         conditions: Joi.object(),
         validators: Joi.array().items(Joi.object()),

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -102,8 +102,7 @@ const WORKFLOW_SCHEMA = Joi.object({
   version: Joi.object({
     versionNumber: Joi.number().required(),
     id: Joi.string().required(),
-  })
-    .unknown(true),
+  }).unknown(true),
   scope: Joi.object({
     project: Joi.string(),
     type: Joi.string().required(),

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -186,6 +186,7 @@ const createWorkflowInstances = async ({
             errors.push(workflowFetchError('Workflow id is missing'))
             return undefined
           }
+          // convert transition list to map
           const [error] = transformTransitions(workflow, workflowIdToStatuses[workflow.id])
           if (error) {
             errors.push(error)

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -184,7 +184,7 @@ const createWorkflowInstances = async ({
           if (workflow.id === undefined) {
         // should never happen
         errors.push(workflowFetchError('Workflow id is missing'))
-        return undefined // add ut
+        return undefined
       }
           const [error] = transformTransitions(workflow, workflowIdToStatuses[workflow.id])
           if (error) {
@@ -529,8 +529,6 @@ const filter: FilterCreator = ({ config, client, paginator, fetchQuery, elements
         .filter(isAdditionOrModificationWorkflowChange)
         .forEach(async change => {
           const workflowInstance = getChangeData(change)
-          // transitionIds are not multi-env friendly, but it is required field in the API
-          // addTransitionIds(workflowInstance)
           originalInstances[workflowInstance.elemID.getFullName()] = workflowInstance.clone()
           const statusInstances = getStatusInstances(change)
           const statusIdToUuid = getUuidMap(statusInstances)

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -182,10 +182,10 @@ const createWorkflowInstances = async ({
           convertTransitionParametersFields(workflow.transitions, convertParametersFieldsToList)
           convertPropertiesToList([...(workflow.statuses ?? []), ...(workflow.transitions ?? [])])
           if (workflow.id === undefined) {
-        // should never happen
-        errors.push(workflowFetchError('Workflow id is missing'))
-        return undefined
-      }
+            // should never happen
+            errors.push(workflowFetchError('Workflow id is missing'))
+            return undefined
+          }
           const [error] = transformTransitions(workflow, workflowIdToStatuses[workflow.id])
           if (error) {
             errors.push(error)
@@ -451,7 +451,6 @@ const replaceStatusIdWithUuid =
     }
     return WALK_NEXT_STEP.SKIP
   }
-
 
 const getWorkflowForDeploy = async (
   workflowInstance: InstanceElement,

--- a/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
@@ -48,9 +48,10 @@ describe('transition ids filter', () => {
 
     it('should remain existing transition ids and add new ids correctly', async () => {
       instance.value.transitions.transition1.id = '18'
+      instance.value.transitions.transition3.id = '20'
       await filter.preDeploy([toChange({ after: instance })])
       expect(instance.value.transitions.transition1.id).toBe('18')
-      expect(instance.value.transitions.transition2.id).toBe('19')
+      expect(instance.value.transitions.transition2.id).toBe('21')
       expect(instance.value.transitions.transition3.id).toBe('20')
     })
 

--- a/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import { FilterResult } from '../../../src/filter'

--- a/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
@@ -1,0 +1,73 @@
+/*
+*                      Copyright 2024 Salto Labs Ltd.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+import _ from 'lodash'
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { FilterResult } from '../../../src/filter'
+import transitionIdsFilter from '../../../src/filters/workflowV2/transition_ids'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { JIRA_WORKFLOW_TYPE } from '../../../src/constants'
+
+describe('transition ids filter', () => {
+  let filter: filterUtils.FilterWith<'preDeploy', FilterResult>
+  let instance: InstanceElement
+  beforeEach(() => {
+    filter = transitionIdsFilter(getFilterParams()) as filterUtils.FilterWith<'preDeploy', FilterResult>
+    instance = new InstanceElement(
+      'instance',
+      createEmptyType(JIRA_WORKFLOW_TYPE),
+      {
+        name: 'name',
+        scope: {
+          type: 'global',
+        },
+        statuses: [],
+        transitions: {
+          transition1: {
+          },
+          transition2: {
+          },
+          transition3: {
+          },
+        },
+      }
+    )
+  })
+  describe('pre deploy', () => {
+    it('should add transitionIds correctly', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions.transition1.id).toBe('1')
+      expect(instance.value.transitions.transition2.id).toBe('2')
+      expect(instance.value.transitions.transition3.id).toBe('3')
+    })
+
+    it('should remain existing transition ids and add new ids correctly', async () => {
+      instance.value.transitions.transition1.id = '18'
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions.transition1.id).toBe('18')
+      expect(instance.value.transitions.transition2.id).toBe('19')
+      expect(instance.value.transitions.transition3.id).toBe('20')
+    })
+
+    it('should not fail if transitionId is invalid', async () => {
+      instance.value.transitions.transition2.id = 'invalid'
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.transitions.transition1.id).toBe('1')
+      expect(instance.value.transitions.transition2.id).toBe('invalid')
+      expect(instance.value.transitions.transition3.id).toBe('2')
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
@@ -1,18 +1,18 @@
 /*
-*                      Copyright 2024 Salto Labs Ltd.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with
-* the License.  You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import _ from 'lodash'
 import { InstanceElement, toChange } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
@@ -26,25 +26,18 @@ describe('transition ids filter', () => {
   let instance: InstanceElement
   beforeEach(() => {
     filter = transitionIdsFilter(getFilterParams()) as filterUtils.FilterWith<'preDeploy', FilterResult>
-    instance = new InstanceElement(
-      'instance',
-      createEmptyType(JIRA_WORKFLOW_TYPE),
-      {
-        name: 'name',
-        scope: {
-          type: 'global',
-        },
-        statuses: [],
-        transitions: {
-          transition1: {
-          },
-          transition2: {
-          },
-          transition3: {
-          },
-        },
-      }
-    )
+    instance = new InstanceElement('instance', createEmptyType(JIRA_WORKFLOW_TYPE), {
+      name: 'name',
+      scope: {
+        type: 'global',
+      },
+      statuses: [],
+      transitions: {
+        transition1: {},
+        transition2: {},
+        transition3: {},
+      },
+    })
   })
   describe('pre deploy', () => {
     it('should add transitionIds correctly', async () => {


### PR DESCRIPTION
_hide workflow transitionId and add it in the deployment_

---

_Additional context for reviewer_
in this pr: 
* add transition_ids filter
* fix workflow schema bug
* fix workflow_filter test

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
