### PR TITLE
allow setting a standalone instance's type using predefined types

### DIFF
--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -32,7 +32,7 @@ const log = logger(module)
 export const generateInstancesWithInitialTypes = <Options extends FetchApiDefinitionsOptions>(
   args: Omit<GenerateTypeArgs<Options>, 'parentName' | 'isMapWithDynamicType' | 'typeNameOverrides'>,
 ): ElementsAndErrors => {
-  const { defQuery, entries, adapterName, typeName, getElemIdFunc, customNameMappingFunctions } = args
+  const { defQuery, entries, adapterName, typeName, getElemIdFunc, customNameMappingFunctions, definedTypes } = args
   const { element: elementDef } = defQuery.query(typeName) ?? {}
   if (elementDef === undefined) {
     log.error('could not find any element definitions for type %s:%s', adapterName, typeName)
@@ -83,6 +83,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
     defQuery,
     getElemIdFunc,
     customNameMappingFunctions,
+    definedTypes,
   })
 
   return { types: [type, ...nestedTypes], instances: instancesWithStandalone }

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -16,6 +16,7 @@
 import {
   ElemIdGetter,
   InstanceElement,
+  ObjectType,
   ReferenceExpression,
   getDeepInnerTypeSync,
   isObjectType,
@@ -35,12 +36,14 @@ const extractStandaloneInstancesFromField =
     getElemIdFunc,
     parent,
     customNameMappingFunctions,
+    definedTypes,
   }: {
     defQuery: ElementAndResourceDefFinder<Options>
     instanceOutput: InstanceElement[]
     getElemIdFunc?: ElemIdGetter
     parent: InstanceElement
     customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
+    definedTypes?: Record<string, ObjectType>
   }): TransformFuncSync =>
   ({ value, field }) => {
     if (field === undefined || isReferenceExpression(value)) {
@@ -52,7 +55,7 @@ const extractStandaloneInstancesFromField =
       return value
     }
 
-    const fieldType = getDeepInnerTypeSync(field.getTypeSync())
+    const fieldType = definedTypes?.[standaloneDef.typeName] ?? getDeepInnerTypeSync(field.getTypeSync())
     if (!isObjectType(fieldType)) {
       throw new Error(`field type for ${field.elemID.getFullName()} is not an object type`)
     }
@@ -106,11 +109,13 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
   defQuery,
   customNameMappingFunctions,
   getElemIdFunc,
+  definedTypes,
 }: {
   instances: InstanceElement[]
   defQuery: ElementAndResourceDefFinder<Options>
   customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   getElemIdFunc?: ElemIdGetter
+  definedTypes?: Record<string, ObjectType>
 }): InstanceElement[] => {
   const instancesToProcess: InstanceElement[] = []
   instances.forEach(inst => instancesToProcess.push(inst))
@@ -134,6 +139,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
         getElemIdFunc,
         parent: inst,
         customNameMappingFunctions,
+        definedTypes,
       }),
     })
     if (value !== undefined) {


### PR DESCRIPTION
we should set standalone instance types based on the defined type, even if it's different from the current field type

---
_Release Notes_: 
None

---
_User Notifications_: 
None