### PR TITLE
SALTO-5424 support defining aliases and importantValues in definitions

### DIFF
--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -152,6 +152,7 @@ export const addAliasToElements = ({
   const allElements = Object.values(elementsMap).flat()
   const elementsById = _.keyBy(allElements, elem => elem.elemID.getFullName())
   const relevantElementsMap = _.pick(elementsMap, Object.keys(aliasMap))
+  const relevantAliasMap = _.pick(aliasMap, Object.keys(relevantElementsMap))
 
   const addAlias = (group: string): void => {
     const aliasData = aliasMap[group]
@@ -162,6 +163,6 @@ export const addAliasToElements = ({
       }
     })
   }
-  const graph = createAliasDependenciesGraph(aliasMap, relevantElementsMap)
+  const graph = createAliasDependenciesGraph(relevantAliasMap, relevantElementsMap)
   graph.walkSync(group => addAlias(group as string)) // TODO_F is the casing ok here?
 }

--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -119,10 +119,9 @@ const createAliasDependenciesGraph = (
 ): DAG<undefined> => {
   const graph = new DAG<undefined>()
   Object.entries(aliasMap).forEach(([typeName, aliasData]) => {
+    const dependencies = new Set<string>()
     aliasData.aliasComponents.forEach(aliasComponent => {
-      const dependencies = new Set<string>()
       if (isConstantComponent(aliasComponent)) {
-        graph.addNode(typeName, dependencies, undefined)
         return
       }
       const { fieldName, referenceFieldName } = aliasComponent
@@ -140,8 +139,8 @@ const createAliasDependenciesGraph = (
           }
         })
       }
-      graph.addNode(typeName, dependencies, undefined)
     })
+    graph.addNode(typeName, dependencies, undefined)
   })
   return graph
 }

--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -117,11 +117,11 @@ const createAliasDependenciesGraph = (
   elementsMap: Record<string, TopLevelElement[]>,
 ): DAG<undefined> => {
   const graph = new DAG<undefined>()
-  Object.keys(aliasMap).forEach(typeName => {
-    const aliasData = aliasMap[typeName]
+  Object.entries(aliasMap).forEach(([typeName, aliasData]) => {
     aliasData.aliasComponents.forEach(aliasComponent => {
       const dependencies = new Set<string>()
       if (isConstantComponent(aliasComponent)) {
+        graph.addNode(typeName, dependencies, undefined)
         return
       }
       const { fieldName, referenceFieldName } = aliasComponent
@@ -133,7 +133,10 @@ const createAliasDependenciesGraph = (
             log.error(`${fieldName} is treated as a reference expression but it is not`)
             return
           }
-          dependencies.add(fieldValue.elemID.typeName)
+          const dependencyTypeName = fieldValue.elemID.typeName
+          if (aliasMap[dependencyTypeName] !== undefined && elementsMap[dependencyTypeName] !== undefined) {
+            dependencies.add(fieldValue.elemID.typeName)
+          }
         })
       }
       graph.addNode(typeName, dependencies, undefined)

--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -25,6 +25,7 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { DAG } from '@salto-io/dag'
+import { collections } from '@salto-io/lowerdash'
 
 const log = logger(module)
 export type AliasComponent = {
@@ -157,7 +158,7 @@ export const addAliasToElements = ({
   const relevantElementsMap = _.pick(elementsMap, Object.keys(aliasMap))
   const relevantAliasMap = _.pick(aliasMap, Object.keys(relevantElementsMap))
 
-  const addAlias = (group: string): void => {
+  const addAlias = (group: collections.set.SetId): void => {
     const aliasData = aliasMap[group]
     relevantElementsMap[group].forEach(element => {
       const alias = calculateAlias({ element, elementsById, aliasData })
@@ -167,5 +168,5 @@ export const addAliasToElements = ({
     })
   }
   const graph = createAliasDependenciesGraph(relevantAliasMap, relevantElementsMap)
-  graph.walkSync(group => addAlias(group as string)) // TODO_F is the casing ok here?
+  graph.walkSync(group => addAlias(group))
 }

--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -23,12 +23,14 @@ import {
   SaltoError,
   Values,
 } from '@salto-io/adapter-api'
+import { ImportantValues } from '@salto-io/adapter-utils'
 import { ConfigChangeSuggestion } from '../../../config' // TODO move
 import { ArgsWithCustomizer } from '../shared/types'
 // eslint-disable-next-line import/no-cycle
 import { GenerateTypeArgs } from './types'
 import { ResolveCustomNameMappingOptionsType } from '../api'
 import { NameMappingFunctionMap, NameMappingOptions } from '../shared'
+import { AliasData } from '../../../add_alias'
 
 export type FieldIDPart<TCustomNameMappingOptions extends string = never> = ArgsWithCustomizer<
   string | undefined,
@@ -157,8 +159,9 @@ type FetchTopLevelElementDefinition<Options extends ElementFetchDefinitionOption
   // when missing, we validate that this is a plain object
   valueGuard?: (val: unknown) => val is ResolveValueType<Options>
 
-  // TODO add:
-  // alias, important attributes
+  alias?: AliasData
+
+  importantValues?: ImportantValues
 }
 
 export type ElementFetchDefinition<Options extends ElementFetchDefinitionOptions = {}> = {

--- a/packages/adapter-components/src/fetch/element/type_element.ts
+++ b/packages/adapter-components/src/fetch/element/type_element.ts
@@ -25,6 +25,7 @@ import {
   ElemID,
   isListType,
   CORE_ANNOTATIONS,
+  Values,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -222,14 +223,27 @@ export const generateType = <Options extends FetchApiDefinitionsOptions>(
   )
 
   const { topLevel } = elementDef ?? {}
-  const { hide, singleton } = topLevel ?? {}
+  const { hide, singleton, importantValues } = topLevel ?? {}
+  const getAnnotations = (): Values | undefined => {
+    if (!hide && importantValues === undefined) {
+      return undefined
+    }
+    const annotations: Values = {}
+    if (hide) {
+      annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
+    }
+    if (importantValues !== undefined) {
+      annotations[CORE_ANNOTATIONS.IMPORTANT_VALUES] = importantValues
+    }
+    return annotations
+  }
 
   const type = new ObjectType({
     elemID: new ElemID(adapterName, naclName),
     fields,
     path,
     isSettings: singleton ?? false,
-    annotations: hide ? { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } : undefined,
+    annotations: getAnnotations(),
   })
 
   return { type, nestedTypes }

--- a/packages/adapter-components/src/filters/add_alias.ts
+++ b/packages/adapter-components/src/filters/add_alias.ts
@@ -1,0 +1,55 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { filter } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { addAliasToElements, AliasData } from '../add_alias'
+import { ApiDefinitions, queryWithDefault } from '../definitions'
+import { UserConfigAdapterFilterCreator } from '../filter_utils'
+
+/**
+ * Add aliases to instances according to definitions.
+ */
+export const addAliasFilterCreator: <
+  TContext,
+  TResult extends void | filter.FilterResult,
+  ClientOptions extends string,
+  PaginationOptions extends string | 'none',
+  Action extends string,
+>(
+  definitions: ApiDefinitions<ClientOptions, PaginationOptions, Action>,
+) => UserConfigAdapterFilterCreator<TContext, TResult> = definitions => () => ({
+  name: 'addAliasFilter',
+  onFetch: async (elements: Element[]) => {
+    if (definitions.fetch !== undefined) {
+      const { instances } = definitions.fetch
+      const defQuery = queryWithDefault(instances)
+      const elementsMap = _.groupBy(elements.filter(isInstanceElement), e => e.elemID.typeName)
+      const allDefs = defQuery.getAll()
+      const aliasMap = Object.entries(allDefs).reduce<Record<string, AliasData>>((currentRecord, [typeName, def]) => {
+        const aliasData = def.element?.topLevel?.alias
+        if (aliasData === undefined) {
+          return currentRecord
+        }
+        return {
+          ...currentRecord,
+          [typeName]: aliasData,
+        }
+      }, {})
+      addAliasToElements({ elementsMap, aliasMap })
+    }
+  },
+})

--- a/packages/adapter-components/src/filters/add_alias.ts
+++ b/packages/adapter-components/src/filters/add_alias.ts
@@ -17,7 +17,7 @@ import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { addAliasToElements, AliasData } from '../add_alias'
-import { ApiDefinitions, queryWithDefault } from '../definitions'
+import { ApiDefinitions, APIDefinitionsOptions, queryWithDefault } from '../definitions'
 import { FilterCreator } from '../filter_utils'
 
 /**
@@ -27,11 +27,9 @@ export const addAliasFilterCreator: <
   TClient,
   TContext,
   TResult extends void | filter.FilterResult,
-  ClientOptions extends string,
-  PaginationOptions extends string | 'none',
-  Action extends string,
+  Options extends APIDefinitionsOptions = {},
 >(
-  definitions: ApiDefinitions<ClientOptions, PaginationOptions, Action>,
+  definitions: ApiDefinitions<Options>,
 ) => FilterCreator<TClient, TContext, TResult> = definitions => () => ({
   name: 'addAliasFilter',
   onFetch: async (elements: Element[]) => {

--- a/packages/adapter-components/src/filters/add_alias.ts
+++ b/packages/adapter-components/src/filters/add_alias.ts
@@ -18,12 +18,13 @@ import { filter } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { addAliasToElements, AliasData } from '../add_alias'
 import { ApiDefinitions, queryWithDefault } from '../definitions'
-import { UserConfigAdapterFilterCreator } from '../filter_utils'
+import { FilterCreator } from '../filter_utils'
 
 /**
  * Add aliases to instances according to definitions.
  */
 export const addAliasFilterCreator: <
+  TClient,
   TContext,
   TResult extends void | filter.FilterResult,
   ClientOptions extends string,
@@ -31,7 +32,7 @@ export const addAliasFilterCreator: <
   Action extends string,
 >(
   definitions: ApiDefinitions<ClientOptions, PaginationOptions, Action>,
-) => UserConfigAdapterFilterCreator<TContext, TResult> = definitions => () => ({
+) => FilterCreator<TClient, TContext, TResult> = definitions => () => ({
   name: 'addAliasFilter',
   onFetch: async (elements: Element[]) => {
     if (definitions.fetch !== undefined) {

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -23,3 +23,4 @@ export { referencedInstanceNamesFilterCreator } from './referenced_instance_name
 export { queryFilterCreator, createParentChildGraph } from './query'
 export { hideTypesFilterCreator } from './hide_types'
 export { defaultDeployFilterCreator } from './default_deploy'
+export { addAliasFilterCreator } from './add_alias'

--- a/packages/adapter-components/test/add_alias.test.ts
+++ b/packages/adapter-components/test/add_alias.test.ts
@@ -29,11 +29,6 @@ describe('addAliasToElements', () => {
   const categoryOrderTypeName = 'category_order'
   const categoryTranslationTypeName = 'category_translation'
   const ZENDESK = 'zendesk'
-  const secondIterationGroupNames = [
-    dynamicContentItemVariantsTypeName,
-    categoryOrderTypeName,
-    categoryTranslationTypeName,
-  ]
 
   const aliasMap: Record<string, AliasData> = {
     [appInstallationTypeName]: {
@@ -172,7 +167,6 @@ describe('addAliasToElements', () => {
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([
       'app installation name',
@@ -194,7 +188,6 @@ describe('addAliasToElements', () => {
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -211,7 +204,6 @@ describe('addAliasToElements', () => {
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -231,7 +223,6 @@ describe('addAliasToElements', () => {
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
@@ -243,7 +234,6 @@ describe('addAliasToElements', () => {
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
       aliasMap,
-      secondIterationGroupNames,
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })

--- a/packages/adapter-components/test/filters/add_alias.test.ts
+++ b/packages/adapter-components/test/filters/add_alias.test.ts
@@ -38,104 +38,119 @@ describe('add alias filter', () => {
   const instType3 = new InstanceElement('inst3', objType3, { name: 'inst3 name', title: 'inst3 title' }, undefined, {
     _parent: [new ReferenceExpression(instType2.elemID, instType2)],
   })
-  const instType4 = new InstanceElement('inst3', objType4, { name: 'inst4 name', title: 'inst4 title', refField: new ReferenceExpression(instType3.elemID, instType3) })
+  const instType4 = new InstanceElement('inst3', objType4, {
+    name: 'inst4 name',
+    title: 'inst4 title',
+    refField: new ReferenceExpression(instType3.elemID, instType3),
+  })
   const instType5 = new InstanceElement('inst5', objType5, { name: 'inst5 name', title: 'inst5 title' })
   let elements: InstanceElement[]
   beforeEach(() => {
     elements = [instType1.clone(), instType2.clone(), instType3.clone(), instType4.clone(), instType5.clone()]
   })
 
+  const createFilter = (definitions: ApiDefinitions): FilterType =>
+    addAliasFilterCreator(definitions)({
+      client: {} as unknown,
+      paginator: undefined as unknown as Paginator,
+      fetchQuery: createMockQuery(),
+      config: {} as unknown,
+    }) as FilterType
 
-  const createFilter = (definitions: ApiDefinitions): FilterType => addAliasFilterCreator(definitions)({
-    client: {} as unknown,
-    paginator: undefined as unknown as Paginator,
-    fetchQuery: createMockQuery(),
-    config: {}  as unknown,
-  }) as FilterType
-
-    describe('when fetch definition is undefined', () => {
-      it('should do nothing on fetch', async () => {
-        const filter = createFilter({} as ApiDefinitions)
-        await filter.onFetch(elements)
-        expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined, undefined, undefined, undefined, undefined])
-      })
+  describe('when fetch definition is undefined', () => {
+    it('should do nothing on fetch', async () => {
+      const filter = createFilter({} as ApiDefinitions)
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+      ])
     })
-    describe('when fetch definition is defined', () => {
-      const definitions = {
-        fetch: { 
-          instances: {
-            customizations: {
-              [type1]: {
-                element: {
-                  topLevel: {
-                    alias: {
-                      aliasComponents: [
-                        {
-                          fieldName: 'name',
-                        },
-                      ],
-                    },
+  })
+  describe('when fetch definition is defined', () => {
+    const definitions = {
+      fetch: {
+        instances: {
+          customizations: {
+            [type1]: {
+              element: {
+                topLevel: {
+                  alias: {
+                    aliasComponents: [
+                      {
+                        fieldName: 'name',
+                      },
+                    ],
                   },
                 },
               },
-              [type2]: {
-                element: {
-                  topLevel: {
-                    alias: {
-                      aliasComponents: [
-                        {
-                          fieldName: 'title',
-                        },
-                      ],
-                    },
+            },
+            [type2]: {
+              element: {
+                topLevel: {
+                  alias: {
+                    aliasComponents: [
+                      {
+                        fieldName: 'title',
+                      },
+                    ],
                   },
                 },
               },
-              [type3]: {
-                element: {
-                  topLevel: {
-                    alias: {
-                      aliasComponents: [
-                        {
-                          fieldName: '_parent.0',
-                          referenceFieldName: '_alias',
-                        },
-                        {
-                          fieldName: 'name',
-                        },
-                      ],
-                      separator: ':',
-                    },
+            },
+            [type3]: {
+              element: {
+                topLevel: {
+                  alias: {
+                    aliasComponents: [
+                      {
+                        fieldName: '_parent.0',
+                        referenceFieldName: '_alias',
+                      },
+                      {
+                        fieldName: 'name',
+                      },
+                    ],
+                    separator: ':',
                   },
                 },
               },
-              [type4]: {
-                element: {
-                  topLevel: {
-                    alias: {
-                      aliasComponents: [
-                        {
-                          fieldName: 'refField',
-                          referenceFieldName: '_alias',
-                        },
-                        {
-                          fieldName: 'title',
-                        },
-                      ],
-                      separator: ':',
-                    },
+            },
+            [type4]: {
+              element: {
+                topLevel: {
+                  alias: {
+                    aliasComponents: [
+                      {
+                        fieldName: 'refField',
+                        referenceFieldName: '_alias',
+                      },
+                      {
+                        fieldName: 'title',
+                      },
+                    ],
+                    separator: ':',
                   },
                 },
               },
             },
           },
         },
-      } as unknown as ApiDefinitions
-      it('should add aliases correctly', async () => {
-        const filter = createFilter(definitions)
-        await filter.onFetch(elements)
-        expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS]))
-          .toEqual(['inst1 name', 'inst2 title', 'inst2 title:inst3 name', 'inst2 title:inst3 name:inst4 title', undefined])
-      })
+      },
+    } as unknown as ApiDefinitions
+    it('should add aliases correctly', async () => {
+      const filter = createFilter(definitions)
+      await filter.onFetch(elements)
+      expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([
+        'inst1 name',
+        'inst2 title',
+        'inst2 title:inst3 name',
+        'inst2 title:inst3 name:inst4 title',
+        undefined,
+      ])
     })
+  })
 })

--- a/packages/adapter-components/test/filters/add_alias.test.ts
+++ b/packages/adapter-components/test/filters/add_alias.test.ts
@@ -1,0 +1,141 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ObjectType, ElemID, CORE_ANNOTATIONS, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { FilterWith } from '../../src/filter_utils'
+import { Paginator } from '../../src/client'
+import { createMockQuery } from '../../src/fetch/query'
+import { addAliasFilterCreator } from '../../src/filters/add_alias'
+import { ApiDefinitions } from '../../src/definitions'
+
+describe('add alias filter', () => {
+  type FilterType = FilterWith<'onFetch'>
+  const adapter = 'adapter'
+  const type1 = 't1'
+  const type2 = 't2'
+  const type3 = 't3'
+  const type4 = 't4'
+  const type5 = 't5'
+  const objType1 = new ObjectType({ elemID: new ElemID(adapter, type1) })
+  const objType2 = new ObjectType({ elemID: new ElemID(adapter, type2) })
+  const objType3 = new ObjectType({ elemID: new ElemID(adapter, type3) })
+  const objType4 = new ObjectType({ elemID: new ElemID(adapter, type4) })
+  const objType5 = new ObjectType({ elemID: new ElemID(adapter, type5) })
+  const instType1 = new InstanceElement('inst1', objType1, { title: 'inst1 title', name: 'inst1 name' })
+  const instType2 = new InstanceElement('inst2', objType2, { title: 'inst2 title', name: 'inst2 name' })
+  const instType3 = new InstanceElement('inst3', objType3, { name: 'inst3 name', title: 'inst3 title' }, undefined, {
+    _parent: [new ReferenceExpression(instType2.elemID, instType2)],
+  })
+  const instType4 = new InstanceElement('inst3', objType4, { name: 'inst4 name', title: 'inst4 title', refField: new ReferenceExpression(instType3.elemID, instType3) })
+  const instType5 = new InstanceElement('inst5', objType5, { name: 'inst5 name', title: 'inst5 title' })
+  let elements: InstanceElement[]
+  beforeEach(() => {
+    elements = [instType1.clone(), instType2.clone(), instType3.clone(), instType4.clone(), instType5.clone()]
+  })
+
+
+  const createFilter = (definitions: ApiDefinitions): FilterType => addAliasFilterCreator(definitions)({
+    client: {} as unknown,
+    paginator: undefined as unknown as Paginator,
+    fetchQuery: createMockQuery(),
+    config: {}  as unknown,
+  }) as FilterType
+
+    describe('when fetch definition is undefined', () => {
+      it('should do nothing on fetch', async () => {
+        const filter = createFilter({} as ApiDefinitions)
+        await filter.onFetch(elements)
+        expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined, undefined, undefined, undefined, undefined])
+      })
+    })
+    describe('when fetch definition is defined', () => {
+      const definitions = {
+        fetch: { 
+          instances: {
+            customizations: {
+              [type1]: {
+                element: {
+                  topLevel: {
+                    alias: {
+                      aliasComponents: [
+                        {
+                          fieldName: 'name',
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              [type2]: {
+                element: {
+                  topLevel: {
+                    alias: {
+                      aliasComponents: [
+                        {
+                          fieldName: 'title',
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              [type3]: {
+                element: {
+                  topLevel: {
+                    alias: {
+                      aliasComponents: [
+                        {
+                          fieldName: '_parent.0',
+                          referenceFieldName: '_alias',
+                        },
+                        {
+                          fieldName: 'name',
+                        },
+                      ],
+                      separator: ':',
+                    },
+                  },
+                },
+              },
+              [type4]: {
+                element: {
+                  topLevel: {
+                    alias: {
+                      aliasComponents: [
+                        {
+                          fieldName: 'refField',
+                          referenceFieldName: '_alias',
+                        },
+                        {
+                          fieldName: 'title',
+                        },
+                      ],
+                      separator: ':',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      } as unknown as ApiDefinitions
+      it('should add aliases correctly', async () => {
+        const filter = createFilter(definitions)
+        await filter.onFetch(elements)
+        expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS]))
+          .toEqual(['inst1 name', 'inst2 title', 'inst2 title:inst3 name', 'inst2 title:inst3 name:inst4 title', undefined])
+      })
+    })
+})

--- a/packages/jira-adapter/src/filters/add_alias.ts
+++ b/packages/jira-adapter/src/filters/add_alias.ts
@@ -35,8 +35,6 @@ import {
 
 const log = logger(module)
 
-const SECOND_ITERATION_TYPES = ['FieldConfigurationItem', 'CustomFieldContext']
-
 const aliasMap: Record<string, AliasData> = {
   Field: {
     aliasComponents: [
@@ -238,7 +236,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
     addAliasToElements({
       elementsMap,
       aliasMap,
-      secondIterationGroupNames: SECOND_ITERATION_TYPES,
     })
   },
 })

--- a/packages/okta-adapter/src/filters/add_alias.ts
+++ b/packages/okta-adapter/src/filters/add_alias.ts
@@ -48,13 +48,6 @@ import {
   APP_GROUP_ASSIGNMENT_TYPE_NAME,
 } from '../constants'
 
-const SECOND_ITERATION_TYPES = [
-  USER_SCHEMA_TYPE_NAME,
-  PROFILE_MAPPING_TYPE_NAME,
-  GROUP_PUSH_TYPE_NAME,
-  APP_GROUP_ASSIGNMENT_TYPE_NAME,
-]
-
 const DEFAULT_ALIAS_TYPES = [
   ...POLICY_RULE_TYPE_NAMES,
   ...POLICY_TYPE_NAMES,
@@ -162,7 +155,6 @@ const filterCreator: FilterCreator = () => ({
     addAliasToElements({
       elementsMap,
       aliasMap,
-      secondIterationGroupNames: SECOND_ITERATION_TYPES,
     })
   },
 })

--- a/packages/zendesk-adapter/src/filters/add_alias.ts
+++ b/packages/zendesk-adapter/src/filters/add_alias.ts
@@ -18,7 +18,6 @@ import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { addAliasToElements, AliasData } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
-import { DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from './dynamic_content'
 import {
   APP_OWNED_TYPE_NAME,
   ARTICLE_ATTACHMENT_TYPE_NAME,
@@ -67,18 +66,6 @@ const ARTICLE_ORDER = 'Article Order'
 const LANGUAGE_SETTINGS = 'language settings'
 const SETTINGS = 'Settings'
 const THEME_SETTINGS = 'Theme settings'
-
-const SECOND_ITERATION_TYPES = [
-  DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME,
-  CATEGORY_ORDER_TYPE_NAME,
-  CATEGORY_TRANSLATION_TYPE_NAME,
-  SECTION_TRANSLATION_TYPE_NAME,
-  SECTION_ORDER_TYPE_NAME,
-  ARTICLE_TRANSLATION_TYPE_NAME,
-  ARTICLE_ORDER_TYPE_NAME,
-  ARTICLE_ATTACHMENT_TYPE_NAME,
-  THEME_SETTINGS_TYPE_NAME,
-]
 
 const aliasMap: Record<string, AliasData> = {
   app_installation: {
@@ -528,7 +515,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
     addAliasToElements({
       elementsMap,
       aliasMap,
-      secondIterationGroupNames: SECOND_ITERATION_TYPES,
     })
   },
 })


### PR DESCRIPTION
- support defining aliases and importantValues in definitions
- build dependencies graph for addAlias function to calculate the order we should create aliases

---

_Additional context for reviewer_

---
_Release Notes_: 
- addAlias function is no longer supports `secondInterationsTypes` parameter, instead it builds a dependencies graph

---
_User Notifications_: 
None
