### PR TITLE
SALTO-4077 - Salesforce: Ignore duplicate retrieve config changes

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -25,7 +25,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     : undefined,
   coverageThreshold: {
     global: {
-      branches: 88.8,
+      branches: 88.7,
       functions: 94,
       lines: 95,
       statements: 95,

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -252,6 +252,7 @@ export const createRetrieveConfigChange = (
       createSkippedListConfigChange({
         type: regexRes?.groups?.type as string,
         instance: regexRes?.groups?.instance as string,
+        reason: regexRes?.[0],
       }),
     )
   log.debug('Created the config changes %o', configChanges)

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -27,8 +27,10 @@ import {
   ConfigChangeSuggestion,
   FetchElements,
   FetchProfile,
+  isMetadataConfigSuggestions,
   MAX_INSTANCES_PER_TYPE,
   MAX_ITEMS_IN_RETRIEVE_REQUEST,
+  MetadataInstance,
   MetadataQuery,
 } from './types'
 import {
@@ -410,6 +412,35 @@ export const retrieveMetadataInstances = async ({
     return result
   }
 
+  const configChangeAlreadyExists = (
+    change: ConfigChangeSuggestion,
+  ): boolean => {
+    if (!isMetadataConfigSuggestions(change)) {
+      return false
+    }
+    if (
+      change.value.metadataType === undefined ||
+      change.value.name === undefined
+    ) {
+      return false
+    }
+    // Note: we assume metadata exclusion config changes refer to a single instance and do not include regexes.
+    const metadataInstance: MetadataInstance = {
+      isFolderType: false,
+      metadataType: change.value.metadataType,
+      name: change.value.name,
+      namespace: change.value.namespace ?? '',
+      changedAt: undefined,
+    }
+    if (fetchProfile.metadataQuery.isInstanceIncluded(metadataInstance)) {
+      log.debug(
+        'Would have ignored config change %o because the instance is already excluded',
+        change,
+      )
+    }
+    return false
+  }
+
   const retrieveInstances = async (
     fileProps: ReadonlyArray<FileProperties>,
     filePropsToSendWithEveryChunk: ReadonlyArray<FileProperties> = [],
@@ -480,7 +511,10 @@ export const retrieveMetadataInstances = async ({
       ).flat()
     }
 
-    configChanges.push(...createRetrieveConfigChange(result))
+    const newConfigChanges = createRetrieveConfigChange(result).filter(
+      (change) => !configChangeAlreadyExists(change),
+    )
+    configChanges.push(...newConfigChanges)
     // if we get an error then result.zipFile will be a single 'nil' XML element, which will be parsed as an object by
     // our XML->json parser. Since we only deal with RETRIEVE_SIZE_LIMIT_ERROR above, here is where we handle all other
     // errors.

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -432,7 +432,7 @@ export const retrieveMetadataInstances = async ({
       namespace: change.value.namespace ?? '',
       changedAt: undefined,
     }
-    if (fetchProfile.metadataQuery.isInstanceIncluded(metadataInstance)) {
+    if (!fetchProfile.metadataQuery.isInstanceIncluded(metadataInstance)) {
       log.debug(
         'Would have ignored config change %o because the instance is already excluded',
         change,

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -188,7 +188,7 @@ describe('Config Changes', () => {
       newConfig = getConfigFromConfigChanges(suggestions, currentConfig)
         ?.config[0]
     })
-    it('should add new exlcuded type', () => {
+    it('should add new excluded type', () => {
       expect(newConfig?.value?.fetch?.metadata?.exclude).toEqual([
         { metadataType: 'Type1' },
         { metadataType: 'ExcludedType' },


### PR DESCRIPTION
When creating a config change suggestion, make sure it isn't already excluded

---

For now we'll only log the cases where this change would take effect. If we see things are OK we can fully enable it.

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A