### PR TITLE
SALTO-5457: Add Remaining Types In Fetch

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -197,7 +197,7 @@ import { hasSoftwareProject } from './utils'
 import { getWorkspaceId } from './workspace_id'
 import { JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
 
-const { getAllElements } = elementUtils.ducktype
+const { getAllElements, addRemainingTypes } = elementUtils.ducktype
 const { findDataField } = elementUtils
 const { computeGetArgs } = fetchUtils.resource
 const { generateTypes, getAllInstances, loadSwagger, addDeploymentAnnotations } = elementUtils.swagger
@@ -720,6 +720,22 @@ export default class JiraAdapter implements AdapterOperations {
       ...jsmElements.elements,
       ...jsmAssetsElements.elements,
     ]
+    const typesConfig = {
+      ...this.userConfig.apiDefinitions.types,
+      ...this.userConfig.jsmApiDefinitions?.types,
+      ...this.userConfig.scriptRunnerApiDefinitions?.types,
+    }
+    
+    // Remaining types should be added once to avoid overlaps between the generated elements,
+    // so we add them once after all elements are generated
+    addRemainingTypes({
+      adapterName: JIRA,
+      elements,
+      typesConfig,
+      supportedTypes: _.merge(supportedTypes, this.userConfig.jsmApiDefinitions?.supportedTypes, this.userConfig.scriptRunnerApiDefinitions?.supportedTypes),
+      typeDefaultConfig: this.userConfig.apiDefinitions.typeDefaults,
+    })
+
     return {
       elements,
       errors: (swaggerResponse.errors ?? [])


### PR DESCRIPTION
In this PR I added support to add all the remaining types while fetch. 

---

_Additional context for reviewer_
More context in [SALTO-5467](https://salto-io.atlassian.net/browse/SALTO-5467)
https://salto-io.atlassian.net/browse/SALTO-5467

---
_Release Notes_: 
_Jira Adpater:_
always have at least an empty type for any deployable instance

---
_User Notifications_: 
_Jira Adapter:_
new empty objectTypes will be added
