### PR TITLE
Fix removed custom headers still exist issue in zendesk webhook after deploment

### DIFF
--- a/packages/zendesk-adapter/src/filters/webhook.ts
+++ b/packages/zendesk-adapter/src/filters/webhook.ts
@@ -54,14 +54,13 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           instance.value.authentication = null
         }
 
-        // Only verify the absence of custom headers if after webhook contains custom headers and have difference
-        // We can not set null for all the custom headers when after webhook custom_headers is undefined since
-        // the existing HTTP method is PATCH which is a merge behaviour which relies on explicit null value to remove.
-        if (!_.isEqual(clonedChange.data.before.value.custom_headers, instance.value.custom_headers) && !_.isNil(instance.value.custom_headers)) {
+        // Only verify the absence of custom headers if after webhook custom headers contains difference.
+        // The PATCH which is a merge behaviour which relies on explicit null value to remove.
+        if (!_.isEqual(clonedChange.data.before.value.custom_headers, instance.value.custom_headers)) {
           // Remove any custom headers which no longer needed in after webhook by setting value as null
           _.forEach(_.keys(clonedChange.data.before.value.custom_headers), key => {
             if (!_.has(instance.value.custom_headers, key)) {
-              instance.value.custom_headers[key] = null
+              _.set(instance.value, ['custom_headers', key], null)
             }
           })
         }

--- a/packages/zendesk-adapter/src/filters/webhook.ts
+++ b/packages/zendesk-adapter/src/filters/webhook.ts
@@ -53,7 +53,20 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         } else if (instance.value.authentication === undefined) {
           instance.value.authentication = null
         }
+
+        // Only verify the absence of custom headers if after webhook contains custom headers and have difference
+        // We can not set null for all the custom headers when after webhook custom_headers is undefined since
+        // the existing HTTP method is PATCH which is a merge behaviour which relies on explicit null value to remove.
+        if (!_.isEqual(clonedChange.data.before.value.custom_headers, instance.value.custom_headers) && !_.isNil(instance.value.custom_headers)) {
+          // Remove any custom headers which no longer needed in after webhook by setting value as null
+          _.forEach(_.keys(clonedChange.data.before.value.custom_headers), key => {
+            if (!_.has(instance.value.custom_headers, key)) {
+              instance.value.custom_headers[key] = null
+            }
+          })
+        }
       }
+
       if (instance.value.authentication) {
         const placeholder = AUTH_TYPE_TO_PLACEHOLDER_AUTH_DATA[instance.value.authentication.type]
         if (placeholder === undefined) {

--- a/packages/zendesk-adapter/test/filters/webhook.test.ts
+++ b/packages/zendesk-adapter/test/filters/webhook.test.ts
@@ -256,7 +256,7 @@ describe('webhook filter', () => {
       clonedWebhookBefore.value.custom_headers = {
         h1: 'v1',
         h2: 'v2',
-        h4: 'v4'
+        h4: 'v4',
       }
       const clonedWebhookAfter = webhook.clone()
       clonedWebhookBefore.value.id = id
@@ -264,7 +264,7 @@ describe('webhook filter', () => {
       clonedWebhookAfter.value.custom_headers = {
         h2: 'v2_changed',
         h3: 'v3',
-        h4: 'v4'
+        h4: 'v4',
       }
       const deployedWebhookAfter = clonedWebhookAfter.clone()
       delete deployedWebhookAfter.value.authentication
@@ -272,7 +272,7 @@ describe('webhook filter', () => {
         h1: null,
         h2: 'v2_changed',
         h3: 'v3',
-        h4: 'v4'
+        h4: 'v4',
       }
       mockDeployChange.mockImplementation(async () => ({}))
       const res = await filter.deploy([
@@ -301,7 +301,7 @@ describe('webhook filter', () => {
       clonedWebhookBefore.value.custom_headers = {
         h1: 'v1',
         h2: 'v2',
-        h4: 'v3'
+        h4: 'v3',
       }
       const clonedWebhookAfter = webhook.clone()
       clonedWebhookBefore.value.id = id
@@ -309,7 +309,7 @@ describe('webhook filter', () => {
       clonedWebhookAfter.value.custom_headers = {
         h1: 'v1',
         h2: 'v2',
-        h4: 'v3'
+        h4: 'v3',
       }
       const deployedWebhookAfter = clonedWebhookAfter.clone()
       delete deployedWebhookAfter.value.authentication
@@ -340,7 +340,7 @@ describe('webhook filter', () => {
       clonedWebhookBefore.value.custom_headers = {
         h2: 'v1',
         h3: 'v2',
-        h4: 'v3'
+        h4: 'v3',
       }
       const clonedWebhookAfter = webhook.clone()
       clonedWebhookBefore.value.id = id
@@ -351,7 +351,7 @@ describe('webhook filter', () => {
       deployedWebhookAfter.value.custom_headers = {
         h2: null,
         h3: null,
-        h4: null
+        h4: null,
       }
       mockDeployChange.mockImplementation(async () => ({}))
       const res = await filter.deploy([
@@ -380,7 +380,7 @@ describe('webhook filter', () => {
       clonedWebhookBefore.value.custom_headers = {
         h2: 'v1',
         h3: 'v2',
-        h4: 'v3'
+        h4: 'v3',
       }
       const clonedWebhookAfter = webhook.clone()
       clonedWebhookBefore.value.id = id
@@ -388,7 +388,11 @@ describe('webhook filter', () => {
       clonedWebhookAfter.value.custom_headers = null
       const deployedWebhookAfter = clonedWebhookAfter.clone()
       delete deployedWebhookAfter.value.authentication
-      deployedWebhookAfter.value.custom_headers = null
+      deployedWebhookAfter.value.custom_headers = {
+        h2: null,
+        h3: null,
+        h4: null,
+      }
       mockDeployChange.mockImplementation(async () => ({}))
       const res = await filter.deploy([
         { action: 'modify', data: { before: clonedWebhookBefore, after: clonedWebhookAfter } },


### PR DESCRIPTION
👋  Salto team, as I dive into the Salto code base for the first time, I'm making an effort to thoroughly understand the existing logic and context. If I have overlooked any details or misinterpreted any part of the code, I would greatly appreciate your input. Please don't hesitate to offer feedback. Thank you for your assistance.

There is an alternative PR https://github.com/salto-io/salto/pull/5520 which just updating the HTTP method from `PATCH` to `PUT` for modification behaviour of Zendesk webhook in order to address this issue. The reason I've created two PRs is that I am not sure the reason of using `PATCH` of webhook mortification behaviour in deployment.

# Description of this PR
We've identified a minor issue during the deployment of webhooks with custom headers from the source environment to the target environment, specifically related to the `PATCH` behaviour. When custom headers are removed from a webhook in the source environment, these changes are not being reflected in the target environment; the removed headers persist in the target webhook.

## Expected behaviour
| Source Webhook Custom Headers   |    Change Behaviour     |  Target Webhook Custom Headers |
|----------|:-------------:|------:|
| h1:v1 |  delete | deleted |
| h2:v2 |  change value from v2 to v2_changed | h2:v2_changed |
| not presented |  add h3:v3 | h3:v3 |
| h4:v4 | no change, value is still v4 | h4:v4 |

## Existing behaviour
| Source Webhook Custom Headers   |    Change Behaviour     |  Target Webhook Custom Headers |
|----------|:-------------:|------:|
| h1:v1 |  delete | h1:v1 |
| h2:v2 |  change value from v2 to v2_changed | h2:v2_changed |
| not presented |  add h3:v3 | h3:v3 |
| h4:v4 | no change, value is still v4 | h4:v4 |

In [Zendesk Webhook API doc](https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/), I believe it missed explicit description of how to delete custom header. By using browser inspector, I believe setting `null` value of a header is the way to delete this header.
<img width="1901" alt="Screenshot 2024-02-28 at 19 58 57" src="https://github.com/salto-io/salto/assets/63993536/81be638d-1462-4cf8-8f16-85717d33be44">

## Changes
- Set `null` for the custom headers which are removed for Zendesk webhook update

## Screenshots
Sandbox webhook removed `h1` and saved change
<img width="1911" alt="Screenshot 2024-02-28 at 19 26 58" src="https://github.com/salto-io/salto/assets/63993536/62dacb17-7a43-4e77-ad80-9a352f59b112">

Salto change set view shows `h1` should be removed
<img width="1910" alt="Screenshot 2024-02-28 at 19 27 50" src="https://github.com/salto-io/salto/assets/63993536/b3614161-78b4-4cc4-9915-c334c9ef0eea">


Production webhook still contains `h1` which should be removed after deployment
<img width="1906" alt="Screenshot 2024-02-28 at 19 28 59" src="https://github.com/salto-io/salto/assets/63993536/a88268e0-ee5c-416e-b400-91b766d69a7b">

---

_Additional context for reviewer_

I was able to run the jest tests locally but could not figure out how to run Salto locally. Therefore, my assumption of the fix is based on the jest test results. Would you please help me test it in your staging if you feel this PR fix is reasonable? Many thanks for the help again.

<img width="866" alt="Screenshot 2024-02-29 at 10 04 28" src="https://github.com/salto-io/salto/assets/63993536/f2a3bede-eb2e-4e4a-8803-43b98799ff9b">

---
_Release Notes_: 
zendesk:
* Fix removed custom headers still exist in zendesk webhook after deployment

---
_User Notifications_: 
None
