### PR TITLE
SALTO-5332 stop creating additionalProperties map field and use the annotation instead

### DIFF
--- a/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements/swagger/deployment/additional_properties.ts
@@ -58,6 +58,8 @@ const removeAdditionalPropertiesFlat = async (
   }
 }
 
+// TODO remove this
+// https://salto-io.atlassian.net/browse/SALTO-5332
 /**
  * Remove the additional properties value we added on fetch in normalizeElementValues before deploy
  * and add its values to the top level values if deployable

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -291,7 +291,7 @@ const getEntriesForType = async (params: GetEntriesParams): Promise<{ entries: V
 
     // special case - should probably move to adapter-specific filter if does not recur
     if (dataField !== undefined && isObjectType(dataFieldType) && isAdditionalPropertiesOnlyObjectType(dataFieldType)) {
-      const propsType = await dataFieldType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.value
+      const propsType = dataFieldType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.value
       if (isObjectType(propsType)) {
         return {
           objType: propsType,

--- a/packages/adapter-components/src/elements/swagger/instance_elements.ts
+++ b/packages/adapter-components/src/elements/swagger/instance_elements.ts
@@ -22,18 +22,15 @@ import {
   ReferenceExpression,
   isReferenceExpression,
   isListType,
-  isMapType,
-  TypeElement,
-  PrimitiveType,
-  MapType,
   ElemIdGetter,
   SaltoError,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
-import { transformElement, TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
+import { TransformFunc, safeJsonStringify, transformValues } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { ADDITIONAL_PROPERTIES_FIELD, ARRAY_ITEMS_FIELD } from './type_elements/swagger_parser'
-import { InstanceCreationParams, shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
+import { ARRAY_ITEMS_FIELD } from './type_elements/swagger_parser'
+import { shouldRecurseIntoEntry, toBasicInstance } from '../instance_elements'
 import { UnauthorizedError, Paginator, PageEntriesExtractor, HTTPError } from '../../client'
 import {
   TypeSwaggerDefaultConfig,
@@ -159,60 +156,6 @@ const extractStandaloneFields = async (
   return allInstances
 }
 
-const getListDeepInnerType = async (type: TypeElement): Promise<ObjectType | PrimitiveType | MapType> => {
-  if (!isListType(type)) {
-    return type
-  }
-  return getListDeepInnerType(await type.getInnerType())
-}
-
-/**
- * Normalize the element's values, by nesting swagger additionalProperties under the
- * additionalProperties field in order to align with the type.
- *
- * Note: The reverse will need to be done pre-deploy (not implemented for fetch-only)
- */
-const normalizeElementValues = (instance: InstanceElement): Promise<InstanceElement> => {
-  const transformAdditionalProps: TransformFunc = async ({ value, field, path }) => {
-    if (!_.isPlainObject(value)) {
-      return value
-    }
-
-    const fieldType = path?.isEqual(instance.elemID) ? await instance.getType() : await field?.getType()
-
-    if (fieldType === undefined) {
-      return value
-    }
-    const fieldInnerType = await getListDeepInnerType(fieldType)
-    if (
-      !isObjectType(fieldInnerType) ||
-      fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD] === undefined ||
-      !isMapType(await fieldInnerType.fields[ADDITIONAL_PROPERTIES_FIELD].getType())
-    ) {
-      return value
-    }
-
-    const additionalProps = _.merge(
-      _.pickBy(value, (_val, key) => !Object.keys(fieldInnerType.fields).includes(key)),
-      // if the value already has additional properties, give them precedence
-      value[ADDITIONAL_PROPERTIES_FIELD],
-    )
-    return {
-      ..._.omit(value, Object.keys(additionalProps)),
-      [ADDITIONAL_PROPERTIES_FIELD]: additionalProps,
-    }
-  }
-
-  return transformElement({
-    element: instance,
-    transformFunc: transformAdditionalProps,
-    strict: false,
-  })
-}
-
-const toInstance = async (args: InstanceCreationParams): Promise<InstanceElement> =>
-  args.normalized ? toBasicInstance(args) : normalizeElementValues(await toBasicInstance(args))
-
 /**
  * Generate instances for the specified types based on the entries from the API responses,
  * using the endpoint's specific config and the adapter's defaults.
@@ -241,7 +184,7 @@ const generateInstancesForType = ({
   const standaloneFields = transformationConfigByType[objType.elemID.name]?.standaloneFields
   return awu(entries)
     .map((entry, index) =>
-      toInstance({
+      toBasicInstance({
         entry,
         type: objType,
         nestName,
@@ -268,7 +211,7 @@ const generateInstancesForType = ({
 }
 
 const isAdditionalPropertiesOnlyObjectType = (type: ObjectType): boolean =>
-  _.isEqual(Object.keys(type.fields), [ADDITIONAL_PROPERTIES_FIELD])
+  _.isEmpty(type.fields) && type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] !== false
 
 const isItemsOnlyObjectType = (type: ObjectType): boolean => _.isEqual(Object.keys(type.fields), [ARRAY_ITEMS_FIELD])
 
@@ -348,14 +291,11 @@ const getEntriesForType = async (params: GetEntriesParams): Promise<{ entries: V
 
     // special case - should probably move to adapter-specific filter if does not recur
     if (dataField !== undefined && isObjectType(dataFieldType) && isAdditionalPropertiesOnlyObjectType(dataFieldType)) {
-      const propsType = await dataFieldType.fields[ADDITIONAL_PROPERTIES_FIELD].getType()
-      if (isMapType(propsType)) {
-        const propsInnerType = await propsType.getInnerType()
-        if (isObjectType(propsInnerType)) {
-          return {
-            objType: propsInnerType,
-            extractValues: true,
-          }
+      const propsType = await dataFieldType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.value
+      if (isObjectType(propsType)) {
+        return {
+          objType: propsType,
+          extractValues: true,
         }
       }
     }

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -20,9 +20,10 @@ import {
   ElemID,
   BuiltinTypes,
   Field,
-  MapType,
   ListType,
   TypeMap,
+  CORE_ANNOTATIONS,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { types as lowerdashTypes, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -167,36 +168,17 @@ export const typeAdder = ({
         return new Field(type, fieldName, createNestedType(fieldSchema, toNestedTypeName(fieldSchema)))
       }),
     )
-
     if (additionalProperties !== undefined) {
-      if (type.fields[ADDITIONAL_PROPERTIES_FIELD] !== undefined) {
-        log.warn(
-          'type %s has both a standard %s field and allows additionalProperties - overriding with an additionalProperties field of type unknown',
-          type.elemID.name,
-          ADDITIONAL_PROPERTIES_FIELD,
-        )
-        Object.assign(type.fields, {
-          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
-            type,
-            ADDITIONAL_PROPERTIES_FIELD,
-            new MapType(BuiltinTypes.UNKNOWN),
-          ),
-        })
-      } else {
-        Object.assign(type.fields, {
-          [ADDITIONAL_PROPERTIES_FIELD]: new Field(
-            type,
-            ADDITIONAL_PROPERTIES_FIELD,
-            new MapType(
-              createNestedType(
-                additionalProperties,
-                // fallback type name when no name is provided in the swagger def
-                `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
-              ),
-            ),
-          ),
-        })
-      }
+      const additionalPropertiesType = createNestedType(
+        additionalProperties,
+        // fallback type name when no name is provided in the swagger def
+        `${objName}_${ADDITIONAL_PROPERTIES_FIELD}`,
+      )
+      type.annotate({
+        [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+          refType: new TypeReference(additionalPropertiesType.elemID, additionalPropertiesType),
+        },
+      })
     }
 
     if (endpoints !== undefined && endpoints.length > 0) {

--- a/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
+++ b/packages/adapter-components/src/elements/swagger/type_elements/element_generator.ts
@@ -23,7 +23,7 @@ import {
   ListType,
   TypeMap,
   CORE_ANNOTATIONS,
-  TypeReference,
+  ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { types as lowerdashTypes, values as lowerdashValues } from '@salto-io/lowerdash'
@@ -176,7 +176,7 @@ export const typeAdder = ({
       )
       type.annotate({
         [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
-          refType: new TypeReference(additionalPropertiesType.elemID, additionalPropertiesType),
+          refType: new ReferenceExpression(additionalPropertiesType.elemID, additionalPropertiesType),
         },
       })
     }

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -289,17 +289,13 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
               primaryOwner: { name: 'primary' },
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -526,10 +522,8 @@ describe('swagger_instance_elements', () => {
             objectTypes.Owner,
             {
               name: 'o1',
-              additionalProperties: {
-                bla: 'BLA',
-                x: { nested: 'value' },
-              },
+              bla: 'BLA',
+              x: { nested: 'value' },
             },
             // path has no effect on equality
             [],
@@ -565,10 +559,8 @@ describe('swagger_instance_elements', () => {
               name: 'def',
               owners: [new ReferenceExpression(dogO1Inst.elemID)],
               primaryOwner: new ReferenceExpression(primaryOInst.elemID),
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             // path has no effect on equality
             [],
@@ -704,16 +696,12 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -796,10 +784,8 @@ describe('swagger_instance_elements', () => {
             objectTypes.Owner,
             {
               name: 'o1',
-              additionalProperties: {
-                bla: 'BLA',
-                x: { nested: 'value' },
-              },
+              bla: 'BLA',
+              x: { nested: 'value' },
             },
             [ADAPTER_NAME, 'Records', 'Owner', 'o1'],
           ),
@@ -940,17 +926,13 @@ describe('swagger_instance_elements', () => {
               owners: [
                 {
                   name: 'o1',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
+                  bla: 'BLA',
+                  x: { nested: 'value' },
                 },
               ],
               primaryOwner: { name: 'primary' },
-              additionalProperties: {
-                food1: { id: 'f1' },
-                food2: { id: 'f2' },
-              },
+              food1: { id: 'f1' },
+              food2: { id: 'f2' },
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'dog'],
           ),
@@ -1060,9 +1042,7 @@ describe('swagger_instance_elements', () => {
             objectTypes.CustomObjectDefinition,
             {
               name: 'Pet',
-              additionalProperties: {
-                something: 'else',
-              },
+              something: 'else',
             },
             [ADAPTER_NAME, 'CustomObjectDefinition', 'Owner', 'Pet'],
           ),
@@ -1133,86 +1113,10 @@ describe('swagger_instance_elements', () => {
               primaryOwner: [
                 {
                   name: 'o3',
-                  additionalProperties: {
-                    bla: 'BLA',
-                    x: { nested: 'value' },
-                  },
-                },
-              ],
-            },
-            [ADAPTER_NAME, 'Records', 'Pet', 'mouse'],
-          ),
-        ),
-      ).toBeTruthy()
-    })
-
-    it('should not put existing field values under additionalProperties even if they unexpectedly contain single values', async () => {
-      const objectTypes = generateObjectTypes()
-
-      mockPaginator = mockFunction<Paginator>().mockImplementation(
-        async function* getAll(getParams, extractPageEntries) {
-          if (getParams.url === '/pet') {
-            yield [
-              {
-                id: 'mouse',
-                name: 'def',
-                owners: { name: 'o3', bla: 'BLA', x: { nested: 'value' } },
-              },
-            ].flatMap(extractPageEntries)
-          }
-        },
-      )
-      const res = await getAllInstances({
-        paginator: mockPaginator,
-        apiConfig: {
-          typeDefaults: {
-            transformation: {
-              idFields: ['id'],
-            },
-          },
-          types: {
-            Pet: {
-              request: {
-                url: '/pet',
-              },
-            },
-          },
-        },
-        fetchQuery: createElementQuery({
-          include: [{ type: 'Pet' }],
-          exclude: [],
-        }),
-        supportedTypes: {
-          Pet: ['Pet'],
-        },
-        objectTypes,
-        computeGetArgs: simpleGetArgs,
-        nestedFieldFinder: returnFullEntry,
-      })
-      expect(res.elements).toHaveLength(1)
-      const petInst = res.elements[0]
-      expect(petInst.elemID.getFullName()).toEqual(`${ADAPTER_NAME}.Pet.instance.mouse`)
-      expect(mockPaginator).toHaveBeenCalledTimes(1)
-      expect(mockPaginator).toHaveBeenCalledWith(
-        { url: '/pet', recursiveQueryParams: undefined, paginationField: undefined },
-        expect.anything(),
-      )
-
-      expect(
-        petInst.isEqual(
-          new InstanceElement(
-            'mouse',
-            objectTypes.Pet,
-            {
-              id: 'mouse',
-              name: 'def',
-              owners: {
-                name: 'o3',
-                additionalProperties: {
                   bla: 'BLA',
                   x: { nested: 'value' },
                 },
-              },
+              ],
             },
             [ADAPTER_NAME, 'Records', 'Pet', 'mouse'],
           ),
@@ -1384,23 +1288,19 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')
         expect(fish.value).toHaveProperty('owners', [
-          { name: 'o1', additionalProperties: { info: { numOfPets: 2 } } },
-          { name: 'o2', additionalProperties: { info: { numOfPets: 2 } } },
+          { name: 'o1', info: { numOfPets: 2 } },
+          { name: 'o2', info: { numOfPets: 2 } },
         ])
       })
 
@@ -1440,17 +1340,13 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')
@@ -1496,17 +1392,13 @@ describe('swagger_instance_elements', () => {
         expect(dog.value).toHaveProperty('owners', [
           {
             name: 'o1',
-            additionalProperties: {
-              nicknames: [{ names: ['n1', 'n2'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n1', 'n2'] }],
+            info: { numOfPets: 2 },
           },
           {
             name: 'o2',
-            additionalProperties: {
-              nicknames: [{ names: ['n3'] }],
-              info: { numOfPets: 2 },
-            },
+            nicknames: [{ names: ['n3'] }],
+            info: { numOfPets: 2 },
           },
         ])
         expect(cat.value).not.toHaveProperty('owners')

--- a/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/instance_elements.test.ts
@@ -20,9 +20,9 @@ import {
   ElemID,
   BuiltinTypes,
   ListType,
-  MapType,
   InstanceElement,
   ReferenceExpression,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import { getAllInstances } from '../../../src/elements/swagger'
@@ -44,8 +44,10 @@ describe('swagger_instance_elements', () => {
         elemID: new ElemID(ADAPTER_NAME, 'Owner'),
         fields: {
           name: { refType: BuiltinTypes.STRING },
-          additionalProperties: {
-            refType: new MapType(BuiltinTypes.UNKNOWN),
+        },
+        annotations: {
+          [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+            refType: new ReferenceExpression(BuiltinTypes.UNKNOWN.elemID, BuiltinTypes.UNKNOWN),
           },
         },
       })
@@ -63,7 +65,11 @@ describe('swagger_instance_elements', () => {
           name: { refType: BuiltinTypes.STRING },
           owners: { refType: new ListType(Owner) },
           primaryOwner: { refType: Owner },
-          additionalProperties: { refType: new MapType(Food) },
+        },
+        annotations: {
+          [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+            refType: new ReferenceExpression(Food.elemID, Food),
+          },
         },
       })
       const Status = new ObjectType({
@@ -945,16 +951,19 @@ describe('swagger_instance_elements', () => {
         elemID: new ElemID(ADAPTER_NAME, 'CustomObjectDefinition'),
         fields: {
           name: { refType: BuiltinTypes.STRING },
-          additionalProperties: {
-            refType: new MapType(BuiltinTypes.UNKNOWN),
+        },
+        annotations: {
+          [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+            refType: new ReferenceExpression(BuiltinTypes.UNKNOWN.elemID, BuiltinTypes.UNKNOWN),
           },
         },
       })
       const CustomObjectDefinitionMapping = new ObjectType({
         elemID: new ElemID(ADAPTER_NAME, 'CustomObjectDefinitionMapping'),
-        fields: {
-          additionalProperties: {
-            refType: new MapType(CustomObjectDefinition),
+        fields: {},
+        annotations: {
+          [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+            refType: new ReferenceExpression(CustomObjectDefinition.elemID, CustomObjectDefinition),
           },
         },
       })
@@ -1544,8 +1553,10 @@ describe('swagger_instance_elements', () => {
         elemID: new ElemID(ADAPTER_NAME, 'Owner'),
         fields: {
           name: { refType: BuiltinTypes.STRING },
-          additionalProperties: {
-            refType: new MapType(BuiltinTypes.UNKNOWN),
+        },
+        annotations: {
+          [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+            refType: new ReferenceExpression(BuiltinTypes.UNKNOWN.elemID, BuiltinTypes.UNKNOWN),
           },
         },
         isSettings: true,

--- a/packages/adapter-components/test/elements/swagger/type_elements.test.ts
+++ b/packages/adapter-components/test/elements/swagger/type_elements.test.ts
@@ -100,7 +100,6 @@ describe('swagger_type_elements', () => {
         const pet = allTypes.Pet as ObjectType
         expect(pet).toBeInstanceOf(ObjectType)
         expect(_.mapValues(pet.fields, f => f.refType.elemID.getFullName())).toEqual({
-          additionalProperties: 'Map<unknown>',
           category: 'myAdapter.Category',
           id: 'number',
           name: 'serviceid',
@@ -138,19 +137,15 @@ describe('swagger_type_elements', () => {
           middleName: 'string',
           // ref to UserAdditional2 in swagger
           middleName2: 'string',
-          // additional properties
-          additionalProperties: 'Map<myAdapter.Order>',
         })
 
-        // additionalProperties explicit property combined with enabled additionalProperties
-        // should be undefined
         const food = allTypes.Food as ObjectType
         expect(food).toBeInstanceOf(ObjectType)
         expect(_.mapValues(food.fields, f => f.refType.elemID.getFullName())).toEqual({
           brand: 'string',
           id: 'number',
           storage: 'List<string>',
-          additionalProperties: 'Map<unknown>',
+          additionalProperties: 'myAdapter.Category',
         })
 
         return { allTypes, parsedConfigs }
@@ -189,7 +184,6 @@ describe('swagger_type_elements', () => {
         const location = allTypes.Location as ObjectType
         expect(location).toBeInstanceOf(ObjectType)
         expect(_.mapValues(location.fields, f => f.refType.elemID.name)).toEqual({
-          additionalProperties: 'Map<unknown>',
           name: 'serviceid',
           // address is defined as anyOf combining primitive and object - should use unknown
           address: 'unknown',
@@ -316,7 +310,6 @@ describe('swagger_type_elements', () => {
         // regular response type with reference
         const pet = allTypes.Pet__new
         expect(Object.keys((pet as ObjectType).fields).sort()).toEqual([
-          'additionalProperties',
           'category',
           'id',
           'name',

--- a/packages/adapter-components/test/fetch/element/openAPI/types.test.ts
+++ b/packages/adapter-components/test/fetch/element/openAPI/types.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import _ from 'lodash'
-import { ObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { OpenAPIDefinition } from '../../../../src/definitions/system/sources'
 import { generateOpenApiTypes } from '../../../../src/fetch/element/openAPI/types'
 import { queryWithDefault } from '../../../../src/definitions'
@@ -71,13 +71,15 @@ describe('generateOpenApiTypes', () => {
         const pet = createdTypes.Pet as ObjectType
         expect(pet).toBeInstanceOf(ObjectType)
         expect(_.mapValues(pet.fields, f => f.refType.elemID.getFullName())).toEqual({
-          additionalProperties: 'Map<unknown>',
           category: 'myAdapter.Category',
           id: 'number',
           name: 'string',
           photoUrls: 'List<string>',
           status: 'string',
           tags: 'List<myAdapter.Tag>',
+        })
+        expect(pet.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+          refType: expect.any(ReferenceExpression),
         })
         expect(pet.path).toEqual([ADAPTER_NAME, 'Types', 'Pet'])
 
@@ -98,7 +100,6 @@ describe('generateOpenApiTypes', () => {
           middleName: 'string',
           // ref to UserAdditional2 in swagger
           middleName2: 'string',
-          additionalProperties: 'Map<myAdapter.Order>',
         })
         expect(user.path).toEqual([ADAPTER_NAME, 'Types', 'Subtypes', 'User', 'User'])
 
@@ -108,7 +109,10 @@ describe('generateOpenApiTypes', () => {
           brand: 'string',
           id: 'number',
           storage: 'List<string>',
-          additionalProperties: 'Map<unknown>',
+          additionalProperties: 'myAdapter.Category',
+        })
+        expect(food.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+          refType: expect.any(ReferenceExpression),
         })
         expect(food.path).toEqual([ADAPTER_NAME, 'Types', 'Subtypes', 'Food', 'Food'])
 
@@ -129,10 +133,12 @@ describe('generateOpenApiTypes', () => {
         const location = createdTypes.Location as ObjectType
         expect(location).toBeInstanceOf(ObjectType)
         expect(_.mapValues(location.fields, f => f.refType.elemID.name)).toEqual({
-          additionalProperties: 'Map<unknown>',
           name: 'string',
           // address is defined as anyOf combining primitive and object - should use unknown
           address: 'unknown',
+        })
+        expect(location.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+          refType: expect.any(ReferenceExpression),
         })
       },
     )
@@ -160,13 +166,15 @@ describe('generateOpenApiTypes', () => {
       const pet = createdTypes.Pet as ObjectType
       expect(pet).toBeInstanceOf(ObjectType)
       expect(_.mapValues(pet.fields, f => f.refType.elemID.getFullName())).toEqual({
-        additionalProperties: 'Map<unknown>',
         category: 'myAdapter.Category',
         id: 'number',
         name: 'string',
         photoUrls: 'List<string>',
         status: 'string',
         tags: 'List<myAdapter.Tag>',
+      })
+      expect(pet.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+        refType: expect.any(ReferenceExpression),
       })
       expect(pet.path).toEqual([ADAPTER_NAME, 'Types', 'Pet'])
 
@@ -187,7 +195,9 @@ describe('generateOpenApiTypes', () => {
         middleName: 'string',
         // ref to UserAdditional2 in swagger
         middleName2: 'string',
-        additionalProperties: 'Map<myAdapter.Order>',
+      })
+      expect(user.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+        refType: expect.any(ReferenceExpression),
       })
       expect(user.path).toEqual([ADAPTER_NAME, 'Types', 'Subtypes', 'User', 'User'])
 
@@ -197,7 +207,7 @@ describe('generateOpenApiTypes', () => {
         brand: 'string',
         id: 'number',
         storage: 'List<string>',
-        additionalProperties: 'Map<unknown>',
+        additionalProperties: 'myAdapter.Category',
       })
       expect(food.path).toEqual([ADAPTER_NAME, 'Types', 'Subtypes', 'Food', 'Food'])
     })
@@ -214,7 +224,6 @@ describe('generateOpenApiTypes', () => {
       }
       const createdTypes = await generateOpenApiTypes({ adapterName: ADAPTER_NAME, openApiDefs, defQuery })
       const expectedPetFields = {
-        additionalProperties: 'Map<unknown>',
         category: 'myAdapter.Category',
         id: 'number',
         name: 'string',
@@ -248,13 +257,15 @@ describe('generateOpenApiTypes', () => {
       const renamedPet = createdTypes.RenamedPet as ObjectType
       expect(renamedPet).toBeInstanceOf(ObjectType)
       expect(_.mapValues(renamedPet.fields, f => f.refType.elemID.getFullName())).toEqual({
-        additionalProperties: 'Map<unknown>',
         category: 'myAdapter.Category',
         id: 'number',
         name: 'string',
         photoUrls: 'List<string>',
         status: 'string',
         tags: 'List<myAdapter.Tag>',
+      })
+      expect(renamedPet.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]).toEqual({
+        refType: expect.any(ReferenceExpression),
       })
     })
 

--- a/packages/adapter-utils/src/additional_properties.ts
+++ b/packages/adapter-utils/src/additional_properties.ts
@@ -43,7 +43,9 @@ export const setAdditionalPropertiesAnnotation = <T extends Element>(
 }
 
 const isAdditionalPropertiesAnnotation = (value: Value): value is AdditionalPropertiesAnnotation =>
-  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) && isReferenceExpression(value?.refType)
+  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) &&
+  isReferenceExpression(value?.refType) &&
+  value.refType.elemID.idType === 'type'
 
 export const extractAdditionalPropertiesField = (objType: ObjectType, name: string): Field | undefined => {
   const additionalProperties = objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]

--- a/packages/adapter-utils/src/additional_properties.ts
+++ b/packages/adapter-utils/src/additional_properties.ts
@@ -22,15 +22,15 @@ import {
   Element,
   ObjectType,
   Value,
-  TypeReference,
-  isTypeReference,
+  ReferenceExpression,
+  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 
 const log = logger(module)
 type AdditionalPropertiesAnnotation = {
-  refType: TypeReference
+  refType: ReferenceExpression
   annotations?: Record<string, Value>
 }
 
@@ -43,7 +43,7 @@ export const setAdditionalPropertiesAnnotation = <T extends Element>(
 }
 
 const isAdditionalPropertiesAnnotation = (value: Value): value is AdditionalPropertiesAnnotation =>
-  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) && isTypeReference(value?.refType)
+  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) && isReferenceExpression(value?.refType)
 
 export const extractAdditionalPropertiesField = (objType: ObjectType, name: string): Field | undefined => {
   const additionalProperties = objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]
@@ -51,7 +51,7 @@ export const extractAdditionalPropertiesField = (objType: ObjectType, name: stri
     return new Field(objType, name, BuiltinTypes.UNKNOWN)
   }
   if (isAdditionalPropertiesAnnotation(additionalProperties)) {
-    const type = additionalProperties.refType.getResolvedValueSync()
+    const type = additionalProperties.refType.value
     if (!isType(type)) {
       log.warn('Additional properties annotations refType reference is not a type')
       return undefined

--- a/packages/adapter-utils/src/additional_properties.ts
+++ b/packages/adapter-utils/src/additional_properties.ts
@@ -21,13 +21,16 @@ import {
   isType,
   Element,
   ObjectType,
-  TypeElement,
   Value,
+  TypeReference,
+  isTypeReference,
 } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 
+const log = logger(module)
 type AdditionalPropertiesAnnotation = {
-  refType: TypeElement
+  refType: TypeReference
   annotations?: Record<string, Value>
 }
 
@@ -40,7 +43,7 @@ export const setAdditionalPropertiesAnnotation = <T extends Element>(
 }
 
 const isAdditionalPropertiesAnnotation = (value: Value): value is AdditionalPropertiesAnnotation =>
-  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) && isType(value?.refType)
+  (value?.annotations === undefined || _.isPlainObject(value?.annotations)) && isTypeReference(value?.refType)
 
 export const extractAdditionalPropertiesField = (objType: ObjectType, name: string): Field | undefined => {
   const additionalProperties = objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]
@@ -48,7 +51,12 @@ export const extractAdditionalPropertiesField = (objType: ObjectType, name: stri
     return new Field(objType, name, BuiltinTypes.UNKNOWN)
   }
   if (isAdditionalPropertiesAnnotation(additionalProperties)) {
-    return new Field(objType, name, additionalProperties.refType, additionalProperties.annotations)
+    const type = additionalProperties.refType.getResolvedValueSync()
+    if (!isType(type)) {
+      log.warn('Additional properties annotations refType reference is not a type')
+      return undefined
+    }
+    return new Field(objType, name, type, additionalProperties.annotations)
   }
   // case additionalProperties = false
   return undefined

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1118,8 +1118,7 @@ export const getSubtypes = (types: ObjectType[], validateUniqueness = false): Ob
   const subtypes: Record<string, ObjectType> = {}
 
   const findSubtypes = (type: ObjectType): void => {
-    const additionalPropertiesRefType =
-      type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.getResolvedValueSync?.()
+    const additionalPropertiesRefType = type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.value
     const fieldsTypes = Object.values(type.fields).map(field => field.getTypeSync())
     const allSubtypes = isType(additionalPropertiesRefType)
       ? [...fieldsTypes, additionalPropertiesRefType]

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1118,8 +1118,13 @@ export const getSubtypes = (types: ObjectType[], validateUniqueness = false): Ob
   const subtypes: Record<string, ObjectType> = {}
 
   const findSubtypes = (type: ObjectType): void => {
-    Object.values(type.fields).forEach(field => {
-      const fieldContainerOrType = field.getTypeSync()
+    const additionalPropertiesRefType =
+      type.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]?.refType?.getResolvedValueSync?.()
+    const fieldsTypes = Object.values(type.fields).map(field => field.getTypeSync())
+    const allSubtypes = isType(additionalPropertiesRefType)
+      ? [...fieldsTypes, additionalPropertiesRefType]
+      : fieldsTypes
+    allSubtypes.forEach(fieldContainerOrType => {
       const fieldType = isContainerType(fieldContainerOrType)
         ? fieldContainerOrType.getInnerTypeSync()
         : fieldContainerOrType

--- a/packages/adapter-utils/test/additional_properties.test.ts
+++ b/packages/adapter-utils/test/additional_properties.test.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import {
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  ElemID,
+  Field,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
 import { extractAdditionalPropertiesField, setAdditionalPropertiesAnnotation } from '../src/additional_properties'
 
 describe('additional_properties', () => {
@@ -45,6 +53,16 @@ describe('additional_properties', () => {
         expect(extractAdditionalPropertiesField(baseObj, fieldName)).toEqual(
           new Field(baseObj, fieldName, BuiltinTypes.UNKNOWN),
         )
+      })
+    })
+    describe('when additional properties refType references something other than a type (should not happen)', () => {
+      it('should return undefined', () => {
+        const objType = baseObj.clone()
+        const someInst = new InstanceElement('mockInst', baseObj)
+        objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = {
+          refType: new ReferenceExpression(someInst.elemID, someInst),
+        }
+        expect(extractAdditionalPropertiesField(objType, fieldName)).toBeUndefined()
       })
     })
     describe('when additional properties annotation is false', () => {

--- a/packages/adapter-utils/test/additional_properties.test.ts
+++ b/packages/adapter-utils/test/additional_properties.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, TypeReference } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { extractAdditionalPropertiesField, setAdditionalPropertiesAnnotation } from '../src/additional_properties'
 
 describe('additional_properties', () => {
@@ -28,7 +28,7 @@ describe('additional_properties', () => {
         elemID: new ElemID('test', 'type.additionalProperties'),
         fields: { field: { refType: BuiltinTypes.STRING } },
       })
-      const annotation = { refType: new TypeReference(typeAdditionalProperties.elemID, typeAdditionalProperties) }
+      const annotation = { refType: new ReferenceExpression(typeAdditionalProperties.elemID, typeAdditionalProperties) }
       expect(
         setAdditionalPropertiesAnnotation(type, annotation).annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES],
       ).toEqual(annotation)

--- a/packages/adapter-utils/test/additional_properties.test.ts
+++ b/packages/adapter-utils/test/additional_properties.test.ts
@@ -14,17 +14,21 @@
  * limitations under the License.
  */
 
-import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, Field, ObjectType, TypeReference } from '@salto-io/adapter-api'
 import { extractAdditionalPropertiesField, setAdditionalPropertiesAnnotation } from '../src/additional_properties'
 
 describe('additional_properties', () => {
   describe('setAdditionalPropertiesAnnotation', () => {
     it('should set additional properties annotation', () => {
       const type = new ObjectType({
-        elemID: new ElemID('test'),
+        elemID: new ElemID('test', 'type'),
         fields: { field: { refType: BuiltinTypes.STRING } },
       })
-      const annotation = { refType: BuiltinTypes.STRING }
+      const typeAdditionalProperties = new ObjectType({
+        elemID: new ElemID('test', 'type.additionalProperties'),
+        fields: { field: { refType: BuiltinTypes.STRING } },
+      })
+      const annotation = { refType: new TypeReference(typeAdditionalProperties.elemID, typeAdditionalProperties) }
       expect(
         setAdditionalPropertiesAnnotation(type, annotation).annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES],
       ).toEqual(annotation)

--- a/packages/adapter-utils/test/additional_properties.test.ts
+++ b/packages/adapter-utils/test/additional_properties.test.ts
@@ -62,7 +62,7 @@ describe('additional_properties', () => {
           fields: { field: { refType: BuiltinTypes.STRING } },
         })
         objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = {
-          refType: additionalPropertiesObjType,
+          refType: new ReferenceExpression(additionalPropertiesObjType.elemID, additionalPropertiesObjType),
           annotations: { someUniqueAnnotation: 'unique' },
         }
         expect(extractAdditionalPropertiesField(objType, fieldName)).toEqual(

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_events.ts
@@ -92,7 +92,9 @@ export const transformNotificationEvent = (notificationEvent: NotificationEvent)
   notificationEvent.notifications?.forEach((notification: Values) => {
     notification.type = notification.notificationType
     delete notification.notificationType
-    delete notification.additionalProperties
+    delete notification.recipient
+    delete notification.field
+    delete notification.projectRole
     delete notification.user
     delete notification.id
   })

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -40,7 +40,6 @@ const NOT_FETCHED_POST_FUNCTION_TYPES = ['GenerateChangeHistoryFunction', 'Issue
 const FETCHED_ONLY_INITIAL_POST_FUNCTION = ['UpdateIssueStatusFunction', 'CreateCommentFunction', 'IssueStoreFunction']
 
 const transformProperties = (item: Status | Transition): void => {
-  item.properties = item.properties?.additionalProperties
   // This is not deployable and we get another property
   // of "jira.issue.editable" with the same value
   delete item.properties?.issueEditable

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -355,9 +355,10 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
       .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE)
       .filter(instance => instance.value.issueTypeMappings !== undefined)
       .forEach(instance => {
-        instance.value.items = Object.entries(instance.value.issueTypeMappings.additionalProperties ?? {}).map(
-          ([issueType, workflow]) => ({ workflow, issueType }),
-        )
+        instance.value.items = Object.entries(instance.value.issueTypeMappings ?? {}).map(([issueType, workflow]) => ({
+          workflow,
+          issueType,
+        }))
         delete instance.value.issueTypeMappings
       })
   },

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_structure.test.ts
@@ -50,7 +50,6 @@ describe('notificationSchemeStructureFilter', () => {
               notificationType: 'type',
               parameter: 'parameter',
               user: 'user',
-              additionalProperties: 'additionalProperties',
             },
           ],
         },

--- a/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/workflow_structure_filter.test.ts
@@ -197,18 +197,14 @@ describe('workflowStructureFilter', () => {
         statuses: [
           {
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'true',
-                issueEditable: true,
-              },
+              'jira.issue.editable': 'true',
+              issueEditable: true,
             },
           },
           {
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'false',
-                issueEditable: false,
-              },
+              'jira.issue.editable': 'false',
+              issueEditable: false,
             },
           },
           {},
@@ -237,19 +233,15 @@ describe('workflowStructureFilter', () => {
           {
             name: 'tran1',
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'true',
-                issueEditable: true,
-              },
+              'jira.issue.editable': 'true',
+              issueEditable: true,
             },
           },
           {
             name: 'tran2',
             properties: {
-              additionalProperties: {
-                'jira.issue.editable': 'false',
-                issueEditable: false,
-              },
+              'jira.issue.editable': 'false',
+              issueEditable: false,
             },
           },
           { name: 'tran3' },

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -113,9 +113,7 @@ describe('workflowScheme', () => {
     it('replace value of issueTypeMappings with items', async () => {
       const instance = new InstanceElement('instance', workflowSchemeType, {
         issueTypeMappings: {
-          additionalProperties: {
-            1234: 'workflow name',
-          },
+          1234: 'workflow name',
         },
       })
       await filter.onFetch?.([instance])

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -48,7 +48,6 @@ const orderPasswordPolicyRuleMethods = (instance: InstanceElement): void => {
   const methodsPath = instance.elemID.createNestedID(
     'actions',
     'selfServicePasswordReset',
-    'additionalProperties',
     'requirement',
     'primary',
     'methods',

--- a/packages/okta-adapter/src/filters/user_schema.ts
+++ b/packages/okta-adapter/src/filters/user_schema.ts
@@ -42,7 +42,7 @@ const log = logger(module)
 const { getTransformationConfigByType } = configUtils
 const { toBasicInstance } = elementUtils
 const { isDefined } = values
-const LINK_PATH = [LINKS_FIELD, 'additionalProperties', 'schema', 'href']
+const LINK_PATH = [LINKS_FIELD, 'schema', 'href']
 
 const getUserSchemaId = (instance: InstanceElement): string | undefined => {
   const url = _.get(instance.value, LINK_PATH)

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -68,20 +68,21 @@ describe('unorderedListsFilter', () => {
         actions: {
           selfServicePasswordReset: {
             access: 'ALLOW',
-            additionalProperties: {
-              requirement: {
-                primary: {
-                  methods: ['push', 'email', 'voice', 'sms'],
-                },
+            requirement: {
+              primary: {
+                methods: ['push', 'email', 'voice', 'sms'],
               },
             },
           },
         },
       })
       await filter.onFetch([policyRuleType, policyRuleInstance])
-      expect(
-        policyRuleInstance.value.actions.selfServicePasswordReset.additionalProperties.requirement.primary.methods,
-      ).toEqual(['email', 'push', 'sms', 'voice'])
+      expect(policyRuleInstance.value.actions.selfServicePasswordReset.requirement.primary.methods).toEqual([
+        'email',
+        'push',
+        'sms',
+        'voice',
+      ])
     })
 
     it('should do nothing if there are no methods defined', async () => {

--- a/packages/okta-adapter/test/filters/user_schema.test.ts
+++ b/packages/okta-adapter/test/filters/user_schema.test.ts
@@ -45,10 +45,8 @@ describe('userSchemaFilter', () => {
     id: 123,
     name: 'A',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/A123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/A123',
       },
     },
     default: false,
@@ -57,10 +55,8 @@ describe('userSchemaFilter', () => {
     id: 234,
     name: 'B',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/B123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/B123',
       },
     },
     default: false,
@@ -69,10 +65,8 @@ describe('userSchemaFilter', () => {
     id: 345,
     name: 'C',
     _links: {
-      additionalProperties: {
-        schema: {
-          href: 'https://okta.com/api/v1/meta/schemas/user/C123',
-        },
+      schema: {
+        href: 'https://okta.com/api/v1/meta/schemas/user/C123',
       },
     },
     default: true,

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -153,6 +153,11 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: ZuoraApiConfig['types'] = {
       dataField: 'definitions',
     },
   },
+  FieldsAdditionalProperties: {
+    transformation: {
+      fieldsToOmit: [],
+    },
+  },
   [CUSTOM_OBJECT_DEFINITION_TYPE]: {
     transformation: {
       idFields: ['type'],

--- a/packages/zuora-billing-adapter/src/filters/object_defs.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_defs.ts
@@ -114,7 +114,14 @@ const addRelationships = (
       }
       const refObjectNames = new Set<string>()
       // sort in order to keep relationship fields list stable
-      _.sortBy(relationships, 'object', ({ fields }) => Object.values(fields ?? {})[0]).forEach(rel => {
+      _.sortBy(
+        relationships,
+        'object',
+        ({ fields }) =>
+          Object.entries(fields ?? {})
+            .filter(([key]) => obj.fields[key] === undefined)
+            .map(([_key, value]) => value)[0],
+      ).forEach(rel => {
         const { cardinality, namespace, object, fields, recordConstraints: constraints, ...additionalDetails } = rel
         // the only cardinalities currently in use are oneToMany / manyToOne
         if (cardinality === 'oneToMany') {

--- a/packages/zuora-billing-adapter/src/filters/object_defs.ts
+++ b/packages/zuora-billing-adapter/src/filters/object_defs.ts
@@ -22,7 +22,6 @@ import {
   InstanceElement,
   ReferenceExpression,
   BuiltinTypes,
-  Values,
 } from '@salto-io/adapter-api'
 import { elements as elementUtils } from '@salto-io/adapter-components'
 import { pathNaclCase, naclCase, extendGeneratedDependencies, safeJsonStringify } from '@salto-io/adapter-utils'
@@ -50,7 +49,7 @@ import { isInstanceOfType } from '../element_utils'
 
 const log = logger(module)
 const { isDefined } = lowerdashValues
-const { toPrimitiveType, ADDITIONAL_PROPERTIES_FIELD } = elementUtils.swagger
+const { toPrimitiveType } = elementUtils.swagger
 const { mapValuesAsync } = promises.object
 // Check whether an element is a custom/standard object definition.
 // Only relevant before the object_defs filter is run.
@@ -63,11 +62,6 @@ const isStandardObjectInstance = (inst: InstanceElement): boolean =>
 const typeName = (inst: InstanceElement): string =>
   isStandardObjectInstance(inst) ? inst.elemID.name : `${inst.elemID.name}${CUSTOM_OBJECT_SUFFIX}`
 
-const flattenAdditionalProperties = (val: Values): Values => ({
-  ..._.omit(val, ADDITIONAL_PROPERTIES_FIELD),
-  ...val[ADDITIONAL_PROPERTIES_FIELD],
-})
-
 const createObjectFromInstance = async (inst: InstanceElement): Promise<ObjectType> => {
   const { schema, type } = inst.value
   const { properties, required, filterable, description, label } = schema
@@ -75,10 +69,10 @@ const createObjectFromInstance = async (inst: InstanceElement): Promise<ObjectTy
   const filterableFields = new Set(filterable)
   const obj = new ObjectType({
     elemID: new ElemID(ZUORA_BILLING, typeName(inst)),
-    fields: _.mapValues(flattenAdditionalProperties(properties), (prop, fieldName) => ({
+    fields: _.mapValues(properties, (prop, fieldName) => ({
       refType: toPrimitiveType(prop.type),
       annotations: {
-        ...flattenAdditionalProperties(prop),
+        ...prop,
         [REQUIRED]: requiredFields.has(fieldName),
         [FILTERABLE]: filterableFields.has(fieldName),
       },
@@ -95,7 +89,7 @@ const createObjectFromInstance = async (inst: InstanceElement): Promise<ObjectTy
       [METADATA_TYPE]: isStandardObjectInstance(inst) ? STANDARD_OBJECT : CUSTOM_OBJECT,
       [LABEL]: label,
       [DESCRIPTION]: description,
-      [INTERNAL_ID]: inst.value.additionalProperties?.Id,
+      [INTERNAL_ID]: inst.value.Id,
       [OBJECT_TYPE]: type,
     },
     // id name changes are currently not allowed so it's ok to use the elem id
@@ -120,60 +114,58 @@ const addRelationships = (
       }
       const refObjectNames = new Set<string>()
       // sort in order to keep relationship fields list stable
-      _.sortBy(relationships, 'object', ({ fields }) => Object.values(fields.additionalProperties ?? {})[0]).forEach(
-        rel => {
-          const { cardinality, namespace, object, fields, recordConstraints: constraints, ...additionalDetails } = rel
-          // the only cardinalities currently in use are oneToMany / manyToOne
-          if (cardinality === 'oneToMany') {
-            // each relationship appears in both directions, so it's enough to look at manyToOne
+      _.sortBy(relationships, 'object', ({ fields }) => Object.values(fields ?? {})[0]).forEach(rel => {
+        const { cardinality, namespace, object, fields, recordConstraints: constraints, ...additionalDetails } = rel
+        // the only cardinalities currently in use are oneToMany / manyToOne
+        if (cardinality === 'oneToMany') {
+          // each relationship appears in both directions, so it's enough to look at manyToOne
+          return
+        }
+        const referencedObjectName = namespace === 'default' ? `${object}${CUSTOM_OBJECT_SUFFIX}` : object
+        refObjectNames.add(referencedObjectName)
+        Object.entries(fields ?? {}).forEach(([src, target]) => {
+          const srcField = obj.fields[src]
+          if (srcField === undefined) {
+            log.warn('Could not find field %s in object %s, not adding relationship', src, name)
             return
           }
-          const referencedObjectName = namespace === 'default' ? `${object}${CUSTOM_OBJECT_SUFFIX}` : object
-          refObjectNames.add(referencedObjectName)
-          Object.entries(fields.additionalProperties ?? {}).forEach(([src, target]) => {
-            const srcField = obj.fields[src]
-            if (srcField === undefined) {
-              log.warn('Could not find field %s in object %s, not adding relationship', src, name)
-              return
-            }
-            const targetObj = findType(referencedObjectName)
-            const targetField =
-              _.isString(target) && targetObj?.fields[target]
-                ? new ReferenceExpression(targetObj.fields[target].elemID)
-                : `${referencedObjectName}.${target}`
-            // we assume each field can be listed in at most one relatioship, so it's ok to override
-            // these annotations
-            if (srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] !== undefined) {
-              log.info('Field %s already has referenceTo defined, extending', srcField.elemID.getFullName())
-            }
-            srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] = [
-              ...(srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] ?? []),
-              targetField,
-            ]
-            if (
-              [FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY, FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS].some(
-                anno => srcField.annotations[anno] !== undefined,
-              )
-            ) {
-              log.warn(
-                'Field %s already has annotation values %s, overriding',
-                srcField.elemID.getFullName(),
-                safeJsonStringify(
-                  _.pick(srcField.annotations, [
-                    FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY,
-                    FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS,
-                  ]),
-                ),
-              )
-            }
-            srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY] = cardinality
-            srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS] = constraints
-          })
-          if (!_.isEmpty(additionalDetails)) {
-            log.warn('Found unexpected additional details on type %s relationship', name)
+          const targetObj = findType(referencedObjectName)
+          const targetField =
+            _.isString(target) && targetObj?.fields[target]
+              ? new ReferenceExpression(targetObj.fields[target].elemID)
+              : `${referencedObjectName}.${target}`
+          // we assume each field can be listed in at most one relatioship, so it's ok to override
+          // these annotations
+          if (srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] !== undefined) {
+            log.info('Field %s already has referenceTo defined, extending', srcField.elemID.getFullName())
           }
-        },
-      )
+          srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] = [
+            ...(srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.REFERENCE_TO] ?? []),
+            targetField,
+          ]
+          if (
+            [FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY, FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS].some(
+              anno => srcField.annotations[anno] !== undefined,
+            )
+          ) {
+            log.warn(
+              'Field %s already has annotation values %s, overriding',
+              srcField.elemID.getFullName(),
+              safeJsonStringify(
+                _.pick(srcField.annotations, [
+                  FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY,
+                  FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS,
+                ]),
+              ),
+            )
+          }
+          srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.CARDINALITY] = cardinality
+          srcField.annotations[FIELD_RELATIONSHIP_ANNOTATIONS.RECORD_CONSTRAINTS] = constraints
+        })
+        if (!_.isEmpty(additionalDetails)) {
+          log.warn('Found unexpected additional details on type %s relationship', name)
+        }
+      })
       if (refObjectNames.size > 0) {
         extendGeneratedDependencies(
           obj,

--- a/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
+++ b/packages/zuora-billing-adapter/src/filters/workflow_and_task_references.ts
@@ -46,7 +46,7 @@ const log = logger(module)
 const { flatMapAsync, toAsyncIterable } = collections.asynciterable
 
 const WORKFLOW_PARAMS_REF = 'Workflow'
-const WORKFLOW_PARAMS_PATH = ['additionalProperties', 'parameters', 'fields']
+const WORKFLOW_PARAMS_PATH = ['parameters', 'fields']
 const TASK_PARAM_FIELDS_PATH = ['parameters', 'fields']
 const TASK_REFS_REGEX = /(\w+\.)*(?<typeName>\w+)\.(?<fieldName>\w+)/g
 

--- a/packages/zuora-billing-adapter/test/adapter.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter.test.ts
@@ -22,11 +22,11 @@ import {
   InstanceElement,
   isInstanceElement,
   ListType,
-  MapType,
   ObjectType,
   isObjectType,
   CORE_ANNOTATIONS,
   ProgressReporter,
+  ReferenceExpression,
 } from '@salto-io/adapter-api'
 import * as adapterComponents from '@salto-io/adapter-components'
 import { elements as elementUtils } from '@salto-io/adapter-components'
@@ -67,9 +67,10 @@ const getObjectDefTypes = (): Record<string, ObjectType> => {
   })
   const customObjectDefinitionsType = new ObjectType({
     elemID: new ElemID(ZUORA_BILLING, 'CustomObjectDefinitions'),
-    fields: {
-      additionalProperties: {
-        refType: new MapType(customObjectDefType),
+    fields: {},
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: {
+        refType: new ReferenceExpression(customObjectDefType.elemID, customObjectDefType),
       },
     },
   })

--- a/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/object_defs.test.ts
@@ -46,9 +46,7 @@ describe('Object defs filter', () => {
     })
 
     const account = new InstanceElement('account', standardObjectDefType, {
-      additionalProperties: {
-        type: 'account',
-      },
+      type: 'account',
       schema: {
         $schema: 'http://json-schema.org/draft-04/schema#',
         title: 'Account',
@@ -63,19 +61,13 @@ describe('Object defs filter', () => {
             type: 'string',
             format: 'uuid',
           },
-          additionalProperties: {
-            AccountNumber: {
-              type: 'string',
-              additionalProperties: {
-                maxLength: 512,
-              },
-            },
-            Name: {
-              type: 'string',
-              additionalProperties: {
-                maxLength: 512,
-              },
-            },
+          AccountNumber: {
+            type: 'string',
+            maxLength: 512,
+          },
+          Name: {
+            type: 'string',
+            maxLength: 512,
           },
         },
         relationships: [
@@ -84,9 +76,7 @@ describe('Object defs filter', () => {
             namespace: 'default',
             object: 'Custom1',
             fields: {
-              additionalProperties: {
-                Id: 'AccountId__c',
-              },
+              Id: 'AccountId__c',
             },
             recordConstraints: {
               create: {
@@ -98,23 +88,19 @@ describe('Object defs filter', () => {
       },
     })
     const accountingcode = new InstanceElement('AccountingCode', standardObjectDefType, {
-      additionalProperties: {
-        type: 'AccountingCode',
-      },
+      type: 'AccountingCode',
       schema: {
         $schema: 'http://json-schema.org/draft-04/schema#',
         title: 'AccountingCode',
         type: 'object',
         required: ['Name', 'Id'],
         properties: {
-          additionalProperties: {
-            deleted: {
-              type: 'boolean',
-            },
-            Category: {
-              type: 'string',
-              maxLength: 512,
-            },
+          deleted: {
+            type: 'boolean',
+          },
+          Category: {
+            type: 'string',
+            maxLength: 512,
           },
           Id: {
             type: 'string',
@@ -124,10 +110,8 @@ describe('Object defs filter', () => {
       },
     })
     const Custom1 = new InstanceElement('Custom1', customObjectDefType, {
-      additionalProperties: {
-        Id: 'some id',
-        type: 'Custom1',
-      },
+      Id: 'some id',
+      type: 'Custom1',
       CreatedById: 'id1',
       UpdatedById: 'id1',
       CreatedDate: '2021-01-01T01:23:45.678Z',
@@ -136,44 +120,36 @@ describe('Object defs filter', () => {
         object: 'Custom1',
         label: 'Custom1',
         properties: {
-          additionalProperties: {
-            field1__c: {
-              format: 'uuid',
-              label: 'field1 label',
-              origin: 'custom',
-              type: 'string',
-              additionalProperties: {
-                description: 'some description',
-              },
-            },
-            field2__c: {
-              label: 'field2 label',
-              type: 'number',
-            },
-            SubscriptionId__c: {
-              format: 'uuid',
-              label: 'Subscription',
-              origin: 'custom',
-              type: 'string',
-              additionalProperties: {
-                description: 'The subscription that is associated with the record.',
-              },
-            },
-            AccountId__c: {
-              format: 'uuid',
-              label: 'Account',
-              origin: 'custom',
-              type: 'string',
-              additionalProperties: {
-                description: 'The account that is associated with the record.',
-              },
-            },
-            Custom2Id__c: {
-              format: 'uuid',
-              label: 'Custom2',
-              origin: 'custom',
-              type: 'string',
-            },
+          field1__c: {
+            format: 'uuid',
+            label: 'field1 label',
+            origin: 'custom',
+            type: 'string',
+            description: 'some description',
+          },
+          field2__c: {
+            label: 'field2 label',
+            type: 'number',
+          },
+          SubscriptionId__c: {
+            format: 'uuid',
+            label: 'Subscription',
+            origin: 'custom',
+            type: 'string',
+            description: 'The subscription that is associated with the record.',
+          },
+          AccountId__c: {
+            format: 'uuid',
+            label: 'Account',
+            origin: 'custom',
+            type: 'string',
+            description: 'The account that is associated with the record.',
+          },
+          Custom2Id__c: {
+            format: 'uuid',
+            label: 'Custom2',
+            origin: 'custom',
+            type: 'string',
           },
           Id: {
             format: 'uuid',
@@ -191,9 +167,7 @@ describe('Object defs filter', () => {
             namespace: 'com_zuora',
             object: 'subscription',
             fields: {
-              additionalProperties: {
-                SubscriptionId__c: 'Id',
-              },
+              SubscriptionId__c: 'Id',
             },
             recordConstraints: {
               create: {
@@ -206,9 +180,7 @@ describe('Object defs filter', () => {
             namespace: 'com_zuora',
             object: 'account',
             fields: {
-              additionalProperties: {
-                AccountId__c: 'Id',
-              },
+              AccountId__c: 'Id',
             },
             recordConstraints: {
               create: {
@@ -221,9 +193,7 @@ describe('Object defs filter', () => {
             namespace: 'com_zuora',
             object: 'account',
             fields: {
-              additionalProperties: {
-                Id: 'Id',
-              },
+              Id: 'Id',
             },
           },
           {
@@ -231,9 +201,7 @@ describe('Object defs filter', () => {
             namespace: 'default',
             object: 'Custom2',
             fields: {
-              additionalProperties: {
-                Custom2Id__c: 'Id',
-              },
+              Custom2Id__c: 'Id',
             },
             recordConstraints: {
               create: {
@@ -245,10 +213,8 @@ describe('Object defs filter', () => {
       },
     })
     const Custom2 = new InstanceElement('Custom2', customObjectDefType, {
-      additionalProperties: {
-        Id: 'some other id',
-        type: 'Custom2',
-      },
+      Id: 'some other id',
+      type: 'Custom2',
       CreatedById: 'id1',
       UpdatedById: 'id1',
       CreatedDate: '2021-01-01T01:23:45.678Z',
@@ -357,6 +323,7 @@ describe('Object defs filter', () => {
       })
       expect(account.annotations).toEqual({
         metadataType: 'StandardObject',
+        objectType: 'account',
       })
     })
     it('should create custom objects and fields correctly, with the __c suffix', () => {
@@ -441,6 +408,7 @@ describe('Object defs filter', () => {
         id: 'some id',
         label: 'Custom1',
         metadataType: 'CustomObject',
+        objectType: 'Custom1',
       })
       // eslint-disable-next-line no-underscore-dangle
       const objRefs = custom1.annotations._generated_dependencies as DetailedDependency[]

--- a/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
+++ b/packages/zuora-billing-adapter/test/filters/workflow_and_task_references.test.ts
@@ -64,37 +64,35 @@ describe('Workflow and task references filter', () => {
       name: 'workflow 1',
       description: 'do things',
       type: 'Workflow::Setup',
-      additionalProperties: {
-        parameters: {
-          fields: [
-            {
-              index: '0',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'BillRunID',
-              field_name: 'Id',
-              object_name: 'Billingrun',
-            },
-            {
-              index: '1',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'workflow_param',
-              field_name: 'param',
-              object_name: 'Workflow',
-            },
-          ],
-        },
-        ondemand_trigger: true,
-        callout_trigger: true,
-        scheduled_trigger: false,
-        status: 'Active',
-        css: {
-          top: '40px',
-          left: '35px',
-        },
+      parameters: {
+        fields: [
+          {
+            index: '0',
+            default: '',
+            datatype: 'Text',
+            required: true,
+            callout_id: 'BillRunID',
+            field_name: 'Id',
+            object_name: 'Billingrun',
+          },
+          {
+            index: '1',
+            default: '',
+            datatype: 'Text',
+            required: true,
+            callout_id: 'workflow_param',
+            field_name: 'param',
+            object_name: 'Workflow',
+          },
+        ],
+      },
+      ondemand_trigger: true,
+      callout_trigger: true,
+      scheduled_trigger: false,
+      status: 'Active',
+      css: {
+        top: '40px',
+        left: '35px',
       },
       notifications: {
         emails: [],
@@ -111,15 +109,13 @@ describe('Workflow and task references filter', () => {
       name: 'workflow 2',
       description: 'do other things',
       type: 'Workflow::Setup',
-      additionalProperties: {
-        ondemand_trigger: true,
-        callout_trigger: true,
-        scheduled_trigger: false,
-        status: 'Active',
-        css: {
-          top: '40px',
-          left: '35px',
-        },
+      ondemand_trigger: true,
+      callout_trigger: true,
+      scheduled_trigger: false,
+      status: 'Active',
+      css: {
+        top: '40px',
+        left: '35px',
       },
       notifications: {
         emails: [],
@@ -136,46 +132,44 @@ describe('Workflow and task references filter', () => {
       name: 'workflow 3',
       description: 'do things',
       type: 'Workflow::Setup',
-      additionalProperties: {
-        parameters: {
-          fields: [
-            {
-              index: '0',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'BillRunID',
-              field_name: 'Id',
-              object_name: 'invalid',
-            },
-            {
-              index: '1',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: '',
-              field_name: '',
-              not_object_name: '',
-            },
-            {
-              index: '2',
-              default: '',
-              datatype: 'Text',
-              required: true,
-              callout_id: 'BillRunID',
-              field_name: 'not_a_field',
-              object_name: 'Billingrun',
-            },
-          ],
-        },
-        ondemand_trigger: true,
-        callout_trigger: true,
-        scheduled_trigger: false,
-        status: 'Active',
-        css: {
-          top: '40px',
-          left: '35px',
-        },
+      parameters: {
+        fields: [
+          {
+            index: '0',
+            default: '',
+            datatype: 'Text',
+            required: true,
+            callout_id: 'BillRunID',
+            field_name: 'Id',
+            object_name: 'invalid',
+          },
+          {
+            index: '1',
+            default: '',
+            datatype: 'Text',
+            required: true,
+            callout_id: '',
+            field_name: '',
+            not_object_name: '',
+          },
+          {
+            index: '2',
+            default: '',
+            datatype: 'Text',
+            required: true,
+            callout_id: 'BillRunID',
+            field_name: 'not_a_field',
+            object_name: 'Billingrun',
+          },
+        ],
+      },
+      ondemand_trigger: true,
+      callout_trigger: true,
+      scheduled_trigger: false,
+      status: 'Active',
+      css: {
+        top: '40px',
+        left: '35px',
       },
       notifications: {
         emails: [],
@@ -396,7 +390,7 @@ describe('Workflow and task references filter', () => {
       const workflows = elements.filter(isInstanceElement).filter(e => e.elemID.typeName === WORKFLOW_DETAILED_TYPE)
       expect(workflows).toHaveLength(3)
 
-      const wf1Param0 = workflows[0].value.additionalProperties.parameters.fields[0]
+      const wf1Param0 = workflows[0].value.parameters.fields[0]
       expect(wf1Param0.object_name).toBeInstanceOf(ReferenceExpression)
       expect((wf1Param0.object_name as ReferenceExpression).elemID.getFullName()).toEqual('zuora_billing.Billingrun')
       expect(wf1Param0.field_name).toBeInstanceOf(ReferenceExpression)
@@ -426,7 +420,7 @@ describe('Workflow and task references filter', () => {
         'zuora_billing.Refund.field.Id',
         'zuora_billing.Refund.field.ReasonCode',
         'zuora_billing.Refund.field.RefundDate',
-        'zuora_billing.Workflow.instance.wf1.additionalProperties.parameters.fields',
+        'zuora_billing.Workflow.instance.wf1.parameters.fields',
       ])
 
       // eslint-disable-next-line no-underscore-dangle
@@ -438,7 +432,7 @@ describe('Workflow and task references filter', () => {
       expect(elements.length).toEqual(origElements.length)
       const wf3 = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'wf3')[0]
 
-      const wf3Param0 = wf3.value.additionalProperties.parameters.fields[0]
+      const wf3Param0 = wf3.value.parameters.fields[0]
       expect(wf3Param0.object_name).not.toBeInstanceOf(ReferenceExpression)
       expect(wf3Param0.object_name).toEqual('invalid')
     })


### PR DESCRIPTION
- Stop creating additionalProperties field upon fetch
- Save reference to a type in _additional_properties annotation


---



---

_Release Notes_: 

_Jira_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

_Okta_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)

_Zuora_billing_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch

_Stripe_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch

---

_User Notifications_: 

_Jira_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Notification Events, Workflows and maybe more)

_Okta_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch (types to be affected: Users, GroupRule, PasswordPolicyRule and maybe more)

_Zuora_billing_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch

_Stripe_Adapter_:
Instances with additionalProperties map field will be flatten upon fetch

