### PR TITLE
SALTO-5436: [Okta] Nest GroupPush and GroupPushRule under the parent app path

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -90,6 +90,7 @@ import profileMappingAdditionFilter from './filters/profile_mapping_addition'
 import omitAuthenticatorMappingFilter from './filters/omit_authenticator_mapping'
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
+import groupPushPathFilter from './filters/group_push_path'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
@@ -138,6 +139,8 @@ const DEFAULT_FILTERS = [
   profileMappingAdditionFilter,
   // should run after fieldReferences
   ...Object.values(commonFilters),
+  // should run after commonFilters,
+  groupPushPathFilter,
   // should run last
   privateApiDeployFilter,
   defaultDeployFilter,

--- a/packages/okta-adapter/src/filters/group_push_path.ts
+++ b/packages/okta-adapter/src/filters/group_push_path.ts
@@ -1,0 +1,60 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { GROUP_PUSH_TYPE_NAME, GROUP_PUSH_RULE_TYPE_NAME, OKTA } from '../constants'
+
+const log = logger(module)
+const { RECORDS_PATH } = elementUtils
+
+/**
+ * Modify GroupPush and GroupPushRule instances paths to be nested under the parent application.
+ * The filter is needed because currently "nestStandaloneInstances" cannot be used,
+ * as GroupPush and GroupPushRule instances are not standalone fields of Applications.
+ */
+const groupPushPathFilter: FilterCreator = () => ({
+  name: 'groupPushPathFilter',
+  onFetch: async (elements: Element[]) => {
+    const groupPushInstances = elements
+      .filter(isInstanceElement)
+      .filter(
+        instance =>
+          instance.elemID.typeName === GROUP_PUSH_TYPE_NAME || instance.elemID.typeName === GROUP_PUSH_RULE_TYPE_NAME,
+      )
+
+    groupPushInstances.forEach(instance => {
+      try {
+        const parentApp = getParent(instance)
+        instance.path = parentApp.path
+          ? [
+              OKTA,
+              RECORDS_PATH,
+              ...parentApp.path.slice(2, parentApp.path.length - 1),
+              instance.elemID.typeName,
+              instance.elemID.name,
+            ]
+          : instance.path
+      } catch (err) {
+        log.warn('Failed to modify path for instance %s, error: %o', instance.elemID.getFullName(), err)
+      }
+    })
+  },
+})
+
+export default groupPushPathFilter

--- a/packages/okta-adapter/test/filters/group_push_path.test.ts
+++ b/packages/okta-adapter/test/filters/group_push_path.test.ts
@@ -1,0 +1,104 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ElemID,
+  Element,
+  InstanceElement,
+  ObjectType,
+  CORE_ANNOTATIONS,
+  ListType,
+  BuiltinTypes,
+  ReferenceExpression,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { elements as elementUtils, filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../utils'
+import { APPLICATION_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_PUSH_RULE_TYPE_NAME, OKTA } from '../../src/constants'
+import groupPushPathFilter from '../../src/filters/group_push_path'
+
+describe('groupPushFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+  const appType = new ObjectType({
+    elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME),
+    fields: {
+      features: { refType: new ListType(BuiltinTypes.STRING) },
+    },
+  })
+  const appWithGroupPush = new InstanceElement(
+    'regular app',
+    appType,
+    {
+      id: 'abc',
+      status: 'ACTIVE',
+      name: 'salesforce',
+      signOnMode: 'SAML_2_0',
+      features: ['IMPORT_USER_SCHEMA', 'GROUP_PUSH'],
+    },
+    [OKTA, elementUtils.RECORDS_PATH, APPLICATION_TYPE_NAME, 'regular_app', 'regular_app'],
+  )
+  const groupPushType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_TYPE_NAME) })
+  const pushRuleType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_PUSH_RULE_TYPE_NAME) })
+  const groupPushA = new InstanceElement(
+    'g1',
+    groupPushType,
+    { mappingId: 'm1', status: 'ACTIVE', userGroupId: 'g1', newAppGroupName: 'A1', groupPushRule: 'r1' },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPush.elemID, appWithGroupPush)] },
+  )
+  const pushRuleInstance = new InstanceElement(
+    'testRule',
+    pushRuleType,
+    {
+      mappingRuleId: 'mr1',
+      name: 'test rule',
+      status: 'ACTIVE',
+      searchExpression: 'sales',
+      searchExpressionType: 'ENDS_WITH',
+    },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPush.elemID, appWithGroupPush)] },
+  )
+
+  describe('fetch', () => {
+    it('should modify group push path to be nested under the parent app', async () => {
+      const elements: Element[] = [appType, groupPushType, pushRuleType, appWithGroupPush, groupPushA, pushRuleInstance]
+      filter = groupPushPathFilter(getFilterParams()) as typeof filter
+      await filter.onFetch(elements)
+      const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+      expect(groupPush?.path).toEqual([
+        OKTA,
+        elementUtils.RECORDS_PATH,
+        APPLICATION_TYPE_NAME,
+        'regular_app',
+        GROUP_PUSH_TYPE_NAME,
+        'g1',
+      ])
+      const groupPushRule = elements
+        .filter(isInstanceElement)
+        .find(i => i.elemID.typeName === GROUP_PUSH_RULE_TYPE_NAME)
+      expect(groupPushRule?.path).toEqual([
+        OKTA,
+        elementUtils.RECORDS_PATH,
+        APPLICATION_TYPE_NAME,
+        'regular_app',
+        GROUP_PUSH_RULE_TYPE_NAME,
+        'testRule',
+      ])
+    })
+  })
+})

--- a/packages/okta-adapter/test/filters/group_push_path.test.ts
+++ b/packages/okta-adapter/test/filters/group_push_path.test.ts
@@ -30,7 +30,7 @@ import { getFilterParams } from '../utils'
 import { APPLICATION_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_PUSH_RULE_TYPE_NAME, OKTA } from '../../src/constants'
 import groupPushPathFilter from '../../src/filters/group_push_path'
 
-describe('groupPushFilter', () => {
+describe('groupPushPathFilter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
   const appType = new ObjectType({
@@ -74,7 +74,6 @@ describe('groupPushFilter', () => {
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPush.elemID, appWithGroupPush)] },
   )
 
-  describe('fetch', () => {
     it('should modify group push path to be nested under the parent app', async () => {
       const elements: Element[] = [appType, groupPushType, pushRuleType, appWithGroupPush, groupPushA, pushRuleInstance]
       filter = groupPushPathFilter(getFilterParams()) as typeof filter
@@ -100,5 +99,16 @@ describe('groupPushFilter', () => {
         'testRule',
       ])
     })
-  })
+    it('it should do nothing if there is no parent app', async () => {
+      const elements: Element[] = [groupPushType, new InstanceElement('noParent', groupPushType, { id: 3}, [OKTA, elementUtils.RECORDS_PATH, GROUP_PUSH_TYPE_NAME, 'noParent'])]
+      filter = groupPushPathFilter(getFilterParams()) as typeof filter
+      await filter.onFetch(elements)
+      const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+      expect(groupPush?.path).toEqual([
+        OKTA,
+        elementUtils.RECORDS_PATH,
+        GROUP_PUSH_TYPE_NAME,
+        'noParent',
+      ])
+    })
 })

--- a/packages/okta-adapter/test/filters/group_push_path.test.ts
+++ b/packages/okta-adapter/test/filters/group_push_path.test.ts
@@ -74,41 +74,42 @@ describe('groupPushPathFilter', () => {
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(appWithGroupPush.elemID, appWithGroupPush)] },
   )
 
-    it('should modify group push path to be nested under the parent app', async () => {
-      const elements: Element[] = [appType, groupPushType, pushRuleType, appWithGroupPush, groupPushA, pushRuleInstance]
-      filter = groupPushPathFilter(getFilterParams()) as typeof filter
-      await filter.onFetch(elements)
-      const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
-      expect(groupPush?.path).toEqual([
-        OKTA,
-        elementUtils.RECORDS_PATH,
-        APPLICATION_TYPE_NAME,
-        'regular_app',
-        GROUP_PUSH_TYPE_NAME,
-        'g1',
-      ])
-      const groupPushRule = elements
-        .filter(isInstanceElement)
-        .find(i => i.elemID.typeName === GROUP_PUSH_RULE_TYPE_NAME)
-      expect(groupPushRule?.path).toEqual([
-        OKTA,
-        elementUtils.RECORDS_PATH,
-        APPLICATION_TYPE_NAME,
-        'regular_app',
-        GROUP_PUSH_RULE_TYPE_NAME,
-        'testRule',
-      ])
-    })
-    it('it should do nothing if there is no parent app', async () => {
-      const elements: Element[] = [groupPushType, new InstanceElement('noParent', groupPushType, { id: 3}, [OKTA, elementUtils.RECORDS_PATH, GROUP_PUSH_TYPE_NAME, 'noParent'])]
-      filter = groupPushPathFilter(getFilterParams()) as typeof filter
-      await filter.onFetch(elements)
-      const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
-      expect(groupPush?.path).toEqual([
+  it('should modify group push path to be nested under the parent app', async () => {
+    const elements: Element[] = [appType, groupPushType, pushRuleType, appWithGroupPush, groupPushA, pushRuleInstance]
+    filter = groupPushPathFilter(getFilterParams()) as typeof filter
+    await filter.onFetch(elements)
+    const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+    expect(groupPush?.path).toEqual([
+      OKTA,
+      elementUtils.RECORDS_PATH,
+      APPLICATION_TYPE_NAME,
+      'regular_app',
+      GROUP_PUSH_TYPE_NAME,
+      'g1',
+    ])
+    const groupPushRule = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_RULE_TYPE_NAME)
+    expect(groupPushRule?.path).toEqual([
+      OKTA,
+      elementUtils.RECORDS_PATH,
+      APPLICATION_TYPE_NAME,
+      'regular_app',
+      GROUP_PUSH_RULE_TYPE_NAME,
+      'testRule',
+    ])
+  })
+  it('it should do nothing if there is no parent app', async () => {
+    const elements: Element[] = [
+      groupPushType,
+      new InstanceElement('noParent', groupPushType, { id: 3 }, [
         OKTA,
         elementUtils.RECORDS_PATH,
         GROUP_PUSH_TYPE_NAME,
         'noParent',
-      ])
-    })
+      ]),
+    ]
+    filter = groupPushPathFilter(getFilterParams()) as typeof filter
+    await filter.onFetch(elements)
+    const groupPush = elements.filter(isInstanceElement).find(i => i.elemID.typeName === GROUP_PUSH_TYPE_NAME)
+    expect(groupPush?.path).toEqual([OKTA, elementUtils.RECORDS_PATH, GROUP_PUSH_TYPE_NAME, 'noParent'])
+  })
 })


### PR DESCRIPTION
Nest group push types under the parent app

---

This is in a dedicated filter and not using "nestStandaloneFields" as group push types are not standalone fields of apps cause the types are in different configs.
This is a temp filter that will be removed once we migrate Okta to the new infra

This change is done without any migration to existing files.

---
_Release Notes_: 

_Okta_adapter_:
- On the next fetch, GroupPush and GroupPushRule types will now be nested under the parent Application type in the element tree

---
_User Notifications_: 
None