### PR TITLE
SALTO-5647 - Saving test state in tmp dir

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,5 +6,10 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
-  }
+  },
+  "cSpell.words": [
+    "asynciterable",
+    "lowerdash",
+    "netsuite"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,10 +6,5 @@
   "[json]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true
-  },
-  "cSpell.words": [
-    "asynciterable",
-    "lowerdash",
-    "netsuite"
-  ]
+  }
 }

--- a/packages/core/test/workspace/local/state/state.test.ts
+++ b/packages/core/test/workspace/local/state/state.test.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import os from 'os'
 import path from 'path'
 import _ from 'lodash'
 import { Readable } from 'stream'
@@ -32,7 +31,7 @@ import {
   ProviderOptionsS3,
 } from '@salto-io/workspace'
 import { hash, collections } from '@salto-io/lowerdash'
-import { mockFunction } from '@salto-io/test-utils'
+import { mockFunction, setupTmpDir } from '@salto-io/test-utils'
 import { getStateContentProvider, loadState, localState } from '../../../../src/local-workspace/state/state'
 import * as stateFunctions from '../../../../src/local-workspace/state/state'
 import { getTopLevelElements } from '../../../common/elements'
@@ -467,6 +466,9 @@ describe('localState', () => {
     let contentProvider: jest.Mocked<StateContentProvider>
     let overridingStateFilesSource: staticFiles.StateStaticFilesSource
     let instanceWithStaticFile: InstanceElement
+
+    const testDir = setupTmpDir()
+
     beforeEach(() => {
       instanceWithStaticFile = new InstanceElement('inst', mockElement, {
         content: new StaticFile({ filepath: 'path', content: Buffer.from('asd') }),
@@ -474,7 +476,7 @@ describe('localState', () => {
       overridingStateFilesSource = mockStaticFilesSource([])
       contentProvider = mockContentProvider({})
       state = localState(
-        path.join(os.tmpdir(), 'empty'),
+        path.join(testDir.name(), 'empty'),
         '',
         inMemRemoteMapCreator(),
         contentProvider,

--- a/packages/core/test/workspace/local/state/state.test.ts
+++ b/packages/core/test/workspace/local/state/state.test.ts
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import os from 'os'
+import path from 'path'
 import _ from 'lodash'
 import { Readable } from 'stream'
 import { createGzip } from 'zlib'
@@ -380,11 +382,11 @@ describe('localState', () => {
       const clone = mockElement.clone()
       const newField = Object.values(mockElement.fields)[0]
       newField.name = 'new_field'
-      clone.fields.newfield = newField
+      clone.fields.newField = newField
       await state.set(clone)
 
       const fromState = (await state.get(mockElement.elemID)) as ObjectType
-      expect(fromState.fields.newfield).toBeDefined()
+      expect(fromState.fields.newField).toBeDefined()
     })
 
     it('should add to state', async () => {
@@ -471,7 +473,13 @@ describe('localState', () => {
       })
       overridingStateFilesSource = mockStaticFilesSource([])
       contentProvider = mockContentProvider({})
-      state = localState('empty', '', inMemRemoteMapCreator(), contentProvider, overridingStateFilesSource)
+      state = localState(
+        path.join(os.tmpdir(), 'empty'),
+        '',
+        inMemRemoteMapCreator(),
+        contentProvider,
+        overridingStateFilesSource,
+      )
     })
     it('should use the overriding files source and not the one from the content provider', async () => {
       await state.set(instanceWithStaticFile)


### PR DESCRIPTION
updateConfig creates a real content provider instead of the mock, so every time the test was run it saved the state file to the local directory. Instead, saving it to the tmp dir.
Also handled some spelling warnings in the file.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
