### PR TITLE
SALTO-5634: add outgoingUnresolvedReferencesValidator to dummy

### DIFF
--- a/packages/dummy-adapter/src/change_validator.ts
+++ b/packages/dummy-adapter/src/change_validator.ts
@@ -18,11 +18,12 @@ import { deployment } from '@salto-io/adapter-components'
 import { GeneratorParams } from './generator'
 import fromAdapterConfig from './change_validators/from_adapter_config'
 
-const { createChangeValidator } = deployment.changeValidators
+const { createChangeValidator, createOutgoingUnresolvedReferencesValidator } = deployment.changeValidators
 
 export const changeValidator = (config: GeneratorParams): ChangeValidator => {
   const validators: Record<string, ChangeValidator> = {
     dummy: fromAdapterConfig(config),
+    outgoingUnresolvedReferences: createOutgoingUnresolvedReferencesValidator(),
   }
 
   return createChangeValidator({ validators })

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -153,7 +153,9 @@ describe('dummy adapter', () => {
           name: 'unresolved',
           val: { brokenRef: new ReferenceExpression(unresolvedId, new UnresolvedReference(unresolvedId)) },
         })
-        const errors = await adapterWithDeployModifiers.deployModifiers.changeValidator?.([toChange({ after: unresolvedReferences })])
+        const errors = await adapterWithDeployModifiers.deployModifiers.changeValidator?.([
+          toChange({ after: unresolvedReferences }),
+        ])
         expect(errors).toHaveLength(1)
         expect(errors?.[0]).toEqual({
           elemID: unresolvedReferences.elemID,

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -23,6 +23,8 @@ import {
   isObjectType,
   CORE_ANNOTATIONS,
   ProgressReporter,
+  ReferenceExpression,
+  UnresolvedReference,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from '../src/adapter'
@@ -140,6 +142,28 @@ describe('dummy adapter', () => {
     })
     it('should NOT return changeError when element is not exist in changes list', async () => {
       expect(await adapterWithDeployModifiers.deployModifiers.changeValidator?.([myInst1Change])).toHaveLength(0)
+    })
+    describe('validators', () => {
+      it('should return all validators', () => {
+        expect(adapterWithDeployModifiers.deployModifiers.changeValidator).toHaveLength(2)
+      })
+      it('should return outgoingUnresolvedReferences error for element with unresolved references', async () => {
+        const unresolvedId = new ElemID('dummy', 'type', 'instance', 'missing')
+        const unresolvedReferences = new InstanceElement('unresolved', objType, {
+          name: 'unresolved',
+          val: { brokenRef: new ReferenceExpression(unresolvedId, new UnresolvedReference(unresolvedId)) },
+        })
+        const errors = await adapterWithDeployModifiers.deployModifiers.changeValidator?.([toChange({ after: unresolvedReferences })])
+        expect(errors).toHaveLength(1)
+        expect(errors?.[0]).toEqual({
+          elemID: unresolvedReferences.elemID,
+          severity: 'Error',
+          message: expect.any(String),
+          detailedMessage: expect.any(String),
+          unresolvedElemIds: [unresolvedId],
+          type: 'unresolvedReferences',
+        })
+      })
     })
   })
   describe('fixElements', () => {


### PR DESCRIPTION
This is needed to test missing dependencies flows, more info in ticket

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None