### PR TITLE
SALTO-5520: fix issue Layout for view screen

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -56,7 +56,7 @@ type issueTypeMappingStruct = {
 type ResponsesRecord = Record<string, Record<string, Promise<graphQLResponseType>>>
 
 const viewOrDefaultScreen = (screenScheme: InstanceElement): string =>
-  screenScheme.value.screens?.view ?? screenScheme.value.screens?.default
+  screenScheme.value.screens.view ?? screenScheme.value.screens.default
 
 // Check if the issueType of the issueTypeMapping is default or is in the issueTypeScheme of the project
 const IsIssueTypeInIssueTypeSchemesOrDefault = (
@@ -117,7 +117,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
         [
           ...new Set(
             issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
-              ?.filter((issueTypeMapping: issueTypeMappingStruct) =>
+              .filter((issueTypeMapping: issueTypeMappingStruct) =>
                 IsIssueTypeInIssueTypeSchemesOrDefault(
                   issueTypeMapping,
                   issueTypeSchemesToIssueTypeList,
@@ -129,8 +129,8 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
                   issueTypeMapping,
                   issueTypeScreenSchemesToiIssueTypeMappings[
                     project.value.issueTypeScreenScheme.issueTypeScreenScheme.id
-                  ]?.length ?? 0,
-                  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id]?.length ?? 0,
+                  ].length,
+                  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].length,
                 ),
               )
               .map(

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -56,7 +56,7 @@ type issueTypeMappingStruct = {
 type ResponsesRecord = Record<string, Record<string, Promise<graphQLResponseType>>>
 
 const viewOrDefaultScreen = (screenScheme: InstanceElement): string =>
-  screenScheme.value.screens.view ?? screenScheme.value.screens.default
+  screenScheme.value.screens?.view ?? screenScheme.value.screens?.default
 
 // Check if the issueType of the issueTypeMapping is default or is in the issueTypeScheme of the project
 const IsIssueTypeInIssueTypeSchemesOrDefault = (
@@ -65,7 +65,7 @@ const IsIssueTypeInIssueTypeSchemesOrDefault = (
   issueTypeSchemeId: string,
 ): boolean =>
   issueTypeMapping.issueTypeId === 'default' ||
-  issueTypeSchemesToIssueTypeList[issueTypeSchemeId].includes(issueTypeMapping.issueTypeId)
+  issueTypeSchemesToIssueTypeList[issueTypeSchemeId]?.includes(issueTypeMapping.issueTypeId)
 
 // we do not want to filter out the default issueTypeScreenScheme in case there is an issueType that is not in the issueTypeMapping
 // we can do it by compare the length of the issueTypeScheme to the length of the issueTypeMapping after we filter the issueTypeMapping
@@ -99,7 +99,12 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
     elements
       .filter(isInstanceElement)
       .filter(e => e.elemID.typeName === ISSUE_TYPE_SCHEMA_NAME)
-      .map(issueTypeScheme => [issueTypeScheme.value.id, issueTypeScheme.value.issueTypeIds]),
+      .map(issueTypeScheme => [
+        issueTypeScheme.value.id,
+        issueTypeScheme.value.issueTypeIds.map(
+          (issueTypeIdRecord: Record<string, string>) => issueTypeIdRecord.issueTypeId,
+        ),
+      ]),
   )
 
   return Object.fromEntries(
@@ -112,11 +117,11 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
         [
           ...new Set(
             issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
-              .filter((issueTypeMapping: issueTypeMappingStruct) =>
+              ?.filter((issueTypeMapping: issueTypeMappingStruct) =>
                 IsIssueTypeInIssueTypeSchemesOrDefault(
                   issueTypeMapping,
                   issueTypeSchemesToIssueTypeList,
-                  project.value.issueTypeScheme.issueTypeScheme.id,
+                  project.value.issueTypeScheme?.issueTypeScheme.id,
                 ),
               )
               .filter((issueTypeMapping: issueTypeMappingStruct) =>
@@ -124,11 +129,14 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
                   issueTypeMapping,
                   issueTypeScreenSchemesToiIssueTypeMappings[
                     project.value.issueTypeScreenScheme.issueTypeScreenScheme.id
-                  ].length,
-                  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].length,
+                  ]?.length ?? 0,
+                  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id]?.length ?? 0,
                 ),
               )
-              .map((struct: issueTypeMappingStruct) => screensSchemesToDefaultOrViewScreens[struct.screenSchemeId]),
+              .map(
+                (issueTypeMapping: issueTypeMappingStruct) =>
+                  screensSchemesToDefaultOrViewScreens[issueTypeMapping.screenSchemeId],
+              ),
           ),
         ],
       ]),

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -58,24 +58,23 @@ type ResponsesRecord = Record<string, Record<string, Promise<graphQLResponseType
 const viewOrDefaultScreen = (screenScheme: InstanceElement): string =>
   screenScheme.value.screens.view ?? screenScheme.value.screens.default
 
-// Filters and deletes from the issueTypeMapping the issue layouts that are not in the issueTypeScheme of the project
-const IsIssueTypeInIssueTypeSchemes = (
+// Check if the issueType of the issueTypeMapping is default or is in the issueTypeScheme of the project
+const IsIssueTypeInIssueTypeSchemesOrDefault = (
   issueTypeMapping: issueTypeMappingStruct,
-  issueTypeSchemesToIssueTypeList: { [key: string]: string[] },
-  project: InstanceElement,
+  issueTypeSchemesToIssueTypeList: Record<string, string[]>,
+  issueTypeSchemeId: string,
 ): boolean =>
   issueTypeMapping.issueTypeId === 'default' ||
-  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].includes(
-    issueTypeMapping.issueTypeId,
-  )
+  issueTypeSchemesToIssueTypeList[issueTypeSchemeId].includes(issueTypeMapping.issueTypeId)
 
 // we do not want to filter out the default issueTypeScreenScheme in case there is an issueType that is not in the issueTypeMapping
-// we can do it by compere the length of the issueTypeScheme to the length of the issueTypeMapping after we filter the issueTypeMapping
+// we can do it by compare the length of the issueTypeScheme to the length of the issueTypeMapping after we filter the issueTypeMapping
 const isRelevantMapping = (
-  struct: issueTypeMappingStruct,
+  issueTypeMapping: issueTypeMappingStruct,
   projectIssueTypeMappingsLength: number,
   projectIssueTypesFullNameLength: number,
-): boolean => struct.issueTypeId !== 'default' || projectIssueTypeMappingsLength <= projectIssueTypesFullNameLength
+): boolean =>
+  issueTypeMapping.issueTypeId !== 'default' || projectIssueTypeMappingsLength <= projectIssueTypesFullNameLength
 
 const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string, number[]> => {
   const screensSchemesToDefaultOrViewScreens = Object.fromEntries(
@@ -114,7 +113,11 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
           ...new Set(
             issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
               .filter((issueTypeMapping: issueTypeMappingStruct) =>
-                IsIssueTypeInIssueTypeSchemes(issueTypeMapping, issueTypeSchemesToIssueTypeList, project),
+                IsIssueTypeInIssueTypeSchemesOrDefault(
+                  issueTypeMapping,
+                  issueTypeSchemesToIssueTypeList,
+                  project.value.issueTypeScheme.issueTypeScheme.id,
+                ),
               )
               .filter((issueTypeMapping: issueTypeMappingStruct) =>
                 isRelevantMapping(

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -72,7 +72,6 @@ describe('issue layout filter', () => {
   let issueTypeScreenSchemeType: ObjectType
   let issueTypeScreenSchemeInstance1: InstanceElement
   let issueTypeScreenSchemeInstance2: InstanceElement
-  let issueTypeScreenSchemeInstance3: InstanceElement
   let issueTypeScreenSchemeInstance: InstanceElement
   let projectType: ObjectType
   let projectInstance1: InstanceElement
@@ -206,24 +205,21 @@ describe('issue layout filter', () => {
         id: '11111',
         projectTypeKey: 'software',
         issueTypeScreenScheme: { issueTypeScreenScheme: { id: 1111 } },
-        issueTypeScheme: { issueTypeScheme: { id: '10' } },
+        issueTypeScheme: { issueTypeScheme: { id: 10 } },
       })
-
       projectInstance2 = new InstanceElement('project2', projectType, {
         id: '22222',
         projectTypeKey: 'software',
-        issueTypeScreenScheme: { issueTypeScreenScheme: { id: 1111 } },
-        issueTypeScheme: { issueTypeScheme: { id: '10' } },
+        issueTypeScreenScheme: { issueTypeScreenScheme: { id: 2222 } },
+        issueTypeScheme: { issueTypeScheme: { id: 10 } },
       })
-
       issueTypeSchemeInstance1 = new InstanceElement('issueTypeScheme1', issueTypeScheme, {
-        id: '10',
-        issueTypeIds: ['100'],
+        id: 10,
+        issueTypeIds: [100],
       })
-
       issueTypeSchemeInstance2 = new InstanceElement('issueTypeScheme2', issueTypeScheme, {
-        id: '20',
-        issueTypeIds: ['100', '200'],
+        id: 20,
+        issueTypeIds: [100, 200],
       })
 
       screenSchemeInstance1 = new InstanceElement('screenScheme1', screenSchemeType, {
@@ -242,7 +238,7 @@ describe('issue layout filter', () => {
         id: 1111,
         issueTypeMappings: [
           {
-            issueTypeId: '100',
+            issueTypeId: 100,
             screenSchemeId: 222,
           },
         ],
@@ -252,24 +248,11 @@ describe('issue layout filter', () => {
         id: 2222,
         issueTypeMappings: [
           {
-            issueTypeId: '100',
-            screenSchemeId: 111,
-          },
-          {
-            issueTypeId: 'default',
-            screenSchemeId: 222,
-          },
-        ],
-      })
-      issueTypeScreenSchemeInstance3 = new InstanceElement('issueTypeScreenScheme3', issueTypeScreenSchemeType, {
-        id: 3333,
-        issueTypeMappings: [
-          {
-            issueTypeId: '100',
+            issueTypeId: 100,
             screenSchemeId: 333,
           },
           {
-            issueTypeId: '200',
+            issueTypeId: 200,
             screenSchemeId: 222,
           },
         ],
@@ -284,21 +267,14 @@ describe('issue layout filter', () => {
       })
 
       elements = [
-        issueTypeType,
         issueTypeScheme,
         issueTypeSchemeInstance1,
         issueTypeSchemeInstance2,
-        screenType,
-        screenSchemeType,
         screenSchemeInstance1,
         screenSchemeInstance2,
         screenSchemeInstance3,
-        issueTypeScreenSchemeItemType,
-        issueTypeScreenSchemeType,
         issueTypeScreenSchemeInstance1,
         issueTypeScreenSchemeInstance2,
-        issueTypeScreenSchemeInstance3,
-        projectType,
         projectInstance1,
       ]
     })
@@ -314,7 +290,7 @@ describe('issue layout filter', () => {
       const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
       expect(Object.entries(res)).toHaveLength(2)
       expect(res['11111'][11]).toBeDefined()
-      expect(res['22222'][11]).toBeDefined()
+      expect(res['22222'][12]).toBeDefined()
     })
     it('should be empty answer if it is a bad response', async () => {
       mockGet.mockImplementation(() => ({
@@ -370,19 +346,19 @@ describe('issue layout filter', () => {
 
     describe('get the correct screens for the issue Layouts', () => {
       it('should return empty list if screen scheme does not have screens', async () => {
-        issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = { issueTypeId: '100', screenSchemeId: 111 }
+        issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = { issueTypeId: 100, screenSchemeId: 111 }
         projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 1111 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '10' } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
-        expect(res[11111]).toEqual({
+        expect(res['11111']).toEqual({
           undefined: Promise.resolve({ data: {} }),
         })
       })
       it('should return the view screen and not the default screen if there is', async () => {
-        issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = { issueTypeId: '100', screenSchemeId: 333 }
+        issueTypeScreenSchemeInstance1.value.issueTypeMappings = [{ issueTypeId: 100, screenSchemeId: 333 }]
         projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 1111 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '10' } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
 
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
@@ -390,22 +366,21 @@ describe('issue layout filter', () => {
         expect(res['11111'][12]).toBeDefined()
       })
       it('should return the default screen if there is no view screen', async () => {
-        issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = { issueTypeId: '100', screenSchemeId: 222 }
+        issueTypeScreenSchemeInstance1.value.issueTypeMappings = [{ issueTypeId: 100, screenSchemeId: 222 }]
         projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 1111 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '10' } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
 
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
         expect(Object.entries(res['11111'])).toHaveLength(1)
         expect(res['11111'][11]).toBeDefined()
       })
-      it('Return the default issueTypeScreenScheme for unhandled issueTypes in the projects scheme', async () => {
-        issueTypeScreenSchemeInstance2.value.issueTypeMappings = [
-          { issueTypeId: '100', screenSchemeId: 222 },
+      it('should return the default issueTypeScreenScheme for unhandled issueTypes in the projects scheme', async () => {
+        issueTypeScreenSchemeInstance1.value.issueTypeMappings = [
+          { issueTypeId: 100, screenSchemeId: 222 },
           { issueTypeId: 'default', screenSchemeId: 333 },
         ]
-        projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 2222 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '20' } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 20 } }
 
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
@@ -414,12 +389,11 @@ describe('issue layout filter', () => {
         expect(res['11111'][12]).toBeDefined()
       })
       it('If the issueTypeScreenScheme directly handles all project issueTypes, do not return its default', async () => {
-        issueTypeScreenSchemeInstance2.value.issueTypeMappings = [
-          { issueTypeId: '100', screenSchemeId: 222 },
+        issueTypeScreenSchemeInstance1.value.issueTypeMappings = [
+          { issueTypeId: 100, screenSchemeId: 222 },
           { issueTypeId: 'default', screenSchemeId: 333 },
         ]
-        projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 2222 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '10' } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
 
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
@@ -428,8 +402,8 @@ describe('issue layout filter', () => {
         expect(res['11111'][12]).toBeUndefined()
       })
       it('do not return the screen of issueType that is in the issueTypeScreenScheme but not in the project issueTypeScheme', async () => {
-        projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 3333 } }
-        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: '10' } }
+        projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 2222 } }
+        projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
 
         const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -102,7 +102,6 @@ describe('issue layout filter', () => {
     screenInstance = new InstanceElement('screen1', screenType, {
       id: 11,
     })
-
     fieldType = createEmptyType('Field')
     fieldInstance1 = new InstanceElement('testField1', fieldType, {
       id: 'testField1',
@@ -215,13 +214,12 @@ describe('issue layout filter', () => {
       })
       issueTypeSchemeInstance1 = new InstanceElement('issueTypeScheme1', issueTypeScheme, {
         id: 10,
-        issueTypeIds: [100],
+        issueTypeIds: [{ issueTypeId: 100 }],
       })
       issueTypeSchemeInstance2 = new InstanceElement('issueTypeScheme2', issueTypeScheme, {
         id: 20,
-        issueTypeIds: [100, 200],
+        issueTypeIds: [{ issueTypeId: 100 }, { issueTypeId: 200 }],
       })
-
       screenSchemeInstance1 = new InstanceElement('screenScheme1', screenSchemeType, {
         id: 111,
       })
@@ -233,7 +231,6 @@ describe('issue layout filter', () => {
         id: 333,
         screens: { default: 13, view: 12 },
       })
-
       issueTypeScreenSchemeInstance1 = new InstanceElement('issueTypeScreenScheme1', issueTypeScreenSchemeType, {
         id: 1111,
         issueTypeMappings: [
@@ -243,7 +240,6 @@ describe('issue layout filter', () => {
           },
         ],
       })
-
       issueTypeScreenSchemeInstance2 = new InstanceElement('issueTypeScreenScheme2', issueTypeScreenSchemeType, {
         id: 2222,
         issueTypeMappings: [
@@ -291,6 +287,15 @@ describe('issue layout filter', () => {
       expect(Object.entries(res)).toHaveLength(2)
       expect(res['11111'][11]).toBeDefined()
       expect(res['22222'][12]).toBeDefined()
+    })
+    it('should return the correct answer if there are multiple issueLayouts in the same project', async () => {
+      projectInstance1.value.issueTypeScreenScheme = { issueTypeScreenScheme: { id: 2222 } }
+      projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 20 } }
+      const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
+      expect(Object.entries(res)).toHaveLength(1)
+      expect(Object.entries(res['11111'])).toHaveLength(2)
+      expect(res['11111'][11]).toBeDefined()
+      expect(res['11111'][12]).toBeDefined()
     })
     it('should be empty answer if it is a bad response', async () => {
       mockGet.mockImplementation(() => ({


### PR DESCRIPTION
I change the code so that it will bring all the issue layouts of the projects and also prevent fetching issue layouts that do not exist
I added a function that will do it and I also deleted part of the code that maps for the second time projects to the issue layout and used the first map
---

_Additional context for reviewer_

---
_Release Notes_: 
Jira adapter: 
* Fixed a bug that prevented fetching some of the issue layouts
---
_User Notifications_: 
None