### PR TITLE
Update README to specify the correct Node.js version

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ docker run salto-cli
 
 ### Building from source
 
-  1. Install Node.js 14 (for M1 Macs use 14.15). You can download it directly from [here](https://nodejs.org/en/download/releases/), or use [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) (simply run `nvm use`) to install it.
-  2. Install [yarn 1](https://yarnpkg.com/en/docs/install).
+  1. Install Node.js 18.9.0. You can download it directly from [here](https://nodejs.org/en/download/releases/), or use [Node Version Manager (NVM)](https://github.com/nvm-sh/nvm) (simply run `nvm use`) to install it.
+  2. Install [yarn](https://yarnpkg.com/en/docs/install).
   3. Fetch dependencies and build:
 
 ```bash


### PR DESCRIPTION
Update README to specify the correct Node.js version.
(also change `yarn 1` to `yarn`, looks like a typo).

---
_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None