### PR TITLE
SALTO-5513: add inbound transition change validator

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -26,6 +26,7 @@ import { statusValidator } from './status'
 import { privateApiValidator } from './private_api'
 import { readOnlyWorkflowValidator } from './workflows/read_only_workflow'
 import { workflowStatusMappingsValidator } from './workflowsV2/status_mappings'
+import { inboundTransitionChangeValidator } from './workflowsV2/inbound_transition'
 import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { permissionTypeValidator } from './permission_type'
@@ -95,6 +96,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigration: workflowSchemeMigrationValidator(client, config, paginator),
     workflowStatusMappings: workflowStatusMappingsValidator,
+    inboundTransition: inboundTransitionChangeValidator,
     issueTypeSchemeMigration: issueTypeSchemeMigrationValidator(client),
     activeSchemeChange: activeSchemeChangeValidator(client),
     masking: maskingValidator(client),

--- a/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
@@ -51,11 +51,14 @@ export const inboundTransitionChangeValidator: ChangeValidator = async changes =
       if (_.isEmpty(statusesWithoutInboundTransition)) {
         return undefined
       }
+      const statusesWithoutInboundTransitionNames = statusesWithoutInboundTransition
+        .map(statusRef => statusRef.value.value.name)
+        .join(', ')
       return {
         elemID: instance.elemID,
         severity: 'Error' as SeverityLevel,
         message: 'Workflow statuses must have at least one inbound transition',
-        detailedMessage: `The following statuses of workflow ${instance.value.name} have no inbound transitions: ${statusesWithoutInboundTransition.map(statusRef => statusRef.value.value.name).join(', ')}. To fix this, remove this status or add an inbound transition to it.`,
+        detailedMessage: `The following statuses of workflow ${instance.value.name} have no inbound transitions: ${statusesWithoutInboundTransitionNames}. To fix this, remove those statuses or add inbound transitions to them.`,
       }
     })
     .filter(isDefined)

--- a/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
@@ -1,0 +1,62 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { collections, values } from '@salto-io/lowerdash'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import {
+  ChangeValidator,
+  SeverityLevel,
+  getChangeData,
+  isInstanceChange,
+  isAdditionOrModificationChange,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { isWorkflowV2Instance, WorkflowV2Instance } from '../../filters/workflowV2/types'
+
+const { isDefined } = values
+const { awu } = collections.asynciterable
+
+const getStatusesWithoutInboundTransitions = (instance: WorkflowV2Instance): ReferenceExpression[] => {
+  const statusesRefsWithInboundTransitions = Object.values(instance.value.transitions)
+    .map(transition => transition.to?.statusReference)
+    .filter(isDefined)
+    .filter(isResolvedReferenceExpression)
+  const statusesRefs = instance.value.statuses
+    .map(status => status.statusReference)
+    .filter(isResolvedReferenceExpression)
+  return _.differenceBy(statusesRefs, statusesRefsWithInboundTransitions, statusRef => statusRef.elemID.getFullName())
+}
+
+export const inboundTransitionChangeValidator: ChangeValidator = async changes =>
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isWorkflowV2Instance)
+    .map(instance => {
+      const statusesWithoutInboundTransition = getStatusesWithoutInboundTransitions(instance)
+      if (_.isEmpty(statusesWithoutInboundTransition)) {
+        return undefined
+      }
+      return {
+        elemID: instance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Workflow statuses must have at least one inbound transition',
+        detailedMessage: `The following statuses of workflow ${instance.value.name} have no inbound transitions: ${statusesWithoutInboundTransition.map(statusRef => statusRef.value.value.name).join(', ')}. To fix this, remove this status or add an inbound transition to it.`,
+      }
+    })
+    .filter(isDefined)
+    .toArray()

--- a/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
@@ -47,19 +47,17 @@ export const inboundTransitionChangeValidator: ChangeValidator = async changes =
     .map(getChangeData)
     .filter(isWorkflowV2Instance)
     .map(instance => {
-      const statusesWithoutInboundTransition = getStatusesWithoutInboundTransitions(instance)
-      if (_.isEmpty(statusesWithoutInboundTransition)) {
-        return undefined
-      }
-      const statusesWithoutInboundTransitionNames = statusesWithoutInboundTransition
+      const statusesWithoutInboundTransitionNames = getStatusesWithoutInboundTransitions(instance)
         .map(statusRef => statusRef.value.value.name)
         .join(', ')
-      return {
-        elemID: instance.elemID,
-        severity: 'Error' as SeverityLevel,
-        message: 'Workflow statuses must have at least one inbound transition',
-        detailedMessage: `The following statuses of workflow ${instance.value.name} have no inbound transitions: ${statusesWithoutInboundTransitionNames}. To fix this, remove those statuses or add inbound transitions to them.`,
-      }
+      return _.isEmpty(statusesWithoutInboundTransitionNames)
+        ? undefined
+        : {
+            elemID: instance.elemID,
+            severity: 'Error' as SeverityLevel,
+            message: 'Workflow statuses must have at least one inbound transition',
+            detailedMessage: `The following statuses of workflow ${instance.value.name} have no inbound transitions: ${statusesWithoutInboundTransitionNames}. To fix this, remove those statuses or add inbound transitions to them.`,
+          }
     })
     .filter(isDefined)
     .toArray()

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -214,6 +214,7 @@ export type ChangeValidatorName =
   | 'statusMigrationChange'
   | 'workflowSchemeMigration'
   | 'workflowStatusMappings'
+  | 'inboundTransition'
   | 'issueTypeSchemeMigration'
   | 'activeSchemeChange'
   | 'masking'
@@ -271,6 +272,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     statusMigrationChange: { refType: BuiltinTypes.BOOLEAN },
     workflowSchemeMigration: { refType: BuiltinTypes.BOOLEAN },
     workflowStatusMappings: { refType: BuiltinTypes.BOOLEAN },
+    inboundTransition: { refType: BuiltinTypes.BOOLEAN },
     issueTypeSchemeMigration: { refType: BuiltinTypes.BOOLEAN },
     activeSchemeChange: { refType: BuiltinTypes.BOOLEAN },
     masking: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
@@ -24,9 +24,11 @@ describe('inboundTransitionChangeValidator', () => {
   let status1: InstanceElement
   let status2: InstanceElement
   let status3: InstanceElement
+  let status4: InstanceElement
   let status1Ref: ReferenceExpression
   let status2Ref: ReferenceExpression
   let status3Ref: ReferenceExpression
+  let status4Ref: ReferenceExpression
 
   beforeEach(() => {
     const statusType = createEmptyType(STATUS_TYPE_NAME)
@@ -39,9 +41,13 @@ describe('inboundTransitionChangeValidator', () => {
     status3 = new InstanceElement('status3', statusType, {
       name: 'status3',
     })
+    status4 = new InstanceElement('status4', statusType, {
+      name: 'status4',
+    })
     status1Ref = new ReferenceExpression(status1.elemID, status1)
     status2Ref = new ReferenceExpression(status2.elemID, status2)
     status3Ref = new ReferenceExpression(status3.elemID, status3)
+    status4Ref = new ReferenceExpression(status4.elemID, status4)
     workflowInstance = new InstanceElement('workflowInstance', createEmptyType(WORKFLOW_CONFIGURATION_TYPE), {
       name: 'workflowInstance',
       version: {
@@ -62,6 +68,9 @@ describe('inboundTransitionChangeValidator', () => {
         {
           statusReference: status3Ref,
         },
+        {
+          statusReference: status4Ref,
+        },
       ],
       transitions: {
         tran1: {
@@ -77,6 +86,14 @@ describe('inboundTransitionChangeValidator', () => {
           id: 'id',
           type: 'DIRECTED',
         },
+        tran3: {
+          name: 'tran3',
+          id: 'id',
+          type: 'DIRECTED',
+          to: {
+            statusReference: status3Ref,
+          },
+        },
       },
     })
     changes = [toChange({ after: workflowInstance })]
@@ -89,15 +106,15 @@ describe('inboundTransitionChangeValidator', () => {
         severity: 'Error',
         message: 'Workflow statuses must have at least one inbound transition',
         detailedMessage:
-          'The following statuses of workflow workflowInstance have no inbound transitions: status2, status3. To fix this, remove this status or add an inbound transition to it.',
+          'The following statuses of workflow workflowInstance have no inbound transitions: status2, status4. To fix this, remove those statuses or add inbound transitions to them.',
       },
     ])
   })
 
   it('should return no error when all statuses have inbound transitions', async () => {
     workflowInstance.value.statuses.pop()
-    workflowInstance.value.transitions.tran3 = {
-      name: 'tran3',
+    workflowInstance.value.transitions.tran4 = {
+      name: 'tran4',
       id: 'id',
       type: 'DIRECTED',
       to: {

--- a/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
@@ -1,0 +1,109 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { toChange, InstanceElement, ChangeDataType, Change, ReferenceExpression } from '@salto-io/adapter-api'
+import { inboundTransitionChangeValidator } from '../../../src/change_validators/workflowsV2/inbound_transition'
+import { STATUS_TYPE_NAME, WORKFLOW_CONFIGURATION_TYPE } from '../../../src/constants'
+import { createEmptyType } from '../../utils'
+
+describe('inboundTransitionChangeValidator', () => {
+  let changes: ReadonlyArray<Change<ChangeDataType>>
+  let workflowInstance: InstanceElement
+  let status1: InstanceElement
+  let status2: InstanceElement
+  let status3: InstanceElement
+  let status1Ref: ReferenceExpression
+  let status2Ref: ReferenceExpression
+  let status3Ref: ReferenceExpression
+
+  beforeEach(() => {
+    const statusType = createEmptyType(STATUS_TYPE_NAME)
+    status1 = new InstanceElement('status1', statusType, {
+      name: 'status1',
+    })
+    status2 = new InstanceElement('status2', statusType, {
+      name: 'status2',
+    })
+    status3 = new InstanceElement('status3', statusType, {
+      name: 'status3',
+    })
+    status1Ref = new ReferenceExpression(status1.elemID, status1)
+    status2Ref = new ReferenceExpression(status2.elemID, status2)
+    status3Ref = new ReferenceExpression(status3.elemID, status3)
+    workflowInstance = new InstanceElement('workflowInstance', createEmptyType(WORKFLOW_CONFIGURATION_TYPE), {
+      name: 'workflowInstance',
+      version: {
+        versionNumber: 1,
+        id: 'id',
+      },
+      scope: {
+        project: 'project',
+        type: 'type',
+      },
+      statuses: [
+        {
+          statusReference: status1Ref,
+        },
+        {
+          statusReference: status2Ref,
+        },
+        {
+          statusReference: status3Ref,
+        },
+      ],
+      transitions: {
+        tran1: {
+          name: 'tran1',
+          id: 'id',
+          type: 'DIRECTED',
+          to: {
+            statusReference: status1Ref,
+          },
+        },
+        tran2: {
+          name: 'tran1',
+          id: 'id',
+          type: 'DIRECTED',
+        },
+      },
+    })
+    changes = [toChange({ after: workflowInstance })]
+  })
+
+  it('should return an error when there are statuses without inbound transition', async () => {
+    expect(await inboundTransitionChangeValidator(changes)).toEqual([
+      {
+        elemID: workflowInstance.elemID,
+        severity: 'Error',
+        message: 'Workflow statuses must have at least one inbound transition',
+        detailedMessage:
+          'The following statuses of workflow workflowInstance have no inbound transitions: status2, status3. To fix this, remove this status or add an inbound transition to it.',
+      },
+    ])
+  })
+
+  it('should return no error when all statuses have inbound transitions', async () => {
+    workflowInstance.value.statuses.pop()
+    workflowInstance.value.transitions.tran3 = {
+      name: 'tran3',
+      id: 'id',
+      type: 'DIRECTED',
+      to: {
+        statusReference: status2Ref,
+      },
+    }
+    expect(await inboundTransitionChangeValidator(changes)).toEqual([])
+  })
+})


### PR DESCRIPTION
_add inbound transition change validator_

---

_Additional context for reviewer_
* statuses without inbound transition are not allowed in the new Workflow API

---
_Release Notes_: 
__None_

---
_User Notifications_: 
_None._
