### PR TITLE
SALTO-5460: [Zendesk] Fix dynamic_content placeholder regex catching non-DC strings

### DIFF
--- a/packages/adapter-utils/src/template.ts
+++ b/packages/adapter-utils/src/template.ts
@@ -121,9 +121,14 @@ export const extractTemplate = (
   // The second part is a split that separates the now-marked ids, so they could be replaced
   // with ReferenceExpression in the loop code.
   // we continuously split the expression to find all kinds of potential references
-  const templateParts = continuousSplit(formula, regexes)
-    .flatMap(extractionFunc)
-    .filter(v => !_.isEmpty(v))
+
+  const a = continuousSplit(formula, regexes)
+  if (formula.includes('dc')) {
+    // console.log('formula: ', formula)
+    console.log('split into: ', a)
+  }
+
+  const templateParts = a.flatMap(extractionFunc).filter(v => !_.isEmpty(v))
   if (templateParts.every(_.isString)) {
     return templateParts.join('')
   }

--- a/packages/adapter-utils/src/template.ts
+++ b/packages/adapter-utils/src/template.ts
@@ -123,9 +123,9 @@ export const extractTemplate = (
   // we continuously split the expression to find all kinds of potential references
 
   const a = continuousSplit(formula, regexes)
-  if (formula.includes('dc')) {
-    // console.log('formula: ', formula)
-    // console.log('split into: ', a)
+  if (formula.includes('irrelevancies')) {
+    console.log('formula:', formula)
+    console.log('split into:', a)
   }
 
   const templateParts = a.flatMap(extractionFunc).filter(v => !_.isEmpty(v))

--- a/packages/adapter-utils/src/template.ts
+++ b/packages/adapter-utils/src/template.ts
@@ -125,7 +125,7 @@ export const extractTemplate = (
   const a = continuousSplit(formula, regexes)
   if (formula.includes('dc')) {
     // console.log('formula: ', formula)
-    console.log('split into: ', a)
+    // console.log('split into: ', a)
   }
 
   const templateParts = a.flatMap(extractionFunc).filter(v => !_.isEmpty(v))

--- a/packages/adapter-utils/src/template.ts
+++ b/packages/adapter-utils/src/template.ts
@@ -121,7 +121,6 @@ export const extractTemplate = (
   // The second part is a split that separates the now-marked ids, so they could be replaced
   // with ReferenceExpression in the loop code.
   // we continuously split the expression to find all kinds of potential references
-
   const templateParts = continuousSplit(formula, regexes)
     .flatMap(extractionFunc)
     .filter(v => !_.isEmpty(v))

--- a/packages/adapter-utils/src/template.ts
+++ b/packages/adapter-utils/src/template.ts
@@ -122,13 +122,9 @@ export const extractTemplate = (
   // with ReferenceExpression in the loop code.
   // we continuously split the expression to find all kinds of potential references
 
-  const a = continuousSplit(formula, regexes)
-  if (formula.includes('irrelevancies')) {
-    console.log('formula:', formula)
-    console.log('split into:', a)
-  }
-
-  const templateParts = a.flatMap(extractionFunc).filter(v => !_.isEmpty(v))
+  const templateParts = continuousSplit(formula, regexes)
+    .flatMap(extractionFunc)
+    .filter(v => !_.isEmpty(v))
   if (templateParts.every(_.isString)) {
     return templateParts.join('')
   }

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -327,11 +327,15 @@ const formulaToTemplate = ({
   // we continuously split the expression to find all kinds of potential references
   return extractTemplate(seekAndMarkPotentialReferences(formula), potentialRegexes, expression => {
     const zendeskReference = expression.match(potentialReferenceTypeRegex)
+    if (expression.includes('dc')) {
+      console.log(formula, expression, zendeskReference)
+    }
     if (zendeskReference) {
       return handleZendeskReference(expression, zendeskReference)
     }
     const dynamicContentReference = expression.match(DYNAMIC_CONTENT_REGEX)
     if (dynamicContentReference) {
+      console.log('do i get here? ', dynamicContentReference)
       return handleDynamicContentReference(expression, dynamicContentReference)
     }
     if (extractReferencesFromFreeText) {

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -310,13 +310,14 @@ const formulaToTemplate = ({
     const elem = (instancesByType[DYNAMIC_CONTENT_ITEM_TYPE_NAME] ?? []).find(
       instance => instance.value.placeholder === dcPlaceholder,
     )
-    console.log('working with placeholder: ', dcPlaceholder)
+    const placeholderNoBrackets = dcPlaceholder.substring(2, dcPlaceholder.length - 2)
+
+    console.log('working with placeholder: ', placeholderNoBrackets)
     if (elem) {
-      console.log('returning: ', ['{{', new ReferenceExpression(elem.elemID, elem), '}}'].join(''))
+      console.log('returning: ', elem.elemID)
       return ['{{', new ReferenceExpression(elem.elemID, elem), '}}']
     }
 
-    const placeholderNoBrackets = dcPlaceholder.substring(1, dcPlaceholder.length - 1)
     if (!_.isEmpty(dcPlaceholder) && enableMissingReferences) {
       const missingInstance = createMissingInstance(
         ZENDESK,
@@ -324,10 +325,7 @@ const formulaToTemplate = ({
         placeholderNoBrackets.startsWith('dc.') ? placeholderNoBrackets.slice(3) : placeholderNoBrackets,
       )
       missingInstance.value.placeholder = dcPlaceholder
-      console.log(
-        'returning: ',
-        ['{{', new ReferenceExpression(missingInstance.elemID, missingInstance), '}}'].join(''),
-      )
+      console.log('returning: ', missingInstance.elemID)
       return ['{{', new ReferenceExpression(missingInstance.elemID, missingInstance), '}}']
     }
     console.log('returning: ', expression)

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -335,7 +335,6 @@ const formulaToTemplate = ({
     if (zendeskReference) {
       return handleZendeskReference(expression, zendeskReference)
     }
-
     const dynamicContentReference = expression.match(DYNAMIC_CONTENT_REGEX_WITH_BRACKETS)
     if (dynamicContentReference) {
       return handleDynamicContentReference(expression, dynamicContentReference)

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -574,9 +574,7 @@ describe('handle templates filter', () => {
           parts: [
             `{{some other irrelevancies-${TICKET_TICKET_FIELD}_`,
             new ReferenceExpression(placeholder1.elemID, placeholder1),
-            ' | something irrelevant | dynamic content now: ',
-            new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
-            ' | and done}}',
+            ' | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}',
           ],
         }),
       )
@@ -588,9 +586,7 @@ describe('handle templates filter', () => {
           parts: [
             `{%some other irrelevancies-${TICKET_TICKET_FIELD}_`,
             new ReferenceExpression(placeholder1.elemID, placeholder1),
-            ' | something irrelevant | dynamic content now: ',
-            new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
-            ' | and done%}',
+            ' | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}',
           ],
         }),
       )

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -196,6 +196,17 @@ describe('handle templates filter', () => {
       },
     ],
   })
+  const macro4 = new InstanceElement('macro4', testType, {
+    id: newId(),
+    actions: [
+      {
+        value:
+          'a lot of info like {{}} and  something that looks like a DC item, such as this email: rdc.blab@gmail.com',
+        field: 'comment_value_html',
+      },
+    ],
+  })
+
   const macroOrganization = new InstanceElement('macroOrg', testType, {
     id: newId(),
     actions: [
@@ -231,7 +242,7 @@ describe('handle templates filter', () => {
     id: newId(),
     actions: [
       {
-        value: `{{some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}`,
+        value: `{{some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.not_dynamic_content_test | and done}}`,
         field: 'comment_value_html',
       },
     ],
@@ -240,7 +251,7 @@ describe('handle templates filter', () => {
     id: newId(),
     actions: [
       {
-        value: `{%some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}`,
+        value: `{%some other irrelevancies-ticket.ticket_field_${placeholder1.value.id} | something irrelevant | dynamic content now: dc.not_dynamic_content_test | and done%}`,
         field: 'comment_value_html',
       },
     ],
@@ -381,6 +392,7 @@ describe('handle templates filter', () => {
       macro1,
       macro2,
       macro3,
+      macro4,
       macroAlmostTemplate,
       macroAlmostTemplate2,
       target,
@@ -574,7 +586,7 @@ describe('handle templates filter', () => {
           parts: [
             `{{some other irrelevancies-${TICKET_TICKET_FIELD}_`,
             new ReferenceExpression(placeholder1.elemID, placeholder1),
-            ' | something irrelevant | dynamic content now: dc.dynamic_content_test | and done}}',
+            ' | something irrelevant | dynamic content now: dc.not_dynamic_content_test | and done}}',
           ],
         }),
       )
@@ -586,7 +598,7 @@ describe('handle templates filter', () => {
           parts: [
             `{%some other irrelevancies-${TICKET_TICKET_FIELD}_`,
             new ReferenceExpression(placeholder1.elemID, placeholder1),
-            ' | something irrelevant | dynamic content now: dc.dynamic_content_test | and done%}',
+            ' | something irrelevant | dynamic content now: dc.not_dynamic_content_test | and done%}',
           ],
         }),
       )
@@ -616,6 +628,13 @@ describe('handle templates filter', () => {
             '}}',
           ],
         }),
+      )
+    })
+
+    it('should not resolve strings that contain dc. if not in a placeholder', () => {
+      const fetchedMacro4 = elements.filter(isInstanceElement).find(i => i.elemID.name === 'macro4')
+      expect(fetchedMacro4?.value.actions[0].value).toEqual(
+        'a lot of info like {{}} and  something that looks like a DC item, such as this email: rdc.blab@gmail.com',
       )
     })
 


### PR DESCRIPTION
The current regex for catching dynamic content placeholders allows for some pretty whacky stuff;
For example, having `{{ blip bloop blep dc.content_item }}` will catch `dc.content_item` as a dynamic content placeholder, even though Zendesk wouldn't allow it. 
Another example is that this issue was caught when a customer tried to note his email, which had the string `dc.stuttgart` in it, and it got replaced by a dynamic content ref - without any brackets at all!

In this PR, i've changed the regex so that it forces the content to be inside brackets, and furthermore forces the brackets to be "close" to the placeholder (so if you have content between the brackets and the placeholder it won't catch it anymroe).

---

Ironically, we already had a test for this in place, but it was testing the wrong thing (i.e the test was *expecting* a dynamic content ref where there shouldn't be one

---
_Release Notes_: 
Zendesk:
Fix bug where non-"Dynamic content item" strings were being parsed as dynamic content and creating broken references

---
_User Notifications_: 
None