### PR TITLE
[WIP] SALTO-5495: Pass acocuntToServiceNameMap to adapters deploy function

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -79,6 +79,7 @@ export type FetchOptions = {
 export type DeployOptions = {
   progressReporter: ProgressReporter
   changeGroup: ChangeGroup
+  accountToServiceNameMap?: Record<string, string>
 }
 
 export type PostFetchOptions = {

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -176,12 +176,13 @@ export const deploy = async (
 ): Promise<DeployResult> => {
   const changedElements = elementSource.createInMemoryElementSource()
   const adaptersElementSource = buildElementsSourceFromElements([], [changedElements, await workspace.elements()])
+  const accountToServiceNameMap = getAccountToServiceNameMap(workspace, accounts)
   const adapters = await getAdapters(
     accounts,
     await workspace.accountCredentials(accounts),
     workspace.accountConfig.bind(workspace),
     adaptersElementSource,
-    getAccountToServiceNameMap(workspace, accounts),
+    accountToServiceNameMap,
   )
 
   const postDeployAction = async (appliedChanges: ReadonlyArray<Change>): Promise<void> =>
@@ -209,6 +210,7 @@ export const deploy = async (
     reportProgress,
     postDeployAction,
     checkOnly,
+    accountToServiceNameMap,
   )
 
   // Add workspace elements as an additional context for resolve so that we can resolve

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -83,6 +83,7 @@ const deployAction = async (
   adapterByAccountName: Record<string, AdapterOperations>,
   checkOnly: boolean,
   progressReporter: ProgressReporter,
+  accountToServiceNameMap: Record<string, string>,
 ): Promise<AdapterDeployResult> => {
   const changes = [...planItem.changes()]
   const accountName = planItem.account
@@ -90,7 +91,7 @@ const deployAction = async (
   if (!adapter) {
     throw new Error(`Missing adapter for ${accountName}`)
   }
-  const opts = { changeGroup: { groupID: planItem.groupKey, changes }, progressReporter }
+  const opts = { changeGroup: { groupID: planItem.groupKey, changes }, progressReporter, accountToServiceNameMap }
   return deployOrValidate({ adapter, adapterName: accountName, opts, checkOnly })
 }
 
@@ -134,6 +135,7 @@ export const deployActions = async (
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>,
   checkOnly: boolean,
+  accountToServiceNameMap: Record<string, string>,
 ): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
   const groups: GroupProperties[] = []
@@ -150,7 +152,7 @@ export const deployActions = async (
         const progressReporter = {
           reportProgress: (progress: Progress) => reportProgress(item, 'started', progress.message),
         }
-        const result = await deployAction(item, adapters, checkOnly, progressReporter)
+        const result = await deployAction(item, adapters, checkOnly, progressReporter, accountToServiceNameMap)
         result.appliedChanges.forEach(appliedChange => appliedChanges.push(appliedChange))
         makeArray(result.extraProperties?.groups).forEach(group =>
           groups.push({

--- a/packages/core/test/core/deploy/deploy_actions.test.ts
+++ b/packages/core/test/core/deploy/deploy_actions.test.ts
@@ -71,6 +71,10 @@ describe('deployActions', () => {
       beforeEach(async () => {
         const instance = new InstanceElement('Instance1', objectType)
         const deployPlan: Plan = await createDeployPlanFromElements([objectType, instance])
+        const accountToServiceNameMap = {
+          adapter: 'adapter',
+        }
+
         const mockAdapterOperations: AdapterOperations = {
           fetch: jest.fn().mockResolvedValue({}),
           deploy: jest.fn().mockImplementation(async deployParams => ({
@@ -93,6 +97,7 @@ describe('deployActions', () => {
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           async () => {},
           false,
+          accountToServiceNameMap,
         )
       })
       it('Should produce the correct errors', () => {
@@ -107,6 +112,9 @@ describe('deployActions', () => {
       beforeEach(async () => {
         const instance1 = new InstanceElement('Instance1', objectType)
         const instance2 = new InstanceElement('Instance2', objectType)
+        const accountToServiceNameMap = {
+          adapter: 'adapter',
+        }
         const deployPlan: Plan = await createDeployPlanFromElements([objectType, instance1, instance2])
         const mockAdapterOperations: AdapterOperations = {
           fetch: jest.fn().mockResolvedValue({}),
@@ -138,6 +146,7 @@ describe('deployActions', () => {
           // eslint-disable-next-line @typescript-eslint/no-empty-function
           async () => {},
           false,
+          accountToServiceNameMap,
         )
       })
       it('Should produce the correct error', () => {


### PR DESCRIPTION
add support of accountToServiceNameMap. now adapter deploy can use accountToServiceNameMap.


---



---
_Release Notes_: 
None

---
_User Notifications_: 
None
