### PR TITLE
SALTO-5263 - Salesforce: Exclude DiscoveryAIModel from Salesforce fetch

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -78,6 +78,9 @@ salesforce {
           metadataType = "StandardValueSet"
           name = "AddressStateCode.*"
         },
+        {
+          metadataType: 'DiscoveryAIModel',
+        },
       ]
     }
     data = {

--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -79,6 +79,13 @@ salesforce {
           name = "AddressStateCode.*"
         },
         {
+          metadataType: 'EclairGeoData',
+        },
+        {
+          metadataType:
+            'OmniUiCard|OmniDataTransform|OmniIntegrationProcedure|OmniInteractionAccessConfig|OmniInteractionConfig|OmniScript',
+        },
+        {
           metadataType: 'DiscoveryAIModel',
         },
       ]

--- a/packages/salesforce-adapter/cpq-sbaa-config-doc.md
+++ b/packages/salesforce-adapter/cpq-sbaa-config-doc.md
@@ -128,6 +128,16 @@ salesforce {
           metadataType = "Layout"
           name = "CaseInteraction-Case Feed Layout"
         },
+        {
+          metadataType: 'EclairGeoData',
+        },
+        {
+          metadataType:
+            'OmniUiCard|OmniDataTransform|OmniIntegrationProcedure|OmniInteractionAccessConfig|OmniInteractionConfig|OmniScript',
+        },
+        {
+          metadataType: 'DiscoveryAIModel',
+        },
       ]
     }
     data = {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -124,6 +124,9 @@ export const configWithCPQ = new InstanceElement(
             metadataType:
               'OmniUiCard|OmniDataTransform|OmniIntegrationProcedure|OmniInteractionAccessConfig|OmniInteractionConfig|OmniScript',
           },
+          {
+            metadataType: 'DiscoveryAIModel',
+          },
         ],
       },
       data: {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -960,6 +960,13 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
                 name: 'CaseInteraction-Case Feed Layout',
               },
               {
+                metadataType: 'EclairGeoData',
+              },
+              {
+                metadataType:
+                  'OmniUiCard|OmniDataTransform|OmniIntegrationProcedure|OmniInteractionAccessConfig|OmniInteractionConfig|OmniScript',
+              },
+              {
                 metadataType: 'DiscoveryAIModel',
               },
             ],

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -959,6 +959,9 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
                 metadataType: 'Layout',
                 name: 'CaseInteraction-Case Feed Layout',
               },
+              {
+                metadataType: 'DiscoveryAIModel',
+              },
             ],
           },
           [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,


### PR DESCRIPTION
Exclude this metadata type, because apparently we should?

---
Added a couple of exclusions that were mistakenly added only to the CPQ default config.

---
_Release Notes_: 
Salesforce: DiscoveryAIModel metadata type is excluded in new workspaces

---
_User Notifications_: 
Salesforce: DiscoveryAIModel metadata type is now excluded by default from new environments