### PR TITLE
SALTO-5498: [Zendesk] Move reference creation for macro attachment to macro filter

### DIFF
--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -244,13 +244,16 @@ const getMacroAttachments = async ({
   if (!isAttachments(attachments)) {
     return []
   }
-  return (
+  const attachmentsContent = (
     await Promise.all(
       attachments.map(async attachment => getAttachmentContent({ client, attachment, macro, attachmentType })),
     )
   )
     .flat()
     .filter(values.isDefined)
+
+  macro.value.attachments = attachmentsContent.map(attachment => new ReferenceExpression(attachment.elemID, attachment))
+  return attachmentsContent
 }
 
 /**

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -123,8 +123,6 @@ describe('macro attachment filter', () => {
         'zendesk.macro_attachment.instance.test__test_txt@uuv',
       ])
       const instances = elements.filter(isInstanceElement)
-      const macro = instances.find(e => e.elemID.typeName === MACRO_TYPE_NAME)
-      expect(macro?.value).toEqual(macroInstance.value)
       const attachment = instances.find(e => e.elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME)
       expect(attachment?.value).toEqual({
         id: attachmentId,


### PR DESCRIPTION
This is meant to avoid an id clash that happens when attachments from different macros have the same ID

---


---
_Release Notes_: 

Zendesk:
Fix bug where macro attachments had clashing IDs on fetch

---
_User Notifications_: 
None