### PR TITLE
SALTO-5608: Move Okta pagination function to adapter components

### DIFF
--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -47,7 +47,8 @@
     "openapi-types": "^7.0.1",
     "qs": "^6.10.1",
     "soap": "^0.44.0",
-    "wu": "^2.1.0"
+    "wu": "^2.1.0",
+    "parse-link-header": "^2.0.0"
   },
   "devDependencies": {
     "@salto-io/test-utils": "0.3.54",
@@ -60,6 +61,7 @@
     "@types/wu": "^2.1.40",
     "@typescript-eslint/eslint-plugin": "4.22.1",
     "@typescript-eslint/parser": "4.22.1",
+    "@types/parse-link-header": "^2.0.0",
     "axios-mock-adapter": "^1.19.0",
     "eslint": "^7.3.2",
     "eslint-config-airbnb": "18.0.1",

--- a/packages/adapter-components/src/fetch/request/pagination/index.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/index.ts
@@ -15,6 +15,7 @@
  */
 export {
   cursorPagination,
+  cursorHeaderPagination,
   itemOffsetPagination,
   offsetAndLimitPagination,
   pageOffsetAndLastPagination,

--- a/packages/adapter-components/src/fetch/request/pagination/queue.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/queue.ts
@@ -70,7 +70,7 @@ export class RequestQueue<ClientOptions extends string> {
         'processNext on queue %s.%s:%s - %d items left',
         this.endpointIdentifier.client,
         this.endpointIdentifier.path,
-        this.endpointIdentifier.method,
+        this.endpointIdentifier.method ?? 'get',
         this.queue.length,
       )
       if (args === undefined) {

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -145,7 +145,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
       adapterName,
       clientName,
       mergedRequestDef.endpoint.path,
-      mergedRequestDef.endpoint.method,
+      mergedRequestDef.endpoint.method ?? 'get',
     )
     const pagesWithContext = await traversePages({
       client: clientDefs[clientName].httpClient,

--- a/packages/okta-adapter/src/client/pagination.ts
+++ b/packages/okta-adapter/src/client/pagination.ts
@@ -29,6 +29,7 @@ const getNextPage = (link: string): URL | undefined => {
   return undefined
 }
 
+// TODO remove this as part of SALTO-5608 (new name is cursorHeaderPagination)
 /**
  * Make paginated requests using the link response header.
  * Only supports next pages under the same endpoint (and uses the same host).


### PR DESCRIPTION
part of the preparations to upgrade okta to the new infra

---

The new infra gets pagination function in a slightly different formant, so in this PR I: 
- added okta's pagination to adapter-component (+ needed adjustments)
- modify logs to fallback `get` when undefined method is undefined

---
_Release Notes_: 
None

---
_User Notifications_: 
None