### PR TITLE
SALTO-5546: add taskMaxRetries and taskRetryDelay to jiraDeployConfigType fields

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -305,6 +305,8 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
 })
 const jiraDeployConfigType = definitions.createUserDeployConfigType(JIRA, changeValidatorConfigType, {
   ...defaultMissingUserFallbackField,
+  taskMaxRetries: { refType: BuiltinTypes.NUMBER },
+  taskRetryDelay: { refType: BuiltinTypes.NUMBER },
   forceDelete: { refType: BuiltinTypes.BOOLEAN },
 })
 


### PR DESCRIPTION
_add taskMaxRetries and taskRetryDelay to jiraDeployConfigType fields_

---

_Additional context for reviewer_
* users who changed them received a validation error

---
_Release Notes_: 
Jira Adapter: 
* fix a bug that caused a validation error when changing the deploy config fields:  `taskMaxRetries` and `taskRetryDelay`


---
_User Notifications_: 
_None_
