### PR TITLE
SALTO-5184: Validating Zendesk automation order isn't empty

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -85,6 +85,7 @@ import {
   inactiveTicketFormInViewValidator,
   immutableTypeAndKeyForUserFieldsValidator,
   localeModificationValidator,
+  emptyAutomationOrderValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ChangeValidatorName, ZendeskDeployConfig, ZendeskFetchConfig, ZendeskConfig } from './config'
@@ -185,6 +186,7 @@ export default ({
     inactiveTicketFormInView: inactiveTicketFormInViewValidator,
     immutableTypeAndKeyForUserFields: immutableTypeAndKeyForUserFieldsValidator,
     localeModification: localeModificationValidator,
+    emptyAutomationOrder: emptyAutomationOrderValidator,
     // *** Guide Order Validators ***
     childInOrder: childInOrderValidator,
     childrenReferences: childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/empty_automation_order.ts
+++ b/packages/zendesk-adapter/src/change_validators/empty_automation_order.ts
@@ -1,0 +1,43 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import {
+  ChangeValidator,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { AUTOMATION_ORDER_TYPE_NAME } from '../constants'
+
+export const emptyAutomationOrderValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === AUTOMATION_ORDER_TYPE_NAME)
+    .flatMap(instance => {
+      if (_.isEmpty(instance.value.active) && _.isEmpty(instance.value.inactive)) {
+        return [
+          {
+            elemID: instance.elemID,
+            severity: 'Error',
+            message: 'Cannot make this change due to empty automation order',
+            detailedMessage: 'Automation order must have at least one active or inactive item',
+          },
+        ]
+      }
+      return []
+    })

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -87,3 +87,4 @@ export { dynamicContentPlaceholderModificationValidator } from './dynamic_conten
 export { inactiveTicketFormInViewValidator } from './inactive_ticket_forms_in_view'
 export { immutableTypeAndKeyForUserFieldsValidator } from './immutable_fields_in_user_fields'
 export { localeModificationValidator } from './locale'
+export { emptyAutomationOrderValidator } from './empty_automation_order'

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2940,6 +2940,7 @@ export type ChangeValidatorName =
   | 'inactiveTicketFormInView'
   | 'immutableTypeAndKeyForUserFields'
   | 'localeModification'
+  | 'emptyAutomationOrder'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -3017,6 +3018,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     inactiveTicketFormInView: { refType: BuiltinTypes.BOOLEAN },
     immutableTypeAndKeyForUserFields: { refType: BuiltinTypes.BOOLEAN },
     localeModification: { refType: BuiltinTypes.BOOLEAN },
+    emptyAutomationOrder: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/test/change_validators/empty_automation_order.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/empty_automation_order.test.ts
@@ -1,0 +1,60 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { AUTOMATION_ORDER_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { emptyAutomationOrderValidator } from '../../src/change_validators/empty_automation_order'
+
+describe('emptyVariantsValidator', () => {
+  const itemType = new ObjectType({
+    elemID: new ElemID(ZENDESK, AUTOMATION_ORDER_TYPE_NAME),
+    isSettings: true,
+  })
+  const item = new InstanceElement('automationOrder', itemType, { name: 'test1', active: [], inactive: [] })
+  it('should return an error for an empty automation order', async () => {
+    const errors = await emptyAutomationOrderValidator([toChange({ after: item })])
+    expect(errors).toEqual([
+      {
+        elemID: item.elemID,
+        severity: 'Error',
+        message: 'Cannot make this change due to empty automation order',
+        detailedMessage: 'Automation order must have at least one active or inactive item',
+      },
+    ])
+  })
+  it('should not return an error when we remove an item', async () => {
+    const errors = await emptyAutomationOrderValidator([toChange({ before: item })])
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when there are active items', async () => {
+    const clonedItem = item.clone()
+    clonedItem.value.active = ['active_item']
+    const errors = await emptyAutomationOrderValidator([toChange({ after: clonedItem })])
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when there are inactive items', async () => {
+    const clonedItem = item.clone()
+    clonedItem.value.inactive = ['inactive_item']
+    const errors = await emptyAutomationOrderValidator([toChange({ after: clonedItem })])
+    expect(errors).toHaveLength(0)
+  })
+  it('should not return an error when there are active and inactive items', async () => {
+    const clonedItem = item.clone()
+    clonedItem.value.active = ['active_item']
+    clonedItem.value.inactive = ['inactive_item']
+    const errors = await emptyAutomationOrderValidator([toChange({ after: clonedItem })])
+    expect(errors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Validating Zendesk automation order isn't empty.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Zendesk_:
- Validating Zendesk automation order isn't empty.

---
_User Notifications_: 
None.
