### PR TITLE
SALTO-5414 support polling as a capability in the new infra

### DIFF
--- a/packages/adapter-components/src/client/index.ts
+++ b/packages/adapter-components/src/client/index.ts
@@ -61,3 +61,4 @@ export {
 export { getAllPagesWithOffsetAndTotal } from './pagination/pagination_async'
 export { createRateLimitersFromConfig, throttle, BottleneckBuckets } from './rate_limit'
 export { createClient } from './client_creator'
+export { executeWithPolling } from './polling'

--- a/packages/adapter-components/src/client/polling.ts
+++ b/packages/adapter-components/src/client/polling.ts
@@ -29,8 +29,7 @@ export const executeWithPolling = async <T>(
 ): Promise<Response<ResponseValue | ResponseValue[]>> => {
   const pollingFunc = async (): Promise<Response<ResponseValue | ResponseValue[]> | undefined> => {
     const response = await singleClientCall(args)
-    if (polling.checkStatus(response)) return response
-    return undefined
+    return polling.checkStatus(response) ? response : undefined
   }
 
   const pollingResult = await withRetry(() => pollingFunc(), {

--- a/packages/adapter-components/src/client/polling.ts
+++ b/packages/adapter-components/src/client/polling.ts
@@ -1,0 +1,44 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { retry } from '@salto-io/lowerdash'
+import { ResponseValue, Response } from './http_connection'
+import { PollingArgs } from '../definitions'
+
+const {
+  withRetry,
+  retryStrategies: { intervals },
+} = retry
+
+export const executeWithPolling = async <T>(
+  args: T,
+  polling: PollingArgs,
+  singleClientCall: (args: T) => Promise<Response<ResponseValue | ResponseValue[]>>,
+): Promise<Response<ResponseValue | ResponseValue[]>> => {
+  const pollingFunc = async (): Promise<Response<ResponseValue | ResponseValue[]> | undefined> => {
+    const response = await singleClientCall(args)
+    if (polling.checkStatus(response)) return response
+    return undefined
+  }
+
+  const pollingResult = await withRetry(() => pollingFunc(), {
+    strategy: intervals({ maxRetries: polling.retries, interval: polling.interval }),
+  })
+  if (pollingResult === undefined) {
+    // should never get here, withRetry would throw
+    throw new Error('Error while waiting for polling')
+  }
+  return pollingResult
+}

--- a/packages/adapter-components/src/definitions/system/requests/index.ts
+++ b/packages/adapter-components/src/definitions/system/requests/index.ts
@@ -22,4 +22,5 @@ export {
   HTTPMethod,
   HTTPEndpointDetails,
   DeployHTTPEndpointDetails,
+  PollingArgs,
 } from './types'

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { Values } from '@salto-io/adapter-api'
+import { Response, ResponseValue } from '../../../client'
 
 export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options'
 
@@ -33,6 +34,14 @@ export type RequestArgs = {
   body?: unknown
 }
 
+export type PollingArgs = {
+  interval: number
+  retries: number
+  checkStatus: (response: Response<ResponseValue | ResponseValue[]>) => boolean
+  // fieldToPoll: string
+  // expectedValues: string[]
+}
+
 export type HTTPEndpointDetails<PaginationOptions extends string | 'none'> = RequestArgs & {
   omitBody?: boolean
 
@@ -43,6 +52,8 @@ export type HTTPEndpointDetails<PaginationOptions extends string | 'none'> = Req
 
   // set this to mark as endpoint as safe for fetch. other endpoints can only be called during deploy.
   readonly?: boolean
+
+  polling?: PollingArgs
 }
 
 export type DeployHTTPEndpointDetails = Omit<HTTPEndpointDetails<'none'>, 'pagination' | 'readonly'>

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -38,8 +38,6 @@ export type PollingArgs = {
   interval: number
   retries: number
   checkStatus: (response: Response<ResponseValue | ResponseValue[]>) => boolean
-  // fieldToPoll: string
-  // expectedValues: string[]
 }
 
 export type HTTPEndpointDetails<PaginationOptions extends string | 'none'> = RequestArgs & {

--- a/packages/adapter-components/src/deployment/deploy/requester.ts
+++ b/packages/adapter-components/src/deployment/deploy/requester.ts
@@ -247,7 +247,13 @@ export const getRequester = <TOptions extends APIDefinitionsOptions>({
       } catch (e) {
         const status = e.response?.status
         if (additionalValidStatuses.includes(status)) {
-          log.debug('Suppressing %d error %o, for path %s in method %s', status, e, args.path, args.method)
+          log.debug(
+            'Suppressing %d error %o, for path %s in method %s',
+            status,
+            e,
+            finalEndpointIdentifier.path,
+            finalEndpointIdentifier.method,
+          )
           return { data: {}, status }
         }
         throw e

--- a/packages/adapter-components/src/deployment/deploy/requester.ts
+++ b/packages/adapter-components/src/deployment/deploy/requester.ts
@@ -247,7 +247,7 @@ export const getRequester = <TOptions extends APIDefinitionsOptions>({
       } catch (e) {
         const status = e.response?.status
         if (additionalValidStatuses.includes(status)) {
-          log.debug('Suppressing %d error %o', status, e)
+          log.debug('Suppressing %d error %o, for path %s in method %s', status, e, args.path, args.method)
           return { data: {}, status }
         }
         throw e

--- a/packages/adapter-components/src/fetch/request/pagination/pagination.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/pagination.ts
@@ -77,7 +77,13 @@ export const traversePages = async <ClientOptions extends string>({
         } catch (e) {
           const status = e.response?.status
           if (additionalValidStatuses.includes(status)) {
-            log.debug('Suppressing %d error %o, for path %s in method %s', status, e, args.path, args.method)
+            log.debug(
+              'Suppressing %d error %o, for path %s in method %s',
+              status,
+              e,
+              finalEndpointIdentifier.url,
+              finalEndpointIdentifier.method,
+            )
             return { data: {}, status }
           }
           throw e

--- a/packages/adapter-components/src/fetch/request/pagination/pagination.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/pagination.ts
@@ -77,7 +77,7 @@ export const traversePages = async <ClientOptions extends string>({
         } catch (e) {
           const status = e.response?.status
           if (additionalValidStatuses.includes(status)) {
-            log.debug('Suppressing %d  fetch error %o', status, e)
+            log.debug('Suppressing %d error %o, for path %s in method %s', status, e, args.path, args.method)
             return { data: {}, status }
           }
           throw e
@@ -85,7 +85,7 @@ export const traversePages = async <ClientOptions extends string>({
       }
 
       const processPage: ClientRequest = async args => {
-        //  SALTO-5575 consider splitting the polling from the pagination
+        //  TODO SALTO-5575 consider splitting the polling from the pagination
         const updatedArgs: ClientBaseParams = {
           url: finalEndpointIdentifier.path,
           ...args,

--- a/packages/adapter-components/src/fetch/request/pagination/pagination.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/pagination.ts
@@ -81,7 +81,7 @@ export const traversePages = async <ClientOptions extends string>({
               'Suppressing %d error %o, for path %s in method %s',
               status,
               e,
-              finalEndpointIdentifier.url,
+              finalEndpointIdentifier.path,
               finalEndpointIdentifier.method,
             )
             return { data: {}, status }

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -154,6 +154,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
       contexts,
       callArgs,
       additionalValidStatuses: mergedEndpointDef.additionalValidStatuses,
+      polling: mergedEndpointDef.polling,
     })
 
     const itemsWithContext = pagesWithContext

--- a/packages/adapter-components/test/client/polling.test.ts
+++ b/packages/adapter-components/test/client/polling.test.ts
@@ -1,0 +1,71 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { executeWithPolling, Response, ResponseValue } from '../../src/client'
+
+describe('polling', () => {
+  describe('executeWithPolling', () => {
+    const polling = {
+      checkStatus: (response: Response<ResponseValue | ResponseValue[]>): boolean => response.status === 200,
+      retries: 3,
+      interval: 100,
+    }
+    it('should call the singleClientCall few times function and return its response', async () => {
+      const singleClientCall = jest
+        .fn()
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: 'still polling',
+            status: 201,
+          }),
+        )
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: 'still polling',
+            status: 201,
+          }),
+        )
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: 'done polling',
+            status: 200,
+          }),
+        )
+      const response = await executeWithPolling<string>('args', polling, singleClientCall)
+      expect(singleClientCall).toHaveBeenCalledTimes(3)
+      expect(singleClientCall).toHaveBeenCalledWith('args')
+      expect(response).toEqual({ data: 'done polling', status: 200 })
+    })
+    it('should throw an error if polling fails', async () => {
+      const singleClientCall = jest
+        .fn()
+        .mockResolvedValue({
+          data: 'still polling',
+          status: 201,
+        })
+        .mockResolvedValue({
+          data: 'still polling',
+          status: 201,
+        })
+        .mockResolvedValue({
+          data: 'still polling',
+          status: 201,
+        })
+
+      await expect(executeWithPolling<string>('args', polling, singleClientCall)).rejects.toThrow()
+    })
+  })
+})

--- a/packages/adapter-components/test/deployment/deploy/requester.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/requester.test.ts
@@ -394,7 +394,7 @@ describe('DeployRequester', () => {
       'test.requestsByAction.customizations.remove[0].request.context.instanceId',
       '{id}',
     )
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -425,7 +425,7 @@ describe('DeployRequester', () => {
       'test.requestsByAction.customizations.remove[0].request.context.instanceId',
       '{id}',
     )
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,
@@ -469,7 +469,7 @@ describe('DeployRequester', () => {
       'test.requestsByAction.customizations.remove[0].request.context.instanceId',
       '{id}',
     )
-    const requester = getRequester({
+    const requester = getRequester<{ additionalAction: AdditionalAction }>({
       clients: definitions.clients,
       deployDefQuery: queryWithDefault(definitions.deploy.instances),
       changeResolver: async change => change,

--- a/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
@@ -328,13 +328,10 @@ describe('pagination', () => {
     })
     it('should call the client few times when polling', async () => {
       client.get
-        .mockResolvedValueOnce(
-          Promise.resolve({
-            data: {
-              a: 'a',
-            },
-            status: 201,
-            statusText: 'OK',
+        .mockRejectedValueOnce(
+          new HTTPError('Something else went wrong', {
+            data: {},
+            status: 404,
           }),
         )
         .mockResolvedValueOnce(
@@ -370,6 +367,7 @@ describe('pagination', () => {
           retries: 5,
           checkStatus: (response: Response<ResponseValue | ResponseValue[]>): boolean => response.status === 200,
         },
+        additionalValidStatuses: [404],
       })
       expect(result).toEqual([{ context: {}, pages: [{ a: 'c' }] }])
       expect(client.get).toHaveBeenCalledTimes(3)

--- a/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
-import { HTTPError, HTTPReadClientInterface, HTTPWriteClientInterface } from '../../../../src/client'
+import {
+  HTTPError,
+  HTTPReadClientInterface,
+  HTTPWriteClientInterface,
+  Response,
+  ResponseValue,
+} from '../../../../src/client'
 import { PaginationFunction } from '../../../../src/definitions'
 import { PaginationFuncCreator } from '../../../../src/definitions/system/requests/pagination'
 import { traversePages } from '../../../../src/fetch/request/pagination'
@@ -319,6 +325,54 @@ describe('pagination', () => {
           contexts: [],
         }),
       ).rejects.toThrow('Something went wrong')
+    })
+    it('should call the client few times when polling', async () => {
+      client.get
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: {
+              a: 'a',
+            },
+            status: 201,
+            statusText: 'OK',
+          }),
+        )
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: {
+              a: 'b',
+            },
+            status: 201,
+            statusText: 'OK',
+          }),
+        )
+        .mockResolvedValueOnce(
+          Promise.resolve({
+            data: {
+              a: 'c',
+            },
+            status: 200,
+            statusText: 'OK',
+          }),
+        )
+      const result = await traversePages({
+        client,
+        endpointIdentifier: {
+          path: '/ep',
+        },
+        paginationDef: {
+          funcCreator: paginationFuncCreator,
+        },
+        callArgs: {},
+        contexts: [],
+        polling: {
+          interval: 100,
+          retries: 5,
+          checkStatus: (response: Response<ResponseValue | ResponseValue[]>): boolean => response.status === 200,
+        },
+      })
+      expect(result).toEqual([{ context: {}, pages: [{ a: 'c' }] }])
+      expect(client.get).toHaveBeenCalledTimes(3)
     })
   })
 })


### PR DESCRIPTION
SALTO-5414 support polling as a capability in the new infra
---

_Additional context for reviewer_
added the polling option for both deploy + fetch
completed the support in additional status codes for deploy

---
_Release Notes_: 
none

---
_User Notifications_: 
none
