### PR TITLE
SALTO-5441: create change validator for issue layout

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -44,6 +44,7 @@ import { screenSchemeDefaultValidator } from './screen_scheme_default'
 import { workflowSchemeDupsValidator } from './workflows/workflow_scheme_dups'
 import { workflowTransitionDuplicateNameValidator } from './workflows/workflow_transition_duplicate_names'
 import { issueTypeSchemeDefaultTypeValidator } from './issue_type_scheme_default_type'
+import { issueLayoutsValidator } from './issue_layouts_validator'
 import { emptyValidatorWorkflowChangeValidator } from './workflows/empty_validator_workflow'
 import { fieldContextValidator } from './field_contexts/field_contexts'
 import { workflowSchemeMigrationValidator } from './workflow_scheme_migration'
@@ -89,6 +90,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     emptyValidatorWorkflowChange: emptyValidatorWorkflowChangeValidator,
     readOnlyWorkflow: readOnlyWorkflowValidator,
     dashboardGadgets: dashboardGadgetsValidator,
+    issueLayouts: issueLayoutsValidator,
     dashboardLayout: dashboardLayoutValidator,
     permissionType: permissionTypeValidator,
     automations: automationsValidator,

--- a/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
+++ b/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
@@ -1,0 +1,143 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Change,
+  ChangeError,
+  ChangeValidator,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  ReferenceExpression,
+  ReadOnlyElementsSource,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+
+import _ from 'lodash'
+
+import { ISSUE_LAYOUT_TYPE } from '../constants'
+
+type issueTypeMappingStruct = {
+  issueTypeId: string | ReferenceExpression
+  screenSchemeId: ReferenceExpression
+}
+
+const getParent = async (instance: InstanceElement, elementsSource: ReadOnlyElementsSource): Promise<InstanceElement> =>
+  elementsSource.get(instance.annotations[CORE_ANNOTATIONS.PARENT][0].elemID)
+
+// Filters and deletes from the issueTypeMapping the issue layouts that are not in the issueTypeScheme of the project
+const intersectionOfIssueType = (
+  issueTypeScreenScheme: issueTypeMappingStruct,
+  projectIssueTypesFullName: string[],
+): boolean =>
+  _.isString(issueTypeScreenScheme.issueTypeId)
+    ? issueTypeScreenScheme.issueTypeId === 'default'
+    : projectIssueTypesFullName.includes(issueTypeScreenScheme.issueTypeId.elemID.getFullName())
+
+// It only leaves the deductive issueTypeScreenScheme if there is an issueType found in the project's issueTypeScheme but not in the issueTypeMapping
+// If there is such a case, it means that the length of the issueTypeScheme is greater than the length of the issueTypeMapping (after the last filter)
+const isScreenOfViewOrDefaultIssueTypeScreenScheme = (
+  issueTypeScreenScheme: issueTypeMappingStruct,
+  relevantIssueTypeMappingsLength: number,
+  projectIssueTypesFullNameLength: number,
+): boolean =>
+  issueTypeScreenScheme.issueTypeId !== 'default' || relevantIssueTypeMappingsLength <= projectIssueTypesFullNameLength
+
+const getProjectIdToIssueLayout = (
+  changes: ReadonlyArray<Change>,
+  elementsSource: ReadOnlyElementsSource,
+): Record<string, InstanceElement[]> =>
+  _.groupBy(
+    changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(async instance => instance.elemID.typeName === ISSUE_LAYOUT_TYPE),
+    async instance => (await getParent(instance, elementsSource)).value.elemID,
+  )
+
+const getIssueLayoutsScreen = async (
+  elementsSource: ReadOnlyElementsSource,
+  project: InstanceElement,
+): Promise<string[]> => {
+  if (project === undefined) return []
+  const projectIssueTypesFullName = (
+    await elementsSource.get(project.value.issueTypeScheme.elemID)
+  ).value.issueTypeIds.map((issueType: ReferenceExpression) => issueType.elemID.getFullName())
+
+  const relevantIssueTypeMappings = (
+    (await Promise.all(
+      (await elementsSource.get(project.value.issueTypeScreenScheme.elemID)).value.issueTypeMappings,
+    )) as issueTypeMappingStruct[]
+  ).filter((issueTypeScreenScheme: issueTypeMappingStruct) =>
+    intersectionOfIssueType(issueTypeScreenScheme, projectIssueTypesFullName),
+  )
+
+  const defaultCheckIssueTypeMappings = relevantIssueTypeMappings.filter(
+    (issueTypeScreenScheme: issueTypeMappingStruct) =>
+      isScreenOfViewOrDefaultIssueTypeScreenScheme(
+        issueTypeScreenScheme,
+        relevantIssueTypeMappings.length,
+        projectIssueTypesFullName.length,
+      ),
+  )
+
+  return (
+    await Promise.all(
+      defaultCheckIssueTypeMappings.map((issueTypeMapping: issueTypeMappingStruct) =>
+        elementsSource.get(issueTypeMapping.screenSchemeId.elemID),
+      ),
+    )
+  )
+    .filter(isInstanceElement)
+    .filter(
+      (screenScheme: InstanceElement) =>
+        screenScheme.value.screens.default !== undefined || screenScheme.value.screens.view !== undefined,
+    )
+    .flatMap((screenScheme: InstanceElement) => screenScheme.value.screens.view ?? screenScheme.value.screens.default)
+    .map((screen: ReferenceExpression) => screen.elemID.getFullName())
+}
+
+export const issueLayoutsValidator: ChangeValidator = async (changes, elementsSource) => {
+  const errors: ChangeError[] = []
+
+  if (elementsSource === undefined) return errors
+
+  const projectIdToIssueLayout: Record<string, InstanceElement[]> = getProjectIdToIssueLayout(changes, elementsSource)
+
+  await Promise.all(
+    Object.values(projectIdToIssueLayout).map(async instances => {
+      const issueLayoutsScreen = await getIssueLayoutsScreen(
+        elementsSource,
+        await getParent(instances[0], elementsSource),
+      )
+      await Promise.all(
+        instances.map(async instance => {
+          if (!issueLayoutsScreen.includes(instance.value.extraDefinerId.elemID.getFullName())) {
+            errors.push({
+              elemID: instance.elemID,
+              severity: 'Error',
+              message: 'Invalid screen in Issue Layout',
+              detailedMessage: `Issue layout ${instance.elemID.getFullName()} references an invalid or non-existing screen.`,
+            })
+          }
+        }),
+      )
+    }),
+  )
+
+  return errors
+}

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -210,6 +210,7 @@ export type ChangeValidatorName =
   | 'readOnlyWorkflow'
   | 'dashboardGadgets'
   | 'dashboardLayout'
+  | 'issueLayouts'
   | 'permissionType'
   | 'automations'
   | 'activeSchemeDeletion'
@@ -269,6 +270,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     readOnlyWorkflow: { refType: BuiltinTypes.BOOLEAN },
     dashboardGadgets: { refType: BuiltinTypes.BOOLEAN },
     dashboardLayout: { refType: BuiltinTypes.BOOLEAN },
+    issueLayouts: { refType: BuiltinTypes.BOOLEAN },
     permissionType: { refType: BuiltinTypes.BOOLEAN },
     automations: { refType: BuiltinTypes.BOOLEAN },
     activeSchemeDeletion: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/test/change_validators/issue_layout.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_layout.test.ts
@@ -1,0 +1,349 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ObjectType,
+  InstanceElement,
+  ChangeValidator,
+  toChange,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+  ElemID,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { issueLayoutsValidator } from '../../src/change_validators/issue_layouts_validator'
+import {
+  ISSUE_LAYOUT_TYPE,
+  ISSUE_TYPE_NAME,
+  ISSUE_TYPE_SCHEMA_NAME,
+  ISSUE_TYPE_SCREEN_SCHEME_TYPE,
+  JIRA,
+  PROJECT_TYPE,
+  SCREEN_SCHEME_TYPE,
+  SCREEN_TYPE_NAME,
+} from '../../src/constants'
+import { generateLayoutId } from '../../src/filters/layouts/layout_service_operations'
+
+describe('issue layouts validator', () => {
+  let validator: ChangeValidator
+  let elements: InstanceElement[]
+  let screenType: ObjectType
+  let screenInstance1: InstanceElement
+  let screenInstance2: InstanceElement
+  let screenInstance3: InstanceElement
+  let screenSchemeType: ObjectType
+  let screenSchemeInstance1: InstanceElement
+  let screenSchemeInstance2: InstanceElement
+  let screenSchemeInstance3: InstanceElement
+  let issueTypeScreenSchemeType: ObjectType
+  let issueTypeScreenSchemeInstance1: InstanceElement
+  let issueTypeScreenSchemeInstance2: InstanceElement
+  let projectType: ObjectType
+  let projectInstance: InstanceElement
+  let newProjectInstance: InstanceElement
+  let issueTypeType: ObjectType
+  let issueTypeInstance1: InstanceElement
+  let issueTypeInstance2: InstanceElement
+  let issueTypeSchemeType: ObjectType
+  let issueTypeSchemeInstance1: InstanceElement
+  let issueTypeSchemeInstance2: InstanceElement
+  let issueLayoutType: ObjectType
+  let issueLayoutInstance: InstanceElement
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    validator = issueLayoutsValidator
+
+    screenSchemeType = new ObjectType({ elemID: new ElemID(JIRA, SCREEN_SCHEME_TYPE) })
+    issueTypeScreenSchemeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_SCREEN_SCHEME_TYPE) })
+    projectType = new ObjectType({ elemID: new ElemID(JIRA, PROJECT_TYPE) })
+    issueTypeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_NAME) })
+    issueTypeSchemeType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_TYPE_SCHEMA_NAME) })
+    issueLayoutType = new ObjectType({ elemID: new ElemID(JIRA, ISSUE_LAYOUT_TYPE) })
+    screenType = new ObjectType({ elemID: new ElemID(JIRA, SCREEN_TYPE_NAME) })
+
+    issueTypeInstance1 = new InstanceElement('issueType1', issueTypeType, {
+      name: 'issueType1',
+      id: 100,
+    })
+    issueTypeInstance2 = new InstanceElement('issueType2', issueTypeType, {
+      name: 'issueType2',
+      id: 200,
+    })
+
+    issueTypeSchemeInstance1 = new InstanceElement('issueTypeScheme1', issueTypeSchemeType, {
+      name: 'issueTypeScheme1',
+      id: 10,
+      issueTypeIds: [new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1)],
+    })
+    issueTypeSchemeInstance2 = new InstanceElement('issueTypeScheme2', issueTypeSchemeType, {
+      name: 'issueTypeScheme2',
+      id: 20,
+      issueTypeIds: [
+        new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+        new ReferenceExpression(issueTypeInstance2.elemID, issueTypeInstance2),
+      ],
+    })
+
+    screenInstance1 = new InstanceElement('screen1', screenType, {
+      name: 'screen1',
+      id: 11,
+    })
+    screenInstance2 = new InstanceElement('screen2', screenType, {
+      name: 'screen2',
+      id: 12,
+    })
+    screenInstance3 = new InstanceElement('screen3', screenType, {
+      name: 'screen3',
+      id: 13,
+    })
+
+    screenSchemeInstance1 = new InstanceElement('screenScheme1', screenSchemeType, {
+      name: 'screenScheme1',
+      id: 111,
+      screens: {},
+    })
+    screenSchemeInstance2 = new InstanceElement('screenScheme2', screenSchemeType, {
+      name: 'screenScheme2',
+      id: 222,
+      screens: { default: new ReferenceExpression(screenInstance1.elemID, screenInstance1) },
+    })
+    screenSchemeInstance3 = new InstanceElement('screenScheme3', screenSchemeType, {
+      name: 'screenScheme3',
+      id: 333,
+      screens: {
+        default: new ReferenceExpression(screenInstance3.elemID, screenInstance3),
+        view: new ReferenceExpression(screenInstance2.elemID, screenInstance2),
+      },
+    })
+
+    issueTypeScreenSchemeInstance1 = new InstanceElement('issueTypeScreenScheme1', issueTypeScreenSchemeType, {
+      name: 'issueTypeScreenScheme1',
+      id: 1111,
+      issueTypeMappings: [
+        {
+          issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+          screenSchemeId: new ReferenceExpression(screenSchemeInstance2.elemID, screenSchemeInstance2),
+        },
+      ],
+    })
+    issueTypeScreenSchemeInstance2 = new InstanceElement('issueTypeScreenScheme2', issueTypeScreenSchemeType, {
+      name: 'issueTypeScreenScheme2',
+      id: 2222,
+      issueTypeMappings: [
+        {
+          issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+          screenSchemeId: new ReferenceExpression(screenSchemeInstance3.elemID, screenSchemeInstance3),
+        },
+        {
+          issueTypeId: 'default',
+          screenSchemeId: new ReferenceExpression(screenSchemeInstance2.elemID, screenSchemeInstance2),
+        },
+      ],
+    })
+
+    projectInstance = new InstanceElement('project1', projectType, {
+      name: 'project1',
+      id: '11111',
+      projectTypeKey: 'software',
+      issueTypeScreenScheme: new ReferenceExpression(
+        issueTypeScreenSchemeInstance1.elemID,
+        issueTypeScreenSchemeInstance1,
+      ),
+      issueTypeScheme: new ReferenceExpression(issueTypeSchemeInstance1.elemID, issueTypeSchemeInstance1),
+    })
+
+    issueLayoutInstance = new InstanceElement(
+      'issueLayout',
+      issueLayoutType,
+      {
+        name: 'issueLayout',
+        id: generateLayoutId({ projectId: projectInstance.value.id, extraDefinerId: screenInstance1.value.id }),
+        extraDefinerId: new ReferenceExpression(screenInstance1.elemID, screenInstance1),
+      },
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)] },
+    )
+
+    elements = [
+      issueTypeInstance1,
+      issueTypeInstance2,
+      issueTypeSchemeInstance1,
+      issueTypeSchemeInstance2,
+      screenInstance1,
+      screenInstance2,
+      screenInstance3,
+      screenSchemeInstance1,
+      screenSchemeInstance2,
+      screenSchemeInstance3,
+      issueTypeScreenSchemeInstance1,
+      issueTypeScreenSchemeInstance2,
+      projectInstance,
+      issueLayoutInstance,
+    ]
+  })
+  it('should not return error when issue layout is linked to relevant project screens', async () => {
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should return error if the issueTypeScreenScheme are empty and there is issueLayout', async () => {
+    issueTypeScreenSchemeInstance1.value.issueTypeMappings = []
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('should not return error if the issue layout is linked to the view screen', async () => {
+    issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = {
+      issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+      screenSchemeId: new ReferenceExpression(screenSchemeInstance3.elemID, screenSchemeInstance3),
+    }
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(screenInstance2.elemID, screenInstance2)
+    issueLayoutInstance.value.id = generateLayoutId({
+      projectId: projectInstance.value.id,
+      extraDefinerId: screenInstance2.value.id,
+    })
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should return error if the issue layout is linked to the default screen if there is view screen', async () => {
+    issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = {
+      issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+      screenSchemeId: new ReferenceExpression(screenSchemeInstance3.elemID, screenSchemeInstance3),
+    }
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(screenInstance3.elemID, screenInstance3)
+    issueLayoutInstance.value.id = generateLayoutId({
+      projectId: projectInstance.value.id,
+      extraDefinerId: screenInstance3.value.id,
+    })
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('should not return error if the issue layout is linked to the default screen if there is no view screen', async () => {
+    issueTypeScreenSchemeInstance1.value.issueTypeMappings[0] = {
+      issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+      screenSchemeId: new ReferenceExpression(screenSchemeInstance2.elemID, screenSchemeInstance2),
+    }
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(screenInstance1.elemID, screenInstance1)
+    issueLayoutInstance.value.id = generateLayoutId({
+      projectId: projectInstance.value.id,
+      extraDefinerId: screenInstance1.value.id,
+    })
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('should return error if the issue layout linked to non existing project', async () => {
+    issueLayoutInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
+      new ReferenceExpression(new ElemID('salto', 'nonExistingProject')),
+    ]
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('should return error if the issue layout linked to non existing screen', async () => {
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(new ElemID('salto', 'nonExistingScreen'))
+    issueLayoutInstance.value.id = generateLayoutId({
+      projectId: projectInstance.value.id,
+      extraDefinerId: 'nonExistingScreen',
+    })
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('Passes if the issue layout links to a default issueTypeScreenScheme for unaddressed projects issue types', async () => {
+    projectInstance.value.issueTypeScreenScheme = new ReferenceExpression(
+      issueTypeScreenSchemeInstance2.elemID,
+      issueTypeScreenSchemeInstance2,
+    )
+    projectInstance.value.issueTypeScheme = new ReferenceExpression(
+      issueTypeSchemeInstance2.elemID,
+      issueTypeSchemeInstance2,
+    )
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(0)
+  })
+  it('Fails if the issue layout links to a default issueTypeScreenScheme if managed all project issue types', async () => {
+    projectInstance.value.issueTypeScreenScheme = new ReferenceExpression(
+      issueTypeScreenSchemeInstance2.elemID,
+      issueTypeScreenSchemeInstance2,
+    )
+    projectInstance.value.issueTypeScheme = new ReferenceExpression(
+      issueTypeSchemeInstance1.elemID,
+      issueTypeSchemeInstance1,
+    )
+    issueTypeScreenSchemeInstance2.value.issueTypeMappings[0] = {
+      issueTypeId: new ReferenceExpression(issueTypeInstance1.elemID, issueTypeInstance1),
+      screenSchemeId: new ReferenceExpression(screenSchemeInstance3.elemID, screenSchemeInstance3),
+    }
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(screenInstance1.elemID, screenInstance1)
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('should return error if the issue layout is linked to screen of different project', async () => {
+    issueLayoutInstance.value.id = generateLayoutId({
+      projectId: projectInstance.value.id,
+      extraDefinerId: screenInstance2.value.id,
+    })
+    issueLayoutInstance.value.extraDefinerId = new ReferenceExpression(screenInstance2.elemID, screenInstance2)
+    newProjectInstance = new InstanceElement('project2', projectType, {
+      name: 'project2',
+      id: '22222',
+      projectTypeKey: 'software',
+      issueTypeScreenScheme: new ReferenceExpression(
+        issueTypeScreenSchemeInstance2.elemID,
+        issueTypeScreenSchemeInstance2,
+      ),
+      issueTypeScheme: new ReferenceExpression(issueTypeSchemeInstance2.elemID, issueTypeSchemeInstance2),
+    })
+    elements.push(newProjectInstance)
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+  it('should return error if the issue layout is linked to non default or view screens', async () => {
+    screenSchemeInstance2.value.screens = { edit: new ReferenceExpression(screenInstance1.elemID, screenInstance1) }
+    const errors = await validator(
+      [toChange({ after: issueLayoutInstance })],
+      buildElementsSourceFromElements(elements),
+    )
+    expect(errors).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
I created a changeValidaitor for the issueLayout that verifies that the issueLayout that the user added are correct and connect to screens that are relevant to the project

---
The code checks whether the screens of the issueLayouts added by the user connect to the screens that are in the project of the same issueLayout


---
_Release Notes_: 
From now on, users who add invalid issueLayouts (whose screen connects to a screen that is not part of the project's list of screens) will receive an error regarding that issueLayout
---
_User Notifications_: 
