### PR TITLE
SALTO-5533 - Salesforce: Fix Quickfetch for allowReferenceTo records

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -55,6 +55,7 @@ import {
   Types,
   createInstanceServiceIds,
   isNameField,
+  toRecord,
 } from '../transformers/transformer'
 import {
   getNamespace,
@@ -566,11 +567,13 @@ export const getAllInstances = async (
           !fetchedRecordIds.has(instance.value[CUSTOM_OBJECT_ID_FIELD]),
       )
       .groupBy((instance) => apiNameSync(instance.getTypeSync()) ?? '')
-    Object.entries(elementSourceInstancesByType).forEach(
-      ([type, instances]) => {
-        elementSourceRecordsByType[type] = instances.map(
-          (instance) => instance.value,
-        )
+    await awu(Object.entries(elementSourceInstancesByType)).forEach(
+      async ([type, instances]) => {
+        elementSourceRecordsByType[type] = await awu(instances)
+          .map((instance) =>
+            toRecord(instance, FIELD_ANNOTATIONS.QUERYABLE, true),
+          )
+          .toArray()
       },
     )
   }

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -77,6 +77,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     const { instances, configChangeSuggestions } = await getAllInstances(
       client,
       customSettingsMap,
+      config,
     )
     elements.push(...instances)
     return {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1186,7 +1186,7 @@ const transformCompoundValues = async (
   )
 }
 
-const toRecord = async (
+export const toRecord = async (
   instance: InstanceElement,
   fieldAnnotationToFilterBy: string,
   withNulls: boolean,

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -2301,6 +2301,7 @@ describe('Custom Object Instances filter', () => {
             refType: Types.primitiveDataTypes.Lookup,
             annotations: {
               [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToTypeName],
+              [FIELD_ANNOTATIONS.QUERYABLE]: true,
             },
           },
         })

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -2342,12 +2342,19 @@ describe('Custom Object Instances filter', () => {
               ),
             )
             const refToType = createCustomObject(refToTypeName)
+            const refToInstance = new InstanceElement(
+              'RefToInstanceFromWorkspace',
+              refToType,
+              {
+                [CUSTOM_OBJECT_ID_FIELD]: refToInstanceId,
+              },
+            )
             const referringInstance = new InstanceElement(
               'ReferringInstance',
               objectType,
               {
                 [CUSTOM_OBJECT_ID_FIELD]: testInstanceId,
-                referenceField: refToInstanceId,
+                referenceField: new ReferenceExpression(refToInstance.elemID),
               },
             )
             filter = filterCreator({
@@ -2357,6 +2364,7 @@ describe('Custom Object Instances filter', () => {
                 fetchProfile,
                 elementsSource: buildElementsSourceFromElements([
                   referringInstance,
+                  refToInstance,
                 ]),
               },
             }) as FilterType

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -2212,17 +2212,37 @@ describe('Custom Object Instances filter', () => {
   describe('Fetch with changes detection', () => {
     let fetchProfile: FetchProfile
     const testTypeName = 'TestType'
+    const testInstanceId = 'TestInstanceId'
+    const refToTypeName = 'RefToType'
+    const refToInstanceId = 'RefToInstanceId'
     const changedAtCutoff = new Date(2023, 12, 21).toISOString()
+    const changedAtSingleton = mockInstances()[CHANGED_AT_SINGLETON]
+    _.set(
+      changedAtSingleton.value,
+      [DATA_INSTANCES_CHANGED_AT_MAGIC, testTypeName],
+      changedAtCutoff,
+    )
+
+    const testRecords: SalesforceRecord[] = [
+      {
+        attributes: {
+          type: testTypeName,
+        },
+        Id: testInstanceId,
+        referenceField: refToInstanceId,
+      },
+      {
+        attributes: {
+          type: refToTypeName,
+        },
+        Id: refToInstanceId,
+      },
+    ]
 
     describe('When enabled', () => {
+      let elements: Element[]
       beforeEach(async () => {
-        const changedAtSingleton = mockInstances()[CHANGED_AT_SINGLETON]
-        _.set(
-          changedAtSingleton.value,
-          [DATA_INSTANCES_CHANGED_AT_MAGIC, testTypeName],
-          changedAtCutoff,
-        )
-
+        setMockQueryResults(testRecords)
         const elementsSource = buildElementsSourceFromElements([
           changedAtSingleton,
         ])
@@ -2234,6 +2254,12 @@ describe('Custom Object Instances filter', () => {
               excluded: false,
               allowRef: false,
             },
+            {
+              typeName: refToTypeName,
+              included: false,
+              excluded: false,
+              allowRef: true,
+            },
           ],
           elementsSourceForQuickFetch: elementsSource,
         })
@@ -2244,15 +2270,162 @@ describe('Custom Object Instances filter', () => {
             fetchProfile,
           },
         }) as FilterType
-        await filter.onFetch([
-          createCustomObject(testTypeName),
-          changedAtSingleton,
-        ])
       })
-      it('Should query using the changed-at value', () => {
-        expect(basicQueryImplementation).toHaveBeenLastCalledWith(
-          expect.stringContaining(`LastModifiedDate > ${changedAtCutoff}`),
-        )
+      describe('Without allowReferenceTo', () => {
+        beforeEach(async () => {
+          elements = [
+            createCustomObject(testTypeName),
+            createCustomObject(refToTypeName),
+            changedAtSingleton,
+          ]
+          await filter.onFetch(elements)
+        })
+        it('Should query using the changed-at value', () => {
+          expect(basicQueryImplementation).toHaveBeenLastCalledWith(
+            expect.stringContaining(`LastModifiedDate > ${changedAtCutoff}`),
+          )
+        })
+        it('Should return the correct elements', () => {
+          expect(elements).toHaveLength(4)
+          expect(elements[3]).toHaveProperty(
+            'value',
+            expect.objectContaining({
+              [CUSTOM_OBJECT_ID_FIELD]: testInstanceId,
+            }),
+          )
+        })
+      })
+      describe('With allowReferenceTo', () => {
+        const objectType = createCustomObject(testTypeName, {
+          referenceField: {
+            refType: Types.primitiveDataTypes.Lookup,
+            annotations: {
+              [FIELD_ANNOTATIONS.REFERENCE_TO]: [refToTypeName],
+            },
+          },
+        })
+        describe('When the referring element is fetched', () => {
+          beforeEach(async () => {
+            elements = [
+              objectType,
+              createCustomObject(refToTypeName),
+              changedAtSingleton,
+            ]
+            await filter.onFetch(elements)
+          })
+          it('Should query for the correct types', () => {
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(testTypeName),
+            )
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(refToTypeName),
+            )
+          })
+          it('Should return the correct elements', () => {
+            expect(elements).toHaveLength(5)
+            expect(elements).toSatisfyAny(
+              (element) =>
+                element?.value?.[CUSTOM_OBJECT_ID_FIELD] === testInstanceId,
+            )
+            expect(elements).toSatisfyAny(
+              (element) =>
+                element?.value?.[CUSTOM_OBJECT_ID_FIELD] === refToInstanceId,
+            )
+          })
+        })
+        describe('When the referring element is in the element source', () => {
+          beforeEach(async () => {
+            setMockQueryResults(
+              testRecords.filter(
+                (record) => record.attributes.type !== testTypeName,
+              ),
+            )
+            const refToType = createCustomObject(refToTypeName)
+            const referringInstance = new InstanceElement(
+              'ReferringInstance',
+              objectType,
+              {
+                [CUSTOM_OBJECT_ID_FIELD]: testInstanceId,
+                referenceField: refToInstanceId,
+              },
+            )
+            filter = filterCreator({
+              client,
+              config: {
+                ...defaultFilterContext,
+                fetchProfile,
+                elementsSource: buildElementsSourceFromElements([
+                  referringInstance,
+                ]),
+              },
+            }) as FilterType
+
+            elements = [objectType, refToType, changedAtSingleton]
+            await filter.onFetch(elements)
+          })
+          it('Should query for the correct types', () => {
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(testTypeName),
+            )
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(refToTypeName),
+            )
+          })
+          it('Should return the correct elements', () => {
+            // In this case the referring instance is from the workspace, so will not be added to the 'elements' param
+            expect(elements).toHaveLength(4)
+            expect(elements).toSatisfyAny(
+              (element) =>
+                element?.value?.[CUSTOM_OBJECT_ID_FIELD] === refToInstanceId,
+            )
+          })
+        })
+        describe('When the referring element is in the element source and updated by the fetch', () => {
+          beforeEach(async () => {
+            const refToType = createCustomObject(refToTypeName)
+            const referringInstance = new InstanceElement(
+              'ReferringInstance',
+              objectType,
+              {
+                [CUSTOM_OBJECT_ID_FIELD]: testInstanceId,
+                referenceField: `${refToInstanceId}__BAD`,
+              },
+            )
+            filter = filterCreator({
+              client,
+              config: {
+                ...defaultFilterContext,
+                fetchProfile,
+                elementsSource: buildElementsSourceFromElements([
+                  referringInstance,
+                ]),
+              },
+            }) as FilterType
+
+            elements = [objectType, refToType, changedAtSingleton]
+            await filter.onFetch(elements)
+          })
+          it('Should query for the correct types', () => {
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(testTypeName),
+            )
+            expect(basicQueryImplementation).toHaveBeenCalledWith(
+              expect.stringContaining(refToTypeName),
+            )
+          })
+          it('Should return the correct elements', () => {
+            // We fetched an update to the referring instance as well as the referred instance
+            expect(elements).toHaveLength(5)
+            expect(elements).toSatisfyAny(
+              (element) =>
+                element?.value?.[CUSTOM_OBJECT_ID_FIELD] === testInstanceId,
+            )
+            expect(elements).toSatisfyAny(
+              (element) =>
+                element?.value?.[CUSTOM_OBJECT_ID_FIELD] === refToInstanceId,
+            )
+          })
+        })
       })
     })
 


### PR DESCRIPTION
When fetch-with-changes-detection is enabled, we only attempt to fetch instances that are referred to from instances that changed.
Instead, we should fetch instances that are referenced by instances in the workspace too, in case any of the referred-to instances changed.

---

~We cheat a little by treating `InstanceElement.value` as a `SalesforceRecord` for the purpose of finding references. This is because the data in the workspace/`elementsSource` is stored as `InstanceElement`s, but the fetched records are `SalesforceRecord`s.~

There is an issue where if the user deleted the last reference to a data record, the referred record will not be removed from the workspace. This is because we don't identify the deletion of the referring record (because we don't support deletions in quickfetch)

---
_Release Notes_: 
Salesforce: Quickfetch now works for data records of types listed in `allowReferenceTo`

---
_User Notifications_: 
N/A