### PR TITLE
SALTO-5482: Allow trexcloud domain in okta login

### DIFF
--- a/packages/okta-adapter/index.ts
+++ b/packages/okta-adapter/index.ts
@@ -15,3 +15,4 @@
  */
 
 export { adapter } from './src/adapter_creator'
+export { validateOktaBaseUrl } from './src/utils'

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -59,7 +59,7 @@ const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials =
   const { value } = config
   const { baseUrl } = value
   const hostName = new URL(baseUrl).hostname
-  if (!hostName.includes(OKTA)) {
+  if (!hostName.includes(OKTA) && !hostName.includes('trexcloud')) {
     throw new Error(`'${hostName}' is not a valid okta account url`)
   }
   return isOAuthConfigCredentials(value)

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -41,7 +41,7 @@ import {
   OktaDeployConfig,
 } from './config'
 import { createConnection } from './client/connection'
-import { OKTA } from './constants'
+import { validateOktaBaseUrl } from './utils'
 import { getAdminUrl } from './client/admin'
 
 const log = logger(module)
@@ -58,10 +58,7 @@ const isOAuthConfigCredentials = (configValue: Readonly<Values>): configValue is
 const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials => {
   const { value } = config
   const { baseUrl } = value
-  const hostName = new URL(baseUrl).hostname
-  if (!hostName.includes(OKTA) && !hostName.includes('trexcloud')) {
-    throw new Error(`'${hostName}' is not a valid okta account url`)
-  }
+  validateOktaBaseUrl(baseUrl)
   return isOAuthConfigCredentials(value)
     ? {
         baseUrl,

--- a/packages/okta-adapter/src/utils.ts
+++ b/packages/okta-adapter/src/utils.ts
@@ -55,3 +55,16 @@ export const extractIdFromUrl = (url: string): string | undefined => {
   log.warn(`Failed to extract id from url: ${url}`)
   return undefined
 }
+
+export const validateOktaBaseUrl = (baseUrl: string): void => {
+  // Okta's org url must be from one of the following formats:
+  //   - Standard domain: companyname.okta.com
+  //   - EMEA domain: companyname.okta-emea.com
+  //   - Sandbox subdomain: companyname.oktapreview.com
+  //   Source: https://developer.okta.com/docs/concepts/okta-organizations/
+  //   Customized domains also works with the Okta domain (https://developer.okta.com/docs/guides/custom-url-domain/main/#about-okta-domain-customizations)
+  if (!/^https:\/\/([a-zA-Z0-9.-]+\.(okta\.com|oktapreview\.com|okta-emea\.com|trexcloud\.com))(\/)?$/.test(baseUrl)) {
+    log.error(`${baseUrl} is not a valid account url`)
+    throw new Error('baseUrl is invalid')
+  }
+}

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -68,6 +68,7 @@ jest.mock('../src/user_utils', () => ({
 }))
 
 describe('Okta adapter', () => {
+  jest.setTimeout(1000 * 7)
   let getElemIdFunc: ElemIdGetter
   const adapterSetup = (credentials: InstanceElement): AdapterOperations => {
     const elementsSource = buildElementsSourceFromElements([])
@@ -114,7 +115,8 @@ describe('Okta adapter', () => {
     })
 
     it('should return all types and instances returned from the infrastructure', async () => {
-      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }))
+      // const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }))
+      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'https://test.okta.com', token: 't' }))
       const result = await adapter.fetch({ progressReporter: { reportProgress: () => null } })
       expect(result.elements).toContain(oktaTestType)
       expect(result.elements).toContain(testInstance)
@@ -123,7 +125,7 @@ describe('Okta adapter', () => {
     it('should config change suggestion and fetch warning when usePrivateApi is enabled and authentication method is OAuth', async () => {
       const oauthCredentials = new InstanceElement(ElemID.CONFIG_NAME, oauthAccessTokenCredentialsType, {
         authType: 'oauth',
-        baseUrl: 'https://okta.com',
+        baseUrl: 'https://a.okta.com',
         refreshToken: 'refresh',
         clientId: 'a',
         clientSecret: 'b',
@@ -147,14 +149,14 @@ describe('Okta adapter', () => {
     })
 
     it('should call getUsers if convertUserIds flag is enabled', async () => {
-      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }))
+      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'https://okta.oktapreview.com', token: 't' }))
       await adapter.fetch({ progressReporter: { reportProgress: () => null } })
       expect(mockGetUsers).toHaveBeenCalledTimes(1)
     })
 
     it('should create updated config for classic orgs when isClassicOrg config flag is undefined', async () => {
       mockIsClassicOrg.mockImplementationOnce(() => true)
-      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'http:/okta.test', token: 't' }))
+      const adapter = adapterSetup(createCredentialsInstance({ baseUrl: 'https://okta-test.okta.com', token: 't' }))
       const result = await adapter.fetch({ progressReporter: { reportProgress: () => null } })
       expect(mockIsClassicOrg).toHaveBeenCalledTimes(1)
       expect(result.updatedConfig).toBeDefined()

--- a/packages/okta-adapter/test/adapter_creator.test.ts
+++ b/packages/okta-adapter/test/adapter_creator.test.ts
@@ -62,7 +62,7 @@ describe('adapter creator', () => {
       beforeEach(async () => {
         mockAxiosAdapter.onGet().reply(200, { id: 'orgId', subdomain: 'my' })
         ;({ accountId } = await adapter.validateCredentials(
-          createCredentialsInstance({ baseUrl: 'http://my-account.okta.net', token: 't' }),
+          createCredentialsInstance({ baseUrl: 'https://my-account.okta.com', token: 't' }),
         ))
       })
       it('should make an authenticated rest call', () => {
@@ -77,7 +77,9 @@ describe('adapter creator', () => {
       let result: Promise<AccountInfo>
       beforeEach(() => {
         mockAxiosAdapter.onGet().reply(403)
-        result = adapter.validateCredentials(createCredentialsInstance({ baseUrl: 'http://my.net', token: 't' }))
+        result = adapter.validateCredentials(
+          createCredentialsInstance({ baseUrl: 'https://my-account.okta.com', token: 't' }),
+        )
       })
       it('should fail', async () => {
         await expect(result).rejects.toThrow()
@@ -110,7 +112,7 @@ describe('adapter creator', () => {
       })
       it('when using production account', async () => {
         const { accountType, isProduction } = await adapter.validateCredentials(
-          createCredentialsInstance({ baseUrl: 'https://my-account.okta.net', token: 't' }),
+          createCredentialsInstance({ baseUrl: 'https://my-account.okta.com', token: 't' }),
         )
         expect(accountType).toEqual('Production')
         expect(isProduction).toEqual(true)
@@ -223,32 +225,32 @@ describe('adapter creator', () => {
             credentials: createCredentialsInstance({ baseUrl: 'https://a.mydomain.com', token: 't' }),
             config: createConfigInstance(DEFAULT_CONFIG),
           }),
-        ).toThrow("a.mydomain.com' is not a valid okta account url")
+        ).toThrow('baseUrl is invalid')
       })
     })
 
     describe('with valid credentials instance', () => {
       it('should not fail for valid domains', () => {
-          const preview = adapter.operations({
-            elementsSource,
-            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.oktapreview.com', token: 't' }),
-            config: createConfigInstance(DEFAULT_CONFIG),
-          })
-          expect(preview).toBeDefined()
+        const preview = adapter.operations({
+          elementsSource,
+          credentials: createCredentialsInstance({ baseUrl: 'https://a-b.oktapreview.com', token: 't' }),
+          config: createConfigInstance(DEFAULT_CONFIG),
+        })
+        expect(preview).toBeDefined()
 
-          const okta = adapter.operations({
-            elementsSource,
-            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.okta.com', token: 't' }),
-            config: createConfigInstance(DEFAULT_CONFIG),
-          })
-          expect(okta).toBeDefined()
+        const okta = adapter.operations({
+          elementsSource,
+          credentials: createCredentialsInstance({ baseUrl: 'https://a-b.okta.com', token: 't' }),
+          config: createConfigInstance(DEFAULT_CONFIG),
+        })
+        expect(okta).toBeDefined()
 
-          const trexcloud = adapter.operations({
-            elementsSource,
-            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.trexcloud.com', token: 't' }),
-            config: createConfigInstance(DEFAULT_CONFIG),
-          })
-          expect(trexcloud).toBeDefined()
+        const trexcloud = adapter.operations({
+          elementsSource,
+          credentials: createCredentialsInstance({ baseUrl: 'https://a-b.trexcloud.com', token: 't' }),
+          config: createConfigInstance(DEFAULT_CONFIG),
+        })
+        expect(trexcloud).toBeDefined()
       })
     })
   })

--- a/packages/okta-adapter/test/adapter_creator.test.ts
+++ b/packages/okta-adapter/test/adapter_creator.test.ts
@@ -214,5 +214,42 @@ describe('adapter creator', () => {
         ).not.toThrow()
       })
     })
+
+    describe('with invalid credentials instance', () => {
+      it('should fail if provided baseUrl is invalid', () => {
+        expect(() =>
+          adapter.operations({
+            elementsSource,
+            credentials: createCredentialsInstance({ baseUrl: 'https://a.mydomain.com', token: 't' }),
+            config: createConfigInstance(DEFAULT_CONFIG),
+          }),
+        ).toThrow("a.mydomain.com' is not a valid okta account url")
+      })
+    })
+
+    describe('with valid credentials instance', () => {
+      it('should not fail for valid domains', () => {
+          const preview = adapter.operations({
+            elementsSource,
+            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.oktapreview.com', token: 't' }),
+            config: createConfigInstance(DEFAULT_CONFIG),
+          })
+          expect(preview).toBeDefined()
+
+          const okta = adapter.operations({
+            elementsSource,
+            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.okta.com', token: 't' }),
+            config: createConfigInstance(DEFAULT_CONFIG),
+          })
+          expect(okta).toBeDefined()
+
+          const trexcloud = adapter.operations({
+            elementsSource,
+            credentials: createCredentialsInstance({ baseUrl: 'https://a-b.trexcloud.com', token: 't' }),
+            config: createConfigInstance(DEFAULT_CONFIG),
+          })
+          expect(trexcloud).toBeDefined()
+      })
+    })
   })
 })

--- a/packages/okta-adapter/test/utils.test.ts
+++ b/packages/okta-adapter/test/utils.test.ts
@@ -17,7 +17,7 @@ import { MockInterface } from '@salto-io/test-utils'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { mockClient } from './utils'
 import OktaClient from '../src/client/client'
-import { extractIdFromUrl, isClassicEngineOrg } from '../src/utils'
+import { extractIdFromUrl, isClassicEngineOrg, validateOktaBaseUrl } from '../src/utils'
 
 describe('okta utils', () => {
   describe('extractIdFromUrl', () => {
@@ -55,6 +55,17 @@ describe('okta utils', () => {
     it('should return false for error', async () => {
       mockConnection.get.mockRejectedValue(new Error('error'))
       expect(await isClassicEngineOrg(client)).toBeFalsy()
+    })
+  })
+  describe('validateOktaBaseUrl', () => {
+    it('should throw error for invalid url', () => {
+      expect(() => validateOktaBaseUrl('http://some.okta.com')).toThrow()
+      expect(() => validateOktaBaseUrl('https://some-account.salesforce.com')).toThrow()
+      expect(() => validateOktaBaseUrl('https://localhost:8080')).toThrow()
+    })
+    it('should not throw error for valid url', () => {
+      expect(() => validateOktaBaseUrl('https://oktaDomain.okta.com/')).not.toThrow()
+      expect(() => validateOktaBaseUrl('https://o-k-t-a.oktapreview.com')).not.toThrow()
     })
   })
 })


### PR DESCRIPTION
This is temporary addition, will remove once all tests are done
More details in linked ticket 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
