### PR TITLE
SALTO-5522: Add data to trace logs of http calls

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -234,6 +234,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
     }
 
     const { url, queryParams, headers, responseType } = params
+    const data = isMethodWithData(params) ? params.data : undefined
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const logResponse = (res: Response<any>): void => {
@@ -248,6 +249,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
           ? `<omitted buffer of length ${res.data.length}>`
           : this.clearValuesFromResponseData(res.data, url),
         headers: this.extractHeaders(res.headers),
+        data: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
       })
 
       log.debug('Response size for %s on %s is %d', method.toUpperCase(), url, responseText.length)

--- a/packages/adapter-components/src/deployment/old_deployment.ts
+++ b/packages/adapter-components/src/deployment/old_deployment.ts
@@ -93,7 +93,7 @@ export const deployChange = async ({
     return undefined
   }
   log.trace(
-    `deploying instance ${instance.elemID.getFullName()} with params ${inspectValue({ method: endpoint.method, url, queryParams, data }, { compact: true, depth: 6 })}`,
+    `deploying instance ${instance.elemID.getFullName()} with params ${inspectValue({ method: endpoint.method, url, queryParams }, { compact: true, depth: 6 })}`,
   )
   try {
     const response = await client[endpoint.method]({


### PR DESCRIPTION
Data logs were missing in POST requests that were part of the deploy

---

I removed the existing data from the deploy log to avoid duplicate write

---
_Release Notes_: 
None

---
_User Notifications_: 
None
