### PR TITLE
SALTO-5275: [Zendesk] Add ability to omit ticket status custom status ticket field from Ticket Forms on fetch

### DIFF
--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -100,7 +100,7 @@ zendesk {
 | extractReferencesFromFreeText      | false                              | When enabled, convert ids in zendesk links in string values to salto references                                                                                        |
 | convertJsonIdsToReferences         | false                              | When enabled, If a field is a json with an 'id' field, convert its value to a reference                                                                                |
 | omitInactive                       | true                               | When enabled, Inactive instances will be omitted from the fetch. This option support default value and specific types can be overridden using the customizations field |
-| omitCustomTicketStatus             | false                              | When enabled, Custom Ticket Status will be omitted from the fetch.                                                                                                     |
+| omitTicketStatusTicketField        | false                              | When enabled, Custom Ticket Status will be omitted from the fetch.                                                                                                     |
 
 ## Fetch entry options
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -100,6 +100,7 @@ zendesk {
 | extractReferencesFromFreeText      | false                              | When enabled, convert ids in zendesk links in string values to salto references                                                                                        |
 | convertJsonIdsToReferences         | false                              | When enabled, If a field is a json with an 'id' field, convert its value to a reference                                                                                |
 | omitInactive                       | true                               | When enabled, Inactive instances will be omitted from the fetch. This option support default value and specific types can be overridden using the customizations field |
+| omitCustomTicketStatus             | false                              | When enabled, Custom Ticket Status will be omitted from the fetch.                                                                                                     |
 
 ## Fetch entry options
 

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -97,6 +97,7 @@ export type ZendeskFetchConfig = definitions.UserFetchConfig & {
   extractReferencesFromFreeText?: boolean
   convertJsonIdsToReferences?: boolean
   omitInactive?: OmitInactiveConfig
+  omitCustomTicketStatus?: boolean
 }
 
 export type ZendeskDeployConfig = definitions.UserDeployConfig &
@@ -3047,6 +3048,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           extractReferencesFromFreeText: { refType: BuiltinTypes.BOOLEAN },
           convertJsonIdsToReferences: { refType: BuiltinTypes.BOOLEAN },
           omitInactive: { refType: OmitInactiveType },
+          omitCustomTicketStatus: { refType: BuiltinTypes.BOOLEAN },
         },
         omitElemID: true,
       }),
@@ -3079,6 +3081,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.extractReferencesFromFreeText`,
       `${FETCH_CONFIG}.convertJsonIdsToReferences`,
       `${FETCH_CONFIG}.omitInactive.customizations`,
+      `${FETCH_CONFIG}.omitCustomTicketStatus`,
       DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -97,7 +97,7 @@ export type ZendeskFetchConfig = definitions.UserFetchConfig & {
   extractReferencesFromFreeText?: boolean
   convertJsonIdsToReferences?: boolean
   omitInactive?: OmitInactiveConfig
-  omitCustomTicketStatus?: boolean
+  omitTicketStatusTicketField?: boolean
 }
 
 export type ZendeskDeployConfig = definitions.UserDeployConfig &
@@ -2784,6 +2784,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
       default: true,
       customizations: {},
     },
+    omitTicketStatusTicketField: false,
   },
   [DEPLOY_CONFIG]: {
     createMissingOrganizations: false,
@@ -3048,7 +3049,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
           extractReferencesFromFreeText: { refType: BuiltinTypes.BOOLEAN },
           convertJsonIdsToReferences: { refType: BuiltinTypes.BOOLEAN },
           omitInactive: { refType: OmitInactiveType },
-          omitCustomTicketStatus: { refType: BuiltinTypes.BOOLEAN },
+          omitTicketStatusTicketField: { refType: BuiltinTypes.BOOLEAN },
         },
         omitElemID: true,
       }),
@@ -3081,7 +3082,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.extractReferencesFromFreeText`,
       `${FETCH_CONFIG}.convertJsonIdsToReferences`,
       `${FETCH_CONFIG}.omitInactive.customizations`,
-      `${FETCH_CONFIG}.omitCustomTicketStatus`,
+      `${FETCH_CONFIG}.omitTicketStatusTicketField`,
       DEPLOY_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -183,7 +183,7 @@ const removeCustomTicketStatusFromTicketFieldIDsField = (
 const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
   name: 'ticketFormDeploy',
   onFetch: async (elements: Element[]): Promise<void> => {
-    if (config[FETCH_CONFIG].omitCustomTicketStatus !== true) {
+    if (config[FETCH_CONFIG].omitTicketStatusTicketField !== true) {
       return
     }
     const genericCustomTicketElement = elements

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -41,6 +41,7 @@ import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NA
 const { awu } = collections.asynciterable
 const SOME_STATUSES = 'SOME_STATUSES'
 const log = logger(module)
+const GENERIC_CUSTOM_TICKET_FIELD_NAME = 'Ticket_status_custom_status'
 
 type Child = {
   // eslint-disable-next-line camelcase
@@ -161,7 +162,6 @@ const removeCustomTicketStatusFromTicketFieldIDsField = (
   customTicketElement: InstanceElement,
 ): void => {
   const ticketFieldIDs: Array<string | ReferenceExpression> = instance.value.ticket_field_ids || []
-
   if (ticketFieldIDs.includes(customTicketElement.value.id)) {
     // found the string ID of the custom ticket
     ticketFieldIDs.splice(ticketFieldIDs.indexOf(customTicketElement.value.id), 1)
@@ -187,18 +187,22 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     if (config[FETCH_CONFIG].omitCustomTicketStatus !== true) {
       return
     }
-    const customTicketElement = elements
+    const genericCustomTicketElement = elements
       .filter(isInstanceElement)
-      .find(instance => instance.elemID.name.includes('Ticket_status_custom_status'))
-    if (customTicketElement === undefined) {
+      .find(instance => instance.elemID.name.includes(GENERIC_CUSTOM_TICKET_FIELD_NAME))
+    if (genericCustomTicketElement === undefined) {
       return
     }
+
     elements
       .filter(isInstanceElement)
       .filter(element => element.elemID.typeName === TICKET_FORM_TYPE_NAME)
-      .map(instance => removeCustomTicketStatusFromTicketFieldIDsField(instance, customTicketElement))
+      .map(instance => removeCustomTicketStatusFromTicketFieldIDsField(instance, genericCustomTicketElement))
 
-    remove(elements, element => customTicketElement.elemID && element.elemID.isEqual(customTicketElement.elemID))
+    remove(
+      elements,
+      element => genericCustomTicketElement.elemID && element.elemID.isEqual(genericCustomTicketElement.elemID),
+    )
   },
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [ticketFormChanges, leftoverChanges] = _.partition(

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -41,7 +41,6 @@ import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NA
 const { awu } = collections.asynciterable
 const SOME_STATUSES = 'SOME_STATUSES'
 const log = logger(module)
-const GENERIC_CUSTOM_TICKET_FIELD_NAME = 'Ticket_status_custom_status'
 
 type Child = {
   // eslint-disable-next-line camelcase
@@ -161,15 +160,15 @@ const removeCustomTicketStatusFromTicketFieldIDsField = (
   instance: InstanceElement,
   customTicketElement: InstanceElement,
 ): void => {
-  const ticketFieldIDs: Array<string | ReferenceExpression> = instance.value.ticket_field_ids || []
+  const ticketFieldIDs: Array<number | ReferenceExpression> = instance.value.ticket_field_ids || []
   if (ticketFieldIDs.includes(customTicketElement.value.id)) {
-    // found the string ID of the custom ticket
+    // found the ID of the custom ticket
     ticketFieldIDs.splice(ticketFieldIDs.indexOf(customTicketElement.value.id), 1)
     return
   }
 
   const foundCustomTicketField = ticketFieldIDs.find(id =>
-    id instanceof ReferenceExpression ? id.elemID === customTicketElement.elemID : false,
+    id instanceof ReferenceExpression ? id.elemID.isEqual(customTicketElement.elemID) : false,
   )
   if (foundCustomTicketField !== undefined) {
     // found a ReferenceExpression pointing to the custom ticket
@@ -189,7 +188,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     }
     const genericCustomTicketElement = elements
       .filter(isInstanceElement)
-      .find(instance => instance.elemID.name.includes(GENERIC_CUSTOM_TICKET_FIELD_NAME))
+      .find(instance => instance.value.type === 'custom_status')
     if (genericCustomTicketElement === undefined) {
       return
     }

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -28,6 +28,7 @@ import {
   ReadOnlyElementsSource,
   ReferenceExpression,
   toChange,
+  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import _, { remove } from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -36,7 +37,13 @@ import { collections } from '@salto-io/lowerdash'
 import { FETCH_CONFIG } from '../config'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
-import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../constants'
+import {
+  ACCOUNT_FEATURES_TYPE_NAME,
+  TICKET_FIELD_TYPE_NAME,
+  TICKET_FORM_TYPE_NAME,
+  TICKET_STATUS_CUSTOM_STATUS_TYPE_NAME,
+  ZENDESK,
+} from '../constants'
 
 const { awu } = collections.asynciterable
 const SOME_STATUSES = 'SOME_STATUSES'
@@ -168,7 +175,7 @@ const removeCustomTicketStatusFromTicketFieldIDsField = (
   }
 
   const foundCustomTicketField = ticketFieldIDs.find(id =>
-    id instanceof ReferenceExpression ? id.elemID.isEqual(customTicketElement.elemID) : false,
+    isReferenceExpression(id) ? id.elemID.isEqual(customTicketElement.elemID) : false,
   )
   if (foundCustomTicketField !== undefined) {
     // found a ReferenceExpression pointing to the custom ticket
@@ -188,7 +195,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
     }
     const genericCustomTicketElement = elements
       .filter(isInstanceElement)
-      .find(instance => instance.value.type === 'custom_status')
+      .find(instance => instance.value.type === TICKET_STATUS_CUSTOM_STATUS_TYPE_NAME)
     if (genericCustomTicketElement === undefined) {
       return
     }

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -24,6 +24,7 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import filterCreator from '../../src/filters/ticket_form'
 import { createFilterCreatorParams } from '../utils'
 import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
@@ -65,7 +66,7 @@ const createElementSource = (customStatusesEnabled: boolean): ReadOnlyElementsSo
 }
 
 describe('ticket form filter', () => {
-  type FilterType = filterUtils.FilterWith<'deploy' | 'onDeploy'>
+  type FilterType = filterUtils.FilterWith<'deploy' | 'onDeploy' | 'onFetch'>
   let filter: FilterType
   const ticketFormType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME) })
   const invalidTicketForm = new InstanceElement('invalid', ticketFormType, {
@@ -107,6 +108,57 @@ describe('ticket form filter', () => {
         child_fields: [{ required_on_statuses: { type: 'NO_STATUSES' } }],
       },
     ],
+  })
+  describe('fetch', () => {
+    const genericCustomTicketStatusField = new InstanceElement(
+      'Ticket_status_custom_status',
+      new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_TYPE_NAME) }),
+      {
+        type: 'custom_status',
+      },
+    )
+    const otherField = new InstanceElement(
+      'other field',
+      new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_TYPE_NAME) }),
+      {
+        type: 'text',
+      },
+    )
+
+    const customTicketFieldRef = new ReferenceExpression(
+      genericCustomTicketStatusField.elemID,
+      genericCustomTicketStatusField,
+    )
+    const otherTicketFieldRef = new ReferenceExpression(otherField.elemID, otherField)
+
+    const elementSourceForm = new InstanceElement('elementSourceForm', ticketFormType, {
+      ticket_field_ids: [customTicketFieldRef, 123456, otherTicketFieldRef],
+    })
+    beforeEach(async () => {
+      jest.clearAllMocks()
+    })
+
+    it('should not remove the generic custom ticket on fetch when flag is off', async () => {
+      const elements = [elementSourceForm, otherField, genericCustomTicketStatusField]
+      filter = filterCreator(
+        createFilterCreatorParams({ elementsSource: buildElementsSourceFromElements(elements) }),
+      ) as FilterType
+
+      await filter.onFetch(elements)
+      expect(elementSourceForm.value.ticket_field_ids).toEqual([customTicketFieldRef, 123456, otherTicketFieldRef])
+    })
+    it('should remove the generic custom ticket on fetch when flag is on', async () => {
+      const elements = [elementSourceForm, otherField, genericCustomTicketStatusField]
+      const config = { ...DEFAULT_CONFIG }
+      config[FETCH_CONFIG].omitCustomTicketStatus = true
+      filter = filterCreator(
+        createFilterCreatorParams({ config, elementsSource: buildElementsSourceFromElements(elements) }),
+      ) as FilterType
+
+      await filter.onFetch(elements)
+      expect(elementSourceForm.value.ticket_field_ids).toEqual([123456, otherTicketFieldRef])
+      expect(elements).toEqual([elementSourceForm, otherField])
+    })
   })
 
   describe('deploy of removal of field and its condition', () => {

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -111,10 +111,11 @@ describe('ticket form filter', () => {
   })
   describe('fetch', () => {
     const genericCustomTicketStatusField = new InstanceElement(
-      'Ticket_status_custom_status',
+      'custom_status',
       new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_TYPE_NAME) }),
       {
         type: 'custom_status',
+        id: 123,
       },
     )
     const otherField = new InstanceElement(
@@ -158,6 +159,22 @@ describe('ticket form filter', () => {
       await filter.onFetch(elements)
       expect(elementSourceForm.value.ticket_field_ids).toEqual([123456, otherTicketFieldRef])
       expect(elements).toEqual([elementSourceForm, otherField])
+    })
+    it('should remove the generic custom ticket on fetch when flag is on and there is no ref', async () => {
+      const elementSourceFormWithID = new InstanceElement('elementSourceFormWithID', ticketFormType, {
+        ticket_field_ids: [123, 123456, otherTicketFieldRef],
+      })
+      const elements = [elementSourceFormWithID, otherField, genericCustomTicketStatusField]
+
+      const config = { ...DEFAULT_CONFIG }
+      config[FETCH_CONFIG].omitCustomTicketStatus = true
+      filter = filterCreator(
+        createFilterCreatorParams({ config, elementsSource: buildElementsSourceFromElements(elements) }),
+      ) as FilterType
+
+      await filter.onFetch(elements)
+      expect(elementSourceFormWithID.value.ticket_field_ids).toEqual([123456, otherTicketFieldRef])
+      expect(elements).toEqual([elementSourceFormWithID, otherField])
     })
   })
 

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -151,7 +151,7 @@ describe('ticket form filter', () => {
     it('should remove the generic custom ticket on fetch when flag is on', async () => {
       const elements = [elementSourceForm, otherField, genericCustomTicketStatusField]
       const config = { ...DEFAULT_CONFIG }
-      config[FETCH_CONFIG].omitCustomTicketStatus = true
+      config[FETCH_CONFIG].omitTicketStatusTicketField = true
       filter = filterCreator(
         createFilterCreatorParams({ config, elementsSource: buildElementsSourceFromElements(elements) }),
       ) as FilterType
@@ -167,7 +167,7 @@ describe('ticket form filter', () => {
       const elements = [elementSourceFormWithID, otherField, genericCustomTicketStatusField]
 
       const config = { ...DEFAULT_CONFIG }
-      config[FETCH_CONFIG].omitCustomTicketStatus = true
+      config[FETCH_CONFIG].omitTicketStatusTicketField = true
       filter = filterCreator(
         createFilterCreatorParams({ config, elementsSource: buildElementsSourceFromElements(elements) }),
       ) as FilterType


### PR DESCRIPTION
Added a config flag, which, if turned on, will make it so that we omit the `Ticket_status_custom_status` ticket field from Ticket Forms on fetch.

---

Added a test

---
_Release Notes_: 

[Zendesk]: 
Added a config flag which allows omitting the `Ticket_status_custom_status` ticket field from Ticket Forms on fetch

---
_User Notifications_: 

[Zendesk]: 
Added a config flag which allows omitting the `Ticket_status_custom_status` ticket field from Ticket Forms on fetch