### PR TITLE
Fix standalone field types

### DIFF
--- a/packages/adapter-components/jest.config.js
+++ b/packages/adapter-components/jest.config.js
@@ -24,7 +24,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     global: {
       branches: 85,
       functions: 94,
-      lines: 95,
+      lines: 94.5,
       statements: 95,
     },
   },

--- a/packages/adapter-components/src/definitions/system/fetch/types.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/types.ts
@@ -33,7 +33,7 @@ export type GenerateTypeArgs<Options extends FetchApiDefinitionsOptions = {}> = 
   customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   typeNameOverrides?: Record<string, string>
   isUnknownEntry?: (value: unknown) => boolean
-  definedTypes?: Record<string, ObjectType>
+  definedTypes: Record<string, ObjectType>
   isSubType?: boolean
   isMapWithDynamicType?: boolean
   getElemIdFunc?: ElemIdGetter

--- a/packages/adapter-components/src/deployment/placeholder_types.ts
+++ b/packages/adapter-components/src/deployment/placeholder_types.ts
@@ -44,6 +44,7 @@ export const overrideInstanceTypeForDeploy = <Options extends FetchApiDefinition
     typeName,
     defQuery,
     isUnknownEntry: isReferenceExpression,
+    definedTypes: {},
   })
   const definedTypes = _.keyBy([generatedType.type, ...generatedType.nestedTypes], t => t.elemID.typeName)
   overrideFieldTypes({ definedTypes, defQuery })

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -44,7 +44,7 @@ export type ElementGenerator = {
 export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>({
   adapterName,
   defQuery,
-  predefinedTypes,
+  predefinedTypes = {},
   customNameMappingFunctions,
   getElemIdFunc,
 }: {

--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -79,6 +79,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
   // TODO filter instances by fetch query before extracting standalone fields (SALTO-5425)
 
   const instancesWithStandalone = extractStandaloneInstances({
+    adapterName,
     instances,
     defQuery,
     getElemIdFunc,

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -15,22 +15,62 @@
  */
 import {
   ElemIdGetter,
+  Field,
   InstanceElement,
   ObjectType,
   ReferenceExpression,
+  Value,
   getDeepInnerTypeSync,
   isObjectType,
   isReferenceExpression,
 } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { TransformFuncSync, invertNaclCase, transformValuesSync } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/types'
 import { createInstance, getInstanceCreationFunctions } from './instance_utils'
 import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
 import { NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'
+import { generateType } from './type_element'
+
+const log = logger(module)
+
+const getStandaloneType = <Options extends FetchApiDefinitionsOptions>({
+  adapterName,
+  defQuery,
+  typeName,
+  entries,
+  definedTypes,
+  standaloneField,
+}: {
+  adapterName: string
+  defQuery: ElementAndResourceDefFinder<Options>
+  typeName: string
+  parentName?: string
+  entries: Value[]
+  definedTypes: Record<string, ObjectType>
+  standaloneField: Field
+}): ObjectType => {
+  const fieldType = definedTypes?.[typeName] ?? getDeepInnerTypeSync(standaloneField.getTypeSync())
+  if (isObjectType(fieldType)) {
+    if (fieldType.elemID.name !== typeName) {
+      throw new Error(
+        `unexpected field type for ${fieldType.elemID.getFullName()} (expected: ${typeName} but found: ${fieldType.elemID.name})`,
+      )
+    }
+    return fieldType
+  }
+
+  log.debug('field type not found, creating type %s for standalone field %s', typeName, standaloneField.name)
+  const { type } = generateType({ adapterName, defQuery, typeName, definedTypes, entries })
+  // update definedTypes to return the new type created
+  definedTypes[type.elemID.name] = type
+  return type
+}
 
 const extractStandaloneInstancesFromField =
   <Options extends FetchApiDefinitionsOptions>({
+    adapterName,
     defQuery,
     instanceOutput,
     getElemIdFunc,
@@ -38,12 +78,13 @@ const extractStandaloneInstancesFromField =
     customNameMappingFunctions,
     definedTypes,
   }: {
+    adapterName: string
     defQuery: ElementAndResourceDefFinder<Options>
     instanceOutput: InstanceElement[]
     getElemIdFunc?: ElemIdGetter
     parent: InstanceElement
     customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
-    definedTypes?: Record<string, ObjectType>
+    definedTypes: Record<string, ObjectType>
   }): TransformFuncSync =>
   ({ value, field }) => {
     if (field === undefined || isReferenceExpression(value)) {
@@ -54,16 +95,16 @@ const extractStandaloneInstancesFromField =
     if (standaloneDef?.typeName === undefined) {
       return value
     }
+    const standaloneEntries = collections.array.makeArray(value)
 
-    const fieldType = definedTypes?.[standaloneDef.typeName] ?? getDeepInnerTypeSync(field.getTypeSync())
-    if (!isObjectType(fieldType)) {
-      throw new Error(`field type for ${field.elemID.getFullName()} is not an object type`)
-    }
-    if (fieldType.elemID.name !== standaloneDef.typeName) {
-      throw new Error(
-        `unexpected field type for ${field.elemID.getFullName()} (expected: ${standaloneDef.typeName} but found: ${fieldType.elemID.name})`,
-      )
-    }
+    const fieldType = getStandaloneType({
+      adapterName,
+      defQuery,
+      typeName: standaloneDef?.typeName,
+      entries: standaloneEntries,
+      definedTypes,
+      standaloneField: field,
+    })
 
     const nestUnderPath = standaloneDef.nestPathUnderParent
       ? [...(parent.path?.slice(2, parent.path?.length - 1) ?? []), field.name]
@@ -75,7 +116,7 @@ const extractStandaloneInstancesFromField =
       nestUnderPath,
       customNameMappingFunctions,
     })
-    const newInstances = collections.array.makeArray(value).map((entry, index) =>
+    const newInstances = standaloneEntries.map((entry, index) =>
       createInstance({
         entry,
         type: fieldType,
@@ -105,17 +146,19 @@ const extractStandaloneInstancesFromField =
  * Note: modifies the instances array in-place.
  */
 export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOptions>({
+  adapterName,
   instances,
   defQuery,
   customNameMappingFunctions,
   getElemIdFunc,
   definedTypes,
 }: {
+  adapterName: string
   instances: InstanceElement[]
   defQuery: ElementAndResourceDefFinder<Options>
   customNameMappingFunctions?: NameMappingFunctionMap<ResolveCustomNameMappingOptionsType<Options>>
   getElemIdFunc?: ElemIdGetter
-  definedTypes?: Record<string, ObjectType>
+  definedTypes: Record<string, ObjectType>
 }): InstanceElement[] => {
   const instancesToProcess: InstanceElement[] = []
   instances.forEach(inst => instancesToProcess.push(inst))
@@ -134,6 +177,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
       strict: false,
       pathID: inst.elemID,
       transformFunc: extractStandaloneInstancesFromField({
+        adapterName,
         defQuery,
         instanceOutput: instancesToProcess,
         getElemIdFunc,

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -36,9 +36,9 @@ import { generateType } from './type_element'
 const log = logger(module)
 
 /*
-* get standalone field type, and create it if it doesn't exist
-* note: in case the field type is created, definedTypes will be modified to include the created types
-*/
+ * get standalone field type, and create it if it doesn't exist
+ * note: in case the field type is created, definedTypes will be modified to include the created types
+ */
 const getOrCreateAndAssignStandaloneType = <Options extends FetchApiDefinitionsOptions>({
   adapterName,
   defQuery,
@@ -69,7 +69,9 @@ const getOrCreateAndAssignStandaloneType = <Options extends FetchApiDefinitionsO
   const { type, nestedTypes } = generateType({ adapterName, defQuery, typeName, definedTypes, entries })
   const additionalTypes = [type, ...nestedTypes]
   // update definedTypes to return the new types created
-  additionalTypes.forEach(t => { definedTypes[t.elemID.name] = t })
+  additionalTypes.forEach(t => {
+    definedTypes[t.elemID.name] = t
+  })
   return type
 }
 

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -31,6 +31,7 @@ describe('instance element', () => {
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
         customNameMappingFunctions: {},
+        definedTypes: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(0)
@@ -46,6 +47,7 @@ describe('instance element', () => {
           typeName: 'myType',
           defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({ customizations: {} }),
           customNameMappingFunctions: {},
+          definedTypes: {},
         }),
       ).toThrow('type myAdapter:myType is not defined as top-level, cannot create instances')
     })
@@ -62,6 +64,7 @@ describe('instance element', () => {
           customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
         }),
         customNameMappingFunctions: {},
+        definedTypes: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(2)
@@ -126,6 +129,7 @@ describe('instance element', () => {
           customTest: name => `custom_${name}`,
           Uri: name => `uri_${name}`,
         },
+        definedTypes: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(2)
@@ -157,6 +161,7 @@ describe('instance element', () => {
           },
         }),
         customNameMappingFunctions: {},
+        definedTypes: {},
       })
       expect(res.errors).toBeUndefined()
       expect(res.instances).toHaveLength(1)


### PR DESCRIPTION
This continues the fix from https://github.com/salto-io/salto/pull/5623

---

This fixes the issue when the top level type is defined in swagger types, but certain standalone field are not
we need to create the missing types and then return them (by updating definedTypes)

---
_Release Notes_: 
None 

---
_User Notifications_: 
None