### PR TITLE
SALTO-5608: Fix link header pagination func

### DIFF
--- a/packages/adapter-components/src/fetch/request/pagination/pagination_functions.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/pagination_functions.ts
@@ -244,8 +244,7 @@ export const cursorHeaderPagination = ({
           }
           return [
             {
-              ...currentParams,
-              ...Object.fromEntries(nextPage.searchParams.entries()),
+              ..._.merge({}, currentParams, { queryParams: Object.fromEntries(nextPage.searchParams.entries()) }),
               ...headers,
             },
           ]

--- a/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
@@ -116,8 +116,7 @@ describe('pagination functions', () => {
         }),
       ).toEqual([
         {
-          after: '123123',
-          limit: '2',
+          queryParams: { after: '123123', limit: '2' }, 
         },
       ])
     })

--- a/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
@@ -116,7 +116,7 @@ describe('pagination functions', () => {
         }),
       ).toEqual([
         {
-          queryParams: { after: '123123', limit: '2' }, 
+          queryParams: { after: '123123', limit: '2' },
         },
       ])
     })


### PR DESCRIPTION
In the previous PR I passed query params wrong

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None