### PR TITLE
SALTO-5659 avoid adding additional delimiter when element only extendsParent

### DIFF
--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -132,7 +132,7 @@ const computeElemIDPartsFunc =
     const res =
       elemIDDef.extendsParent && parent !== undefined
         ? // the delimiter between parent and child will be doubled
-          [invertNaclCase(parent.elemID.name), '', ...nonEmptyParts]
+          [invertNaclCase(parent.elemID.name), ...(nonEmptyParts.length > 0 ? ['', ...nonEmptyParts] : [])]
         : nonEmptyParts
 
     if (nonEmptyParts.length < parts.length) {

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -151,6 +151,17 @@ describe('id utils', () => {
         'parent_b__A_A@fuus',
       )
     })
+    it('should avoid extra delimiter when extending parent and no parts', () => {
+      const func = createElemIDFunc({
+        elemIDDef: {
+          extendsParent: true,
+        },
+        typeID,
+        customNameMappingFunctions: {},
+      })
+      const parent = new InstanceElement('parent:b', new ObjectType({ elemID: typeID }))
+      expect(func({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed', parent })).toEqual('parent_b@f')
+    })
     it('should set name to _config for singleton', () => {
       const func = createElemIDFunc({
         elemIDDef: {


### PR DESCRIPTION
Fixed a bug in the new create elemId function.  Where for an elemId with extendsParent = true but without any parts. We added a redundant delimiter at the end of the elemId


---



---
_Release Notes_: 
None

---
_User Notifications_: 
None
