### PR TITLE
SALTO-4832 - Salesforce: handle the case where SF returns an HTML page as an error

### DIFF
--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -24,7 +24,6 @@ import {
   ERROR_PROPERTIES,
   INVALID_GRANT,
   isSalesforceError,
-  SALESFORCE_CONNECTION_ERROR,
   SALESFORCE_ERRORS,
   SalesforceError,
 } from '../constants'
@@ -65,7 +64,6 @@ type ErrorMapper<T extends Error> = {
 }
 
 export type ErrorMappers = {
-  [SALESFORCE_CONNECTION_ERROR]: ErrorMapper<Error>
   [ERROR_HTTP_502]: ErrorMapper<Error>
   [SALESFORCE_ERRORS.REQUEST_LIMIT_EXCEEDED]: ErrorMapper<SalesforceError>
   [INVALID_GRANT]: ErrorMapper<Error>
@@ -78,13 +76,10 @@ const withSalesforceError = (
 ): string => `${saltoErrorMessage}\n\nUnderlying Error: ${salesforceError}`
 
 export const ERROR_MAPPERS: ErrorMappers = {
-  [SALESFORCE_CONNECTION_ERROR]: {
-    test: (error: Error): error is Error =>
-      CONNECTION_ERROR_HTML_PAGE_REGEX.test(error.message),
-    map: (): string => ERROR_HTTP_502_MESSAGE,
-  },
   [ERROR_HTTP_502]: {
-    test: (error: Error): error is Error => error.message === ERROR_HTTP_502,
+    test: (error: Error): error is Error =>
+      error.message === ERROR_HTTP_502 ||
+      CONNECTION_ERROR_HTML_PAGE_REGEX.test(error.message),
     map: (error: Error): string =>
       withSalesforceError(error.message, ERROR_HTTP_502_MESSAGE),
   },

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -593,6 +593,7 @@ export const SOCKET_TIMEOUT = 'ESOCKETTIMEDOUT'
 export const INVALID_GRANT = 'invalid_grant'
 export const ENOTFOUND = 'ENOTFOUND'
 export const ERROR_HTTP_502 = 'ERROR_HTTP_502'
+export const SALESFORCE_CONNECTION_ERROR = 'Salesforce Connection Error'
 
 export const TASK_CUSTOM_OBJECT = 'Task'
 export const EVENT_CUSTOM_OBJECT = 'Event'

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -593,7 +593,6 @@ export const SOCKET_TIMEOUT = 'ESOCKETTIMEDOUT'
 export const INVALID_GRANT = 'invalid_grant'
 export const ENOTFOUND = 'ENOTFOUND'
 export const ERROR_HTTP_502 = 'ERROR_HTTP_502'
-export const SALESFORCE_CONNECTION_ERROR = 'Salesforce Connection Error'
 
 export const TASK_CUSTOM_OBJECT = 'Task'
 export const EVENT_CUSTOM_OBJECT = 'Event'

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -46,6 +46,7 @@ import {
   ErrorProperty,
   INVALID_GRANT,
   RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+  SALESFORCE_CONNECTION_ERROR,
   SALESFORCE_ERRORS,
 } from '../src/constants'
 import {
@@ -445,6 +446,13 @@ describe('salesforce client', () => {
       keyof ErrorMappers,
       types.NonEmptyArray<TestInput> | TestInput
     > = {
+      [SALESFORCE_CONNECTION_ERROR]: {
+        errorProperties: {
+          [ERROR_PROPERTIES.MESSAGE]:
+            '<html lang="en-US"><head><title>Error Page</title></head><body><h3>An unexpected connection error occurred.</h3></body></html>',
+        },
+        expectedMessage: ERROR_HTTP_502_MESSAGE,
+      },
       [SALESFORCE_ERRORS.REQUEST_LIMIT_EXCEEDED]: [
         {
           errorProperties: {
@@ -517,7 +525,7 @@ describe('salesforce client', () => {
       )
     })
 
-    describe('when login throws invaid_grant error', () => {
+    describe('when login throws invalid_grant error', () => {
       beforeEach(() => {
         const mocks = mockClient()
         testClient = mocks.client

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -46,7 +46,6 @@ import {
   ErrorProperty,
   INVALID_GRANT,
   RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
-  SALESFORCE_CONNECTION_ERROR,
   SALESFORCE_ERRORS,
 } from '../src/constants'
 import {
@@ -446,13 +445,6 @@ describe('salesforce client', () => {
       keyof ErrorMappers,
       types.NonEmptyArray<TestInput> | TestInput
     > = {
-      [SALESFORCE_CONNECTION_ERROR]: {
-        errorProperties: {
-          [ERROR_PROPERTIES.MESSAGE]:
-            '<html lang="en-US"><head><title>Error Page</title></head><body><h3>An unexpected connection error occurred.</h3></body></html>',
-        },
-        expectedMessage: ERROR_HTTP_502_MESSAGE,
-      },
       [SALESFORCE_ERRORS.REQUEST_LIMIT_EXCEEDED]: [
         {
           errorProperties: {
@@ -481,12 +473,21 @@ describe('salesforce client', () => {
           `Unable to communicate with the salesforce org at ${TEST_HOSTNAME}.` +
           ' This may indicate that the org no longer exists, e.g. a sandbox that was deleted, or due to other network issues.',
       },
-      [ERROR_HTTP_502]: {
-        errorProperties: {
-          [ERROR_PROPERTIES.MESSAGE]: ERROR_HTTP_502,
+      [ERROR_HTTP_502]: [
+        {
+          errorProperties: {
+            [ERROR_PROPERTIES.MESSAGE]:
+              '<html lang="en-US"><head><title>Error Page</title></head><body><h3>An unexpected connection error occurred.</h3></body></html>',
+          },
+          expectedMessage: ERROR_HTTP_502_MESSAGE,
         },
-        expectedMessage: ERROR_HTTP_502_MESSAGE,
-      },
+        {
+          errorProperties: {
+            [ERROR_PROPERTIES.MESSAGE]: ERROR_HTTP_502,
+          },
+          expectedMessage: ERROR_HTTP_502_MESSAGE,
+        },
+      ],
       [INVALID_GRANT]: {
         errorProperties: {
           [ERROR_PROPERTIES.NAME]: INVALID_GRANT,


### PR DESCRIPTION
Sometimes Salesforce returns a whole HTML page when it encounters an internal connection error. Let's handle this.

---



---
_Release Notes_: 
Salesforce: better handling of internal Salesforce errors.

---
_User Notifications_: 
N/A