### PR TITLE
Fix removed custom headers still exist issue in zendesk webhook after deploment

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1836,7 +1836,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       },
       modify: {
         url: '/api/v2/webhooks/{webhookId}',
-        method: 'patch',
+        method: 'put',
         deployAsField: 'webhook',
         urlParamsToFields: {
           webhookId: 'id',

--- a/packages/zendesk-adapter/system_config_doc.md
+++ b/packages/zendesk-adapter/system_config_doc.md
@@ -3292,7 +3292,7 @@ zendesk {
           }
           modify = {
             url = "/api/v2/webhooks/{webhookId}"
-            method = "patch"
+            method = "put"
             deployAsField = "webhook"
             urlParamsToFields = {
               webhookId = "id"


### PR DESCRIPTION
👋  Salto team, as I dive into the Salto code base for the first time, I'm making an effort to thoroughly understand the existing logic and context. If I have overlooked any details or misinterpreted any part of the code, I would greatly appreciate your input. Please don't hesitate to offer feedback. Thank you for your assistance.

This PR is an alternative fix of PR https://github.com/salto-io/salto/pull/5516, I guess we should be able to fix this issue by changing the HTTP method from `PATCH` to `PUT` for modification behaviour of Zendesk webhook since `PUT` is a full replacement behaviour. The reason I've created two PRs is that I am not sure the reason of using `PATCH` of webhook mortification behaviour in deployment.

# Description of this PR
We've identified a minor issue during the deployment of webhooks with custom headers from the source environment to the target environment, specifically related to the `PATCH` behaviour. When custom headers are removed from a webhook in the source environment, these changes are not being reflected in the target environment; the removed headers persist in the target webhook.

## Expected behaviour
| Source Webhook Custom Headers   |    Change Behaviour     |  Target Webhook Custom Headers |
|----------|:-------------:|------:|
| h1:v1 |  delete | deleted |
| h2:v2 |  change value from v2 to v2_changed | h2:v2_changed |
| not presented |  add h3:v3 | h3:v3 |
| h4:v4 | no change, value is still v4 | h4:v4 |

## Existing behaviour
| Source Webhook Custom Headers   |    Change Behaviour     |  Target Webhook Custom Headers |
|----------|:-------------:|------:|
| h1:v1 |  delete | h1:v1 |
| h2:v2 |  change value from v2 to v2_changed | h2:v2_changed |
| not presented |  add h3:v3 | h3:v3 |
| h4:v4 | no change, value is still v4 | h4:v4 |

In [Zendesk Webhook API doc](https://developer.zendesk.com/api-reference/webhooks/webhooks-api/webhooks/), I believe it missed explicit description of how to delete custom header. By using browser inspector, I believe setting `null` value of a header is the way to delete this header when HTTP method is `PATCH`.
<img width="1901" alt="Screenshot 2024-02-28 at 19 58 57" src="https://github.com/salto-io/salto/assets/63993536/81be638d-1462-4cf8-8f16-85717d33be44">

## Changes
- Change HTTP method from `PATCH` to `PUT` for Zendesk webhook update
- Retain the authentication `type` and `add_position` as long as authentication is same. For `PUT`, you can keep the authentication without passing the data as long as `type` and `add_position` are same.

## Screenshots
Sandbox webhook removed `h1` and saved change
<img width="1911" alt="Screenshot 2024-02-28 at 19 26 58" src="https://github.com/salto-io/salto/assets/63993536/62dacb17-7a43-4e77-ad80-9a352f59b112">

Salto change set view shows `h1` should be removed
<img width="1910" alt="Screenshot 2024-02-28 at 19 27 50" src="https://github.com/salto-io/salto/assets/63993536/b3614161-78b4-4cc4-9915-c334c9ef0eea">

Production webhook still contains `h1` which should be removed after deployment
<img width="1906" alt="Screenshot 2024-02-28 at 19 28 59" src="https://github.com/salto-io/salto/assets/63993536/a88268e0-ee5c-416e-b400-91b766d69a7b">

---

_Additional context for reviewer_
I could not find any related tests against this config changes. Therefore, I've run all the tests under `packages/zendesk-adapter` and they all passed. Same results were applied to the CI. Would you please help me test it in your staging if you feel this PR fix is reasonable? Many thanks for the help again.

---
_Release Notes_: 
Fix removed custom headers still exist in zendesk webhook after deployment

---
_User Notifications_: 
Removed headers will be set with `null` value in Zendesk webhook customer headers
