### PR TITLE
SALTO-2392: change the default behavior of resolveAccountSpecificValues so if undefined do not fetch SuiteQL tables

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -733,7 +733,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
 ): Promise<{ elements: TopLevelElement[]; largeSuiteQLTables: string[] }> => {
-  if (config.fetch.resolveAccountSpecificValues === false || !client.isSuiteAppConfigured()) {
+  if (config.fetch.resolveAccountSpecificValues || !client.isSuiteAppConfigured()) {
     return { elements: [], largeSuiteQLTables: [] }
   }
   const suiteQLTableType = new ObjectType({

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -733,7 +733,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
 ): Promise<{ elements: TopLevelElement[]; largeSuiteQLTables: string[] }> => {
-  if (config.fetch.resolveAccountSpecificValues || !client.isSuiteAppConfigured()) {
+  if (config.fetch.resolveAccountSpecificValues !== true || !client.isSuiteAppConfigured()) {
     return { elements: [], largeSuiteQLTables: [] }
   }
   const suiteQLTableType = new ObjectType({


### PR DESCRIPTION
This changes the default behavior of fetching the SuiteQL tables for ASV resolving - we will fetch the tables only when `fetch.resolveAccountSpecificValues` is `true`.
We still transform data elements to be in the new format in `data_account_sepcific_values` filter.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- change the default behavior of fetching the SuiteQL tables for ASV resolving

---
_User Notifications_: 
None
