### PR TITLE
SALTO-5479: RemoveDependencyFromObjectTypeToObjectSchema

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -25,6 +25,7 @@ import { workflowDependencyChanger } from './workflow'
 import { fieldContextDependencyChanger } from './field_contexts'
 import { fieldConfigurationDependencyChanger } from './field_configuration'
 import { jsmProjectToJsmFieldDependencyChanger } from './jsm_project_to_jsm_field'
+import { rootObjectTypeToObjectSchemaDependencyChanger } from './root_object_type_to_schema'
 
 const { awu } = collections.asynciterable
 
@@ -33,6 +34,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   projectDependencyChanger,
   workflowDependencyChanger,
   dashboardGadgetsDependencyChanger,
+  rootObjectTypeToObjectSchemaDependencyChanger, // Must run before removalsDependencyChanger
   removalsDependencyChanger,
   globalFieldContextsDependencyChanger,
   projectContextsDependencyChanger,

--- a/packages/jira-adapter/src/dependency_changers/root_object_type_to_schema.ts
+++ b/packages/jira-adapter/src/dependency_changers/root_object_type_to_schema.ts
@@ -1,0 +1,73 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  DependencyChange,
+  DependencyChanger,
+  InstanceElement,
+  RemovalChange,
+  dependencyChange,
+  getChangeData,
+  isInstanceChange,
+  isRemovalChange,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { deployment } from '@salto-io/adapter-components'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE } from '../constants'
+
+const createDependencyChange = (
+  objectTypeChange: deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>,
+  objectSchemaChange: deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>,
+): DependencyChange[] => [dependencyChange('remove', objectTypeChange.key, objectSchemaChange.key)]
+
+/*
+ * This dependency changer is used to remove a dependency from root object type to it's schema
+ * upon removal because we added the reference for Salto's internal use. but no real dependency exists
+ * In this direction. We also have parent annotation that is used for the real dependency.
+ */
+export const rootObjectTypeToObjectSchemaDependencyChanger: DependencyChanger = async changes => {
+  const instanceChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(({ change }) => isRemovalChange(change))
+    .filter((change): change is deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>> =>
+      isInstanceChange(change.change),
+    )
+  const relevantChanges = instanceChanges.filter(change => {
+    const instance = getChangeData(change.change)
+    if (instance.elemID.typeName === OBJECT_SCHEMA_TYPE) {
+      return true
+    }
+    return (
+      instance.elemID.typeName === OBJECT_TYPE_TYPE &&
+      instance.value.parentObjectTypeId?.elemID.typeName === OBJECT_SCHEMA_TYPE
+    )
+  })
+
+  const [objectTypeChanges, objectSchemaChanges] = _.partition(
+    relevantChanges,
+    change => getChangeData(change.change).elemID.typeName === OBJECT_TYPE_TYPE,
+  )
+
+  if (_.isEmpty(objectTypeChanges) || _.isEmpty(objectSchemaChanges)) {
+    return []
+  }
+  return objectTypeChanges.flatMap(change => {
+    const objectTypeChange = change as deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>
+    return objectSchemaChanges
+      .map(objectSchemaChange => createDependencyChange(objectTypeChange, objectSchemaChange))
+      .flat()
+  })
+}

--- a/packages/jira-adapter/test/dependency_changers/root_object_type_to_schema.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/root_object_type_to_schema.test.ts
@@ -1,0 +1,121 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InstanceElement, toChange, DependencyChange, CORE_ANNOTATIONS, ReferenceExpression } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { createEmptyType } from '../utils'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE } from '../../src/constants'
+import { rootObjectTypeToObjectSchemaDependencyChanger } from '../../src/dependency_changers/root_object_type_to_schema'
+
+describe('rootObjectTypeToObjectSchemaDependencyChanger', () => {
+  let dependencyChanges: DependencyChange[]
+  let objectTypeInstance: InstanceElement
+  let objectSchemaInstance: InstanceElement
+  describe('rootObjectTypeToObjectSchemaDependencyChanger with expected changes', () => {
+    beforeEach(async () => {
+      objectSchemaInstance = new InstanceElement('objectSchemaInstance', createEmptyType(OBJECT_SCHEMA_TYPE), {
+        id: '0',
+        name: 'objectSchemaInstanceName',
+      })
+      objectTypeInstance = new InstanceElement('objectTypeInstance', createEmptyType(OBJECT_TYPE_TYPE), {
+        id: '1',
+        name: 'objectTypeInstanceName',
+        parentObjectTypeId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)],
+      })
+    })
+    it('should remove dependencies from root objectType to objectSchema when they are both removal change', async () => {
+      objectTypeInstance.value.parentObjectTypeId = new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeInstance })],
+        [1, toChange({ before: objectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await rootObjectTypeToObjectSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(1)
+      expect(dependencyChanges[0].action).toEqual('remove')
+      expect(dependencyChanges[0].dependency.source).toEqual(0)
+      expect(dependencyChanges[0].dependency.target).toEqual(1)
+    })
+    it('should not remove dependencies from root objectType to objectSchema when objetType is modification change', async () => {
+      const objectTypeInstanceAfter = objectTypeInstance.clone()
+      objectTypeInstanceAfter.value.name = 'objectTypeInstanceName2'
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeInstance, after: objectTypeInstanceAfter })],
+        [1, toChange({ before: objectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await rootObjectTypeToObjectSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove dependencies from root objectType to objectSchema when objectSchema is modification change', async () => {
+      const objectSchemaInstanceAfter = objectSchemaInstance.clone()
+      objectSchemaInstanceAfter.value.name = 'objectSchemaInstanceName2'
+      const inputChanges = new Map([
+        [0, toChange({ before: objectSchemaInstance, after: objectSchemaInstanceAfter })],
+        [1, toChange({ after: objectTypeInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await rootObjectTypeToObjectSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove dependencies from objectType to objectSchema when objectType is not root', async () => {
+      const childObjectTtpyeInstance = objectTypeInstance.clone()
+      childObjectTtpyeInstance.value.parentObjectTypeId = new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance)
+      const inputChanges = new Map([
+        [0, toChange({ before: childObjectTtpyeInstance  })],
+        [1, toChange({ before: objectSchemaInstance })],
+        [2, toChange({ before: objectTypeInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await rootObjectTypeToObjectSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(1)
+      expect(dependencyChanges[0].action).toEqual('remove')
+      expect(dependencyChanges[0].dependency.source).toEqual(2)
+      expect(dependencyChanges[0].dependency.target).toEqual(1)
+    })
+  })
+  describe('rootObjectTypeToObjectSchemaDependencyChanger with unexpected changes', () => {
+    beforeEach(async () => {
+      objectSchemaInstance = new InstanceElement('objectSchemaInstance', createEmptyType(OBJECT_SCHEMA_TYPE), {
+        id: '0',
+        name: 'objectSchemaInstanceName',
+      })
+      objectTypeInstance = new InstanceElement('objectTypeInstance', createEmptyType(OBJECT_TYPE_TYPE), {
+        id: '1',
+        name: 'objectTypeInstanceName',
+        parentObjectTypeId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)],
+      })
+    })
+    it('should not remove dependencies from root objectType to objectSchema when no parentObjectTypeId is defined', async () => {
+      delete objectTypeInstance.value.parentObjectTypeId
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeInstance })],
+        [1, toChange({ before: objectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await rootObjectTypeToObjectSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
In this PR I removed the connection between the root object type and the its objectSchema upon removals.

---

_Additional context for reviewer_
Much more context in https://salto-io.atlassian.net/browse/SALTO-5479.

---
_Release Notes_: 
_Jira Adpater:_
* Resolved a bug that occurred when attempting to delete a root objectType and its corresponding objectSchema.

---
_User Notifications_: 
None
