### PR TITLE
SALTO-5503: EnableJSM button to activate JSMPremium

### DIFF
--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -28,6 +28,7 @@ type ConfigOptionsType = {
   enableScriptRunnerAddon?: boolean
   enableJSM?: boolean
 }
+
 export const optionsType = createMatchingObjectType<ConfigOptionsType>({
   elemID: optionsElemId,
   fields: {
@@ -55,6 +56,7 @@ export const getConfig = async (options?: InstanceElement): Promise<InstanceElem
     }
     if (options.value.enableJSM) {
       defaultConf.value.fetch.enableJSM = true
+      defaultConf.value.fetch.enableJSMPremium = true
     }
   }
   return defaultConf

--- a/packages/jira-adapter/test/config_creator.test.ts
+++ b/packages/jira-adapter/test/config_creator.test.ts
@@ -56,6 +56,7 @@ describe('config creator', () => {
     const config = await getConfig(options)
     expect(config.value.fetch.enableScriptRunnerAddon).toBeTrue()
     expect(config.value.fetch.enableJSM).toBeTrue()
+    expect(config.value.fetch.enableJSMPremium).toBeTrue()
   })
   it('get config should return correctly when enableJSM is true', async () => {
     const config = await getConfig(options)


### PR DESCRIPTION
In this PR I added the OSS support for enableJSMPremium to work

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
