### PR TITLE
SALTO-5429: [MA] Switch elem id name mapping to functions that can be overwritten

### DIFF
--- a/packages/adapter-components/src/config/ducktype.ts
+++ b/packages/adapter-components/src/config/ducktype.ts
@@ -33,7 +33,7 @@ import {
 } from './transformation'
 
 import { validateRequestConfig } from './request'
-import { UserFetchConfig } from '../definitions/user'
+import { UserFetchConfig, UserFetchConfigOptions } from '../definitions/user'
 import { DefaultWithCustomizations } from '../definitions'
 
 const { isDefined } = lowerDashValues
@@ -107,9 +107,9 @@ export const validateApiDefinitionConfig = (
  * Verify that all fetch types exist in the endpoint definitions.
  * Note: This validation is only relevant for ducktype adapters.
  */
-export const validateFetchConfig = (
+export const validateFetchConfig = <Options extends UserFetchConfigOptions>(
   fetchConfigPath: string,
-  userFetchConfig: UserFetchConfig,
+  userFetchConfig: UserFetchConfig<Options>,
   adapterApiConfig: AdapterApiConfig,
 ): void => {
   validateSupportedTypes(fetchConfigPath, userFetchConfig, Object.keys(adapterApiConfig.supportedTypes))

--- a/packages/adapter-components/src/config/shared.ts
+++ b/packages/adapter-components/src/config/shared.ts
@@ -34,7 +34,7 @@ import {
   FetchRequestDefaultConfig,
   getConfigTypeName,
 } from './request'
-import { UserFetchConfig } from '../definitions/user'
+import { UserFetchConfig, UserFetchConfigOptions } from '../definitions/user'
 
 export class InvalidSingletonType extends Error {}
 
@@ -158,9 +158,9 @@ export const getConfigWithDefault = <
 /**
  * Verify that all fetch types are supported.
  */
-export const validateSupportedTypes = (
+export const validateSupportedTypes = <Options extends UserFetchConfigOptions>(
   fetchConfigPath: string,
-  userFetchConfig: UserFetchConfig,
+  userFetchConfig: UserFetchConfig<Options>,
   supportedTypesNames: string[],
 ): void => {
   const invalidIncludedTypes = [...userFetchConfig.include, ...userFetchConfig.exclude]

--- a/packages/adapter-components/src/config/swagger.ts
+++ b/packages/adapter-components/src/config/swagger.ts
@@ -39,7 +39,7 @@ import {
   TransformationDefaultConfig,
   validateTransoformationConfig,
 } from './transformation'
-import { UserFetchConfig } from '../definitions/user'
+import { UserFetchConfig, UserFetchConfigOptions } from '../definitions/user'
 
 const { isDefined } = lowerDashValues
 const { findDuplicates } = collections.array
@@ -250,9 +250,9 @@ export const validateApiDefinitionConfig = (
  * Verify that all fetch types are supported.
  * Note: This validation is only relevant for swagger adapters.
  */
-export const validateFetchConfig = (
+export const validateFetchConfig = <Options extends UserFetchConfigOptions>(
   fetchConfigPath: string,
-  userFetchConfig: UserFetchConfig,
+  userFetchConfig: UserFetchConfig<Options>,
   adapterApiConfig: AdapterSwaggerApiConfig,
 ): void => {
   validateSupportedTypes(fetchConfigPath, userFetchConfig, Object.keys(adapterApiConfig.supportedTypes))

--- a/packages/adapter-components/src/definitions/system/api.ts
+++ b/packages/adapter-components/src/definitions/system/api.ts
@@ -20,15 +20,31 @@ import { FetchApiDefinitions } from './fetch'
 import { DeployApiDefinitions } from './deploy'
 import { ReferenceDefinitions } from './references'
 
-export type ApiDefinitions<
-  ClientOptions extends string = 'main',
-  PaginationOptions extends string | 'none' = 'none',
-  AdditionalAction extends string = never,
-> = {
+export type APIDefinitionsOptions = {
+  clientOptions?: string
+  paginationOptions?: string
+  customNameMappingOptions?: string
+  additionalAction?: string
+}
+
+export type ResolveClientOptionsType<Options extends Pick<APIDefinitionsOptions, 'clientOptions'>> =
+  Options['clientOptions'] extends string ? Options['clientOptions'] : 'main'
+
+export type ResolvePaginationOptionsType<Options extends Pick<APIDefinitionsOptions, 'paginationOptions'>> =
+  Options['paginationOptions'] extends string ? Options['paginationOptions'] : 'none'
+
+export type ResolveCustomNameMappingOptionsType<
+  Options extends Pick<APIDefinitionsOptions, 'customNameMappingOptions'>,
+> = Options['customNameMappingOptions'] extends string ? Options['customNameMappingOptions'] : never
+
+export type ResolveAdditionalActionType<Options extends Pick<APIDefinitionsOptions, 'additionalAction'>> =
+  Options['additionalAction'] extends string ? Options['additionalAction'] : never
+
+export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   // sources are processed and used to populate initial options for clients and components, in order of definition,
   // followed by the rest of the adjustments
   sources?: {
-    openAPI?: OpenAPIDefinition<ClientOptions>[]
+    openAPI?: OpenAPIDefinition<ResolveClientOptionsType<Options>>[]
   }
 
   // TODO add auth definitions
@@ -36,14 +52,17 @@ export type ApiDefinitions<
 
   // clients will be initialized as part of a big "client" in the adapter creator,
   // but need to be "registered" here in order to be used by the infra
-  clients: OptionsWithDefault<ApiClientDefinition<PaginationOptions>, ClientOptions>
+  clients: OptionsWithDefault<
+    ApiClientDefinition<ResolvePaginationOptionsType<Options>>,
+    ResolveClientOptionsType<Options>
+  >
 
   // supported pagination options. when missing, no pagination is used (TODO add warning)
-  pagination: Record<PaginationOptions, PaginationDefinitions<ClientOptions>>
+  pagination: Record<ResolvePaginationOptionsType<Options>, PaginationDefinitions<ResolveClientOptionsType<Options>>>
 
   // rules for reference extraction (during fetch) and serialization (during deploy)
   references?: ReferenceDefinitions
 
-  fetch?: FetchApiDefinitions<ClientOptions>
-  deploy?: DeployApiDefinitions<AdditionalAction, ClientOptions>
+  fetch?: FetchApiDefinitions<Options>
+  deploy?: DeployApiDefinitions<ResolveAdditionalActionType<Options>, ResolveClientOptionsType<Options>>
 }

--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -110,7 +110,7 @@ export type ElemIDCreatorArgs<TCustomNameMappingOptions extends string = never> 
   serviceIDDef?: string[]
   typeID: ElemID
   singleton?: boolean
-  customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>
+  customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
 }
 
 export type ElementFetchDefinitionOptions = {

--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -30,7 +30,7 @@ import { GenerateTypeArgs } from './types'
 import { ResolveCustomNameMappingOptionsType } from '../api'
 import { NameMappingFunctionMap, NameMappingOptions } from '../shared'
 
-export type FieldIDPart<TCustomNameMappingOptions extends string> = ArgsWithCustomizer<
+export type FieldIDPart<TCustomNameMappingOptions extends string = never> = ArgsWithCustomizer<
   string | undefined,
   {
     fieldName: string
@@ -44,20 +44,20 @@ export type FieldIDPart<TCustomNameMappingOptions extends string> = ArgsWithCust
   Values
 >
 
-export type IDPartsDefinition<TCustomNameMappingOptions extends string> = {
+export type IDPartsDefinition<TCustomNameMappingOptions extends string = never> = {
   parts?: FieldIDPart<TCustomNameMappingOptions>[]
   // the delimiter to use between parts - default is '_'
   delimiter?: string
 }
 
-export type ElemIDDefinition<TCustomNameMappingOptions extends string> =
+export type ElemIDDefinition<TCustomNameMappingOptions extends string = never> =
   IDPartsDefinition<TCustomNameMappingOptions> & {
     // default - true when parent annotation exists?
     // TODO check if still needed when implementing SALTO-5421
     extendsParent?: boolean
   }
 
-export type PathDefinition<TCustomNameMappingOptions extends string> = {
+export type PathDefinition<TCustomNameMappingOptions extends string = never> = {
   // when id parts info is missing, inherited from elemID (but the values are path-nacl-cased)
   pathParts?: IDPartsDefinition<TCustomNameMappingOptions>[]
 }
@@ -104,7 +104,7 @@ export type ElementsAndErrors = {
   configSuggestions?: ConfigChangeSuggestion[]
 }
 
-export type ElemIDCreatorArgs<TCustomNameMappingOptions extends string> = {
+export type ElemIDCreatorArgs<TCustomNameMappingOptions extends string = never> = {
   elemIDDef: ElemIDDefinition<TCustomNameMappingOptions>
   getElemIdFunc?: ElemIdGetter
   serviceIDDef?: string[]
@@ -114,13 +114,12 @@ export type ElemIDCreatorArgs<TCustomNameMappingOptions extends string> = {
 }
 
 export type ElementFetchDefinitionOptions = {
-  values?: Values
+  valueType?: Values
   customNameMappingOptions?: string
 }
 
-type ResolveValuesType<Options extends Pick<ElementFetchDefinitionOptions, 'values'>> = Options['values'] extends Values
-  ? Options['values']
-  : Values
+type ResolveValueType<Options extends Pick<ElementFetchDefinitionOptions, 'valueType'>> =
+  Options['valueType'] extends Values ? Options['valueType'] : Values
 
 type FetchTopLevelElementDefinition<Options extends ElementFetchDefinitionOptions = {}> = {
   isTopLevel: true
@@ -156,7 +155,7 @@ type FetchTopLevelElementDefinition<Options extends ElementFetchDefinitionOption
 
   // guard for validating the value is as expected.
   // when missing, we validate that this is a plain object
-  valueGuard?: (val: unknown) => val is ResolveValuesType<Options>
+  valueGuard?: (val: unknown) => val is ResolveValueType<Options>
 
   // TODO add:
   // alias, important attributes

--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -110,7 +110,7 @@ export type ElemIDCreatorArgs<TCustomNameMappingOptions extends string> = {
   serviceIDDef?: string[]
   typeID: ElemID
   singleton?: boolean
-  customNameMapping: NameMappingFunctionMap<TCustomNameMappingOptions>
+  customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>
 }
 
 export type ElementFetchDefinitionOptions = {

--- a/packages/adapter-components/src/definitions/system/fetch/fetch.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/fetch.ts
@@ -15,9 +15,13 @@
  */
 import { FetchResourceDefinition } from './resource'
 // eslint-disable-next-line import/no-cycle
-import { ElementFetchDefinition } from './element'
+import { ElementFetchDefinition, ElementFetchDefinitionOptions } from './element'
 import { DefaultWithCustomizations } from '../shared/types'
 import { FetchRequestDefinition } from './request'
+import { APIDefinitionsOptions, ResolveClientOptionsType } from '../api'
+
+export type FetchApiDefinitionsOptions = Pick<APIDefinitionsOptions, 'clientOptions' | 'customNameMappingOptions'> &
+  Pick<ElementFetchDefinitionOptions, 'values'>
 
 /**
  * Fetch flow:
@@ -31,18 +35,18 @@ import { FetchRequestDefinition } from './request'
  * - Once all fragments of a resource have been fetched, the resource is created using the mergeAndTransform definition
  * - Once all resources have been generated, elements are produced
  */
-export type InstanceFetchApiDefinitions<ClientOptions extends string = 'main'> = {
+export type InstanceFetchApiDefinitions<Options extends FetchApiDefinitionsOptions = {}> = {
   // "edges" specifying how to generate resources from endpoint calls.
-  requests?: FetchRequestDefinition<ClientOptions>[]
+  requests?: FetchRequestDefinition<ResolveClientOptionsType<Options>>[]
 
   // a resource aggregates fragments associated with the same logical entity from various requests by a service id,
   // and transforms the value that will become the instance(s). it is mainly used for orchestrating the structure and
   // requests for complex types
   resource?: FetchResourceDefinition
 
-  element?: ElementFetchDefinition
+  element?: ElementFetchDefinition<Options>
 }
 
-export type FetchApiDefinitions<ClientOptions extends string = 'main'> = {
-  instances: DefaultWithCustomizations<InstanceFetchApiDefinitions<ClientOptions>>
+export type FetchApiDefinitions<Options extends FetchApiDefinitionsOptions = {}> = {
+  instances: DefaultWithCustomizations<InstanceFetchApiDefinitions<Options>>
 }

--- a/packages/adapter-components/src/definitions/system/fetch/fetch.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/fetch.ts
@@ -22,7 +22,7 @@ import { APIDefinitionsOptions, ResolveClientOptionsType, ResolveCustomNameMappi
 import { NameMappingFunctionMap } from '../shared'
 
 export type FetchApiDefinitionsOptions = Pick<APIDefinitionsOptions, 'clientOptions' | 'customNameMappingOptions'> &
-  Pick<ElementFetchDefinitionOptions, 'values'>
+  Pick<ElementFetchDefinitionOptions, 'valueType'>
 
 /**
  * Fetch flow:
@@ -50,5 +50,5 @@ export type InstanceFetchApiDefinitions<Options extends FetchApiDefinitionsOptio
 
 export type FetchApiDefinitions<Options extends FetchApiDefinitionsOptions = {}> = {
   instances: DefaultWithCustomizations<InstanceFetchApiDefinitions<Options>>
-  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
 }

--- a/packages/adapter-components/src/definitions/system/fetch/fetch.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/fetch.ts
@@ -18,7 +18,8 @@ import { FetchResourceDefinition } from './resource'
 import { ElementFetchDefinition, ElementFetchDefinitionOptions } from './element'
 import { DefaultWithCustomizations } from '../shared/types'
 import { FetchRequestDefinition } from './request'
-import { APIDefinitionsOptions, ResolveClientOptionsType } from '../api'
+import { APIDefinitionsOptions, ResolveClientOptionsType, ResolveCustomNameMappingOptionsType } from '../api'
+import { NameMappingFunctionMap } from '../shared'
 
 export type FetchApiDefinitionsOptions = Pick<APIDefinitionsOptions, 'clientOptions' | 'customNameMappingOptions'> &
   Pick<ElementFetchDefinitionOptions, 'values'>
@@ -49,4 +50,5 @@ export type InstanceFetchApiDefinitions<Options extends FetchApiDefinitionsOptio
 
 export type FetchApiDefinitions<Options extends FetchApiDefinitionsOptions = {}> = {
   instances: DefaultWithCustomizations<InstanceFetchApiDefinitions<Options>>
+  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
 }

--- a/packages/adapter-components/src/definitions/system/fetch/index.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/index.ts
@@ -16,7 +16,7 @@
 /* eslint-disable import/no-cycle */
 
 export { ContextCombinationDefinition } from './dependencies'
-export { FetchApiDefinitions, InstanceFetchApiDefinitions } from './fetch'
+export { FetchApiDefinitions, InstanceFetchApiDefinitions, FetchApiDefinitionsOptions } from './fetch'
 export { FetchRequestDefinition } from './request'
 export { ResourceTransformFunc } from './resource'
 export { ElementFieldCustomization, FieldIDPart, ElementFetchDefinition } from './element'

--- a/packages/adapter-components/src/definitions/system/fetch/types.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/types.ts
@@ -16,16 +16,21 @@
 import { ElemIdGetter, ObjectType, Values } from '@salto-io/adapter-api'
 import { DefQuery } from '../utils'
 // eslint-disable-next-line import/no-cycle
-import { InstanceFetchApiDefinitions } from './fetch'
+import { FetchApiDefinitionsOptions, InstanceFetchApiDefinitions } from './fetch'
+import { NameMappingFunctionMap } from '../shared'
+import { ResolveCustomNameMappingOptionsType } from '../api'
 
-export type ElementAndResourceDefFinder = DefQuery<Pick<InstanceFetchApiDefinitions, 'element' | 'resource'>>
+export type ElementAndResourceDefFinder<Options extends FetchApiDefinitionsOptions = {}> = DefQuery<
+  Pick<InstanceFetchApiDefinitions<Options>, 'element' | 'resource'>
+>
 
-export type GenerateTypeArgs = {
+export type GenerateTypeArgs<Options extends FetchApiDefinitionsOptions = {}> = {
   adapterName: string
   typeName: string
   parentName?: string
   entries: Values[]
-  defQuery: ElementAndResourceDefFinder
+  defQuery: ElementAndResourceDefFinder<Options>
+  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   typeNameOverrides?: Record<string, string>
   isUnknownEntry?: (value: unknown) => boolean
   definedTypes?: Record<string, ObjectType>

--- a/packages/adapter-components/src/definitions/system/fetch/types.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/types.ts
@@ -30,7 +30,7 @@ export type GenerateTypeArgs<Options extends FetchApiDefinitionsOptions = {}> = 
   parentName?: string
   entries: Values[]
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   typeNameOverrides?: Record<string, string>
   isUnknownEntry?: (value: unknown) => boolean
   definedTypes?: Record<string, ObjectType>

--- a/packages/adapter-components/src/definitions/system/fetch/types.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/types.ts
@@ -30,7 +30,7 @@ export type GenerateTypeArgs<Options extends FetchApiDefinitionsOptions = {}> = 
   parentName?: string
   entries: Values[]
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   typeNameOverrides?: Record<string, string>
   isUnknownEntry?: (value: unknown) => boolean
   definedTypes?: Record<string, ObjectType>

--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -14,13 +14,20 @@
  * limitations under the License.
  */
 
-export { ApiDefinitions } from './api'
+export {
+  ApiDefinitions,
+  APIDefinitionsOptions,
+  ResolveClientOptionsType,
+  ResolvePaginationOptionsType,
+  ResolveCustomNameMappingOptionsType,
+} from './api'
 export * as deploy from './deploy'
 export * as fetch from './fetch'
 export * from './requests'
 export {
   DATA_FIELD_ENTIRE_OBJECT,
   NameMappingOptions,
+  NameMappingFunctionMap,
   DefaultWithCustomizations,
   ArgsWithCustomizer,
   OptionsWithDefault,

--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -27,6 +27,7 @@ export * from './requests'
 export {
   DATA_FIELD_ENTIRE_OBJECT,
   NameMappingOptions,
+  NameMappingFunction,
   NameMappingFunctionMap,
   DefaultWithCustomizations,
   ArgsWithCustomizer,

--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -21,9 +21,13 @@ export const DATA_FIELD_ENTIRE_OBJECT = '.'
 
 export type NameMappingOptions = 'lowercase' | 'uppercase'
 
+export type NameMappingFunction = (name: unknown) => string
+
 export type NameMappingFunctionMap<TCustomOptions extends string = never> = Record<
-  Exclude<TCustomOptions, NameMappingOptions>,
-  (name: string) => string
+  Exclude<TCustomOptions, NameMappingOptions>, // We need this exclusion for 2 reasons:
+  // 1. In case TCustomOptions are not defined and fallback to the default options (NameMappingOptions), we don't want TS to enforce us to define their mapping
+  // 2. We don't want to allow the default options logic to be overridden by a custom one
+  NameMappingFunction
 >
 
 export type ContextParams = Record<string, unknown>

--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -21,6 +21,11 @@ export const DATA_FIELD_ENTIRE_OBJECT = '.'
 
 export type NameMappingOptions = 'lowercase' | 'uppercase'
 
+export type NameMappingFunctionMap<TCustomOptions extends string = never> = Record<
+  Exclude<TCustomOptions, NameMappingOptions>,
+  (name: string) => string
+>
+
 export type ContextParams = Record<string, unknown>
 
 export type GeneratedItem<TContext = ContextParams, TVal = unknown> = {

--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -24,9 +24,10 @@ export type NameMappingOptions = 'lowercase' | 'uppercase'
 export type NameMappingFunction = (name: unknown) => string
 
 export type NameMappingFunctionMap<TCustomOptions extends string = never> = Record<
-  Exclude<TCustomOptions, NameMappingOptions>, // We need this exclusion for 2 reasons:
+  // We need this exclusion for 2 reasons:
   // 1. In case TCustomOptions are not defined and fallback to the default options (NameMappingOptions), we don't want TS to enforce us to define their mapping
   // 2. We don't want to allow the default options logic to be overridden by a custom one
+  Exclude<TCustomOptions, NameMappingOptions>,
   NameMappingFunction
 >
 

--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -18,6 +18,8 @@ import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { DefaultWithCustomizations } from './shared/types'
 import { UserFetchConfig } from '../user'
 import { FetchApiDefinitions, FetchApiDefinitionsOptions } from './fetch'
+import { NameMappingFunctionMap } from './shared'
+import { ResolveCustomNameMappingOptionsType } from './api'
 
 /**
  * merge a single custom definition with a default, assuming they came from a DefaultWithCustomizations definition.
@@ -119,7 +121,12 @@ export const mergeWithUserElemIDDefinitions = <Options extends FetchApiDefinitio
   fetchConfig?: FetchApiDefinitions<Options>
 }): FetchApiDefinitions<Options> => {
   if (userElemID === undefined) {
-    return fetchConfig ?? { instances: { customizations: {} } }
+    return (
+      fetchConfig ?? {
+        instances: { customizations: {} },
+        customNameMappingFunctions: {} as NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>,
+      }
+    )
   }
   return _.merge({}, fetchConfig, {
     instances: {

--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -18,8 +18,6 @@ import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { DefaultWithCustomizations } from './shared/types'
 import { UserFetchConfig } from '../user'
 import { FetchApiDefinitions, FetchApiDefinitionsOptions } from './fetch'
-import { NameMappingFunctionMap } from './shared'
-import { ResolveCustomNameMappingOptionsType } from './api'
 
 /**
  * merge a single custom definition with a default, assuming they came from a DefaultWithCustomizations definition.
@@ -124,7 +122,6 @@ export const mergeWithUserElemIDDefinitions = <Options extends FetchApiDefinitio
     return (
       fetchConfig ?? {
         instances: { customizations: {} },
-        customNameMappingFunctions: {} as NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>,
       }
     )
   }

--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { DefaultWithCustomizations } from './shared/types'
 import { UserFetchConfig } from '../user'
-import { FetchApiDefinitions } from './fetch'
+import { FetchApiDefinitions, FetchApiDefinitionsOptions } from './fetch'
 
 /**
  * merge a single custom definition with a default, assuming they came from a DefaultWithCustomizations definition.
@@ -111,13 +111,13 @@ export const getNestedWithDefault = <T, TNested, K extends string>(
  * this function combines these two, by treating the user-provided overrides as customizations
  * and giving them precedence when merging with the system definitions
  */
-export const mergeWithUserElemIDDefinitions = <ClientOptions extends string>({
+export const mergeWithUserElemIDDefinitions = <Options extends FetchApiDefinitionsOptions>({
   userElemID,
   fetchConfig,
 }: {
-  userElemID: UserFetchConfig['elemID']
-  fetchConfig?: FetchApiDefinitions<ClientOptions>
-}): FetchApiDefinitions<ClientOptions> => {
+  userElemID: UserFetchConfig<Options>['elemID']
+  fetchConfig?: FetchApiDefinitions<Options>
+}): FetchApiDefinitions<Options> => {
   if (userElemID === undefined) {
     return fetchConfig ?? { instances: { customizations: {} } }
   }

--- a/packages/adapter-components/src/definitions/user/fetch_config.ts
+++ b/packages/adapter-components/src/definitions/user/fetch_config.ts
@@ -26,6 +26,8 @@ import {
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { ElemIDDefinition, FieldIDPart } from '../system/fetch/element'
+import { NameMappingOptions, ResolveCustomNameMappingOptionsType } from '../system'
+import { FetchApiDefinitionsOptions } from '../system/fetch'
 
 export type DefaultFetchCriteria = {
   name?: string
@@ -36,15 +38,23 @@ type FetchEntry<T extends Record<string, unknown> | undefined> = {
   criteria?: T
 }
 
-export type ElemIDCustomization = ElemIDDefinition & {
-  // when true - appends the added fields to the system-defined ones
-  // when false - overrides the system's default for the specified type
-  extendSystemPartsDefinition?: boolean
+export type ElemIDCustomization<TCustomNameMappingOptions extends string> =
+  ElemIDDefinition<TCustomNameMappingOptions> & {
+    // when true - appends the added fields to the system-defined ones
+    // when false - overrides the system's default for the specified type
+    extendSystemPartsDefinition?: boolean
+  }
+
+export type UserFetchConfigOptions = Pick<FetchApiDefinitionsOptions, 'customNameMappingOptions'> & {
+  fetchCriteria?: Record<string, unknown>
 }
 
-export type UserFetchConfig<T extends Record<string, unknown> | undefined = DefaultFetchCriteria> = {
-  include: FetchEntry<T>[]
-  exclude: FetchEntry<T>[]
+type ResolveFetchCriteriaType<Options extends Pick<UserFetchConfigOptions, 'fetchCriteria'>> =
+  Options['fetchCriteria'] extends Record<string, unknown> ? Options['fetchCriteria'] : DefaultFetchCriteria
+
+export type UserFetchConfig<Options extends UserFetchConfigOptions = {}> = {
+  include: FetchEntry<ResolveFetchCriteriaType<Options>>[]
+  exclude: FetchEntry<ResolveFetchCriteriaType<Options>>[]
   hideTypes?: boolean
   // TODO deprecate and remove once the migration is complete and everything is async
   asyncPagination?: boolean
@@ -52,10 +62,10 @@ export type UserFetchConfig<T extends Record<string, unknown> | undefined = Defa
   // TODO validate that the types are valid and top-level
   // TODO (informative, remove after discussions) - not using default+customizations to avoid questions about
   //   priorities between user default and system custom
-  elemID?: Record<string, ElemIDCustomization>
+  elemID?: Record<string, ElemIDCustomization<ResolveCustomNameMappingOptionsType<Options>>>
 }
 
-export const createUserFetchConfigType = ({
+export const createUserFetchConfigType = <TCustomNameMappingOptions extends string>({
   adapterName,
   additionalFields,
   fetchCriteriaType,
@@ -95,7 +105,8 @@ export const createUserFetchConfigType = ({
     fetchEntryType.fields.criteria = new Field(fetchEntryType, 'criteria', fetchCriteriaType)
   }
 
-  const elemIDPartType = createMatchingObjectType<Omit<FieldIDPart, 'condition' | 'custom'>>({
+  // TODO: find if there's a way to specify the generic type here of TCustomNameMappingOptions
+  const elemIDPartType = createMatchingObjectType<Omit<FieldIDPart<NameMappingOptions>, 'condition' | 'custom'>>({
     elemID: new ElemID(adapterName, 'ElemIDPart'),
     fields: {
       fieldName: {
@@ -113,7 +124,7 @@ export const createUserFetchConfigType = ({
     },
   })
 
-  const elemIDCustomizationType = createMatchingObjectType<ElemIDCustomization>({
+  const elemIDCustomizationType = createMatchingObjectType<ElemIDCustomization<TCustomNameMappingOptions>>({
     elemID: new ElemID(adapterName, 'ElemIDCustomization'),
     fields: {
       extendsParent: {
@@ -134,7 +145,7 @@ export const createUserFetchConfigType = ({
     },
   })
 
-  const type = createMatchingObjectType<UserFetchConfig>({
+  const type = createMatchingObjectType<UserFetchConfig<{ customNameMappingOptions: TCustomNameMappingOptions }>>({
     elemID: new ElemID(adapterName, 'userFetchConfig'),
     fields: {
       include: {

--- a/packages/adapter-components/src/definitions/user/fetch_config.ts
+++ b/packages/adapter-components/src/definitions/user/fetch_config.ts
@@ -105,7 +105,7 @@ export const createUserFetchConfigType = <TCustomNameMappingOptions extends stri
     fetchEntryType.fields.criteria = new Field(fetchEntryType, 'criteria', fetchCriteriaType)
   }
 
-  // TODO: find if there's a way to specify the generic type here of TCustomNameMappingOptions
+  // TODO SALTO-5595: find if there's a way to specify the generic type here of TCustomNameMappingOptions
   const elemIDPartType = createMatchingObjectType<Omit<FieldIDPart<NameMappingOptions>, 'condition' | 'custom'>>({
     elemID: new ElemID(adapterName, 'ElemIDPart'),
     fields: {

--- a/packages/adapter-components/src/definitions/user/fetch_config.ts
+++ b/packages/adapter-components/src/definitions/user/fetch_config.ts
@@ -38,7 +38,7 @@ type FetchEntry<T extends Record<string, unknown> | undefined> = {
   criteria?: T
 }
 
-export type ElemIDCustomization<TCustomNameMappingOptions extends string> =
+export type ElemIDCustomization<TCustomNameMappingOptions extends string = never> =
   ElemIDDefinition<TCustomNameMappingOptions> & {
     // when true - appends the added fields to the system-defined ones
     // when false - overrides the system's default for the specified type
@@ -65,7 +65,7 @@ export type UserFetchConfig<Options extends UserFetchConfigOptions = {}> = {
   elemID?: Record<string, ElemIDCustomization<ResolveCustomNameMappingOptionsType<Options>>>
 }
 
-export const createUserFetchConfigType = <TCustomNameMappingOptions extends string>({
+export const createUserFetchConfigType = <TCustomNameMappingOptions extends string = never>({
   adapterName,
   additionalFields,
   fetchCriteriaType,

--- a/packages/adapter-components/src/definitions/user/index.ts
+++ b/packages/adapter-components/src/definitions/user/index.ts
@@ -17,7 +17,13 @@
 // eslint-disable-next-line import/no-cycle
 export { UserConfig, createUserConfigType, ConfigTypeCreator } from './user_config'
 // eslint-disable-next-line import/no-cycle
-export { UserFetchConfig, createUserFetchConfigType, ElemIDCustomization, DefaultFetchCriteria } from './fetch_config'
+export {
+  UserFetchConfig,
+  createUserFetchConfigType,
+  ElemIDCustomization,
+  DefaultFetchCriteria,
+  UserFetchConfigOptions,
+} from './fetch_config'
 export {
   UserDeployConfig,
   createUserDeployConfigType,

--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -19,24 +19,28 @@ import { createClientConfigType, ClientBaseConfig, ClientRateLimitConfig } from 
 import { UserFetchConfig, createUserFetchConfigType } from './fetch_config'
 import { UserDeployConfig, createChangeValidatorConfigType, createUserDeployConfigType } from './deploy_config'
 
-export type UserConfig = {
+export type UserConfig<TCustomNameMappingOptions extends string> = {
   client: ClientBaseConfig<ClientRateLimitConfig>
-  fetch: UserFetchConfig
+  fetch: UserFetchConfig<{ customNameMappingOptions: TCustomNameMappingOptions }>
   deploy?: UserDeployConfig
 }
 
-export type ConfigTypeCreator = (args: {
+type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string> = {
   adapterName: string
-  defaultConfig?: Partial<UserConfig>
+  defaultConfig?: Partial<UserConfig<TCustomNameMappingOptions>>
   additionalFields?: Record<string, FieldDefinition>
   additionalFetchFields?: Record<string, FieldDefinition>
   additionalDeployFields?: Record<string, FieldDefinition>
   additionalClientFields?: Record<string, FieldDefinition>
   changeValidatorNames?: string[]
   omitElemID?: boolean
-}) => ObjectType
+}
 
-export const createUserConfigType: ConfigTypeCreator = ({
+export type ConfigTypeCreator<TCustomNameMappingOptions extends string> = (
+  args: ConfigTypeCreatorParams<TCustomNameMappingOptions>,
+) => ObjectType
+
+export const createUserConfigType = <TCustomNameMappingOptions extends string>({
   adapterName,
   defaultConfig,
   changeValidatorNames = [],
@@ -45,8 +49,8 @@ export const createUserConfigType: ConfigTypeCreator = ({
   additionalDeployFields,
   additionalClientFields,
   omitElemID,
-}) =>
-  createMatchingObjectType<Partial<UserConfig>>({
+}: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType =>
+  createMatchingObjectType<Partial<UserConfig<TCustomNameMappingOptions>>>({
     elemID: new ElemID(adapterName),
     fields: {
       client: {

--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -19,13 +19,13 @@ import { createClientConfigType, ClientBaseConfig, ClientRateLimitConfig } from 
 import { UserFetchConfig, createUserFetchConfigType } from './fetch_config'
 import { UserDeployConfig, createChangeValidatorConfigType, createUserDeployConfigType } from './deploy_config'
 
-export type UserConfig<TCustomNameMappingOptions extends string> = {
+export type UserConfig<TCustomNameMappingOptions extends string = never> = {
   client: ClientBaseConfig<ClientRateLimitConfig>
   fetch: UserFetchConfig<{ customNameMappingOptions: TCustomNameMappingOptions }>
   deploy?: UserDeployConfig
 }
 
-type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string> = {
+type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string = never> = {
   adapterName: string
   defaultConfig?: Partial<UserConfig<TCustomNameMappingOptions>>
   additionalFields?: Record<string, FieldDefinition>
@@ -36,11 +36,11 @@ type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string> = {
   omitElemID?: boolean
 }
 
-export type ConfigTypeCreator<TCustomNameMappingOptions extends string> = (
+export type ConfigTypeCreator<TCustomNameMappingOptions extends string = never> = (
   args: ConfigTypeCreatorParams<TCustomNameMappingOptions>,
 ) => ObjectType
 
-export const createUserConfigType = <TCustomNameMappingOptions extends string>({
+export const createUserConfigType = <TCustomNameMappingOptions extends string = never>({
   adapterName,
   defaultConfig,
   changeValidatorNames = [],

--- a/packages/adapter-components/src/deployment/placeholder_types.ts
+++ b/packages/adapter-components/src/deployment/placeholder_types.ts
@@ -43,6 +43,7 @@ export const overrideInstanceTypeForDeploy = ({
     typeName,
     defQuery,
     isUnknownEntry: isReferenceExpression,
+    customNameMappingFunctions: {},
   })
   const definedTypes = _.keyBy([generatedType.type, ...generatedType.nestedTypes], t => t.elemID.typeName)
   adjustFieldTypes({ definedTypes, defQuery })

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -103,7 +103,7 @@ export const getInstanceFilePath = ({
   const fileName = fileNameParts?.every(p => _.isString(p) || _.isNumber(p)) ? fileNameParts.join('_') : undefined
   const naclCaseFileName = fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)
   const mappedNaclCaseFileName = nameMapping
-    ? getNameMapping({ name: naclCaseFileName, nameMapping, customNameMapping: {} })
+    ? getNameMapping({ name: naclCaseFileName, nameMapping, customNameMappingFunctions: {} })
     : naclCaseFileName
   return isSettingType
     ? [adapterName, RECORDS_PATH, SETTINGS_NESTED_PATH, pathNaclCase(typeName)]
@@ -128,7 +128,7 @@ export const generateInstanceNameFromConfig = (
   )
   const instanceName = getInstanceName(values, idFields, typeName)
   return instanceName !== undefined
-    ? getNameMapping({ name: instanceName, nameMapping, customNameMapping: {} })
+    ? getNameMapping({ name: instanceName, nameMapping, customNameMappingFunctions: {} })
     : instanceName
 }
 
@@ -167,7 +167,9 @@ export const getInstanceNaclName = ({
   const newName = parentName ? `${parentName}${nameWithSeparator}` : String(name)
   const naclName = naclCase(newName)
 
-  const desiredName = nameMapping ? getNameMapping({ name: naclName, nameMapping, customNameMapping: {} }) : naclName
+  const desiredName = nameMapping
+    ? getNameMapping({ name: naclName, nameMapping, customNameMappingFunctions: {} })
+    : naclName
   return getElemIdFunc && serviceIdField
     ? getElemIdFunc(
         adapterName,

--- a/packages/adapter-components/src/elements/instance_elements.ts
+++ b/packages/adapter-components/src/elements/instance_elements.ts
@@ -102,7 +102,9 @@ export const getInstanceFilePath = ({
   const fileNameParts = fileNameFields !== undefined ? fileNameFields.map(field => _.get(entry, field)) : undefined
   const fileName = fileNameParts?.every(p => _.isString(p) || _.isNumber(p)) ? fileNameParts.join('_') : undefined
   const naclCaseFileName = fileName ? pathNaclCase(naclCase(fileName)) : pathNaclCase(naclName)
-  const mappedNaclCaseFileName = nameMapping ? getNameMapping(naclCaseFileName, nameMapping) : naclCaseFileName
+  const mappedNaclCaseFileName = nameMapping
+    ? getNameMapping({ name: naclCaseFileName, nameMapping, customNameMapping: {} })
+    : naclCaseFileName
   return isSettingType
     ? [adapterName, RECORDS_PATH, SETTINGS_NESTED_PATH, pathNaclCase(typeName)]
     : [
@@ -125,7 +127,9 @@ export const generateInstanceNameFromConfig = (
     apiDefinitions.typeDefaults.transformation,
   )
   const instanceName = getInstanceName(values, idFields, typeName)
-  return instanceName !== undefined ? getNameMapping(instanceName, nameMapping) : instanceName
+  return instanceName !== undefined
+    ? getNameMapping({ name: instanceName, nameMapping, customNameMapping: {} })
+    : instanceName
 }
 
 export const removeNullValuesTransformFunc: TransformFuncSync = ({ value }) => (value === null ? undefined : value)
@@ -163,7 +167,7 @@ export const getInstanceNaclName = ({
   const newName = parentName ? `${parentName}${nameWithSeparator}` : String(name)
   const naclName = naclCase(newName)
 
-  const desiredName = nameMapping ? getNameMapping(naclName, nameMapping) : naclName
+  const desiredName = nameMapping ? getNameMapping({ name: naclName, nameMapping, customNameMapping: {} }) : naclName
   return getElemIdFunc && serviceIdField
     ? getElemIdFunc(
         adapterName,

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -49,7 +49,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
 }: {
   adapterName: string
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   predefinedTypes?: Record<string, ObjectType>
   getElemIdFunc?: ElemIdGetter
 }): ElementGenerator => {

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -44,12 +44,12 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
   adapterName,
   defQuery,
   predefinedTypes,
-  customNameMapping,
+  customNameMappingFunctions,
   getElemIdFunc,
 }: {
   adapterName: string
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   predefinedTypes?: Record<string, ObjectType>
   getElemIdFunc?: ElemIdGetter
 }): ElementGenerator => {
@@ -84,7 +84,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
           typeName,
           definedTypes: predefinedTypes,
           getElemIdFunc,
-          customNameMapping,
+          customNameMappingFunctions,
         })
       } catch (e) {
         // TODO decide how to handle error based on args (SALTO-5427)

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -18,12 +18,13 @@ import { ElemIdGetter, Element, ObjectType, SeverityLevel, Values } from '@salto
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
-import { ElementQuery } from '../query'
 import { FetchElements } from '../types'
 import { generateInstancesWithInitialTypes } from './instance_element'
 import { adjustFieldTypes } from './type_utils'
 import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/types'
 import { InvalidSingletonType } from '../../config/shared' // TODO move
+import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
+import { NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'
 
 const log = logger(module)
 
@@ -39,15 +40,16 @@ export type ElementGenerator = {
   generate: () => FetchElements
 }
 
-export const getElementGenerator = ({
+export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>({
   adapterName,
   defQuery,
   predefinedTypes,
+  customNameMapping,
   getElemIdFunc,
 }: {
   adapterName: string
-  fetchQuery: ElementQuery
-  defQuery: ElementAndResourceDefFinder
+  defQuery: ElementAndResourceDefFinder<Options>
+  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   predefinedTypes?: Record<string, ObjectType>
   getElemIdFunc?: ElemIdGetter
 }): ElementGenerator => {
@@ -82,6 +84,7 @@ export const getElementGenerator = ({
           typeName,
           definedTypes: predefinedTypes,
           getElemIdFunc,
+          customNameMapping,
         })
       } catch (e) {
         // TODO decide how to handle error based on args (SALTO-5427)

--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -80,7 +80,7 @@ export const serviceIDKeyCreator =
  * If the name mapping option or the relevant custom mapping is not provided,
  * the function returns the name as is, after converting it to a string.
  */
-export const getNameMapping = <TCustomNameMappingOptions extends string>({
+export const getNameMapping = <TCustomNameMappingOptions extends string = never>({
   name,
   customNameMappingFunctions,
   nameMapping,
@@ -96,15 +96,15 @@ export const getNameMapping = <TCustomNameMappingOptions extends string>({
   const nameMappingFunctions = {
     ...DEFAULT_NAME_MAPPING_FUNCTIONS,
     ...customNameMappingFunctions,
+    // Unfortunately, TypeScript doesn't recognize that a union of NameMappingOptions and
+    // Exclude<TCustomNameMappingOptions, NameMappingOptions> is equivalent to
+    // NameMappingOptions | TCustomNameMappingOptions. Therefore, explicit casting is necessary :(
   } as Record<NameMappingOptions | TCustomNameMappingOptions, NameMappingFunction>
-  // Unfortunately, TypeScript doesn't recognize that a union of NameMappingOptions and
-  // Exclude<TCustomNameMappingOptions, NameMappingOptions> is equivalent to
-  // NameMappingOptions | TCustomNameMappingOptions. Therefore, explicit casting is necessary :(
   return nameMappingFunctions[nameMapping]?.(name) ?? String(name)
 }
 
 const computeElemIDPartsFunc =
-  <TCustomNameMappingOptions extends string>(
+  <TCustomNameMappingOptions extends string = never>(
     elemIDDef: ElemIDDefinition<TCustomNameMappingOptions>,
     customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>,
   ): PartsCreator =>
@@ -142,7 +142,7 @@ const computeElemIDPartsFunc =
   }
 
 export const createElemIDFunc =
-  <TCustomNameMappingOptions extends string>({
+  <TCustomNameMappingOptions extends string = never>({
     elemIDDef,
     getElemIdFunc,
     serviceIDDef,
@@ -173,7 +173,7 @@ export const createElemIDFunc =
   }
 
 export const getElemPath =
-  <TCustomNameMappingOptions extends string>({
+  <TCustomNameMappingOptions extends string = never>({
     def,
     elemIDCreator,
     typeID,

--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -86,7 +86,7 @@ export const getNameMapping = <TCustomNameMappingOptions extends string = never>
   nameMapping,
 }: {
   name: unknown
-  customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>
+  customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
   nameMapping?: TCustomNameMappingOptions | NameMappingOptions
 }): string => {
   if (!nameMapping) {
@@ -100,13 +100,19 @@ export const getNameMapping = <TCustomNameMappingOptions extends string = never>
     // Exclude<TCustomNameMappingOptions, NameMappingOptions> is equivalent to
     // NameMappingOptions | TCustomNameMappingOptions. Therefore, explicit casting is necessary :(
   } as Record<NameMappingOptions | TCustomNameMappingOptions, NameMappingFunction>
-  return nameMappingFunctions[nameMapping]?.(name) ?? String(name)
+
+  const requestedMappingFunction = nameMappingFunctions[nameMapping]
+  if (requestedMappingFunction) {
+    return requestedMappingFunction(name)
+  }
+  log.warn('No name mapping function found for %s', nameMapping)
+  return String(name)
 }
 
 const computeElemIDPartsFunc =
   <TCustomNameMappingOptions extends string = never>(
     elemIDDef: ElemIDDefinition<TCustomNameMappingOptions>,
-    customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>,
+    customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>,
   ): PartsCreator =>
   ({ entry, parent }) => {
     const parts = (elemIDDef.parts ?? [])
@@ -186,7 +192,7 @@ export const getElemPath =
     typeID: ElemID
     singleton?: boolean
     nestUnderPath?: string[]
-    customNameMappingFunctions: NameMappingFunctionMap<TCustomNameMappingOptions>
+    customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
   }): PartsCreator =>
   ({ entry, parent, defaultName }) => {
     if (singleton) {

--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -32,7 +32,7 @@ const log = logger(module)
 export const generateInstancesWithInitialTypes = <Options extends FetchApiDefinitionsOptions>(
   args: Omit<GenerateTypeArgs<Options>, 'parentName' | 'isMapWithDynamicType' | 'typeNameOverrides'>,
 ): ElementsAndErrors => {
-  const { defQuery, entries, adapterName, typeName, getElemIdFunc, customNameMapping } = args
+  const { defQuery, entries, adapterName, typeName, getElemIdFunc, customNameMappingFunctions } = args
   const { element: elementDef } = defQuery.query(typeName) ?? {}
   if (elementDef === undefined) {
     log.error('could not find any element definitions for type %s:%s', adapterName, typeName)
@@ -56,7 +56,12 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
   // create a temporary type recursively so we can correctly extract standalone instances
   // note that all types should be re-generated at the end once instance values have been finalized
   const { type, nestedTypes } = generateType(args)
-  const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type, getElemIdFunc, customNameMapping })
+  const { toElemName, toPath } = getInstanceCreationFunctions({
+    defQuery,
+    type,
+    getElemIdFunc,
+    customNameMappingFunctions,
+  })
   // TODO should also nacl-case field names on predefined fields similarly (SALTO-5422)
   const instances = entries
     .map(value => toInstanceValue({ value, type, defQuery }))
@@ -77,7 +82,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
     instances,
     defQuery,
     getElemIdFunc,
-    customNameMapping,
+    customNameMappingFunctions,
   })
 
   return { types: [type, ...nestedTypes], instances: instancesWithStandalone }

--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -20,6 +20,7 @@ import { createInstance, getInstanceCreationFunctions, toInstanceValue } from '.
 import { extractStandaloneInstances } from './standalone'
 import { GenerateTypeArgs } from '../../definitions/system/fetch/types'
 import { InvalidSingletonType } from '../../config/shared' // TODO move
+import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
 
 const log = logger(module)
 
@@ -28,10 +29,10 @@ const log = logger(module)
  * Note: it is recommended to re-generate types after all instances of all types have been created,
  * since there might be some overlaps between subtypes.
  */
-export const generateInstancesWithInitialTypes = (
-  args: Omit<GenerateTypeArgs, 'parentName' | 'isMapWithDynamicType' | 'typeNameOverrides'>,
+export const generateInstancesWithInitialTypes = <Options extends FetchApiDefinitionsOptions>(
+  args: Omit<GenerateTypeArgs<Options>, 'parentName' | 'isMapWithDynamicType' | 'typeNameOverrides'>,
 ): ElementsAndErrors => {
-  const { defQuery, entries, adapterName, typeName, getElemIdFunc } = args
+  const { defQuery, entries, adapterName, typeName, getElemIdFunc, customNameMapping } = args
   const { element: elementDef } = defQuery.query(typeName) ?? {}
   if (elementDef === undefined) {
     log.error('could not find any element definitions for type %s:%s', adapterName, typeName)
@@ -55,7 +56,7 @@ export const generateInstancesWithInitialTypes = (
   // create a temporary type recursively so we can correctly extract standalone instances
   // note that all types should be re-generated at the end once instance values have been finalized
   const { type, nestedTypes } = generateType(args)
-  const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type, getElemIdFunc })
+  const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type, getElemIdFunc, customNameMapping })
   // TODO should also nacl-case field names on predefined fields similarly (SALTO-5422)
   const instances = entries
     .map(value => toInstanceValue({ value, type, defQuery }))
@@ -76,6 +77,7 @@ export const generateInstancesWithInitialTypes = (
     instances,
     defQuery,
     getElemIdFunc,
+    customNameMapping,
   })
 
   return { types: [type, ...nestedTypes], instances: instancesWithStandalone }

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -105,12 +105,12 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   defQuery,
   type,
   getElemIdFunc,
-  customNameMapping,
+  customNameMappingFunctions,
 }: {
   type: ObjectType
   defQuery: ElementAndResourceDefFinder<Options>
   getElemIdFunc?: ElemIdGetter
-  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
 }): {
   toElemName: ElemIDCreator
   toPath: PartsCreator
@@ -136,14 +136,14 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
     getElemIdFunc,
     serviceIDDef: resourceDef?.serviceIDFields,
     typeID: type.elemID,
-    customNameMapping,
+    customNameMappingFunctions,
   })
   const toPath = getElemPath({
     def: elementDef.topLevel.path,
     singleton,
     elemIDCreator: toElemName,
     typeID: type.elemID,
-    customNameMapping,
+    customNameMappingFunctions,
   })
 
   return { toElemName, toPath }

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -110,7 +110,7 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   type: ObjectType
   defQuery: ElementAndResourceDefFinder<Options>
   getElemIdFunc?: ElemIdGetter
-  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
 }): {
   toElemName: ElemIDCreator
   toPath: PartsCreator

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -34,13 +34,13 @@ const extractStandaloneInstancesFromField =
     instanceOutput,
     getElemIdFunc,
     parent,
-    customNameMapping,
+    customNameMappingFunctions,
   }: {
     defQuery: ElementAndResourceDefFinder<Options>
     instanceOutput: InstanceElement[]
     getElemIdFunc?: ElemIdGetter
     parent: InstanceElement
-    customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+    customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   }): TransformFuncSync =>
   ({ value, field }) => {
     if (field === undefined || isReferenceExpression(value)) {
@@ -66,7 +66,7 @@ const extractStandaloneInstancesFromField =
       defQuery,
       type: fieldType,
       getElemIdFunc,
-      customNameMapping,
+      customNameMappingFunctions,
     })
     const newInstances = collections.array.makeArray(value).map((entry, index) =>
       createInstance({
@@ -103,12 +103,12 @@ const extractStandaloneInstancesFromField =
 export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOptions>({
   instances,
   defQuery,
-  customNameMapping,
+  customNameMappingFunctions,
   getElemIdFunc,
 }: {
   instances: InstanceElement[]
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   getElemIdFunc?: ElemIdGetter
 }): InstanceElement[] => {
   const instancesToProcess: InstanceElement[] = []
@@ -132,7 +132,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
         instanceOutput: instancesToProcess,
         getElemIdFunc,
         parent: inst,
-        customNameMapping,
+        customNameMappingFunctions,
       }),
     })
     if (value !== undefined) {

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -40,7 +40,7 @@ const extractStandaloneInstancesFromField =
     instanceOutput: InstanceElement[]
     getElemIdFunc?: ElemIdGetter
     parent: InstanceElement
-    customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+    customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   }): TransformFuncSync =>
   ({ value, field }) => {
     if (field === undefined || isReferenceExpression(value)) {
@@ -108,7 +108,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
 }: {
   instances: InstanceElement[]
   defQuery: ElementAndResourceDefFinder<Options>
-  customNameMappingFunctions: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   getElemIdFunc?: ElemIdGetter
 }): InstanceElement[] => {
   const instancesToProcess: InstanceElement[] = []

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -25,18 +25,22 @@ import { TransformFuncSync, invertNaclCase, transformValuesSync } from '@salto-i
 import { collections } from '@salto-io/lowerdash'
 import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/types'
 import { createInstance, getInstanceCreationFunctions } from './instance_utils'
+import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
+import { NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'
 
 const extractStandaloneInstancesFromField =
-  ({
+  <Options extends FetchApiDefinitionsOptions>({
     defQuery,
     instanceOutput,
     getElemIdFunc,
     parent,
+    customNameMapping,
   }: {
-    defQuery: ElementAndResourceDefFinder
+    defQuery: ElementAndResourceDefFinder<Options>
     instanceOutput: InstanceElement[]
     getElemIdFunc?: ElemIdGetter
     parent: InstanceElement
+    customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   }): TransformFuncSync =>
   ({ value, field }) => {
     if (field === undefined || isReferenceExpression(value)) {
@@ -58,7 +62,12 @@ const extractStandaloneInstancesFromField =
       )
     }
 
-    const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type: fieldType, getElemIdFunc })
+    const { toElemName, toPath } = getInstanceCreationFunctions({
+      defQuery,
+      type: fieldType,
+      getElemIdFunc,
+      customNameMapping,
+    })
     const newInstances = collections.array.makeArray(value).map((entry, index) =>
       createInstance({
         entry,
@@ -91,13 +100,15 @@ const extractStandaloneInstancesFromField =
  *
  * Note: modifies the instances array in-place.
  */
-export const extractStandaloneInstances = ({
+export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOptions>({
   instances,
   defQuery,
+  customNameMapping,
   getElemIdFunc,
 }: {
   instances: InstanceElement[]
-  defQuery: ElementAndResourceDefFinder
+  defQuery: ElementAndResourceDefFinder<Options>
+  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   getElemIdFunc?: ElemIdGetter
 }): InstanceElement[] => {
   const instancesToProcess: InstanceElement[] = []
@@ -121,6 +132,7 @@ export const extractStandaloneInstances = ({
         instanceOutput: instancesToProcess,
         getElemIdFunc,
         parent: inst,
+        customNameMapping,
       }),
     })
     if (value !== undefined) {

--- a/packages/adapter-components/src/fetch/element/type_element.ts
+++ b/packages/adapter-components/src/fetch/element/type_element.ts
@@ -34,11 +34,12 @@ import { SUBTYPES_PATH, TYPES_PATH } from '../../elements/constants'
 import { ARRAY_ITEMS_FIELD } from '../../elements/swagger/type_elements/swagger_parser'
 import { computeTypesToRename, toNestedTypeName, NESTING_SEPARATOR } from './type_utils'
 import { GenerateTypeArgs } from '../../definitions/system/fetch/types'
+import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
 
 const log = logger(module)
 
-const generateNestedType = (
-  args: lowerdashTypes.PickyRequired<GenerateTypeArgs, 'parentName'>,
+const generateNestedType = <Options extends FetchApiDefinitionsOptions>(
+  args: lowerdashTypes.PickyRequired<GenerateTypeArgs<Options>, 'parentName'>,
 ): NestedTypeWithNestedTypes => {
   const { typeName, parentName, entries, isUnknownEntry, isMapWithDynamicType } = args
 
@@ -148,8 +149,8 @@ const normalizeType = (type: ObjectType): ObjectType => {
  *
  * Note: field customizations should be applied separately, once all types have been created
  */
-export const generateType = (
-  args: Omit<GenerateTypeArgs, 'parentName' | 'isMapWithDynamicType'>,
+export const generateType = <Options extends FetchApiDefinitionsOptions>(
+  args: Omit<GenerateTypeArgs<Options>, 'parentName' | 'isMapWithDynamicType'>,
 ): ObjectTypeWithNestedTypes => {
   const {
     adapterName,

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -38,6 +38,7 @@ import {
 import { logger } from '@salto-io/logging'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/types'
+import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
 
 const { isDefined } = lowerdashValues
 const log = logger(module)
@@ -53,11 +54,11 @@ export const toNestedTypeName = (parentName: string, nestedTypeName: string): st
  * - when extracting a standalone field, the provided typename will be used as the extracted instances' type
  *   (and the referring field's type as well)
  */
-export const computeTypesToRename = ({
+export const computeTypesToRename = <Options extends FetchApiDefinitionsOptions>({
   defQuery,
   typeNameOverrides,
 }: {
-  defQuery: ElementAndResourceDefFinder
+  defQuery: ElementAndResourceDefFinder<Options>
   typeNameOverrides?: Record<string, string>
 }): Record<string, string> =>
   typeNameOverrides ??
@@ -221,13 +222,13 @@ export const markServiceIdField = (
 /**
  * Adjust field definitions based on the defined customization.
  */
-export const adjustFieldTypes = ({
+export const adjustFieldTypes = <Options extends FetchApiDefinitionsOptions>({
   definedTypes,
   defQuery,
   finalTypeNames,
 }: {
   definedTypes: Record<string, ObjectType>
-  defQuery: ElementAndResourceDefFinder
+  defQuery: ElementAndResourceDefFinder<Options>
   finalTypeNames?: Set<string>
 }): void => {
   Object.entries(definedTypes).forEach(([typeName, type]) => {

--- a/packages/adapter-components/src/fetch/fetch.ts
+++ b/packages/adapter-components/src/fetch/fetch.ts
@@ -19,7 +19,15 @@ import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { types } from '@salto-io/lowerdash'
 import { ElementQuery } from './query'
-import { ApiDefinitions, getNestedWithDefault, mergeWithDefault, queryWithDefault } from '../definitions'
+import {
+  ApiDefinitions,
+  APIDefinitionsOptions,
+  getNestedWithDefault,
+  mergeWithDefault,
+  NameMappingFunctionMap,
+  queryWithDefault,
+  ResolveCustomNameMappingOptionsType,
+} from '../definitions'
 import { getUniqueConfigSuggestions } from '../elements/ducktype' // TODO move
 import { getRequester } from './request/requester'
 import { createResourceManager } from './resource/resource_manager'
@@ -38,24 +46,19 @@ const log = logger(module)
  * - resources are aggregated by service id, and when ready sent to the element generator
  * - once all resources have been produced, the element generator generates all instances and types
  */
-export const getElements = async <
-  ClientOptions extends string = 'main',
-  PaginationOptions extends string | 'none' = 'none',
-  AdditionalAction extends string = never,
->({
+export const getElements = async <Options extends APIDefinitionsOptions>({
   adapterName,
   fetchQuery,
   definitions,
+  customNameMapping,
   predefinedTypes,
   getElemIdFunc,
   additionalRequestContext,
 }: {
   adapterName: string
   fetchQuery: ElementQuery
-  definitions: types.PickyRequired<
-    ApiDefinitions<ClientOptions, PaginationOptions, AdditionalAction>,
-    'clients' | 'pagination' | 'fetch'
-  >
+  definitions: types.PickyRequired<ApiDefinitions<Options>, 'clients' | 'pagination' | 'fetch'>
+  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   predefinedTypes?: Record<string, ObjectType>
   getElemIdFunc?: ElemIdGetter
   additionalRequestContext?: Record<string, unknown>
@@ -77,7 +80,7 @@ export const getElements = async <
   // the requester is responsible for making all "direct" client requests for a given resource including pagination,
   // i.e., the requests listed under the `requests` definition,
   // and returning the extracted items based on the transformation definition
-  const requester = getRequester<ClientOptions, PaginationOptions>({
+  const requester = getRequester<Options>({
     adapterName,
     clients,
     pagination,
@@ -90,8 +93,8 @@ export const getElements = async <
     adapterName,
     defQuery: queryWithDefault(fetch.instances),
     predefinedTypes: _.pickBy(predefinedTypes, isObjectType),
-    fetchQuery,
     getElemIdFunc,
+    customNameMapping,
   })
 
   // the resource manager is responsible for orchestrating the generation of elements,

--- a/packages/adapter-components/src/fetch/fetch.ts
+++ b/packages/adapter-components/src/fetch/fetch.ts
@@ -24,9 +24,7 @@ import {
   APIDefinitionsOptions,
   getNestedWithDefault,
   mergeWithDefault,
-  NameMappingFunctionMap,
   queryWithDefault,
-  ResolveCustomNameMappingOptionsType,
 } from '../definitions'
 import { getUniqueConfigSuggestions } from '../elements/ducktype' // TODO move
 import { getRequester } from './request/requester'
@@ -92,8 +90,7 @@ export const getElements = async <Options extends APIDefinitionsOptions>({
     defQuery: queryWithDefault(fetch.instances),
     predefinedTypes: _.pickBy(predefinedTypes, isObjectType),
     getElemIdFunc,
-    customNameMappingFunctions:
-      fetch.customNameMappingFunctions ?? ({} as NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>),
+    customNameMappingFunctions: fetch.customNameMappingFunctions,
   })
 
   // the resource manager is responsible for orchestrating the generation of elements,

--- a/packages/adapter-components/src/fetch/fetch.ts
+++ b/packages/adapter-components/src/fetch/fetch.ts
@@ -24,9 +24,7 @@ import {
   APIDefinitionsOptions,
   getNestedWithDefault,
   mergeWithDefault,
-  NameMappingFunctionMap,
   queryWithDefault,
-  ResolveCustomNameMappingOptionsType,
 } from '../definitions'
 import { getUniqueConfigSuggestions } from '../elements/ducktype' // TODO move
 import { getRequester } from './request/requester'
@@ -50,7 +48,6 @@ export const getElements = async <Options extends APIDefinitionsOptions>({
   adapterName,
   fetchQuery,
   definitions,
-  customNameMapping,
   predefinedTypes,
   getElemIdFunc,
   additionalRequestContext,
@@ -58,7 +55,6 @@ export const getElements = async <Options extends APIDefinitionsOptions>({
   adapterName: string
   fetchQuery: ElementQuery
   definitions: types.PickyRequired<ApiDefinitions<Options>, 'clients' | 'pagination' | 'fetch'>
-  customNameMapping: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   predefinedTypes?: Record<string, ObjectType>
   getElemIdFunc?: ElemIdGetter
   additionalRequestContext?: Record<string, unknown>
@@ -94,7 +90,7 @@ export const getElements = async <Options extends APIDefinitionsOptions>({
     defQuery: queryWithDefault(fetch.instances),
     predefinedTypes: _.pickBy(predefinedTypes, isObjectType),
     getElemIdFunc,
-    customNameMapping,
+    customNameMappingFunctions: fetch.customNameMappingFunctions,
   })
 
   // the resource manager is responsible for orchestrating the generation of elements,

--- a/packages/adapter-components/src/fetch/fetch.ts
+++ b/packages/adapter-components/src/fetch/fetch.ts
@@ -24,7 +24,9 @@ import {
   APIDefinitionsOptions,
   getNestedWithDefault,
   mergeWithDefault,
+  NameMappingFunctionMap,
   queryWithDefault,
+  ResolveCustomNameMappingOptionsType,
 } from '../definitions'
 import { getUniqueConfigSuggestions } from '../elements/ducktype' // TODO move
 import { getRequester } from './request/requester'
@@ -90,7 +92,8 @@ export const getElements = async <Options extends APIDefinitionsOptions>({
     defQuery: queryWithDefault(fetch.instances),
     predefinedTypes: _.pickBy(predefinedTypes, isObjectType),
     getElemIdFunc,
-    customNameMappingFunctions: fetch.customNameMappingFunctions,
+    customNameMappingFunctions:
+      fetch.customNameMappingFunctions ?? ({} as NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>),
   })
 
   // the resource manager is responsible for orchestrating the generation of elements,

--- a/packages/adapter-components/src/fetch/query/query.ts
+++ b/packages/adapter-components/src/fetch/query/query.ts
@@ -15,7 +15,7 @@
  */
 import { InstanceElement, Value } from '@salto-io/adapter-api'
 import { MockInterface } from '@salto-io/test-utils'
-import { UserFetchConfig } from '../../definitions/user'
+import { UserFetchConfig, UserFetchConfigOptions } from '../../definitions/user'
 
 export const ALL_TYPES = '.*'
 
@@ -46,8 +46,8 @@ const isPredicatesMatch = (
     .filter(([key]) => key in criteria)
     .every(([key, value]) => criteria[key]({ instance, value }))
 
-export const createElementQuery = <T extends Record<string, unknown>>(
-  fetchConfig: UserFetchConfig<T | undefined>,
+export const createElementQuery = <Options extends UserFetchConfigOptions>(
+  fetchConfig: UserFetchConfig<Options>,
   allCriteria: Record<string, QueryCriterion> = {},
 ): ElementQuery => ({
   isTypeMatch: (typeName: string) => {

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -69,7 +69,6 @@ const createExtractor = <ClientOptions extends string>(
     )
 }
 
-// TODO SVH: double-check it it's okay that ClientOptions are now optional
 export const getRequester = <Options extends APIDefinitionsOptions>({
   adapterName,
   clients,

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -25,7 +25,12 @@ import { createValueTransformer } from '../utils'
 import { traversePages } from './pagination/pagination'
 import { noPagination } from './pagination'
 import { computeArgCombinations } from '../resource/request_parameters'
-import { HTTPEndpointDetails } from '../../definitions/system'
+import {
+  APIDefinitionsOptions,
+  HTTPEndpointDetails,
+  ResolveClientOptionsType,
+  ResolvePaginationOptionsType,
+} from '../../definitions/system'
 import { FetchRequestDefinition } from '../../definitions/system/fetch'
 
 const log = logger(module)
@@ -64,27 +69,30 @@ const createExtractor = <ClientOptions extends string>(
     )
 }
 
-export const getRequester = <ClientOptions extends string, PaginationOptions extends string | 'none'>({
+// TODO SVH: double-check it it's okay that ClientOptions are now optional
+export const getRequester = <Options extends APIDefinitionsOptions>({
   adapterName,
   clients,
   pagination,
   requestDefQuery,
 }: {
   adapterName: string
-  clients: ApiDefinitions<ClientOptions, PaginationOptions>['clients']
-  pagination: ApiDefinitions<ClientOptions, PaginationOptions>['pagination']
-  requestDefQuery: DefQuery<FetchRequestDefinition<ClientOptions>[]>
-}): Requester<ClientOptions> => {
+  clients: ApiDefinitions<Options>['clients']
+  pagination: ApiDefinitions<Options>['pagination']
+  requestDefQuery: DefQuery<FetchRequestDefinition<ResolveClientOptionsType<Options>>[]>
+}): Requester<ResolveClientOptionsType<Options>> => {
   const clientDefs = _.mapValues(clients.options, ({ endpoints, ...def }) => ({
     endpoints: queryWithDefault(endpoints),
     ...def,
   }))
 
   const getMergedRequestDefinition = (
-    requestDef: FetchRequestDefinition<ClientOptions>,
+    requestDef: FetchRequestDefinition<ResolveClientOptionsType<Options>>,
   ): {
-    merged: FetchRequestDefinition<ClientOptions> & { endpoint: HTTPEndpointDetails<PaginationOptions> }
-    clientName: ClientOptions
+    merged: FetchRequestDefinition<ResolveClientOptionsType<Options>> & {
+      endpoint: HTTPEndpointDetails<ResolvePaginationOptionsType<Options>>
+    }
+    clientName: ResolveClientOptionsType<Options>
   } => {
     const { endpoint: requestEndpoint } = requestDef
     const clientName = requestEndpoint.client ?? clients.default
@@ -107,7 +115,11 @@ export const getRequester = <ClientOptions extends string, PaginationOptions ext
     }
   }
 
-  const request: Requester<ClientOptions>['request'] = async ({ contexts, requestDef, typeName }) => {
+  const request: Requester<ResolveClientOptionsType<Options>>['request'] = async ({
+    contexts,
+    requestDef,
+    typeName,
+  }) => {
     // TODO optimizations for requests made from multiple "flows":
     // * cache only the "unconsumed" extracted items by request hash, and keep them available until consumed
     // * add promises for in-flight requests, to avoid making the same request multiple times in parallel
@@ -163,7 +175,7 @@ export const getRequester = <ClientOptions extends string, PaginationOptions ext
     }) as ValueGeneratedItem[]
   }
 
-  const requestAllForResource: Requester<ClientOptions>['requestAllForResource'] = async ({
+  const requestAllForResource: Requester<ResolveClientOptionsType<Options>>['requestAllForResource'] = async ({
     callerIdentifier,
     contextPossibleArgs,
   }) =>

--- a/packages/adapter-components/src/filter_utils.ts
+++ b/packages/adapter-components/src/filter_utils.ts
@@ -17,7 +17,7 @@ import { ElemIdGetter, ReadOnlyElementsSource, SaltoError } from '@salto-io/adap
 import { filter } from '@salto-io/adapter-utils'
 import { Paginator } from './client'
 import { ElementQuery } from './fetch/query'
-import { UserConfig, ApiDefinitions } from './definitions'
+import { UserConfig, ApiDefinitions, APIDefinitionsOptions, ResolveCustomNameMappingOptionsType } from './definitions'
 
 export type Filter<TResult extends void | filter.FilterResult = void> = filter.Filter<TResult>
 
@@ -27,13 +27,11 @@ export type FilterWith<M extends keyof Filter, TResult extends void | filter.Fil
 >
 
 export type FilterOptions<
-  TContext = UserConfig,
+  TOptions extends APIDefinitionsOptions = {},
+  TContext = UserConfig<ResolveCustomNameMappingOptionsType<TOptions>>,
   TAdditional = {},
-  ClientOptions extends string = 'main',
-  PaginationOptions extends string | 'none' = 'none',
-  AdditionalAction extends string = never,
 > = {
-  definitions: ApiDefinitions<ClientOptions, PaginationOptions, AdditionalAction>
+  definitions: ApiDefinitions<TOptions>
   config: TContext
   getElemIdFunc?: ElemIdGetter
   fetchQuery: ElementQuery
@@ -44,13 +42,8 @@ export type AdapterFilterCreator<
   TContext,
   TResult extends void | filter.FilterResult = void,
   TAdditional = {},
-  ClientOptions extends string = 'main',
-  PaginationOptions extends string | 'none' = 'none',
-  AdditionalAction extends string = never,
-> = filter.FilterCreator<
-  TResult,
-  FilterOptions<TContext, TAdditional, ClientOptions, PaginationOptions, AdditionalAction>
->
+  TOptions extends APIDefinitionsOptions = {},
+> = filter.FilterCreator<TResult, FilterOptions<TOptions, TContext, TAdditional>>
 
 export type UserConfigAdapterFilterCreator<
   TContext,
@@ -72,14 +65,10 @@ export const filterRunner = <
   TContext,
   TResult extends void | filter.FilterResult = void,
   TAdditional = {},
-  ClientOptions extends string = 'main',
-  PaginationOptions extends string | 'none' = 'none',
-  AdditionalAction extends string = never,
+  TOptions extends APIDefinitionsOptions = {},
 >(
-  opts: FilterOptions<TContext, TAdditional, ClientOptions, PaginationOptions, AdditionalAction>,
-  filterCreators: ReadonlyArray<
-    AdapterFilterCreator<TContext, TResult, TAdditional, ClientOptions, PaginationOptions, AdditionalAction>
-  >,
+  opts: FilterOptions<TOptions, TContext, TAdditional>,
+  filterCreators: ReadonlyArray<AdapterFilterCreator<TContext, TResult, TAdditional, TOptions>>,
   onFetchAggregator: (results: TResult[]) => TResult | void = () => undefined,
 ): Required<Filter<TResult>> => filter.filtersRunner(opts, filterCreators, onFetchAggregator)
 

--- a/packages/adapter-components/src/filters/default_deploy.ts
+++ b/packages/adapter-components/src/filters/default_deploy.ts
@@ -20,24 +20,20 @@ import { deployChanges } from '../deployment'
 import { generateLookupFunc } from '../references'
 import { ChangeAndContext } from '../definitions/system/deploy'
 import { createChangeElementResolver } from '../resolve_utils'
+import { APIDefinitionsOptions } from '../definitions'
 
 /**
  * Default deploy based on deploy definitions.
  * Note: when there are other filters running custom deploy, they should usually run before this filter.
  */
 export const defaultDeployFilterCreator =
-  <
-    TResult extends void | filter.FilterResult,
-    ClientOptions extends string,
-    PaginationOptions extends string | 'none',
-    AdditionalAction extends string,
-  >({
+  <TResult extends void | filter.FilterResult, TOptions extends APIDefinitionsOptions>({
     deployChangeFunc,
     convertError,
   }: {
     deployChangeFunc?: (args: ChangeAndContext) => Promise<void>
     convertError: (elemID: ElemID, error: Error) => Error | SaltoElementError
-  }): AdapterFilterCreator<{}, TResult, {}, ClientOptions, PaginationOptions, AdditionalAction> =>
+  }): AdapterFilterCreator<{}, TResult, {}, TOptions> =>
   ({ definitions, elementSource }) => ({
     name: 'defaultDeployFilter',
     deploy: async (changes, changeGroup) => {

--- a/packages/adapter-components/src/filters/hide_types.ts
+++ b/packages/adapter-components/src/filters/hide_types.ts
@@ -15,7 +15,7 @@
  */
 import { Element, isObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
-import { UserFetchConfig } from '../definitions/user'
+import { UserFetchConfig, UserFetchConfigOptions } from '../definitions/user'
 import { UserConfigAdapterFilterCreator } from '../filter_utils'
 
 /**
@@ -23,7 +23,8 @@ import { UserConfigAdapterFilterCreator } from '../filter_utils'
  * Note: This should apply only to hard-coded types - it is the adapter's responsibility to ensure this.
  */
 export const hideTypesFilterCreator: <
-  TContext extends { fetch: Pick<UserFetchConfig, 'hideTypes'> },
+  TOptions extends UserFetchConfigOptions,
+  TContext extends { fetch: Pick<UserFetchConfig<TOptions>, 'hideTypes'> },
   TResult extends void | filter.FilterResult = void,
 >() => UserConfigAdapterFilterCreator<TContext, TResult> =
   () =>

--- a/packages/adapter-components/test/definitions/system/utils.test.ts
+++ b/packages/adapter-components/test/definitions/system/utils.test.ts
@@ -242,7 +242,8 @@ describe('system definitions utils', () => {
   })
 
   describe('mergeWithUserElemIDDefinitions', () => {
-    let mergedDef: FetchApiDefinitions<'main'>
+    // TODO SVH: add types here etc
+    let mergedDef: FetchApiDefinitions
 
     beforeAll(() => {
       mergedDef = mergeWithUserElemIDDefinitions({

--- a/packages/adapter-components/test/definitions/system/utils.test.ts
+++ b/packages/adapter-components/test/definitions/system/utils.test.ts
@@ -242,8 +242,9 @@ describe('system definitions utils', () => {
   })
 
   describe('mergeWithUserElemIDDefinitions', () => {
-    // TODO SVH: add types here etc
-    let mergedDef: FetchApiDefinitions
+    let mergedDef: FetchApiDefinitions<{
+      customNameMappingOptions: 'defaultMapping' | 'systemMapping' | 'otherMapping'
+    }>
 
     beforeAll(() => {
       mergedDef = mergeWithUserElemIDDefinitions({
@@ -253,7 +254,7 @@ describe('system definitions utils', () => {
               element: {
                 topLevel: {
                   elemID: {
-                    parts: [{ fieldName: 'something else' }],
+                    parts: [{ fieldName: 'something else', mapping: 'defaultMapping' }],
                   },
                 },
               },
@@ -264,7 +265,7 @@ describe('system definitions utils', () => {
                   topLevel: {
                     isTopLevel: true,
                     elemID: {
-                      parts: [{ fieldName: 'a' }],
+                      parts: [{ fieldName: 'a', mapping: 'systemMapping' }],
                       delimiter: 'X',
                     },
                   },
@@ -275,7 +276,7 @@ describe('system definitions utils', () => {
                   topLevel: {
                     isTopLevel: true,
                     elemID: {
-                      parts: [{ fieldName: 'a' }],
+                      parts: [{ fieldName: 'a', mapping: 'systemMapping' }],
                     },
                   },
                 },
@@ -285,17 +286,22 @@ describe('system definitions utils', () => {
                   topLevel: {
                     isTopLevel: true,
                     elemID: {
-                      parts: [{ fieldName: 'a' }],
+                      parts: [{ fieldName: 'a', mapping: 'lowercase' }],
                     },
                   },
                 },
               },
             },
           },
+          customNameMappingFunctions: {
+            defaultMapping: name => `${name}Default`,
+            systemMapping: name => `${name}System`,
+            otherMapping: name => `${name}Other`,
+          },
         },
         userElemID: {
           type1: {
-            parts: [{ fieldName: 'b' }],
+            parts: [{ fieldName: 'b', mapping: 'otherMapping' }],
           },
           type3: {
             parts: [{ fieldName: 'b' }],
@@ -314,7 +320,7 @@ describe('system definitions utils', () => {
           topLevel: {
             isTopLevel: true,
             elemID: {
-              parts: [{ fieldName: 'b' }],
+              parts: [{ fieldName: 'b', mapping: 'otherMapping' }],
               delimiter: 'X',
             },
           },
@@ -327,7 +333,7 @@ describe('system definitions utils', () => {
           topLevel: {
             isTopLevel: true,
             elemID: {
-              parts: [{ fieldName: 'a' }],
+              parts: [{ fieldName: 'a', mapping: 'systemMapping' }],
             },
           },
         },
@@ -339,7 +345,7 @@ describe('system definitions utils', () => {
           topLevel: {
             isTopLevel: true,
             elemID: {
-              parts: [{ fieldName: 'a' }, { fieldName: 'b' }],
+              parts: [{ fieldName: 'a', mapping: 'lowercase' }, { fieldName: 'b' }],
             },
           },
         },
@@ -358,7 +364,7 @@ describe('system definitions utils', () => {
     })
     it('should not modify system default', () => {
       expect(mergedDef.instances.default?.element?.topLevel?.elemID).toEqual({
-        parts: [{ fieldName: 'something else' }],
+        parts: [{ fieldName: 'something else', mapping: 'defaultMapping' }],
       })
     })
   })

--- a/packages/adapter-components/test/deployment/deploy/deploy.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/deploy.test.ts
@@ -40,7 +40,10 @@ jest.mock('../../../src/deployment/deploy/requester', () => ({
 
 describe('deployChanges', () => {
   let changes: Change<InstanceElement>[]
-  let definitions: types.PickyRequired<ApiDefinitions<'main', 'none', 'activate' | 'deactivate'>, 'clients' | 'deploy'>
+  let definitions: types.PickyRequired<
+    ApiDefinitions<{ additionalAction: 'activate' | 'deactivate' }>,
+    'clients' | 'deploy'
+  >
   let client: MockInterface<HTTPReadClientInterface & HTTPWriteClientInterface>
 
   // TODO extend coverage (concurrency, error handling, references)

--- a/packages/adapter-components/test/deployment/deploy/requester.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/requester.test.ts
@@ -31,11 +31,13 @@ import { getRequester } from '../../../src/deployment/deploy/requester'
 import { ApiDefinitions, queryWithDefault } from '../../../src/definitions'
 import { noPagination } from '../../../src/fetch/request/pagination'
 
+type AdditionalAction = 'activate' | 'deactivate'
+
 describe('DeployRequester', () => {
   let type: ObjectType
   let instance: InstanceElement
   let client: MockInterface<HTTPWriteClientInterface & HTTPReadClientInterface>
-  let definitions: types.PickyRequired<ApiDefinitions<'main', 'none', 'activate' | 'deactivate'>, 'clients' | 'deploy'>
+  let definitions: types.PickyRequired<ApiDefinitions<{ additionalAction: AdditionalAction }>, 'clients' | 'deploy'>
 
   beforeEach(() => {
     type = new ObjectType({
@@ -217,7 +219,7 @@ describe('DeployRequester', () => {
   // TODO extend (these cases are from the old infra deployChange tests)
 
   it('When no endpoint for deploying the element should throw an error', async () => {
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -238,7 +240,7 @@ describe('DeployRequester', () => {
       status: 200,
       data: {},
     })
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -284,7 +286,7 @@ describe('DeployRequester', () => {
         },
       },
     })
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(defs),
       changeResolver: async change => change,
@@ -318,7 +320,7 @@ describe('DeployRequester', () => {
       'test.requestsByAction.customizations.remove[0].request.context.instanceId',
       '{id}',
     )
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -346,7 +348,7 @@ describe('DeployRequester', () => {
       'test.requestsByAction.customizations.remove[0].request.context.instanceId',
       '{id}',
     )
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -381,7 +383,7 @@ describe('DeployRequester', () => {
       status: 200,
       data: {},
     })
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -435,7 +437,7 @@ describe('DeployRequester', () => {
       data: {},
     })
 
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -480,7 +482,7 @@ describe('DeployRequester', () => {
       },
     })
 
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -24,7 +24,6 @@ import {
 } from '@salto-io/adapter-api'
 import { getElementGenerator } from '../../../src/fetch/element/element'
 import { queryWithDefault } from '../../../src/definitions'
-import { createMockQuery } from '../../../src/fetch/query'
 import { InstanceFetchApiDefinitions } from '../../../src/definitions/system/fetch'
 
 describe('element', () => {
@@ -36,7 +35,7 @@ describe('element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        fetchQuery: createMockQuery(),
+        customNameMapping: {},
       })
       generator.pushEntries({
         entries: [],
@@ -53,7 +52,7 @@ describe('element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        fetchQuery: createMockQuery(),
+        customNameMapping: {},
       })
       generator.pushEntries({
         entries: [],
@@ -72,9 +71,17 @@ describe('element', () => {
       const generator = getElementGenerator({
         adapterName: 'myAdapter',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-          customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
+         
+          customizations: {
+            myType: {
+              element: {
+                topLevel: { isTopLevel: true },
+              },
+            },
+          },
+       ,
         }),
-        fetchQuery: createMockQuery(),
+        customNameMapping: {},
       })
       generator.pushEntries({
         entries,
@@ -120,7 +127,7 @@ describe('element', () => {
         { str: 'A', num: 2, arr: [{ st: 'X', unknown: true }] },
         { str: 'CCC', arr: [{ unknown: 'text' }] },
       ]
-      const generator = getElementGenerator({
+      const generator = getElementGenerator<{ customNameMappingOptions: 'customTest' }>({
         adapterName: 'myAdapter',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: {
@@ -133,7 +140,7 @@ describe('element', () => {
                 topLevel: {
                   isTopLevel: true,
                   elemID: {
-                    parts: [{ fieldName: 'str' }],
+                    parts: [{ fieldName: 'str', mapping: 'customTest' }],
                   },
                 },
               },
@@ -149,7 +156,9 @@ describe('element', () => {
             },
           },
         }),
-        fetchQuery: createMockQuery(),
+        customNameMapping: {
+          customTest: name => `${name}CustomTest`,
+        },
       })
       generator.pushEntries({
         entries,
@@ -160,8 +169,8 @@ describe('element', () => {
       expect(res.elements).toHaveLength(4)
       expect(res.elements.map(e => e.elemID.getFullName()).sort()).toEqual([
         'myAdapter.myType',
-        'myAdapter.myType.instance.A',
-        'myAdapter.myType.instance.CCC',
+        'myAdapter.myType.instance.ACustomTest',
+        'myAdapter.myType.instance.CCCCustomTest',
         'myAdapter.myType__arr',
       ])
       const objType = res.elements
@@ -179,14 +188,14 @@ describe('element', () => {
       })
       expect(
         isEqualElements(
-          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'A'),
-          new InstanceElement('A', objType, entries[0], []),
+          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'ACustomTest'),
+          new InstanceElement('ACustomTest', objType, entries[0], []),
         ),
       ).toBeTruthy()
       expect(
         isEqualElements(
-          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'CCC'),
-          new InstanceElement('CCC', objType, entries[1], []),
+          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'CCCCustomTest'),
+          new InstanceElement('CCCCustomTest', objType, entries[1], []),
         ),
       ).toBeTruthy()
     })

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -71,7 +71,6 @@ describe('element', () => {
       const generator = getElementGenerator({
         adapterName: 'myAdapter',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-         
           customizations: {
             myType: {
               element: {
@@ -79,7 +78,6 @@ describe('element', () => {
               },
             },
           },
-       ,
         }),
         customNameMappingFunctions: {},
       })
@@ -127,9 +125,12 @@ describe('element', () => {
         { str: 'A', otherField: 'B', num: 2, arr: [{ st: 'X', unknown: true }] },
         { str: 'CCC', otherField: 'DDD', arr: [{ unknown: 'text' }] },
       ]
-      const generator = getElementGenerator<{ customNameMappingOptions: 'firstCustom' | 'secondCustom' }>({
+      const generator = getElementGenerator({
         adapterName: 'myAdapter',
-        defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+        defQuery: queryWithDefault<
+          InstanceFetchApiDefinitions<{ customNameMappingOptions: 'firstCustom' | 'secondCustom' }>,
+          string
+        >({
           customizations: {
             myType: {
               resource: {

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -35,7 +35,7 @@ describe('element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       generator.pushEntries({
         entries: [],
@@ -52,7 +52,7 @@ describe('element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       generator.pushEntries({
         entries: [],
@@ -81,7 +81,7 @@ describe('element', () => {
           },
        ,
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       generator.pushEntries({
         entries,
@@ -124,10 +124,10 @@ describe('element', () => {
     })
     it('should create instances and matching type based on defined customizations', () => {
       const entries = [
-        { str: 'A', num: 2, arr: [{ st: 'X', unknown: true }] },
-        { str: 'CCC', arr: [{ unknown: 'text' }] },
+        { str: 'A', otherField: 'B', num: 2, arr: [{ st: 'X', unknown: true }] },
+        { str: 'CCC', otherField: 'DDD', arr: [{ unknown: 'text' }] },
       ]
-      const generator = getElementGenerator<{ customNameMappingOptions: 'customTest' }>({
+      const generator = getElementGenerator<{ customNameMappingOptions: 'firstCustom' | 'secondCustom' }>({
         adapterName: 'myAdapter',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: {
@@ -140,7 +140,10 @@ describe('element', () => {
                 topLevel: {
                   isTopLevel: true,
                   elemID: {
-                    parts: [{ fieldName: 'str', mapping: 'customTest' }],
+                    parts: [
+                      { fieldName: 'str', mapping: 'firstCustom' },
+                      { fieldName: 'otherField', mapping: 'secondCustom' },
+                    ],
                   },
                 },
               },
@@ -156,8 +159,9 @@ describe('element', () => {
             },
           },
         }),
-        customNameMapping: {
-          customTest: name => `${name}CustomTest`,
+        customNameMappingFunctions: {
+          firstCustom: name => `${name}CustomTest`,
+          secondCustom: name => `Second${name}`,
         },
       })
       generator.pushEntries({
@@ -169,8 +173,8 @@ describe('element', () => {
       expect(res.elements).toHaveLength(4)
       expect(res.elements.map(e => e.elemID.getFullName()).sort()).toEqual([
         'myAdapter.myType',
-        'myAdapter.myType.instance.ACustomTest',
-        'myAdapter.myType.instance.CCCCustomTest',
+        'myAdapter.myType.instance.ACustomTest_SecondB',
+        'myAdapter.myType.instance.CCCCustomTest_SecondDDD',
         'myAdapter.myType__arr',
       ])
       const objType = res.elements
@@ -180,6 +184,7 @@ describe('element', () => {
       expect(_.mapValues(objType?.fields, f => f.getTypeSync().elemID.name)).toEqual({
         str: 'serviceid',
         num: 'number',
+        otherField: 'string',
         arr: 'List<myAdapter.myType__arr>',
       })
       expect(_.mapValues(subType?.fields, f => f.getTypeSync().elemID.name)).toEqual({
@@ -188,14 +193,14 @@ describe('element', () => {
       })
       expect(
         isEqualElements(
-          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'ACustomTest'),
-          new InstanceElement('ACustomTest', objType, entries[0], []),
+          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'ACustomTest_SecondB'),
+          new InstanceElement('ACustomTest_SecondB', objType, entries[0], []),
         ),
       ).toBeTruthy()
       expect(
         isEqualElements(
-          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'CCCCustomTest'),
-          new InstanceElement('CCCCustomTest', objType, entries[1], []),
+          res.elements.filter(isInstanceElement).find(e => e.elemID.name === 'CCCCustomTest_SecondDDD'),
+          new InstanceElement('CCCCustomTest_SecondDDD', objType, entries[1], []),
         ),
       ).toBeTruthy()
     })

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -88,7 +88,7 @@ describe('id utils', () => {
             parts: [{ fieldName: 'a' }],
           },
           typeID,
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('A')
       const func2 = createElemIDFunc({
@@ -101,7 +101,7 @@ describe('id utils', () => {
           delimiter: '-',
         },
         typeID,
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(func2({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual('A')
       expect(func2({ entry: { a: 'A', c: 'C', d: 123 }, defaultName: 'unnamed' })).toEqual('A_C@b')
@@ -116,7 +116,7 @@ describe('id utils', () => {
           typeID,
           getElemIdFunc: () => new ElemID('a', 'b', 'instance', 'NAME'),
           serviceIDDef: ['a'],
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('NAME')
     })
@@ -125,14 +125,14 @@ describe('id utils', () => {
         createElemIDFunc({
           elemIDDef: {},
           typeID,
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('unnamed')
       expect(
         createElemIDFunc({
           elemIDDef: { parts: [{ fieldName: 'nonexistent' }] },
           typeID,
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('unnamed')
     })
@@ -143,7 +143,7 @@ describe('id utils', () => {
           extendsParent: true,
         },
         typeID,
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       const parent = new InstanceElement('parent:b', new ObjectType({ elemID: typeID }))
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed', parent })).toEqual('parent_b__A@fuu')
@@ -158,7 +158,7 @@ describe('id utils', () => {
         },
         singleton: true,
         typeID,
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual(ElemID.CONFIG_NAME)
     })
@@ -168,7 +168,7 @@ describe('id utils', () => {
           parts: [{ fieldName: 'a' }, { custom: () => () => 'CUSTOM', fieldName: 'ignore' }],
         },
         typeID,
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual('A_CUSTOM')
     })
@@ -191,9 +191,9 @@ describe('id utils', () => {
               parts: [{ fieldName: 'a' }],
             },
             typeID,
-            customNameMapping: {},
+            customNameMappingFunctions: {},
           }),
-          customNameMapping: {
+          customNameMappingFunctions: {
             customTest: () => 'thisIsACuteCustomName',
           },
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
@@ -212,9 +212,9 @@ describe('id utils', () => {
               parts: [{ fieldName: 'a' }],
             },
             typeID,
-            customNameMapping: {},
+            customNameMappingFunctions: {},
           }),
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual(['myAdapter', 'Records', 'Settings', 'myType'])
     })
@@ -227,7 +227,7 @@ describe('id utils', () => {
           getNameMapping({
             name: 'name',
             nameMapping: undefined,
-            customNameMapping: {},
+            customNameMappingFunctions: {},
           }),
         ).toEqual('name')
       })
@@ -240,7 +240,7 @@ describe('id utils', () => {
             getNameMapping({
               name: 'NAME',
               nameMapping: 'lowercase',
-              customNameMapping: {},
+              customNameMappingFunctions: {},
             }),
           ).toEqual('name')
         })
@@ -252,7 +252,7 @@ describe('id utils', () => {
             getNameMapping({
               name: 'name',
               nameMapping: 'uppercase',
-              customNameMapping: {},
+              customNameMappingFunctions: {},
             }),
           ).toEqual('NAME')
         })
@@ -264,7 +264,7 @@ describe('id utils', () => {
             getNameMapping({
               name: 'name',
               nameMapping: 'test',
-              customNameMapping: {
+              customNameMappingFunctions: {
                 test: () => 'test',
               },
             }),

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -20,12 +20,13 @@ import {
   serviceIDKeyCreator,
   createElemIDFunc,
   getElemPath,
+  getNameMapping,
 } from '../../../src/fetch/element/id_utils'
 
 describe('id utils', () => {
   const typeID = new ElemID('myAdapter', 'myType')
   describe('createServiceIDs', () => {
-    it('should calculate the service id for a given object and defintion', () => {
+    it('should calculate the service id for a given object and definition', () => {
       expect(
         createServiceIDs({
           entry: { a: 'A', b: 'B', c: 'C' },
@@ -80,13 +81,14 @@ describe('id utils', () => {
   })
 
   describe('createElemIDFunc', () => {
-    it('should calculate a nacl-cased elem name for a given object and defintion', () => {
+    it('should calculate a nacl-cased elem name for a given object and definition', () => {
       expect(
         createElemIDFunc({
           elemIDDef: {
             parts: [{ fieldName: 'a' }],
           },
           typeID,
+          customNameMapping: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('A')
       const func2 = createElemIDFunc({
@@ -99,6 +101,7 @@ describe('id utils', () => {
           delimiter: '-',
         },
         typeID,
+        customNameMapping: {},
       })
       expect(func2({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual('A')
       expect(func2({ entry: { a: 'A', c: 'C', d: 123 }, defaultName: 'unnamed' })).toEqual('A_C@b')
@@ -113,6 +116,7 @@ describe('id utils', () => {
           typeID,
           getElemIdFunc: () => new ElemID('a', 'b', 'instance', 'NAME'),
           serviceIDDef: ['a'],
+          customNameMapping: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('NAME')
     })
@@ -121,12 +125,14 @@ describe('id utils', () => {
         createElemIDFunc({
           elemIDDef: {},
           typeID,
+          customNameMapping: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('unnamed')
       expect(
         createElemIDFunc({
           elemIDDef: { parts: [{ fieldName: 'nonexistent' }] },
           typeID,
+          customNameMapping: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual('unnamed')
     })
@@ -137,6 +143,7 @@ describe('id utils', () => {
           extendsParent: true,
         },
         typeID,
+        customNameMapping: {},
       })
       const parent = new InstanceElement('parent:b', new ObjectType({ elemID: typeID }))
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed', parent })).toEqual('parent_b__A@fuu')
@@ -151,6 +158,7 @@ describe('id utils', () => {
         },
         singleton: true,
         typeID,
+        customNameMapping: {},
       })
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual(ElemID.CONFIG_NAME)
     })
@@ -160,16 +168,22 @@ describe('id utils', () => {
           parts: [{ fieldName: 'a' }, { custom: () => () => 'CUSTOM', fieldName: 'ignore' }],
         },
         typeID,
+        customNameMapping: {},
       })
       expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' })).toEqual('A_CUSTOM')
     })
   })
+
   describe('getElemPath', () => {
-    it('should calculate a nacl-cased elem name for a given object and defintion', () => {
+    it('should calculate a nacl-cased elem name for a given object and definition', () => {
       expect(
         getElemPath({
           def: {
-            pathParts: [{ parts: [{ fieldName: 'a' }] }],
+            pathParts: [
+              {
+                parts: [{ fieldName: 'a', mapping: 'customTest' }],
+              },
+            ],
           },
           typeID,
           elemIDCreator: createElemIDFunc({
@@ -177,9 +191,13 @@ describe('id utils', () => {
               parts: [{ fieldName: 'a' }],
             },
             typeID,
+            customNameMapping: {},
           }),
+          customNameMapping: {
+            customTest: () => 'thisIsACuteCustomName',
+          },
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
-      ).toEqual(['myAdapter', 'Records', 'myType', 'A'])
+      ).toEqual(['myAdapter', 'Records', 'myType', 'thisIsACuteCustomName'])
     })
     it('should set path to settings folder if singleton', () => {
       expect(
@@ -194,9 +212,65 @@ describe('id utils', () => {
               parts: [{ fieldName: 'a' }],
             },
             typeID,
+            customNameMapping: {},
           }),
+          customNameMapping: {},
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual(['myAdapter', 'Records', 'Settings', 'myType'])
+    })
+  })
+
+  describe('getNameMapping', () => {
+    describe('when mapping is not defined', () => {
+      it('should return the name as is', () => {
+        expect(
+          getNameMapping({
+            name: 'name',
+            nameMapping: undefined,
+            customNameMapping: {},
+          }),
+        ).toEqual('name')
+      })
+    })
+
+    describe('when mapping is defined', () => {
+      describe('when mapping is lowercase', () => {
+        it('should return the name in lowercase', () => {
+          expect(
+            getNameMapping({
+              name: 'NAME',
+              nameMapping: 'lowercase',
+              customNameMapping: {},
+            }),
+          ).toEqual('name')
+        })
+      })
+
+      describe('when mapping is uppercase', () => {
+        it('should return the name in uppercase', () => {
+          expect(
+            getNameMapping({
+              name: 'name',
+              nameMapping: 'uppercase',
+              customNameMapping: {},
+            }),
+          ).toEqual('NAME')
+        })
+      })
+
+      describe('when mapping is a custom function', () => {
+        it('should return the name after applying the custom function', () => {
+          expect(
+            getNameMapping({
+              name: 'name',
+              nameMapping: 'test',
+              customNameMapping: {
+                test: () => 'test',
+              },
+            }),
+          ).toEqual('test')
+        })
+      })
     })
   })
 })

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -30,7 +30,7 @@ describe('instance element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(0)
@@ -45,7 +45,7 @@ describe('instance element', () => {
           entries: [],
           typeName: 'myType',
           defQuery: queryWithDefault<InstanceFetchApiDefinitions, string><{}>({ customizations: {} }),
-          customNameMapping: {},
+          customNameMappingFunctions: {},
         }),
       ).toThrow('type myAdapter:myType is not defined as top-level, cannot create instances')
     })
@@ -61,7 +61,7 @@ describe('instance element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(2)
@@ -95,7 +95,7 @@ describe('instance element', () => {
       ).toBeTruthy()
     })
     it('should create instances and matching type based on defined customizations', () => {
-      const res = generateInstancesWithInitialTypes<{ customNameMappingOptions: 'customTest' }>({
+      const res = generateInstancesWithInitialTypes<{ customNameMappingOptions: 'customTest' | 'Uri' }>({
         adapterName: 'myAdapter',
         entries: [
           { str: 'A', num: 2, arr: [{ st: 'X', unknown: true }] },
@@ -119,8 +119,9 @@ describe('instance element', () => {
             },
           },
         }),
-        customNameMapping: {
+        customNameMappingFunctions: {
           customTest: name => `custom_${name}`,
+          Uri: name => `uri_${name}`,
         },
       })
       expect(res.errors).toBeUndefined()
@@ -152,7 +153,7 @@ describe('instance element', () => {
             myType: { element: { topLevel: { isTopLevel: true } } },
           },
         }),
-        customNameMapping: {},
+        customNameMappingFunctions: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(1)

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -44,7 +44,7 @@ describe('instance element', () => {
           adapterName: 'myAdapter',
           entries: [],
           typeName: 'myType',
-          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string><{}>({ customizations: {} }),
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: {} }),
           customNameMappingFunctions: {},
         }),
       ).toThrow('type myAdapter:myType is not defined as top-level, cannot create instances')
@@ -95,14 +95,17 @@ describe('instance element', () => {
       ).toBeTruthy()
     })
     it('should create instances and matching type based on defined customizations', () => {
-      const res = generateInstancesWithInitialTypes<{ customNameMappingOptions: 'customTest' | 'Uri' }>({
+      const res = generateInstancesWithInitialTypes({
         adapterName: 'myAdapter',
         entries: [
           { str: 'A', num: 2, arr: [{ st: 'X', unknown: true }] },
           { str: 'CCC', arr: [{ unknown: 'text' }] },
         ],
         typeName: 'myType',
-        defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+        defQuery: queryWithDefault<
+          InstanceFetchApiDefinitions<{ customNameMappingOptions: 'customTest' | 'Uri' }>,
+          string
+        >({
           customizations: {
             myType: {
               resource: {

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -30,6 +30,7 @@ describe('instance element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
+        customNameMapping: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(0)
@@ -43,7 +44,8 @@ describe('instance element', () => {
           adapterName: 'myAdapter',
           entries: [],
           typeName: 'myType',
-          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: {} }),
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string><{}>({ customizations: {} }),
+          customNameMapping: {},
         }),
       ).toThrow('type myAdapter:myType is not defined as top-level, cannot create instances')
     })
@@ -59,6 +61,7 @@ describe('instance element', () => {
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
+        customNameMapping: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(2)
@@ -92,7 +95,7 @@ describe('instance element', () => {
       ).toBeTruthy()
     })
     it('should create instances and matching type based on defined customizations', () => {
-      const res = generateInstancesWithInitialTypes({
+      const res = generateInstancesWithInitialTypes<{ customNameMappingOptions: 'customTest' }>({
         adapterName: 'myAdapter',
         entries: [
           { str: 'A', num: 2, arr: [{ st: 'X', unknown: true }] },
@@ -109,13 +112,16 @@ describe('instance element', () => {
                 topLevel: {
                   isTopLevel: true,
                   elemID: {
-                    parts: [{ fieldName: 'str' }],
+                    parts: [{ fieldName: 'str', mapping: 'customTest' }],
                   },
                 },
               },
             },
           },
         }),
+        customNameMapping: {
+          customTest: name => `custom_${name}`,
+        },
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(2)
@@ -132,8 +138,8 @@ describe('instance element', () => {
         unknown: 'unknown',
       })
       expect(res.instances.map(e => e.elemID.getFullName()).sort()).toEqual([
-        'myAdapter.myType.instance.A',
-        'myAdapter.myType.instance.CCC',
+        'myAdapter.myType.instance.custom_A',
+        'myAdapter.myType.instance.custom_CCC',
       ])
     })
     it('should omit nulls and undefined values from instances and nacl-case field names', () => {
@@ -146,6 +152,7 @@ describe('instance element', () => {
             myType: { element: { topLevel: { isTopLevel: true } } },
           },
         }),
+        customNameMapping: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(1)

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -67,7 +67,7 @@ describe('fetch', () => {
     })
     // TODO split into multiple tests per component and add cases
     it('should generate elements correctly', async () => {
-      const res = await getElements({
+      const res = await getElements<{ customNameMappingOptions: 'custom' }>({
         adapterName: 'myAdapter',
         definitions: {
           clients: {
@@ -97,7 +97,7 @@ describe('fetch', () => {
                 element: {
                   topLevel: {
                     elemID: {
-                      parts: [{ fieldName: 'name' }],
+                      parts: [{ fieldName: 'name', mapping: 'custom' }],
                     },
                   },
                 },
@@ -188,21 +188,23 @@ describe('fetch', () => {
                 },
               },
             },
+            customNameMappingFunctions: {
+              custom: name => `${name}Custom`,
+            },
           },
         },
         fetchQuery: createMockQuery(),
-        customNameMapping: {},
       })
       expect(res.errors).toEqual([])
       expect(res.configChanges).toHaveLength(0)
       expect(res.elements.map(e => e.elemID.getFullName()).sort()).toEqual([
         'myAdapter.field',
-        'myAdapter.field.instance.field1',
+        'myAdapter.field.instance.field1Custom',
         'myAdapter.group',
-        'myAdapter.group.instance.group1',
+        'myAdapter.group.instance.group1Custom',
         'myAdapter.option',
-        'myAdapter.option.instance.opt1',
-        'myAdapter.option.instance.opt2',
+        'myAdapter.option.instance.opt1Custom',
+        'myAdapter.option.instance.opt2Custom',
       ])
       // TODO continue
     })

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -191,6 +191,7 @@ describe('fetch', () => {
           },
         },
         fetchQuery: createMockQuery(),
+        customNameMapping: {},
       })
       expect(res.errors).toEqual([])
       expect(res.configChanges).toHaveLength(0)

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -61,7 +61,7 @@ type JiraFetchFilters = definitions.DefaultFetchCriteria & {
   type?: string
 }
 
-type JiraFetchConfig = definitions.UserFetchConfig<JiraFetchFilters> & {
+type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFilters }> & {
   fallbackToInternalId?: boolean
   addTypeToFieldName?: boolean
   convertUsersIds?: boolean


### PR DESCRIPTION
Currently, the only name mappings defined are `lowercase` and `uppercase`, without a simple structured way to add custom mappings to meet adapter requirements. For example, in Jira, there's a **filter** designed to omit the internal id from the name, as mentioned in [this comment](https://github.com/salto-io/salto/pull/5409#discussion_r1481069530).

In this PR, we suggest a structurally typed approach to adding custom mapping options, where the default ones (`lowercase` and `uppercase`) remain common and do not require a special definition.

It works by defining the possible options as an enum, since this mapping is a user-facing config, and providing a corresponding map from these enums to their mapping functions.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
