### PR TITLE
SALTO-5683: Fix JSM Calendar duplication 

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -133,7 +133,7 @@ import jqlReferencesFilter from './filters/jql/jql_references'
 import userFilter from './filters/user'
 import changePortalGroupFieldsFilter from './filters/change_portal_group_fields'
 import { JIRA, PROJECT_TYPE, SERVICE_DESK } from './constants'
-import { paginate, removeScopedObjects } from './client/pagination'
+import { paginate, filterResponseEntries } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
 import { getChangeGroupIds } from './group_change'
 import fetchCriteria from './fetch_criteria'
@@ -440,7 +440,7 @@ export default class JiraAdapter implements AdapterOperations {
     const paginator = createPaginator({
       client: this.client,
       paginationFuncCreator: paginate,
-      customEntryExtractor: removeScopedObjects,
+      customEntryExtractor: filterResponseEntries,
       asyncRun: config.fetch.asyncPagination ?? true,
     })
 

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -46,12 +46,8 @@ const notTeamBoard = (obj: clientUtils.ResponseValue): boolean =>
   !(_.isPlainObject(obj) && 'type' in obj && obj.type === 'simple' && 'self' in obj && isBoardSelfUrl(obj.self))
 
 // filters out calendars that are unrelated to the porject.
-const notRelatedCalendars = (obj: clientUtils.ResponseValue): boolean => {
-  const a = !(_.isPlainObject(obj) && 'canCreate' in obj && obj.canCreate === false && 'calendars' in obj)
-  // eslint-disable-next-line no-console
-  // console.log(`isPlainObject(obj): ${_.isPlainObject(obj)} and 'canCreate' in obj: ${'canCreate' in obj} and obj.canCreate === false: ${obj.canCreate === false} and 'calendars' in obj: ${'calendars' in obj} and a: ${a}`)
-  return a
-}
+const notRelatedCalendars = (obj: clientUtils.ResponseValue): boolean =>
+  !(_.isPlainObject(obj) && 'canCreate' in obj && obj.canCreate === false && 'calendars' in obj)
 
 const filterResponseEntriesRecursively = <T extends clientUtils.ResponseValue>(response: T | T[]): T | T[] => {
   if (Array.isArray(response)) {

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -45,19 +45,31 @@ const notTeamScopeObject = (obj: clientUtils.ResponseValue): boolean =>
 const notTeamBoard = (obj: clientUtils.ResponseValue): boolean =>
   !(_.isPlainObject(obj) && 'type' in obj && obj.type === 'simple' && 'self' in obj && isBoardSelfUrl(obj.self))
 
-const removeScopedObjectsImpl = <T extends clientUtils.ResponseValue>(response: T | T[]): T | T[] => {
+// filters out calendars that are unrelated to the porject.
+const notRelatedCalendars = (obj: clientUtils.ResponseValue): boolean => {
+  const a = !(_.isPlainObject(obj) && 'canCreate' in obj && obj.canCreate === false && 'calendars' in obj)
+  // eslint-disable-next-line no-console
+  // console.log(`isPlainObject(obj): ${_.isPlainObject(obj)} and 'canCreate' in obj: ${'canCreate' in obj} and obj.canCreate === false: ${obj.canCreate === false} and 'calendars' in obj: ${'calendars' in obj} and a: ${a}`)
+  return a
+}
+
+const filterResponseEntriesRecursively = <T extends clientUtils.ResponseValue>(response: T | T[]): T | T[] => {
   if (Array.isArray(response)) {
-    return response.filter(notTeamScopeObject).filter(notTeamBoard).flatMap(removeScopedObjectsImpl) as T[]
+    return response
+      .filter(notTeamScopeObject)
+      .filter(notTeamBoard)
+      .filter(notRelatedCalendars)
+      .flatMap(filterResponseEntriesRecursively) as T[]
   }
   if (_.isObject(response)) {
-    return _.mapValues(response, removeScopedObjectsImpl) as T
+    return _.mapValues(response, filterResponseEntriesRecursively) as T
   }
   return response
 }
 
-export const removeScopedObjects: clientUtils.PageEntriesExtractor = (
+export const filterResponseEntries: clientUtils.PageEntriesExtractor = (
   entry: clientUtils.ResponseValue,
-): clientUtils.ResponseValue[] => makeArray(removeScopedObjectsImpl([entry]))
+): clientUtils.ResponseValue[] => makeArray(filterResponseEntriesRecursively([entry]))
 
 export const paginate: clientUtils.PaginationFuncCreator = args => {
   if (ITEM_INDEX_PAGINATION_URLS.includes(args.getParams?.url)) {


### PR DESCRIPTION
In this PR I fixed the JSM Calendar duplication. 

---

_Additional context for reviewer_
much more context can be found in https://salto-io.atlassian.net/issues/SALTO-5683?jql=assignee%20in%20%28currentUser%28%29%29%20AND%20statusCategory%20in%20%282%2C%204%29%20ORDER%20BY%20statusCategory%20ASC%2C%20updated%20DESC

---
_Release Notes_: 
_Jira Adapter:_
* Fixed duplication error that arose from a bad response for Calendar instances. 

---
_User Notifications_: 
None
