### PR TITLE
SALTO-5514: SFDC client retry on 406

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -389,8 +389,8 @@ const retryErrorsByCodeWrapper =
       return true
     }
     if (errorCodesToRetry.some((code) => response.statusCode === code)) {
-      log.trace(
-        `Retrying on ${response.statusCode} due to known salesforce issues. Err: ${err}`,
+      log.warn(
+        `Retrying on ${response.statusCode} due to known salesforce issues. Err: ${err}, headers: ${response.headers}, status message: ${response.statusMessage}`,
       )
       return true
     }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -116,6 +116,8 @@ const DEFAULT_READ_METADATA_CHUNK_SIZE: Required<ReadMetadataChunkSizeConfig> =
     },
   }
 
+const errorCodesToRetry = [400, 406]
+
 // This is attempting to work around issues where the Salesforce API sometimes
 // returns invalid responses for no apparent reason, causing jsforce to crash.
 // We hope retrying will help...
@@ -380,14 +382,16 @@ const sendChunked = async <TIn, TOut>({
 
 export class ApiLimitsTooLowError extends Error {}
 
-const retry400ErrorWrapper =
+const retryErrorsByCodeWrapper =
   (strategy: RetryStrategy): RetryStrategy =>
   (err, response, body) => {
     if (strategy(err, response, body)) {
       return true
     }
-    if (response.statusCode === 400) {
-      log.trace(`Retrying on 400 due to known salesforce issues. Err: ${err}`)
+    if (errorCodesToRetry.some((code) => response.statusCode === code)) {
+      log.trace(
+        `Retrying on ${response.statusCode} due to known salesforce issues. Err: ${err}`,
+      )
       return true
     }
     return false
@@ -396,7 +400,7 @@ const createRetryOptions = (
   retryOptions: Required<ClientRetryConfig>,
 ): RequestRetryOptions => ({
   maxAttempts: retryOptions.maxAttempts,
-  retryStrategy: retry400ErrorWrapper(
+  retryStrategy: retryErrorsByCodeWrapper(
     RetryStrategies[retryOptions.retryStrategy],
   ),
   timeout: retryOptions.timeout,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -390,7 +390,7 @@ const retryErrorsByCodeWrapper =
     }
     if (errorCodesToRetry.some((code) => response.statusCode === code)) {
       log.warn(
-        `Retrying on ${response.statusCode} due to known salesforce issues. Err: ${err}, headers: ${response.headers}, status message: ${response.statusMessage}`,
+        `Retrying on ${response.statusCode} due to known salesforce issues. Err: ${err}, headers: ${response.headers}, status message: ${response.statusMessage}, body: ${body}`,
       )
       return true
     }

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -197,6 +197,26 @@ describe('salesforce client', () => {
       expect(res).toEqual([])
     })
 
+    it('retries with 406 error', async () => {
+      const dodoScope = nock('http://dodo22')
+        .post(/.*/)
+        .times(1)
+        .reply(406, {})
+        .post(/.*/)
+        .reply(
+          200,
+          {
+            'a:Envelope': {
+              'a:Body': { a: { result: { metadataObjects: [] } } },
+            },
+          },
+          headers,
+        )
+      const res = await client.listMetadataTypes()
+      expect(dodoScope.isDone()).toBeTruthy()
+      expect(res).toEqual([])
+    })
+
     it('fails if max attempts was reached ', async () => {
       const dodoScope = nock('http://dodo22')
         .persist()


### PR DESCRIPTION
SFDC client retry on 406.

---

_Additional context for reviewer_
None.

---
_Release Notes_:

_Salesforce_:
- Automatically retrying requests which fail with a 406 status. We are seeing these errors in the wild and they are always resolved by retrying.

---
_User Notifications_: 
None.
