### PR TITLE
SALTO-5388 fix omitting values of overridden types

### DIFF
--- a/packages/adapter-components/src/deployment/placeholder_types.ts
+++ b/packages/adapter-components/src/deployment/placeholder_types.ts
@@ -23,7 +23,7 @@ import {
   TypeReference,
 } from '@salto-io/adapter-api'
 import { ElementAndResourceDefFinder } from '../definitions/system/fetch/types'
-import { generateType, adjustFieldTypes } from '../fetch/element'
+import { generateType, overrideFieldTypes } from '../fetch/element'
 import { FetchApiDefinitionsOptions } from '../definitions/system/fetch'
 
 /**
@@ -46,7 +46,7 @@ export const overrideInstanceTypeForDeploy = <Options extends FetchApiDefinition
     isUnknownEntry: isReferenceExpression,
   })
   const definedTypes = _.keyBy([generatedType.type, ...generatedType.nestedTypes], t => t.elemID.typeName)
-  adjustFieldTypes({ definedTypes, defQuery })
+  overrideFieldTypes({ definedTypes, defQuery })
   clonedInstance.refType = new TypeReference(generatedType.type.elemID, generatedType.type)
   return clonedInstance
 }

--- a/packages/adapter-components/src/fetch/element/index.ts
+++ b/packages/adapter-components/src/fetch/element/index.ts
@@ -19,7 +19,7 @@ export {
   markServiceIdField,
   toNestedTypeName,
   toPrimitiveType,
-  adjustFieldTypes,
+  overrideFieldTypes,
 } from './type_utils'
 export { generateInstancesWithInitialTypes } from './instance_element'
 export { generateType } from './type_element'

--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -16,7 +16,7 @@
 import { logger } from '@salto-io/logging'
 import { ElementsAndErrors } from '../../definitions/system/fetch/element'
 import { generateType } from './type_element'
-import { createInstance, getInstanceCreationFunctions, toInstanceValue } from './instance_utils'
+import { createInstance, getInstanceCreationFunctions, recursiveNaclCase } from './instance_utils'
 import { extractStandaloneInstances } from './standalone'
 import { GenerateTypeArgs } from '../../definitions/system/fetch/types'
 import { InvalidSingletonType } from '../../config/shared' // TODO move
@@ -64,7 +64,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
   })
   // TODO should also nacl-case field names on predefined fields similarly (SALTO-5422)
   const instances = entries
-    .map(value => toInstanceValue({ value, type, defQuery }))
+    .map(value => recursiveNaclCase(value))
     .map((entry, index) =>
       createInstance({
         entry,

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -36,7 +36,7 @@ import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/type
  * - when used as an instance value, the relevant type elements' fields should also be nacl-cased separately.
  * - in most cases, this transformation should be reverted before deploy. this can be done be setting invert=true
  */
-const recursiveNaclCase = (value: Values, invert = false): Values => {
+export const recursiveNaclCase = (value: Values, invert = false): Values => {
   const func = invert ? invertNaclCase : naclCase
   return _.cloneDeepWith(value, val => (_.isPlainObject(val) ? _.mapKeys(val, (_v, k) => func(k)) : val))
 }
@@ -70,7 +70,7 @@ const omitValues =
  *
  * Note: standalone fields' values with referenceFromParent=false should be omitted separately
  */
-export const toInstanceValue = <Options extends FetchApiDefinitionsOptions>({
+export const omitInstanceValues = <Options extends FetchApiDefinitionsOptions>({
   value,
   defQuery,
   type,
@@ -80,8 +80,7 @@ export const toInstanceValue = <Options extends FetchApiDefinitionsOptions>({
   type: ObjectType
 }): Values =>
   transformValuesSync({
-    // nacl-case all keys recursively
-    values: recursiveNaclCase(value),
+    values: value,
     type,
     transformFunc: omitValues(defQuery),
     strict: false,
@@ -98,7 +97,7 @@ export type InstanceCreationParams = {
 
 /**
  * Generate an instance for a single entry returned for a given type, and set its elem id and path.
- * Assuming the entry is already in its final structure (after running toInstanceValue).
+ * Assuming the entry is already in its final structure (after nacl-case), except for omitting fields
  */
 export const getInstanceCreationFunctions = <Options extends FetchApiDefinitionsOptions>({
   defQuery,

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -220,9 +220,9 @@ export const markServiceIdField = (
 }
 
 /**
- * Adjust field definitions based on the defined customization.
+ * Adjust field types based on the defined customization.
  */
-export const adjustFieldTypes = <Options extends FetchApiDefinitionsOptions>({
+export const overrideFieldTypes = <Options extends FetchApiDefinitionsOptions>({
   definedTypes,
   defQuery,
   finalTypeNames,
@@ -240,19 +240,53 @@ export const adjustFieldTypes = <Options extends FetchApiDefinitionsOptions>({
     const { element: elementDef, resource: resourceDef } = defQuery.query(typeName) ?? {}
 
     Object.entries(elementDef?.fieldCustomizations ?? {}).forEach(([fieldName, customization]) => {
-      if (customization.fieldType !== undefined) {
-        overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: customization.fieldType })
+      const { fieldType, restrictions } = customization
+      if (fieldType !== undefined) {
+        overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: fieldType })
       }
       const field = type.fields[fieldName]
       if (field === undefined) {
         log.debug('field %s.%s is undefined, not applying customizations', typeName, fieldName)
         return
       }
-      const { hide, restrictions, standalone, omit } = customization
       if (restrictions) {
         log.debug('applying restrictions to field %s.%s', type.elemID.name, fieldName)
         field.annotate({ [CORE_ANNOTATIONS.RESTRICTION]: createRestriction(restrictions) })
       }
+    })
+    // mark service ids after applying field customizations, in order to set the right type
+    // (serviceid for strings / serviceid_number for numbers)
+    resourceDef?.serviceIDFields?.forEach(fieldName => markServiceIdField(fieldName, type.fields, typeName))
+  })
+}
+
+/**
+ * Hide and omit fields based on the defined customization.
+ */
+export const hideAndOmitFields = <Options extends FetchApiDefinitionsOptions>({
+  definedTypes,
+  defQuery,
+  finalTypeNames,
+}: {
+  definedTypes: Record<string, ObjectType>
+  defQuery: ElementAndResourceDefFinder<Options>
+  finalTypeNames?: Set<string>
+}): void => {
+  Object.entries(definedTypes).forEach(([typeName, type]) => {
+    if (finalTypeNames?.has(typeName)) {
+      log.trace('type %s is marked as final, not adjusting', type.elemID.getFullName())
+      return
+    }
+
+    const { element: elementDef } = defQuery.query(typeName) ?? {}
+
+    Object.entries(elementDef?.fieldCustomizations ?? {}).forEach(([fieldName, customization]) => {
+      const field = type.fields[fieldName]
+      if (field === undefined) {
+        log.debug('field %s.%s is undefined, not applying customizations', typeName, fieldName)
+        return
+      }
+      const { hide, standalone, omit } = customization
       if (hide) {
         log.debug('hiding field %s.%s', type.elemID.name, fieldName)
 
@@ -264,8 +298,5 @@ export const adjustFieldTypes = <Options extends FetchApiDefinitionsOptions>({
         delete type.fields[fieldName]
       }
     })
-    // mark service ids after applying field customizations, in order to set the right type
-    // (serviceid for strings / serviceid_number for numbers)
-    resourceDef?.serviceIDFields?.forEach(fieldName => markServiceIdField(fieldName, type.fields, typeName))
   })
 }

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -146,10 +146,10 @@ describe('instance element', () => {
         'myAdapter.myType.instance.custom_CCC',
       ])
     })
-    it('should omit nulls and undefined values from instances and nacl-case field names', () => {
+    it('should nacl-case field names', () => {
       const res = generateInstancesWithInitialTypes({
         adapterName: 'myAdapter',
-        entries: [{ str: 'A', nullVal: null, missing: undefined, 'with spaces': 'a' }],
+        entries: [{ str: 'A', 'with spaces': 'a' }],
         typeName: 'myType',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
           customizations: {
@@ -162,7 +162,7 @@ describe('instance element', () => {
       expect(res.instances).toHaveLength(1)
       expect(res.types).toHaveLength(1)
       expect(res.types.map(e => e.elemID.getFullName())).toEqual(['myAdapter.myType'])
-      expect(Object.keys(res.types[0].fields).sort()).toEqual(['missing', 'nullVal', 'str', 'with_spaces@s'])
+      expect(Object.keys(res.types[0].fields).sort()).toEqual(['str', 'with_spaces@s'])
       expect(res.instances[0].value).toEqual({ str: 'A', 'with_spaces@s': 'a' })
     })
   })


### PR DESCRIPTION
* make sure predefined types are used for field type overrides
* first override fields types and then remove omitted field values, to fix a bug where we didn't omit nested values of overwritten fields

(this is in the new infra, not impacting existing adapters)

---
_Release Notes_: 
None

---
_User Notifications_: 
None