### PR TITLE
SALTO-5314 - Fix fetchTarget file cabinet bug

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -378,7 +378,10 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
           ...folder,
         })),
         // remove excluded folders before creating the query
-        folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
+        folder => {
+          const fileCabinetFullPath = `${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`
+          return query.isFileMatch(fileCabinetFullPath) || query.isParentFolderMatch(fileCabinetFullPath)
+        },
       )
       log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
       const filesResults =

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -577,17 +577,22 @@ describe('suiteapp_file_cabinet', () => {
       expect(elements).toEqual([expectedResults[0], expectedResults[1], expectedResults[3]])
     })
 
-    it.only('should query all folders if the fetch target is .*ts', async () => {
-			const allTSFilesRegex = ['.', ',*', '.*t', '.*ts'].map(matcher => new RegExp(`^${matcher}$`))
-			query.isParentFolderMatch.mockImplementationOnce(() => true).mockImplementation(path => allTSFilesRegex.some(fileMatcher => fileMatcher.test(path)))
-      const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
-			const testWhereQuery = "hideinbundle = 'F' AND folder IN (5, 3, 4)"
+    it('should query all folders if the fetch target is .*ts', async () => {
+      const allTSFilesRegex = ['.', ',*', '.*t', '.*ts'].map(matcher => new RegExp(`^${matcher}$`))
+      query.isParentFolderMatch
+        .mockImplementationOnce(() => true)
+        .mockImplementation(path => allTSFilesRegex.some(fileMatcher => fileMatcher.test(path)))
+      const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+        query,
+        maxFileCabinetSizeInGB,
+      )
+      const testWhereQuery = "hideinbundle = 'F' AND folder IN (5, 3, 4)"
       const suiteQlQuery =
         'SELECT name, id, filesize, isinactive, isonline,' +
         ' addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle' +
         ` FROM file WHERE ${testWhereQuery} ORDER BY id ASC`
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
-			expect(elements).toEqual(expectedResults)
+      expect(elements).toEqual(expectedResults)
     })
 
     it('should not query folder if no file in that folder is matched by the query', async () => {

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -577,6 +577,19 @@ describe('suiteapp_file_cabinet', () => {
       expect(elements).toEqual([expectedResults[0], expectedResults[1], expectedResults[3]])
     })
 
+    it.only('should query all folders if the fetch target is .*ts', async () => {
+			const allTSFilesRegex = ['.', ',*', '.*t', '.*ts'].map(matcher => new RegExp(`^${matcher}$`))
+			query.isParentFolderMatch.mockImplementationOnce(() => true).mockImplementation(path => allTSFilesRegex.some(fileMatcher => fileMatcher.test(path)))
+      const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
+			const testWhereQuery = "hideinbundle = 'F' AND folder IN (5, 3, 4)"
+      const suiteQlQuery =
+        'SELECT name, id, filesize, isinactive, isonline,' +
+        ' addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle' +
+        ` FROM file WHERE ${testWhereQuery} ORDER BY id ASC`
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
+			expect(elements).toEqual(expectedResults)
+    })
+
     it('should not query folder if no file in that folder is matched by the query', async () => {
       query.isParentFolderMatch.mockImplementationOnce(() => true).mockImplementation(() => false)
       query.isFileMatch.mockImplementation(path => path === '/folder6/file21')


### PR DESCRIPTION
_fix fetching fileCabinet elements with fetchTarget_

---

_The Issue_:
Description: Fetching fileCabinet items using quick fetch did not fetch changes. In `suiteapp_file_cabinet.ts` we filter out folders before querying all files to avoid querying redundant folders. When fetching with fetchTarget and passing only the file path or any string that doesn't match the parent folders name we filter out the folder and do not query it.

The [ticket](https://salto-io.atlassian.net/jira/software/c/projects/SALTO/issues/SALTO-5314?filter=myopenissues&jql=project%20%3D%20Salto%20and%20assignee%20IN%20%28currentUser%28%29%29%20and%20statusCategory%20in%20%28%22To%20Do%22%2C%20%22In%20Progress%22%29%0AORDER%20BY%20created%20DESC)

_Fix_:
* Dont filter folders in case they are a parent folder of one of the fileMatchers we get.
---
_Release Notes_: 
_Netsuite Adapter_:
* fix fetching file cabinet elements with fetchTarget

---
_User Notifications_: 
_None_
