### PR TITLE
SALTO-5515: Utilize NS concurrency limit by having fairness between the inner concurrency limiters

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -334,8 +334,8 @@ export default class SdfClient {
     commandArguments: Values,
     projectCommandActionExecutor: CommandActionExecutor,
   ): Promise<ActionResult> {
-    const actionResult = await this.globalLimiter.schedule(() =>
-      this.sdfCallsLimiter.schedule(() =>
+    const actionResult = await this.sdfCallsLimiter.schedule(() =>
+      this.globalLimiter.schedule(() =>
         projectCommandActionExecutor.executeAction({
           commandName,
           runInInteractiveMode: false,

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -155,7 +155,7 @@ export default class SuiteAppClient {
     const limiter = new Bottleneck({
       maxConcurrent: params.config?.suiteAppConcurrencyLimit ?? DEFAULT_CONCURRENCY,
     })
-    this.callsLimiter = fn => params.globalLimiter.schedule(() => limiter.schedule(fn))
+    this.callsLimiter = fn => limiter.schedule(() => params.globalLimiter.schedule(fn))
 
     const accountIdUrl = toUrlAccountId(params.credentials.accountId)
     this.suiteQLUrl = new URL(`https://${accountIdUrl}.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql`)


### PR DESCRIPTION
After seeing that increasing the total concurrency doesn’t affect the fetch duration I saw in the logs that when having a load of SuiteApp calls that are triggered ~together, no SDF request is executed.

The reason for that is that we first use the global limiter and only then the specific SDF/SuiteApp limiter.
We should flip the order of the funnel: first SDF/SuiteApp limiter and only then the global one, since this way we will respect also the fairness between them.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter: SALTO-5515: Utilize NS concurrency limit by having fairness between the inner concurrency limiters
---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
