### PR TITLE
SALTO-5585 - Salesforce: Log bulk load results

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1173,6 +1173,7 @@ export default class SalesforceClient {
     const { job } = batch
     await new Promise((resolve) => job.on('close', resolve))
     const result = (await batch.then()) as BatchResultInfo[]
+    log.trace('client.bulkLoadOperation result: %o', result)
     return flatValues(result)
   }
 }


### PR DESCRIPTION
We're already doing this for metadata, let's do it for data as well

---
```
2024-03-13T13:39:49.877Z trace salesforce-adapter/client/client client.bulkLoadOperation result: [
  { id: '001Dn0000063rYsIAI', success: true, errors: [ [length]: 0 ] },
  [length]: 1
]
```

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A