### PR TITLE
SALTO-5362: fix statusReference bug in getTransitionKey

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -16,10 +16,13 @@
 
 import { invertNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { SaltoError, Value } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { Status, Transition, WorkflowV1Instance } from './types'
+import { Status, Transition as WorkflowTransitionV1, WorkflowV1Instance } from './types'
 import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../script_runner/workflow/workflow_cloud'
-import { WorkflowTransitionV2 } from '../workflowV2/types'
+import { isWorkflowV2Transition, WorkflowTransitionV2 } from '../workflowV2/types'
+
+const { makeArray } = collections.array
 
 export const TRANSITION_PARTS_SEPARATOR = '::'
 
@@ -36,7 +39,7 @@ const getTransitionTypeFromKey = (key: string): string => {
   return type === 'Circular' ? 'Global' : type
 }
 
-const getTransitionType = (transition: Transition): TransitionType => {
+const getTransitionType = (transition: WorkflowTransitionV1 | WorkflowTransitionV2): TransitionType => {
   if (transition.type?.toLowerCase() === 'initial') {
     return 'Initial'
   }
@@ -78,11 +81,17 @@ export const createStatusMap = (statuses: Status[]): Map<string, string> =>
       .map(status => [status.id, status.name]),
   )
 
-export const getTransitionKey = (transition: Transition, statusesMap: Map<string, string>): string => {
+export const getTransitionKey = (
+  transition: WorkflowTransitionV1 | WorkflowTransitionV2,
+  statusesMap: Map<string, string>,
+): string => {
   const type = getTransitionType(transition)
   const fromSorted =
     type === 'Directed'
-      ? (transition.from?.map(from => (typeof from === 'string' ? from : from.id ?? '')) ?? [])
+      ? (isWorkflowV2Transition(transition)
+          ? makeArray(transition.from).map(from => from.statusReference)
+          : makeArray(transition.from).map(from => (typeof from === 'string' ? from : from.id ?? ''))
+        )
           .map(from => statusesMap.get(from) ?? from)
           .sort()
           .join(',')
@@ -127,7 +136,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
       ]
 }
 
-export const walkOverTransitionIds = (transition: Transition, func: (value: Value) => void): void => {
+export const walkOverTransitionIds = (transition: WorkflowTransitionV1, func: (value: Value) => void): void => {
   transition.rules?.postFunctions
     ?.filter(postFunction => postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE)
     .forEach(postFunction => {
@@ -155,7 +164,7 @@ export const expectedToActualTransitionIds = ({
   expectedTransitionIds,
   statusesMap,
 }: {
-  transitions: Transition[]
+  transitions: WorkflowTransitionV1[]
   expectedTransitionIds: Map<string, string>
   statusesMap: Map<string, string>
 }): Record<string, string> =>

--- a/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/empty_validator_workflow.test.ts
@@ -18,7 +18,7 @@ import { emptyValidatorWorkflowChangeValidator } from '../../../src/change_valid
 import { WORKFLOW_CONFIGURATION_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType } from '../../utils'
 
-describe('workflowPropertiesValidator', () => {
+describe('emptyValidatorWorkflow', () => {
   let changes: ReadonlyArray<Change<ChangeDataType>>
   describe('workflowV1', () => {
     let instance: InstanceElement
@@ -125,6 +125,7 @@ describe('workflowPropertiesValidator', () => {
           tran1: {
             name: 'tran1',
             id: 'id',
+            type: 'DIRECTED',
             validators: [
               {
                 parameters: {

--- a/packages/jira-adapter/test/change_validators/workflows/workflow_properties.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/workflow_properties.test.ts
@@ -75,6 +75,7 @@ describe('workflowPropertiesValidator', () => {
           tran1: {
             name: 'tran1',
             id: 'id',
+            type: 'DIRECTED',
             properties: [
               {
                 key: 'key',

--- a/packages/jira-adapter/test/change_validators/workflows/workflow_transition_duplicate_name.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/workflow_transition_duplicate_name.test.ts
@@ -59,9 +59,9 @@ describe('workflowTransitionDuplicateNameValidator', () => {
         id: '123',
         statuses: [],
         transitions: {
-          'transition1__From__none__Initial@fffsff': { name: 'transition1', id: '1' },
-          'transition2__From__open__Directed@fffsff': { name: 'transition2', id: '2' },
-          'transition3__From__any_status__Global@fffssff': { name: 'transition3', id: '3' },
+          'transition1__From__none__Initial@fffsff': { name: 'transition1', type: 'Initial', id: '1' },
+          'transition2__From__open__Directed@fffsff': { name: 'transition2', type: 'Directed', id: '2' },
+          'transition3__From__any_status__Global@fffssff': { name: 'transition3', type: 'Global', id: '3' },
         },
       })
       afterInstance = new InstanceElement('afterInstance', workflowV2Type, {
@@ -77,9 +77,9 @@ describe('workflowTransitionDuplicateNameValidator', () => {
         id: '123',
         statuses: [],
         transitions: {
-          'transition1__From__none__Initial@fffsff': { name: 'transition1', id: '1' },
-          'transition2__From__open__Directed__1@fffsff': { name: 'transition2', id: '2' },
-          'transition2__From__open__Directed__2@fffsff': { name: 'transition2', id: '3' },
+          'transition1__From__none__Initial@fffsff': { name: 'transition1', type: 'Initial', id: '1' },
+          'transition2__From__open__Directed__1@fffsff': { name: 'transition2', type: 'Directed', id: '2' },
+          'transition2__From__open__Directed__2@fffsff': { name: 'transition2', type: 'Directed', id: '3' },
         },
       })
     }
@@ -93,10 +93,26 @@ describe('workflowTransitionDuplicateNameValidator', () => {
       expect(result).toHaveLength(0)
     })
     it('should return correct errors for workflows with duplicate transition keys', async () => {
-      instance.value.transitions['transition4__From__open__Directed__1@fffsffff'] = { name: 'transition4', id: '4' }
-      instance.value.transitions['transition4__From__open__Directed__2@fffsffff'] = { name: 'transition4', id: '5' }
-      instance.value.transitions['transition5__From__open__Directed__3@fffsffff'] = { name: 'transition5', id: '6' }
-      instance.value.transitions['transition5__From__open__Directed__4@fffsffff'] = { name: 'transition5', id: '7' }
+      instance.value.transitions['transition4__From__open__Directed__1@fffsffff'] = {
+        name: 'transition4',
+        type: 'Directed',
+        id: '4',
+      }
+      instance.value.transitions['transition4__From__open__Directed__2@fffsffff'] = {
+        name: 'transition4',
+        type: 'Directed',
+        id: '5',
+      }
+      instance.value.transitions['transition5__From__open__Directed__3@fffsffff'] = {
+        name: 'transition5',
+        type: 'Directed',
+        id: '6',
+      }
+      instance.value.transitions['transition5__From__open__Directed__4@fffsffff'] = {
+        name: 'transition5',
+        type: 'Directed',
+        id: '7',
+      }
 
       const result = await workflowTransitionDuplicateNameValidator([
         toChange({ after: instance }),

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
@@ -52,6 +52,7 @@ const resolvedWorkflowV2Instance = new InstanceElement('instance', createEmptyTy
   transitions: {
     [TRANSITION_KEY]: {
       name: 'tran1',
+      type: 'DIRECTED',
       actions: [
         {
           parameters: {
@@ -92,6 +93,7 @@ const restoredWorkflowV2Instance = new InstanceElement('instance', createEmptyTy
   transitions: {
     [TRANSITION_KEY]: {
       name: 'tran1',
+      type: 'DIRECTED',
       actions: [
         {
           parameters: {
@@ -242,6 +244,7 @@ describe('Scriptrunner references', () => {
     const transitionV2 = {
       name: 'tran1',
       id: '11',
+      type: 'DIRECTED',
       actions: [
         {
           ruleKey: 'rule1',
@@ -329,6 +332,7 @@ describe('Scriptrunner references', () => {
           tran1: {
             id: '11',
             name: 'tran1',
+            type: 'DIRECTED',
             actions: [
               {
                 ruleKey: 'rule1',
@@ -353,6 +357,7 @@ describe('Scriptrunner references', () => {
           tran2: {
             id: '21',
             name: 'tran2',
+            type: 'DIRECTED',
             actions: [
               {
                 ruleKey: 'rule1',
@@ -495,6 +500,7 @@ describe('Scriptrunner references', () => {
           tran1: {
             id: '11',
             name: 'tran1',
+            type: 'DIRECTED',
             actions: [
               {
                 ruleKey: 'rule1',

--- a/packages/jira-adapter/test/filters/workflow/empty_validator_workflow.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/empty_validator_workflow.test.ts
@@ -113,6 +113,7 @@ describe('empty validator workflow', () => {
           tran1: {
             name: 'tran1',
             id: 'id',
+            type: 'Directed',
             validators: [
               {
                 parameters: {

--- a/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/transition_ids.test.ts
@@ -32,9 +32,18 @@ describe('transition ids filter', () => {
       },
       statuses: [],
       transitions: {
-        transition1: {},
-        transition2: {},
-        transition3: {},
+        transition1: {
+          type: 'DIRECTED',
+          name: 'transition1',
+        },
+        transition2: {
+          type: 'DIRECTED',
+          name: 'transition2',
+        },
+        transition3: {
+          type: 'DIRECTED',
+          name: 'transition3',
+        },
       },
     })
   })

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -93,7 +93,7 @@ describe('workflow filter', () => {
     beforeEach(() => {
       mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function* get() {
         yield [
-          { id: { entityId: '1' }, statuses: [{ id: '11', name: 'Quack' }] },
+          { id: { entityId: '1' }, statuses: [{ id: '11', name: 'Create'}, { id: '2', name: 'another one'}] },
           { id: { entityId: '2' }, statuses: [{ id: '22', name: 'Quack Quack' }] },
         ]
       })
@@ -134,6 +134,16 @@ describe('workflow filter', () => {
                     statusReference: '11',
                   },
                 },
+                {
+                  type: 'DIRECTED',
+                  name: 'ToStatus2',
+                  from: [{
+                    statusReference: '11',
+                  }],
+                  to : {
+                    statusReference: '2',
+                  },
+                }
               ],
               statuses: [
                 {
@@ -141,6 +151,9 @@ describe('workflow filter', () => {
                   properties: {
                     'jira.issue.editable': 'true',
                   },
+                },
+                {
+                  id: '2',
                 },
               ],
             },
@@ -205,6 +218,16 @@ describe('workflow filter', () => {
               statusReference: '11',
             },
           },
+          [TRANSITION_NAME_TO_KEY.ToStatus2]: {
+            type: 'DIRECTED',
+            name: 'ToStatus2',
+            from: [{
+              statusReference: '11',
+            }],
+            to : {
+              statusReference: '2',
+            },
+          },
         },
         statuses: [
           {
@@ -215,6 +238,9 @@ describe('workflow filter', () => {
                 value: 'true',
               },
             ],
+          },
+          {
+            id: '2',
           },
         ],
       })

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -981,7 +981,12 @@ describe('workflow filter', () => {
                   type: 'global',
                 },
                 statuses: [],
-                transitions: [],
+                transitions: [
+                  {
+                    name: 'Create',
+                    type: 'INITIAL',
+                  },
+                ],
               },
             ],
             taskId: '1',
@@ -1115,7 +1120,12 @@ describe('workflow filter', () => {
                     type: 'global',
                   },
                   statuses: [],
-                  transitions: [],
+                  transitions: [
+                    {
+                      type: 'INITIAL',
+                      name: 'Create',
+                    },
+                  ],
                 },
               ],
             },


### PR DESCRIPTION
_fix statusReference bug in getTransitionKey_

---

_Additional context for reviewer_

_Bug description:_ 
The function `getTransitionKey` is used to create a unique key for the transitions map. The unique key is structured from `transitionName`, `transitionType` and `from` statuses.
The `from` part is different in WorkflowV2 comparing to the old workflow which caused this bug:

key before the fix: 
```
Resolve_Issue__From____Directed@sfffsszdzdff 
```
key after the fix: 
```
Resolve_Issue__From__Open__Directed@sfffsszdzdff 
```

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
