### PR TITLE
SALTO-5534 - Salesforce: support data records deletions in quickfetch

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -135,6 +135,7 @@ import {
 import {
   addDefaults,
   apiNameSync,
+  buildDataRecordsSoqlQueries,
   getFLSProfiles,
   getFullName,
   instanceInternalId,
@@ -167,6 +168,7 @@ import {
   ArtificialTypes,
   CUSTOM_FIELD,
   CUSTOM_OBJECT,
+  CUSTOM_OBJECT_ID_FIELD,
   FLOW_METADATA_TYPE,
   LAST_MODIFIED_DATE,
   OWNER_ID,
@@ -1046,13 +1048,12 @@ export default class SalesforceAdapter implements AdapterOperations {
       await querySalesforceForRecordIdsOfInstances(workspaceInstances),
     )
 
-    return _(workspaceInstances)
+    return workspaceInstances
       .filter(
         (instance) =>
           !instanceIdsInSalesforce.has(instanceInternalId(instance)),
       )
       .map((instance) => instance.elemID)
-      .value()
   }
 
   private async getDeletedElemIdsForPartialFetch({

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -44,7 +44,6 @@ import {
 import {
   buildSelectQueries,
   getFieldNamesForQuery,
-  isInstanceOfCustomObjectSync,
   QueryOperator,
   SoqlQuery,
 } from '../../src/filters/utils'
@@ -2275,29 +2274,14 @@ describe('Custom Object Instances filter', () => {
         }) as FilterType
 
         const testType = createCustomObject(testTypeName)
-        const existingInstanceThatDoesntExistInSalesforce = new InstanceElement(
-          'DeletedInstance',
-          testType,
-          {
-            [CUSTOM_OBJECT_ID_FIELD]: 'deletedId',
-          },
-        )
-        elements = [
-          testType,
-          existingInstanceThatDoesntExistInSalesforce,
-          changedAtSingleton,
-        ]
+        elements = [testType, changedAtSingleton]
+        await filter.onFetch(elements)
       })
       describe('Without allowReferenceTo', () => {
         beforeEach(async () => {
           const testType = createCustomObject(testTypeName)
-          const existingInstanceThatDoesntExistInSalesforce =
-            new InstanceElement('DeletedInstance', testType, {
-              [CUSTOM_OBJECT_ID_FIELD]: 'deletedId',
-            })
           elements = [
             testType,
-            existingInstanceThatDoesntExistInSalesforce,
             createCustomObject(refToTypeName),
             changedAtSingleton,
           ]
@@ -2315,18 +2299,6 @@ describe('Custom Object Instances filter', () => {
             expect.objectContaining({
               [CUSTOM_OBJECT_ID_FIELD]: testInstanceId,
             }),
-          )
-        })
-        it('Should query for deleted items', () => {
-          expect(basicQueryImplementation).toHaveBeenCalledWith(
-            expect.stringContaining("Id IN ('deletedId')"),
-          )
-        })
-        it('Should remove deleted instance', () => {
-          expect(elements).not.toSatisfyAny(
-            (element) =>
-              isInstanceOfCustomObjectSync(element) &&
-              element.value[CUSTOM_OBJECT_ID_FIELD] === 'deletedId',
           )
         })
       })


### PR DESCRIPTION
In the quickfetch case we need to determine which records were deleted on the Salesforce side so we can delete them on our end. The simple way to do this would be to use a SOQL query with all the IDs of the records that exist in the workspace and see which of them are not returned. 

---

There's a small optimization of not querying for IDs of records that we just fetched, because we know those records were not deleted.

Tests:
- Do a full fetch, delete an account, do a quickfetch, observe the account being deleted.

---
_Release Notes_: 
Salesforce: quickfetch will now correctly identify deleted records

---
_User Notifications_: 
N/A
