### PR TITLE
SALTO-5461 - Salesforce: Propagate warnings from successful deploy results

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -295,6 +295,14 @@ const processDeployResponse = (
     return rawElemId
   }
 
+  const problemTypeToSeverity = (messageType: string): SeverityLevel => {
+    if (['Info', 'Warning', 'Error'].includes(messageType)) {
+      return messageType as SeverityLevel
+    }
+    log.warn('unknown messageType %s', messageType)
+    return 'Warning'
+  }
+
   const allFailureMessages = makeArray(result.details).flatMap((detail) =>
     makeArray(detail.componentFailures),
   )
@@ -324,7 +332,7 @@ const processDeployResponse = (
     .map((message) => ({
       elemID: getElemIdForDeployError(message),
       message: message.problem,
-      severity: message.problemType as SeverityLevel, // Salesforce problem types happen to match our severity levels
+      severity: problemTypeToSeverity(message.problemType),
     }))
 
   const componentErrors = failedComponentErrors.concat(

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -299,7 +299,11 @@ const processDeployResponse = (
     makeArray(detail.componentFailures),
   )
 
-  const componentErrors = allFailureMessages
+  const allSuccessMessages = makeArray(result.details).flatMap((detail) =>
+    makeArray(detail.componentSuccesses),
+  )
+
+  const failedComponentErrors = allFailureMessages
     .filter((failure) => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
     .map((failure) => ({
@@ -307,6 +311,19 @@ const processDeployResponse = (
       message: failure.problem,
       severity: 'Error' as SeverityLevel,
     }))
+
+  const successfulComponentWarnings = allSuccessMessages
+    .filter((message) => message.problem)
+    .filter((failure) => !isUnFoundDelete(failure, deletionsPackageName))
+    .map((message) => ({
+      elemID: getElemIdForDeployError(message),
+      message: message.problem,
+      severity: message.problemType as SeverityLevel, // Salesforce problem types happen to match our severity levels
+    }))
+
+  const componentErrors = failedComponentErrors.concat(
+    successfulComponentWarnings,
+  )
 
   const testFailures = makeArray(result.details).flatMap((detail) =>
     makeArray((detail.runTestResult as RunTestsResult)?.failures),
@@ -367,10 +384,6 @@ const processDeployResponse = (
     // if rollbackOnError and we did not succeed, nothing was applied as well
     return { successfulFullNames: [], errors }
   }
-
-  const allSuccessMessages = makeArray(result.details).flatMap((detail) =>
-    makeArray(detail.componentSuccesses),
-  )
 
   // We want to treat deletes for things we haven't found as success
   // Note that if we deploy with ignoreWarnings, these might show up in the success list

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -303,6 +303,8 @@ const processDeployResponse = (
     makeArray(detail.componentSuccesses),
   )
 
+  log.info('deletionsPackageName = %s', deletionsPackageName)
+
   const failedComponentErrors = allFailureMessages
     .filter((failure) => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
@@ -314,7 +316,11 @@ const processDeployResponse = (
 
   const successfulComponentWarnings = allSuccessMessages
     .filter((message) => message.problem)
-    .filter((failure) => !isUnFoundDelete(failure, deletionsPackageName))
+    .filter((message) => !isUnFoundDelete(message, deletionsPackageName))
+    .filter((message) => {
+      log.info('fullName: %s', message.fullName)
+      return true
+    })
     .map((message) => ({
       elemID: getElemIdForDeployError(message),
       message: message.problem,

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -329,6 +329,15 @@ const processDeployResponse = (
       severity: problemTypeToSeverity(message.problemType),
     }))
 
+  if (successfulComponentProblems.length > 0) {
+    log.debug(
+      'Some components that deployed successfully had problems: %s',
+      successfulComponentProblems
+        .map(({ elemID, message }) => `[${elemID}] "${message}"`)
+        .join(', '),
+    )
+  }
+
   const componentErrors = failedComponentErrors.concat(
     successfulComponentProblems,
   )

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -311,8 +311,6 @@ const processDeployResponse = (
     makeArray(detail.componentSuccesses),
   )
 
-  log.info('deletionsPackageName = %s', deletionsPackageName)
-
   const failedComponentErrors = allFailureMessages
     .filter((failure) => !isUnFoundDelete(failure, deletionsPackageName))
     .map(getUserFriendlyDeployMessage)
@@ -322,13 +320,9 @@ const processDeployResponse = (
       severity: 'Error' as SeverityLevel,
     }))
 
-  const successfulComponentWarnings = allSuccessMessages
+  const successfulComponentProblems = allSuccessMessages
     .filter((message) => message.problem)
     .filter((message) => !isUnFoundDelete(message, deletionsPackageName))
-    .filter((message) => {
-      log.info('fullName: %s', message.fullName)
-      return true
-    })
     .map((message) => ({
       elemID: getElemIdForDeployError(message),
       message: message.problem,
@@ -336,7 +330,7 @@ const processDeployResponse = (
     }))
 
   const componentErrors = failedComponentErrors.concat(
-    successfulComponentWarnings,
+    successfulComponentProblems,
   )
 
   const testFailures = makeArray(result.details).flatMap((detail) =>

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1162,7 +1162,7 @@ describe('SalesforceAdapter CRUD', () => {
           expect(result.appliedChanges).toBeEmpty()
         })
       })
-      describe('when the successful element has warnings', () => {
+      describe('when the successful element has a problem', () => {
         let result: DeployResult
         beforeEach(async () => {
           const deployResultParams = {
@@ -1194,7 +1194,7 @@ describe('SalesforceAdapter CRUD', () => {
             progressReporter: nullProgressReporter,
           })
         })
-        it('Should return the warnings from successful components', () => {
+        it('Should return the problem from successful components', () => {
           expect(result.errors).toSatisfyAny(
             (error) =>
               error.elemID.isEqual(successElement.elemID) &&


### PR DESCRIPTION
See ticket for an example of such a message on a successful deploy of a component

---

I made a couple of fixes to the E2E utils while I was at it.

---
_Release Notes_: 
Salesforce: info/warning messages from successfully deployed components will now be shown

---
_User Notifications_: 
N/A