### PR TITLE
SALTO-5548: Salesforce metadataTypes Change Validator Bugfix

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/metadata_types.ts
+++ b/packages/salesforce-adapter/src/change_validators/metadata_types.ts
@@ -24,7 +24,12 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { apiNameSync, metadataTypeSync } from '../filters/utils'
-import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE } from '../constants'
+import {
+  API_NAME,
+  CUSTOM_METADATA,
+  CUSTOM_OBJECT,
+  METADATA_TYPE,
+} from '../constants'
 
 const { isDefined } = values
 
@@ -47,12 +52,21 @@ const getAffectedType = (change: Change): ObjectType | undefined => {
 }
 
 const isMetadataType = (objectType: ObjectType): boolean => {
+  // Artifical Types
   if (objectType.annotations[METADATA_TYPE] === undefined) {
-    return false // this is an artificial type
+    return false
   }
+  // CustomObject Metadata Type
   if (metadataTypeSync(objectType) === CUSTOM_OBJECT) {
     return (
       objectType.elemID.typeName === CUSTOM_OBJECT &&
+      objectType.annotations[API_NAME] === undefined
+    )
+  }
+  // CustomMetadata Metadata Type
+  if (metadataTypeSync(objectType) === CUSTOM_METADATA) {
+    return (
+      objectType.elemID.typeName === CUSTOM_METADATA &&
       objectType.annotations[API_NAME] === undefined // this would be the 'CustomObject' metadata type
     )
   }

--- a/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
@@ -23,7 +23,12 @@ import {
 } from '@salto-io/adapter-api'
 import deployNonDeployableTypes from '../../src/change_validators/metadata_types'
 import { createMetadataObjectType } from '../../src/transformers/transformer'
-import { CUSTOM_OBJECT, METADATA_TYPE, SALESFORCE } from '../../src/constants'
+import {
+  CUSTOM_METADATA,
+  CUSTOM_OBJECT,
+  METADATA_TYPE,
+  SALESFORCE,
+} from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { createField } from '../utils'
 
@@ -33,6 +38,7 @@ describe('deployNonDeployableTypes', () => {
     beforeEach(async () => {
       validatorResult = await deployNonDeployableTypes([
         toChange({ after: mockTypes.Account }),
+        toChange({ after: mockTypes.CustomMetadataRecordType }),
       ])
     })
     it('should not generate errors', () => {
@@ -81,20 +87,29 @@ describe('deployNonDeployableTypes', () => {
       )
     })
   })
-  describe('When deploying the CustomObject metadata type', () => {
-    const metadataType = createMetadataObjectType({
+  describe('When deploying the CustomObject and CustomMetadata metadata types', () => {
+    const customObjectMetadataType = createMetadataObjectType({
       annotations: {
         [METADATA_TYPE]: CUSTOM_OBJECT,
       },
     })
+    const customMetadataMetadataType = createMetadataObjectType({
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_METADATA,
+      },
+    })
     beforeEach(async () => {
       validatorResult = await deployNonDeployableTypes([
-        toChange({ after: metadataType }),
+        toChange({ after: customObjectMetadataType }),
+        toChange({ after: customMetadataMetadataType }),
       ])
     })
     it('should generate errors', () => {
-      expect(validatorResult).toSatisfyAll((error) =>
-        error.elemID.isEqual(metadataType.elemID),
+      expect(validatorResult).toHaveLength(2)
+      const [customObjectError, customMetadataError] = validatorResult
+      expect(customObjectError.elemID).toEqual(customObjectMetadataType.elemID)
+      expect(customMetadataError.elemID).toEqual(
+        customMetadataMetadataType.elemID,
       )
     })
   })


### PR DESCRIPTION
Fixed a bug where the Change Validator created incorrect errors on CustomMetadataTypes.

---

Here's an example output with changes to the `CustomMetadata` metadata type and a `CustomMetadata` custom type.

```
Salto will perform the following actions:

| salesforce.CMT2__mdt
  | EntityDef__c
    M label

Please review the following messages; changes with errors will not be deployed.
    Deploying a non-deployable type
    envs/env1/salesforce/Types/CustomMetadata.nacl(line: 1)
    Error: The type CustomMetadata is not a custom type and can't be deployed


Resources and actions are indicated with the following symbols:
  + create
  M change
  - remove
Impacts: 1 type and 0 instances.
```

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
