### PR TITLE
SALTO-5022: Adding service URLs for SF auto response rules

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flows.ts
+++ b/packages/salesforce-adapter/src/change_validators/flows.ts
@@ -41,7 +41,7 @@ import {
 } from '../filters/utils'
 import { SalesforceConfig } from '../types'
 import SalesforceClient from '../client/client'
-import { FLOW_URL_SUFFIX } from '../elements_url_retreiver/lightining_url_resolvers'
+import { FLOW_URL_SUFFIX } from '../elements_url_retreiver/lightning_url_resolvers'
 
 const { awu } = collections.asynciterable
 const PREFER_ACTIVE_FLOW_VERSIONS_DEFAULT = false

--- a/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/elements_url_retreiver.ts
@@ -16,7 +16,7 @@
 import { Element } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
-import { ElementIDResolver, resolvers } from './lightining_url_resolvers'
+import { ElementIDResolver, resolvers } from './lightning_url_resolvers'
 
 const log = logger(module)
 const { awu } = collections.asynciterable

--- a/packages/salesforce-adapter/src/elements_url_retreiver/lightning_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retreiver/lightning_url_resolvers.ts
@@ -135,6 +135,21 @@ const assignmentRulesResolver: UrlResolver = async (element, baseUrl) => {
   return undefined
 }
 
+const autoResponseRulesResolver: UrlResolver = async (element, baseUrl) => {
+  const apiName = await safeApiName(element)
+  if (apiName === undefined) {
+    return undefined
+  }
+
+  if (
+    isInstanceOfTypeSync('AutoResponseRules')(element) &&
+    ['Lead', 'Case'].includes(apiName)
+  ) {
+    return new URL(`${baseUrl}lightning/setup/${apiName}Responses/home`)
+  }
+  return undefined
+}
+
 const metadataTypeResolver: UrlResolver = async (element, baseUrl) => {
   const internalId = getInternalId(element)
   if (
@@ -282,6 +297,7 @@ export const resolvers: UrlResolver[] = [
   generalConstantsResolver,
   settingsConstantsResolver,
   assignmentRulesResolver,
+  autoResponseRulesResolver,
   metadataTypeResolver,
   objectResolver,
   fieldResolver,

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -87,9 +87,7 @@ describe('lightningElementsUrlRetriever', () => {
           elemID: new ElemID('salesforce', 'PermissionSetGroup'),
           annotations: { metadataType: 'PermissionSetGroup' },
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/PermSetGroups/home',
           ),
@@ -101,9 +99,7 @@ describe('lightningElementsUrlRetriever', () => {
           elemID: new ElemID('salesforce', 'BusinessHoursSettings'),
           annotations: { metadataType: 'BusinessHoursSettings' },
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/BusinessHours/home',
           ),
@@ -118,9 +114,7 @@ describe('lightningElementsUrlRetriever', () => {
             annotations: { metadataType: 'BusinessHoursSettings' },
           }),
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/BusinessHours/home',
           ),
@@ -136,9 +130,7 @@ describe('lightningElementsUrlRetriever', () => {
           }),
           { fullName: 'Lead' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/LeadRules/home',
           ),
@@ -154,9 +146,7 @@ describe('lightningElementsUrlRetriever', () => {
           }),
           { fullName: 'Case' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/CaseResponses/home',
           ),
@@ -164,9 +154,7 @@ describe('lightningElementsUrlRetriever', () => {
       })
 
       it('standard object', async () => {
-        await expect(
-          elementUrlRetriever?.retrieveUrl(standardObject),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(standardObject)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/Details/view',
           ),
@@ -174,9 +162,7 @@ describe('lightningElementsUrlRetriever', () => {
       })
 
       it('custom object', async () => {
-        await expect(
-          elementUrlRetriever?.retrieveUrl(customObject),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(customObject)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/someId/Details/view',
           ),
@@ -190,9 +176,7 @@ describe('lightningElementsUrlRetriever', () => {
           BuiltinTypes.NUMBER,
           { apiName: 'standardField' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/FieldsAndRelationships/standardField/view',
           ),
@@ -206,9 +190,7 @@ describe('lightningElementsUrlRetriever', () => {
           BuiltinTypes.NUMBER,
           { internalId: 'someId' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/FieldsAndRelationships/someId/view',
           ),
@@ -222,9 +204,7 @@ describe('lightningElementsUrlRetriever', () => {
           BuiltinTypes.NUMBER,
           { apiName: 'standardField' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/someId/FieldsAndRelationships/standardField/view',
           ),
@@ -238,9 +218,7 @@ describe('lightningElementsUrlRetriever', () => {
           BuiltinTypes.NUMBER,
           { internalId: 'fieldId' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/someId/FieldsAndRelationships/fieldId/view',
           ),
@@ -254,9 +232,7 @@ describe('lightningElementsUrlRetriever', () => {
           BuiltinTypes.NUMBER,
           { relationshipName: 'someRelationshipName' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/FieldsAndRelationships/someRelationshipName/view',
           ),
@@ -268,9 +244,7 @@ describe('lightningElementsUrlRetriever', () => {
           elemID: new ElemID('salesforce', 'custom__mdt'),
           annotations: { internalId: 'someId', apiName: 'custom__mdt' },
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/CustomMetadata/page?address=%2FsomeId%3Fsetupid%3DCustomMetadata',
           ),
@@ -282,9 +256,7 @@ describe('lightningElementsUrlRetriever', () => {
           processType: 'Flow',
           internalId: 'someId',
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/builder_platform_interaction/flowBuilder.app?flowId=someId',
           ),
@@ -296,9 +268,7 @@ describe('lightningElementsUrlRetriever', () => {
           processType: 'Workflow',
           internalId: 'someId',
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ProcessAutomation/home',
           ),
@@ -314,9 +284,7 @@ describe('lightningElementsUrlRetriever', () => {
           }),
           { internalId: 'someId' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/Queues/page?address=%2Fp%2Fown%2FQueue%2Fd%3Fid%3DsomeId',
           ),
@@ -338,9 +306,7 @@ describe('lightningElementsUrlRetriever', () => {
             ],
           },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/PageLayouts/someId/view',
           ),
@@ -362,9 +328,7 @@ describe('lightningElementsUrlRetriever', () => {
             ],
           },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/ObjectManager/Account/ButtonsLinksActions/someId/view',
           ),
@@ -383,9 +347,7 @@ describe('lightningElementsUrlRetriever', () => {
             ],
           },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/_classic/%2FsomeId',
           ),
@@ -397,9 +359,7 @@ describe('lightningElementsUrlRetriever', () => {
           PATH_ASSISTANT_METADATA_TYPE,
           mockTypes.PathAssistant,
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/setup/PathAssistantSetupHome/page?address=%2Fui%2Fsetup%2Fpathassistant%2FPathAssistantSetupPage%3Fisdtp%3Dp1',
           ),
@@ -411,9 +371,7 @@ describe('lightningElementsUrlRetriever', () => {
           elemID: new ElemID('salesforce', 'someType'),
           annotations: { internalId: 'someId' },
         })
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             'https://salto5-dev-ed.lightning.force.com/lightning/_classic/%2FsomeId',
           ),
@@ -426,9 +384,7 @@ describe('lightningElementsUrlRetriever', () => {
           customObject,
           { Id: 'instanceId' },
         )
-        await expect(
-          elementUrlRetriever?.retrieveUrl(element),
-        ).resolves.toEqual(
+        expect(await elementUrlRetriever?.retrieveUrl(element)).toEqual(
           new URL(
             `https://salto5-dev-ed.lightning.force.com/lightning/r/${customObject.annotations.apiName}/instanceId/view`,
           ),
@@ -441,9 +397,7 @@ describe('lightningElementsUrlRetriever', () => {
         })
         expect(elementUrlRetriever).toBeDefined()
         if (elementUrlRetriever !== undefined) {
-          await expect(
-            elementUrlRetriever.retrieveUrl(element),
-          ).resolves.toBeUndefined()
+          expect(await elementUrlRetriever.retrieveUrl(element)).toBeUndefined()
         }
       })
     })

--- a/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
+++ b/packages/salesforce-adapter/test/elements_url_retreiver.test.ts
@@ -145,6 +145,24 @@ describe('lightningElementsUrlRetriever', () => {
         )
       })
 
+      it('AutoResponseRulesResolver', async () => {
+        const element = new InstanceElement(
+          'Case',
+          new ObjectType({
+            elemID: new ElemID('salesforce', 'AutoResponseRules'),
+            annotations: { metadataType: 'AutoResponseRules' },
+          }),
+          { fullName: 'Case' },
+        )
+        await expect(
+          elementUrlRetriever?.retrieveUrl(element),
+        ).resolves.toEqual(
+          new URL(
+            'https://salto5-dev-ed.lightning.force.com/lightning/setup/CaseResponses/home',
+          ),
+        )
+      })
+
       it('standard object', async () => {
         await expect(
           elementUrlRetriever?.retrieveUrl(standardObject),


### PR DESCRIPTION
Also doing some cleanup in `lightning_url_resolvers.ts`.

---

_Additional context for reviewer_
In SF there are exactly 2 instances of `AutoResponseRules`: Lead and Case. Adding a `_service_url` for them will allow us to support **Go To Service** for them.

---
_Release Notes_: 

_Salesforce Adapter_:
- Support for Go To Service for Auto Response Rules elements.

---
_User Notifications_: 
None.
