### PR TITLE
SALTO-5485: remove backward compatibility

### DIFF
--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { parser } from '@salto-io/parser'
 import * as errors from './src/errors'
 import * as nacl from './src/workspace/nacl_files'
 import {
@@ -135,6 +134,5 @@ export {
   Author,
   createPathIndexForElement,
   buildStaticFilesCache,
-  parser,
   listElementsDependenciesInWorkspace,
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -121,9 +121,7 @@ export type MultiEnvSource = {
   load: (args: SourceLoadParams) => Promise<EnvsChanges>
   getSearchableNames(env: string): Promise<string[]>
   getStaticFile: (
-    args: string | { filePath: string; encoding: BufferEncoding; env: string; isTemplate?: boolean },
-    encoding?: BufferEncoding,
-    env?: string,
+    args: { filePath: string; encoding: BufferEncoding; env: string; isTemplate?: boolean },
   ) => Promise<StaticFile | undefined>
   getAll: (env: string) => Promise<AsyncIterable<Element>>
   promote: (env: string, idsToMove: ElemID[], idsToRemove?: Record<string, ElemID[]>) => Promise<EnvsChanges>

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -120,9 +120,12 @@ export type MultiEnvSource = {
   clear(args?: { nacl?: boolean; staticResources?: boolean; cache?: boolean }): Promise<void>
   load: (args: SourceLoadParams) => Promise<EnvsChanges>
   getSearchableNames(env: string): Promise<string[]>
-  getStaticFile: (
-    args: { filePath: string; encoding: BufferEncoding; env: string; isTemplate?: boolean },
-  ) => Promise<StaticFile | undefined>
+  getStaticFile: (args: {
+    filePath: string
+    encoding: BufferEncoding
+    env: string
+    isTemplate?: boolean
+  }) => Promise<StaticFile | undefined>
   getAll: (env: string) => Promise<AsyncIterable<Element>>
   promote: (env: string, idsToMove: ElemID[], idsToRemove?: Record<string, ElemID[]>) => Promise<EnvsChanges>
   getElementIdsBySelectors: (

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -118,8 +118,7 @@ export type NaclFilesSource<Changes = ChangeSet<Change>> = Omit<ElementsSource, 
   load: (args: SourceLoadParams) => Promise<Changes>
   getSearchableNames(): Promise<string[]>
   getStaticFile: (
-    args: string | { filePath: string; encoding: BufferEncoding; isTemplate?: boolean },
-    encoding?: BufferEncoding,
+    args: { filePath: string; encoding: BufferEncoding; isTemplate?: boolean },
   ) => Promise<StaticFile | undefined>
   isPathIncluded: (filePath: string) => { included: boolean; isNacl?: boolean }
 }
@@ -1094,25 +1093,11 @@ const buildNaclFilesSource = (
     },
     getSearchableNames: async (): Promise<string[]> =>
       awu((await getState())?.searchableNamesIndex?.keys() ?? []).toArray(),
-    getStaticFile: async (args, encoding) => {
-      let filePath: string
-      let fileEncoding: BufferEncoding
-
-      // Check if args is a string or an object and assign values accordingly
-      if (_.isString(args)) {
-        if (encoding === undefined) {
-          throw new Error("When 'args' is a string, 'encoding' must be provided")
-        }
-        filePath = args
-        fileEncoding = encoding
-      } else {
-        filePath = args.filePath
-        fileEncoding = args.encoding
-      }
+    getStaticFile: async (args) => {
       const staticFile = await staticFilesSource.getStaticFile({
-        filepath: filePath,
-        encoding: fileEncoding,
-        isTemplate: _.isObject(args) ? args.isTemplate : undefined,
+        filepath: args.filePath,
+        encoding: args.encoding,
+        isTemplate: args.isTemplate,
       })
       if (isStaticFile(staticFile)) {
         return staticFile

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -117,9 +117,11 @@ export type NaclFilesSource<Changes = ChangeSet<Change>> = Omit<ElementsSource, 
   getElementsSource: () => Promise<ElementsSource>
   load: (args: SourceLoadParams) => Promise<Changes>
   getSearchableNames(): Promise<string[]>
-  getStaticFile: (
-    args: { filePath: string; encoding: BufferEncoding; isTemplate?: boolean },
-  ) => Promise<StaticFile | undefined>
+  getStaticFile: (args: {
+    filePath: string
+    encoding: BufferEncoding
+    isTemplate?: boolean
+  }) => Promise<StaticFile | undefined>
   isPathIncluded: (filePath: string) => { included: boolean; isNacl?: boolean }
 }
 
@@ -1093,7 +1095,7 @@ const buildNaclFilesSource = (
     },
     getSearchableNames: async (): Promise<string[]> =>
       awu((await getState())?.searchableNamesIndex?.keys() ?? []).toArray(),
-    getStaticFile: async (args) => {
+    getStaticFile: async args => {
       const staticFile = await staticFilesSource.getStaticFile({
         filepath: args.filePath,
         encoding: args.encoding,

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -54,7 +54,7 @@ export const buildHistoryStateStaticFilesSource = (dirStore: StateStaticFilesSto
       })
       existingFiles.add(getStaticFileUniqueName(file))
     },
-    getStaticFile: async (args) => {
+    getStaticFile: async args => {
       if (args.hash === undefined) {
         throw new Error(`path ${args.filepath} was passed without a hash to getStaticFile`)
       }
@@ -62,7 +62,8 @@ export const buildHistoryStateStaticFilesSource = (dirStore: StateStaticFilesSto
         args.filepath,
         args.hash,
         dirStore.getFullPath(args.filepath),
-        async () => (await dirStore.get(getStaticFileUniqueName({ filepath: args.filepath, hash: args.hash as string })))?.buffer,
+        async () =>
+          (await dirStore.get(getStaticFileUniqueName({ filepath: args.filepath, hash: args.hash as string })))?.buffer,
         args.encoding,
         _.isObject(args) ? args.isTemplate : undefined,
       )

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -54,33 +54,16 @@ export const buildHistoryStateStaticFilesSource = (dirStore: StateStaticFilesSto
       })
       existingFiles.add(getStaticFileUniqueName(file))
     },
-    getStaticFile: async (args, encoding, hash) => {
-      let filepath: string
-      let fileEncoding: BufferEncoding
-      let fileHash: string | undefined
-
-      // Check if args is a string or an object and assign values accordingly
-      if (_.isString(args)) {
-        if (encoding === undefined) {
-          throw new Error("When 'args' is a string, 'encoding' must be provided")
-        }
-        filepath = args
-        fileEncoding = encoding
-        fileHash = hash
-      } else {
-        filepath = args.filepath
-        fileEncoding = args.encoding
-        fileHash = args.hash
-      }
-      if (fileHash === undefined) {
-        throw new Error(`path ${filepath} was passed without a hash to getStaticFile`)
+    getStaticFile: async (args) => {
+      if (args.hash === undefined) {
+        throw new Error(`path ${args.filepath} was passed without a hash to getStaticFile`)
       }
       return new LazyStaticFile(
-        filepath,
-        fileHash,
-        dirStore.getFullPath(filepath),
-        async () => (await dirStore.get(getStaticFileUniqueName({ filepath, hash: fileHash as string })))?.buffer,
-        fileEncoding,
+        args.filepath,
+        args.hash,
+        dirStore.getFullPath(args.filepath),
+        async () => (await dirStore.get(getStaticFileUniqueName({ filepath: args.filepath, hash: args.hash as string })))?.buffer,
+        args.encoding,
         _.isObject(args) ? args.isTemplate : undefined,
       )
     },

--- a/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
@@ -15,7 +15,6 @@
  */
 import { hash as lowerdashHash } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import _ from 'lodash'
 import { DirectoryStore } from '../../dir_store'
 import { StateStaticFilesSource } from '../../static_files/common'
 import { LazyStaticFile } from '../../static_files/source'
@@ -38,37 +37,20 @@ export const buildOverrideStateStaticFilesSource = (dirStore: DirectoryStore<Buf
       filename: file.filepath,
     })
   },
-  getStaticFile: async (args, encoding, hash) => {
-    let filePath: string
-    let fileEncoding: BufferEncoding
-    let fileHash: string | undefined
-
-    // Check if args is a string or an object and assign values accordingly
-    if (_.isString(args)) {
-      if (encoding === undefined) {
-        throw new Error("When 'args' is a string, 'encoding' must be provided")
-      }
-      filePath = args
-      fileEncoding = encoding
-      fileHash = hash
-    } else {
-      filePath = args.filepath
-      fileEncoding = args.encoding
-      fileHash = args.hash
-    }
-    if (fileHash === undefined) {
-      throw new Error(`path ${filePath} was passed without a hash to getStaticFile`)
+  getStaticFile: async (args) => {
+    if (args.hash === undefined) {
+      throw new Error(`path ${args.filepath} was passed without a hash to getStaticFile`)
     }
     return new LazyStaticFile(
-      filePath,
-      fileHash,
-      dirStore.getFullPath(filePath),
+      args.filepath,
+      args.hash,
+      dirStore.getFullPath(args.filepath),
       async () => {
-        const content = (await dirStore.get(filePath))?.buffer
-        return content !== undefined && lowerdashHash.toMD5(content) === fileHash ? content : undefined
+        const content = (await dirStore.get(args.filepath))?.buffer
+        return content !== undefined && lowerdashHash.toMD5(content) === args.hash ? content : undefined
       },
-      fileEncoding,
-      _.isObject(args) ? args.isTemplate : undefined,
+      args.encoding,
+      args.isTemplate,
     )
   },
 

--- a/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
@@ -37,7 +37,7 @@ export const buildOverrideStateStaticFilesSource = (dirStore: DirectoryStore<Buf
       filename: file.filepath,
     })
   },
-  getStaticFile: async (args) => {
+  getStaticFile: async args => {
     if (args.hash === undefined) {
       throw new Error(`path ${args.filepath} was passed without a hash to getStaticFile`)
     }

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -26,9 +26,12 @@ export abstract class InvalidStaticFile {
 export type StaticFilesSource = {
   // Load is optional for backwards compatibility
   load?(): Promise<string[]>
-  getStaticFile: (
-    args: { filepath: string; encoding: BufferEncoding; hash?: string; isTemplate?: boolean },
-  ) => Promise<StaticFile | InvalidStaticFile>
+  getStaticFile: (args: {
+    filepath: string
+    encoding: BufferEncoding
+    hash?: string
+    isTemplate?: boolean
+  }) => Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>
   persistStaticFile: (staticFile: StaticFile) => Promise<void>
   flush: () => Promise<void>

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -27,9 +27,7 @@ export type StaticFilesSource = {
   // Load is optional for backwards compatibility
   load?(): Promise<string[]>
   getStaticFile: (
-    args: string | { filepath: string; encoding: BufferEncoding; hash?: string; isTemplate?: boolean },
-    encoding?: BufferEncoding,
-    hash?: string,
+    args: { filepath: string; encoding: BufferEncoding; hash?: string; isTemplate?: boolean },
   ) => Promise<StaticFile | InvalidStaticFile>
   getContent: (filepath: string) => Promise<Buffer>
   persistStaticFile: (staticFile: StaticFile) => Promise<void>

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -145,9 +145,12 @@ export const buildStaticFilesSource = (
 
       return [...newFiles, ...deletedFiles, ...modifiedFilesSet.keys()]
     },
-    getStaticFile: async (
-      args: { filepath: string; encoding: BufferEncoding; hash?: string; isTemplate?: boolean },
-    ): Promise<StaticFile | InvalidStaticFile> => {
+    getStaticFile: async (args: {
+      filepath: string
+      encoding: BufferEncoding
+      hash?: string
+      isTemplate?: boolean
+    }): Promise<StaticFile | InvalidStaticFile> => {
       try {
         const staticFileData = await getStaticFileData(args.filepath)
         if (args.hash !== undefined && staticFileData.hash !== args.hash) {

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -153,7 +153,7 @@ export const createMockNaclFileSource = (
         }),
       ),
     ),
-    getStaticFile: mockFunction<NaclFilesSource['getStaticFile']>().mockImplementation(async (args) => {
+    getStaticFile: mockFunction<NaclFilesSource['getStaticFile']>().mockImplementation(async args => {
       const sfile = await staticFileSource.getStaticFile({ filepath: args.filePath, encoding: args.encoding })
       return isStaticFile(sfile) ? sfile : undefined
     }),

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -153,22 +153,8 @@ export const createMockNaclFileSource = (
         }),
       ),
     ),
-    getStaticFile: mockFunction<NaclFilesSource['getStaticFile']>().mockImplementation(async (args, enc) => {
-      let filePath: string
-      let fileEncoding: BufferEncoding
-
-      // Check if args is a string or an object and assign values accordingly
-      if (_.isString(args)) {
-        if (enc === undefined) {
-          throw new Error("When 'args' is a string, 'encoding' must be provided")
-        }
-        filePath = args
-        fileEncoding = enc
-      } else {
-        filePath = args.filePath
-        fileEncoding = args.encoding
-      }
-      const sfile = await staticFileSource.getStaticFile({ filepath: filePath, encoding: fileEncoding })
+    getStaticFile: mockFunction<NaclFilesSource['getStaticFile']>().mockImplementation(async (args) => {
+      const sfile = await staticFileSource.getStaticFile({ filepath: args.filePath, encoding: args.encoding })
       return isStaticFile(sfile) ? sfile : undefined
     }),
     isPathIncluded: mockFunction<NaclFilesSource['isPathIncluded']>().mockImplementation(filePath => ({

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -32,7 +32,7 @@ export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFil
   getStaticFile: jest
     .fn()
     .mockImplementation(
-      (args: { filepath: string; }) =>
+      (args: { filepath: string }) =>
         staticFiles.find(sf => sf.filepath === args.filepath) ?? new MissingStaticFile(args.filepath),
     ),
   getContent: jest

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -32,7 +32,7 @@ export const mockStaticFilesSource = (staticFiles: StaticFile[] = []): StaticFil
   getStaticFile: jest
     .fn()
     .mockImplementation(
-      (args: { filepath: string; _encoding: BufferEncoding }) =>
+      (args: { filepath: string; }) =>
         staticFiles.find(sf => sf.filepath === args.filepath) ?? new MissingStaticFile(args.filepath),
     ),
   getContent: jest


### PR DESCRIPTION
1. remove parser form workspace index
2. remove backwards compatibility in getStaticFile 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
