### PR TITLE
SALTO-5684: Rename the default access policy

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -87,6 +87,7 @@ import omitAuthenticatorMappingFilter from './filters/omit_authenticator_mapping
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import groupPushPathFilter from './filters/group_push_path'
+import renameDefaultAccessPolicy from './filters/rename_default_access_policy'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
 import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
@@ -103,6 +104,7 @@ const { createPaginator } = clientUtils
 const log = logger(module)
 
 const DEFAULT_FILTERS = [
+  renameDefaultAccessPolicy,
   standardRolesFilter,
   deleteFieldsFilter,
   userTypeFilter,

--- a/packages/okta-adapter/src/filters/rename_default_access_policy.ts
+++ b/packages/okta-adapter/src/filters/rename_default_access_policy.ts
@@ -1,0 +1,103 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import {
+  CORE_ANNOTATIONS,
+  ElemIdGetter,
+  InstanceElement,
+  ReferenceExpression,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { getParent, hasValidParent, naclCase } from '@salto-io/adapter-utils'
+import { elements as elementUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { FilterCreator } from '../filter'
+import { ACCESS_POLICY_RULE_TYPE_NAME, ACCESS_POLICY_TYPE_NAME, OKTA } from '../constants'
+
+const log = logger(module)
+
+const getDefaultAccessPolicyName = (name: string, instance: InstanceElement, getElemIdFunc?: ElemIdGetter): string => {
+  const naclCasedName = naclCase(name)
+  if (getElemIdFunc === undefined) {
+    return naclCasedName
+  }
+
+  const serviceIds = elementUtils.createServiceIds({
+    entry: instance.value,
+    serviceIDFields: ['id'],
+    typeID: instance.refType.elemID,
+  })
+
+  return getElemIdFunc(OKTA, serviceIds, naclCasedName).name
+}
+
+/**
+ * Each Okta tenant has exactly one default access policy configured marked with "system = true"
+ * The default policy can be renamed, but it has a specific function and can only be partially modified,
+ * therefore, we should verify default policies across envs will have the same elemID.
+ * The filter modifies elemID for the default access policy and all its rules
+ * */
+const filter: FilterCreator = ({ getElemIdFunc }) => ({
+  name: 'renameDefaultAccessPolicy',
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    const defaultAccessPolicy = instances
+      .filter(instance => instance.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+      .find(instance => instance.value.system === true)
+    if (defaultAccessPolicy === undefined) {
+      log.debug('The default access policy was not found, skipping renaming')
+      return
+    }
+
+    const defaultPolicyRules = instances
+      .filter(instance => instance.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+      .filter(instance =>
+        hasValidParent(instance)
+          ? getParent(instance).elemID.getFullName() === defaultAccessPolicy.elemID.getFullName()
+          : false,
+      )
+
+    const defaultName = 'Default Policy'
+    const updatedName = getDefaultAccessPolicyName(defaultName, defaultAccessPolicy, getElemIdFunc)
+    const renamedPolicy = new InstanceElement(
+      updatedName,
+      defaultAccessPolicy.getTypeSync(),
+      defaultAccessPolicy.value,
+      defaultAccessPolicy.path,
+      defaultAccessPolicy.annotations,
+    )
+
+    const renamedRules = defaultPolicyRules.map(
+      rule =>
+        new InstanceElement(
+          getDefaultAccessPolicyName(`${defaultName}__${rule.value.name}`, rule, getElemIdFunc),
+          rule.getTypeSync(),
+          rule.value,
+          rule.path,
+          {
+            ...rule.annotations,
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(renamedPolicy.elemID, renamedPolicy)],
+          },
+        ),
+    )
+
+    _.pullAll(elements, [defaultAccessPolicy, ...defaultPolicyRules])
+    elements.push(renamedPolicy)
+    renamedRules.forEach(rule => elements.push(rule))
+  },
+})
+
+export default filter

--- a/packages/okta-adapter/test/filters/rename_default_access_policy.test.ts
+++ b/packages/okta-adapter/test/filters/rename_default_access_policy.test.ts
@@ -1,0 +1,127 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  ElemIdGetter,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { mockFunction } from '@salto-io/test-utils'
+import renameDefaultAccessPolicy from '../../src/filters/rename_default_access_policy'
+import { getFilterParams } from '../utils'
+import { OKTA, ACCESS_POLICY_TYPE_NAME, ACCESS_POLICY_RULE_TYPE_NAME } from '../../src/constants'
+
+describe('renameDefaultAccessPolicy', () => {
+  let filter: filterUtils.FilterWith<'onFetch'>
+  let type: ObjectType
+  let ruleType: ObjectType
+  let elemIdGetter: jest.MockedFunction<ElemIdGetter>
+  beforeEach(() => {
+    elemIdGetter = mockFunction<ElemIdGetter>().mockImplementation(
+      (adapterName, _serviceIds, name) => new ElemID(adapterName, name),
+    )
+
+    filter = renameDefaultAccessPolicy(getFilterParams({ getElemIdFunc: elemIdGetter })) as typeof filter
+
+    type = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_TYPE_NAME) })
+    ruleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
+  })
+
+  it('should rename the default access policy and its children rules', async () => {
+    const custom = new InstanceElement('customized default policy name', type, {
+      name: 'customized name',
+      system: true,
+      type: 'ACCESS_POLICY',
+    })
+    const rule = new InstanceElement('customized_name__rule', ruleType, { name: 'rule', priority: 3 }, undefined, {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(custom.elemID, custom)],
+    })
+
+    const elements = [custom, type, ruleType, rule]
+    await filter.onFetch(elements)
+    const accesPolicies = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+    expect(accesPolicies).toHaveLength(1)
+    expect(accesPolicies[0].elemID.name).toEqual('Default_Policy@s')
+
+    const accesRules = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+    expect(accesRules).toHaveLength(1)
+    expect(accesRules[0].elemID.name).toEqual('Default_Policy__rule@suu')
+    expect((accesRules[0].annotations[CORE_ANNOTATIONS.PARENT]?.[0] as ReferenceExpression).elemID).toEqual(
+      accesPolicies[0].elemID,
+    )
+  })
+
+  it('should not rename non default policies and its children rules', async () => {
+    const custom = new InstanceElement('my_policy@s', type, {
+      name: 'my policy',
+      system: false,
+      type: 'ACCESS_POLICY',
+    })
+    const rule = new InstanceElement(
+      'my_policy__rule',
+      ruleType,
+      { name: 'rule', priority: 3, system: true },
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(custom.elemID, custom)] },
+    )
+
+    const elements = [custom, type, ruleType, rule]
+    await filter.onFetch(elements)
+    const accesPolicies = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+    expect(accesPolicies).toHaveLength(1)
+    expect(accesPolicies[0].elemID.name).toEqual('my_policy@s')
+
+    const accesRules = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_RULE_TYPE_NAME)
+    expect(accesRules).toHaveLength(1)
+    expect(accesRules[0].elemID.name).toEqual('my_policy__rule')
+    expect(accesRules[0].annotations[CORE_ANNOTATIONS.PARENT]).toEqual([new ReferenceExpression(custom.elemID, custom)])
+  })
+
+  it('should use elem id getter', async () => {
+    const custom = new InstanceElement('customized default policy name', type, {
+      name: 'customized name',
+      system: true,
+      type: 'ACCESS_POLICY',
+    })
+
+    elemIdGetter.mockReturnValue(new ElemID(OKTA, 'customized name'))
+
+    const elements = [custom, type]
+    await filter.onFetch(elements)
+    expect(elemIdGetter).toHaveBeenCalledWith(OKTA, expect.any(Object), 'Default_Policy@s')
+    const accesPolicies = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+    expect(accesPolicies).toHaveLength(1)
+    expect(accesPolicies[0].elemID.name).toEqual('customized name')
+  })
+  it('should use the default name when elemIdGetter was not passed', async () => {
+    filter = renameDefaultAccessPolicy(getFilterParams({})) as typeof filter
+
+    const custom = new InstanceElement('customized default policy name', type, {
+      name: 'customized name',
+      system: true,
+      type: 'ACCESS_POLICY',
+    })
+    const elements = [custom, type]
+    await filter.onFetch(elements)
+    const accesPolicies = elements.filter(e => isInstanceElement(e) && e.elemID.typeName === ACCESS_POLICY_TYPE_NAME)
+    expect(accesPolicies).toHaveLength(1)
+    expect(accesPolicies[0].elemID.name).toEqual('Default_Policy@s')
+  })
+})


### PR DESCRIPTION
This fixes an issue with deployment of default access policies when it was renamed in one env but not the other

---

every Okta tenant has one default access policy, the default policy has a certain rule in the configuration and therefore cannot be added (only modified in certain properties). The issue occurred during env compare when the default policies have different names across envs. As the elemIDs are different, salto identifies the changes as addition and removal instead of modification. To resolve the issue, we create a constant elemID for the default policy, alias and path remains the same for better UX.

I also had to rename all children rules as the point to the parent policy.

---
_Release Notes_: 
_Okta_adapter_:
- Fix an issue with deployment of default authentication policies in certain cases. To resolve, run next fetch with "regenerate elemIDs"

---
_User Notifications_: 
_Okta_adapter_:
- When running fetch with "regenerate elemIDs", elemID for the default access policy will change
