### PR TITLE
SALTO-5604: nestUnderParent standalone flag doesn't affect paths

### DIFF
--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -185,6 +185,7 @@ export const getElemPath =
     typeID,
     singleton,
     nestUnderPath,
+    createSelfFolder,
     customNameMappingFunctions,
   }: {
     def: PathDefinition<TCustomNameMappingOptions> | undefined
@@ -192,6 +193,7 @@ export const getElemPath =
     typeID: ElemID
     singleton?: boolean
     nestUnderPath?: string[]
+    createSelfFolder?: boolean
     customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
   }): PartsCreator =>
   ({ entry, parent, defaultName }) => {
@@ -209,5 +211,12 @@ export const getElemPath =
     const pathParts = basicPathParts.map(pathNaclCase)
 
     const { adapter: adapterName, typeName } = typeID
-    return [adapterName, RECORDS_PATH, ...(nestUnderPath ?? [pathNaclCase(typeName)]), ...pathParts]
+    const lastPart = pathParts[pathParts.length - 1]
+    return [
+      adapterName,
+      RECORDS_PATH, 
+      ...(nestUnderPath ?? [pathNaclCase(typeName)]),
+      ...pathParts,
+      ...(createSelfFolder && lastPart ? [lastPart] : [])
+    ]
   }

--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -214,9 +214,9 @@ export const getElemPath =
     const lastPart = pathParts[pathParts.length - 1]
     return [
       adapterName,
-      RECORDS_PATH, 
+      RECORDS_PATH,
       ...(nestUnderPath ?? [pathNaclCase(typeName)]),
       ...pathParts,
-      ...(createSelfFolder && lastPart ? [lastPart] : [])
+      ...(createSelfFolder && lastPart ? [lastPart] : []),
     ]
   }

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -129,8 +129,9 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   const { elemID: elemIDDef, singleton } = elementDef.topLevel
 
   // if there is at least one standalone field with nestPathUnderParent, we should create a folder to instance
-  const createSelfFolder = Object.entries(elementDef.fieldCustomizations ?? {})
-    .some(([_fieldName, fieldDef]) => fieldDef.standalone?.nestPathUnderParent)
+  const createSelfFolder = Object.entries(elementDef.fieldCustomizations ?? {}).some(
+    ([_fieldName, fieldDef]) => fieldDef.standalone?.nestPathUnderParent,
+  )
 
   // if this is a singleton, the instance name has to be 'config' and cannot be customized
   const elemIDCreator = elemIDDef?.custom && !singleton ? elemIDDef.custom : createElemIDFunc

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -91,7 +91,6 @@ export type InstanceCreationParams = {
   entry: Values
   type: ObjectType
   defaultName: string
-  nestUnderPath?: string[]
   parent?: InstanceElement
   toElemName: ElemIDCreator
   toPath: PartsCreator
@@ -106,11 +105,13 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   type,
   getElemIdFunc,
   customNameMappingFunctions,
+  nestUnderPath,
 }: {
   type: ObjectType
   defQuery: ElementAndResourceDefFinder<Options>
   getElemIdFunc?: ElemIdGetter
   customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+  nestUnderPath?: string[]
 }): {
   toElemName: ElemIDCreator
   toPath: PartsCreator
@@ -126,6 +127,10 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   }
 
   const { elemID: elemIDDef, singleton } = elementDef.topLevel
+
+  // if there is at least one standalone field with nestPathUnderParent, we should create a folder to instance
+  const createSelfFolder = Object.entries(elementDef.fieldCustomizations ?? {})
+    .some(([_fieldName, fieldDef]) => fieldDef.standalone?.nestPathUnderParent)
 
   // if this is a singleton, the instance name has to be 'config' and cannot be customized
   const elemIDCreator = elemIDDef?.custom && !singleton ? elemIDDef.custom : createElemIDFunc
@@ -144,6 +149,8 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
     elemIDCreator: toElemName,
     typeID: type.elemID,
     customNameMappingFunctions,
+    nestUnderPath,
+    createSelfFolder,
   })
 
   return { toElemName, toPath }
@@ -159,7 +166,6 @@ export const createInstance = ({
   toElemName,
   toPath,
   defaultName,
-  nestUnderPath,
   parent,
 }: InstanceCreationParams): InstanceElement => {
   const annotations = _.pick(entry, Object.keys(INSTANCE_ANNOTATIONS))
@@ -169,6 +175,6 @@ export const createInstance = ({
     annotations[INSTANCE_ANNOTATIONS.PARENT].push(new ReferenceExpression(parent.elemID, parent))
   }
 
-  const args = { entry, parent, defaultName, nestUnderPath }
+  const args = { entry, parent, defaultName }
   return new InstanceElement(toElemName(args), type, value, toPath(args), annotations)
 }

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -63,9 +63,15 @@ const extractStandaloneInstancesFromField =
     }
 
     const nestUnderPath = standaloneDef.nestPathUnderParent
-    ? [...(parent.path?.slice(2, parent.path?.length - 1) ?? []), field.name]
-    : undefined
-    const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type: fieldType, getElemIdFunc, nestUnderPath, customNameMappingFunctions })
+      ? [...(parent.path?.slice(2, parent.path?.length - 1) ?? []), field.name]
+      : undefined
+    const { toElemName, toPath } = getInstanceCreationFunctions({
+      defQuery,
+      type: fieldType,
+      getElemIdFunc,
+      nestUnderPath,
+      customNameMappingFunctions,
+    })
     const newInstances = collections.array.makeArray(value).map((entry, index) =>
       createInstance({
         entry,

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -62,12 +62,10 @@ const extractStandaloneInstancesFromField =
       )
     }
 
-    const { toElemName, toPath } = getInstanceCreationFunctions({
-      defQuery,
-      type: fieldType,
-      getElemIdFunc,
-      customNameMappingFunctions,
-    })
+    const nestUnderPath = standaloneDef.nestPathUnderParent
+    ? [...(parent.path?.slice(2, parent.path?.length - 1) ?? []), field.name]
+    : undefined
+    const { toElemName, toPath } = getInstanceCreationFunctions({ defQuery, type: fieldType, getElemIdFunc, nestUnderPath, customNameMappingFunctions })
     const newInstances = collections.array.makeArray(value).map((entry, index) =>
       createInstance({
         entry,
@@ -76,9 +74,6 @@ const extractStandaloneInstancesFromField =
         toPath,
         defaultName: `${invertNaclCase(parent.elemID.name)}__unnamed_${index}`,
         parent: standaloneDef.addParentAnnotation !== false ? parent : undefined,
-        nestUnderPath: standaloneDef.nestPathUnderParent
-          ? [...(parent.path?.slice(2, parent.path?.length - 1) ?? []), field.name]
-          : undefined,
       }),
     )
     newInstances.forEach(inst => instanceOutput.push(inst))

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -250,7 +250,7 @@ describe('id utils', () => {
           }),
           nestUnderPath: ['ParentType', 'FieldName'],
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
-      ).toEqual(['myAdapter', 'Records','ParentType', 'FieldName', 'A'])
+      ).toEqual(['myAdapter', 'Records', 'ParentType', 'FieldName', 'A'])
     })
     it('it should work with both nestUnderPath and createSelfFolder', () => {
       expect(
@@ -268,7 +268,7 @@ describe('id utils', () => {
           nestUnderPath: ['ParentType', 'FieldName'],
           createSelfFolder: true,
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
-      ).toEqual(['myAdapter', 'Records','ParentType', 'FieldName', 'A', 'A'])
+      ).toEqual(['myAdapter', 'Records', 'ParentType', 'FieldName', 'A', 'A'])
     })
   })
 

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -218,6 +218,58 @@ describe('id utils', () => {
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual(['myAdapter', 'Records', 'Settings', 'myType'])
     })
+    it('it should create self folder if createSelfFolder is true', () => {
+      expect(
+        getElemPath({
+          def: {
+            pathParts: [{ parts: [{ fieldName: 'a' }] }],
+          },
+          typeID,
+          elemIDCreator: createElemIDFunc({
+            elemIDDef: {
+              parts: [{ fieldName: 'a' }],
+            },
+            typeID,
+          }),
+          createSelfFolder: true,
+        })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
+      ).toEqual(['myAdapter', 'Records', 'myType', 'A', 'A'])
+    })
+    it('it should nest under path if nested path provided and ignore the curent instance type name', () => {
+      expect(
+        getElemPath({
+          def: {
+            pathParts: [{ parts: [{ fieldName: 'a' }] }],
+          },
+          typeID,
+          elemIDCreator: createElemIDFunc({
+            elemIDDef: {
+              parts: [{ fieldName: 'a' }],
+            },
+            typeID,
+          }),
+          nestUnderPath: ['ParentType', 'FieldName'],
+        })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
+      ).toEqual(['myAdapter', 'Records','ParentType', 'FieldName', 'A'])
+    })
+    it('it should work with both nestUnderPath and createSelfFolder', () => {
+      expect(
+        getElemPath({
+          def: {
+            pathParts: [{ parts: [{ fieldName: 'a' }] }],
+          },
+          typeID,
+          elemIDCreator: createElemIDFunc({
+            elemIDDef: {
+              parts: [{ fieldName: 'a' }],
+            },
+            typeID,
+          }),
+          nestUnderPath: ['ParentType', 'FieldName'],
+          createSelfFolder: true,
+        })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
+      ).toEqual(['myAdapter', 'Records','ParentType', 'FieldName', 'A', 'A'])
+    })
   })
 
   describe('getNameMapping', () => {

--- a/packages/adapter-components/test/fetch/element/instance_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_utils.test.ts
@@ -1,0 +1,94 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { ElemID, ObjectType } from '@salto-io/adapter-api'
+import { queryWithDefault } from '../../../src/definitions'
+import { InstanceFetchApiDefinitions } from '../../../src/definitions/system/fetch'
+import { getInstanceCreationFunctions, createInstance } from '../../../src/fetch/element/instance_utils'
+
+describe('instance utils', () => {
+  const type = new ObjectType({ elemID: new ElemID('myAdapter', 'myType') })
+  describe('getInstanceCreationFunctions', () => {
+    describe('instance with standalone fields', () => {
+      const customizations: Record<string, InstanceFetchApiDefinitions> = {
+          myType: {
+            resource: {
+              directFetch: true,
+            },
+            element: {
+              topLevel: {
+                isTopLevel: true,
+                elemID: {
+                  parts: [{ fieldName: 'str' }],
+                },
+              },
+              fieldCustomizations: {
+                standaloneA: { standalone: { typeName: 'anotherType', nestPathUnderParent: true } },
+                standaloneB: { standalone: { typeName: 'anotherType', nestPathUnderParent: false } },
+              },
+            },
+          },
+      }
+      it('should create self folder for instance if it has any standalone fields with nestPathUnderParent', () => {
+        const { toElemName, toPath } = getInstanceCreationFunctions({
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations }),
+          type,
+        })
+        const instance = createInstance({
+          entry: { str: 'A', num: 2 },
+          type,
+          toPath,
+          toElemName,
+          defaultName: 'test',
+        })
+        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A', 'A'])
+      })
+      it('should not create self folder for instance if its has no standalone fields', () => {
+        const clonedCustomizations = _.cloneDeep(customizations)
+        delete clonedCustomizations?.myType?.element?.fieldCustomizations
+        const { toElemName, toPath } = getInstanceCreationFunctions({
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: clonedCustomizations }),
+          type,
+        })
+        const instance = createInstance({
+          entry: { str: 'A', num: 2 },
+          type,
+          toPath,
+          toElemName,
+          defaultName: 'test',
+        })
+        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A'])
+      })
+      it('should not create self folder for instance all its standalone fields disabled nestPathUnderParent', () => {
+        const clonedCustomizations = _.cloneDeep(customizations)
+        _.set(clonedCustomizations, 'myType.element.fieldCustomizations.standaloneA.standalone.nestPathUnderParent', undefined)
+
+        const { toElemName, toPath } = getInstanceCreationFunctions({
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: clonedCustomizations }),
+          type,
+        })
+        const instance = createInstance({
+          entry: { str: 'A', num: 2 },
+          type,
+          toPath,
+          toElemName,
+          defaultName: 'test',
+        })
+        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A'])
+      })
+    })
+  })
+  })

--- a/packages/adapter-components/test/fetch/element/instance_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_utils.test.ts
@@ -24,23 +24,23 @@ describe('instance utils', () => {
   describe('getInstanceCreationFunctions', () => {
     describe('instance with standalone fields', () => {
       const customizations: Record<string, InstanceFetchApiDefinitions> = {
-          myType: {
-            resource: {
-              directFetch: true,
+        myType: {
+          resource: {
+            directFetch: true,
+          },
+          element: {
+            topLevel: {
+              isTopLevel: true,
+              elemID: {
+                parts: [{ fieldName: 'str' }],
+              },
             },
-            element: {
-              topLevel: {
-                isTopLevel: true,
-                elemID: {
-                  parts: [{ fieldName: 'str' }],
-                },
-              },
-              fieldCustomizations: {
-                standaloneA: { standalone: { typeName: 'anotherType', nestPathUnderParent: true } },
-                standaloneB: { standalone: { typeName: 'anotherType', nestPathUnderParent: false } },
-              },
+            fieldCustomizations: {
+              standaloneA: { standalone: { typeName: 'anotherType', nestPathUnderParent: true } },
+              standaloneB: { standalone: { typeName: 'anotherType', nestPathUnderParent: false } },
             },
           },
+        },
       }
       it('should create self folder for instance if it has any standalone fields with nestPathUnderParent', () => {
         const { toElemName, toPath } = getInstanceCreationFunctions({
@@ -54,7 +54,7 @@ describe('instance utils', () => {
           toElemName,
           defaultName: 'test',
         })
-        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A', 'A'])
+        expect(instance.path).toEqual(['myAdapter', 'Records', 'myType', 'A', 'A'])
       })
       it('should not create self folder for instance if its has no standalone fields', () => {
         const clonedCustomizations = _.cloneDeep(customizations)
@@ -70,11 +70,15 @@ describe('instance utils', () => {
           toElemName,
           defaultName: 'test',
         })
-        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A'])
+        expect(instance.path).toEqual(['myAdapter', 'Records', 'myType', 'A'])
       })
       it('should not create self folder for instance all its standalone fields disabled nestPathUnderParent', () => {
         const clonedCustomizations = _.cloneDeep(customizations)
-        _.set(clonedCustomizations, 'myType.element.fieldCustomizations.standaloneA.standalone.nestPathUnderParent', undefined)
+        _.set(
+          clonedCustomizations,
+          'myType.element.fieldCustomizations.standaloneA.standalone.nestPathUnderParent',
+          undefined,
+        )
 
         const { toElemName, toPath } = getInstanceCreationFunctions({
           defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: clonedCustomizations }),
@@ -87,8 +91,8 @@ describe('instance utils', () => {
           toElemName,
           defaultName: 'test',
         })
-        expect(instance.path).toEqual(['myAdapter', 'Records','myType', 'A'])
+        expect(instance.path).toEqual(['myAdapter', 'Records', 'myType', 'A'])
       })
     })
   })
-  })
+})


### PR DESCRIPTION
nestUnderParent didn't affect the nacls path

---

In order to keep the behavior we have today for `nestStandaloneInstances`, both parent and children paths should be adjusted - 
1. the parent file should be nested under its own folder
2. the children filed should be nested under the parent folder -> field name

will add tests once finalized 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
