### PR TITLE
SALTO-5637: Don't fetch ProfileMapping properties for new envs

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -95,6 +95,8 @@ const TRANSFORMATION_DEFAULTS: configUtils.TransformationDefaultConfig = {
   nestStandaloneInstances: true,
 }
 
+const DEFAULT_INCLUDE_PROFILE_MAPPING_PROPERTIES = false
+
 // Policy type is split to different kinds of policies
 // The full list of policy types is taken from here:
 // https://developer.okta.com/docs/reference/api/policy/#policy-types
@@ -1824,7 +1826,7 @@ export const DEFAULT_CONFIG: OktaConfig = {
     convertUsersIds: DEFAULT_CONVERT_USERS_IDS_VALUE,
     enableMissingReferences: true,
     includeGroupMemberships: false,
-    includeProfileMappingProperties: true,
+    includeProfileMappingProperties: DEFAULT_INCLUDE_PROFILE_MAPPING_PROPERTIES,
     getUsersStrategy: DEFAULT_GET_USERS_STRATEGY,
   },
   [API_DEFINITIONS_CONFIG]: DEFAULT_API_DEFINITIONS,

--- a/packages/okta-adapter/src/filters/profile_mapping_properties.ts
+++ b/packages/okta-adapter/src/filters/profile_mapping_properties.ts
@@ -35,7 +35,7 @@ const getProfileMapping = async (mappingId: string, client: OktaClient): Promise
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'profileMappingPropertiesFilter',
   onFetch: async (elements: Element[]) => {
-    if (config[FETCH_CONFIG].includeProfileMappingProperties === false) {
+    if (!config[FETCH_CONFIG].includeProfileMappingProperties === true) {
       log.debug('Fetch of profile mapping properties is disabled')
       return
     }

--- a/packages/okta-adapter/test/filters/profile_mapping_properties.test.ts
+++ b/packages/okta-adapter/test/filters/profile_mapping_properties.test.ts
@@ -65,15 +65,15 @@ describe('profileMappingPropertiesFilter', () => {
   })
 
   it('should do nothing when includeProfileMappingProperties config flag is disabled', async () => {
-    const config = _.cloneDeep(DEFAULT_CONFIG)
-    config[FETCH_CONFIG].includeProfileMappingProperties = false
     const elements = [mappingType, mappingInstanceA, mappingInstanceB]
-    filter = profileMappingPropertiesFilter(getFilterParams({ client, config })) as typeof filter
+    filter = profileMappingPropertiesFilter(getFilterParams({ client, config: DEFAULT_CONFIG })) as typeof filter
     await filter.onFetch(elements)
     expect(elements.filter(isInstanceElement).every(instance => !instance.value.properties)).toEqual(true)
     expect(mockGet).toHaveBeenCalledTimes(0)
   })
   it('should add profile mapping properties for ProfileMapping instances when flag is enabled', async () => {
+    const config = _.cloneDeep(DEFAULT_CONFIG)
+    config[FETCH_CONFIG].includeProfileMappingProperties = true
     const elements = [mappingType, mappingInstanceA, mappingInstanceB]
     mockGet.mockImplementation(params => {
       if (params.url === '/api/v1/mappings/abc123') {
@@ -84,7 +84,7 @@ describe('profileMappingPropertiesFilter', () => {
       }
       throw new Error('Err')
     })
-    filter = profileMappingPropertiesFilter(getFilterParams({ client, config: DEFAULT_CONFIG })) as typeof filter
+    filter = profileMappingPropertiesFilter(getFilterParams({ client, config })) as typeof filter
     await filter.onFetch(elements)
     expect(mockGet).toHaveBeenCalledTimes(2)
     const mappingInstances = elements.filter(isInstanceElement)


### PR DESCRIPTION
modify the default value of `includeProfileMappingProperties` flag to false

---

The change will only apply for new envs

---
_Release Notes_: 

_Okta_adapter_:
- In new environments, ProfileMapping properties object will not be fetch by default, and can be included by turning `includeProfileMappingProperties` flag to true. Existing envs will not be affected.

---
_User Notifications_: 
None
