### PR TITLE
SALTO-5667: Omit required field from AccessPolicyRule constraints when it's optional

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -67,6 +67,7 @@ import standardRolesFilter from './filters/standard_roles'
 import userTypeFilter from './filters/user_type'
 import userSchemaFilter from './filters/user_schema'
 import oktaExpressionLanguageFilter from './filters/expression_language'
+import accessPolicyRuleConstraintsFilter from './filters/access_policy_rule_constraints'
 import defaultPolicyRuleDeployment from './filters/default_rule_deployment'
 import authorizationRuleFilter from './filters/authorization_server_rule'
 import privateApiDeployFilter from './filters/private_api_deploy'
@@ -118,6 +119,7 @@ const DEFAULT_FILTERS = [
   oktaExpressionLanguageFilter,
   profileEnrollmentAttributesFilter,
   addImportantValues,
+  accessPolicyRuleConstraintsFilter,
   defaultPolicyRuleDeployment,
   schemaFieldsRemovalFilter,
   appLogoFilter,

--- a/packages/okta-adapter/src/filters/access_policy_rule_constraints.ts
+++ b/packages/okta-adapter/src/filters/access_policy_rule_constraints.ts
@@ -1,0 +1,114 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Joi from 'joi'
+import {
+  Change,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  Values,
+} from '@salto-io/adapter-api'
+import { createSchemeGuard, resolvePath } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { ACCESS_POLICY_RULE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+const AUTHENTICATOR_CONSTRAINTS_PATH = ['actions', 'appSignOn', 'verificationMethod', 'constraints']
+
+type ConstraintsEntry = {
+  knowledge: Values
+  possession: Values
+}
+const CONSTRAINTS_ENTRY_SCHEMA = Joi.object({
+  knowledge: Joi.object(),
+  possession: Joi.object(),
+}).unknown(true)
+
+const CONSTRAINTS_ARRAY_SCHEMA = Joi.array().items(CONSTRAINTS_ENTRY_SCHEMA).required()
+
+const isConstraintsArray = createSchemeGuard<ConstraintsEntry[]>(
+  CONSTRAINTS_ARRAY_SCHEMA,
+  'Received an invalid constraints',
+)
+
+/**
+ * Removes the `required` field from `possession` or `knowledge` object when it is optionl.
+ * By default, this field is true. If the `knowledge` or `possession` constraint has values for excludedAuthenticationMethods then the required value is false.
+ * (source: https://developer.okta.com/docs/reference/api/policy/#constraints)
+ */
+const filter: FilterCreator = () => {
+  const originalChangeByElemID: Record<string, InstanceElement> = {}
+  return {
+    name: 'accessPolicyRuleConstraintsFilter',
+    preDeploy: async (changes: Change<InstanceElement>[]) => {
+      changes
+        .filter(isAdditionOrModificationChange)
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+        .forEach(async instance => {
+          originalChangeByElemID[instance.elemID.getFullName()] = instance.clone()
+          const constraintsArray = resolvePath(
+            instance,
+            instance.elemID.createNestedID(...AUTHENTICATOR_CONSTRAINTS_PATH),
+          )
+          if (isConstraintsArray(constraintsArray)) {
+            constraintsArray.forEach(constraint => {
+              const { possession, knowledge } = constraint
+              if (
+                possession?.additionalProperties?.required === true &&
+                possession?.excludedAuthenticationMethods === undefined
+              ) {
+                log.debug(
+                  'omitting "required" field from possession object %o in instance %s',
+                  possession,
+                  instance.elemID.getFullName(),
+                )
+                delete possession.additionalProperties.required
+              }
+              if (
+                knowledge?.additionalProperties?.required === true &&
+                knowledge?.excludedAuthenticationMethods === undefined
+              ) {
+                log.debug(
+                  'omitting "required" field from knowledge object %o in instance %s',
+                  knowledge,
+                  instance.elemID.getFullName(),
+                )
+                delete knowledge.additionalProperties.required
+              }
+            })
+          }
+        })
+    },
+    onDeploy: async (changes: Change<InstanceElement>[]) => {
+      changes
+        .filter(isAdditionOrModificationChange)
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+        .forEach(async instance => {
+          if (originalChangeByElemID[instance.elemID.getFullName()] !== undefined) {
+            instance.value = originalChangeByElemID[instance.elemID.getFullName()].value
+          }
+        })
+    },
+  }
+}
+
+export default filter

--- a/packages/okta-adapter/src/filters/access_policy_rule_constraints.ts
+++ b/packages/okta-adapter/src/filters/access_policy_rule_constraints.ts
@@ -103,8 +103,9 @@ const filter: FilterCreator = () => {
         .filter(isInstanceElement)
         .filter(instance => instance.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
         .forEach(async instance => {
+          // restore actions to its original value
           if (originalChangeByElemID[instance.elemID.getFullName()] !== undefined) {
-            instance.value = originalChangeByElemID[instance.elemID.getFullName()].value
+            instance.value.actions = originalChangeByElemID[instance.elemID.getFullName()].value.actions
           }
         })
     },

--- a/packages/okta-adapter/test/filters/access_policy_rule_constraints.test.ts
+++ b/packages/okta-adapter/test/filters/access_policy_rule_constraints.test.ts
@@ -1,0 +1,190 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType, toChange, getChangeData, isInstanceElement } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { getFilterParams } from '../utils'
+import accessPolicyRuleConstraintsFilter from '../../src/filters/access_policy_rule_constraints'
+import { ACCESS_POLICY_RULE_TYPE_NAME, OKTA } from '../../src/constants'
+
+describe('accessPolicyRuleConstraintsFilter', () => {
+  type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+  let filter: FilterType
+  const ruleType = new ObjectType({
+    elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME),
+  })
+  const baseRuleInstace = new InstanceElement('rule', ruleType, {
+    name: 'rule',
+    status: 'ACTIVE',
+    actions: {
+      appSignOn: {
+        verificationMethod: {},
+      },
+    },
+  })
+  describe('preDeploy', () => {
+    it('should remove "required" field from the constraints if it is true and "excludedAuthenticationMethods" is not configured', async () => {
+      const rule = baseRuleInstace.clone()
+      rule.value.actions.appSignOn.verificationMethod.constraints = [
+         {
+            knowledge: { reauthenticateIn: 'PT0S', additionalProperties: { required: true } },
+            possession: { deviceBound: 'REQUIRED', additionalProperties: { required: true } },
+         },
+         { possession: { additionalProperties: { required: true }, type: ['password'] } },
+       ]
+      const changes = [toChange({ after: rule })]
+      filter = accessPolicyRuleConstraintsFilter(getFilterParams()) as typeof filter
+      await filter.preDeploy(changes)
+      const inst = changes.map(getChangeData).filter(isInstanceElement)
+      expect(inst[0].value).toEqual({
+        name: 'rule',
+        status: 'ACTIVE',
+        actions: {
+          appSignOn: {
+            verificationMethod: {
+              constraints: [
+                {
+                  knowledge: { reauthenticateIn: 'PT0S', additionalProperties: {} },
+                  possession: { deviceBound: 'REQUIRED', additionalProperties: {} },
+                },
+                { possession: { additionalProperties: {}, type: ['password'] } },
+              ],
+            },
+          },
+        },
+      })
+    })
+    it('should not remove "required" field from the constraints if it is true but "excludedAuthenticationMethods" is configured', async () => {
+      const rule = baseRuleInstace.clone()
+      rule.value.actions.appSignOn.verificationMethod.constraints = [
+        {
+          knowledge: {
+            reauthenticateIn: 'PT0S',
+            additionalProperties: { required: true },
+            excludedAuthenticationMethods: [],
+          },
+          possession: { deviceBound: 'REQUIRED', additionalProperties: { required: true } },
+        },
+        {
+          possession: {
+            additionalProperties: { required: true },
+            type: ['password'],
+            excludedAuthenticationMethods: [{ key: 'google_otp' }],
+          },
+        },
+      ]
+      const changes = [toChange({ after: rule })]
+      filter = accessPolicyRuleConstraintsFilter(getFilterParams()) as typeof filter
+      await filter.preDeploy(changes)
+      const inst = changes.map(getChangeData).filter(isInstanceElement)
+      expect(inst[0].value).toEqual({
+        name: 'rule',
+        status: 'ACTIVE',
+        actions: {
+          appSignOn: {
+            verificationMethod: {
+              constraints: [
+                {
+                  knowledge: {
+                    reauthenticateIn: 'PT0S',
+                    additionalProperties: { required: true },
+                    excludedAuthenticationMethods: [],
+                  },
+                  possession: { deviceBound: 'REQUIRED', additionalProperties: {} },
+                },
+                {
+                  possession: {
+                    additionalProperties: { required: true },
+                    type: ['password'],
+                    excludedAuthenticationMethods: [{ key: 'google_otp' }],
+                  },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+    it('should not remove "required" field from the constraints if it is set to false', async () => {
+      const rule = baseRuleInstace.clone()
+      rule.value.actions.appSignOn.verificationMethod.constraints = [
+        {
+          knowledge: { reauthenticateIn: 'PT0S', additionalProperties: { required: false } },
+          possession: { deviceBound: 'REQUIRED', additionalProperties: { required: false } },
+        },
+      ]
+      const changes = [toChange({ after: rule })]
+      filter = accessPolicyRuleConstraintsFilter(getFilterParams()) as typeof filter
+      await filter.preDeploy(changes)
+      const inst = changes.map(getChangeData).filter(isInstanceElement)
+      expect(inst[0].value).toEqual({
+        name: 'rule',
+        status: 'ACTIVE',
+        actions: {
+          appSignOn: {
+            verificationMethod: {
+              constraints: [
+                {
+                  knowledge: { reauthenticateIn: 'PT0S', additionalProperties: { required: false } },
+                  possession: { deviceBound: 'REQUIRED', additionalProperties: { required: false } },
+                },
+              ],
+            },
+          },
+        },
+      })
+    })
+    it('should do nothing if "required" field is missing', async () => {
+      const rule = baseRuleInstace.clone()
+      rule.value.actions.appSignOn.verificationMethod.constraints = [
+        { knowledge: { reauthenticateIn: 'PT0S' } },
+        { possession: { deviceBound: 'REQUIRED' } },
+      ]
+      const changes = [toChange({ after: rule })]
+      filter = accessPolicyRuleConstraintsFilter(getFilterParams()) as typeof filter
+      await filter.preDeploy(changes)
+      const inst = changes.map(getChangeData).filter(isInstanceElement)
+      expect(inst[0].value).toEqual({
+        name: 'rule',
+        status: 'ACTIVE',
+        actions: {
+          appSignOn: {
+            verificationMethod: {
+              constraints: [{ knowledge: { reauthenticateIn: 'PT0S' } }, { possession: { deviceBound: 'REQUIRED' } }],
+            },
+          },
+        },
+      })
+    })
+  })
+
+  describe('onDeploy', () => {
+    it('should restore instance values', async () => {
+      const rule = baseRuleInstace.clone()
+      rule.value.actions.appSignOn.verificationMethod.constraints = [
+         {
+            knowledge: { reauthenticateIn: 'PT0S', additionalProperties: { required: true } },
+            possession: { deviceBound: 'REQUIRED', additionalProperties: { required: true } },
+         },
+         { possession: { additionalProperties: { required: true }, type: ['password'] } },
+       ]
+      const changes = [toChange({ after: rule })]
+      await filter.preDeploy(changes) // pre deploy sets the mappings
+      await filter.onDeploy(changes)
+      const instances = changes.map(getChangeData).filter(isInstanceElement)
+      expect(instances[0].value).toEqual(rule.value)
+    })
+  })
+})

--- a/packages/okta-adapter/test/filters/access_policy_rule_constraints.test.ts
+++ b/packages/okta-adapter/test/filters/access_policy_rule_constraints.test.ts
@@ -258,10 +258,10 @@ describe('accessPolicyRuleConstraintsFilter', () => {
       const rule = baseRuleInstace.clone()
       rule.value.actions.appSignOn.verificationMethod.constraints = [
         {
-          knowledge: { reauthenticateIn: 'PT0S', required: true},
+          knowledge: { reauthenticateIn: 'PT0S', required: true },
           possession: { deviceBound: 'REQUIRED', required: true },
         },
-        { possession: { required: true , type: ['password'] } },
+        { possession: { required: true, type: ['password'] } },
       ]
       const changes = [toChange({ after: rule })]
       await filter.preDeploy(changes) // pre deploy sets the mappings


### PR DESCRIPTION
Fix issue with deployment of AccessPolicyRule

---

the `required` field is optional and should be set to true when no authentication method is excluded.
The filter omits this field when it optional in order to handle misalignments in envs (when source env supports this but target env doesn't)

---
_Release Notes_: 

_Okta_Adapter_:
- Fix bug in deployment of Access Policy Rules with `required` field set

---
_User Notifications_: 
None