### PR TITLE
SALTO-2392: turn resolveAccountSpecificValues off by default

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -92,7 +92,6 @@ import { parsedDatasetType } from '../src/type_parsers/analytics_parsers/parsed_
 import { parsedWorkbookType } from '../src/type_parsers/analytics_parsers/parsed_workbook'
 import { bundleType as bundle } from '../src/types/bundle_type'
 import { addApplicationIdToType } from '../src/transformer'
-import { UNKNOWN_TYPE_REFERENCES_ELEM_ID } from '../src/filters/data_account_specific_values'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -986,8 +985,6 @@ describe('Netsuite adapter E2E with real account', () => {
           .concat(filesToImport)
           .concat(existingFileCabinetInstances)
           .concat(newFileCabinetInstancesElemIds)
-          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID })
-          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID.createNestedID('instance', ElemID.CONFIG_NAME) })
 
         const expectedElements = _.uniq(allTypes.map(type => type.elemID.getFullName())).sort()
 

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -90,7 +90,7 @@ const changeValidator: NetsuiteChangeValidator = async (changes, _deployReferenc
     return []
   }
 
-  if (config?.fetch.resolveAccountSpecificValues !== false && elementsSource !== undefined) {
+  if (config?.fetch.resolveAccountSpecificValues && elementsSource !== undefined) {
     const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
     const suiteQLTablesMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
     return relevantChangedInstances.flatMap(instance =>

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -733,7 +733,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
 ): Promise<{ elements: TopLevelElement[]; largeSuiteQLTables: string[] }> => {
-  if (config.fetch.resolveAccountSpecificValues === false || !client.isSuiteAppConfigured()) {
+  if (!config.fetch.resolveAccountSpecificValues || !client.isSuiteAppConfigured()) {
     return { elements: [], largeSuiteQLTables: [] }
   }
   const suiteQLTableType = new ObjectType({

--- a/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
@@ -381,7 +381,7 @@ const resolveAccountSpecificValues = ({
 const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }) => ({
   name: 'dataAccountSpecificValues',
   onFetch: async elements => {
-    if (config.fetch.resolveAccountSpecificValues === false) {
+    if (!config.fetch.resolveAccountSpecificValues) {
       return
     }
     const instances = elements.filter(isInstanceElement)
@@ -402,7 +402,7 @@ const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }
     addReferenceTypes(elements)
   },
   preDeploy: async changes => {
-    if (config.fetch.resolveAccountSpecificValues === false) {
+    if (!config.fetch.resolveAccountSpecificValues) {
       return
     }
     const relevantChangedInstances = changes

--- a/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_internal_id.ts
@@ -63,7 +63,7 @@ const isNestedPath = (path: ElemID | undefined): path is ElemID => path !== unde
 const filterCreator: LocalFilterCreator = ({ config }) => ({
   name: 'dataInstancesInternalId',
   onFetch: async elements => {
-    if (config.fetch.resolveAccountSpecificValues !== false) {
+    if (config.fetch.resolveAccountSpecificValues) {
       return
     }
     const newInstancesMap: Record<string, InstanceElement> = {}
@@ -121,7 +121,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
   },
 
   preDeploy: async changes => {
-    if (config.fetch.resolveAccountSpecificValues !== false) {
+    if (config.fetch.resolveAccountSpecificValues) {
       return
     }
     await awu(changes).forEach(async change => {


### PR DESCRIPTION
**This PR is not rebased on the newest main but on the bumped version**

---

_Additional context for reviewer_

---
_Release Notes_: 
SALTO-2392: disable resolveAccountSpecificValues by default

---
_User Notifications_: 
ACCOUNT_SPECIFIC_VALUE will not be resolved in workflows & data elements, on fetch & deploy