### PR TITLE
SALTO-5497: Add SubType subgoals to api_config in jira

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2141,6 +2141,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       fieldsToHide: [{ fieldName: 'id' }],
     },
   },
+  SLA__config__goals__subGoals: {
+    transformation: {
+      fieldsToHide: [{ fieldName: 'id' }],
+      fieldsToOmit: [{ fieldName: 'goalId' }],
+    },
+  },
   SLA__config__definition__pause: {
     transformation: {
       fieldsToOmit: [{ fieldName: 'type' }, { fieldName: 'missing' }],

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1267,7 +1267,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: FIELD_TYPE_NAME },
   },
   {
-    src: { field: 'calendarId', parentTypes: ['SLA__config__goals'] },
+    src: { field: 'calendarId', parentTypes: ['SLA__config__goals', 'SLA__config__goals__subGoals'] },
     serializationStrategy: 'id',
     jiraMissingRefStrategy: 'typeAndValue',
     target: { type: CALENDAR_TYPE },


### PR DESCRIPTION
In this PR I added the subType `SLA__config__goals__subGoals` to the SLA and modified the 'calendar' field to be a reference expression.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adpater:_
* In SLA nacls, whenever there are subgoals fields - The calendar field will change from id to referenceExpression. 

---
_User Notifications_: 
_Jira Adpater:_
* In SLA nacls, whenever there are subgoals fields - The calendar field will change from id to referenceExpression. 
