### PR TITLE
SALTO-5448 SALTO-5612: Salesforce new Custom Object And Fields Change Validator 

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -48,6 +48,7 @@ import deletedNonQueryableFields from './change_validators/deleted_non_queryable
 import instanceWithUnknownType from './change_validators/instance_with_unknown_type'
 import artificialTypes from './change_validators/artifical_types'
 import taskOrEventFieldsModifications from './change_validators/task_or_event_fields_modifications'
+import newFieldsAndObjectsFLS from './change_validators/new_fields_and_objects_fls'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 import metadataTypes from './change_validators/metadata_types'
@@ -106,6 +107,7 @@ export const changeValidators: Record<
   artificialTypes: () => artificialTypes,
   metadataTypes: () => metadataTypes,
   taskOrEventFieldsModifications: () => taskOrEventFieldsModifications,
+  newFieldsAndObjectsFLS: (config) => newFieldsAndObjectsFLS(config),
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/new_fields_and_objects_fls.ts
+++ b/packages/salesforce-adapter/src/change_validators/new_fields_and_objects_fls.ts
@@ -16,39 +16,64 @@
 import {
   ChangeError,
   ChangeValidator,
-  Element,
+  Field,
   getChangeData,
   isAdditionChange,
-  isField,
+  isFieldChange,
   isObjectType,
+  ObjectType,
 } from '@salto-io/adapter-api'
 import { isCustom } from '../transformers/transformer'
 import { apiNameSync, getFLSProfiles } from '../filters/utils'
 import { SalesforceConfig } from '../types'
 
-const createFLSInfo = (
-  element: Element,
+const createObjectFLSInfo = (
+  field: ObjectType,
   flsProfiles: string[],
-): ChangeError => {
-  const typeOrField = isField(element) ? 'CustomField' : 'CustomObject'
-  return {
-    message: `${typeOrField} visibility in Profiles.`,
-    detailedMessage: `Deploying this new ${typeOrField} will make it accessible by the following Profiles: [${flsProfiles.join(', ')}].`,
-    severity: 'Info',
-    elemID: element.elemID,
-  }
-}
+): ChangeError => ({
+  message: 'CustomObject visibility in Profiles.',
+  detailedMessage: `Deploying this new CustomObject will make it and it's CustomFields accessible by the following Profiles: [${flsProfiles.join(', ')}].`,
+  severity: 'Info',
+  elemID: field.elemID,
+})
+
+const createFieldFLSInfo = (
+  field: Field,
+  flsProfiles: string[],
+): ChangeError => ({
+  message: 'CustomField visibility in Profiles.',
+  detailedMessage: `Deploying this new CustomField will make it accessible by the following Profiles: [${flsProfiles.join(', ')}].`,
+  severity: 'Info',
+  elemID: field.elemID,
+})
 
 const changeValidator =
   (config: SalesforceConfig): ChangeValidator =>
   async (changes) => {
     const flsProfiles = getFLSProfiles(config)
-    return changes
+
+    const addedCustomObjects = changes
       .filter(isAdditionChange)
-      .map((change) => getChangeData(change))
-      .filter((element) => isObjectType(element) || isField(element))
-      .filter((element) => isCustom(apiNameSync(element)))
-      .map((element) => createFLSInfo(element, flsProfiles))
+      .map(getChangeData)
+      .filter(isObjectType)
+      .filter((objectType) => isCustom(apiNameSync(objectType)))
+    const addedCustomObjectsApiNames = new Set(
+      addedCustomObjects.map((customObject) => apiNameSync(customObject)),
+    )
+    const addedCustomObjectsInfos = addedCustomObjects.map((customObject) =>
+      createObjectFLSInfo(customObject, flsProfiles),
+    )
+    const addedCustomFieldsInfos = changes
+      .filter(isAdditionChange)
+      .filter(isFieldChange)
+      .map(getChangeData)
+      // Do not create FLS info on fields that are part of a new custom object
+      .filter(
+        (field) => !addedCustomObjectsApiNames.has(apiNameSync(field.parent)),
+      )
+      .map((field) => createFieldFLSInfo(field, flsProfiles))
+
+    return [...addedCustomFieldsInfos, ...addedCustomObjectsInfos]
   }
 
 export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -162,6 +162,7 @@ export type ChangeValidatorName =
   | 'artificialTypes'
   | 'metadataTypes'
   | 'taskOrEventFieldsModifications'
+  | 'newFieldsAndObjectsFLS'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -879,6 +880,7 @@ const changeValidatorConfigType =
       artificialTypes: { refType: BuiltinTypes.BOOLEAN },
       metadataTypes: { refType: BuiltinTypes.BOOLEAN },
       taskOrEventFieldsModifications: { refType: BuiltinTypes.BOOLEAN },
+      newFieldsAndObjectsFLS: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/new_fields_and_objects_fls.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/new_fields_and_objects_fls.test.ts
@@ -42,7 +42,14 @@ describe('new Fields and Objects FLS Change Validator', () => {
     addedObject = createCustomObjectType('TestType__c', {
       annotations: { [API_NAME]: 'TestType__c' },
     })
-    changes = [addedField, addedObject].map((element) =>
+    // Make sure we don't create info on Field that is added alongside it's parent
+    const addedObjectField = new Field(
+      addedObject,
+      'TestField__c',
+      BuiltinTypes.STRING,
+      { [API_NAME]: 'TestType__c.TestField__c' },
+    )
+    changes = [addedField, addedObject, addedObjectField].map((element) =>
       toChange({ after: element }),
     )
   })


### PR DESCRIPTION
Salesforce new Custom Object And Fields Change Validator 

---

This is another iteration of https://github.com/salto-io/salto/pull/5552 that enables the CV and does not create Change Infos on added CustomFields if there's addition on their parent CustomObject.

Example:

```
CustomObject visibility in Profiles.
    envs/env1/salesforce/Objects/TestObject__c/TestObject__cStandardFields.nacl(line: 1)
    envs/env1/salesforce/Objects/TestObject__c/TestObject__cAnnotations.nacl(line: 1)
    envs/env1/salesforce/Objects/TestObject__c/TestObject__cCustomFields.nacl(line: 1)
    Info: Deploying this new CustomObject will make it and it's CustomFields accessible by the following Profiles: [Admin].
    CustomField visibility in Profiles.
    envs/env1/salesforce/Objects/Account/AccountCustomFields.nacl(line: 379)
    Info: Deploying this new CustomField will make it accessible by the following Profiles: [Admin].
```

---
_Release Notes_: 
Salesforce Adapter:
- Add a Change Validator that notifies users that the adapter will enable the FLS to certain Profiles on addition of new CustomField or CustomObject.

---
_User Notifications_: 
_None_
