### PR TITLE
SALTO-5609 - Salesforce: Exclude SF translations by default

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -88,6 +88,9 @@ salesforce {
         {
           metadataType: 'DiscoveryAIModel',
         },
+        {
+          metadataType: 'Translations',
+        },
       ]
     }
     data = {

--- a/packages/salesforce-adapter/cpq-sbaa-config-doc.md
+++ b/packages/salesforce-adapter/cpq-sbaa-config-doc.md
@@ -138,6 +138,9 @@ salesforce {
         {
           metadataType: 'DiscoveryAIModel',
         },
+        {
+          metadataType: 'Translations',
+        },
       ]
     }
     data = {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -127,6 +127,9 @@ export const configWithCPQ = new InstanceElement(
           {
             metadataType: 'DiscoveryAIModel',
           },
+          {
+            metadataType: 'Translations',
+          },
         ],
       },
       data: {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -973,6 +973,9 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
               {
                 metadataType: 'DiscoveryAIModel',
               },
+              {
+                metadataType: 'Translations',
+              },
             ],
           },
           [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,


### PR DESCRIPTION
We've seen errors associated with this type, and it is not used by customers.

---

---
_Release Notes_: 
Salesforce: The 'Translations' type is now excluded from fetches in new workspaces.

---
_User Notifications_: 
N/A
