### PR TITLE
SALTO-5415 support customizing the http response codes

### DIFF
--- a/packages/adapter-components/test/client/common.ts
+++ b/packages/adapter-components/test/client/common.ts
@@ -35,7 +35,7 @@ export const validateCreds = async ({
   }
 }
 
-export const createConnection: ConnectionCreator<Credentials> = (retryOptions, timeout) =>
+export const createConnection: ConnectionCreator<Credentials> = (retryOptions, timeout, validStatuses) =>
   axiosConnection({
     retryOptions,
     authParamsFunc: async ({ username, password }: Credentials) => ({
@@ -50,4 +50,5 @@ export const createConnection: ConnectionCreator<Credentials> = (retryOptions, t
     baseURLFunc: async () => BASE_URL,
     credValidateFunc: validateCreds,
     timeout,
+    validStatuses,
   })

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -42,7 +42,10 @@ describe('client_http_connection', () => {
         .reply(200, {
           accountId: 'ACCOUNT_ID',
         })
-      const validateRes = validateCredentials({ username: 'user123', password: 'pass' }, { createConnection })
+      const validateRes = validateCredentials(
+        { username: 'user123', password: 'pass' },
+        { validStatuses: [404], createConnection },
+      )
       expect(await validateRes).toEqual({
         accountId: 'ACCOUNT_ID:user123',
         accountType: 'Sandbox',
@@ -52,6 +55,7 @@ describe('client_http_connection', () => {
       const req = mockAxiosAdapter.history.get[0]
       expect(req.url).toEqual('/users/me')
       expect(req.auth).toEqual({ username: 'user123', password: 'pass' })
+      expect(req.validateStatus(404)).toBeTruthy()
       // already verified the customheader1 header in the onGet header matcher
     })
     it('should throw Unauthorized on UnauthorizedError', async () => {


### PR DESCRIPTION
SALTO-5415 support customizing the http response codes
---

_Additional context for reviewer_:
tested in zendesk by removing this: https://github.com/salto-io/salto/blob/main/packages/zendesk-adapter/src/client/client.ts#L97-L100

---
_Release Notes_: 
when creating a connection, we are now able to set an array of validStatuses that the client will not throw an error for them

---
_User Notifications_: 
none
