### PR TITLE
SALTO-5679: Improve CLI ouput

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 import _ from 'lodash'
-import { EOL } from 'os'
 import { collections, promises } from '@salto-io/lowerdash'
 import {
   PlanItem,
@@ -184,7 +183,6 @@ const deployPlan = async (
   )
   outputLine(deployErrorsOutput(result.errors), output)
   outputLine(deployPhaseEpilogue(nonErroredActions.length, result.errors.length, checkOnly), output)
-  output.stdout.write(EOL)
   log.debug(`${result.errors.length} errors occurred:\n${result.errors.map(err => err.message).join('\n')}`)
 
   if (executingDeploy) {

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -330,7 +330,6 @@ export const formatDeployActions = ({
       ...deployAction.subActions.map(action => indent(`- ${action}`, 1)),
       deployAction.documentationURL ?? '',
     ]),
-    emptyLine(),
   ]
 }
 
@@ -345,10 +344,10 @@ export const formatExecutionPlan = async (
     isPreDeploy: true,
   })
   const planErrorsOutput: string[] = _.isEmpty(formattedPlanChangeErrors)
-    ? [emptyLine()]
-    : [emptyLine(), header(Prompts.PLAN_CHANGE_ERRS_HEADER), formattedPlanChangeErrors, emptyLine()]
+    ? []
+    : [emptyLine(), header(Prompts.PLAN_CHANGE_ERRS_HEADER), formattedPlanChangeErrors]
   if (_.isEmpty(plan)) {
-    return [emptyLine(), Prompts.EMPTY_PLAN, ...planErrorsOutput, emptyLine()].join('\n')
+    return [emptyLine(), Prompts.EMPTY_PLAN, ...planErrorsOutput].join('\n')
   }
   const actionCount = formatCountPlanItemTypes(plan)
   const planSteps = await formatDetailedChanges(
@@ -359,11 +358,10 @@ export const formatExecutionPlan = async (
     emptyLine(),
     planSteps,
     ...planErrorsOutput,
-    emptyLine(),
     ...preDeployCallToActions,
+    emptyLine(),
     subHeader(Prompts.EXPLAIN_PREVIEW_RESULT),
     actionCount,
-    emptyLine(),
     emptyLine(),
   ].join('\n')
 }
@@ -372,10 +370,10 @@ const deployPhaseIndent = 2
 const formatItemName = (itemName: string): string => indent(header(`${itemName}:`), deployPhaseIndent)
 
 export const deployPhaseHeader = (checkOnly: boolean): string =>
-  header([emptyLine(), Prompts.START_DEPLOY_EXEC(checkOnly), emptyLine()].join('\n'))
+  header([emptyLine(), Prompts.START_DEPLOY_EXEC(checkOnly)].join('\n'))
 
 export const cancelDeployOutput = (checkOnly: boolean): string =>
-  [emptyLine(), Prompts.CANCEL_DEPLOY(checkOnly), emptyLine()].join('\n')
+  [emptyLine(), Prompts.CANCEL_DEPLOY(checkOnly)].join('\n')
 
 export const deployErrorsOutput = (allErrors: DeployError[]): string => {
   const getErrorMessage = (err: DeployError): string =>

--- a/packages/cli/src/outputer.ts
+++ b/packages/cli/src/outputer.ts
@@ -22,6 +22,10 @@ import { formatStepStart, formatStepCompleted, formatStepFailed } from './format
 const log = logger(module)
 
 export const outputLine = (text: string, output: CliOutput): void => {
+  if (text === '') {
+    return
+  }
+
   output.stdout.write(`${text}\n`)
   log.debug(text)
 }

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -114,10 +114,10 @@ ${Prompts.ACCOUNT_ADD_HELP}
   public static readonly FETCH_SUB_HEADER = `This might take a few minutes. You can go grab your favorite beverage.
 The steps are: I. Fetching configs, II. Calculating difference and III. Applying the changes`
   public static readonly FETCH_GET_CHANGES_START = (adapters: string[]): string =>
-    `Fetching the latest configs from: ${adapters}`
+    `Fetching the latest configs from: ${adapters.join(', ')}`
 
   public static readonly FETCH_GET_CHANGES_FINISH = (adapters: string[]): string =>
-    `Finished fetching the latest configs from: ${adapters}`
+    `Finished fetching the latest configs from: ${adapters.join(', ')}`
 
   public static readonly FETCH_GET_CHANGES_FAIL = 'Fetching failed'
   public static readonly FETCH_CALC_DIFF_START = 'Calculating the difference between local and remote'


### PR DESCRIPTION
- Removing many extra newlines.
- Improving adapter names.

---

_Additional context for reviewer_
Just stuff I ran into using the CLI.

Example before changes:
<img width="960" alt="Before" src="https://github.com/salto-io/salto/assets/1666471/e87d85fc-d233-4bbd-93e4-527c8c7c1710">

After:
<img width="956" alt="After" src="https://github.com/salto-io/salto/assets/1666471/88cfc082-48c2-46c1-935d-efb0c123ae80">

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
