### PR TITLE
SALTO-5408 - Salesforce: Validate Salesforce CustomField businessOwnerUser user existence

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -25,7 +25,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     : undefined,
   coverageThreshold: {
     global: {
-      branches: 88.69,
+      branches: 88.65,
       functions: 94,
       lines: 95,
       statements: 95,

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -30,6 +30,7 @@ import changeValidator from '../../src/change_validators/unknown_users'
 import {
   createInstanceElement,
   createMetadataObjectType,
+  Types,
 } from '../../src/transformers/transformer'
 import {
   CUSTOM_OBJECT,
@@ -40,7 +41,7 @@ import {
 } from '../../src/constants'
 import { SalesforceRecord } from '../../src/client/types'
 import { mockTypes } from '../mock_elements'
-import { createCustomObjectType } from '../utils'
+import { createCustomObjectType, createField } from '../utils'
 import * as filterUtilsModule from '../../src/filters/utils'
 
 jest.mock('../../src/filters/utils', () => ({
@@ -98,7 +99,7 @@ describe('unknown user change validator', () => {
     })
   })
   describe('when a username exists in Salesforce', () => {
-    let change: Change
+    let changes: Change[]
     beforeEach(() => {
       const beforeRecord = createInstanceElement(
         { fullName: 'someName', defaultCaseUser: IRRELEVANT_USERNAME },
@@ -106,13 +107,29 @@ describe('unknown user change validator', () => {
       )
       const afterRecord = beforeRecord.clone()
       afterRecord.value.defaultCaseUser = TEST_USERNAME
-      change = toChange({ before: beforeRecord, after: afterRecord })
+
+      const typeForCustomField = mockTypes.Account.clone()
+      const fieldBefore = createField(
+        typeForCustomField,
+        Types.primitiveDataTypes.Text,
+        'SomeField',
+        {
+          businessOwnerUser: IRRELEVANT_USERNAME,
+        },
+      )
+      const fieldAfter = fieldBefore.clone()
+      fieldAfter.annotations.businessOwnerUser = TEST_USERNAME
+
+      changes = [
+        toChange({ before: beforeRecord, after: afterRecord }),
+        toChange({ before: fieldBefore, after: fieldAfter }),
+      ]
 
       setupClientMock([TEST_USERNAME])
     })
 
     it('should pass validation', async () => {
-      const changeErrors = await validator([change])
+      const changeErrors = await validator(changes)
       expect(changeErrors).toBeEmpty()
     })
   })
@@ -557,6 +574,31 @@ describe('unknown user change validator', () => {
         'elemID',
         instanceElemId.createNestedID('assignmentRule', '1', 'ruleEntry', '0'),
       )
+    })
+  })
+  describe('when the user information is in a CustomField annotation', () => {
+    let changes: Change[]
+    beforeEach(() => {
+      const typeForCustomField = mockTypes.Account.clone()
+      const fieldAfter = createField(
+        typeForCustomField,
+        Types.primitiveDataTypes.Text,
+        'SomeField',
+        {
+          businessOwnerUser: TEST_USERNAME,
+        },
+      )
+      changes = [toChange({ after: fieldAfter })]
+
+      setupClientMock([IRRELEVANT_USERNAME])
+    })
+    it('should fail validation', async () => {
+      const changeErrors = await validator(changes)
+      expect(changeErrors).toEqual([
+        expect.objectContaining({
+          elemID: getChangeData(changes[0]).elemID,
+        }),
+      ])
     })
   })
 })

--- a/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unknown_users.test.ts
@@ -576,7 +576,7 @@ describe('unknown user change validator', () => {
       )
     })
   })
-  describe('when the user information is in a CustomField annotation', () => {
+  describe('when the user information is in a CustomField businessOwnerUser annotation', () => {
     let changes: Change[]
     beforeEach(() => {
       const typeForCustomField = mockTypes.Account.clone()
@@ -592,7 +592,7 @@ describe('unknown user change validator', () => {
 
       setupClientMock([IRRELEVANT_USERNAME])
     })
-    it('should fail validation', async () => {
+    it('should return a change error', async () => {
       const changeErrors = await validator(changes)
       expect(changeErrors).toEqual([
         expect.objectContaining({


### PR DESCRIPTION
There's an annotation on custom fields that refers to a user. Let's validate that user too

---
This is different from the current validations because it runs on annotations of all custom fields as opposed to the values of specific fields. Thus a separate function.

<img width="1523" alt="image" src="https://github.com/salto-io/salto/assets/117099820/5531c658-1cbc-49ff-b7a0-d7727fd17c79">


---
_Release Notes_: 
Salesforce: Will now validate custom fields' Data Owner property

---
_User Notifications_: 
N/A