### PR TITLE
SALTO-5356: Don't return unresolvedReferences change error for incoming references validator

### DIFF
--- a/packages/core/src/core/plan/change_validators/incoming_unresolved_references.ts
+++ b/packages/core/src/core/plan/change_validators/incoming_unresolved_references.ts
@@ -19,8 +19,6 @@ import {
   ModificationChange,
   RemovalChange,
   SaltoError,
-  SaltoErrorType,
-  UnresolvedReferenceError,
   getChangeData,
   isModificationChange,
   isRemovalOrModificationChange,
@@ -33,7 +31,7 @@ const getChangeType = <T>(change: ModificationChange<T> | RemovalChange<T>): str
   isModificationChange(change) ? 'modified' : 'deleted'
 
 export const incomingUnresolvedReferencesValidator =
-  (validationErrors: ReadonlyArray<SaltoError>): ChangeValidator<UnresolvedReferenceError> =>
+  (validationErrors: ReadonlyArray<SaltoError>): ChangeValidator =>
   async changes => {
     const unresolvedErrors = validationErrors.filter(isUnresolvedRefError)
     return changes
@@ -53,8 +51,6 @@ export const incomingUnresolvedReferencesValidator =
           detailedMessage:
             `${group.length} other elements contain references to this ${changeType} element, which are no longer valid.` +
             ' You may continue with deploying this change, but the deployment might fail.',
-          unresolvedElemIds: [elemID],
-          type: 'unresolvedReferences' as SaltoErrorType,
         }
       })
   }

--- a/packages/core/test/core/plan/change_validators/incoming_unresolved_references.test.ts
+++ b/packages/core/test/core/plan/change_validators/incoming_unresolved_references.test.ts
@@ -59,7 +59,6 @@ describe('incomingUnresolvedReferencesValidator', () => {
       expect(errors.length).toEqual(1)
       expect(errors[0].elemID).toEqual(firstInstance.elemID)
       expect(errors[0].severity).toEqual('Warning')
-      expect(errors[0].unresolvedElemIds).toEqual([firstInstance.elemID])
     })
 
     it('should return an error for modified elements', async () => {
@@ -71,7 +70,6 @@ describe('incomingUnresolvedReferencesValidator', () => {
       expect(errors.length).toEqual(1)
       expect(errors[0].elemID).toEqual(firstInstance.elemID)
       expect(errors[0].severity).toEqual('Warning')
-      expect(errors[0].unresolvedElemIds).toEqual([firstInstance.elemID])
     })
 
     it('should filter addition errors', async () => {
@@ -101,7 +99,6 @@ describe('incomingUnresolvedReferencesValidator', () => {
       expect(errors.length).toEqual(1)
       expect(errors[0].elemID).toEqual(firstInstance.elemID)
       expect(errors[0].severity).toEqual('Warning')
-      expect(errors[0].unresolvedElemIds).toEqual([firstInstance.elemID])
     })
   })
 })


### PR DESCRIPTION
This is necessary in order to distinguish between change errors (incoming references errors and outcoming references errors)

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
