### PR TITLE
SALTO-5677: Add contextStrategyLookup field to ReferenceDefinitions

### DIFF
--- a/packages/adapter-components/src/definitions/system/api.ts
+++ b/packages/adapter-components/src/definitions/system/api.ts
@@ -25,6 +25,7 @@ export type APIDefinitionsOptions = {
   paginationOptions?: string
   customNameMappingOptions?: string
   additionalAction?: string
+  contextStrategies?: string
 }
 
 export type ResolveClientOptionsType<Options extends Pick<APIDefinitionsOptions, 'clientOptions'>> =
@@ -39,6 +40,9 @@ export type ResolveCustomNameMappingOptionsType<
 
 export type ResolveAdditionalActionType<Options extends Pick<APIDefinitionsOptions, 'additionalAction'>> =
   Options['additionalAction'] extends string ? Options['additionalAction'] : never
+
+export type ResolveContextStrategiesType<Options extends Pick<APIDefinitionsOptions, 'contextStrategies'>> =
+  Options['contextStrategies'] extends string ? Options['contextStrategies'] : never
 
 export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   // sources are processed and used to populate initial options for clients and components, in order of definition,
@@ -61,7 +65,7 @@ export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   pagination: Record<ResolvePaginationOptionsType<Options>, PaginationDefinitions<ResolveClientOptionsType<Options>>>
 
   // rules for reference extraction (during fetch) and serialization (during deploy)
-  references?: ReferenceDefinitions
+  references?: ReferenceDefinitions<ResolveContextStrategiesType<Options>>
 
   fetch?: FetchApiDefinitions<Options>
   deploy?: DeployApiDefinitions<ResolveAdditionalActionType<Options>, ResolveClientOptionsType<Options>>

--- a/packages/adapter-components/src/definitions/system/api.ts
+++ b/packages/adapter-components/src/definitions/system/api.ts
@@ -25,7 +25,7 @@ export type APIDefinitionsOptions = {
   paginationOptions?: string
   customNameMappingOptions?: string
   additionalAction?: string
-  contextStrategies?: string
+  referenceContextStrategies?: string
 }
 
 export type ResolveClientOptionsType<Options extends Pick<APIDefinitionsOptions, 'clientOptions'>> =
@@ -41,8 +41,9 @@ export type ResolveCustomNameMappingOptionsType<
 export type ResolveAdditionalActionType<Options extends Pick<APIDefinitionsOptions, 'additionalAction'>> =
   Options['additionalAction'] extends string ? Options['additionalAction'] : never
 
-export type ResolveContextStrategiesType<Options extends Pick<APIDefinitionsOptions, 'contextStrategies'>> =
-  Options['contextStrategies'] extends string ? Options['contextStrategies'] : never
+export type ResolveReferenceContextStrategiesType<
+  Options extends Pick<APIDefinitionsOptions, 'referenceContextStrategies'>,
+> = Options['referenceContextStrategies'] extends string ? Options['referenceContextStrategies'] : never
 
 export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   // sources are processed and used to populate initial options for clients and components, in order of definition,
@@ -65,7 +66,7 @@ export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   pagination: Record<ResolvePaginationOptionsType<Options>, PaginationDefinitions<ResolveClientOptionsType<Options>>>
 
   // rules for reference extraction (during fetch) and serialization (during deploy)
-  references?: ReferenceDefinitions<ResolveContextStrategiesType<Options>>
+  references?: ReferenceDefinitions<ResolveReferenceContextStrategiesType<Options>>
 
   fetch?: FetchApiDefinitions<Options>
   deploy?: DeployApiDefinitions<ResolveAdditionalActionType<Options>, ResolveClientOptionsType<Options>>

--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -20,7 +20,7 @@ export {
   ResolveClientOptionsType,
   ResolvePaginationOptionsType,
   ResolveCustomNameMappingOptionsType,
-  ResolveContextStrategiesType,
+  ResolveReferenceContextStrategiesType,
 } from './api'
 export * as deploy from './deploy'
 export * as fetch from './fetch'

--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -20,10 +20,10 @@ export {
   ResolveClientOptionsType,
   ResolvePaginationOptionsType,
   ResolveCustomNameMappingOptionsType,
+  ResolveContextStrategiesType,
 } from './api'
 export * as deploy from './deploy'
 export * as fetch from './fetch'
-export * as sources from './sources'
 export * from './requests'
 export {
   DATA_FIELD_ENTIRE_OBJECT,
@@ -37,5 +37,4 @@ export {
   AdjustFunction,
   ContextParams,
 } from './shared'
-export { RequiredDefinitions } from './types'
 export * from './utils'

--- a/packages/adapter-components/src/definitions/system/references.ts
+++ b/packages/adapter-components/src/definitions/system/references.ts
@@ -13,10 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FieldReferenceDefinition } from '../../references'
+import { ContextFunc, FieldReferenceDefinition } from '../../references'
 
-export type ReferenceDefinitions = {
+export type ReferenceDefinitions<T extends string = never> = {
   // rules for finding references - converting values to references in fetch, and references to values in deploy.
   // this is an array of arrays because rules can be run in multiple iterations during fetch
-  rules: FieldReferenceDefinition<never>[]
+  rules: FieldReferenceDefinition<T>[]
+  contextStrategyLookup?: Record<T, ContextFunc>
 }

--- a/packages/adapter-components/src/filters/field_references.ts
+++ b/packages/adapter-components/src/filters/field_references.ts
@@ -18,7 +18,7 @@ import { filter } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { AdapterFilterCreator } from '../filter_utils'
 import { FieldReferenceDefinition, addReferences } from '../references'
-import { APIDefinitionsOptions, ResolveContextStrategiesType } from '../definitions'
+import { APIDefinitionsOptions, ResolveReferenceContextStrategiesType } from '../definitions'
 
 const { makeArray } = collections.array
 
@@ -27,7 +27,7 @@ const { makeArray } = collections.array
  */
 export const fieldReferencesFilterCreator =
   <TResult extends void | filter.FilterResult, TOptions extends APIDefinitionsOptions = {}>(
-    referenceRules?: FieldReferenceDefinition<ResolveContextStrategiesType<TOptions>>[],
+    referenceRules?: FieldReferenceDefinition<ResolveReferenceContextStrategiesType<TOptions>>[],
   ): AdapterFilterCreator<{}, TResult, {}, TOptions> =>
   ({ definitions }) => ({
     name: 'fieldReferencesFilter',

--- a/packages/adapter-components/src/filters/field_references.ts
+++ b/packages/adapter-components/src/filters/field_references.ts
@@ -18,7 +18,7 @@ import { filter } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { AdapterFilterCreator } from '../filter_utils'
 import { FieldReferenceDefinition, addReferences } from '../references'
-import { APIDefinitionsOptions } from '../definitions'
+import { APIDefinitionsOptions, ResolveContextStrategiesType } from '../definitions'
 
 const { makeArray } = collections.array
 
@@ -26,15 +26,16 @@ const { makeArray } = collections.array
  * replace values with references based on a set of rules
  */
 export const fieldReferencesFilterCreator =
-  <TResult extends void | filter.FilterResult, Options extends APIDefinitionsOptions = {}>(
-    referenceRules?: FieldReferenceDefinition<never>[],
-  ): AdapterFilterCreator<{}, TResult, {}, Options> =>
+  <TResult extends void | filter.FilterResult, TOptions extends APIDefinitionsOptions = {}>(
+    referenceRules?: FieldReferenceDefinition<ResolveContextStrategiesType<TOptions>>[],
+  ): AdapterFilterCreator<{}, TResult, {}, TOptions> =>
   ({ definitions }) => ({
     name: 'fieldReferencesFilter',
     onFetch: async (elements: Element[]) => {
       await addReferences({
         elements,
         defs: makeArray(referenceRules).concat(makeArray(definitions.references?.rules)),
+        contextStrategyLookup: definitions.references?.contextStrategyLookup,
       })
     },
   })

--- a/packages/serviceplaceholder-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/fetch/fetch.ts
@@ -164,6 +164,47 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       },
     },
   },
+
+  made_up_type_a: {
+    requests: [
+      {
+        endpoint: {
+          path: '/api/v2/made_up_type_a',
+        },
+        transformation: {
+          root: 'made_up_type_a',
+        },
+      },
+    ],
+    resource: {
+      directFetch: true,
+    },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+      },
+    },
+  },
+  made_up_type_b: {
+    requests: [
+      {
+        endpoint: {
+          path: '/api/v2/made_up_type_b',
+        },
+        transformation: {
+          root: 'made_up_type_b',
+        },
+      },
+    ],
+    resource: {
+      directFetch: true,
+    },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+      },
+    },
+  },
 })
 
 export const createFetchDefinitions = (

--- a/packages/serviceplaceholder-adapter/src/definitions/references.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/references.ts
@@ -13,9 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from 'lodash'
 import { definitions, references as referenceUtils } from '@salto-io/adapter-components'
+import { ContextStrategies, Options } from './types'
 
-const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
+const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<ContextStrategies>[] = [
   // TODO adjust and remove unneeded examples and documentation
 
   // all fields called group_id or group_ids are assumed to reference group instances by their id field
@@ -37,6 +39,16 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
     target: { type: 'ticket_form' },
   },
 
+  // The parent_id type can differ based on the parent_type field
+  {
+    src: { instanceTypes: ['made_up_type_a'], field: 'parent_id' },
+    serializationStrategy: 'id',
+    sourceTransformation: 'asString',
+    target: {
+      typeContext: 'useParentType',
+    },
+  },
+
   // the field id under the (nested) types
   // ticket_form__end_user_conditions__child_fields, ticket_form__agent_conditions__child_fields
   // (in practice, these are in nested fields of ticket_form instances)
@@ -51,6 +63,9 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
   },
 ]
 
-export const REFERENCES: definitions.ApiDefinitions['references'] = {
+export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
   rules: REFERENCE_RULES,
+  contextStrategyLookup: {
+    useParentType: ({ instance }) => _.get(instance.value, 'parent_type'),
+  },
 }

--- a/packages/serviceplaceholder-adapter/src/definitions/references.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/references.ts
@@ -15,9 +15,9 @@
  */
 import _ from 'lodash'
 import { definitions, references as referenceUtils } from '@salto-io/adapter-components'
-import { ContextStrategies, Options } from './types'
+import { ReferenceContextStrategies, Options } from './types'
 
-const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<ContextStrategies>[] = [
+const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<ReferenceContextStrategies>[] = [
   // TODO adjust and remove unneeded examples and documentation
 
   // all fields called group_id or group_ids are assumed to reference group instances by their id field
@@ -45,7 +45,7 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<ContextStrategies
     serializationStrategy: 'id',
     sourceTransformation: 'asString',
     target: {
-      typeContext: 'useParentType',
+      typeContext: 'parentType',
     },
   },
 
@@ -66,6 +66,6 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<ContextStrategies
 export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
   rules: REFERENCE_RULES,
   contextStrategyLookup: {
-    useParentType: ({ instance }) => _.get(instance.value, 'parent_type'),
+    parentType: ({ instance }) => _.get(instance.value, 'parent_type'),
   },
 }

--- a/packages/serviceplaceholder-adapter/src/definitions/types.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/types.ts
@@ -20,9 +20,11 @@ import { definitions } from '@salto-io/adapter-components'
 export type AdditionalAction = never
 export type ClientOptions = 'main'
 export type PaginationOptions = 'cursor'
+export type ContextStrategies = 'useParentType'
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions
   additionalAction: AdditionalAction
+  contextStrategies: ContextStrategies
 }

--- a/packages/serviceplaceholder-adapter/src/definitions/types.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/types.ts
@@ -20,11 +20,11 @@ import { definitions } from '@salto-io/adapter-components'
 export type AdditionalAction = never
 export type ClientOptions = 'main'
 export type PaginationOptions = 'cursor'
-export type ContextStrategies = 'useParentType'
+export type ReferenceContextStrategies = 'parentType'
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions
   additionalAction: AdditionalAction
-  contextStrategies: ContextStrategies
+  referenceContextStrategies: ReferenceContextStrategies
 }

--- a/packages/serviceplaceholder-adapter/test/adapter.test.ts
+++ b/packages/serviceplaceholder-adapter/test/adapter.test.ts
@@ -117,6 +117,8 @@ describe('adapter', () => {
           'business_hours_schedule',
           'business_hours_schedule_holiday',
           'group',
+          'made_up_type_a',
+          'made_up_type_b',
         ])
         expect(elements.map(e => e.elemID.getFullName()).sort()).toEqual([
           'serviceplaceholder.business_hours_schedule',
@@ -127,6 +129,12 @@ describe('adapter', () => {
           'serviceplaceholder.group',
           'serviceplaceholder.group.instance.group_1@s',
           'serviceplaceholder.group.instance.group_2@s',
+          'serviceplaceholder.made_up_type_a',
+          'serviceplaceholder.made_up_type_a.instance.made_up_1@s',
+          'serviceplaceholder.made_up_type_a.instance.made_up_2@s',
+          'serviceplaceholder.made_up_type_a.instance.made_up_3@s',
+          'serviceplaceholder.made_up_type_b',
+          'serviceplaceholder.made_up_type_b.instance.made_up_1@s',
         ])
         expect(
           elements
@@ -144,6 +152,18 @@ describe('adapter', () => {
           start_date: '2024-02-20',
           start_year: '2024',
         })
+        const madeUp2Values = elements
+          .filter(isInstanceElement)
+          .find(e => e.elemID.getFullName() === 'serviceplaceholder.made_up_type_a.instance.made_up_2@s')?.value
+        expect(madeUp2Values?.parent_id?.elemID?.fullName).toEqual(
+          'serviceplaceholder.made_up_type_a.instance.made_up_1@s',
+        )
+        const madeUp3Values = elements
+          .filter(isInstanceElement)
+          .find(e => e.elemID.getFullName() === 'serviceplaceholder.made_up_type_a.instance.made_up_3@s')?.value
+        expect(madeUp3Values?.parent_id?.elemID?.fullName).toEqual(
+          'serviceplaceholder.made_up_type_b.instance.made_up_1@s',
+        )
       })
 
       describe('deploy', () => {

--- a/packages/serviceplaceholder-adapter/test/fetch_mock_replies.json
+++ b/packages/serviceplaceholder-adapter/test/fetch_mock_replies.json
@@ -70,5 +70,43 @@
       "url": "https://localhost:80/api/v2/business_hours/schedules/4442604931859/holidays"
     },
     "headers": { "x-rate-limit": "700", "x-rate-limit-remaining": "696" }
+  },
+  {
+    "url": "/api/v2/made_up_type_a",
+    "method": "GET",
+    "status": 200,
+    "response": {
+      "made_up_type_a": [
+        {
+          "id": 1,
+          "name": "made up 1"
+        },
+        {
+          "id": 2,
+          "name": "made up 2",
+          "parent_id": "1",
+          "parent_type": "made_up_type_a"
+        },
+        {
+          "id": 3,
+          "name": "made up 3",
+          "parent_id": "1",
+          "parent_type": "made_up_type_b"
+        }
+      ]
+    }
+  },
+  {
+    "url": "/api/v2/made_up_type_b",
+    "method": "GET",
+    "status": 200,
+    "response": {
+      "made_up_type_b": [
+        {
+          "id": 1,
+          "name": "made up 1"
+        }
+      ]
+    }
   }
 ]


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

Enable defining contextStrategyLookup within the new reference definitions - to be used in the `field_references` filter.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
