### PR TITLE
SALTO-5596: Classify NS testing accounts as non-production

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -123,6 +123,14 @@ const isLegalEdge = (
   (startNode.value.changeType === 'addition' || startNode.value.addedObjects.has(serviceId)) &&
   startNode.id !== endNode.id
 
+const determineAccountType = (accountId: string, envType: EnvType): EnvType | 'TEST'=> {
+  if (accountId.toUpperCase().startsWith('TSTDRV') || accountId.toUpperCase().startsWith('TD')) {
+    log.debug(`using 'TEST' account type although ${envType} envType is returned from NS since we assume ${accountId} indicates a testing account`)
+    return 'TEST'
+  }
+  return envType
+}
+
 export default class NetsuiteClient {
   private sdfClient: SdfClient
   private suiteAppClient?: SuiteAppClient
@@ -170,10 +178,11 @@ export default class NetsuiteClient {
     if (systemInformation?.envType === undefined) {
       return { accountId }
     }
+    const accountType = determineAccountType(accountId, systemInformation.envType)
     return {
       accountId,
-      isProduction: systemInformation.envType === EnvType.PRODUCTION,
-      accountType: EnvType[systemInformation.envType],
+      isProduction: accountType === EnvType.PRODUCTION,
+      accountType,
     }
   }
 

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -123,9 +123,11 @@ const isLegalEdge = (
   (startNode.value.changeType === 'addition' || startNode.value.addedObjects.has(serviceId)) &&
   startNode.id !== endNode.id
 
-const determineAccountType = (accountId: string, envType: EnvType): EnvType | 'TEST'=> {
+const determineAccountType = (accountId: string, envType: EnvType): EnvType | 'TEST' => {
   if (accountId.toUpperCase().startsWith('TSTDRV') || accountId.toUpperCase().startsWith('TD')) {
-    log.debug(`using 'TEST' account type although ${envType} envType is returned from NS since we assume ${accountId} indicates a testing account`)
+    log.debug(
+      `using 'TEST' account type although ${envType} envType is returned from NS since we assume ${accountId} indicates a testing account`,
+    )
     return 'TEST'
   }
   return envType

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -144,6 +144,30 @@ describe('NetsuiteAdapter creator', () => {
             const accountInfo = await adapter.validateCredentials(cred)
             expect(accountInfo).toEqual({ accountId, accountType: 'PRODUCTION', isProduction: true })
           })
+
+          it('Should return accountInfo with accountType = TEST and isProduction = false when identifying TSTDRV account', async () => {
+            suiteAppClientValidateMock.mockResolvedValueOnce({
+              time: new Date(),
+              appVersion: [1, 2, 3],
+              envType: EnvType.PRODUCTION,
+            })
+            const testAccountId = 'TSTDRV1234567'
+            netsuiteValidateMock.mockResolvedValueOnce({ accountId: testAccountId })
+            const accountInfo = await adapter.validateCredentials(cred)
+            expect(accountInfo).toEqual({ accountId: testAccountId, accountType: 'TEST', isProduction: false })
+          })
+
+          it('Should return accountInfo with accountType = TEST and isProduction = false when identifying TD account', async () => {
+            suiteAppClientValidateMock.mockResolvedValueOnce({
+              time: new Date(),
+              appVersion: [1, 2, 3],
+              envType: EnvType.PRODUCTION,
+            })
+            const testAccountId = 'TD1234567'
+            netsuiteValidateMock.mockResolvedValueOnce({ accountId: testAccountId })
+            const accountInfo = await adapter.validateCredentials(cred)
+            expect(accountInfo).toEqual({ accountId: testAccountId, accountType: 'TEST', isProduction: false })
+          })
         })
 
         describe('When systemInformation contains envType !== PRODUCTION', () => {


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
NetSuite Adapter:
SALTO-5596: do not classify testing accounts as production

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
