### PR TITLE
SALTO-5242: [Zendesk] Fix bug for deployment with additions of app installations

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -85,6 +85,7 @@ import {
   inactiveTicketFormInViewValidator,
   immutableTypeAndKeyForUserFieldsValidator,
   localeModificationValidator,
+  appInstallationValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ChangeValidatorName, ZendeskDeployConfig, ZendeskFetchConfig, ZendeskConfig } from './config'
@@ -185,6 +186,7 @@ export default ({
     inactiveTicketFormInView: inactiveTicketFormInViewValidator,
     immutableTypeAndKeyForUserFields: immutableTypeAndKeyForUserFieldsValidator,
     localeModification: localeModificationValidator,
+    appInstallation: appInstallationValidator(client),
     // *** Guide Order Validators ***
     childInOrder: childInOrderValidator,
     childrenReferences: childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/app_installation.ts
+++ b/packages/zendesk-adapter/src/change_validators/app_installation.ts
@@ -1,0 +1,106 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeError,
+  ChangeValidator,
+  ElemID,
+  getChangeData,
+  isAdditionChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import ZendeskClient from '../client/client'
+import { APP_INSTALLATION_TYPE_NAME } from '../constants'
+import { isValidApp } from '../filters/app_installations'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+const { isDefined } = lowerDashValues
+
+const APPS_SECTION_URL = 'admin/apps-integrations/apps/support-apps'
+
+export const createChangeError = (
+  instanceElemId: ElemID,
+  prefilledFields: Array<string>,
+  baseUrl: string,
+): ChangeError => ({
+  elemID: instanceElemId,
+  severity: 'Info',
+  message: 'App installation creation detected',
+  detailedMessage: 'App installation creation detected',
+  deployActions: {
+    preAction: {
+      title: 'Some App installation required fields will not be set',
+      description: `App installation ${instanceElemId.name} will be deployed with the placeholder values for the following fields: ${prefilledFields.length === 1 ? prefilledFields[0] : prefilledFields.join(', ')}. Salto will guide you on modifying them post deploy`,
+      subActions: [],
+    },
+    postAction: {
+      title: 'Set app installation fields',
+      description: `Please manually set the following fields for app installation ${instanceElemId.name} via the Zendesk UI: ${prefilledFields.length === 1 ? prefilledFields[0] : prefilledFields.join(', ')}`,
+      showOnFailure: false,
+      subActions: [
+        `Go to Zendesk Apps panel at ${baseUrl}${APPS_SECTION_URL}`,
+        'Hover over the created app',
+        'Click on the Gear icon > Change Settings',
+        'Edit the fields in the "App Installation" section',
+        'Click "Update"',
+      ],
+    },
+  },
+})
+
+export const appInstallationValidator: (client: ZendeskClient) => ChangeValidator = client => async changes => {
+  const potentialChanges = changes
+    .filter(isAdditionChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(changeData => changeData.elemID.typeName === APP_INSTALLATION_TYPE_NAME)
+
+  const errors = await awu(potentialChanges)
+    .flatMap(async changeData => {
+      try {
+        const res = (
+          await client.get({
+            url: `/api/support/apps/${changeData.value.app_id}/installations/new`,
+            responseType: 'json',
+          })
+        ).data
+        if (isValidApp(res) && res.installation !== undefined) {
+          const prefilledFields = res.installation.settings
+            .map(field =>
+              field.secure === true && field.required === true && !(field.key in changeData.value.settings)
+                ? field.key
+                : undefined,
+            )
+            .filter(isDefined)
+          if (prefilledFields.length > 0) {
+            return [createChangeError(changeData.elemID, prefilledFields, client.getUrl().href)]
+          }
+        }
+        return []
+      } catch (e) {
+        log.warn(`Failed to fetch app installation details. error: ${e}`)
+        return []
+      }
+    })
+    .filter(isDefined)
+    .toArray()
+
+  return errors
+}

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -87,3 +87,4 @@ export { dynamicContentPlaceholderModificationValidator } from './dynamic_conten
 export { inactiveTicketFormInViewValidator } from './inactive_ticket_forms_in_view'
 export { immutableTypeAndKeyForUserFieldsValidator } from './immutable_fields_in_user_fields'
 export { localeModificationValidator } from './locale'
+export { appInstallationValidator } from './app_installation'

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2940,6 +2940,7 @@ export type ChangeValidatorName =
   | 'inactiveTicketFormInView'
   | 'immutableTypeAndKeyForUserFields'
   | 'localeModification'
+  | 'appInstallation'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -3017,6 +3018,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     inactiveTicketFormInView: { refType: BuiltinTypes.BOOLEAN },
     immutableTypeAndKeyForUserFields: { refType: BuiltinTypes.BOOLEAN },
     localeModification: { refType: BuiltinTypes.BOOLEAN },
+    appInstallation: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -63,6 +63,9 @@ export type SubjectCondition = {
   value?: unknown
 }
 
+export type ValidApp = {
+  installation: { settings: { secure: boolean; required: boolean; key: string; type: string }[] }
+}
 const TYPES_WITH_SUBJECT_CONDITIONS = ['routing_attribute_value']
 export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
@@ -124,6 +127,27 @@ const CONDITION_SUBJECT_SCHEMA = Joi.array()
     }).unknown(true),
   )
   .required()
+
+const EXPECTED_APP_SCHEMA = Joi.object({
+  installation: Joi.object({
+    settings: Joi.array()
+      .items(
+        Joi.object({
+          secure: Joi.bool(),
+          required: Joi.bool(),
+          key: Joi.string().required(),
+          type: Joi.string().required(),
+        }).unknown(true),
+      )
+      .required(),
+  })
+    .unknown(true)
+    .optional(),
+})
+  .unknown(true)
+  .required()
+
+export const isValidApp = createSchemeGuard<ValidApp>(EXPECTED_APP_SCHEMA, 'Received an invalid value for app response')
 
 export const isConditions = createSchemeGuard<Condition[]>(CONDITION_SCHEMA, 'Found invalid values for conditions')
 export const isSubjectConditions = createSchemeGuard<SubjectCondition[]>(

--- a/packages/zendesk-adapter/test/change_validators/app_installation.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/app_installation.test.ts
@@ -1,0 +1,98 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import ZendeskClient from '../../src/client/client'
+import { APP_INSTALLATION_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { appInstallationValidator, createChangeError } from '../../src/change_validators/app_installation'
+
+describe('appInstallationValidator', () => {
+  let client: ZendeskClient
+  let mockGet: jest.SpyInstance
+
+  const appInstallation = new InstanceElement(
+    ElemID.CONFIG_NAME,
+    new ObjectType({ elemID: new ElemID(ZENDESK, APP_INSTALLATION_TYPE_NAME) }),
+    {
+      app_id: 1234,
+      name: 'test_app_ins',
+      settings: {
+        name: 'hello',
+        second_field: 1234,
+      },
+    },
+  )
+  beforeEach(async () => {
+    jest.clearAllMocks()
+  })
+  beforeAll(async () => {
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+  })
+
+  it('Should return an error when there are missing fields', async () => {
+    mockGet = jest.spyOn(client, 'get')
+    mockGet.mockImplementation(params => {
+      if (params.url === `/api/support/apps/${appInstallation.value.app_id}/installations/new`) {
+        return {
+          status: 200,
+          data: {
+            installation: {
+              settings: [
+                { key: 'name', secure: false, required: true, type: 'text' },
+                { key: 'second_field', secure: false, required: true, type: 'number' },
+                { key: 'third_field', secure: false, required: false, type: 'text' },
+                { key: 'fourth_field', secure: true, required: true, type: 'number' },
+                { key: 'last_field', secure: true, required: true, type: 'text' },
+              ],
+            },
+          },
+        }
+      }
+      throw new Error('Err')
+    })
+
+    const cv = appInstallationValidator(client)
+    const errors = await cv([toChange({ after: appInstallation })])
+    expect(errors).toEqual([
+      createChangeError(appInstallation.elemID, ['fourth_field', 'last_field'], client.getUrl().href),
+    ])
+  })
+  it('Should not return errors when there are no missing fields', async () => {
+    mockGet = jest.spyOn(client, 'get')
+    mockGet.mockImplementation(params => {
+      if (params.url === `/api/support/apps/${appInstallation.value.app_id}/installations/new`) {
+        return {
+          status: 200,
+          data: {
+            installation: {
+              settings: [
+                { key: 'name', secure: false, required: true, type: 'text' },
+                { key: 'second_field', secure: false, required: true, type: 'number' },
+                { key: 'third_field', secure: false, required: false, type: 'text' },
+              ],
+            },
+          },
+        }
+      }
+      throw new Error('Err')
+    })
+
+    const cv = appInstallationValidator(client)
+    const errors = await cv([toChange({ after: appInstallation })])
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/zendesk-adapter/test/filters/app_installations.test.ts
+++ b/packages/zendesk-adapter/test/filters/app_installations.test.ts
@@ -105,7 +105,7 @@ describe('app installation filter', () => {
         endpointDetails: expect.anything(),
         fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
       })
-      expect(mockGet).toHaveBeenCalledTimes(1)
+      expect(mockGet).toHaveBeenCalledTimes(2)
       expect(mockGet).toHaveBeenCalledWith({
         url: '/api/v2/apps/job_statuses/123',
       })
@@ -176,7 +176,7 @@ describe('app installation filter', () => {
         endpointDetails: expect.anything(),
         fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
       })
-      expect(mockGet).toHaveBeenCalledTimes(1)
+      expect(mockGet).toHaveBeenCalledTimes(2)
       expect(mockGet).toHaveBeenCalledWith({
         url: '/api/v2/apps/job_statuses/123',
       })
@@ -198,7 +198,7 @@ describe('app installation filter', () => {
         endpointDetails: expect.anything(),
         fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
       })
-      expect(mockGet).toHaveBeenCalledTimes(1)
+      expect(mockGet).toHaveBeenCalledTimes(2)
       expect(mockGet).toHaveBeenCalledWith({
         url: '/api/v2/apps/job_statuses/123',
       })
@@ -220,7 +220,7 @@ describe('app installation filter', () => {
         endpointDetails: expect.anything(),
         fieldsToIgnore: ['app', 'settings.title', 'settings_objects'],
       })
-      expect(mockGet).toHaveBeenCalledTimes(0)
+      expect(mockGet).toHaveBeenCalledTimes(1)
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(1)
       expect(res.deployResult.appliedChanges).toHaveLength(0)


### PR DESCRIPTION
When creating an app installation, you *have* to send all required field. This is not really a problem normally, unless you duplicate an existing app installation from another env, in which case fields that are secret will not be present in the nacl, which results in a deployment error.
In this PR, i add a call to ZD API during deployment to see if we are missing any required fields, and if we are - fill them with placeholders.
I also added a CV with instructions to the user to edit those fields after the deployment.

---
<img width="1908" alt="Screenshot 2024-03-26 at 13 09 10" src="https://github.com/salto-io/salto/assets/13694783/b8e9c5bf-bcfd-4ac2-9c97-5459dd69db88">
<img width="1303" alt="Screenshot 2024-03-26 at 13 09 16" src="https://github.com/salto-io/salto/assets/13694783/4d66ce0b-c097-4d5e-93b4-051661e61d99">



---
_Release Notes_: 
Zendesk:
Fix issue when creating app installations with missing fields

---
_User Notifications_: 
None