### PR TITLE
SALTO-5161: [Zendesk] Move caching for users request in Zendesk to be…

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -149,7 +149,7 @@ import organizationsFilter from './filters/organizations'
 import hideAccountFeatures from './filters/hide_account_features'
 import auditTimeFilter from './filters/audit_logs'
 import sideConversationsFilter from './filters/side_conversation'
-import { isCurrentUserResponse } from './user_utils'
+import { isCurrentUserResponse, getUsers } from './users/user_utils'
 import addAliasFilter from './filters/add_alias'
 import macroFilter from './filters/macro'
 import customRoleDeployFilter from './filters/custom_role_deploy'
@@ -165,6 +165,7 @@ import customObjectFieldsOrderFilter from './filters/custom_objects/custom_objec
 import customObjectFieldOptionsFilter from './filters/custom_field_options/custom_object_field_options'
 import { createFixElementFunctions } from './fix_elements'
 import guideThemeSettingFilter from './filters/guide_theme_settings'
+import { GetUsersResponse } from './users/types'
 
 const { makeArray } = collections.array
 const log = logger(module)
@@ -457,14 +458,17 @@ export default class ZendeskAdapter implements AdapterOperations {
   private createClientBySubdomain: (subdomain: string, deployRateLimit?: boolean) => ZendeskClient
   private getClientBySubdomain: (subdomain: string, deployRateLimit?: boolean) => ZendeskClient
   private brandsList: Promise<InstanceElement[]> | undefined
+  private usersPromise: Promise<GetUsersResponse> | undefined
   private createFiltersRunner: ({
     filterRunnerClient,
     paginator,
     brandIdToClient,
+    usersPromise,
   }: {
     filterRunnerClient?: ZendeskClient
     paginator?: clientUtils.Paginator
     brandIdToClient?: BrandIdToClient
+    usersPromise: Promise<GetUsersResponse>
   }) => Promise<Required<Filter>>
 
   public constructor({
@@ -484,6 +488,7 @@ export default class ZendeskAdapter implements AdapterOperations {
     this.client = client
     this.elementsSource = elementsSource
     this.brandsList = undefined
+    this.usersPromise = undefined
     this.paginator = createPaginator({
       client: this.client,
       paginationFuncCreator: paginate,
@@ -516,10 +521,12 @@ export default class ZendeskAdapter implements AdapterOperations {
       filterRunnerClient,
       paginator,
       brandIdToClient = {},
+      usersPromise,
     }: {
       filterRunnerClient?: ZendeskClient
       paginator?: clientUtils.Paginator
       brandIdToClient?: BrandIdToClient
+      usersPromise: Promise<GetUsersResponse>
     }) =>
       filtersRunner(
         {
@@ -530,6 +537,7 @@ export default class ZendeskAdapter implements AdapterOperations {
           fetchQuery: this.fetchQuery,
           elementsSource,
           brandIdToClient,
+          usersPromise,
         },
         filterCreators,
         concatObjects,
@@ -540,6 +548,7 @@ export default class ZendeskAdapter implements AdapterOperations {
         client,
         config,
         elementsSource,
+        usersPromise: this.getUsersPromise(),
       }),
     )
   }
@@ -707,7 +716,9 @@ export default class ZendeskAdapter implements AdapterOperations {
       ]),
     )
     // This exposes different subdomain clients for Guide related types filters
-    const result = (await (await this.createFiltersRunner({ brandIdToClient })).onFetch(elements)) as FilterResult
+    const result = (await (
+      await this.createFiltersRunner({ brandIdToClient, usersPromise: this.getUsersPromise() })
+    ).onFetch(elements)) as FilterResult
     const updatedConfig =
       this.configInstance && configChanges
         ? configUtils.getUpdatedCofigFromConfigChanges({
@@ -726,6 +737,13 @@ export default class ZendeskAdapter implements AdapterOperations {
       this.logIdsFunc()
     }
     return { elements, errors: fetchErrors, updatedConfig: configWithOmitInactive }
+  }
+
+  private getUsersPromise(): Promise<GetUsersResponse> {
+    if (this.usersPromise === undefined) {
+      this.usersPromise = getUsers(this.paginator, this.userConfig[FETCH_CONFIG].resolveUserIDs)
+    }
+    return this.usersPromise
   }
 
   private getBrandsFromElementsSource(): Promise<InstanceElement[]> {
@@ -764,6 +782,7 @@ export default class ZendeskAdapter implements AdapterOperations {
               client,
               paginationFuncCreator: paginate,
             }),
+            usersPromise: this.getUsersPromise(),
           })
           await brandRunner.preDeploy(subdomainToGuideChanges[subdomain])
           const { deployResult: brandDeployResults } = await brandRunner.deploy(subdomainToGuideChanges[subdomain])
@@ -816,7 +835,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       ),
     })) as Change<InstanceElement>[]
     const sourceChanges = _.keyBy(changesToDeploy, change => getChangeData(change).elemID.getFullName())
-    const runner = await this.createFiltersRunner({})
+    const runner = await this.createFiltersRunner({ usersPromise: this.getUsersPromise() })
     const resolvedChanges = await awu(changesToDeploy)
       .map(async change =>
         SKIP_RESOLVE_TYPE_NAMES.includes(getChangeData(change).elemID.typeName)
@@ -875,6 +894,7 @@ export default class ZendeskAdapter implements AdapterOperations {
       changeValidator: createChangeValidator({
         client: this.client,
         config: this.userConfig,
+        usersPromise: this.getUsersPromise(),
         apiConfig: this.userConfig[API_DEFINITIONS_CONFIG],
         fetchConfig: this.userConfig[FETCH_CONFIG],
         deployConfig: this.userConfig[DEPLOY_CONFIG],

--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -88,6 +88,7 @@ import {
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ChangeValidatorName, ZendeskDeployConfig, ZendeskFetchConfig, ZendeskConfig } from './config'
+import { GetUsersResponse } from './users/types'
 
 const {
   deployTypesNotSupportedValidator,
@@ -99,6 +100,7 @@ const {
 export default ({
   client,
   config,
+  usersPromise,
   apiConfig,
   fetchConfig,
   deployConfig,
@@ -107,6 +109,7 @@ export default ({
 }: {
   client: ZendeskClient
   config: ZendeskConfig
+  usersPromise: Promise<GetUsersResponse>
   apiConfig: configUtils.AdapterDuckTypeApiConfig
   fetchConfig: ZendeskFetchConfig
   deployConfig?: ZendeskDeployConfig
@@ -146,9 +149,9 @@ export default ({
     customStatusCategory: customStatusCategoryValidator,
     customStatusActiveDefault: customStatusActiveDefaultValidator,
     defaultCustomStatuses: defaultCustomStatusesValidator,
-    customRoleRemoval: customRoleRemovalValidator(client, fetchConfig),
+    customRoleRemoval: customRoleRemovalValidator(usersPromise),
     sideConversations: sideConversationsValidator,
-    users: usersValidator(client, fetchConfig),
+    users: usersValidator(usersPromise),
     requiredAppOwnedParameters: requiredAppOwnedParametersValidator,
     oneTranslationPerLocale: oneTranslationPerLocaleValidator,
     articleRemoval: articleRemovalValidator,

--- a/packages/zendesk-adapter/src/change_validators/custom_role_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/custom_role_removal.ts
@@ -14,54 +14,45 @@
  * limitations under the License.
  */
 import _ from 'lodash'
-import { ChangeValidator, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
-import { client as clientUtils } from '@salto-io/adapter-components'
-import { getUsers } from '../user_utils'
-import { paginate } from '../client/pagination'
-import ZendeskClient from '../client/client'
+import { ChangeValidator, SaltoError, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
+import { User } from '../users/types'
 import { CUSTOM_ROLE_TYPE_NAME } from '../constants'
-import { ZendeskFetchConfig } from '../config'
-
-const { createPaginator } = clientUtils
 
 /*
  * Checks that no user with agent role is associated with the removed custom_role
  *
  */
-export const customRoleRemovalValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchConfig) => ChangeValidator =
-  (client, fetchConfig) => async changes => {
-    const relevantInstances = changes
-      .filter(isRemovalChange)
-      .filter(isInstanceChange)
-      .filter(change => getChangeData(change).elemID.typeName === CUSTOM_ROLE_TYPE_NAME)
-      .map(getChangeData)
+export const customRoleRemovalValidator: (
+  usersPromise: Promise<{ users: User[]; errors?: SaltoError[] }>,
+) => ChangeValidator = usersPromise => async changes => {
+  const relevantInstances = changes
+    .filter(isRemovalChange)
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === CUSTOM_ROLE_TYPE_NAME)
+    .map(getChangeData)
 
-    if (_.isEmpty(relevantInstances)) {
-      return []
-    }
-
-    const paginator = createPaginator({
-      client,
-      paginationFuncCreator: paginate,
-    })
-    const { users } = await getUsers(paginator, fetchConfig.resolveUserIDs)
-    if (_.isEmpty(users)) {
-      return []
-    }
-    const agentUsers = users.filter(user => user.role === 'agent' && user.custom_role_id !== undefined)
-    const agentsByCustomRoleId = _.groupBy(agentUsers, agentUser => agentUser.custom_role_id)
-    return relevantInstances
-      .filter(customRoleInstance => agentsByCustomRoleId[customRoleInstance.value.id] !== undefined)
-      .map(customRoleInstance => {
-        const relatedAgents = agentsByCustomRoleId[customRoleInstance.value.id]
-        return {
-          elemID: customRoleInstance.elemID,
-          severity: 'Error',
-          message: 'Cannot remove a custom role with associated agents',
-          detailedMessage: `${relatedAgents.length} agents are associated with this role (partial list): [${relatedAgents
-            .map(agent => agent.email)
-            .slice(0, 10)
-            .join(', ')}].\nPlease disconnect the agents from the role in the Zendesk UI before deploying this change.`,
-        }
-      })
+  if (_.isEmpty(relevantInstances)) {
+    return []
   }
+
+  const { users } = await usersPromise
+  if (_.isEmpty(users)) {
+    return []
+  }
+  const agentUsers = users.filter(user => user.role === 'agent' && user.custom_role_id !== undefined)
+  const agentsByCustomRoleId = _.groupBy(agentUsers, agentUser => agentUser.custom_role_id)
+  return relevantInstances
+    .filter(customRoleInstance => agentsByCustomRoleId[customRoleInstance.value.id] !== undefined)
+    .map(customRoleInstance => {
+      const relatedAgents = agentsByCustomRoleId[customRoleInstance.value.id]
+      return {
+        elemID: customRoleInstance.elemID,
+        severity: 'Error',
+        message: 'Cannot remove a custom role with associated agents',
+        detailedMessage: `${relatedAgents.length} agents are associated with this role (partial list): [${relatedAgents
+          .map(agent => agent.email)
+          .slice(0, 10)
+          .join(', ')}].\nPlease disconnect the agents from the role in the Zendesk UI before deploying this change.`,
+      }
+    })
+}

--- a/packages/zendesk-adapter/src/change_validators/users.ts
+++ b/packages/zendesk-adapter/src/change_validators/users.ts
@@ -28,22 +28,17 @@ import { resolvePath } from '@salto-io/adapter-utils'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { client as clientUtils, resolveValues } from '@salto-io/adapter-components'
+import { resolveValues } from '@salto-io/adapter-components'
 import {
-  getUsers,
   MISSING_USERS_DOC_LINK,
   MISSING_USERS_ERROR_MSG,
   TYPE_NAME_TO_REPLACER,
-  User,
   VALID_USER_VALUES,
-} from '../user_utils'
+} from '../users/user_utils'
 import { lookupFunc } from '../filters/field_references'
-import { paginate } from '../client/pagination'
-import ZendeskClient from '../client/client'
 import { CUSTOM_ROLE_TYPE_NAME } from '../constants'
-import { ZendeskFetchConfig } from '../config'
+import { GetUsersResponse, User } from '../users/types'
 
-const { createPaginator } = clientUtils
 const { awu } = collections.asynciterable
 const { isDefined } = lowerDashValues
 const log = logger(module)
@@ -107,8 +102,8 @@ const handleExistingUsers = ({
  *  1. If we could not use user fallback value for some reason, we will return an error.
  *  2. If the user has no permissions to its field, we will return a warning (default user included).
  */
-export const usersValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchConfig) => ChangeValidator =
-  (client, fetchConfig) => async (changes, elementSource) => {
+export const usersValidator: (usersPromise: Promise<GetUsersResponse>) => ChangeValidator =
+  usersPromise => async (changes, elementSource) => {
     const relevantInstances = await awu(changes)
       .filter(isAdditionOrModificationChange)
       .filter(isInstanceChange)
@@ -121,11 +116,7 @@ export const usersValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchCo
       return []
     }
 
-    const paginator = createPaginator({
-      client,
-      paginationFuncCreator: paginate,
-    })
-    const { users } = await getUsers(paginator, fetchConfig.resolveUserIDs)
+    const { users } = await usersPromise
 
     const existingUsersEmails = new Set(users.map(user => user.email))
     const instancesUserPaths = relevantInstances.flatMap(instance => {

--- a/packages/zendesk-adapter/src/filter.ts
+++ b/packages/zendesk-adapter/src/filter.ts
@@ -17,6 +17,7 @@ import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
 import ZendeskClient from './client/client'
 import { FilterContext } from './config'
+import { GetUsersResponse } from './users/types'
 
 export const { filtersRunner } = filterUtils
 
@@ -28,6 +29,7 @@ export type FilterAdditionalParams = {
   elementsSource: ReadOnlyElementsSource
   brandIdToClient?: BrandIdToClient
   fetchQuery: elementUtils.query.ElementQuery
+  usersPromise?: Promise<GetUsersResponse>
 }
 
 export type FilterCreator = filterUtils.FilterCreator<

--- a/packages/zendesk-adapter/src/filters/audit_logs.ts
+++ b/packages/zendesk-adapter/src/filters/audit_logs.ts
@@ -30,7 +30,6 @@ import Joi from 'joi'
 import { createSchemeGuard, getParent } from '@salto-io/adapter-utils'
 import moment from 'moment-timezone'
 import { collections } from '@salto-io/lowerdash'
-import { FilterCreator } from '../filter'
 import {
   APP_INSTALLATION_TYPE_NAME,
   APP_OWNED_TYPE_NAME,
@@ -57,8 +56,9 @@ import {
   ZENDESK,
 } from '../constants'
 import ZendeskClient from '../client/client'
-import { getIdByName } from '../user_utils'
+import { getIdByName } from '../users/user_utils'
 import { FETCH_CONFIG, GUIDE_GLOBAL_TYPES, GUIDE_TYPES_TO_HANDLE_BY_BRAND } from '../config'
+import { FilterCreator } from '../filter'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -392,7 +392,7 @@ const addNewChangedBy = async ({
 /**
  * this filter adds changed_at and changed_by annotations
  */
-const filterCreator: FilterCreator = ({ elementsSource, client, paginator, config }) => ({
+const filterCreator: FilterCreator = ({ elementsSource, client, config, usersPromise }) => ({
   name: 'changeByAndChangedAt',
   onFetch: async (elements: Element[]): Promise<void> => {
     if (elementsSource === undefined) {
@@ -428,8 +428,7 @@ const filterCreator: FilterCreator = ({ elementsSource, client, paginator, confi
       return
     }
     await addPrevChangedBy(elementsSource, idByInstance)
-
-    const idToName = await getIdByName(paginator, config[FETCH_CONFIG].resolveUserIDs)
+    const idToName = usersPromise === undefined ? {} : await getIdByName(usersPromise)
     await addNewChangedBy({ instances, idToName, newLastAuditTime, auditTimeInstance, client })
   },
 })

--- a/packages/zendesk-adapter/src/filters/custom_objects/custom_object_fields.ts
+++ b/packages/zendesk-adapter/src/filters/custom_objects/custom_object_fields.ts
@@ -27,11 +27,10 @@ import {
   isInstanceChange,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { references as referencesUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { references as referencesUtils } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { inspectValue } from '@salto-io/adapter-utils'
-import { FilterCreator } from '../../filter'
 import {
   CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME,
   CUSTOM_FIELD_OPTIONS_FIELD_NAME,
@@ -48,12 +47,11 @@ import {
   transformCustomObjectLookupField,
   transformRelationshipFilterField,
 } from './utils'
-import { paginate } from '../../client/pagination'
-import { getIdByEmail, getUsers } from '../../user_utils'
+import { getIdByEmail } from '../../users/user_utils'
+import { FilterCreator } from '../../filter'
 
 const { makeArray } = collections.array
 const { createMissingInstance } = referencesUtils
-const { createPaginator } = clientUtils
 
 const log = logger(module)
 
@@ -317,12 +315,8 @@ const getUserConditions = (changes: Change[]): CustomObjectCondition[] => {
  *  preDeploy handles values that are users, including fallback user
  *  onDeploy reverts the preDeploy
  */
-const customObjectFieldsFilter: FilterCreator = ({ config, client }) => {
+const customObjectFieldsFilter: FilterCreator = ({ config, usersPromise }) => {
   const userPathToOriginalValue: Record<string, string> = {}
-  const paginator = createPaginator({
-    client,
-    paginationFuncCreator: paginate,
-  })
   return {
     name: 'customObjectFieldOptionsFilter',
     onFetch: async (elements: Element[]) => {
@@ -331,7 +325,7 @@ const customObjectFieldsFilter: FilterCreator = ({ config, client }) => {
       const instances = elements.filter(isInstanceElement)
 
       // It is possible to key all instance by id because the internal Id is unique across all types (SALTO-4805)
-      const usersById = await getIdByEmail(paginator, config[FETCH_CONFIG].resolveUserIDs)
+      const usersById = usersPromise === undefined ? {} : await getIdByEmail(usersPromise)
       const instancesById = _.keyBy(
         instances.filter(instance => _.isNumber(instance.value.id)),
         instance => _.parseInt(instance.value.id),
@@ -372,10 +366,13 @@ const customObjectFieldsFilter: FilterCreator = ({ config, client }) => {
     // non-user references are handled by handle_template_expressions.ts
     preDeploy: async changes => {
       const userConditions = getUserConditions(changes)
-      if (userConditions.length === 0) {
+      if (userConditions.length === 0 || usersPromise === undefined) {
+        if (usersPromise === undefined) {
+          log.trace('getUserPromise is undefined in preDeploy')
+        }
         return
       }
-      const { users } = await getUsers(paginator, config[FETCH_CONFIG].resolveUserIDs)
+      const { users } = await usersPromise
       const usersByEmail = _.keyBy(users, user => user.email)
 
       const missingUserConditions: CustomObjectCondition[] = []

--- a/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
@@ -15,12 +15,11 @@
  */
 
 import { ChangeError, ElemID, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, definitions } from '@salto-io/adapter-components'
+import { definitions } from '@salto-io/adapter-components'
 import { resolvePath, setPath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { paginate } from '../client/pagination'
 import { DEPLOY_CONFIG, FETCH_CONFIG } from '../config'
 import {
   MISSING_USERS_DOC_LINK,
@@ -28,15 +27,13 @@ import {
   TYPE_NAME_TO_REPLACER,
   VALID_USER_VALUES,
   getUserFallbackValue,
-  getUsers,
-  User,
-} from '../user_utils'
+} from '../users/user_utils'
 import { FixElementsHandler } from './types'
 import { CUSTOM_OBJECT_FIELD_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TRIGGER_TYPE_NAME } from '../constants'
 import { FieldsParams, ValueReplacer, replaceConditionsAndActionsCreator } from '../replacers_utils'
+import { User } from '../users/types'
 
 const log = logger(module)
-const { createPaginator } = clientUtils
 
 const fallbackUserIsMissingError = (
   instance: InstanceElement,
@@ -140,13 +137,9 @@ const isRelevantElement = (element: unknown): element is InstanceElement =>
  * 2. If provided fallback user is not valid, return error severity errors
  */
 export const fallbackUsersHandler: FixElementsHandler =
-  ({ client, config }) =>
+  ({ client, config, usersPromise }) =>
   async elements => {
-    const paginator = createPaginator({
-      client,
-      paginationFuncCreator: paginate,
-    })
-    const { users } = await getUsers(paginator, config[FETCH_CONFIG].resolveUserIDs)
+    const { users } = await usersPromise
     const { defaultMissingUserFallback } = config[DEPLOY_CONFIG] || {}
     if (
       defaultMissingUserFallback === undefined ||

--- a/packages/zendesk-adapter/src/users/types.ts
+++ b/packages/zendesk-adapter/src/users/types.ts
@@ -13,16 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FixElementsFunc, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import ZendeskClient from '../client/client'
-import { ZendeskConfig } from '../config'
-import { GetUsersResponse } from '../users/types'
+import { SaltoError } from '@salto-io/adapter-api'
 
-export type FixElementsArgs = {
-  client: ZendeskClient
-  config: ZendeskConfig
-  elementsSource: ReadOnlyElementsSource
-  usersPromise: Promise<GetUsersResponse>
+export type User = {
+  id: number
+  name: string
+  email: string
+  role: string
+  // eslint-disable-next-line camelcase
+  custom_role_id?: number | null
+  locale: string
 }
 
-export type FixElementsHandler = (args: FixElementsArgs) => FixElementsFunc
+export type CurrentUserResponse = {
+  user: User
+}
+
+export type GetUsersResponse = { users: User[]; errors?: SaltoError[] }

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -2617,10 +2617,9 @@ describe('adapter', () => {
             },
           }),
         })
-
         expect(createClientSpy).toHaveBeenCalledTimes(2)
         expect(createFiltersRunnerSpy).toHaveBeenCalledTimes(3)
-        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(1, {}) // Regular deploy
+        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(1, { usersPromise: Promise.resolve({}) }) // Regular deploy
         expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(2, guideFilterRunnerCall) // guide deploy
         expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(3, guideFilterRunnerCall) // guide deploy
       })

--- a/packages/zendesk-adapter/test/adapter_creator.test.ts
+++ b/packages/zendesk-adapter/test/adapter_creator.test.ts
@@ -23,6 +23,11 @@ import { configType } from '../src/config'
 import { ZENDESK } from '../src/constants'
 import * as connection from '../src/client/connection'
 
+jest.mock('../src/users/user_utils', () => ({
+  ...jest.requireActual<{}>('../src/users/user_utils'),
+  getUsers: () => ({ users: [], errors: [] }),
+}))
+
 describe('adapter creator', () => {
   let mockAxiosAdapter: MockAdapter
   beforeEach(() => {

--- a/packages/zendesk-adapter/test/change_validator.test.ts
+++ b/packages/zendesk-adapter/test/change_validator.test.ts
@@ -32,6 +32,7 @@ describe('change validator creator', () => {
           deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
           typesDeployedViaParent: [],
           typesWithNoDeploy: [],
+          usersPromise: Promise.resolve({ users: [], errors: [] }),
         })([]),
       ).toEqual([])
     })
@@ -46,6 +47,7 @@ describe('change validator creator', () => {
           deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
           typesDeployedViaParent: [],
           typesWithNoDeploy: [],
+          usersPromise: Promise.resolve({ users: [], errors: [] }),
         })([
           toChange({ after: new ObjectType({ elemID: new ElemID(ZENDESK, 'obj') }) }),
           toChange({ before: new ObjectType({ elemID: new ElemID(ZENDESK, 'obj2') }) }),
@@ -80,6 +82,7 @@ describe('change validator creator', () => {
           deployConfig: DEFAULT_CONFIG[DEPLOY_CONFIG],
           typesDeployedViaParent: [],
           typesWithNoDeploy: [],
+          usersPromise: Promise.resolve({ users: [], errors: [] }),
         })([
           toChange({ after: new InstanceElement('inst1', type) }),
           toChange({ before: new InstanceElement('inst2', type) }),

--- a/packages/zendesk-adapter/test/change_validators/custom_role_removal.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/custom_role_removal.test.ts
@@ -14,14 +14,19 @@
  * limitations under the License.
  */
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { createPaginator } from '@salto-io/adapter-components/src/client'
 import { ZENDESK, CUSTOM_ROLE_TYPE_NAME } from '../../src/constants'
 import { customRoleRemovalValidator } from '../../src/change_validators/custom_role_removal'
 import ZendeskClient from '../../src/client/client'
 import { ZendeskFetchConfig } from '../../src/config'
+import { paginate } from '../../src/client/pagination'
+import { GetUsersResponse } from '../../src/users/types'
+import { getUsers } from '../../src/users/user_utils'
 
 describe('customRoleRemovalValidator', () => {
   let client: ZendeskClient
   let mockGet: jest.SpyInstance
+  let getUsersPromise: Promise<GetUsersResponse>
   const config = { resolveUserIDs: true } as ZendeskFetchConfig
   const customRoleType = new ObjectType({
     elemID: new ElemID(ZENDESK, CUSTOM_ROLE_TYPE_NAME),
@@ -47,11 +52,13 @@ describe('customRoleRemovalValidator', () => {
         ],
       },
     }))
+    const paginator = createPaginator({ client, paginationFuncCreator: paginate })
+    getUsersPromise = getUsers(paginator, config.resolveUserIDs)
   })
 
   it('should return an error if the custom role is deleted and it has associated agents', async () => {
     const changes = [toChange({ before: customRole1 }), toChange({ before: customRole2 })]
-    const changeValidator = customRoleRemovalValidator(client, config)
+    const changeValidator = customRoleRemovalValidator(getUsersPromise)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(2)
     expect(errors).toEqual([
@@ -73,7 +80,7 @@ describe('customRoleRemovalValidator', () => {
   })
   it('should not return an error if custom role is deleted but it has no associated agents', async () => {
     const changes = [toChange({ before: customRole3 })]
-    const changeValidator = customRoleRemovalValidator(client, config)
+    const changeValidator = customRoleRemovalValidator(getUsersPromise)
     const errors = await changeValidator(changes)
     expect(errors).toHaveLength(0)
   })

--- a/packages/zendesk-adapter/test/filters/audit_logs.test.ts
+++ b/packages/zendesk-adapter/test/filters/audit_logs.test.ts
@@ -28,7 +28,7 @@ import ZendeskClient from '../../src/client/client'
 import filterCreator, { AUDIT_TIME_TYPE_ID, DELETED_USER } from '../../src/filters/audit_logs'
 import { createFilterCreatorParams } from '../utils'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
-import { getIdByName } from '../../src/user_utils'
+import { getIdByName } from '../../src/users/user_utils'
 import {
   ARTICLE_TRANSLATION_TYPE_NAME,
   AUDIT_TIME_TYPE_NAME,
@@ -43,8 +43,8 @@ const BEFORE_TIME = '2023-02-08T04:34:53Z'
 const BETWEEN_TIME = '2023-02-08T08:34:53Z'
 const AFTER_TIME = '2023-02-08T10:34:53Z'
 const AFTER_AFTER_TIME = '2023-02-08T10:38:53Z'
-jest.mock('../../src/user_utils', () => ({
-  ...jest.requireActual<{}>('../../src/user_utils'),
+jest.mock('../../src/users/user_utils', () => ({
+  ...jest.requireActual<{}>('../../src/users/user_utils'),
   getIdByName: jest.fn(),
 }))
 

--- a/packages/zendesk-adapter/test/filters/custom_objects/custom_object_fields.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_objects/custom_object_fields.test.ts
@@ -35,16 +35,22 @@ import filterCreator from '../../../src/filters/custom_objects/custom_object_fie
 import { createFilterCreatorParams } from '../../utils'
 import { DEFAULT_CONFIG, DEPLOY_CONFIG } from '../../../src/config'
 
-const USER = { id: 111, email: 'User' }
-const DEFAULT_USER = { id: 222, email: 'DefaultUser' }
-jest.mock('../../../src/user_utils', () => ({
-  ...jest.requireActual<{}>('../../../src/user_utils'),
+const USER = { id: 111, email: 'User', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' }
+const DEFAULT_USER = { id: 222, email: 'DefaultUser', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' }
+jest.mock('../../../src/users/user_utils', () => ({
+  ...jest.requireActual<{}>('../../../src/users/user_utils'),
   getIdByEmail: () => ({ [USER.id]: USER.email }),
   getUsers: () => ({ users: [USER, DEFAULT_USER], errors: [] }),
 }))
 
 type FilterType = filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'deploy' | 'onDeploy'>
-const customObjectFieldsFilter = filterCreator(createFilterCreatorParams({})) as FilterType
+const customObjectFieldsFilter = filterCreator(
+  createFilterCreatorParams({
+    usersPromise: Promise.resolve({
+      users: [USER, DEFAULT_USER],
+    }),
+  }),
+) as FilterType
 
 const missingRef = (type: string, id: string): ReferenceExpression => {
   const missingInstance = referenceUtils.createMissingInstance(ZENDESK, type, id)

--- a/packages/zendesk-adapter/test/filters/user.test.ts
+++ b/packages/zendesk-adapter/test/filters/user.test.ts
@@ -27,10 +27,10 @@ import { mockFunction } from '@salto-io/test-utils'
 import { ZENDESK } from '../../src/constants'
 import filterCreator from '../../src/filters/user'
 import { createFilterCreatorParams } from '../utils'
-import { getIdByEmail, getUsers } from '../../src/user_utils'
+import { getIdByEmail, getUsers } from '../../src/users/user_utils'
 
-jest.mock('../../src/user_utils', () => ({
-  ...jest.requireActual<{}>('../../src/user_utils'),
+jest.mock('../../src/users/user_utils', () => ({
+  ...jest.requireActual<{}>('../../src/users/user_utils'),
   getIdByEmail: jest.fn(),
   getUsers: jest.fn(),
 }))
@@ -182,10 +182,17 @@ describe('user filter', () => {
     it('returns a warning if users query is forbidden, and does not replace anything', async () => {
       const elements = [macroType.clone(), macroInstance.clone()]
       const errors: SaltoError[] = [{ message: 'Bad user, go away!', severity: 'Warning' }]
-      getUsersMock.mockResolvedValueOnce({ users: [], errors })
       getIdByEmailMock.mockResolvedValueOnce({})
       const paginator = mockFunction<clientUtils.Paginator>()
-      const newFilter = filterCreator(createFilterCreatorParams({ paginator })) as FilterType
+      const newFilter = filterCreator(
+        createFilterCreatorParams({
+          paginator,
+          usersPromise: Promise.resolve({
+            users: [],
+            errors,
+          }),
+        }),
+      ) as FilterType
       expect(await newFilter.onFetch(elements)).toEqual({ errors })
       const instances = elements.filter(isInstanceElement)
       const macro = instances.find(e => e.elemID.typeName === 'macro')
@@ -208,14 +215,19 @@ describe('user filter', () => {
       getUsersMock = getUsers as jest.MockedFunction<typeof getUsers>
     })
     it('should change the emails to user ids', async () => {
-      filter = filterCreator(createFilterCreatorParams({ paginator: mockPaginator })) as FilterType
-      getUsersMock.mockResolvedValue({
-        users: [
-          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
-          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
-          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
-        ],
-      })
+      const users = [
+        { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
+        { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
+        { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+      ]
+      filter = filterCreator(
+        createFilterCreatorParams({
+          paginator: mockPaginator,
+          usersPromise: Promise.resolve({
+            users,
+          }),
+        }),
+      ) as FilterType
       getIdByEmailMock.mockResolvedValue({ 1: 'a@a.com', 2: 'b@b.com', 3: 'c@c.com' })
       const instances = [macroInstance, userSegmentInstance, articleInstance].map(e => e.clone())
       await filter.onFetch(instances)
@@ -245,15 +257,21 @@ describe('user filter', () => {
     })
   })
   describe('onDeploy', () => {
-    const filter = filterCreator(createFilterCreatorParams({ paginator: mockPaginator })) as FilterType
     it('should change the user ids to emails', async () => {
-      getUsersMock.mockResolvedValue({
-        users: [
-          { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
-          { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
-          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
-        ],
-      })
+      const users = [
+        { id: 1, email: 'a@a.com', role: 'admin', custom_role_id: 123, name: 'a', locale: 'en-US' },
+        { id: 2, email: 'b@b.com', role: 'admin', custom_role_id: 123, name: 'b', locale: 'en-US' },
+        { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+      ]
+      const filter = filterCreator(
+        createFilterCreatorParams({
+          paginator: mockPaginator,
+          usersPromise: Promise.resolve({
+            users,
+          }),
+        }),
+      ) as FilterType
+
       getIdByEmailMock.mockResolvedValue({ 1: 'a@a.com', 2: 'b@b.com', 3: 'c@c.com' })
       const instances = [macroInstance, userSegmentInstance, articleInstance].map(e => e.clone())
       const changes = instances.map(instance => toChange({ after: instance }))

--- a/packages/zendesk-adapter/test/fix_elements/fallback_user.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/fallback_user.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ChangeError, ElemID, InstanceElement, ObjectType, Element } from '@salto-io/adapter-api'
+import { User } from '../../src/users/types'
 import ZendeskClient from '../../src/client/client'
 import {
   ARTICLE_TYPE_NAME,
@@ -23,13 +24,11 @@ import {
   ZENDESK,
 } from '../../src/constants'
 import { fallbackUsersHandler } from '../../src/fix_elements/fallback_user'
-import * as userUtils from '../../src/user_utils'
 import { DEPLOY_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { FixElementsArgs } from '../../src/fix_elements/types'
 
 describe('fallbackUsersHandler', () => {
   let client: ZendeskClient
-  const mockGetUsers = jest.spyOn(userUtils, 'getUsers')
   const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, MACRO_TYPE_NAME) })
   const articleType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) })
 
@@ -71,13 +70,6 @@ describe('fallbackUsersHandler', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    mockGetUsers.mockResolvedValue({
-      users: [
-        { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
-        { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
-      ],
-    })
-
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
@@ -94,6 +86,12 @@ describe('fallbackUsersHandler', () => {
           [DEPLOY_CONFIG]: { defaultMissingUserFallback: 'fallback@.com' },
           [FETCH_CONFIG]: { resolveUserIDs: true },
         },
+        usersPromise: Promise.resolve({
+          users: [
+            { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+            { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
+          ],
+        }),
       } as FixElementsArgs)(instances)
     })
     it('should replace missing user emails or ids', () => {
@@ -157,6 +155,12 @@ describe('fallbackUsersHandler', () => {
           [DEPLOY_CONFIG]: { defaultMissingUserFallback: 'non-existing-user@.com' },
           [FETCH_CONFIG]: { resolveUserIDs: true },
         },
+        usersPromise: Promise.resolve({
+          users: [
+            { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+            { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
+          ],
+        }),
       } as FixElementsArgs)(instances)
     })
     it('should not replace missing user emails or ids', () => {
@@ -191,6 +195,12 @@ describe('fallbackUsersHandler', () => {
           [DEPLOY_CONFIG]: { defaultMissingUserFallback: undefined },
           [FETCH_CONFIG]: { resolveUserIDs: true },
         },
+        usersPromise: Promise.resolve({
+          users: [
+            { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+            { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
+          ],
+        }),
       } as FixElementsArgs)(instances)
       expect(fixedElements).toEqual([])
       expect(errors).toEqual([])
@@ -201,14 +211,18 @@ describe('fallbackUsersHandler', () => {
     let fallbackResponse: { fixedElements: Element[]; errors: ChangeError[] }
 
     beforeEach(async () => {
-      mockGetUsers.mockResolvedValue({ users: [], errors: [{ message: 'No users here!', severity: 'Warning' }] })
+      jest.clearAllMocks()
       const instances = [macroInstance, articleInstance].map(e => e.clone())
+      const users: User[] = []
       fallbackResponse = await fallbackUsersHandler({
         client,
         config: {
           [DEPLOY_CONFIG]: { defaultMissingUserFallback: 'notDeployer@.com' },
           [FETCH_CONFIG]: { resolveUserIDs: false },
         },
+        usersPromise: Promise.resolve({
+          users,
+        }),
       } as FixElementsArgs)(instances)
     })
 
@@ -222,7 +236,6 @@ describe('fallbackUsersHandler', () => {
     let fallbackResponse: { fixedElements: Element[]; errors: ChangeError[] }
 
     beforeEach(async () => {
-      mockGetUsers.mockResolvedValue({ users: [], errors: [{ message: 'No users here!', severity: 'Warning' }] })
       const instances = [macroInstance, articleInstance].map(e => e.clone())
       jest.spyOn(client, 'get').mockImplementation(({ url }) => {
         if (url === '/api/v2/users/me') {
@@ -239,6 +252,10 @@ describe('fallbackUsersHandler', () => {
           [DEPLOY_CONFIG]: { defaultMissingUserFallback: '##DEPLOYER##' },
           [FETCH_CONFIG]: { resolveUserIDs: false },
         },
+        usersPromise: Promise.resolve({
+          users: [{}],
+          errors: [{ message: 'No users here!', severity: 'Warning' }],
+        }),
       } as FixElementsArgs)(instances)
     })
 
@@ -267,6 +284,12 @@ describe('fallbackUsersHandler', () => {
         [DEPLOY_CONFIG]: { defaultMissingUserFallback: 'fallback@.com' },
         [FETCH_CONFIG]: { resolveUserIDs: true },
       },
+      usersPromise: Promise.resolve({
+        users: [
+          { id: 3, email: 'c@c.com', role: 'admin', custom_role_id: 123, name: 'c', locale: 'en-US' },
+          { id: 4, email: 'fallback@.com', role: 'agent', custom_role_id: 12, name: 'fallback', locale: 'en-US' },
+        ],
+      }),
     } as FixElementsArgs)(instances)
     expect(fallbackResponse.fixedElements).toEqual([])
   })

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -20,7 +20,7 @@ import { mockFunction } from '@salto-io/test-utils'
 import ZendeskClient from '../src/client/client'
 import { ZendeskDeployConfig } from '../src/config'
 import { SECTION_TRANSLATION_TYPE_NAME, ZENDESK } from '../src/constants'
-import * as usersUtilsModule from '../src/user_utils'
+import * as usersUtilsModule from '../src/users/user_utils'
 
 const logError = jest.fn()
 jest.mock('@salto-io/logging', () => {
@@ -38,7 +38,7 @@ describe('userUtils', () => {
     beforeEach(() => {
       jest.isolateModules(() => {
         // eslint-disable-next-line global-require
-        userUtils = require('../src/user_utils')
+        userUtils = require('../src/users/user_utils')
       })
     })
 
@@ -66,33 +66,6 @@ describe('userUtils', () => {
         { id: 2, email: 'e@e.com', role: 'agent', name: 'e', locale: 'en-US', custom_role_id: undefined },
       ])
     })
-    it('should cache results when between getUsers calls', async () => {
-      const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function* get() {
-        yield [
-          {
-            users: [
-              { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
-              { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
-              { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
-            ],
-          },
-        ]
-      })
-      const { users } = await userUtils.getUsers(mockPaginator, true)
-      expect(users).toEqual([
-        { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
-        { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
-        { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
-      ])
-      const { users: getUsersAfterCache } = await userUtils.getUsers(mockPaginator, true)
-      expect(getUsersAfterCache).toEqual([
-        { id: 1, email: 'a@a.com', name: 'a', locale: 'en-US' },
-        { id: 2, email: 'b@b.com', name: 'b', locale: 'en-US' },
-        { id: 2, email: 'd@d.com', role: 'agent', custom_role_id: null, name: 'd', locale: 'en-US' },
-      ])
-      await userUtils.getUsers(mockPaginator, true)
-      expect(mockPaginator).toHaveBeenCalledTimes(1)
-    })
     it('should return empty list if users are in invalid format', async () => {
       const mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function* get() {
         yield [
@@ -119,7 +92,7 @@ describe('userUtils', () => {
     beforeEach(() => {
       jest.isolateModules(() => {
         // eslint-disable-next-line global-require
-        userUtils = require('../src/user_utils')
+        userUtils = require('../src/users/user_utils')
       })
     })
     it('should return valid id-email record when called', async () => {
@@ -134,8 +107,8 @@ describe('userUtils', () => {
           },
         ]
       })
-
-      const idByEmail = await userUtils.getIdByEmail(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByEmail = await userUtils.getIdByEmail(getUsersPromise)
       expect(idByEmail).toEqual({
         1: 'a@a.com',
         2: 'b@b.com',
@@ -153,17 +126,18 @@ describe('userUtils', () => {
           },
         ]
       })
-      const idByEmail = await userUtils.getIdByEmail(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByEmail = await userUtils.getIdByEmail(getUsersPromise)
       expect(idByEmail).toEqual({
         1: 'a@a.com',
         2: 'b@b.com',
       })
-      const idByEmailAfterCache = await userUtils.getIdByEmail(mockPaginator, true)
+      const idByEmailAfterCache = await userUtils.getIdByEmail(getUsersPromise)
       expect(idByEmailAfterCache).toEqual({
         1: 'a@a.com',
         2: 'b@b.com',
       })
-      await userUtils.getIdByEmail(mockPaginator, true)
+      await userUtils.getIdByEmail(getUsersPromise)
       expect(mockPaginator).toHaveBeenCalledTimes(1)
     })
     it('should return empty object if users are in invalid format, getIdByEmail', async () => {
@@ -174,7 +148,8 @@ describe('userUtils', () => {
           },
         ]
       })
-      const idByEmail = await userUtils.getIdByEmail(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByEmail = await userUtils.getIdByEmail(getUsersPromise)
       expect(idByEmail).toEqual({})
       expect(mockPaginator).toHaveBeenCalledTimes(1)
     })
@@ -185,7 +160,7 @@ describe('userUtils', () => {
     beforeEach(() => {
       jest.isolateModules(() => {
         // eslint-disable-next-line global-require
-        userUtils = require('../src/user_utils')
+        userUtils = require('../src/users/user_utils')
       })
     })
     it('should return valid id-name record when called', async () => {
@@ -200,8 +175,8 @@ describe('userUtils', () => {
           },
         ]
       })
-
-      const idByName = await userUtils.getIdByName(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByName = await userUtils.getIdByName(getUsersPromise)
       expect(idByName).toEqual({
         1: 'a',
         2: 'b',
@@ -219,17 +194,18 @@ describe('userUtils', () => {
           },
         ]
       })
-      const idByName = await userUtils.getIdByName(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByName = await userUtils.getIdByName(getUsersPromise)
       expect(idByName).toEqual({
         1: 'a',
         2: 'b',
       })
-      const idByEmailAfterCache = await userUtils.getIdByName(mockPaginator, true)
+      const idByEmailAfterCache = await userUtils.getIdByName(getUsersPromise)
       expect(idByEmailAfterCache).toEqual({
         1: 'a',
         2: 'b',
       })
-      await userUtils.getIdByName(mockPaginator, true)
+      await userUtils.getIdByName(getUsersPromise)
       expect(mockPaginator).toHaveBeenCalledTimes(1)
     })
     it('should return empty object if users are in invalid format, getIdByName', async () => {
@@ -240,7 +216,8 @@ describe('userUtils', () => {
           },
         ]
       })
-      const idByName = await userUtils.getIdByName(mockPaginator, true)
+      const getUsersPromise = userUtils.getUsers(mockPaginator, true)
+      const idByName = await userUtils.getIdByName(getUsersPromise)
       expect(idByName).toEqual({})
       expect(mockPaginator).toHaveBeenCalledTimes(1)
     })

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -21,6 +21,7 @@ import { DEFAULT_CONFIG, ZendeskConfig } from '../src/config'
 import ZendeskClient from '../src/client/client'
 import { paginate } from '../src/client/pagination'
 import { BrandIdToClient } from '../src/filter'
+import { GetUsersResponse } from '../src/users/types'
 
 type FilterCreatorParams = {
   client: ZendeskClient
@@ -29,6 +30,7 @@ type FilterCreatorParams = {
   fetchQuery: elementUtils.query.ElementQuery
   elementsSource: ReadOnlyElementsSource
   brandIdToClient: BrandIdToClient
+  usersPromise: Promise<GetUsersResponse>
 }
 
 export const createFilterCreatorParams = ({
@@ -43,6 +45,7 @@ export const createFilterCreatorParams = ({
   fetchQuery = elementUtils.query.createMockQuery(),
   elementsSource = buildElementsSourceFromElements([]),
   brandIdToClient = {},
+  usersPromise = Promise.resolve({ users: [], errors: [] }),
 }: Partial<FilterCreatorParams>): FilterCreatorParams => ({
   client,
   paginator,
@@ -50,4 +53,5 @@ export const createFilterCreatorParams = ({
   fetchQuery,
   elementsSource,
   brandIdToClient,
+  usersPromise,
 })


### PR DESCRIPTION
Re-creating the PR that i previously reverted. 

The getUsers query currently runs on a global scope and caches the user data.
This means having more than one workspace on a single process can cause data leakage and unexpected behaviour, which happens when running SAAS locally.

In this PR I move the scope of the query from global to the zendesk adapter, which prevents the leak.
This is essentially identical to the pattern added [here in Okta](https://github.com/salto-io/salto/pull/5261/files#diff-fdd8ade86a6a37213a71a3465db95e5e94e20ec7bc026beab906303cc6630a1aR127).

---

I ran Saas locally with my changes, added logs and made sure that the query executes correctly and that fetch and deployment works properly.

---

_Release Notes_: 
Zendesk:
Fix leakage of users when running Saas locally with multiple environments

---
_User Notifications_: 
None