### PR TITLE
fetch support for basic workato deploy

### DIFF
--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -24,7 +24,7 @@ import {
   CLIENT_CONFIG,
   validateFetchConfig,
   FETCH_CONFIG,
-  DEFAULT_CONFIG,
+  getDefaultConfig,
   WorkatoFetchConfig,
 } from './config'
 import WorkatoClient from './client/client'
@@ -41,13 +41,13 @@ const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials =
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): WorkatoConfig => {
   const configValue = config?.value ?? {}
-
+  const defaultConfig = getDefaultConfig(configValue.fetch?.enableFetchSturctureV2)
   const apiDefinitions = configUtils.mergeWithDefaultConfig(
-    DEFAULT_CONFIG.apiDefinitions,
+    defaultConfig.apiDefinitions,
     config?.value.apiDefinitions,
   ) as configUtils.AdapterDuckTypeApiConfig
 
-  const fetch = configUtils.mergeWithDefaultConfig(DEFAULT_CONFIG.fetch, config?.value.fetch) as WorkatoFetchConfig
+  const fetch = configUtils.mergeWithDefaultConfig(defaultConfig.fetch, config?.value.fetch) as WorkatoFetchConfig
 
   const adapterConfig: { [K in keyof Required<WorkatoConfig>]: WorkatoConfig[K] } = {
     client: configValue.client,
@@ -71,7 +71,7 @@ export const adapter: Adapter = {
     const updatedConfig = configUtils.configMigrations.migrateDeprecatedIncludeList(
       // Creating new instance is required because the type is not resolved in context.config
       new InstanceElement(ElemID.CONFIG_NAME, configType, context.config?.value),
-      DEFAULT_CONFIG,
+      getDefaultConfig(context.config?.value.fetch?.enableFetchSturctureV2),
     )
 
     const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -26,6 +26,7 @@ import {
   FETCH_CONFIG,
   getDefaultConfig,
   WorkatoFetchConfig,
+  ENABLE_DEPLOY_SUPPORT_FLAG,
 } from './config'
 import WorkatoClient from './client/client'
 import { createConnection } from './client/connection'
@@ -41,7 +42,7 @@ const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials =
 
 const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined): WorkatoConfig => {
   const configValue = config?.value ?? {}
-  const defaultConfig = getDefaultConfig(configValue.fetch?.enableFetchSturctureV2)
+  const defaultConfig = getDefaultConfig(configValue.enableDeploySupport)
   const apiDefinitions = configUtils.mergeWithDefaultConfig(
     defaultConfig.apiDefinitions,
     config?.value.apiDefinitions,
@@ -54,6 +55,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     fetch,
     apiDefinitions,
     deploy: configValue.deploy,
+    enableDeploySupport: configValue.enableDeploySupport,
   }
 
   validateClientConfig(CLIENT_CONFIG, adapterConfig.client)
@@ -71,7 +73,7 @@ export const adapter: Adapter = {
     const updatedConfig = configUtils.configMigrations.migrateDeprecatedIncludeList(
       // Creating new instance is required because the type is not resolved in context.config
       new InstanceElement(ElemID.CONFIG_NAME, configType, context.config?.value),
-      getDefaultConfig(context.config?.value.fetch?.enableFetchSturctureV2),
+      getDefaultConfig(context.config?.value.fetch?.[ENABLE_DEPLOY_SUPPORT_FLAG]),
     )
 
     const config = adapterConfigFromConfig(updatedConfig?.config[0] ?? context.config)

--- a/packages/workato-adapter/test/adapter.test.ts
+++ b/packages/workato-adapter/test/adapter.test.ts
@@ -31,7 +31,7 @@ import { types } from '@salto-io/lowerdash'
 import mockReplies from './mock_replies.json'
 import { adapter } from '../src/adapter_creator'
 import { usernameTokenCredentialsType } from '../src/auth'
-import { configType, DEFAULT_CONFIG, FETCH_CONFIG, DEFAULT_TYPES, API_DEFINITIONS_CONFIG } from '../src/config'
+import { configType, getDefaultConfig, FETCH_CONFIG, DEFAULT_TYPES, API_DEFINITIONS_CONFIG } from '../src/config'
 import { RECIPE_CODE_TYPE } from '../src/constants'
 
 type MockReply = {
@@ -65,7 +65,7 @@ describe('adapter', () => {
         const { elements } = await adapter
           .operations({
             credentials: new InstanceElement('config', usernameTokenCredentialsType, { token: 'token456' }),
-            config: new InstanceElement('config', configType, DEFAULT_CONFIG),
+            config: new InstanceElement('config', configType, getDefaultConfig()),
             elementsSource: buildElementsSourceFromElements([]),
           })
           .fetch({ progressReporter: { reportProgress: () => null } })
@@ -252,9 +252,9 @@ describe('adapter', () => {
           .operations({
             credentials: new InstanceElement('config', usernameTokenCredentialsType, { token: 'token456' }),
             config: new InstanceElement('config', configType, {
-              ...DEFAULT_CONFIG,
+              ...getDefaultConfig(),
               fetch: {
-                ...DEFAULT_CONFIG.fetch,
+                ...getDefaultConfig().fetch,
                 include: [{ type: '(?!recipe$).*' }, { type: 'recipe', criteria: { name: 'test.*' } }],
               },
             }),
@@ -408,7 +408,7 @@ describe('adapter', () => {
           credentials: new InstanceElement('config', usernameTokenCredentialsType, { token: 'token456' }),
           config: new InstanceElement('config', configType, {
             [FETCH_CONFIG]: {
-              ...DEFAULT_CONFIG[FETCH_CONFIG],
+              ...getDefaultConfig()[FETCH_CONFIG],
               serviceConnectionNames: {
                 salesforce: ['sfdev1'],
                 salesforce2: ['dev2 sfdc account'],

--- a/packages/workato-adapter/test/config.test.ts
+++ b/packages/workato-adapter/test/config.test.ts
@@ -1,0 +1,48 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { API_DEFINITIONS_CONFIG, ENABLE_DEPLOY_SUPPORT_FLAG, getDefaultConfig } from '../src/config'
+
+describe('config', () => {
+  describe('getDefaultConfig', () => {
+    describe('without deploy support', () => {
+      it('should include extended_schema in fieldToOmit', () => {
+        const config = getDefaultConfig(false)
+        expect(config[ENABLE_DEPLOY_SUPPORT_FLAG]).toBe(false)
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).toBeDefined()
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).toContainEqual({
+          fieldName: 'extended_input_schema',
+        })
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).toContainEqual({
+          fieldName: 'extended_output_schema',
+        })
+      })
+    })
+    describe('with deploy support', () => {
+      it('should add flag and not include extended_schemas in fieldToOmit', () => {
+        const config = getDefaultConfig(true)
+        expect(config[ENABLE_DEPLOY_SUPPORT_FLAG]).toBe(true)
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).toBeDefined()
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).not.toContainEqual({
+          fieldName: 'extended_input_schema',
+        })
+        expect(config[API_DEFINITIONS_CONFIG].typeDefaults.transformation?.fieldsToOmit).not.toContainEqual({
+          fieldName: 'extended_output_schema',
+        })
+      })
+    })
+  })
+})

--- a/packages/workato-adapter/test/filters/add_root_folder.test.ts
+++ b/packages/workato-adapter/test/filters/add_root_folder.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils, filterUtils, elements as elementUtils } from '@s
 import filterCreator from '../../src/filters/add_root_folder'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { getDefaultConfig } from '../../src/config'
 import { WORKATO } from '../../src/constants'
 
 describe('Add root filter', () => {
@@ -36,7 +36,7 @@ describe('Add root filter', () => {
         client,
         paginationFuncCreator: paginate,
       }),
-      config: DEFAULT_CONFIG,
+      config: getDefaultConfig(),
       fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })

--- a/packages/workato-adapter/test/filters/field_references.test.ts
+++ b/packages/workato-adapter/test/filters/field_references.test.ts
@@ -27,7 +27,7 @@ import { client as clientUtils, filterUtils, elements as elementUtils } from '@s
 import filterCreator from '../../src/filters/field_references'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { getDefaultConfig } from '../../src/config'
 import { WORKATO } from '../../src/constants'
 
 describe('Field references filter', () => {
@@ -45,7 +45,7 @@ describe('Field references filter', () => {
         client,
         paginationFuncCreator: paginate,
       }),
-      config: DEFAULT_CONFIG,
+      config: getDefaultConfig(),
       fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })

--- a/packages/workato-adapter/test/filters/project_issuetypes.test.ts
+++ b/packages/workato-adapter/test/filters/project_issuetypes.test.ts
@@ -19,7 +19,7 @@ import _ from 'lodash'
 import { WORKATO } from '../../src/constants'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { getDefaultConfig } from '../../src/config'
 import filterCreator from '../../src/filters/cross_service/jira/project_issuetypes'
 
 describe('projectIssuetype filter', () => {
@@ -44,7 +44,7 @@ describe('projectIssuetype filter', () => {
         client,
         paginationFuncCreator: paginate,
       }),
-      config: DEFAULT_CONFIG,
+      config: getDefaultConfig(),
       fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
   })

--- a/packages/workato-adapter/test/filters/recipe_references.test.ts
+++ b/packages/workato-adapter/test/filters/recipe_references.test.ts
@@ -30,7 +30,7 @@ import { DetailedDependency } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/cross_service/recipe_references'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { DEFAULT_TYPES, DEFAULT_ID_FIELDS, SUPPORTED_TYPES, DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
+import { DEFAULT_ID_FIELDS, SUPPORTED_TYPES, getDefaultConfig, FETCH_CONFIG, DEFAULT_TYPES } from '../../src/config'
 import { WORKATO } from '../../src/constants'
 
 /* eslint-disable camelcase */
@@ -57,7 +57,7 @@ describe('Recipe references filter', () => {
       }),
       config: {
         fetch: {
-          ...DEFAULT_CONFIG[FETCH_CONFIG],
+          ...getDefaultConfig()[FETCH_CONFIG],
           serviceConnectionNames: {
             salesforce: ['salesforce sandbox 1'],
             netsuite: ['netsuite sbx 123'],
@@ -1542,7 +1542,7 @@ describe('Recipe references filter', () => {
         }),
         config: {
           fetch: {
-            ...DEFAULT_CONFIG[FETCH_CONFIG],
+            ...getDefaultConfig()[FETCH_CONFIG],
             serviceConnectionNames: {
               salesforce: ['salesforce sandbox 1'],
               netsuite: ['netsuite sbx 123'],
@@ -2336,7 +2336,7 @@ describe('Recipe references filter', () => {
           paginationFuncCreator: paginate,
         }),
         config: {
-          fetch: _.omit(DEFAULT_CONFIG[FETCH_CONFIG], 'serviceConnectionNames'),
+          fetch: _.omit(getDefaultConfig()[FETCH_CONFIG], 'serviceConnectionNames'),
           apiDefinitions: {
             typeDefaults: {
               transformation: {
@@ -2378,7 +2378,7 @@ describe('Recipe references filter', () => {
         }),
         config: {
           fetch: {
-            ...DEFAULT_CONFIG[FETCH_CONFIG],
+            ...getDefaultConfig()[FETCH_CONFIG],
             serviceConnectionNames: {
               salesforce: ['salesforce sandbox 1 unresolved'],
               netsuite: ['netsuite sbx 123'],
@@ -2484,7 +2484,7 @@ describe('Recipe references filter', () => {
         }),
         config: {
           fetch: {
-            ...DEFAULT_CONFIG[FETCH_CONFIG],
+            ...getDefaultConfig()[FETCH_CONFIG],
             serviceConnectionNames: {
               salesforce: ['secondary salesforce', 'salesforce sandbox 1'],
               netsuite: ['secondary netsuite'],

--- a/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
+++ b/packages/workato-adapter/test/filters/referenced_id_fields.test.ts
@@ -24,7 +24,7 @@ import {
   isInstanceElement,
 } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils, elements as elemUtils } from '@salto-io/adapter-components'
-import { DEFAULT_CONFIG, FETCH_CONFIG, SUPPORTED_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
+import { getDefaultConfig, FETCH_CONFIG, SUPPORTED_TYPES, DEFAULT_ID_FIELDS } from '../../src/config'
 import WorkatoClient from '../../src/client/client'
 import { WORKATO } from '../../src/constants'
 import { paginate } from '../../src/client/pagination'
@@ -118,7 +118,7 @@ describe('referenced id fields filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: {
-        fetch: DEFAULT_CONFIG[FETCH_CONFIG],
+        fetch: getDefaultConfig()[FETCH_CONFIG],
         apiDefinitions: {
           typeDefaults: {
             transformation: {
@@ -180,7 +180,7 @@ describe('referenced id fields filter', () => {
         paginationFuncCreator: paginate,
       }),
       config: {
-        fetch: DEFAULT_CONFIG[FETCH_CONFIG],
+        fetch: getDefaultConfig()[FETCH_CONFIG],
         apiDefinitions: {
           typeDefaults: {
             transformation: {

--- a/packages/workato-adapter/test/filters/service_url.test.ts
+++ b/packages/workato-adapter/test/filters/service_url.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils, filterUtils, elements as elementUtils } from '@s
 import filterCreator from '../../src/filters/service_url'
 import WorkatoClient from '../../src/client/client'
 import { paginate } from '../../src/client/pagination'
-import { DEFAULT_CONFIG } from '../../src/config'
+import { getDefaultConfig } from '../../src/config'
 import {
   CONNECTION_TYPE,
   RECIPE_TYPE,
@@ -97,7 +97,7 @@ describe('service_url', () => {
         client,
         paginationFuncCreator: paginate,
       }),
-      config: DEFAULT_CONFIG,
+      config: getDefaultConfig(),
       fetchQuery: elementUtils.query.createMockQuery(),
     }) as FilterType
 


### PR DESCRIPTION
not omit extended_input/output_schema when using new flag - FETCH_V2_FIELDS_TO_OMIT
From now on, users should use the FETCH_V2_FIELDS_TO_OMIT on theirs config and start getting the extended_schemas

---

preperation for deploy support - https://github.com/salto-io/salto/pull/4096 
When deploying Workato we will use the Recipe Lifecycle Managment feature. When using it without extended_schema recipe could stop, recipe parameters could change without announcing and hazards could pop up. So, we change the fetch structure, such that extended_schema enter to the Nacl

---
_Release Notes_: 


---
_User Notifications_: 
None
