### PR TITLE
SALTO-5641: add data and headers to log when http request fails

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -15,7 +15,7 @@
  */
 import _ from 'lodash'
 import { ResponseType } from 'axios'
-import {inspectValue, safeJsonStringify} from '@salto-io/adapter-utils'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -15,7 +15,7 @@
  */
 import _ from 'lodash'
 import { ResponseType } from 'axios'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import {inspectValue, safeJsonStringify} from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -288,8 +288,9 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
         headers: this.extractHeaders(res.headers),
       }
     } catch (e) {
+      const dataToLog = Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data
       log.warn(
-        `failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, data: ${safeJsonStringify(e?.response?.data)}, stack: ${e.stack}`,
+        `failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, data: ${safeJsonStringify(e?.response?.data ?? dataToLog)}, headers: ${safeJsonStringify(headers)} stack: ${e.stack}`,
       )
       if (e.code === 'ETIMEDOUT') {
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -239,7 +239,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
     const data = isMethodWithData(params) ? params.data : undefined
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const logResponse = (res: Response<any>): void => {
+    const logResponse = (res: Response<any>, error?: any): void => {
       log.debug('Received response for %s on %s', method.toUpperCase(), url)
 
       const responseText = safeJsonStringify({
@@ -254,9 +254,17 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
         data: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
       })
 
-      log.debug('Response size for %s on %s is %d', method.toUpperCase(), url, responseText.length)
-
-      log.trace('Full HTTP response for %s on %s: %s', method.toUpperCase(), url, responseText)
+      if (error === undefined) {
+        log.trace(
+          'Full HTTP response for %s on %s (size: %d): %s',
+          method.toUpperCase(),
+          url,
+          responseText.length,
+          responseText,
+        )
+      } else {
+        log.warn(`failed to ${method} ${url} with error: ${error}, stack: ${error.stack}, ${responseText}`)
+      }
     }
 
     try {
@@ -288,15 +296,18 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
         headers: this.extractHeaders(res.headers),
       }
     } catch (e) {
-      const dataToLog = Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data
-      log.warn(
-        `failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, data: ${safeJsonStringify(e?.response?.data ?? dataToLog)}, headers: ${safeJsonStringify(this.extractHeaders(headers))} stack: ${e.stack}`,
+      logResponse(
+        {
+          data: e?.response?.data ?? data,
+          status: e?.response?.status ?? 'undefined',
+          headers: e?.response?.headers ?? headers,
+        },
+        e,
       )
       if (e.code === 'ETIMEDOUT') {
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)
       }
       if (e.response !== undefined) {
-        logResponse(e.response)
         throw new HTTPError(`Failed to ${method} ${url} with error: ${e}`, {
           status: e.response.status,
           data: e.response.data,

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -290,7 +290,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
     } catch (e) {
       const dataToLog = Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data
       log.warn(
-        `failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, data: ${safeJsonStringify(e?.response?.data ?? dataToLog)}, headers: ${safeJsonStringify(headers)} stack: ${e.stack}`,
+        `failed to ${method} ${url} ${safeJsonStringify(queryParams)}: ${e}, data: ${safeJsonStringify(e?.response?.data ?? dataToLog)}, headers: ${safeJsonStringify(this.extractHeaders(headers))} stack: ${e.stack}`,
       )
       if (e.code === 'ETIMEDOUT') {
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)

--- a/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/organization_existence.test.ts
@@ -236,12 +236,15 @@ describe('OrganizationExistence', () => {
       ],
     })
     await getOrganizationsByIds(['1', '2'], client)
+    const responseText =
+      '{"url":"/api/v2/organizations/show_many?ids=1,2","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}'
 
     expect(logTrace).toHaveBeenCalledWith([
-      'Full HTTP response for %s on %s: %s',
+      'Full HTTP response for %s on %s (size: %d): %s',
       'GET',
       '/api/v2/organizations/show_many?ids=1,2',
-      '{"url":"/api/v2/organizations/show_many?ids=1,2","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
+      responseText.length,
+      responseText,
     ])
   })
 })

--- a/packages/zendesk-adapter/test/client/client.test.ts
+++ b/packages/zendesk-adapter/test/client/client.test.ts
@@ -201,32 +201,48 @@ describe('client', () => {
       await client.get({ url: 'organizations/show_many' })
       await client.get({ url: 'organizations/autocomplete' })
 
+      const responseText1 =
+        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}'
+
       expect(logTrace).toHaveBeenNthCalledWith(1, [
-        'Full HTTP response for %s on %s: %s',
+        'Full HTTP response for %s on %s (size: %d): %s',
         'GET',
         'organizations/show_many',
-        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}',
+        responseText1.length,
+        responseText1,
       ])
+
+      const responseText2 =
+        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}'
 
       expect(logTrace).toHaveBeenNthCalledWith(2, [
-        'Full HTTP response for %s on %s: %s',
+        'Full HTTP response for %s on %s (size: %d): %s',
         'GET',
         'organizations/autocomplete',
-        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"org1"},{"id":2,"name":"org2"}]}}',
+        responseText2.length,
+        responseText2,
       ])
+
+      const responseText3 =
+        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}'
 
       expect(logTrace).toHaveBeenNthCalledWith(3, [
-        'Full HTTP response for %s on %s: %s',
+        'Full HTTP response for %s on %s (size: %d): %s',
         'GET',
         'organizations/show_many',
-        '{"url":"organizations/show_many","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
+        responseText3.length,
+        responseText3,
       ])
 
+      const responseText4 =
+        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}'
+
       expect(logTrace).toHaveBeenNthCalledWith(4, [
-        'Full HTTP response for %s on %s: %s',
+        'Full HTTP response for %s on %s (size: %d): %s',
         'GET',
         'organizations/autocomplete',
-        '{"url":"organizations/autocomplete","method":"GET","status":200,"response":{"organizations":[{"id":1,"name":"<OMITTED>"},{"id":2,"name":"<OMITTED>"}]}}',
+        responseText4.length,
+        responseText4,
       ])
     })
   })


### PR DESCRIPTION
add data and headers to log when http request fails

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
