### PR TITLE
SALTO-5527: Fix E2E

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -237,9 +237,9 @@ export const createInstances = (
     { [CORE_ANNOTATIONS.PARENT]: [jsmProject] },
   )
   const SLA = new InstanceElement(
-    `${randomString}_SUP`,
+    'Lemon_SUP',
     findType(SLA_TYPE_NAME, fetchedElements),
-    createSLAValues(randomString, fetchedElements),
+    createSLAValues(fetchedElements),
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [jsmProject] },
   )

--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/SLA.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/SLA.ts
@@ -18,8 +18,8 @@ import { ElemID, Values, Element, TemplateExpression } from '@salto-io/adapter-a
 import { createReference } from '../../../utils'
 import { JIRA } from '../../../../src/constants'
 
-export const createSLAValues = (name: string, allElements: Element[]): Values => ({
-  name,
+export const createSLAValues = (allElements: Element[]): Values => ({
+  name: 'Lemon',
   config: {
     definition: {
       start: [


### PR DESCRIPTION
changed SLA name in the e2e. 

---

_Additional context for reviewer_
For some reason the e2e doesn't work with the random string for the SLA any more (Failed all the time). If I just change the name to a normal random name it works. 

---
_Release Notes_: 
_Jira adapter:_
* Fix e2e due to cannot deploy SLA.

---
_User Notifications_: 
None
