### PR TITLE
SALTO-5690: add timeDebug and timeTrace to logger

### DIFF
--- a/packages/adapter-components/src/client/decorators.ts
+++ b/packages/adapter-components/src/client/decorators.ts
@@ -56,7 +56,7 @@ export const logDecorator = (
     const desc = logOperationDecorator(originalMethod, this.clientName, keys, additionalKeysFunc)
     try {
       // eslint-disable-next-line @typescript-eslint/return-await
-      return await log.time(originalMethod.call, desc)
+      return await log.timeDebug(originalMethod.call, desc)
     } catch (e) {
       log.warn('failed to run %s client call %s: %s', this.clientName, desc, e.message)
       throw e

--- a/packages/adapter-components/src/deployment/change_validators/create_change_validator.ts
+++ b/packages/adapter-components/src/deployment/change_validators/create_change_validator.ts
@@ -35,7 +35,7 @@ export const createChangeValidator =
     return _.flatten(
       await Promise.all(
         activeValidators.map(([name, validator]) =>
-          log.time(() => validator(changes, elementSource), `validator ${name}`),
+          log.timeDebug(() => validator(changes, elementSource), `validator ${name}`),
         ),
       ),
     )

--- a/packages/adapter-components/src/fetch/resource/resource_manager.ts
+++ b/packages/adapter-components/src/fetch/resource/resource_manager.ts
@@ -63,7 +63,7 @@ export const createResourceManager = <ClientOptions extends string>({
   elementGenerator: ElementGenerator
   initialRequestContext?: Record<string, unknown>
 }): ResourceManager => ({
-  fetch: log.time(
+  fetch: log.timeDebug(
     () => async query => {
       const createTypeFetcher: TypeFetcherCreator = ({ typeName, context }) =>
         createTypeResourceFetcher({

--- a/packages/adapter-components/test/client/decorators.test.ts
+++ b/packages/adapter-components/test/client/decorators.test.ts
@@ -62,7 +62,7 @@ describe('client_decorators', () => {
     let inst: TestCls
 
     beforeAll(() => {
-      log = jest.spyOn(logging, 'time')
+      log = jest.spyOn(logging, 'timeDebug')
       inst = new TestCls()
     })
     beforeEach(() => {
@@ -71,14 +71,14 @@ describe('client_decorators', () => {
 
     it('should log', async () => {
       await inst.doSomethingElse()
-      expect(logging.time).toHaveBeenCalledTimes(1)
-      expect(logging.time).toHaveBeenCalledWith(expect.anything(), 'cli:client.doSomethingElse()')
+      expect(logging.timeDebug).toHaveBeenCalledTimes(1)
+      expect(logging.timeDebug).toHaveBeenCalledWith(expect.anything(), 'cli:client.doSomethingElse()')
     })
 
     it('should log with arguments', async () => {
       await inst.doSomethingWithDetails({ str: 'bla', num: 123, arr: [{ str: 'str' }, { str: 'STR' }] })
-      expect(logging.time).toHaveBeenCalledTimes(1)
-      expect(logging.time).toHaveBeenCalledWith(expect.anything(), 'cli:client.doSomethingWithDetails(bla, str)')
+      expect(logging.timeDebug).toHaveBeenCalledTimes(1)
+      expect(logging.timeDebug).toHaveBeenCalledWith(expect.anything(), 'cli:client.doSomethingWithDetails(bla, str)')
     })
   })
 

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -64,7 +64,7 @@ const compareListWithOrderMatching = ({
   afterId: ElemID | undefined
   options: DetailedCompareOptions | undefined
 }): DetailedChange[] =>
-  log.time(() => {
+  log.timeDebug(() => {
     const indexMapping = getArrayIndexMapping(before, after)
 
     const itemsChanges = _.flatten(

--- a/packages/adapter-utils/src/decorators.ts
+++ b/packages/adapter-utils/src/decorators.ts
@@ -20,5 +20,5 @@ const log = logger(module)
 
 export const logDuration = (message: string): decorators.InstanceMethodDecorator =>
   decorators.wrapMethodWith(
-    async (original: decorators.OriginalCall): Promise<unknown> => log.time(original.call, message),
+    async (original: decorators.OriginalCall): Promise<unknown> => log.timeDebug(original.call, message),
   )

--- a/packages/adapter-utils/src/filter.ts
+++ b/packages/adapter-utils/src/filter.ts
@@ -112,7 +112,7 @@ export const filtersRunner = <R extends FilterResult | void, T, DeployInfo = voi
       const filterResults = (
         await promises.array.series(
           filtersWith('onFetch').map(
-            filter => () => log.time(() => filter.onFetch(elements), `(${filter.name}):onFetch`),
+            filter => () => log.timeDebug(() => filter.onFetch(elements), `(${filter.name}):onFetch`),
           ),
         )
       ).filter(isDefined)
@@ -127,7 +127,7 @@ export const filtersRunner = <R extends FilterResult | void, T, DeployInfo = voi
       await promises.array.series(
         filtersWith('preDeploy')
           .reverse()
-          .map(filter => () => log.time(() => filter.preDeploy(changes), `(${filter.name}):preDeploy`)),
+          .map(filter => () => log.timeDebug(() => filter.preDeploy(changes), `(${filter.name}):preDeploy`)),
       )
     },
     /**
@@ -136,7 +136,7 @@ export const filtersRunner = <R extends FilterResult | void, T, DeployInfo = voi
     deploy: async (changes, changeGroup) =>
       awu(filtersWith('deploy')).reduce(
         async (total, current) => {
-          const { deployResult, leftoverChanges } = await log.time(
+          const { deployResult, leftoverChanges } = await log.timeDebug(
             () => current.deploy(total.leftoverChanges, changeGroup),
             `(${current.name}):deploy`,
           )
@@ -161,7 +161,7 @@ export const filtersRunner = <R extends FilterResult | void, T, DeployInfo = voi
     onDeploy: async (changes, deployResult) => {
       await promises.array.series(
         filtersWith('onDeploy').map(
-          filter => () => log.time(() => filter.onDeploy(changes, deployResult), `(${filter.name}):onDeploy`),
+          filter => () => log.timeDebug(() => filter.onDeploy(changes, deployResult), `(${filter.name}):onDeploy`),
         ),
       )
     },
@@ -176,7 +176,7 @@ export const filtersRunner = <R extends FilterResult | void, T, DeployInfo = voi
     onPostFetch: async args => {
       await promises.array.series(
         filtersWith('onPostFetch').map(
-          filter => () => log.time(() => filter.onPostFetch(args), `(${filter.name}):onPostFetch`),
+          filter => () => log.timeDebug(() => filter.onPostFetch(args), `(${filter.name}):onPostFetch`),
         ),
       )
     },

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -298,7 +298,7 @@ export const getArrayIndexMapping = (before: Value[], after: Value[]): IndexMapp
  *   Here we chose the results for such case to be ['a', 'b'].
  */
 export const applyListChanges = (element: ChangeDataType, changes: DetailedChange[]): void =>
-  log.time(() => {
+  log.timeDebug(() => {
     const ids = changes.map(change => change.id)
     if (
       ids.some(id => !isIndexPathPart(id.name)) ||

--- a/packages/adapter-utils/test/decorators.test.ts
+++ b/packages/adapter-utils/test/decorators.test.ts
@@ -42,7 +42,7 @@ describe('decorators', () => {
     let inst: TestCls
 
     beforeAll(() => {
-      log = jest.spyOn(logging, 'time')
+      log = jest.spyOn(logging, 'timeDebug')
       inst = new TestCls()
     })
     beforeEach(() => {
@@ -50,14 +50,14 @@ describe('decorators', () => {
     })
     it('should log the time it took to run sync functions', () => {
       inst.syncFunc()
-      expect(logging.time).toHaveBeenCalledTimes(1)
-      expect(logging.time).toHaveBeenCalledWith(expect.anything(), 'running sync')
+      expect(logging.timeDebug).toHaveBeenCalledTimes(1)
+      expect(logging.timeDebug).toHaveBeenCalledWith(expect.anything(), 'running sync')
     })
 
     it('should log the time it took to run async functions', async () => {
       await inst.asyncFunc()
-      expect(logging.time).toHaveBeenCalledTimes(1)
-      expect(logging.time).toHaveBeenCalledWith(expect.anything(), 'running async')
+      expect(logging.timeDebug).toHaveBeenCalledTimes(1)
+      expect(logging.timeDebug).toHaveBeenCalledWith(expect.anything(), 'running async')
     })
   })
 })

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -185,7 +185,7 @@ export const deploy = async (
   )
 
   const postDeployAction = async (appliedChanges: ReadonlyArray<Change>): Promise<void> =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       // This function is inside 'postDeployAction' because it assumes the state is already updated
       const getUpdatedElement = async (change: Change): Promise<ChangeDataType> => {
         const changeElem = getChangeData(change)

--- a/packages/core/src/core/diff.ts
+++ b/packages/core/src/core/diff.ts
@@ -30,7 +30,7 @@ const getFilteredIds = (
   source: elementSource.ElementsSource,
   referenceSourcesIndex: remoteMap.ReadOnlyRemoteMap<ElemID[]>,
 ): Promise<ElemID[]> =>
-  log.time(
+  log.timeDebug(
     async () =>
       awu(
         await selectElementIdsByTraversal({
@@ -177,7 +177,7 @@ export const getEnvsDeletionsDiff = async (
   envs: ReadonlyArray<string>,
   selectors: ElementSelector[],
 ): Promise<Record<string, ElemID[]>> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     const envsElemIds: Record<string, ElemID[]> = Object.fromEntries(
       await awu(envs)
         .map(async env => [

--- a/packages/core/src/core/merge_content.ts
+++ b/packages/core/src/core/merge_content.ts
@@ -56,7 +56,7 @@ export const mergeStrings = (
     incoming: string
   },
 ): string | undefined =>
-  log.time(
+  log.timeDebug(
     () => {
       const contents = [current, base ?? '', incoming]
       log.debug(

--- a/packages/core/src/core/plan/dependency/dependency.ts
+++ b/packages/core/src/core/plan/dependency/dependency.ts
@@ -50,7 +50,7 @@ const updateDeps = (
 export const addNodeDependencies =
   (changers: ReadonlyArray<DependencyChanger>): PlanTransformer =>
   graph =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       if (changers.length === 0) {
         // If there are no changers we return here to avoid creating changeData for no reason
         return graph

--- a/packages/core/src/core/plan/dependency/reference_dependency.ts
+++ b/packages/core/src/core/plan/dependency/reference_dependency.ts
@@ -60,7 +60,7 @@ const isReferenceValueChanged = (change: Change<ChangeDataType>, refElemId: Elem
 }
 
 export const addReferencesDependency: DependencyChanger = async changes =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     const changesById = collections.iterable.groupBy(changes, ([_id, change]) => getChangeElemId(change))
 
     const addChangeDependency = async ([id, change]: ChangeEntry): Promise<Iterable<DependencyChange>> => {

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -209,7 +209,7 @@ export const filterInvalidChanges = (
   diffGraph: DiffGraph<ChangeDataType>,
   changeValidators: Record<string, ChangeValidator>,
 ): Promise<FilterResult> =>
-  log.time(
+  log.timeDebug(
     async () => {
       if (Object.keys(changeValidators).length === 0) {
         // Shortcut to avoid grouping all changes if there are no validators to run

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -79,7 +79,7 @@ export const getCustomGroupIds = async (
 // If we add / remove an object type, we can omit all the field add / remove
 // changes from the same group since they are included in the parent change
 const removeRedundantFieldNodes = (graph: DataNodeMap<Change>, groupKey: GroupKeyFunc): DataNodeMap<Change> =>
-  log.time(() => {
+  log.timeDebug(() => {
     const groupIdToAddedOrRemovedTypesMap = new DefaultMap<string, Map<string, collections.set.SetId>>(() => new Map())
     wu(graph.keys()).forEach(nodeId => {
       const change = graph.getData(nodeId)

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -231,7 +231,7 @@ const addDifferentElements =
     compareOptions?: CompareOptions,
   ): PlanTransformer =>
   graph =>
-    log.time(
+    log.timeDebug(
       async () => {
         const outputGraph = graph.clone()
         const sieve = new Set<string>()
@@ -350,7 +350,7 @@ const addDifferentElements =
 const resolveNodeElements =
   (before: ReadOnlyElementsSource, after: ReadOnlyElementsSource): PlanTransformer =>
   graph =>
-    log.time(
+    log.timeDebug(
       async () => {
         const beforeItemsToResolve: ChangeDataType[] = []
         const afterItemsToResolve: ChangeDataType[] = []
@@ -365,12 +365,12 @@ const resolveNodeElements =
         })
 
         const resolvedBefore = _.keyBy(
-          await log.time(() => resolve(beforeItemsToResolve, before), 'Resolving before items'),
+          await log.timeDebug(() => resolve(beforeItemsToResolve, before), 'Resolving before items'),
           e => e.elemID.getFullName(),
         ) as Record<string, ChangeDataType>
 
         const resolvedAfter = _.keyBy(
-          await log.time(() => resolve(afterItemsToResolve, after), 'Resolving after items'),
+          await log.timeDebug(() => resolve(afterItemsToResolve, after), 'Resolving after items'),
           e => e.elemID.getFullName(),
         ) as Record<string, ChangeDataType>
 
@@ -459,7 +459,7 @@ export const getPlan = async ({
 }: GetPlanParameters): Promise<Plan> => {
   const numBeforeElements = await awu(await before.list()).length()
   const numAfterElements = await awu(await after.list()).length()
-  return log.time(
+  return log.timeDebug(
     async () => {
       const diffGraph = await buildDiffGraph(
         addDifferentElements(before, after, topLevelFilters, numBeforeElements + numAfterElements, compareOptions),

--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -284,7 +284,7 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
       filenames: string[],
       options: dirStore.GetFileOptions,
     ): Promise<(dirStore.File<T> | undefined)[]> =>
-      log.time(
+      log.timeDebug(
         () =>
           withLimitedConcurrency(
             filenames.map(f => () => get(f, options)),

--- a/packages/core/src/local-workspace/s3_dir_store.ts
+++ b/packages/core/src/local-workspace/s3_dir_store.ts
@@ -101,7 +101,7 @@ export const buildS3DirectoryStore = ({
     })
 
   const list = async (): Promise<string[]> =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       const paths = new Set<string>(Object.keys(updated))
       let currentPage: AWS.ListObjectsV2CommandOutput | undefined
       try {

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -215,7 +215,7 @@ export const buildAcyclicGroupedGraph = <T>(
   groupKey: GroupKeyFunc,
   disjointGroups?: Set<NodeId>,
 ): GroupDAG<T> =>
-  log.time(
+  log.timeDebug(
     () => {
       const updatedGroupKey = breakToDisjointGroups(source, groupKey, disjointGroups)
       return buildAcyclicGroupedGraphImpl(source, updatedGroupKey, groupKey)

--- a/packages/jira-adapter/src/users.ts
+++ b/packages/jira-adapter/src/users.ts
@@ -119,7 +119,7 @@ export const getUserMapFuncCreator = (paginator: clientUtils.Paginator, isDataCe
   return async (): Promise<UserMap | undefined> => {
     if (idMap === undefined) {
       if (usersCallPromise === undefined) {
-        usersCallPromise = log.time(async () => paginateUsers(paginator, isDataCenter), 'users pagination')
+        usersCallPromise = log.timeDebug(async () => paginateUsers(paginator, isDataCenter), 'users pagination')
       }
       try {
         idMap = Object.fromEntries(

--- a/packages/jira-adapter/src/weak_references/field_configuration_items.ts
+++ b/packages/jira-adapter/src/weak_references/field_configuration_items.ts
@@ -80,7 +80,7 @@ const getFieldReferences = (instance: InstanceElement): ReferenceInfo[] => {
  * Marks each field reference in field configuration as a weak reference.
  */
 const getFieldConfigurationItemsReferences: GetCustomReferencesFunc = async elements =>
-  log.time(
+  log.timeDebug(
     () =>
       elements
         .filter(isInstanceElement)
@@ -100,7 +100,7 @@ const fieldExists = async (fieldName: string, elementSource: ReadOnlyElementsSou
 const removeMissingFields: WeakReferencesHandler['removeWeakReferences'] =
   ({ elementsSource }) =>
   async elements =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       const fixedElements = await awu(elements)
         .filter(isInstanceElement)
         .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -413,7 +413,7 @@ export default class NetsuiteClient {
       try {
         log.debug('deploying %d changes', dependencyGraph.nodes.size)
         // eslint-disable-next-line no-await-in-loop
-        await log.time(
+        await log.timeDebug(
           () => this.sdfClient.deploy(suiteAppId, { manifestDependencies, validateOnly }, dependencyGraph),
           'sdfDeploy',
         )
@@ -621,7 +621,7 @@ export default class NetsuiteClient {
       const desc = `client.${name}`
       try {
         // eslint-disable-next-line @typescript-eslint/return-await
-        return await log.time(call, desc)
+        return await log.timeDebug(call, desc)
       } catch (e) {
         log.error('failed to run Netsuite client command on: %o', e)
         throw e

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -456,7 +456,7 @@ export default class SoapClient {
     const client = await this.getClient()
     try {
       return await this.callsLimiter(async () =>
-        log.time(
+        log.timeDebug(
           () => SoapClient.soapRequestWithRetries(client, operation, body, this.timeout),
           `${operation}-soap-request`,
         ),

--- a/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
+++ b/packages/netsuite-adapter/src/elements_source_index/elements_source_index.ts
@@ -196,7 +196,7 @@ export const createElementsSourceIndex = (
   return {
     getIndexes: async () => {
       if (cachedIndex === undefined) {
-        cachedIndex = await log.time(
+        cachedIndex = await log.timeDebug(
           () => createIndexes(elementsSource, isPartial, deletedElements ?? []),
           'createIndexes',
         )

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -187,7 +187,7 @@ const fetchSystemNotes = async (
   employeeNames: Record<string, string>,
   timeZone: string | undefined,
 ): Promise<Record<string, ModificationInformation>> => {
-  const systemNotes = await log.time(() => querySystemNotes(client, queryIds, lastFetchTime), 'querySystemNotes')
+  const systemNotes = await log.timeDebug(() => querySystemNotes(client, queryIds, lastFetchTime), 'querySystemNotes')
   if (_.isEmpty(systemNotes)) {
     log.warn('System note query failed')
     return {}

--- a/packages/netsuite-adapter/src/filters/service_urls.ts
+++ b/packages/netsuite-adapter/src/filters/service_urls.ts
@@ -51,7 +51,7 @@ const SERVICE_URL_SETTERS = {
 const setServiceUrls = async (elements: Element[], client: NetsuiteClient): Promise<void> => {
   // setConstantUrls should run last
   await awu(Object.entries(SERVICE_URL_SETTERS).concat([[setConstantUrls.name, setConstantUrls]])).forEach(
-    ([setterName, setter]) => log.time(() => setter(elements, client), `serviceUrls.${setterName}`),
+    ([setterName, setter]) => log.timeDebug(() => setter(elements, client), `serviceUrls.${setterName}`),
   )
 }
 

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -97,7 +97,7 @@ export const getUsers = async (
   paginator: clientUtils.Paginator,
   searchUsersParams?: SearchUsersParams,
 ): Promise<User[]> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     const paginationArgs = {
       url: '/api/v1/users',
       paginationField: 'after',

--- a/packages/salesforce-adapter/src/custom_references.ts
+++ b/packages/salesforce-adapter/src/custom_references.ts
@@ -300,7 +300,7 @@ const getProfilesCustomReferences = async (
   const profilesAndPermissionSets = elements
     .filter(isInstanceElement)
     .filter((instance) => instance.elemID.typeName === PROFILE_METADATA_TYPE)
-  const refs = log.time(
+  const refs = log.timeDebug(
     () => profilesAndPermissionSets.flatMap(referencesFromProfile),
     `Generating references from ${profilesAndPermissionSets.length} profiles/permission sets`,
   )

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -155,12 +155,12 @@ const addDependenciesAnnotation = async (
   log.debug(`Extracting formula refs from ${field.elemID.getFullName()}`)
 
   try {
-    const formulaIdentifiers: string[] = log.time(
+    const formulaIdentifiers: string[] = log.timeDebug(
       () => extractFormulaIdentifiers(formula),
       `Parse formula '${formula.slice(0, 15)}'`,
     )
 
-    const identifiersInfo = await log.time(
+    const identifiersInfo = await log.timeDebug(
       () =>
         Promise.all(
           formulaIdentifiers.map(async (identifier) =>

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -305,7 +305,7 @@ export const resolve = (
   elementsSource: ReadOnlyElementsSource,
   { shouldResolveReferences = true }: ResolveOpts = {},
 ): Promise<Element[]> =>
-  log.time(
+  log.timeDebug(
     async () => {
       // Create a clone of the input elements to ensure we do not modify the input
       const elementsToResolve = getClonedElements(elements)

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -761,7 +761,7 @@ export const validateElements = async (
   elements: Element[],
   elementsSource: ReadOnlyElementsSource,
 ): Promise<ValidationError[]> =>
-  log.time(
+  log.timeDebug(
     async () => {
       const resolved = await resolve(elements, elementsSource)
       const errors = resolved.flatMap(e => {

--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -290,7 +290,7 @@ export const selectElementIdsByTraversal = async ({
   referenceSourcesIndex: ReadOnlyRemoteMap<ElemID[]>
   compact?: boolean
 }): Promise<AsyncIterable<ElemID>> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     const determinedSelectors = selectors.filter(
       selector => !isWildcardSelector(selector.origin) && !hasReferencedBy(selector),
     )

--- a/packages/workspace/src/workspace/index_utils.ts
+++ b/packages/workspace/src/workspace/index_utils.ts
@@ -89,7 +89,7 @@ export const updateIndex = async <T>({
   isCacheValid: boolean
   updateChanges: (changes: Change<Element>[], index: RemoteMap<T>) => Promise<void>
 }): Promise<void> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     let relevantChanges = changes
     const isVersionMatch = (await mapVersions.get(indexVersionKey)) === indexVersion
     if (!isCacheValid || !isVersionMatch) {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -173,7 +173,7 @@ const addToSource = async ({
   overrideTargetElements?: boolean
   valuesOverrides?: Record<string, Value>
 }): Promise<DetailedChange[]> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     const idsByParent = _.groupBy(ids, id => id.createTopLevelParentID().parent.getFullName())
     const fullChanges = await awu(Object.values(idsByParent))
       .flatMap(async gids => {

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -446,7 +446,7 @@ const buildNaclFilesState = async ({
     currentState.parsedNaclFiles.get(file.filename)
 
   const handleAdditionsOrModifications = (naclFiles: AwuIterable<ParsedNaclFile>): Promise<void> =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       await naclFiles.forEach(async naclFile => {
         const parsedFile = await getNaclFile(naclFile)
         log.trace('Updating indexes of %s nacl file: %s', !parsedFile ? 'added' : 'modified', naclFile.filename)
@@ -492,7 +492,7 @@ const buildNaclFilesState = async ({
     }, 'handle additions/modifications of nacl files')
 
   const handleDeletions = (naclFiles: AwuIterable<ParsedNaclFile>): Promise<void> =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       const toDelete: string[] = []
       await naclFiles.forEach(async naclFile => {
         const oldNaclFile = await getNaclFile(naclFile)

--- a/packages/workspace/src/workspace/path_index.ts
+++ b/packages/workspace/src/workspace/path_index.ts
@@ -204,12 +204,12 @@ const updateIndex = async ({
 }
 
 export const updatePathIndex = async (args: PathIndexArgs): Promise<void> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     await updateIndex({ ...args, getHintsFunction: getElementsPathHints })
   }, 'updatePathIndex')
 
 export const updateTopLevelPathIndex = async (args: PathIndexArgs): Promise<void> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     await updateIndex({ ...args, getHintsFunction: getTopLevelPathHints })
   }, 'updateTopLevelPathIndex')
 

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -291,7 +291,7 @@ export const updateReferenceIndexes = async (
   isCacheValid: boolean,
   getCustomReferences: GetCustomReferencesFunc,
 ): Promise<void> =>
-  log.time(async () => {
+  log.timeDebug(async () => {
     let relevantChanges = changes
     let initialIndex = false
     const isVersionMatch = (await mapVersions.get(REFERENCE_INDEXES_KEY)) === REFERENCE_INDEXES_VERSION

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -89,7 +89,7 @@ export const buildInMemState = (loadData: () => Promise<StateData>, persistent =
   }
 
   const updateStateElements = async (changes: DetailedChange[]): Promise<void> =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       const state = (await stateData()).elements
       const changesByTopLevelElement = _.groupBy(changes, change =>
         change.id.createTopLevelParentID().parent.getFullName(),

--- a/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/history_static_files_source.ts
@@ -79,6 +79,6 @@ export const buildHistoryStateStaticFilesSource = (dirStore: StateStaticFilesSto
       log.debug('clear ignored in history state static files source')
     },
 
-    flush: () => log.time(() => dirStore.flush(), 'Flushing history static state files source'),
+    flush: () => log.timeDebug(() => dirStore.flush(), 'Flushing history static state files source'),
   }
 }

--- a/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
+++ b/packages/workspace/src/workspace/state/static_files_sources/override_static_files_source.ts
@@ -58,7 +58,7 @@ export const buildOverrideStateStaticFilesSource = (dirStore: DirectoryStore<Buf
   delete: file => dirStore.delete(file.filepath),
   clear: dirStore.clear,
   flush: () =>
-    log.time(async () => {
+    log.timeDebug(async () => {
       await dirStore.flush()
     }, 'Flushing override static state files source'),
 })

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -391,8 +391,8 @@ export const listElementsDependenciesInWorkspace = async ({
   elemIDsToSkip?: ElemID[]
   envToListFrom?: string
 }): Promise<{ dependencies: Record<string, ElemID[]>; missing: ElemID[] }> =>
-  log.time(async () => {
-    const workspaceBaseLevelIds = await log.time(
+  log.timeDebug(async () => {
+    const workspaceBaseLevelIds = await log.timeDebug(
       async () => new Set(await workspace.getSearchableNamesOfEnv(envToListFrom)),
       `getSearchableNames for env: ${envToListFrom}`,
     )


### PR DESCRIPTION
add timeDebug and timeTrace to logger

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
