### PR TITLE
SALTO-5660: Salesforce Quick Fetch logs

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -528,6 +528,9 @@ const fetchAndProcessMergeErrors = async (
     )
     const fetchResults = await Promise.all(
       Object.entries(accountsToAdapters).map(async ([accountName, adapter]) => {
+        if (withChangesDetection) {
+          log.debug('Running quick fetch for account %s', accountName)
+        }
         const fetchResult = await adapter.fetch({
           progressReporter: progressReporters[accountName],
           withChangesDetection,

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -529,7 +529,7 @@ const fetchAndProcessMergeErrors = async (
     const fetchResults = await Promise.all(
       Object.entries(accountsToAdapters).map(async ([accountName, adapter]) => {
         if (withChangesDetection) {
-          log.debug('Running quick fetch for account %s', accountName)
+          log.debug('Running fetch with changes detection for account %s', accountName)
         }
         const fetchResult = await adapter.fetch({
           progressReporter: progressReporters[accountName],

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -31,6 +31,7 @@ import {
   PartialFetchData,
   Element,
   ProgressReporter,
+  isInstanceElement,
 } from '@salto-io/adapter-api'
 import {
   filter,
@@ -640,6 +641,21 @@ export default class SalesforceAdapter implements AdapterOperations {
         )
       }
       return { isPartial: true, deletedElements: deletedElemIds }
+    }
+
+    if (withChangesDetection) {
+      const relevantFetchedElementIds = elements
+        .filter(
+          (element) =>
+            isCustomObjectSync(element) || isInstanceElement(element),
+        )
+        .map((element) => element.elemID.getFullName())
+      const logTraceOrDebug =
+        relevantFetchedElementIds.length > 100 ? log.trace : log.debug
+      logTraceOrDebug(
+        'Fetched the following elements in quick fetch: %s',
+        safeJsonStringify(relevantFetchedElementIds),
+      )
     }
     return {
       elements,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -650,13 +650,12 @@ export default class SalesforceAdapter implements AdapterOperations {
             isCustomObjectSync(element) || isInstanceElement(element),
         )
         .map((element) => element.elemID.getFullName())
-      const logTraceOrDebug =
-        relevantFetchedElementIds.length > 100 ? log.trace : log.debug
-      logTraceOrDebug(
+      ;(relevantFetchedElementIds.length > 100 ? log.trace : log.debug)(
         'Fetched the following elements in quick fetch: %s',
         safeJsonStringify(relevantFetchedElementIds),
       )
     }
+    metadataQuery.logData()
     return {
       elements,
       errors: onFetchFilterResult.errors ?? [],

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -20,8 +20,6 @@ import {
   InstanceElement,
   Values,
 } from '@salto-io/adapter-api'
-import { logger } from '@salto-io/logging'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
 import { ArtificialTypes, DATA_INSTANCES_CHANGED_AT_MAGIC } from '../constants'
@@ -34,8 +32,6 @@ import {
 } from './utils'
 import { MetadataInstanceElement } from '../transformers/transformer'
 import { LastChangeDateOfTypesWithNestedInstances } from '../types'
-
-const log = logger(module)
 
 const createCurrentChangedAtSingletonValues = (
   lastChangeDateOfTypesWithNestedInstances:
@@ -116,10 +112,6 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
           mostRecentChangedAt,
         )
       })
-    log.trace(
-      'ChangedAtSingleton values: %s',
-      safeJsonStringify(changedAtInstance.value),
-    )
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -20,6 +20,8 @@ import {
   InstanceElement,
   Values,
 } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
 import { ArtificialTypes, DATA_INSTANCES_CHANGED_AT_MAGIC } from '../constants'
@@ -32,6 +34,8 @@ import {
 } from './utils'
 import { MetadataInstanceElement } from '../transformers/transformer'
 import { LastChangeDateOfTypesWithNestedInstances } from '../types'
+
+const log = logger(module)
 
 const createCurrentChangedAtSingletonValues = (
   lastChangeDateOfTypesWithNestedInstances:
@@ -112,6 +116,10 @@ const filterCreator: LocalFilterCreator = ({ config }) => ({
           mostRecentChangedAt,
         )
       })
+    log.trace(
+      'ChangedAtSingleton values: %s',
+      safeJsonStringify(changedAtInstance.value),
+    )
   },
 })
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -1019,6 +1019,7 @@ export type MetadataQuery<T = MetadataInstance> = {
   isFetchWithChangesDetection: () => boolean
   isPartialFetch: () => boolean
   getFolderPathsByName: (folderType: string) => Record<string, string>
+  logData: () => void
 }
 
 export type TypeFetchCategory = 'Always' | 'IfReferenced' | 'Never'

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2238,6 +2238,7 @@ public class LargeClass${index} {
         isTargetedFetch: jest.fn(),
         isFetchWithChangesDetection: jest.fn(),
         getFolderPathsByName: jest.fn(),
+        logData: jest.fn(),
       }
       const excludeFilePropMock = mockFileProperties({
         fullName: 'fullName',

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -811,6 +811,7 @@ describe('buildMetadataQuery', () => {
         isPartialFetch: jest.fn(),
         isTargetedFetch: jest.fn(),
         getFolderPathsByName: jest.fn(),
+        logData: jest.fn(),
       }
       filePropsMetadataQuery = buildFilePropsMetadataQuery(metadataQuery)
     })


### PR DESCRIPTION
Add logs for Salesforce Quick Fetch

---

As part of this PR, also added a log in core that indicates we are running a quick-fetch for a specific account.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
