### PR TITLE
SATLO-5705 fix copyFromResponse on additions

### DIFF
--- a/packages/adapter-components/src/definitions/system/deploy/deploy.ts
+++ b/packages/adapter-components/src/definitions/system/deploy/deploy.ts
@@ -41,9 +41,12 @@ export type DeployableRequestDefinition<ClientOptions extends string> = {
 
   // define what (if any) part of the response should be copied back to the workspace (via the original change).
   // by default, only values of fields marked as service id are copied
-  copyFromResponse?: TransformDefinition<ChangeAndContext> & {
+  copyFromResponse?: {
     // default: true
+    // note: if the request's transformation defines nestUnderField, it is used as the root when extracting service ids
     updateServiceIDs?: boolean
+    // default: nothing
+    additional?: TransformDefinition<ChangeAndContext>
   }
 }
 

--- a/packages/adapter-components/src/deployment/definition_helpers.ts
+++ b/packages/adapter-components/src/deployment/definition_helpers.ts
@@ -83,9 +83,6 @@ export const createStandardItemDeployDefinition = <AdditionalAction extends stri
             nestUnderField,
           },
         },
-        copyFromResponse: {
-          root: nestUnderField,
-        },
       },
       customizations: _.omit(standardCustomizationsByAction, withoutActions ?? []),
     },

--- a/packages/adapter-components/src/deployment/placeholder_types.ts
+++ b/packages/adapter-components/src/deployment/placeholder_types.ts
@@ -48,6 +48,13 @@ export const overrideInstanceTypeForDeploy = <Options extends FetchApiDefinition
   })
   const definedTypes = _.keyBy([generatedType.type, ...generatedType.nestedTypes], t => t.elemID.typeName)
   overrideFieldTypes({ definedTypes, defQuery })
+  // make sure all service id fields are there even on additions (which might not have values for them)
+  defQuery.query(typeName)?.resource?.serviceIDFields?.forEach(fieldName => {
+    if (generatedType.type.fields[fieldName] === undefined) {
+      generatedType.type.fields[fieldName] = instance.getTypeSync().fields[fieldName]
+    }
+  })
+
   clonedInstance.refType = new TypeReference(generatedType.type.elemID, generatedType.type)
   return clonedInstance
 }

--- a/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
+++ b/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
@@ -251,7 +251,9 @@ describe('createAdapter', () => {
                         },
                       },
                       copyFromResponse: {
-                        root: 'schedule',
+                        additional: {
+                          root: 'schedule',
+                        },
                       },
                     },
                     {

--- a/packages/adapter-components/test/deployment/placeholder_types.test.ts
+++ b/packages/adapter-components/test/deployment/placeholder_types.test.ts
@@ -32,77 +32,83 @@ import { InstanceFetchApiDefinitions } from '../../src/definitions/system/fetch'
 const ADAPTER_NAME = 'myAdapter'
 
 describe('ducktype deployment functions', () => {
-  const objType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'obj') })
-  const instance = new InstanceElement('inst', objType, {
-    name: 'test',
-    id: 4,
-    success: true,
-    ref: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')),
-    complex: [
-      {
-        field1: 'test1',
-        field2: 1,
-        field3: [{ nested: 1 }, { nested: 2 }],
-        field4: [
-          { nested: 1 },
-          { nested: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')) },
-        ],
-      },
-      {
-        field1: 'test2',
-        field2: 2,
-        field3: [{ nested: 3 }],
-        field4: [
-          { nested: 3 },
-          { nested: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')) },
-        ],
-      },
-    ],
-  })
-  const expectedType = new ObjectType({
-    elemID: objType.elemID,
-    fields: {
-      name: { refType: BuiltinTypes.STRING },
-      id: { refType: BuiltinTypes.SERVICE_ID_NUMBER },
-      success: { refType: BuiltinTypes.BOOLEAN },
-      ref: { refType: BuiltinTypes.UNKNOWN },
-      complex: {
-        refType: new ListType(
-          new ObjectType({
-            elemID: new ElemID(ADAPTER_NAME, 'obj__complex'),
-            fields: {
-              field1: { refType: BuiltinTypes.STRING },
-              field2: { refType: BuiltinTypes.NUMBER },
-              field3: {
-                refType: new ListType(
-                  new ObjectType({
-                    elemID: new ElemID(ADAPTER_NAME, 'obj__complex__field3'),
-                    fields: {
-                      nested: { refType: BuiltinTypes.NUMBER },
-                    },
-                    path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex', 'field3'],
-                  }),
-                ),
+  let objType: ObjectType
+  let expectedType: ObjectType
+  let instance: InstanceElement
+  beforeEach(() => {
+    objType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'obj') })
+    instance = new InstanceElement('inst', objType, {
+      name: 'test',
+      id: 4,
+      success: true,
+      ref: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')),
+      complex: [
+        {
+          field1: 'test1',
+          field2: 1,
+          field3: [{ nested: 1 }, { nested: 2 }],
+          field4: [
+            { nested: 1 },
+            { nested: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')) },
+          ],
+        },
+        {
+          field1: 'test2',
+          field2: 2,
+          field3: [{ nested: 3 }],
+          field4: [
+            { nested: 3 },
+            { nested: new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test')) },
+          ],
+        },
+      ],
+    })
+    expectedType = new ObjectType({
+      elemID: objType.elemID,
+      fields: {
+        name: { refType: BuiltinTypes.STRING },
+        id: { refType: BuiltinTypes.SERVICE_ID_NUMBER },
+        success: { refType: BuiltinTypes.BOOLEAN },
+        ref: { refType: BuiltinTypes.UNKNOWN },
+        complex: {
+          refType: new ListType(
+            new ObjectType({
+              elemID: new ElemID(ADAPTER_NAME, 'obj__complex'),
+              fields: {
+                field1: { refType: BuiltinTypes.STRING },
+                field2: { refType: BuiltinTypes.NUMBER },
+                field3: {
+                  refType: new ListType(
+                    new ObjectType({
+                      elemID: new ElemID(ADAPTER_NAME, 'obj__complex__field3'),
+                      fields: {
+                        nested: { refType: BuiltinTypes.NUMBER },
+                      },
+                      path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex', 'field3'],
+                    }),
+                  ),
+                },
+                field4: {
+                  refType: new ListType(
+                    new ObjectType({
+                      elemID: new ElemID(ADAPTER_NAME, 'obj__complex__field4'),
+                      fields: {
+                        nested: { refType: BuiltinTypes.UNKNOWN },
+                      },
+                      path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex', 'field4'],
+                    }),
+                  ),
+                },
               },
-              field4: {
-                refType: new ListType(
-                  new ObjectType({
-                    elemID: new ElemID(ADAPTER_NAME, 'obj__complex__field4'),
-                    fields: {
-                      nested: { refType: BuiltinTypes.UNKNOWN },
-                    },
-                    path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex', 'field4'],
-                  }),
-                ),
-              },
-            },
-            path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex'],
-          }),
-        ),
+              path: [ADAPTER_NAME, TYPES_PATH, SUBTYPES_PATH, 'obj', 'complex'],
+            }),
+          ),
+        },
       },
-    },
-    path: [ADAPTER_NAME, TYPES_PATH, 'obj'],
+      path: [ADAPTER_NAME, TYPES_PATH, 'obj'],
+    })
   })
+
   describe('overrideInstanceTypeForDeploy', () => {
     it('should generate correct type based on instance values', () => {
       const instanceForDeploy = overrideInstanceTypeForDeploy({
@@ -147,6 +153,25 @@ describe('ducktype deployment functions', () => {
       const [change] = changes as Change<InstanceElement>[]
       expect(change.action).toEqual('add')
       expect(getChangeData(change).refType).toEqual(originalType)
+    })
+    it('should copy service id fields from type if they do not exist in the instance', () => {
+      objType.fields.id = expectedType.fields.id
+      delete instance.value.id
+      const instanceForDeploy = overrideInstanceTypeForDeploy({
+        instance,
+        defQuery: queryWithDefault<Pick<InstanceFetchApiDefinitions, 'element' | 'resource'>>({
+          default: {
+            resource: {
+              serviceIDFields: ['id'],
+            },
+          },
+          customizations: {
+            obj: {},
+          },
+        }),
+      })
+      expect(instanceForDeploy).toBeDefined()
+      expect(instanceForDeploy.refType.type).toEqual(expectedType)
     })
   })
   describe('restoreInstanceTypeFromDeploy', () => {


### PR DESCRIPTION
1. Fix a bug in the new `overrideInstanceTypeForDeploy` that caused service id fields to not be marked correctly on additions if they did not exist on the instance
2. improve the `copyFromResponse` logic - separate the service id copy from custom transformations in order to avoid confusing / misaligned cases, and change the default behavior when copying service ids to use the request's `nestUnderField` as its `root`

---
_Release Notes_: 
None (not used yet)

---
_User Notifications_: 
None