### PR TITLE
SALTO-5655: Disabling useUnknownInCatchVariables

### DIFF
--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,8 @@
         "incremental": true,
         "composite": true,
         "noEmitOnError": true,
-        "experimentalDecorators": true
+        "experimentalDecorators": true,
+        "useUnknownInCatchVariables": false,
     },
     "files": [],
     "include": []


### PR DESCRIPTION
TS 4.4 starts treating all errors in try-catch clauses as `unknown` by default (a change from the previous `any`). Since our codebase never uses type guards for errors, this emits errors for all try-catch clauses when using newer versions (I’m experiencing this in VS code).

Disabling this feature using the `useUnknownInCatchVariables` fixes this. We can remove this config if and when we want to start guarding our try-catch clauses.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
