### PR TITLE
Revert "SALTO-5332 keep additional properties from swagger as annotation and not field (#5443)"

### DIFF
--- a/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
@@ -58,8 +58,6 @@ const removeAdditionalPropertiesFlat = async (
   }
 }
 
-// TODO remove this
-// https://salto-io.atlassian.net/browse/SALTO-5332
 /**
  * Remove the additional properties value we added on fetch in normalizeElementValues before deploy
  * and add its values to the top level values if deployable

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -22,15 +22,18 @@ import {
   ReferenceExpression,
   isReferenceExpression,
   isListType,
+  isMapType,
+  TypeElement,
+  PrimitiveType,
+  MapType,
   ElemIdGetter,
   SaltoError,
-  isMapType,
 } from '@salto-io/adapter-api'
-import { TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
+import { transformElement, TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { ADDITIONAL_PROPERTIES_FIELD, ARRAY_ITEMS_FIELD } from './type_elements/swagger_parser'
-import { shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
+import { InstanceCreationParams, shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
 import { UnauthorizedError, Paginator, PageEntriesExtractor, HTTPError } from '../../client'
 import {
   TypeSwaggerDefaultConfig,
@@ -156,6 +159,60 @@ const extractStandaloneFields = async (
   return allInstances
 }
 
+const getListDeepInnerType = async (type: TypeElement): Promise<ObjectType | PrimitiveType | MapType> => {
+  if (!isListType(type)) {
+    return type
+  }
+  return getListDeepInnerType(await type.getInnerType())
+}
+
+/**
+ * Normalize the element's values, by nesting swagger additionalProperties under the
+ * additionalProperties field in order to align with the type.
+ *
+ * Note: The reverse will need to be done pre-deploy (not implemented for fetch-only)
+ */
+const normalizeElementValues = (instance: InstanceElement): Promise<InstanceElement> => {
+  const transformAdditionalProps: TransformFunc = async ({ value, field, path }) => {
+    if (!_.isPlainObject(value)) {
+      return value
+    }
+
+    const fieldType = path?.isEqual(instance.elemID) ? await instance.getType() : await field?.getType()
+
+    if (fieldType === undefined) {
+      return value
+    }
+    const fieldInnerType = await getListDeepInnerType(fieldType)
+    if (
+      !isObjectType(fieldInnerType) ||
+      fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD] === undefined ||
+      !isMapType(await fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD].getType())
+    ) {
+      return value
+    }
+
+    const additionalProps = _.merge(
+      _.pickBy(value, (_val, key) => !Object.keys(fieldInnerType.fields).includes(key)),
+      // if the value already has additional properties, give them precedence
+      value[ADDITIONAL_PROPERTIES_FIELD],
+    )
+    return {
+      ..._.omit(value, Object.keys(additionalProps)),
+      [ADDITIONAL_PROPERTIES_FIELD]: additionalProps,
+    }
+  }
+
+  return transformElement({
+    element: instance,
+    transformFunc: transformAdditionalProps,
+    strict: false,
+  })
+}
+
+const toInstance = async (args: InstanceCreationParams): Promise<InstanceElement> =>
+  args.normalized ? toBasicInstance(args) : normalizeElementValues(await toBasicInstance(args))
+
 /**
  * Generate instances for the specified types based on the entries from the API responses,
  * using the endpoint's specific config and the adapter's defaults.
@@ -184,7 +241,7 @@ const generateInstancesForType = ({
   const standaloneFields = transformationConfigByType[objType.elemID.name]?.standaloneFields
   return awu(entries)
     .map((entry, index) =>
-      toBasicInstance({
+      toInstance({
         entry,
         type: objType,
         nestName,
@@ -210,10 +267,10 @@ const generateInstancesForType = ({
     .toArray()
 }
 
-const isItemsOnlyObjectType = (type: ObjectType): boolean => _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
-
 const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean =>
   _.isEqual(Object.keys(type.fields), [ADDITIONAL_PROPERTIES_FIELD])
+
+const isItemsOnlyObjectType = (type: ObjectType): boolean => _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
 
 const normalizeType = async (type: ObjectType | undefined): Promise<ObjectType | undefined> => {
   if (type !== undefined && isItemsOnlyObjectType(type)) {

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -20,9 +20,9 @@ import {
   ElemID,
   BuiltinTypes,
   Field,
+  MapType,
   ListType,
   TypeMap,
-  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { types as lowerdashTypes, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -165,13 +165,36 @@ const typeAdder = ({
         return new Field(type, fieldName, createNestedType(fieldSchema, toNestedTypeName(fieldSchema)))
       }),
     )
+
     if (additionalProperties !== undefined) {
-      const additionalPropertiesType = createNestedType(
-        additionalProperties,
-        // fallback type name when no name is provided in the swagger def
-        `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
-      )
-      type.annotate({ [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: { refType: additionalPropertiesType } })
+      if (type.fields[ADDITIONAL_PROPERTIES_FIELD] !== undefined) {
+        log.warn(
+          'type %s has both a standard %s field and allows additionalProperties - overriding with an additionalProperties field of type unknown',
+          type.elemID.name,
+          ADDITIONAL_PROPERTIES_FIELD,
+        )
+        Object.assign(type.fields, {
+          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
+            type,
+            ADDITIONAL_PROPERTIES_FIELD,
+            new MapType(BuiltinTypes.UNKNOWN),
+          ),
+        })
+      } else {
+        Object.assign(type.fields, {
+          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
+            type,
+            ADDITIONAL_PROPERTIES_FIELD,
+            new MapType(
+              createNestedType(
+                additionalProperties,
+                // fallback type name when no name is provided in the swagger def
+                `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
+              ),
+            ),
+          ),
+        })
+      }
     }
 
     if (endpoints !== undefined && endpoints.length > 0) {

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -100,6 +100,7 @@ describe('swagger_type_elements', () => {
         const pet = allTypes.Pet as ObjectType
         expect(pet).toBeInstanceOf(ObjectType)
         expect(_.mapValues(pet.fields, f => f.refType.elemID.getFullName())).toEqual({
+          additionalProperties: 'Map<unknown>',
           category: 'myAdapter.Category',
           id: 'number',
           name: 'serviceid',
@@ -137,15 +138,19 @@ describe('swagger_type_elements', () => {
           middleName: 'string',
           // ref to UserAdditional2 in swagger
           middleName2: 'string',
+          // additional properties
+          additionalProperties: 'Map<myAdapter.Order>',
         })
 
+        // additionalProperties explicit property combined with enabled additionalProperties
+        // should be undefined
         const food = allTypes.Food as ObjectType
         expect(food).toBeInstanceOf(ObjectType)
         expect(_.mapValues(food.fields, f => f.refType.elemID.getFullName())).toEqual({
           brand: 'string',
           id: 'number',
           storage: 'List<string>',
-          additionalProperties: 'myAdapter.Category',
+          additionalProperties: 'Map<unknown>',
         })
 
         return { allTypes, parsedConfigs }
@@ -184,6 +189,7 @@ describe('swagger_type_elements', () => {
         const location = allTypes.Location as ObjectType
         expect(location).toBeInstanceOf(ObjectType)
         expect(_.mapValues(location.fields, f => f.refType.elemID.name)).toEqual({
+          additionalProperties: 'Map<unknown>',
           name: 'serviceid',
           // address is defined as anyOf combining primitive and object - should use unknown
           address: 'unknown',
@@ -310,6 +316,7 @@ describe('swagger_type_elements', () => {
         // regular response type with reference
         const pet = allTypes.Pet__new
         expect(Object.keys((pet as ObjectType).fields).sort()).toEqual([
+          'additionalProperties',
           'category',
           'id',
           'name',

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1118,12 +1118,11 @@ export const getSubtypes = async (types: ObjectType[], validateUniqueness = fals
   const subtypes: Record<string, ObjectType> = {}
 
   const findSubtypes = async (type: ObjectType): Promise<void> => {
-    const fieldsTypes = await Promise.all(Object.values(type.fields).map(field => field.getType()))
-    const additionalPropertiesRefType = type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType
-    await awu(
-      additionalPropertiesRefType !== undefined ? [...fieldsTypes, additionalPropertiesRefType] : fieldsTypes,
-    ).forEach(async refType => {
-      const fieldType = isContainerType(refType) ? await refType.getInnerType() : refType
+    await awu(Object.values(type.fields)).forEach(async field => {
+      const fieldContainerOrType = await field.getType()
+      const fieldType = isContainerType(fieldContainerOrType)
+        ? await fieldContainerOrType.getInnerType()
+        : fieldContainerOrType
 
       if (!isObjectType(fieldType) || types.includes(fieldType)) {
         return

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -92,9 +92,7 @@ export const transformNotificationEvent = (notificationEvent: NotificationEvent)
   notificationEvent.notifications?.forEach((notification: Values) => {
     notification.type = notification.notificationType
     delete notification.notificationType
-    delete notification.recipient
-    delete notification.field
-    delete notification.projectRole
+    delete notification.additionalProperties
     delete notification.user
     delete notification.id
   })

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -40,6 +40,7 @@ const NOT_FETCHED_POST_FUNCTION_TYPES = ['GenerateChangeHistoryFunction', 'Issue
 const FETCHED_ONLY_INITIAL_POST_FUNCTION = ['UpdateIssueStatusFunction', 'CreateCommentFunction', 'IssueStoreFunction']
 
 const transformProperties = (item: Status | Transition): void => {
+  item.properties = item.properties?.additionalProperties
   // This is not deployable and we get another property
   // of "jira.issue.editable" with the same value
   delete item.properties?.issueEditable

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -355,10 +355,9 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
       .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE)
       .filter(instance => instance.value.issueTypeMappings !== undefined)
       .forEach(instance => {
-        instance.value.items = Object.entries(instance.value.issueTypeMappings ?? {}).map(([issueType, workflow]) => ({
-          workflow,
-          issueType,
-        }))
+        instance.value.items = Object.entries(instance.value.issueTypeMappings.additionalProperties ?? {}).map(
+          ([issueType, workflow]) => ({ workflow, issueType }),
+        )
         delete instance.value.issueTypeMappings
       })
   },

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
@@ -50,6 +50,7 @@ describe('notificationSchemeStructureFilter', () => {
               notificationType: 'type',
               parameter: 'parameter',
               user: 'user',
+              additionalProperties: 'additionalProperties',
             },
           ],
         },

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -197,14 +197,18 @@ describe('workflowStructureFilter', () => {
         statuses: [
           {
             properties: {
-              'jira.issue.editable': 'true',
-              issueEditable: true,
+              additionalProperties: {
+                'jira.issue.editable': 'true',
+                issueEditable: true,
+              },
             },
           },
           {
             properties: {
-              'jira.issue.editable': 'false',
-              issueEditable: false,
+              additionalProperties: {
+                'jira.issue.editable': 'false',
+                issueEditable: false,
+              },
             },
           },
           {},
@@ -233,15 +237,19 @@ describe('workflowStructureFilter', () => {
           {
             name: 'tran1',
             properties: {
-              'jira.issue.editable': 'true',
-              issueEditable: true,
+              additionalProperties: {
+                'jira.issue.editable': 'true',
+                issueEditable: true,
+              },
             },
           },
           {
             name: 'tran2',
             properties: {
-              'jira.issue.editable': 'false',
-              issueEditable: false,
+              additionalProperties: {
+                'jira.issue.editable': 'false',
+                issueEditable: false,
+              },
             },
           },
           { name: 'tran3' },

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -113,7 +113,9 @@ describe('workflowScheme', () => {
     it('replace value of issueTypeMappings with items', async () => {
       const instance = new InstanceElement('instance', workflowSchemeType, {
         issueTypeMappings: {
-          1234: 'workflow name',
+          additionalProperties: {
+            1234: 'workflow name',
+          },
         },
       })
       await filter.onFetch?.([instance])

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -48,6 +48,7 @@ const orderPasswordPolicyRuleMethods = (instance: InstanceElement): void => {
   const methodsPath = instance.elemID.createNestedID(
     'actions',
     'selfServicePasswordReset',
+    'additionalProperties',
     'requirement',
     'primary',
     'methods',

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -42,7 +42,7 @@ const log = logger(module)
 const { getTransformationConfigByType } = configUtils
 const { toBasicInstance } = elementUtils
 const { isDefined } = values
-const LINK_PATH = [LINKS_FIELD, 'schema', 'href']
+const LINK_PATH = [LINKS_FIELD, 'additionalProperties', 'schema', 'href']
 
 const getUserSchemaId = (instance: InstanceElement): string | undefined => {
   const url = _.get(instance.value, LINK_PATH)

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -68,21 +68,20 @@ describe('unorderedListsFilter', () => {
         actions: {
           selfServicePasswordReset: {
             access: 'ALLOW',
-            requirement: {
-              primary: {
-                methods: ['push', 'email', 'voice', 'sms'],
+            additionalProperties: {
+              requirement: {
+                primary: {
+                  methods: ['push', 'email', 'voice', 'sms'],
+                },
               },
             },
           },
         },
       })
       await filter.onFetch([policyRuleType, policyRuleInstance])
-      expect(policyRuleInstance.value.actions.selfServicePasswordReset.requirement.primary.methods).toEqual([
-        'email',
-        'push',
-        'sms',
-        'voice',
-      ])
+      expect(
+        policyRuleInstance.value.actions.selfServicePasswordReset.additionalProperties.requirement.primary.methods,
+      ).toEqual(['email', 'push', 'sms', 'voice'])
     })
 
     it('should do nothing if there are no methods defined', async () => {

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -45,8 +45,10 @@ describe('userSchemaFilter', () => {
     id: 123,
     name: 'A',
     _links: {
-      schema: {
-        href: 'https://okta.com/api/v1/meta/schemas/user/A123',
+      additionalProperties: {
+        schema: {
+          href: 'https://okta.com/api/v1/meta/schemas/user/A123',
+        },
       },
     },
     default: false,
@@ -55,8 +57,10 @@ describe('userSchemaFilter', () => {
     id: 234,
     name: 'B',
     _links: {
-      schema: {
-        href: 'https://okta.com/api/v1/meta/schemas/user/B123',
+      additionalProperties: {
+        schema: {
+          href: 'https://okta.com/api/v1/meta/schemas/user/B123',
+        },
       },
     },
     default: false,
@@ -65,8 +69,10 @@ describe('userSchemaFilter', () => {
     id: 345,
     name: 'C',
     _links: {
-      schema: {
-        href: 'https://okta.com/api/v1/meta/schemas/user/C123',
+      additionalProperties: {
+        schema: {
+          href: 'https://okta.com/api/v1/meta/schemas/user/C123',
+        },
       },
     },
     default: true,


### PR DESCRIPTION
 
---



---
_Release Notes_: 
Jira_Adapter:
Revert: Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

Okta_Adapter:
Revert: Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)

---
_User Notifications_: 
Jira_Adapter:
Revert: Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

Okta_Adapter:
Revert: Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)
