### PR TITLE
SALTO-5421 support definitions in serviceUrl generic filter

### DIFF
--- a/packages/adapter-components/src/deployment/old_deployment.ts
+++ b/packages/adapter-components/src/deployment/old_deployment.ts
@@ -83,7 +83,7 @@ export const deployChange = async ({
 
   const url = createUrl({
     instance,
-    baseUrl: endpoint.url,
+    url: endpoint.url,
     urlParamsToFields: endpoint.urlParamsToFields,
     additionalUrlVars,
   })

--- a/packages/adapter-components/src/fetch/resource/request_parameters.ts
+++ b/packages/adapter-components/src/fetch/resource/request_parameters.ts
@@ -147,16 +147,16 @@ const computeDependsOnURLs = (
 
 export const createUrl = ({
   instance,
-  baseUrl,
+  url,
   urlParamsToFields,
   additionalUrlVars,
 }: {
   instance: InstanceElement
-  baseUrl: string
+  url: string
   urlParamsToFields?: UrlParams
   additionalUrlVars?: Record<string, string>
 }): string =>
-  replaceArgs(baseUrl, {
+  replaceArgs(url, {
     ...instance.value,
     ..._.mapValues(urlParamsToFields ?? {}, fieldName =>
       resolvePath(instance, instance.elemID.createNestedID(...fieldName.split(FIELD_PATH_DELIMITER))),

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { serviceUrlFilterCreator, addUrlToInstance } from './service_url'
+export { serviceUrlFilterCreator, addUrlToInstance, serviceUrlFilterCreatorDeprecated, transformConfigToFetchDefinitionsForServiceUrl } from './service_url'
 export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
 export { queryFilterCreator, createParentChildGraph } from './query'
 export { hideTypesFilterCreator } from './hide_types'

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -17,7 +17,7 @@ export {
   serviceUrlFilterCreator,
   addUrlToInstance,
   serviceUrlFilterCreatorDeprecated,
-  transformConfigToFetchDefinitionsForServiceUrl,
+  configDefToInstanceFetchApiDefinitionsForServiceUrl,
 } from './service_url'
 export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
 export { queryFilterCreator, createParentChildGraph } from './query'

--- a/packages/adapter-components/src/filters/index.ts
+++ b/packages/adapter-components/src/filters/index.ts
@@ -13,7 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export { serviceUrlFilterCreator, addUrlToInstance, serviceUrlFilterCreatorDeprecated, transformConfigToFetchDefinitionsForServiceUrl } from './service_url'
+export {
+  serviceUrlFilterCreator,
+  addUrlToInstance,
+  serviceUrlFilterCreatorDeprecated,
+  transformConfigToFetchDefinitionsForServiceUrl,
+} from './service_url'
 export { referencedInstanceNamesFilterCreator } from './referenced_instance_names'
 export { queryFilterCreator, createParentChildGraph } from './query'
 export { hideTypesFilterCreator } from './hide_types'

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -37,7 +37,7 @@ import { AdapterApiConfig, TransformationConfig, TypeConfig } from '../config'
 
 const log = logger(module)
 
-export const transformConfigToFetchDefinitionsForServiceUrl = (
+export const configDefToInstanceFetchApiDefinitionsForServiceUrl = (
   configDef?: TypeConfig<TransformationConfig, ActionName>,
   additionalConfigDef?: TypeConfig<TransformationConfig, ActionName>,
 ): InstanceFetchApiDefinitions => {
@@ -126,7 +126,7 @@ export const serviceUrlFilterCreatorDeprecated: <
   const customizations = Object.fromEntries(
     Array.from(typeNamesSet).map(typeName => [
       typeName,
-      transformConfigToFetchDefinitionsForServiceUrl(
+      configDefToInstanceFetchApiDefinitionsForServiceUrl(
         config.apiDefinitions.types[typeName],
         additionalApiDefinitions?.types[typeName],
       ),

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -38,10 +38,10 @@ import { AdapterApiConfig, TransformationConfig, TypeConfig } from '../config'
 const log = logger(module)
 
 export const transformConfigToFetchDefinitionsForServiceUrl = (
-  configDef: TypeConfig<TransformationConfig, ActionName>,
+  configDef?: TypeConfig<TransformationConfig, ActionName>,
   additionalConfigDef?: TypeConfig<TransformationConfig, ActionName>,
 ): InstanceFetchApiDefinitions => {
-  const serviceUrl = additionalConfigDef?.transformation?.serviceUrl ?? configDef.transformation?.serviceUrl
+  const serviceUrl = additionalConfigDef?.transformation?.serviceUrl ?? configDef?.transformation?.serviceUrl
   return {
     element: {
       topLevel: {
@@ -119,11 +119,12 @@ export const serviceUrlFilterCreatorDeprecated: <
   additionalApiDefinitions?: AdapterApiConfig,
 ) => FilterCreator<TClient, TContext, TResult> = (baseUrl, additionalApiDefinitions) => args => {
   const { config } = args
+  const typeNamesSet = new Set([...Object.keys(config.apiDefinitions.types), ...Object.keys(additionalApiDefinitions?.types ?? {})])
   const customizations = Object.fromEntries(
-    Object.entries(config.apiDefinitions.types).map(([typeName, apiDef]) => [
+    Array.from(typeNamesSet).map(typeName => ([
       typeName,
-      transformConfigToFetchDefinitionsForServiceUrl(apiDef, additionalApiDefinitions?.types[typeName]),
-    ]),
+      transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[typeName], additionalApiDefinitions?.types[typeName]),
+    ])),
   )
 
   const definitions = {

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -61,7 +61,7 @@ export const addUrlToInstance: <ClientOptions extends string = 'main'>(
   if (serviceUrl === undefined) {
     return
   }
-  // TODO_F use custom function from serviceUrl
+  // TODO_F use custom function from serviceUrl SALTO-5580
   // parent is ReferenceExpression during fetch, and serialized into full value during deploy
   const parentValues = instance.annotations[CORE_ANNOTATIONS.PARENT]?.map((parent: unknown) =>
     isReferenceExpression(parent) ? parent.value.value : parent,

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -42,7 +42,7 @@ export const configDefToInstanceFetchApiDefinitionsForServiceUrl = (
   configDef?: TypeConfig<TransformationConfig, ActionName>,
 ): InstanceFetchApiDefinitions | undefined => {
   const serviceUrl = configDef?.transformation?.serviceUrl
-  return serviceUrl
+  return serviceUrl !== undefined
     ? {
         element: {
           topLevel: {

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -119,12 +119,18 @@ export const serviceUrlFilterCreatorDeprecated: <
   additionalApiDefinitions?: AdapterApiConfig,
 ) => FilterCreator<TClient, TContext, TResult> = (baseUrl, additionalApiDefinitions) => args => {
   const { config } = args
-  const typeNamesSet = new Set([...Object.keys(config.apiDefinitions.types), ...Object.keys(additionalApiDefinitions?.types ?? {})])
+  const typeNamesSet = new Set([
+    ...Object.keys(config.apiDefinitions.types),
+    ...Object.keys(additionalApiDefinitions?.types ?? {}),
+  ])
   const customizations = Object.fromEntries(
-    Array.from(typeNamesSet).map(typeName => ([
+    Array.from(typeNamesSet).map(typeName => [
       typeName,
-      transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[typeName], additionalApiDefinitions?.types[typeName]),
-    ])),
+      transformConfigToFetchDefinitionsForServiceUrl(
+        config.apiDefinitions.types[typeName],
+        additionalApiDefinitions?.types[typeName],
+      ),
+    ]),
   )
 
   const definitions = {

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { FilterWith } from '../../src/filter_utils'
 import { Paginator } from '../../src/client'
-import { serviceUrlFilterCreator } from '../../src/filters/service_url'
+import { serviceUrlFilterCreatorDeprecated } from '../../src/filters/service_url'
 import { createMockQuery } from '../../src/fetch/query'
 
 describe('service url filter', () => {
@@ -46,7 +46,7 @@ describe('service url filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    filter = serviceUrlFilterCreator(baseUrl)({
+    filter = serviceUrlFilterCreatorDeprecated(baseUrl)({
       client: {} as unknown,
       paginator: undefined as unknown as Paginator,
       fetchQuery: createMockQuery(),

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -259,7 +259,11 @@ export const workflowSchemeMigrationValidator =
       .map(async change => {
         await updateSchemeId(change, client, paginator, config)
         const instance = getChangeData(change)
-        addUrlToInstance(instance, client.baseUrl, transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[instance.elemID.typeName]))
+        addUrlToInstance(
+          instance,
+          client.baseUrl,
+          transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[instance.elemID.typeName]),
+        )
         const changedItems = await getChangedItemsFromChange(
           change,
           workflowSchemesToProjects[getChangeData(change).elemID.getFullName()],

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -41,7 +41,7 @@ import { JiraConfig } from '../config/config'
 import { PROJECT_TYPE, WORKFLOW_SCHEME_TYPE_NAME } from '../constants'
 import { doesProjectHaveIssues } from './projects/project_deletion'
 
-const { addUrlToInstance, transformConfigToFetchDefinitionsForServiceUrl } = filters
+const { addUrlToInstance, configDefToInstanceFetchApiDefinitionsForServiceUrl } = filters
 const { awu } = collections.asynciterable
 const { isDefined } = values
 
@@ -262,7 +262,7 @@ export const workflowSchemeMigrationValidator =
         addUrlToInstance(
           instance,
           client.baseUrl,
-          transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[instance.elemID.typeName]),
+          configDefToInstanceFetchApiDefinitionsForServiceUrl(config.apiDefinitions.types[instance.elemID.typeName]),
         )
         const changedItems = await getChangedItemsFromChange(
           change,

--- a/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
+++ b/packages/jira-adapter/src/change_validators/workflow_scheme_migration.ts
@@ -32,7 +32,7 @@ import {
 import { values, collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import Joi from 'joi'
-import { filters, client as clientUtils } from '@salto-io/adapter-components'
+import { client as clientUtils, filters } from '@salto-io/adapter-components'
 import os from 'os'
 import { createSchemeGuard, getInstancesFromElementSource, validateReferenceExpression } from '@salto-io/adapter-utils'
 import { updateSchemeId } from '../filters/workflow_scheme'
@@ -41,7 +41,7 @@ import { JiraConfig } from '../config/config'
 import { PROJECT_TYPE, WORKFLOW_SCHEME_TYPE_NAME } from '../constants'
 import { doesProjectHaveIssues } from './projects/project_deletion'
 
-const { addUrlToInstance } = filters
+const { addUrlToInstance, transformConfigToFetchDefinitionsForServiceUrl } = filters
 const { awu } = collections.asynciterable
 const { isDefined } = values
 
@@ -259,7 +259,7 @@ export const workflowSchemeMigrationValidator =
       .map(async change => {
         await updateSchemeId(change, client, paginator, config)
         const instance = getChangeData(change)
-        addUrlToInstance(instance, client.baseUrl, config.apiDefinitions)
+        addUrlToInstance(instance, client.baseUrl, transformConfigToFetchDefinitionsForServiceUrl(config.apiDefinitions.types[instance.elemID.typeName]))
         const changedItems = await getChangedItemsFromChange(
           change,
           workflowSchemesToProjects[getChangeData(change).elemID.getFullName()],

--- a/packages/jira-adapter/src/filters/service_url/service_url.ts
+++ b/packages/jira-adapter/src/filters/service_url/service_url.ts
@@ -19,6 +19,6 @@ import { JiraConfig } from '../../config/config'
 import { FilterCreator, FilterResult } from '../../filter'
 
 const filter: FilterCreator = params =>
-  filters.serviceUrlFilterCreator<JiraClient, JiraConfig, FilterResult>(params.client.baseUrl)(params)
+  filters.serviceUrlFilterCreatorDeprecated<JiraClient, JiraConfig, FilterResult>(params.client.baseUrl)(params)
 
 export default filter

--- a/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
+++ b/packages/jira-adapter/src/filters/service_url/service_url_jsm.ts
@@ -19,7 +19,7 @@ import { JiraConfig } from '../../config/config'
 import { FilterCreator, FilterResult } from '../../filter'
 
 const filter: FilterCreator = params =>
-  filters.serviceUrlFilterCreator<JiraClient, JiraConfig, FilterResult>(
+  filters.serviceUrlFilterCreatorDeprecated<JiraClient, JiraConfig, FilterResult>(
     params.client.baseUrl,
     params.config.jsmApiDefinitions,
   )(params)

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -88,7 +88,7 @@ export const getFilledJspUrls = (instance: InstanceElement, config: JiraConfig, 
       jspRequests.query &&
       fetchUtils.resource.createUrl({
         instance,
-        baseUrl: jspRequests.query,
+        url: jspRequests.query,
       }),
   }
 }

--- a/packages/okta-adapter/src/deployment.ts
+++ b/packages/okta-adapter/src/deployment.ts
@@ -126,7 +126,7 @@ export const deployStatusChange = async (
   }
   const url = createUrl({
     instance,
-    baseUrl: endpoint.url,
+    url: endpoint.url,
     urlParamsToFields: endpoint.urlParamsToFields,
   })
   try {

--- a/packages/okta-adapter/src/filters/service_url.ts
+++ b/packages/okta-adapter/src/filters/service_url.ts
@@ -20,7 +20,7 @@ import OktaClient from '../client/client'
 import { getAdminUrl } from '../client/admin'
 
 const filter: FilterCreator = params =>
-  filters.serviceUrlFilterCreator<OktaClient, FilterContext, FilterResult>(
+  filters.serviceUrlFilterCreatorDeprecated<OktaClient, FilterContext, FilterResult>(
     getAdminUrl(params.client.baseUrl) ?? params.client.baseUrl,
     params.config[PRIVATE_API_DEFINITIONS_CONFIG],
   )(params)

--- a/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
@@ -162,7 +162,7 @@ const updateElementPositions = async (
           await client.put({
             url: createUrl({
               instance: resolvedChild,
-              baseUrl: childUpdateApi.url,
+              url: childUpdateApi.url,
               urlParamsToFields: childUpdateApi.urlParamsToFields,
             }),
             data: { position: i },

--- a/packages/zendesk-adapter/src/filters/service_url.ts
+++ b/packages/zendesk-adapter/src/filters/service_url.ts
@@ -19,6 +19,6 @@ import { FilterCreator, FilterResult } from '../filter'
 import ZendeskClient from '../client/client'
 
 const filter: FilterCreator = params =>
-  filters.serviceUrlFilterCreator<ZendeskClient, FilterContext, FilterResult>(params.client.getUrl().href)(params)
+  filters.serviceUrlFilterCreatorDeprecated<ZendeskClient, FilterContext, FilterResult>(params.client.getUrl().href)(params)
 
 export default filter

--- a/packages/zendesk-adapter/src/filters/service_url.ts
+++ b/packages/zendesk-adapter/src/filters/service_url.ts
@@ -19,6 +19,8 @@ import { FilterCreator, FilterResult } from '../filter'
 import ZendeskClient from '../client/client'
 
 const filter: FilterCreator = params =>
-  filters.serviceUrlFilterCreatorDeprecated<ZendeskClient, FilterContext, FilterResult>(params.client.getUrl().href)(params)
+  filters.serviceUrlFilterCreatorDeprecated<ZendeskClient, FilterContext, FilterResult>(params.client.getUrl().href)(
+    params,
+  )
 
 export default filter

--- a/packages/zendesk-adapter/test/filters/guide_orders.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_orders.test.ts
@@ -190,7 +190,7 @@ const testDeploy = async (
   expect(mockPut).toHaveBeenCalledWith({
     url: createUrl({
       instance: createChildElement(),
-      baseUrl: updateApi.url,
+      url: updateApi.url,
       urlParamsToFields: updateApi.urlParamsToFields,
     }),
     data: { position: 0 },
@@ -198,7 +198,7 @@ const testDeploy = async (
   expect(mockPut).toHaveBeenCalledWith({
     url: createUrl({
       instance: createChildElement(1),
-      baseUrl: updateApi.url,
+      url: updateApi.url,
       urlParamsToFields: updateApi.urlParamsToFields,
     }),
     data: { position: 1 },


### PR DESCRIPTION
Make service url filter support the new definition type



---

_Additional context for reviewer_

---
_Release Notes_: 
- Service url filter support the new definition type, should have no effect on users

---
_User Notifications_: 
None
