### PR TITLE
SALTO-5507: add getElementsAuthorsById to Workspace

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -383,6 +383,7 @@ export const mockWorkspace = ({
     getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
     getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
     getElementAuthorInformation: mockFunction<Workspace['getElementAuthorInformation']>().mockResolvedValue({}),
+    getElementsAuthorsById: mockFunction<Workspace['getElementsAuthorsById']>().mockResolvedValue({}),
     getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
     getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
     getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -235,6 +235,7 @@ export type Workspace = {
   ) => Promise<{ id: ElemID; type: ReferenceType }[]>
   getElementIncomingReferences: (id: ElemID, envName?: string) => Promise<ElemID[]>
   getElementAuthorInformation: (id: ElemID, envName?: string) => Promise<AuthorInformation>
+  getElementsAuthorsById: (envName?: string) => Promise<Record<string, AuthorInformation>>
   getAllChangedByAuthors: (envName?: string) => Promise<Author[]>
   getChangedElementsByAuthors: (authors: Author[], envName?: string) => Promise<ElemID[]>
   getElementNaclFiles: (id: ElemID) => Promise<string[]>
@@ -1189,6 +1190,9 @@ export const loadWorkspace = async (
     return currentWorkspaceState.states[env].changedBy.isEmpty()
   }
 
+  const getSearchableNamesOfEnv = async (env?: string): Promise<string[]> =>
+    (await getLoadedNaclFilesSource()).getSearchableNamesOfEnv(env ?? currentEnv())
+
   const workspace: Workspace = {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1294,6 +1298,11 @@ export const loadWorkspace = async (
         throw new Error(`getElementAuthorInformation only support base ids, received ${id.getFullName()}`)
       }
       return (await (await getWorkspaceState()).states[envName].authorInformation.get(id.getFullName())) ?? {}
+    },
+    getElementsAuthorsById: async (envName = currentEnv()) => {
+      const authorInformationMap = (await getWorkspaceState()).states[envName].authorInformation
+      const entries = await awu(authorInformationMap.entries()).toArray()
+      return Object.fromEntries(entries.map(entry => [entry.key, entry.value]))
     },
     getAllChangedByAuthors,
     getChangedElementsByAuthors,
@@ -1534,8 +1543,7 @@ export const loadWorkspace = async (
     getValue: async (id: ElemID, env?: string): Promise<Value | undefined> => (await elements(env)).get(id),
     getSearchableNames: async (): Promise<string[]> =>
       (await getLoadedNaclFilesSource()).getSearchableNames(currentEnv()),
-    getSearchableNamesOfEnv: async (env?: string): Promise<string[]> =>
-      (await getLoadedNaclFilesSource()).getSearchableNamesOfEnv(env ?? currentEnv()),
+    getSearchableNamesOfEnv,
     listUnresolvedReferences: async (completeFromEnv?: string): Promise<UnresolvedElemIDs> => {
       const getUnresolvedElemIDsFromErrors = (validationErrors: readonly ValidationError[]): ElemID[] => {
         const workspaceErrors = validationErrors.filter(isUnresolvedRefError).map(e => e.target.createBaseID().parent)

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1190,9 +1190,6 @@ export const loadWorkspace = async (
     return currentWorkspaceState.states[env].changedBy.isEmpty()
   }
 
-  const getSearchableNamesOfEnv = async (env?: string): Promise<string[]> =>
-    (await getLoadedNaclFilesSource()).getSearchableNamesOfEnv(env ?? currentEnv())
-
   const workspace: Workspace = {
     uid: workspaceConfig.uid,
     name: workspaceConfig.name,
@@ -1543,7 +1540,8 @@ export const loadWorkspace = async (
     getValue: async (id: ElemID, env?: string): Promise<Value | undefined> => (await elements(env)).get(id),
     getSearchableNames: async (): Promise<string[]> =>
       (await getLoadedNaclFilesSource()).getSearchableNames(currentEnv()),
-    getSearchableNamesOfEnv,
+    getSearchableNamesOfEnv: async (env?: string): Promise<string[]> =>
+      (await getLoadedNaclFilesSource()).getSearchableNamesOfEnv(env ?? currentEnv()),
     listUnresolvedReferences: async (completeFromEnv?: string): Promise<UnresolvedElemIDs> => {
       const getUnresolvedElemIDsFromErrors = (validationErrors: readonly ValidationError[]): ElemID[] => {
         const workspaceErrors = validationErrors.filter(isUnresolvedRefError).map(e => e.target.createBaseID().parent)

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3487,6 +3487,89 @@ describe('workspace', () => {
     })
   })
 
+  describe('getElementsAuthorsById', () => {
+    const CHANGED_BY = 'Test User'
+    const CHANGED_AT = '2024-01-01T00:00:00Z'
+    let workspace: Workspace
+    const testFile = `
+      type test.ChangedByOnly {
+        annotations {
+          string _changed_by {
+          }
+          string _changed_at {
+
+          }
+        }
+        _changed_by = "${CHANGED_BY}"
+      }
+      type test.ChangedAtOnly {
+        annotations {
+          string _changed_by {
+          }
+          string _changed_at {
+            
+          }
+        }
+        _changed_at = "${CHANGED_AT}"
+      }
+
+      type test.Both {
+        annotations {
+          string _changed_by {
+          }
+          string _changed_at {
+            
+          }
+        }
+        _changed_by = "${CHANGED_BY}"
+        _changed_at = "${CHANGED_AT}"
+      }
+
+      type test.MissingAuthor {
+        annotations {
+          string _changed_by {
+          }
+          string _changed_at {
+          }
+        }
+      }
+    `
+    const naclFileStore = mockDirStore(undefined, undefined, {
+      'testFile.nacl': testFile,
+    })
+    beforeEach(async () => {
+      workspace = await createWorkspace(naclFileStore, undefined, undefined, undefined, undefined, undefined, {
+        '': {
+          naclFiles: createMockNaclFileSource([]),
+        },
+        default: {
+          naclFiles: await naclFilesSource(
+            'default',
+            naclFileStore,
+            mockStaticFilesSource(),
+            persistentMockCreateRemoteMap(),
+            true,
+          ),
+          state: createState([]),
+        },
+      })
+    })
+    it('should return correct AuthorInformations for all the Elements in the workspace', async () => {
+      expect(await workspace.getElementsAuthorsById()).toEqual({
+        'test.ChangedByOnly': {
+          changedBy: CHANGED_BY,
+        },
+        'test.ChangedAtOnly': {
+          changedAt: CHANGED_AT,
+        },
+        'test.Both': {
+          changedBy: CHANGED_BY,
+          changedAt: CHANGED_AT,
+        },
+      })
+    })
+  })
+
   describe('hasElementsInEnv', () => {
     let workspace: Workspace
     beforeEach(async () => {


### PR DESCRIPTION
Add a method to Workspace that returns all the Elements author informations for a given env. 

---

_None_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
