### PR TITLE
SALTO-5380 - Salesforce: Remove element names from CV messages

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
+++ b/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
@@ -69,8 +69,8 @@ const createSortOrderError = (
 ): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Error',
-  message: `Duplicate rule instances for ${objectName} must be in sequential order.`,
-  detailedMessage: `Please set or update the order of the instances while making sure it starts from 1 and always increases by 1 (gaps are not allowed). Order is: ${order}. You can learn more about this deployment preview error here: https://help.salto.io/en/articles/8032257-duplicate-rules-must-be-in-sequential-order`,
+  message: 'Duplicate rule instances must be in sequential order.',
+  detailedMessage: `Please set or update the order of the instances in object '${objectName}' while making sure it starts from 1 and always increases by 1 (gaps are not allowed). Order is: ${order}. You can learn more about this deployment preview error here: https://help.salto.io/en/articles/8032257-duplicate-rules-must-be-in-sequential-order`,
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/invalid_listview_filterscope.ts
+++ b/packages/salesforce-adapter/src/change_validators/invalid_listview_filterscope.ts
@@ -64,8 +64,8 @@ const invalidListViewFilterScopeError = (
 ): ChangeError => ({
   elemID: element.elemID,
   severity: 'Error',
-  message: `${element.elemID.getFullName()} uses '${element.value.filterScope}' as the 'filterScope' property of a ListView element. This is not allowed by SalesForce. See https://developer.salesforce.com/docs/atlas.en-us.236.0.api_meta.meta/api_meta/meta_listview.htm#filterScope`,
-  detailedMessage: `You cannot use '${element.value.filterScope}' as a filterScope of a ListView`,
+  message: 'Invalid filterScope value of a ListView',
+  detailedMessage: `${element.elemID.getFullName()} uses '${element.value.filterScope}' as the 'filterScope' property of a ListView element. This is not allowed by SalesForce. See https://developer.salesforce.com/docs/atlas.en-us.236.0.api_meta.meta/api_meta/meta_listview.htm#filterScope`,
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/map_keys.ts
@@ -78,7 +78,7 @@ const getMapKeyErrors = async (
             errors.push({
               elemID: path,
               severity: 'Error',
-              message: `Nested value '${mapDef.key}' not found in field '${fieldName}`,
+              message: 'Nested value not found in field',
               detailedMessage: `${typeName} ${after.value.fullName} field ${fieldName}: Nested value '${mapDef.key}' not found`,
             })
             return undefined
@@ -104,7 +104,7 @@ const getMapKeyErrors = async (
             errors.push({
               elemID: after.elemID.createNestedID(fieldName, ...previewPrefix),
               severity: 'Error',
-              message: `Incorrect map key in ${typeName} ${after.value.fullName} field ${fieldName}: ${previewPrefix?.join(API_NAME_SEPARATOR)} should be ${expectedPath.slice(0, previewPrefix.length).join(API_NAME_SEPARATOR)}`,
+              message: 'Incorrect map key in field',
               detailedMessage: `${typeName} ${after.value.fullName} field ${fieldName}: Incorrect map key ${actualPath?.join(API_NAME_SEPARATOR)}, should be ${expectedPath.join(API_NAME_SEPARATOR)}`,
             })
           }

--- a/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_picklist_values.ts
@@ -89,7 +89,7 @@ const createUnknownPicklistValueChangeError = (
   allowedValues: string[],
 ): ChangeError => ({
   elemID: instance.elemID,
-  message: `Unknown picklist value "${unknownValue}" on field ${field.elemID.name}`,
+  message: 'Unknown picklist value',
   detailedMessage: `Unknown picklist value "${unknownValue}" on ${instance.elemID.getFullName()}.${field.elemID.name}, Supported values are ${safeJsonStringify(allowedValues)}. You can learn more about this deployment preview error here: https://help.salto.io/en/articles/7907887-unknown-picklist-value`,
   severity: 'Warning',
 })

--- a/packages/salesforce-adapter/src/change_validators/unknown_users.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_users.ts
@@ -259,7 +259,7 @@ const getSalesforceUsers = async (
 const unknownUserError = ({ elemId, field, user }: UserRef): ChangeError => ({
   elemID: elemId,
   severity: 'Error',
-  message: `User ${user} doesn't exist`,
+  message: 'User does not exist',
   detailedMessage: `The field ${field} in '${elemId.getFullName()}' refers to the user '${user}' which does not exist in this Salesforce environment`,
 })
 


### PR DESCRIPTION
Some CV messages are too detailed and won't be grouped as expected

---


---
_Release Notes_: 
Salesforce: Minor changes to change validator messages

---
_User Notifications_: 
N/A