### PR TITLE
Run SuiteQL queries concurrently

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -28,6 +28,17 @@ export const SUITE_QL_RESULTS_SCHEMA = {
       type: 'array',
       items: { type: 'object' },
     },
+    links: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          rel: { type: 'string' },
+          href: { type: 'string' },
+        },
+        required: ['rel', 'href'],
+      },
+    },
   },
   required: ['hasMore', 'items'],
   additionalProperties: true,
@@ -37,6 +48,10 @@ export type SuiteQLResults = {
   hasMore: boolean
   items: Values[]
   totalResults?: number
+  links?: {
+    rel: string
+    href: string
+  }[]
 }
 
 export const SAVED_SEARCH_RESULTS_SCHEMA = {


### PR DESCRIPTION
Use the first SuiteQL result's "last page" link to determine how many pages are there for the SuiteQL query, and then query all pages using `Promise.all`.

NOTE - there's still the bottleneck limiter that run max of 4/5 requests at the same time.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Run SuiteQL queries concurrently

---
_User Notifications_: 
None