### PR TITLE
 SALTO-5249: [Zendesk] Throw during Workspace deployment when the Zendesk client returns 200 with an error

### DIFF
--- a/packages/zendesk-adapter/src/filters/workspace.ts
+++ b/packages/zendesk-adapter/src/filters/workspace.ts
@@ -60,16 +60,16 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     const deployResult = await deployChanges(workspaceChanges, async change => {
       const response = await deployChange(change, client, config.apiDefinitions, ['selected_macros'])
       // It's possible for the deployment to return with status 200 and still have errors.
-      if (
-        response !== undefined &&
-        !_.isArray(response) &&
-        response.errors !== undefined &&
-        Array.isArray(response.errors) &&
-        response.errors.length > 0
-      ) {
+      if (response !== undefined && !_.isArray(response) && response.errors !== undefined) {
+        let errorMsg = 'Something went wrong'
+        if (Array.isArray(response.errors) && response.errors.length > 0) {
+          errorMsg = String(response.errors[0])
+        } else if (typeof response.errors === 'string') {
+          errorMsg = response.errors
+        }
         throw createSaltoElementError({
           // caught by deployChanges
-          message: response.errors[0],
+          message: errorMsg,
           severity: 'Error',
           elemID: getChangeData(change).elemID,
         })

--- a/packages/zendesk-adapter/test/filters/workspace.test.ts
+++ b/packages/zendesk-adapter/test/filters/workspace.test.ts
@@ -182,11 +182,30 @@ describe('workspace filter', () => {
       expect(res.deployResult.appliedChanges).toHaveLength(0)
     })
   })
-  it('should return error when client returns with status 200 and errors', async () => {
+  it('should return error when client returns with status 200 and errors in an array', async () => {
     const clonedWSAfter = workspace.clone()
     delete clonedWSAfter.value.title
 
     mockDeployChange.mockImplementation(async () => ({ errors: ['zendesk error'], status: 200 }))
+
+    const res = await filter.deploy([{ action: 'add', data: { after: clonedWSAfter } }])
+    expect(mockDeployChange).toHaveBeenCalledTimes(1)
+    expect(mockDeployChange).toHaveBeenCalledWith({
+      change: { action: 'add', data: { after: clonedWSAfter } },
+      client: expect.anything(),
+      endpointDetails: expect.anything(),
+      fieldsToIgnore: ['selected_macros'],
+    })
+
+    expect(res.leftoverChanges).toHaveLength(0)
+    expect(res.deployResult.errors).toHaveLength(1)
+    expect(res.deployResult.appliedChanges).toHaveLength(0)
+  })
+  it('should return error when client returns with status 200 and errors as string', async () => {
+    const clonedWSAfter = workspace.clone()
+    delete clonedWSAfter.value.title
+
+    mockDeployChange.mockImplementation(async () => ({ errors: 'zendesk error', status: 200 }))
 
     const res = await filter.deploy([{ action: 'add', data: { after: clonedWSAfter } }])
     expect(mockDeployChange).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
Same thing as https://github.com/salto-io/salto/pull/5438 - we saw that an error can also be a string, so add a case to catch that
---

---
_Release Notes_: 

Zendesk:
Fail deployment when Zendesk returns errors when changing workspaces

---
_User Notifications_: 
None