### PR TITLE
SALTO-4142 - Netsuite weak references addition

### DIFF
--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -57,7 +57,8 @@
     "shell-quote": "^1.7.3",
     "uuid": "^8.3.0",
     "wu": "^2.1.0",
-    "xml-js": "^1.6.11"
+    "xml-js": "^1.6.11",
+    "joi": "^17.4.0"
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.3.54",

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -24,6 +24,8 @@ import {
   AdapterOperations,
 } from '@salto-io/adapter-api'
 import { SdkDownloadService } from '@salto-io/suitecloud-cli'
+import { combineCustomReferenceGetters } from '@salto-io/adapter-components'
+import _ from 'lodash'
 import Bottleneck from 'bottleneck'
 import { DEFAULT_CONCURRENCY } from './config/constants'
 import { configType } from './config/types'
@@ -35,6 +37,7 @@ import SdfClient from './client/sdf_client'
 import NetsuiteClient from './client/client'
 import NetsuiteAdapter from './adapter'
 import loadElementsFromFolder from './sdf_folder_loader'
+import { customReferenceHandlers } from './custom_references'
 
 const configID = new ElemID(NETSUITE)
 
@@ -181,4 +184,7 @@ export const adapter: Adapter = {
     }
   },
   loadElementsFromFolder,
+  getCustomReferences: combineCustomReferenceGetters(
+    _.mapValues(customReferenceHandlers, handler => handler.findWeakReferences),
+  ),
 }

--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -61,6 +61,7 @@ import unreferencedFileAdditionValidator from './change_validators/unreferenced_
 import unreferencedDatasetsValidator from './change_validators/check_referenced_datasets'
 import analyticsSilentFailureValidator from './change_validators/analytics_post_deploy_notification'
 import bundleChangesValidator from './change_validators/bundle_changes'
+import customRecordEmptyPermissionListValidator from './change_validators/custom_record_empty_permission_list'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -107,6 +108,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   unreferencedDatasets: unreferencedDatasetsValidator,
   analyticsSilentFailure: analyticsSilentFailureValidator,
   undeployableBundleChanges: bundleChangesValidator,
+  customRecordEmptyPermissionList: customRecordEmptyPermissionListValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validators/custom_record_empty_permission_list.ts
+++ b/packages/netsuite-adapter/src/change_validators/custom_record_empty_permission_list.ts
@@ -22,12 +22,12 @@ const USE_PERMISSION_LIST = 'USEPERMISSIONLIST'
 const REQUIRE_CUSTOM_RECORD_ENTRIES_PERMISSION = 'CUSTRECORDENTRYPERM'
 const NO_PERMISSION_REQUIRED = 'NONENEEDED'
 
-const hasPermissions = (customRecord: ObjectType): boolean =>
-  values.isPlainRecord(customRecord.annotations.permissions?.permission) &&
-  Object.keys(customRecord.annotations.permissions.permission).length > 0
+const hasPermissions = (customRecordType: ObjectType): boolean =>
+  values.isPlainRecord(customRecordType.annotations.permissions?.permission) &&
+  Object.keys(customRecordType.annotations.permissions.permission).length > 0
 
-const usePermissionOnListWithEmptyList = (customRecord: ObjectType): boolean =>
-  customRecord.annotations.accesstype === USE_PERMISSION_LIST && !hasPermissions(customRecord)
+const usePermissionOnListWithEmptyList = (customRecordType: ObjectType): boolean =>
+  customRecordType.annotations.accesstype === USE_PERMISSION_LIST && !hasPermissions(customRecordType)
 
 const changeValidator: NetsuiteChangeValidator = async changes =>
   changes
@@ -36,13 +36,13 @@ const changeValidator: NetsuiteChangeValidator = async changes =>
     .filter(isObjectType)
     .filter(isCustomRecordType)
     .filter(usePermissionOnListWithEmptyList)
-    .map(customRecord => ({
-      elemID: customRecord.elemID,
+    .map(customRecordType => ({
+      elemID: customRecordType.elemID,
       severity: 'Error',
-      message: 'Access type is permission list with no permissions specified',
+      message: 'Access Type is "Permission List" with No Permissions Specified',
       detailedMessage:
-        `Cannot deploy a Custom Record Type without permissions when the access type is set to '${USE_PERMISSION_LIST}'.` +
-        `To deploy this Custom Record Type, either add permissions or change the access type to '${REQUIRE_CUSTOM_RECORD_ENTRIES_PERMISSION}' or '${NO_PERMISSION_REQUIRED}'.`,
+        `Cannot deploy a Custom Record Type without specifying permissions when the access type is set to '${USE_PERMISSION_LIST}'.` +
+        `To deploy this Custom Record Type, you must either add permissions or change the access type to '${REQUIRE_CUSTOM_RECORD_ENTRIES_PERMISSION}' or '${NO_PERMISSION_REQUIRED}'.`,
     }))
 
 export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/custom_record_empty_permission_list.ts
+++ b/packages/netsuite-adapter/src/change_validators/custom_record_empty_permission_list.ts
@@ -1,0 +1,44 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { getChangeData, isAdditionOrModificationChange, isObjectType, ObjectType } from '@salto-io/adapter-api'
+import { values } from '@salto-io/lowerdash'
+import { NetsuiteChangeValidator } from './types'
+import { isCustomRecordType } from '../types'
+
+const hasPermissions = (customRecord: ObjectType): boolean =>
+  values.isPlainRecord(customRecord.annotations.permissions.permission) &&
+  Object.keys(customRecord.annotations.permissions.permission).length > 0
+
+const usesPermissionListWithEmptyList = (customRecord: ObjectType): boolean =>
+  customRecord.annotations.accesstype === 'USEPERMISSIONLIST' && !hasPermissions(customRecord)
+
+const changeValidator: NetsuiteChangeValidator = async changes =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isObjectType)
+    .filter(isCustomRecordType)
+    .filter(usesPermissionListWithEmptyList)
+    .map(customRecord => ({
+      elemID: customRecord.elemID,
+      severity: 'Error',
+      message: 'Access type is permission list with no permissions specified',
+      detailedMessage:
+        "Cannot deploy a Custom Record Type without permissions when the access type is set to 'USEPERMISSIONLIST'." +
+        "To deploy this Custom Record Type, either add permissions or change the access type to 'CUSTRECORDENTRYPERM' or 'NONENEEDED'.",
+    }))
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_list_item_without_scriptid.ts
@@ -18,25 +18,21 @@ import {
   isModificationChange,
   InstanceElement,
   isInstanceChange,
-  ReferenceExpression,
   ModificationChange,
   ChangeError,
-  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
 import { NetsuiteChangeValidator } from './types'
 import { PERMISSIONS, ROLE } from '../constants'
+import {
+  RolePermissionObject,
+  isRolePermissionObject,
+} from '../custom_references/weak_references/permissions_references'
 
 const log = logger(module)
 
 const PERMISSION = 'permission'
-
-type RolePermissionObject = {
-  permkey: string | ReferenceExpression
-  permlevel: string
-  restriction?: string
-}
 
 export type ItemInList = RolePermissionObject
 
@@ -59,18 +55,6 @@ export type ItemListGetters = {
   getItemString: GetItemString
   getListPath: GetListPath
   getDetailedMessage: GetMessage
-}
-
-const isRolePermissionObject = (obj: unknown): obj is RolePermissionObject => {
-  const returnVal =
-    values.isPlainRecord(obj) &&
-    (typeof obj.permkey === 'string' || isReferenceExpression(obj.permkey)) &&
-    typeof obj.permlevel === 'string' &&
-    (typeof obj.restriction === 'string' || obj.restriction === undefined)
-  if (!returnVal) {
-    log.warn('There is a role permission with a different shape: %o', obj)
-  }
-  return returnVal
 }
 
 const getRoleListPath: GetListPath = () => [PERMISSIONS, PERMISSION]

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -282,6 +282,7 @@ export type NetsuiteValidatorName =
   | 'analyticsSilentFailure'
   | 'undeployableBundleChanges'
   | 'removeListItemWithoutScriptID'
+  | 'customRecordEmptyPermissionList'
 
 export type NonSuiteAppValidatorName = 'removeFileCabinet' | 'removeStandardTypes'
 
@@ -645,6 +646,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     analyticsSilentFailure: { refType: BuiltinTypes.BOOLEAN },
     undeployableBundleChanges: { refType: BuiltinTypes.BOOLEAN },
     removeListItemWithoutScriptID: { refType: BuiltinTypes.BOOLEAN },
+    customRecordEmptyPermissionList: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/custom_references/index.ts
+++ b/packages/netsuite-adapter/src/custom_references/index.ts
@@ -1,0 +1,20 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { permissionsHandler } from './weak_references/permissions_references'
+
+export const customReferenceHandlers = {
+  permissionsReferences: permissionsHandler,
+}

--- a/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
@@ -1,0 +1,236 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeError,
+  FixElementsFunc,
+  GetCustomReferencesFunc,
+  InstanceElement,
+  ObjectType,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+  ReferenceInfo,
+  Value,
+  isInstanceElement,
+  isObjectType,
+  isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { WeakReferencesHandler } from '@salto-io/adapter-components'
+import { collections, values } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { CUSTOM_RECORD_TYPE, PERMISSIONS, ROLE, SCRIPT_ID } from '../../constants'
+import { isCustomRecordType } from '../../types'
+
+const { awu } = collections.asynciterable
+
+export type RolePermissionObject = {
+  permkey: string | ReferenceExpression
+  permlevel: string
+  restriction?: string
+}
+
+type CustomRecordPermissionObject = {
+  permittedlevel: string
+  permittedrole: string | ReferenceExpression
+  restriction?: string
+}
+
+type permissionObject = RolePermissionObject | CustomRecordPermissionObject
+
+type RoleOrCustomRecord = 'role' | 'customrecordtype'
+
+export const isRolePermissionObject = (obj: unknown): obj is RolePermissionObject => {
+  const returnVal =
+    values.isPlainRecord(obj) &&
+    (typeof obj.permkey === 'string' || isReferenceExpression(obj.permkey)) &&
+    typeof obj.permlevel === 'string' &&
+    (typeof obj.restriction === 'string' || obj.restriction === undefined)
+  return returnVal
+}
+
+const isCustomRecordPermissionObject = (obj: unknown): obj is CustomRecordPermissionObject => {
+  const returnVal =
+    values.isPlainRecord(obj) &&
+    (typeof obj.permittedrole === 'string' || isReferenceExpression(obj.permittedrole)) &&
+    typeof obj.permittedlevel === 'string' &&
+    (typeof obj.restriction === 'string' || obj.restriction === undefined)
+  return returnVal
+}
+
+const isPermissionObject = (obj: unknown, permissionType: RoleOrCustomRecord): obj is permissionObject =>
+  permissionType === ROLE ? isRolePermissionObject(obj) : isCustomRecordPermissionObject(obj)
+
+export const getPermissionsListPath = (): string[] => [PERMISSIONS, 'permission']
+
+const getPermissionWeakElementReferences = (
+  roleOrCustomRecord: ObjectType | InstanceElement,
+): Record<string, ReferenceExpression> => {
+  const permissionRecord: Record<string, ReferenceExpression> = {}
+  const listPathValue = _.get(
+    isInstanceElement(roleOrCustomRecord) ? roleOrCustomRecord.value : roleOrCustomRecord.annotations,
+    getPermissionsListPath(),
+  )
+  if (values.isPlainRecord(listPathValue)) {
+    Object.entries(listPathValue).forEach(([key, value]) => {
+      if (isRolePermissionObject(value) && isReferenceExpression(value.permkey)) {
+        permissionRecord[key] = value.permkey
+      } else if (isCustomRecordPermissionObject(value) && isReferenceExpression(value.permittedrole)) {
+        permissionRecord[key] = value.permittedrole
+      }
+    })
+  }
+  return permissionRecord
+}
+
+const getWeakElementReferences = (roleOrCustomRecord: ObjectType | InstanceElement): ReferenceInfo[] => {
+  const rolePermissionReferences = getPermissionWeakElementReferences(roleOrCustomRecord)
+  const permissionPath = isInstanceElement(roleOrCustomRecord)
+    ? getPermissionsListPath()
+    : ['attr', ...getPermissionsListPath()]
+  return Object.entries(rolePermissionReferences).flatMap(([name, referenceElement]) => ({
+    source: roleOrCustomRecord.elemID.createNestedID(...permissionPath, name),
+    target: referenceElement.elemID,
+    type: 'weak' as const,
+  }))
+}
+
+const isRoleOrCustomRecordElement = (element: Value): element is InstanceElement | ObjectType =>
+  (isInstanceElement(element) && element.elemID.typeName === ROLE) ||
+  (isObjectType(element) && isCustomRecordType(element))
+
+/**
+ * Marks each element reference in an order type as a weak reference.
+ */
+const getPermissionsReferences: GetCustomReferencesFunc = async elements =>
+  elements.filter(isRoleOrCustomRecordElement).flatMap(getWeakElementReferences)
+
+const getValidPermissions = (
+  permissionField: Record<string, unknown>,
+  permissionType: RoleOrCustomRecord,
+): Record<string, permissionObject> =>
+  Object.entries(permissionField).reduce(
+    (acc, [key, value]) => {
+      if (isPermissionObject(value, permissionType)) {
+        acc[key] = value
+      }
+      return acc
+    },
+    {} as Record<string, permissionObject>,
+  )
+
+const getFixedPermissionField = async (
+  permissions: Record<string, unknown>,
+  elementsSource: ReadOnlyElementsSource,
+  permissionType: RoleOrCustomRecord,
+): Promise<Record<string, permissionObject>> => {
+  const validPermissions = getValidPermissions(permissions, permissionType)
+  return awu(Object.entries(validPermissions)).reduce(
+    async (acc, [key, value]) => {
+      const permissionRefAttribute = isRolePermissionObject(value) ? value.permkey : value.permittedrole
+      if (
+        !isReferenceExpression(permissionRefAttribute) ||
+        (await elementsSource.get(permissionRefAttribute.elemID.createTopLevelParentID().parent)) !== undefined
+      ) {
+        acc[key] = value
+      }
+      return acc
+    },
+    {} as Record<string, permissionObject>,
+  )
+}
+
+const getFixedElementsAndUpdatedPaths = async (
+  roleOrCustomRecord: InstanceElement | ObjectType,
+  elementsSource: ReadOnlyElementsSource,
+  permissionType: RoleOrCustomRecord,
+): Promise<InstanceElement | ObjectType | undefined> => {
+  const permissionField = _.get(
+    isInstanceElement(roleOrCustomRecord) ? roleOrCustomRecord.value : roleOrCustomRecord.annotations,
+    getPermissionsListPath(),
+  )
+  if (!values.isPlainRecord(permissionField)) {
+    return undefined
+  }
+
+  const fixedPermissionField = await getFixedPermissionField(permissionField, elementsSource, permissionType)
+
+  if (Object.keys(fixedPermissionField).length === Object.keys(permissionField).length) {
+    return undefined
+  }
+
+  const fixedObject = roleOrCustomRecord.clone()
+  _.set(
+    isInstanceElement(fixedObject) ? fixedObject.value : fixedObject.annotations,
+    getPermissionsListPath(),
+    fixedPermissionField,
+  )
+  return fixedObject
+}
+
+const getMessageByPathAndElemTypeName = (
+  elem: InstanceElement | ObjectType,
+  fullPath: string,
+  elementTypeName: string,
+): ChangeError => ({
+  elemID: elem.elemID,
+  severity: 'Info',
+  message: `Deploying ${fullPath} without all attached ${elementTypeName}`,
+  detailedMessage: `This ${fullPath} is attached to some ${elementTypeName} that do not exist in the target environment. It will be deployed without referencing these ${elementTypeName}.`,
+})
+
+/**
+ * Remove invalid references (not references or missing references) from order types.
+ */
+const removeMissingOrderElements: WeakReferencesHandler<{
+  elementsSource: ReadOnlyElementsSource
+}>['removeWeakReferences'] =
+  ({ elementsSource }): FixElementsFunc =>
+  async elements => {
+    const fixedRoles = await awu(elements)
+      .filter(isInstanceElement)
+      .filter(instance => instance.elemID.typeName === ROLE)
+      .map(role => getFixedElementsAndUpdatedPaths(role, elementsSource, ROLE))
+      .filter(isInstanceElement)
+      .toArray()
+
+    const roleErrors: ChangeError[] = fixedRoles.map(role => {
+      const fullPath = `${role.value[SCRIPT_ID]}.${getPermissionsListPath().join('.')}`
+      const elementTypeName = `${CUSTOM_RECORD_TYPE}s`
+      return getMessageByPathAndElemTypeName(role, fullPath, elementTypeName)
+    })
+
+    const fixedCustomRecords = await awu(elements)
+      .filter(isObjectType)
+      .filter(isCustomRecordType)
+      .map(custRecord => getFixedElementsAndUpdatedPaths(custRecord, elementsSource, CUSTOM_RECORD_TYPE))
+      .filter(values.isDefined)
+      .toArray()
+
+    const customRecordErrors: ChangeError[] = fixedCustomRecords.map(custRecord => {
+      const fullPath = `${custRecord.annotations.scriptid}.annotations.${getPermissionsListPath().join('.')}`
+      const elementTypeName = `${ROLE}s`
+      return getMessageByPathAndElemTypeName(custRecord, fullPath, elementTypeName)
+    })
+
+    return { fixedElements: [...fixedRoles, ...fixedCustomRecords], errors: [...roleErrors, ...customRecordErrors] }
+  }
+
+export const permissionsHandler: WeakReferencesHandler<{
+  elementsSource: ReadOnlyElementsSource
+}> = {
+  findWeakReferences: getPermissionsReferences,
+  removeWeakReferences: removeMissingOrderElements,
+}

--- a/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
@@ -25,15 +25,6 @@ describe('custom record empty permission list validator', () => {
       metadataType: 'customrecordtype',
       [SCRIPT_ID]: 'customrecord_test',
       accesstype: 'USEPERMISSIONLIST',
-      permissions: {
-        permission: {
-          SYSTEM_ADMINISTRATOR: {
-            permittedlevel: 'CREATE',
-            permittedrole: 'SYSTEM_ADMINISTRATOR',
-            restriction: 'EDIT',
-          },
-        },
-      },
     },
   })
 
@@ -41,7 +32,6 @@ describe('custom record empty permission list validator', () => {
     customRecord = custRecordObject.clone()
   })
   it('should return an error when there is a custom record without permissions and with accesstype USEPERMISSIONLIST', async () => {
-    delete customRecord.annotations.permissions.permission
     const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
     expect(errors.length).toBe(1)
     expect(errors[0]).toEqual({
@@ -54,11 +44,19 @@ describe('custom record empty permission list validator', () => {
     })
   })
   it('should not return an error when there are permissions', async () => {
+    customRecord.annotations.permissions = {
+      permission: {
+        SYSTEM_ADMINISTRATOR: {
+          permittedlevel: 'CREATE',
+          permittedrole: 'SYSTEM_ADMINISTRATOR',
+          restriction: 'EDIT',
+        },
+      },
+    }
     const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
     expect(errors.length).toBe(0)
   })
   it('should not return an error when the accesstype is different than USEPERMISSIONLIST', async () => {
-    delete customRecord.annotations.permissions.permission
     customRecord.annotations.accesstype = 'CUSTRECORDENTRYPERM'
     const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
     expect(errors.length).toBe(0)

--- a/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
@@ -37,10 +37,10 @@ describe('custom record empty permission list validator', () => {
     expect(errors[0]).toEqual({
       elemID: customRecord.elemID,
       severity: 'Error',
-      message: 'Access type is permission list with no permissions specified',
+      message: 'Access Type is "Permission List" with No Permissions Specified',
       detailedMessage:
-        "Cannot deploy a Custom Record Type without permissions when the access type is set to 'USEPERMISSIONLIST'." +
-        "To deploy this Custom Record Type, either add permissions or change the access type to 'CUSTRECORDENTRYPERM' or 'NONENEEDED'.",
+        "Cannot deploy a Custom Record Type without specifying permissions when the access type is set to 'USEPERMISSIONLIST'." +
+        "To deploy this Custom Record Type, you must either add permissions or change the access type to 'CUSTRECORDENTRYPERM' or 'NONENEEDED'.",
     })
   })
   it('should not return an error when there are permissions', async () => {

--- a/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/custom_record_empty_permission_list.test.ts
@@ -1,0 +1,66 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
+import { NETSUITE, SCRIPT_ID } from '../../src/constants'
+import customRecordEmptyPermissionList from '../../src/change_validators/custom_record_empty_permission_list'
+
+describe('custom record empty permission list validator', () => {
+  let customRecord: ObjectType
+  const custRecordObject = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord_test'),
+    annotations: {
+      metadataType: 'customrecordtype',
+      [SCRIPT_ID]: 'customrecord_test',
+      accesstype: 'USEPERMISSIONLIST',
+      permissions: {
+        permission: {
+          SYSTEM_ADMINISTRATOR: {
+            permittedlevel: 'CREATE',
+            permittedrole: 'SYSTEM_ADMINISTRATOR',
+            restriction: 'EDIT',
+          },
+        },
+      },
+    },
+  })
+
+  beforeEach(() => {
+    customRecord = custRecordObject.clone()
+  })
+  it('should return an error when there is a custom record without permissions and with accesstype USEPERMISSIONLIST', async () => {
+    delete customRecord.annotations.permissions.permission
+    const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
+    expect(errors.length).toBe(1)
+    expect(errors[0]).toEqual({
+      elemID: customRecord.elemID,
+      severity: 'Error',
+      message: 'Access type is permission list with no permissions specified',
+      detailedMessage:
+        "Cannot deploy a Custom Record Type without permissions when the access type is set to 'USEPERMISSIONLIST'." +
+        "To deploy this Custom Record Type, either add permissions or change the access type to 'CUSTRECORDENTRYPERM' or 'NONENEEDED'.",
+    })
+  })
+  it('should not return an error when there are permissions', async () => {
+    const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
+    expect(errors.length).toBe(0)
+  })
+  it('should not return an error when the accesstype is different than USEPERMISSIONLIST', async () => {
+    delete customRecord.annotations.permissions.permission
+    customRecord.annotations.accesstype = 'CUSTRECORDENTRYPERM'
+    const errors = await customRecordEmptyPermissionList([toChange({ after: customRecord })])
+    expect(errors.length).toBe(0)
+  })
+})

--- a/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
+++ b/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
@@ -1,0 +1,309 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  isInstanceElement,
+  isObjectType,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import {
+  getPermissionsListPath,
+  permissionsHandler,
+} from '../../../src/custom_references/weak_references/permissions_references'
+import { roleType } from '../../../src/autogen/types/standard_types/role'
+import { NETSUITE, PERMISSIONS, ROLE, SCRIPT_ID } from '../../../src/constants'
+import { isCustomRecordType } from '../../../src/types'
+
+describe('order_elements', () => {
+  let role1: InstanceElement
+  let role2: InstanceElement
+  let role3: InstanceElement
+  let custRecord1: ObjectType
+  let custRecord2: ObjectType
+
+  const AdapterConfigType = new ObjectType({
+    elemID: new ElemID('adapter'),
+    isSettings: true,
+  })
+  const adapterConfig = new InstanceElement(ElemID.CONFIG_NAME, AdapterConfigType)
+
+  const roleInstance1 = new InstanceElement('customrole_1', roleType().type, {
+    [SCRIPT_ID]: 'customrole_1',
+    [PERMISSIONS]: {
+      permission: {
+        LIST_CUSTRECORDENTRY: {
+          permkey: 'LIST_CUSTRECORDENTRY',
+          permlevel: 'VIEW',
+        },
+        customrecord_1: {
+          permkey: 'temp',
+          permlevel: 'VIEW',
+        },
+        customrecord_2: {
+          permkey: 'temp',
+          permlevel: 'EDIT',
+        },
+        wrong_permission: {
+          wrongField: 2,
+        },
+      },
+    },
+  })
+
+  const roleInstance2 = new InstanceElement('customrole_2', roleType().type, {
+    [SCRIPT_ID]: 'customrole_2',
+    [PERMISSIONS]: {
+      permission: {
+        LIST_CUSTRECORDENTRY: {
+          permkey: 'LIST_CUSTRECORDENTRY',
+          permlevel: 'VIEW',
+        },
+        customrecord_1: {
+          permkey: 'temp',
+          permlevel: 'VIEW',
+        },
+        customrecord_2: {
+          permkey: 'temp',
+          permlevel: 'EDIT',
+        },
+      },
+    },
+  })
+  const roleInstance3 = new InstanceElement('customrole_3', roleType().type, {
+    [SCRIPT_ID]: 'customrole_3',
+    [PERMISSIONS]: {},
+  })
+
+  const custRecordObject1 = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord_1'),
+    annotations: {
+      metadataType: 'customrecordtype',
+      [SCRIPT_ID]: 'customrecord_1',
+      permissions: {
+        permission: {
+          customrole_1: {
+            permittedlevel: 'VIEW',
+            permittedrole: 'temp',
+          },
+          customrole_2: {
+            permittedlevel: 'VIEW',
+            permittedrole: 'temp',
+          },
+          SYSTEM_ADMINISTRATOR: {
+            permittedlevel: 'CREATE',
+            permittedrole: 'SYSTEM_ADMINISTRATOR',
+            restriction: 'EDIT',
+          },
+          wrong_permission: {
+            wrongField: 2,
+          },
+        },
+      },
+    },
+  })
+
+  const custRecordObject2 = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord_2'),
+    annotations: {
+      metadataType: 'customrecordtype',
+      [SCRIPT_ID]: 'customrecord_2',
+      permissions: {
+        permission: {
+          customrole_1: {
+            permittedlevel: 'VIEW',
+            permittedrole: 'temp',
+          },
+          customrole_2: {
+            permittedlevel: 'VIEW',
+            permittedrole: 'temp',
+          },
+          SYSTEM_ADMINISTRATOR: {
+            permittedlevel: 'CREATE',
+            permittedrole: 'SYSTEM_ADMINISTRATOR',
+            restriction: 'EDIT',
+          },
+        },
+      },
+    },
+  })
+
+  roleInstance1.value.permissions.permission.customrecord_1.permkey = new ReferenceExpression(
+    custRecordObject1.elemID.createNestedID('attr', SCRIPT_ID),
+    custRecordObject1.annotations.scriptid,
+    custRecordObject1,
+  )
+  roleInstance1.value.permissions.permission.customrecord_2.permkey = new ReferenceExpression(
+    custRecordObject2.elemID.createNestedID('attr', SCRIPT_ID),
+    custRecordObject2.annotations.scriptid,
+    custRecordObject1,
+  )
+
+  roleInstance2.value.permissions.permission.customrecord_1.permkey = new ReferenceExpression(
+    custRecordObject1.elemID.createNestedID('attr', SCRIPT_ID),
+    custRecordObject1.annotations.scriptid,
+    custRecordObject1,
+  )
+  roleInstance2.value.permissions.permission.customrecord_2.permkey = new ReferenceExpression(
+    custRecordObject2.elemID.createNestedID('attr', SCRIPT_ID),
+    custRecordObject2.annotations.scriptid,
+    custRecordObject1,
+  )
+
+  custRecordObject1.annotations.permissions.permission.customrole_1.permittedrole = new ReferenceExpression(
+    roleInstance1.elemID.createNestedID(SCRIPT_ID),
+    roleInstance1.value.scriptid,
+    roleInstance1,
+  )
+  custRecordObject1.annotations.permissions.permission.customrole_2.permittedrole = new ReferenceExpression(
+    roleInstance2.elemID.createNestedID(SCRIPT_ID),
+    roleInstance2.value.scriptid,
+    roleInstance2,
+  )
+
+  custRecordObject2.annotations.permissions.permission.customrole_1.permittedrole = new ReferenceExpression(
+    roleInstance1.elemID.createNestedID(SCRIPT_ID),
+    roleInstance1.value.scriptid,
+    roleInstance1,
+  )
+  custRecordObject2.annotations.permissions.permission.customrole_2.permittedrole = new ReferenceExpression(
+    roleInstance2.elemID.createNestedID(SCRIPT_ID),
+    roleInstance2.value.scriptid,
+    roleInstance2,
+  )
+
+  beforeEach(() => {
+    role1 = roleInstance1.clone()
+    role2 = roleInstance2.clone()
+    role3 = roleInstance3.clone()
+    custRecord1 = custRecordObject1.clone()
+    custRecord2 = custRecordObject2.clone()
+  })
+
+  describe('findWeakReferences', () => {
+    it('should return weak references for roles permissions', async () => {
+      const references = await permissionsHandler.findWeakReferences([role1], adapterConfig)
+
+      expect(references).toEqual([
+        {
+          source: role1.elemID.createNestedID(...getPermissionsListPath(), 'customrecord_1'),
+          target: custRecord1.elemID.createNestedID('attr', SCRIPT_ID),
+          type: 'weak',
+        },
+        {
+          source: role1.elemID.createNestedID(...getPermissionsListPath(), 'customrecord_2'),
+          target: custRecord2.elemID.createNestedID('attr', SCRIPT_ID),
+          type: 'weak',
+        },
+      ])
+    })
+    it('should return weak references for custom records permissions', async () => {
+      const references = await permissionsHandler.findWeakReferences([custRecord1], adapterConfig)
+
+      expect(references).toEqual([
+        {
+          source: custRecord1.elemID.createNestedID('attr', ...getPermissionsListPath(), 'customrole_1'),
+          target: role1.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+        {
+          source: custRecord1.elemID.createNestedID('attr', ...getPermissionsListPath(), 'customrole_2'),
+          target: role2.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+      ])
+    })
+  })
+
+  describe('removeWeakReferences', () => {
+    it('should remove the invalid references and keep vaid ones from role', async () => {
+      const clonedRole1 = role1.clone()
+      const elementsSource = buildElementsSourceFromElements([custRecord1])
+      const fixes = await permissionsHandler.removeWeakReferences({ elementsSource })([role1])
+      expect(clonedRole1).toEqual(role1)
+
+      expect(fixes.errors).toEqual([
+        {
+          elemID: role1.elemID,
+          severity: 'Info',
+          message: 'Deploying customrole_1.permissions.permission without all attached customrecordtypes',
+          detailedMessage:
+            'This customrole_1.permissions.permission is attached to some customrecordtypes that do not exist in the target environment. It will be deployed without referencing these customrecordtypes.',
+        },
+      ])
+
+      expect(fixes.fixedElements).toHaveLength(1)
+      const fixedElement = fixes.fixedElements[0]
+      expect(isInstanceElement(fixedElement) && fixedElement.elemID.typeName === ROLE).toBeTruthy()
+      const fixedRole = fixedElement as InstanceElement
+      expect(fixedRole.value.permissions.permission.customrecord_1).toEqual(
+        role1.value.permissions.permission.customrecord_1,
+      )
+      expect(fixedRole.value.permissions.permission.customrecord_2).toBeUndefined()
+      expect(fixedRole.value.permissions.permission.wrong_permission).toBeUndefined()
+    })
+    it('should remove the invalid references and keep vaid ones from custom record', async () => {
+      const clonedCustomRecord = custRecord1.clone()
+      const elementsSource = buildElementsSourceFromElements([role1])
+      const fixes = await permissionsHandler.removeWeakReferences({ elementsSource })([custRecord1])
+      expect(clonedCustomRecord).toEqual(custRecord1)
+
+      expect(fixes.errors).toEqual([
+        {
+          elemID: custRecord1.elemID,
+          severity: 'Info',
+          message: 'Deploying customrecord_1.annotations.permissions.permission without all attached roles',
+          detailedMessage:
+            'This customrecord_1.annotations.permissions.permission is attached to some roles that do not exist in the target environment. It will be deployed without referencing these roles.',
+        },
+      ])
+
+      expect(fixes.fixedElements).toHaveLength(1)
+      const fixedElement = fixes.fixedElements[0]
+      expect(isObjectType(fixedElement) && isCustomRecordType(fixedElement)).toBeTruthy()
+      const fixedCustomRecord = fixedElement as ObjectType
+      expect(fixedCustomRecord.annotations.permissions.permission.customrole_1).toEqual(
+        custRecord1.annotations.permissions.permission.customrole_1,
+      )
+      expect(fixedCustomRecord.annotations.permissions.permission.customrole_2).toBeUndefined()
+      expect(fixedCustomRecord.annotations.permissions.permission.wrong_permission).toBeUndefined()
+    })
+
+    it('should do nothing if all references are valid', async () => {
+      const clonedCustomRecord = custRecord2.clone()
+      const clonedRole = role2.clone()
+      const elementsSource = buildElementsSourceFromElements([role1, role2, custRecord1, custRecord2])
+      const fixes = await permissionsHandler.removeWeakReferences({ elementsSource })([custRecord2, role2])
+      expect(clonedCustomRecord).toEqual(custRecord2)
+      expect(clonedRole).toEqual(role2)
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+
+    it('should do nothing if there is no permission field', async () => {
+      const clonedRole3 = role3.clone()
+      const elementsSource = buildElementsSourceFromElements([])
+      const fixes = await permissionsHandler.removeWeakReferences({ elementsSource })([role3])
+      expect(clonedRole3).toEqual(role3)
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+  })
+})

--- a/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
+++ b/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
@@ -30,7 +30,7 @@ import { roleType } from '../../../src/autogen/types/standard_types/role'
 import { NETSUITE, PERMISSIONS, ROLE, SCRIPT_ID } from '../../../src/constants'
 import { isCustomRecordType } from '../../../src/types'
 
-describe('order_elements', () => {
+describe('permissions_references', () => {
   let role1: InstanceElement
   let role2: InstanceElement
   let role3: InstanceElement

--- a/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
+++ b/packages/netsuite-adapter/test/custom_references/weak_references/permissions_references.test.ts
@@ -151,7 +151,7 @@ describe('permissions_references', () => {
   roleInstance1.value.permissions.permission.customrecord_2.permkey = new ReferenceExpression(
     custRecordObject2.elemID.createNestedID('attr', SCRIPT_ID),
     custRecordObject2.annotations.scriptid,
-    custRecordObject1,
+    custRecordObject2,
   )
 
   roleInstance2.value.permissions.permission.customrecord_1.permkey = new ReferenceExpression(
@@ -162,7 +162,7 @@ describe('permissions_references', () => {
   roleInstance2.value.permissions.permission.customrecord_2.permkey = new ReferenceExpression(
     custRecordObject2.elemID.createNestedID('attr', SCRIPT_ID),
     custRecordObject2.annotations.scriptid,
-    custRecordObject1,
+    custRecordObject2,
   )
 
   custRecordObject1.annotations.permissions.permission.customrole_1.permittedrole = new ReferenceExpression(
@@ -239,11 +239,11 @@ describe('permissions_references', () => {
 
       expect(fixes.errors).toEqual([
         {
-          elemID: role1.elemID,
+          elemID: role1.elemID.createNestedID(...getPermissionsListPath()),
           severity: 'Info',
-          message: 'Deploying customrole_1.permissions.permission without all attached customrecordtypes',
+          message: 'Deploying without all attached permissions',
           detailedMessage:
-            'This customrole_1.permissions.permission is attached to some customrecordtypes that do not exist in the target environment. It will be deployed without referencing these customrecordtypes.',
+            'This customrole_1.permissions.permission is referenced by certain customrecordtypes that do not exist in the target environment. As a result, it will be deployed without those references.',
         },
       ])
 
@@ -265,11 +265,11 @@ describe('permissions_references', () => {
 
       expect(fixes.errors).toEqual([
         {
-          elemID: custRecord1.elemID,
+          elemID: custRecord1.elemID.createNestedID('annotation', ...getPermissionsListPath()),
           severity: 'Info',
-          message: 'Deploying customrecord_1.annotations.permissions.permission without all attached roles',
+          message: 'Deploying without all attached permissions',
           detailedMessage:
-            'This customrecord_1.annotations.permissions.permission is attached to some roles that do not exist in the target environment. It will be deployed without referencing these roles.',
+            'This customrecord_1.annotations.permissions.permission is referenced by certain roles that do not exist in the target environment. As a result, it will be deployed without those references.',
         },
       ])
 

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -42,7 +42,7 @@ import { RemoteMap, RemoteMapEntry } from './remote_map'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-export const REFERENCE_INDEXES_VERSION = 6
+export const REFERENCE_INDEXES_VERSION = 7
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ChangeReferences = {


### PR DESCRIPTION
_Added weak references to Netsuite
Currently applied to references in permissions between roles and custom record types_

---

_SALTO-4142: https://salto-io.atlassian.net/browse/SALTO-4142_

---
_Release Notes_: 
_Fix elements will now remove permissions with unresolved references_

---
_User Notifications_: 
_None_
