### PR TITLE
SALTO-5576: Modify default page size in Okta

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -86,6 +86,9 @@ const DEFAULT_FIELDS_TO_OMIT: configUtils.FieldToOmitType[] = [
   { fieldName: 'createdBy' },
   { fieldName: 'lastUpdatedBy' },
 ]
+const REQUEST_DEFAULTS: Omit<configUtils.FetchRequestConfig, 'url'> = {
+  queryParams: { limit: '200' },
+}
 const TRANSFORMATION_DEFAULTS: configUtils.TransformationDefaultConfig = {
   idFields: DEFAULT_ID_FIELDS,
   fieldsToOmit: DEFAULT_FIELDS_TO_OMIT,
@@ -302,6 +305,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__groups: {
     request: {
       url: '/api/v1/groups',
+      queryParams: { limit: '10000' } // maximum page size allowed
     },
   },
   Group: {
@@ -358,7 +362,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__apps: {
     request: {
       url: '/api/v1/apps',
-      queryParams: { limit: '200' },
       recurseInto: [
         {
           type: 'api__v1__apps___appId___groups@uuuuuu_00123_00125uu',
@@ -431,7 +434,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   'api__v1__apps___appId___groups@uuuuuu_00123_00125uu': {
     request: {
       url: 'api/v1/apps/{appId}/groups',
-      queryParams: { limit: '200' },
     },
   },
   ApplicationGroupAssignment: {
@@ -1039,7 +1041,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__groups__rules: {
     request: {
       url: '/api/v1/groups/rules',
-      queryParams: { limit: '200' },
     },
   },
   GroupRule: {
@@ -1802,6 +1803,7 @@ export const DUCKTYPE_API_DEFINITIONS: OktaDuckTypeApiConfig = {
 export const DEFAULT_API_DEFINITIONS: OktaSwaggerApiConfig = {
   swagger: DEFAULT_SWAGGER_CONFIG,
   typeDefaults: {
+    request: REQUEST_DEFAULTS,
     transformation: TRANSFORMATION_DEFAULTS,
   },
   types: DEFAULT_TYPE_CUSTOMIZATIONS,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -305,7 +305,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
   api__v1__groups: {
     request: {
       url: '/api/v1/groups',
-      queryParams: { limit: '10000' } // maximum page size allowed
+      queryParams: { limit: '10000' }, // maximum page size allowed
     },
   },
   Group: {


### PR DESCRIPTION
Until now we used the maximum page size for specific endpoint, I switched it to be used by default

---

_Additional context for reviewer_
- Not all endpoints support page size but it has no affect for unsupported endpoints
- I prefer to put this as default as every now and then we find out we can increase page size for another type (usually default is 20 or 50)
- groups maximum page size is different from all other endpoints and it defined to be 10000 (which is the default one, but now that we override the default it needs to be mentioned explicitly)

---
_Release Notes_: 
None

---
_User Notifications_: 
None