### PR TITLE
SALTO-5471: Fix Assets Folder Structure

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
@@ -100,8 +100,8 @@ const createAssetsObjectTypeOrder = (
     )
     return undefined
   }
-  const name = naclCase(`${invertNaclCase(treeParent.elemID.name)}_order`)
-  const subFolder = treeParent.elemID.typeName === OBJECT_TYPE_TYPE ? ['childOrder'] : ['objectTypes', 'childOrder']
+  const name = naclCase(`${invertNaclCase(treeParent.elemID.name)}_childOrder`)
+  const subFolder = treeParent.elemID.typeName === OBJECT_TYPE_TYPE ? [] : ['objectTypes']
   return new InstanceElement(
     name,
     orderType,

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
@@ -131,6 +131,13 @@ describe('assetsObjectTypeOrderFilter', () => {
       ])
       const orderType = elements.filter(isObjectType).find(e => e.elemID.typeName === OBJECT_TYPE_ORDER_TYPE)
       expect(orderType).toBeDefined()
+      expect(orderInstances[0].path).toEqual([
+        JIRA,
+        elementUtils.RECORDS_PATH,
+        'ObjectSchema',
+        'objectTypes',
+        'assetsSchema_childOrder',
+      ])
     })
     it('should do nothing for instnaces without parentObjectTypeId', async () => {
       const elements = [

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
@@ -123,7 +123,7 @@ describe('assetsObjectTypeOrderFilter', () => {
         .filter(isInstanceElement)
         .filter(e => e.elemID.typeName === OBJECT_TYPE_ORDER_TYPE)
       expect(orderInstances[1]).toBeDefined()
-      expect(orderInstances[1].elemID.name).toEqual('parent_Object_Type_Instance_order')
+      expect(orderInstances[1].elemID.name).toEqual('parent_Object_Type_Instance_childOrder')
       expect(orderInstances[1].value.objectTypes).toEqual([
         new ReferenceExpression(assetsObjectTypeInstanceOne.elemID, assetsObjectTypeInstanceOne),
         new ReferenceExpression(assetsObjectTypeInstanceTwo.elemID, assetsObjectTypeInstanceTwo),


### PR DESCRIPTION
In this PR I fixed The assets folders structure to be more intuitive. 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter_:
* New Folder structure:
objectType1
....|__ attributes (folder)
....|__ childObjectType1 (folder)
....|__ childObjectType2 (folder)
....|__ objectType1.nacl
....|__objectType1_childOrder.nacl
* New name for the child order nacl. 
* The change is on type ObjectTypeOrder (Name change and path change)

---
_User Notifications_: 
_Jira Adapter_:
* New Folder structure:
objectType1
....|__ attributes (folder)
....|__ childObjectType1 (folder)
....|__ childObjectType2 (folder)
....|__ objectType1.nacl
....|__objectType1_childOrder.nacl
* New name for the child order nacl. 
* The change is on type ObjectTypeOrder (Name change and path change)