### PR TITLE
SALTO-5497: Omit id field in SLA sub types

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2139,13 +2139,12 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   },
   SLA__config__goals: {
     transformation: {
-      fieldsToHide: [{ fieldName: 'id' }],
+      fieldsToOmit: [{ fieldName: 'id' }],
     },
   },
   SLA__config__goals__subGoals: {
     transformation: {
-      fieldsToHide: [{ fieldName: 'id' }],
-      fieldsToOmit: [{ fieldName: 'goalId' }],
+      fieldsToOmit: [{ fieldName: 'goalId' }, { fieldName: 'id' }],
     },
   },
   SLA__config__definition__pause: {


### PR DESCRIPTION
In this PR I omitted the ids in SLA golas and sub goals since they are not needed. 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* Omitted Id fields in SLA subTypes. 

---
_User Notifications_: 
None
