### PR TITLE
SALTO-5480 - Retrying SFDC requests on no healthy upstream

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -137,6 +137,7 @@ const errorMessagesToRetry = [
   'ECONNREFUSED',
   'Internal_Error',
   'UNABLE_TO_LOCK_ROW', // we saw this in both fetch and deploy
+  'no healthy upstream',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
Retrying SFDC requests on no healthy upstream

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
