### PR TITLE
SALTO-2392: change the default behavior of resolveAccountSpecificValues so if undefined do not fetch SuiteQL tables

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -733,7 +733,7 @@ export const getSuiteQLTableElements = async (
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
 ): Promise<{ elements: TopLevelElement[]; largeSuiteQLTables: string[] }> => {
-  if (config.fetch.resolveAccountSpecificValues === false || !client.isSuiteAppConfigured()) {
+  if (config.fetch.resolveAccountSpecificValues !== true || !client.isSuiteAppConfigured()) {
     return { elements: [], largeSuiteQLTables: [] }
   }
   const suiteQLTableType = new ObjectType({


### PR DESCRIPTION
This changes the default behavior of fetching the SuiteQL tables for ASV resolving - we will fetch the tables only when `fetch.resolveAccountSpecificValues` is true.
We still transform data elements to be in the new format in data_account_sepcific_values filter.

---

_Additional context for reviewer_
This PR supposes to replace the intended behavior in https://github.com/salto-io/salto/pull/5504 as it will still allow us to resolve ASVs in a smarter way but without persisting the SuiteQL tables by default, unless `fetch.resolveAccountSpecificValues` is set to true.

---
_Release Notes_: 
Netsuite Adapter:
- change the default behavior of fetching the SuiteQL tables for ASV resolving


---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
