### PR TITLE
SALTO-5501: fix account id filter before bug

### DIFF
--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -36,7 +36,7 @@ type EventValues = {
   notification: {
     id: string
     notificationType: string
-    parameter?: string
+    parameter?: string | { id: string }
   }
 }
 
@@ -98,8 +98,13 @@ export const transformNotificationEvent = (notificationEvent: NotificationEvent)
   })
 }
 
+const getEventParameter = (eventEntry: EventValues): string | undefined =>
+  typeof eventEntry.notification?.parameter === 'object' && 'id' in eventEntry.notification.parameter
+    ? eventEntry.notification.parameter.id
+    : eventEntry.notification?.parameter
+
 const getEventKey = (eventEntry: EventValues): string =>
-  `${eventEntry.event?.id}-${eventEntry.notification?.notificationType}-${eventEntry.notification?.parameter}`
+  `${eventEntry.event?.id}-${eventEntry.notification?.notificationType}-${getEventParameter(eventEntry)}`
 
 const getEventsValues = (notificationEvents: NotificationEvent[]): EventValues[] =>
   notificationEvents.flatMap((eventEntry: Values) =>

--- a/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
+++ b/packages/jira-adapter/test/filters/account_id/account_id_filter.test.ts
@@ -171,7 +171,7 @@ describe('account_id_filter', () => {
     it('returns account id structure to a simple and correct string on pre deploy on all 5 types', async () => {
       await filter.preDeploy(displayChanges)
       common.checkSimpleInstanceIds(getChangeData(displayChanges[0]), '0')
-      common.checkSimpleInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
+      common.checkObjectedInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.before, '1')
       common.checkSimpleInstanceIds((displayChanges[1] as ModificationChange<InstanceElement>).data.after, '2')
     })
     it('does not change non deployable objects on deploy', async () => {

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
@@ -435,7 +435,9 @@ describe('notificationSchemeDeploymentFilter', () => {
     })
     describe('removal change', () => {
       it('should remove instance', async () => {
-        const removal = toChange({ before: instance })
+        const instanceClone = instance.clone()
+        instanceClone.value.notificationSchemeEvents[0].notifications[0].parameter = { id: 'abc' }
+        const removal = toChange({ before: instanceClone })
         const res = await filter.deploy([removal])
         expect(res.deployResult.appliedChanges).toHaveLength(1)
         expect(res.deployResult.errors).toHaveLength(0)


### PR DESCRIPTION
See details in the Jira Ticket.
The `account_id_filter` is using a dictionary cache that is based on path. When we run it on both before and after, and when they are not the same structure, we create two entries for the same change and override data that is not account_id.

I had to make a small change in notification scheme that was based on the before having the `account_id_filter` changes.
This fix also fixed another small bug that existed only in the OSS

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that could cause partial success for deployments 

---
_User Notifications_: 
None