### PR TITLE
SALTO-5631: Fix Error Throwing In gqlPost

### DIFF
--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -146,13 +146,12 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
     })
     if (isGraphQLResponse(response.data)) {
       if (response.data.errors !== undefined && response.data.errors.length > 0) {
-        log.error(
+        log.warn(
           'received the following errors for POST on %s with query: (%s). errors: %o',
           args.url,
           safeJsonStringify(args.query),
           response.data.errors,
         )
-        throw new Error(`Received GQL error: ${safeJsonStringify(response.data.errors)}`)
       }
       return response.data
     }

--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -138,7 +138,7 @@ describe('client', () => {
     mockAxios.onPost().replyOnce(200, { response: 'not as expected' })
     await expect(client.gqlPost({ url: 'www.test.com', query: 'query' })).rejects.toThrow()
   })
-  it('check if gqlpost throws an error if the response has an error', async () => {
+  it('check if gqlpost returns the data when data as expected and there are errors.', async () => {
     const error = {
       message: 'Requested issue layout configuration is not found',
       locations: [{ line: 65, column: 3 }],
@@ -146,6 +146,7 @@ describe('client', () => {
       extensions: { statusCode: 404, errorType: 'DataFetchingException', classification: 'DataFetchingException' },
     }
     mockAxios.onPost().reply(200, { data: { layoutConfiguration: null }, errors: [error] })
-    await expect(client.gqlPost({ url: 'www.test.com', query: 'query' })).rejects.toThrow()
+    result = await client.gqlPost({ url: 'www.test.com', query: 'query' })
+    expect(result).toEqual({ data: { layoutConfiguration: null }, errors: [error] })
   })
 })


### PR DESCRIPTION
In this PR I fixed the error throwing in gqlPost

---

_Additional context for reviewer_
More context can be found in: https://salto-io.atlassian.net/browse/SALTO-5631

---
_Release Notes_: 
_Jira Adapter:_
* Fixed error throwing in gqlPost for requestForm. 

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
