### PR TITLE
SALTO-5626: [Zendesk] Add modern pagination to dynamic_content_item

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -1478,6 +1478,8 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   dynamic_content_item: {
     request: {
       url: '/api/v2/dynamic_content/items',
+      queryParams: { ...DEFAULT_QUERY_PARAMS },
+      paginationField: CURSOR_BASED_PAGINATION_FIELD,
     },
     transformation: {
       dataField: '.',

--- a/packages/zendesk-adapter/test/mock_replies/myBrand_mock_replies.json
+++ b/packages/zendesk-adapter/test/mock_replies/myBrand_mock_replies.json
@@ -10,11 +10,26 @@
           "created_at": "2021-08-08T05:56:22Z",
           "updated_at": "2021-12-19T18:56:05Z",
           "intervals": [
-            { "start_time": 1980, "end_time": 2460 },
-            { "start_time": 3420, "end_time": 3900 },
-            { "start_time": 4860, "end_time": 5340 },
-            { "start_time": 6300, "end_time": 6780 },
-            { "start_time": 7710, "end_time": 8190 }
+            {
+              "start_time": 1980,
+              "end_time": 2460
+            },
+            {
+              "start_time": 3420,
+              "end_time": 3900
+            },
+            {
+              "start_time": 4860,
+              "end_time": 5340
+            },
+            {
+              "start_time": 6300,
+              "end_time": 6780
+            },
+            {
+              "start_time": 7710,
+              "end_time": 8190
+            }
           ]
         },
         {
@@ -24,11 +39,26 @@
           "created_at": "2021-08-08T05:56:44Z",
           "updated_at": "2021-08-08T05:56:44Z",
           "intervals": [
-            { "start_time": 1980, "end_time": 2460 },
-            { "start_time": 3420, "end_time": 3900 },
-            { "start_time": 4860, "end_time": 5340 },
-            { "start_time": 6300, "end_time": 6780 },
-            { "start_time": 7740, "end_time": 8220 }
+            {
+              "start_time": 1980,
+              "end_time": 2460
+            },
+            {
+              "start_time": 3420,
+              "end_time": 3900
+            },
+            {
+              "start_time": 4860,
+              "end_time": 5340
+            },
+            {
+              "start_time": 6300,
+              "end_time": 6780
+            },
+            {
+              "start_time": 7740,
+              "end_time": 8220
+            }
           ]
         },
         {
@@ -38,11 +68,26 @@
           "created_at": "2021-08-08T05:56:47Z",
           "updated_at": "2021-12-19T18:56:55Z",
           "intervals": [
-            { "start_time": 1980, "end_time": 2460 },
-            { "start_time": 3420, "end_time": 3900 },
-            { "start_time": 4860, "end_time": 5340 },
-            { "start_time": 6300, "end_time": 6780 },
-            { "start_time": 7740, "end_time": 8220 }
+            {
+              "start_time": 1980,
+              "end_time": 2460
+            },
+            {
+              "start_time": 3420,
+              "end_time": 3900
+            },
+            {
+              "start_time": 4860,
+              "end_time": 5340
+            },
+            {
+              "start_time": 6300,
+              "end_time": 6780
+            },
+            {
+              "start_time": 7740,
+              "end_time": 8220
+            }
           ]
         }
       ],
@@ -52,7 +97,14 @@
   {
     "url": "/api/v2/business_hours/schedules/1900000004365/holidays",
     "response": {
-      "holidays": [{ "id": 4416453812631, "name": "Holiday1", "start_date": "2021-12-19", "end_date": "2021-12-20" }],
+      "holidays": [
+        {
+          "id": 4416453812631,
+          "name": "Holiday1",
+          "start_date": "2021-12-19",
+          "end_date": "2021-12-20"
+        }
+      ],
       "url": "https://myBrand.zendesk.com/api/v2/business_hours/schedules/1900000004365/holidays"
     }
   },
@@ -66,13 +118,22 @@
   {
     "url": "/api/v2/business_hours/schedules/1500001035461/holidays",
     "response": {
-      "holidays": [{ "id": 4416449821591, "name": "Holi2", "start_date": "2021-12-22", "end_date": "2021-12-22" }],
+      "holidays": [
+        {
+          "id": 4416449821591,
+          "name": "Holi2",
+          "start_date": "2021-12-22",
+          "end_date": "2021-12-22"
+        }
+      ],
       "url": "https://myBrand.zendesk.com/api/v2/business_hours/schedules/1500001035461/holidays"
     }
   },
   {
     "url": "/api/v2/organization_fields",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "organization_fields": [
         {
@@ -203,10 +264,30 @@
           "created_at": "2021-08-08T18:23:06Z",
           "updated_at": "2021-08-08T18:23:06Z",
           "custom_field_options": [
-            { "id": 1900000066065, "name": "123", "raw_name": "123", "value": "123" },
-            { "id": 1900000066085, "name": "v1", "raw_name": "v1", "value": "v1" },
-            { "id": 1900000066105, "name": "v2", "raw_name": "v2", "value": "v2" },
-            { "id": 1900000066125, "name": "v3", "raw_name": "v3", "value": "v3" }
+            {
+              "id": 1900000066065,
+              "name": "123",
+              "raw_name": "123",
+              "value": "123"
+            },
+            {
+              "id": 1900000066085,
+              "name": "v1",
+              "raw_name": "v1",
+              "value": "v1"
+            },
+            {
+              "id": 1900000066105,
+              "name": "v2",
+              "raw_name": "v2",
+              "value": "v2"
+            },
+            {
+              "id": 1900000066125,
+              "name": "v3",
+              "raw_name": "v3",
+              "value": "v3"
+            }
           ]
         }
       ],
@@ -217,6 +298,9 @@
   },
   {
     "url": "/api/v2/dynamic_content/items",
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "items": [
         {
@@ -288,14 +372,22 @@
           ]
         }
       ],
-      "next_page": null,
-      "previous_page": null,
-      "count": 2
+      "meta": {
+        "has_more": false,
+        "after_cursor": null,
+        "before_cursor": null
+      },
+      "links": {
+        "prev": null,
+        "next": null
+      }
     }
   },
   {
     "url": "/api/v2/brands",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "brands": [
         {
@@ -311,7 +403,13 @@
           "is_deleted": false,
           "logo": null,
           "ticket_form_ids": [
-            1500000859362, 1500002488461, 1500002488481, 1500002488501, 1900000172165, 1900000882985, 1900000911005
+            1500000859362,
+            1500002488461,
+            1500002488481,
+            1500002488501,
+            1900000172165,
+            1900000882985,
+            1900000911005
           ],
           "signature_template": "{{agent.signature}}",
           "created_at": "2021-05-18T19:00:43Z",
@@ -331,7 +429,13 @@
           "is_deleted": false,
           "logo": null,
           "ticket_form_ids": [
-            1500000859362, 1500002488461, 1500002488481, 1500002488501, 1900000172165, 1900000882985, 1900000911005
+            1500000859362,
+            1500002488461,
+            1500002488481,
+            1500002488501,
+            1900000172165,
+            1900000882985,
+            1900000911005
           ],
           "signature_template": "{{agent.signature}}",
           "created_at": "2021-05-18T19:00:43Z",
@@ -351,7 +455,13 @@
           "is_deleted": false,
           "logo": null,
           "ticket_form_ids": [
-            1500000859362, 1500002488461, 1500002488481, 1500002488501, 1900000172165, 1900000882985, 1900000911005
+            1500000859362,
+            1500002488461,
+            1500002488481,
+            1500002488501,
+            1900000172165,
+            1900000882985,
+            1900000911005
           ],
           "signature_template": "{{agent.signature}}",
           "created_at": "2021-05-18T19:00:43Z",
@@ -366,7 +476,9 @@
   },
   {
     "url": "/api/v2/oauth/clients",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "clients": [
         {
@@ -407,7 +519,9 @@
           "identifier": "myBrand_test",
           "company": "myBrand",
           "description": "this client is used in the test environment",
-          "redirect_uri": ["http://localhost:8080/zendesk-oauth2-redirect"],
+          "redirect_uri": [
+            "http://localhost:8080/zendesk-oauth2-redirect"
+          ],
           "secret": "d4445e7ab9",
           "created_at": "2021-12-02T14:41:26Z",
           "updated_at": "2021-12-02T14:42:35Z",
@@ -422,7 +536,9 @@
           "identifier": "myBrand_test_oauth",
           "company": "myBrand",
           "description": "",
-          "redirect_uri": ["http://localhost:8080/zendesk-oauth2-redirect"],
+          "redirect_uri": [
+            "http://localhost:8080/zendesk-oauth2-redirect"
+          ],
           "secret": "9aec4f0114",
           "created_at": "2021-12-15T08:10:45Z",
           "updated_at": "2021-12-15T08:10:45Z",
@@ -437,7 +553,9 @@
           "identifier": "myBrand_zendesk_client",
           "company": "myBrand",
           "description": "",
-          "redirect_uri": ["http://localhost:8000"],
+          "redirect_uri": [
+            "http://localhost:8000"
+          ],
           "secret": "6767266ae6",
           "created_at": "2021-11-29T15:00:18Z",
           "updated_at": "2021-12-13T14:02:15Z",
@@ -446,12 +564,21 @@
         }
       ]
     },
-    "meta": { "has_more": false, "after_cursor": null, "before_cursor": null },
-    "links": { "prev": null, "next": null }
+    "meta": {
+      "has_more": false,
+      "after_cursor": null,
+      "before_cursor": null
+    },
+    "links": {
+      "prev": null,
+      "next": null
+    }
   },
   {
     "url": "/api/v2/organizations",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "organizations": [
         {
@@ -467,7 +594,9 @@
           "details": "Test details",
           "notes": "",
           "group_id": 1500002894482,
-          "tags": ["123"],
+          "tags": [
+            "123"
+          ],
           "organization_fields": {
             "dropdown_26": "123",
             "org_field301": null,
@@ -488,7 +617,10 @@
           "external_id": null,
           "created_at": "2021-08-08T05:21:33Z",
           "updated_at": "2021-08-08T05:21:33Z",
-          "domain_names": ["test1.myBrand.io", "test2.myBrand.io"],
+          "domain_names": [
+            "test1.myBrand.io",
+            "test2.myBrand.io"
+          ],
           "details": "",
           "notes": "",
           "group_id": null,
@@ -537,7 +669,9 @@
   },
   {
     "url": "/api/v2/automations",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "automations": [
         {
@@ -547,11 +681,24 @@
           "active": true,
           "updated_at": "2021-05-18T19:00:46Z",
           "created_at": "2021-05-18T19:00:46Z",
-          "actions": [{ "field": "status", "value": "closed" }],
+          "actions": [
+            {
+              "field": "status",
+              "value": "closed"
+            }
+          ],
           "conditions": {
             "all": [
-              { "field": "status", "operator": "is", "value": "solved" },
-              { "field": "SOLVED", "operator": "greater_than", "value": "96" }
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "solved"
+              },
+              {
+                "field": "SOLVED",
+                "operator": "greater_than",
+                "value": "96"
+              }
             ],
             "any": []
           },
@@ -577,8 +724,16 @@
           ],
           "conditions": {
             "all": [
-              { "field": "PENDING", "operator": "is", "value": "24" },
-              { "field": "ticket_is_public", "operator": "is", "value": "public" }
+              {
+                "field": "PENDING",
+                "operator": "is",
+                "value": "24"
+              },
+              {
+                "field": "ticket_is_public",
+                "operator": "is",
+                "value": "public"
+              }
             ],
             "any": []
           },
@@ -604,8 +759,16 @@
           ],
           "conditions": {
             "all": [
-              { "field": "PENDING", "operator": "is", "value": "120" },
-              { "field": "ticket_is_public", "operator": "is", "value": "public" }
+              {
+                "field": "PENDING",
+                "operator": "is",
+                "value": "120"
+              },
+              {
+                "field": "ticket_is_public",
+                "operator": "is",
+                "value": "public"
+              }
             ],
             "any": []
           },
@@ -619,11 +782,24 @@
           "active": true,
           "updated_at": "2021-12-18T21:11:54Z",
           "created_at": "2021-08-08T05:52:34Z",
-          "actions": [{ "field": "status", "value": "closed" }],
+          "actions": [
+            {
+              "field": "status",
+              "value": "closed"
+            }
+          ],
           "conditions": {
             "all": [
-              { "field": "status", "operator": "is", "value": "solved" },
-              { "field": "SOLVED", "operator": "greater_than", "value": "120" }
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "solved"
+              },
+              {
+                "field": "SOLVED",
+                "operator": "greater_than",
+                "value": "120"
+              }
             ],
             "any": []
           },
@@ -637,15 +813,46 @@
           "active": true,
           "updated_at": "2021-11-12T23:56:11Z",
           "created_at": "2021-11-12T23:56:11Z",
-          "actions": [{ "field": "current_tags", "value": "Social" }],
+          "actions": [
+            {
+              "field": "current_tags",
+              "value": "Social"
+            }
+          ],
           "conditions": {
-            "all": [{ "field": "OPEN", "operator": "is", "value": "0" }],
+            "all": [
+              {
+                "field": "OPEN",
+                "operator": "is",
+                "value": "0"
+              }
+            ],
             "any": [
-              { "field": "via_id", "operator": "is", "value": "30" },
-              { "field": "via_id", "operator": "is", "value": "26" },
-              { "field": "via_id", "operator": "is", "value": "38" },
-              { "field": "via_id", "operator": "is", "value": "86" },
-              { "field": "via_id", "operator": "is", "value": "78" }
+              {
+                "field": "via_id",
+                "operator": "is",
+                "value": "30"
+              },
+              {
+                "field": "via_id",
+                "operator": "is",
+                "value": "26"
+              },
+              {
+                "field": "via_id",
+                "operator": "is",
+                "value": "38"
+              },
+              {
+                "field": "via_id",
+                "operator": "is",
+                "value": "86"
+              },
+              {
+                "field": "via_id",
+                "operator": "is",
+                "value": "78"
+              }
             ]
           },
           "position": 10001,
@@ -659,7 +866,10 @@
   },
   {
     "url": "/api/v2/macros",
-    "params": { "page[size]": "100", "access": "shared" },
+    "params": {
+      "page[size]": "100",
+      "access": "shared"
+    },
     "response": {
       "macros": [
         {
@@ -672,11 +882,26 @@
           "position": 2,
           "description": "clone of the original",
           "actions": [
-            { "field": "status", "value": "solved" },
-            { "field": "priority", "value": "normal" },
-            { "field": "type", "value": "incident" },
-            { "field": "assignee_id", "value": "current_user" },
-            { "field": "group_id", "value": "current_groups" },
+            {
+              "field": "status",
+              "value": "solved"
+            },
+            {
+              "field": "priority",
+              "value": "normal"
+            },
+            {
+              "field": "type",
+              "value": "incident"
+            },
+            {
+              "field": "assignee_id",
+              "value": "current_user"
+            },
+            {
+              "field": "group_id",
+              "value": "current_groups"
+            },
             {
               "field": "comment_value",
               "value": "Thanks for your request. This issue you reported is a known issue. For more information, please visit our forums. "
@@ -694,11 +919,26 @@
           "position": 1,
           "description": null,
           "actions": [
-            { "field": "status", "value": "solved" },
-            { "field": "priority", "value": "normal" },
-            { "field": "type", "value": "incident" },
-            { "field": "assignee_id", "value": "current_user" },
-            { "field": "group_id", "value": "current_groups" },
+            {
+              "field": "status",
+              "value": "solved"
+            },
+            {
+              "field": "priority",
+              "value": "normal"
+            },
+            {
+              "field": "type",
+              "value": "incident"
+            },
+            {
+              "field": "assignee_id",
+              "value": "current_user"
+            },
+            {
+              "field": "group_id",
+              "value": "current_groups"
+            },
             {
               "field": "comment_value",
               "value": "Thanks for your request. This issue you reported is a known issue. For more information, please visit our forums. "
@@ -716,14 +956,19 @@
           "position": 3,
           "description": null,
           "actions": [
-            { "field": "status", "value": "pending" },
+            {
+              "field": "status",
+              "value": "pending"
+            },
             {
               "field": "comment_value",
               "value": "Hello {{ticket.requester.name}}. Our agent {{current_user.name}} has tried to contact you about this request but we haven't heard back from you yet. Please let us know if we can be of further assistance. Thanks. "
             }
           ],
           "restriction": null,
-          "attachments": [4621166392467]
+          "attachments": [
+            4621166392467
+          ]
         },
         {
           "url": "https://myBrand.zendesk.com/api/v2/macros/1500027465822.json",
@@ -735,7 +980,10 @@
           "position": 6,
           "description": null,
           "actions": [
-            { "field": "status", "value": "pending" },
+            {
+              "field": "status",
+              "value": "pending"
+            },
             {
               "field": "comment_value_html",
               "value": "<p>Hello {{ticket.requester.name}}. Our agent {{current_user.name}} has tried to contact you about this request but we haven't heard back from you yet. Please let us know if we can be of further assistance. Thanks. </p>"
@@ -757,7 +1005,10 @@
           "position": 4,
           "description": null,
           "actions": [
-            { "field": "priority", "value": "low" },
+            {
+              "field": "priority",
+              "value": "low"
+            },
             {
               "field": "comment_value",
               "value": "We're currently experiencing unusually high traffic. We'll get back to you as soon as possible."
@@ -774,7 +1025,12 @@
           "created_at": "2021-12-14T13:38:03Z",
           "position": 10001,
           "description": "create a new category for macros",
-          "actions": [{ "field": "status", "value": "solved" }],
+          "actions": [
+            {
+              "field": "status",
+              "value": "solved"
+            }
+          ],
           "restriction": null
         },
         {
@@ -787,8 +1043,14 @@
           "position": 5,
           "description": null,
           "actions": [
-            { "field": "group_id", "value": "current_groups" },
-            { "field": "assignee_id", "value": "current_user" }
+            {
+              "field": "group_id",
+              "value": "current_groups"
+            },
+            {
+              "field": "assignee_id",
+              "value": "current_user"
+            }
           ],
           "restriction": null
         },
@@ -801,7 +1063,12 @@
           "created_at": "2021-12-16T18:12:06Z",
           "position": 10002,
           "description": null,
-          "actions": [{ "field": "status", "value": "solved" }],
+          "actions": [
+            {
+              "field": "status",
+              "value": "solved"
+            }
+          ],
           "restriction": null
         }
       ],
@@ -829,21 +1096,44 @@
       "count": 1
     }
   },
-  { "url": "/api/v2/macros/attachments/4621166392467/content", "response": "hello" },
+  {
+    "url": "/api/v2/macros/attachments/4621166392467/content",
+    "response": "hello"
+  },
   {
     "url": "/api/v2/channels/twitter/monitored_twitter_handles",
-    "response": { "monitored_twitter_handles": [], "next_page": null, "previous_page": null, "count": 0 }
+    "response": {
+      "monitored_twitter_handles": [],
+      "next_page": null,
+      "previous_page": null,
+      "count": 0
+    }
   },
-  { "url": "/api/v2/macros/categories", "response": { "categories": ["MacroCategory"] } },
+  {
+    "url": "/api/v2/macros/categories",
+    "response": {
+      "categories": [
+        "MacroCategory"
+      ]
+    }
+  },
   {
     "url": "/api/v2/macros/actions",
     "response": {
       "actions": [
         {
           "title": "Set subject",
-          "values": { "type": "text", "list": [] },
+          "values": {
+            "type": "text",
+            "list": []
+          },
           "value": "subject",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Set subject",
           "output_key": null,
@@ -855,13 +1145,30 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "open", "title": "Open", "enabled": true },
-              { "value": "pending", "title": "Pending", "enabled": true },
-              { "value": "solved", "title": "Solved", "enabled": true }
+              {
+                "value": "open",
+                "title": "Open",
+                "enabled": true
+              },
+              {
+                "value": "pending",
+                "title": "Pending",
+                "enabled": true
+              },
+              {
+                "value": "solved",
+                "title": "Solved",
+                "enabled": true
+              }
             ]
           },
           "value": "status",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Status",
           "output_key": null,
@@ -870,9 +1177,23 @@
         },
         {
           "title": "Brand",
-          "values": { "type": "list", "list": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }] },
+          "values": {
+            "type": "list",
+            "list": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
+          },
           "value": "brand_id",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Brand",
           "output_key": null,
@@ -884,18 +1205,55 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "default_ticket_form", "title": "(default form)", "enabled": true },
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "default_ticket_form",
+                "title": "(default form)",
+                "enabled": true
+              },
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           "value": "ticket_form_id",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Form",
           "output_key": null,
@@ -907,14 +1265,35 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           "value": "priority",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Priority",
           "output_key": null,
@@ -926,14 +1305,35 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           "value": "type",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Type",
           "output_key": null,
@@ -945,16 +1345,45 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "", "title": "-", "enabled": true },
-              { "value": "current_groups", "title": "(current user's groups)", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "current_groups",
+                "title": "(current user's groups)",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           "value": "group_id",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Group",
           "output_key": null,
@@ -966,18 +1395,55 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "", "title": "-", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           "value": "assignee_id",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Assignee",
           "output_key": null,
@@ -986,9 +1452,17 @@
         },
         {
           "title": "Set tags",
-          "values": { "type": "text", "list": [] },
+          "values": {
+            "type": "text",
+            "list": []
+          },
           "value": "set_tags",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Set tags",
           "output_key": null,
@@ -997,9 +1471,17 @@
         },
         {
           "title": "Add tags",
-          "values": { "type": "text", "list": [] },
+          "values": {
+            "type": "text",
+            "list": []
+          },
           "value": "current_tags",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Add tags",
           "output_key": null,
@@ -1008,9 +1490,17 @@
         },
         {
           "title": "Remove tags",
-          "values": { "type": "text", "list": [] },
+          "values": {
+            "type": "text",
+            "list": []
+          },
           "value": "remove_tags",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Remove tags",
           "output_key": null,
@@ -1022,16 +1512,45 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           "value": "cc",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Add follower",
           "output_key": null,
@@ -1043,12 +1562,25 @@
           "values": {
             "type": "list_with_textarea",
             "list": [
-              { "value": "channel:all", "title": "Channel: All", "enabled": true },
-              { "value": "channel:web", "title": "Channel: Web", "enabled": true }
+              {
+                "value": "channel:all",
+                "title": "Channel: All",
+                "enabled": true
+              },
+              {
+                "value": "channel:web",
+                "title": "Channel: Web",
+                "enabled": true
+              }
             ]
           },
           "value": "comment_value",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Comment/description",
           "output_key": null,
@@ -1057,9 +1589,17 @@
         },
         {
           "title": "Comment/description",
-          "values": { "type": "textarea", "list": [] },
+          "values": {
+            "type": "textarea",
+            "list": []
+          },
           "value": "comment_value_html",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Comment/description",
           "output_key": null,
@@ -1071,12 +1611,25 @@
           "values": {
             "type": "list",
             "list": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true }
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              }
             ]
           },
           "value": "comment_mode_is_public",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Comment mode",
           "output_key": null,
@@ -1088,12 +1641,25 @@
           "values": {
             "type": "multiselect_list",
             "list": [
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           "value": "custom_fields_1900004086785",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Product components",
           "output_key": null,
@@ -1105,13 +1671,30 @@
           "values": {
             "type": "multiselect_list",
             "list": [
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           "value": "custom_fields_1500012620641",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "Customer Tier",
           "output_key": null,
@@ -1123,12 +1706,25 @@
           "values": {
             "type": "multiselect_list",
             "list": [
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           "value": "custom_fields_1500009152882",
-          "operators": [{ "value": "is", "title": "Is" }],
+          "operators": [
+            {
+              "value": "is",
+              "title": "Is"
+            }
+          ],
           "group": "ticket",
           "title_for_field": "agent dropdown 643 for agent",
           "output_key": null,
@@ -1140,7 +1736,9 @@
   },
   {
     "url": "/api/v2/groups",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "groups": [
         {
@@ -1244,8 +1842,18 @@
           "created_at": "2021-08-08T05:24:59Z",
           "updated_at": "2021-08-08T05:24:59Z",
           "resources": [
-            { "identifier": "slack_target", "resource_id": 1900000033645, "type": "targets", "deleted": false },
-            { "identifier": "slack_trigger", "resource_id": 1900002626665, "type": "triggers", "deleted": false }
+            {
+              "identifier": "slack_target",
+              "resource_id": 1900000033645,
+              "type": "targets",
+              "deleted": false
+            },
+            {
+              "identifier": "slack_trigger",
+              "resource_id": 1900002626665,
+              "type": "triggers",
+              "deleted": false
+            }
           ]
         }
       ],
@@ -1256,7 +1864,9 @@
   },
   {
     "url": "/api/v2/oauth/global_clients",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "global_clients": [
         {
@@ -1293,7 +1903,11 @@
           "header_logo_url": null,
           "favicon_url": null
         },
-        "apps": { "use": true, "create_private": true, "create_public": false },
+        "apps": {
+          "use": true,
+          "create_private": true,
+          "create_public": false
+        },
         "tickets": {
           "agent_ticket_deletion": false,
           "list_newest_comments_first": true,
@@ -1324,8 +1938,14 @@
           "using_skill_based_routing": true,
           "edit_ticket_skills_permission": 1
         },
-        "agents": { "agent_workspace": true, "focus_mode": false, "aw_self_serve_migration_enabled": true },
-        "groups": { "check_group_name_uniqueness": true },
+        "agents": {
+          "agent_workspace": true,
+          "focus_mode": false,
+          "aw_self_serve_migration_enabled": true
+        },
+        "groups": {
+          "check_group_name_uniqueness": true
+        },
         "chat": {
           "enabled": false,
           "integrated": false,
@@ -1345,8 +1965,13 @@
           "recordings_public": true,
           "uk_mobile_forwarding": true
         },
-        "twitter": { "shorten_url": "never" },
-        "google_apps": { "has_google_apps": false, "has_google_apps_admin": false },
+        "twitter": {
+          "shorten_url": "never"
+        },
+        "google_apps": {
+          "has_google_apps": false,
+          "has_google_apps_admin": false
+        },
         "user": {
           "tagging": true,
           "time_zone_selection": true,
@@ -1356,11 +1981,27 @@
           "end_user_phone_number_validation": false,
           "have_gravatars_enabled": true
         },
-        "screencast": { "enabled_for_tickets": false, "host": null, "tickets_recorder_id": null },
-        "lotus": { "prefer_lotus": true, "reporting": true, "pod_id": 23 },
-        "gooddata_advanced_analytics": { "enabled": true },
-        "statistics": { "forum": true, "search": true, "rule_usage": true },
-        "billing": { "backend": "zuora" },
+        "screencast": {
+          "enabled_for_tickets": false,
+          "host": null,
+          "tickets_recorder_id": null
+        },
+        "lotus": {
+          "prefer_lotus": true,
+          "reporting": true,
+          "pod_id": 23
+        },
+        "gooddata_advanced_analytics": {
+          "enabled": true
+        },
+        "statistics": {
+          "forum": true,
+          "search": true,
+          "rule_usage": true
+        },
+        "billing": {
+          "backend": "zuora"
+        },
         "active_features": {
           "on_hold_status": false,
           "user_tagging": true,
@@ -1410,36 +2051,74 @@
           "ticket_forms_instructions": "Please choose your issue below",
           "raw_ticket_forms_instructions": "Please choose your issue below"
         },
-        "brands": { "default_brand_id": 1500000550682, "require_brand_on_new_tickets": false },
-        "api": { "accepted_api_agreement": true, "api_password_access": "true", "api_token_access": "false" },
+        "brands": {
+          "default_brand_id": 1500000550682,
+          "require_brand_on_new_tickets": false
+        },
+        "api": {
+          "accepted_api_agreement": true,
+          "api_password_access": "true",
+          "api_token_access": "false"
+        },
         "rule": {
           "macro_most_used": true,
           "macro_order": "alphabetical",
-          "skill_based_filtered_views": [1500027465742],
+          "skill_based_filtered_views": [
+            1500027465742
+          ],
           "using_skill_based_routing": true,
           "enable_macro_suggestions": false
         },
-        "limits": { "attachment_size": 52428800 },
-        "onboarding": { "checklist_onboarding_version": 5, "onboarding_segments": null, "product_sign_up": null },
-        "cross_sell": { "show_chat_tooltip": true, "xsell_source": null },
+        "limits": {
+          "attachment_size": 52428800
+        },
+        "onboarding": {
+          "checklist_onboarding_version": 5,
+          "onboarding_segments": null,
+          "product_sign_up": null
+        },
+        "cross_sell": {
+          "show_chat_tooltip": true,
+          "xsell_source": null
+        },
         "cdn": {
           "cdn_provider": "default",
           "fallback_cdn_provider": "cloudfront",
           "hosts": [
-            { "name": "default", "url": "https://p23.zdassets.com" },
-            { "name": "cloudfront", "url": "https://d33qujptx4c27b.cloudfront.net" }
+            {
+              "name": "default",
+              "url": "https://p23.zdassets.com"
+            },
+            {
+              "name": "cloudfront",
+              "url": "https://d33qujptx4c27b.cloudfront.net"
+            }
           ]
         },
-        "metrics": { "account_size": "1-99" },
-        "ticket_sharing_partners": { "support_addresses": [] },
-        "localization": { "locale_ids": [2, 30] },
+        "metrics": {
+          "account_size": "1-99"
+        },
+        "ticket_sharing_partners": {
+          "support_addresses": []
+        },
+        "localization": {
+          "locale_ids": [
+            2,
+            30
+          ]
+        },
         "knowledge": {
           "search_articles": true,
           "search_community_posts": true,
           "search_external_content": true,
           "require_article_templates": false
         },
-        "routing": { "enabled": false, "autorouting_tag": "", "max_email_capacity": 1, "max_messaging_capacity": 1 }
+        "routing": {
+          "enabled": false,
+          "autorouting_tag": "",
+          "max_email_capacity": 1,
+          "max_messaging_capacity": 1
+        }
       }
     }
   },
@@ -1756,9 +2435,21 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "open", "title": "Open", "enabled": true },
-              { "value": "pending", "title": "Pending", "enabled": true },
-              { "value": "solved", "title": "Solved", "enabled": true }
+              {
+                "value": "open",
+                "title": "Open",
+                "enabled": true
+              },
+              {
+                "value": "pending",
+                "title": "Pending",
+                "enabled": true
+              },
+              {
+                "value": "solved",
+                "title": "Solved",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1768,7 +2459,13 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -1778,14 +2475,46 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "default_ticket_form", "title": "(default form)", "enabled": true },
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "default_ticket_form",
+                "title": "(default form)",
+                "enabled": true
+              },
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1796,10 +2525,26 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1810,10 +2555,26 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1824,12 +2585,36 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "current_groups", "title": "(current user's groups)", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "current_groups",
+                "title": "(current user's groups)",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1840,14 +2625,46 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1882,12 +2699,36 @@
             "nullable": false,
             "repeatable": true,
             "values": [
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1898,8 +2739,16 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "channel:all", "title": "Channel: All", "enabled": true },
-              { "value": "channel:web", "title": "Channel: Web", "enabled": true }
+              {
+                "value": "channel:all",
+                "title": "Channel: All",
+                "enabled": true
+              },
+              {
+                "value": "channel:web",
+                "title": "Channel: Web",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1918,8 +2767,16 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true }
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1930,8 +2787,16 @@
             "nullable": true,
             "repeatable": true,
             "values": [
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1942,9 +2807,21 @@
             "nullable": true,
             "repeatable": true,
             "values": [
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -1955,8 +2832,16 @@
             "nullable": true,
             "repeatable": true,
             "values": [
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           }
         ]
@@ -1965,17 +2850,28 @@
   },
   {
     "url": "/api/v2/apps/installations",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "installations": [
         {
           "id": 1900000132965,
           "app_id": 10,
           "product": "support",
-          "settings": { "name": "Salesforce", "title": "Salesforce" },
+          "settings": {
+            "name": "Salesforce",
+            "title": "Salesforce"
+          },
           "settings_objects": [
-            { "name": "name", "value": "Salesforce" },
-            { "name": "title", "value": "Salesforce" }
+            {
+              "name": "name",
+              "value": "Salesforce"
+            },
+            {
+              "name": "title",
+              "value": "Salesforce"
+            }
           ],
           "enabled": true,
           "updated": "20220216230231",
@@ -1984,7 +2880,9 @@
           "role_restrictions": null,
           "recurring_payment": false,
           "collapsible": true,
-          "plan_information": { "name": null },
+          "plan_information": {
+            "name": null
+          },
           "paid": false,
           "has_unpaid_subscription": false,
           "has_incomplete_subscription": false,
@@ -1996,32 +2894,53 @@
           "id": 1900000132805,
           "app_id": 156097,
           "product": "support",
-          "settings": { "name": "Slack", "title": "Slack" },
+          "settings": {
+            "name": "Slack",
+            "title": "Slack"
+          },
           "settings_objects": [
-            { "name": "name", "value": "Slack" },
-            { "name": "title", "value": "Slack" }
+            {
+              "name": "name",
+              "value": "Slack"
+            },
+            {
+              "name": "title",
+              "value": "Slack"
+            }
           ],
           "enabled": true,
           "updated": "20210713144937",
           "updated_at": "2021-08-08T05:25:01Z",
           "created_at": "2021-08-08T05:24:57Z",
-          "role_restrictions": [2, 1500001601021],
+          "role_restrictions": [
+            2,
+            1500001601021
+          ],
           "recurring_payment": false,
           "collapsible": true,
-          "plan_information": { "name": null },
+          "plan_information": {
+            "name": null
+          },
           "paid": false,
           "has_unpaid_subscription": false,
           "has_incomplete_subscription": false,
           "stripe_publishable_key": null,
           "stripe_account": null,
-          "group_restrictions": [1500002894482]
+          "group_restrictions": [
+            1500002894482
+          ]
         }
       ]
     }
   },
   {
     "url": "/api/v2/sharing_agreements",
-    "response": { "sharing_agreements": [], "next_page": null, "previous_page": null, "count": 0 }
+    "response": {
+      "sharing_agreements": [],
+      "next_page": null,
+      "previous_page": null,
+      "count": 0
+    }
   },
   {
     "url": "/api/v2/routing/attributes",
@@ -2066,8 +2985,16 @@
           "updated_at": "2021-08-08T05:49:29Z",
           "conditions": {
             "all": [
-              { "subject": "brand_id", "operator": "is", "value": "1500000550682" },
-              { "subject": "subject_includes_word", "operator": "includes", "value": "Spain Spanish" }
+              {
+                "subject": "brand_id",
+                "operator": "is",
+                "value": "1500000550682"
+              },
+              {
+                "subject": "subject_includes_word",
+                "operator": "includes",
+                "value": "Spain Spanish"
+              }
             ],
             "any": []
           }
@@ -2088,7 +3015,10 @@
           "name": "San Francisco",
           "created_at": "2021-08-08T05:50:03Z",
           "updated_at": "2021-08-08T05:50:28Z",
-          "conditions": { "all": [], "any": [] }
+          "conditions": {
+            "all": [],
+            "any": []
+          }
         },
         {
           "url": "https://myBrand.zendesk.com/api/v2/routing/attributes/76738421-f80c-11eb-b3db-1ded4e71c25a/values/8c9c46f0-f80c-11eb-8231-518002863887.json",
@@ -2105,7 +3035,9 @@
   },
   {
     "url": "/api/v2/recipient_addresses",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "recipient_addresses": [
         {
@@ -2154,7 +3086,9 @@
   },
   {
     "url": "/api/v2/trigger_categories",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "trigger_categories": [
         {
@@ -2195,7 +3129,9 @@
   },
   {
     "url": "/api/v2/ticket_fields",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "ticket_fields": [
         {
@@ -2270,9 +3206,18 @@
           "removable": false,
           "agent_description": null,
           "system_field_options": [
-            { "name": "Open", "value": "open" },
-            { "name": "Pending", "value": "pending" },
-            { "name": "Solved", "value": "solved" }
+            {
+              "name": "Open",
+              "value": "open"
+            },
+            {
+              "name": "Pending",
+              "value": "pending"
+            },
+            {
+              "name": "Solved",
+              "value": "solved"
+            }
           ],
           "sub_type_id": 0
         },
@@ -2300,10 +3245,22 @@
           "removable": true,
           "agent_description": null,
           "system_field_options": [
-            { "name": "Question", "value": "question" },
-            { "name": "Incident", "value": "incident" },
-            { "name": "Problem", "value": "problem" },
-            { "name": "Task", "value": "task" }
+            {
+              "name": "Question",
+              "value": "question"
+            },
+            {
+              "name": "Incident",
+              "value": "incident"
+            },
+            {
+              "name": "Problem",
+              "value": "problem"
+            },
+            {
+              "name": "Task",
+              "value": "task"
+            }
           ]
         },
         {
@@ -2330,10 +3287,22 @@
           "removable": true,
           "agent_description": null,
           "system_field_options": [
-            { "name": "Low", "value": "low" },
-            { "name": "Normal", "value": "normal" },
-            { "name": "High", "value": "high" },
-            { "name": "Urgent", "value": "urgent" }
+            {
+              "name": "Low",
+              "value": "low"
+            },
+            {
+              "name": "Normal",
+              "value": "normal"
+            },
+            {
+              "name": "High",
+              "value": "high"
+            },
+            {
+              "name": "Urgent",
+              "value": "urgent"
+            }
           ],
           "sub_type_id": 0
         },
@@ -2449,8 +3418,20 @@
           "removable": true,
           "agent_description": "List of product components",
           "custom_field_options": [
-            { "id": 12341, "name": "Component A", "raw_name": "Component A", "value": "component_a", "default": false },
-            { "id": 12342, "name": "Component B", "raw_name": "Component B", "value": "component_b", "default": false }
+            {
+              "id": 12341,
+              "name": "Component A",
+              "raw_name": "Component A",
+              "value": "component_a",
+              "default": false
+            },
+            {
+              "id": 12342,
+              "name": "Component B",
+              "raw_name": "Component B",
+              "value": "component_b",
+              "default": false
+            }
           ]
         },
         {
@@ -2477,8 +3458,20 @@
           "removable": true,
           "agent_description": null,
           "custom_field_options": [
-            { "id": 1500020384301, "name": "Free", "raw_name": "Free", "value": "free", "default": false },
-            { "id": 1500020384321, "name": "Paying", "raw_name": "Paying", "value": "paying", "default": false },
+            {
+              "id": 1500020384301,
+              "name": "Free",
+              "raw_name": "Free",
+              "value": "free",
+              "default": false
+            },
+            {
+              "id": 1500020384321,
+              "name": "Paying",
+              "raw_name": "Paying",
+              "value": "paying",
+              "default": false
+            },
             {
               "id": 1500020384341,
               "name": "Enterprise",
@@ -2512,8 +3505,20 @@
           "removable": true,
           "agent_description": null,
           "custom_field_options": [
-            { "id": 1500015072702, "name": "v1", "raw_name": "v1", "value": "v1", "default": false },
-            { "id": 1500015072722, "name": "v2", "raw_name": "v2", "value": "v2_modified", "default": false }
+            {
+              "id": 1500015072702,
+              "name": "v1",
+              "raw_name": "v1",
+              "value": "v1",
+              "default": false
+            },
+            {
+              "id": 1500015072722,
+              "name": "v2",
+              "raw_name": "v2",
+              "value": "v2_modified",
+              "default": false
+            }
           ]
         },
         {
@@ -2596,7 +3601,9 @@
   },
   {
     "url": "/api/v2/user_fields",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "user_fields": [
         {
@@ -2631,9 +3638,24 @@
           "created_at": "2021-08-08T05:26:26Z",
           "updated_at": "2021-08-08T05:26:26Z",
           "custom_field_options": [
-            { "id": 1500001753322, "name": "Choice1", "raw_name": "Choice1", "value": "choice1_tag" },
-            { "id": 1500001753342, "name": "another choice", "raw_name": "another choice", "value": "another_choice" },
-            { "id": 1500001753362, "name": "bla", "raw_name": "bla", "value": "bla_edited" }
+            {
+              "id": 1500001753322,
+              "name": "Choice1",
+              "raw_name": "Choice1",
+              "value": "choice1_tag"
+            },
+            {
+              "id": 1500001753342,
+              "name": "another choice",
+              "raw_name": "another choice",
+              "value": "another_choice"
+            },
+            {
+              "id": 1500001753362,
+              "name": "bla",
+              "raw_name": "bla",
+              "value": "bla_edited"
+            }
           ]
         },
         {
@@ -3084,17 +4106,35 @@
           "id": 1500001200962,
           "title": "New Workspace 123",
           "description": "",
-          "macro_ids": [1500016953922, 1500016953942, 1900002626825],
+          "macro_ids": [
+            1500016953922,
+            1500016953942,
+            1900002626825
+          ],
           "ticket_form_id": 1500000859362,
           "apps": [],
           "position": 1,
           "activated": true,
           "conditions": {
             "all": [
-              { "field": "brand_id", "operator": "is", "value": "1500000550682" },
-              { "field": "priority", "operator": "greater_than", "value": "normal" }
+              {
+                "field": "brand_id",
+                "operator": "is",
+                "value": "1500000550682"
+              },
+              {
+                "field": "priority",
+                "operator": "greater_than",
+                "value": "normal"
+              }
             ],
-            "any": [{ "field": "type", "operator": "is_not", "value": "question" }]
+            "any": [
+              {
+                "field": "type",
+                "operator": "is_not",
+                "value": "question"
+              }
+            ]
           },
           "updated_at": "2021-08-08T05:44:21Z",
           "created_at": "2021-08-08T05:44:21Z",
@@ -3138,16 +4178,65 @@
           "title": "SLA 501",
           "description": "SLA description",
           "position": 1,
-          "filter": { "all": [{ "field": "ticket_form_id", "operator": "is", "value": 1500002488481 }], "any": [] },
+          "filter": {
+            "all": [
+              {
+                "field": "ticket_form_id",
+                "operator": "is",
+                "value": 1500002488481
+              }
+            ],
+            "any": []
+          },
           "policy_metrics": [
-            { "priority": "low", "metric": "first_reply_time", "target": 1440, "business_hours": false },
-            { "priority": "low", "metric": "agent_work_time", "target": 2880, "business_hours": false },
-            { "priority": "normal", "metric": "first_reply_time", "target": 60, "business_hours": false },
-            { "priority": "normal", "metric": "agent_work_time", "target": 360, "business_hours": false },
-            { "priority": "high", "metric": "first_reply_time", "target": 10, "business_hours": false },
-            { "priority": "high", "metric": "agent_work_time", "target": 29, "business_hours": false },
-            { "priority": "urgent", "metric": "first_reply_time", "target": 5, "business_hours": false },
-            { "priority": "urgent", "metric": "agent_work_time", "target": 30, "business_hours": false }
+            {
+              "priority": "low",
+              "metric": "first_reply_time",
+              "target": 1440,
+              "business_hours": false
+            },
+            {
+              "priority": "low",
+              "metric": "agent_work_time",
+              "target": 2880,
+              "business_hours": false
+            },
+            {
+              "priority": "normal",
+              "metric": "first_reply_time",
+              "target": 60,
+              "business_hours": false
+            },
+            {
+              "priority": "normal",
+              "metric": "agent_work_time",
+              "target": 360,
+              "business_hours": false
+            },
+            {
+              "priority": "high",
+              "metric": "first_reply_time",
+              "target": 10,
+              "business_hours": false
+            },
+            {
+              "priority": "high",
+              "metric": "agent_work_time",
+              "target": 29,
+              "business_hours": false
+            },
+            {
+              "priority": "urgent",
+              "metric": "first_reply_time",
+              "target": 5,
+              "business_hours": false
+            },
+            {
+              "priority": "urgent",
+              "metric": "agent_work_time",
+              "target": 30,
+              "business_hours": false
+            }
           ],
           "created_at": "2021-08-08T05:53:49Z",
           "updated_at": "2021-08-08T05:53:50Z"
@@ -3158,12 +4247,35 @@
           "title": "SLA 502",
           "description": null,
           "position": 2,
-          "filter": { "all": [], "any": [] },
+          "filter": {
+            "all": [],
+            "any": []
+          },
           "policy_metrics": [
-            { "priority": "low", "metric": "periodic_update_time", "target": 1200, "business_hours": false },
-            { "priority": "normal", "metric": "periodic_update_time", "target": 600, "business_hours": false },
-            { "priority": "high", "metric": "periodic_update_time", "target": 300, "business_hours": false },
-            { "priority": "urgent", "metric": "periodic_update_time", "target": 300, "business_hours": false }
+            {
+              "priority": "low",
+              "metric": "periodic_update_time",
+              "target": 1200,
+              "business_hours": false
+            },
+            {
+              "priority": "normal",
+              "metric": "periodic_update_time",
+              "target": 600,
+              "business_hours": false
+            },
+            {
+              "priority": "high",
+              "metric": "periodic_update_time",
+              "target": 300,
+              "business_hours": false
+            },
+            {
+              "priority": "urgent",
+              "metric": "periodic_update_time",
+              "target": 300,
+              "business_hours": false
+            }
           ],
           "created_at": "2021-08-08T05:54:10Z",
           "updated_at": "2021-08-08T05:54:11Z"
@@ -3188,8 +4300,16 @@
           "end_user_visible": true,
           "position": 1,
           "ticket_field_ids": [
-            1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500004937742, 1900000813305, 1500009152882,
-            1500009152902, 1500009152922, 1500004937802
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500004937742,
+            1900000813305,
+            1500009152882,
+            1500009152902,
+            1500009152922,
+            1500004937802
           ],
           "active": true,
           "default": true,
@@ -3210,7 +4330,13 @@
           "end_user_visible": false,
           "position": 2,
           "ticket_field_ids": [
-            1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500009152922, 1500004937742, 1500009152882
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500009152922,
+            1500004937742,
+            1500009152882
           ],
           "active": true,
           "default": false,
@@ -3230,7 +4356,13 @@
           "raw_display_name": "",
           "end_user_visible": false,
           "position": 3,
-          "ticket_field_ids": [1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500004937742],
+          "ticket_field_ids": [
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500004937742
+          ],
           "active": true,
           "default": false,
           "created_at": "2021-08-08T05:42:03Z",
@@ -3249,7 +4381,13 @@
           "raw_display_name": "",
           "end_user_visible": false,
           "position": 4,
-          "ticket_field_ids": [1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500004937742],
+          "ticket_field_ids": [
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500004937742
+          ],
           "active": true,
           "default": false,
           "created_at": "2021-08-08T05:42:09Z",
@@ -3269,7 +4407,12 @@
           "end_user_visible": false,
           "position": 5,
           "ticket_field_ids": [
-            1500004937762, 1500004937822, 1500004937842, 1500009152882, 1500004937722, 1500004937742
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500009152882,
+            1500004937722,
+            1500004937742
           ],
           "active": true,
           "default": false,
@@ -3290,7 +4433,13 @@
           "end_user_visible": false,
           "position": 6,
           "ticket_field_ids": [
-            1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500004937742, 1900004086785, 1500004937802,
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500004937742,
+            1900004086785,
+            1500004937802,
             1500012620641
           ],
           "active": true,
@@ -3312,7 +4461,13 @@
           "end_user_visible": true,
           "position": 7,
           "ticket_field_ids": [
-            1500004937762, 1500004937822, 1500004937842, 1500004937722, 1500004937742, 1500004937802, 1900004086785,
+            1500004937762,
+            1500004937822,
+            1500004937842,
+            1500004937722,
+            1500004937742,
+            1500004937802,
+            1900004086785,
             1500004937782
           ],
           "active": true,
@@ -3332,7 +4487,9 @@
   },
   {
     "url": "/api/v2/triggers",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "triggers": [
         {
@@ -3342,13 +4499,34 @@
           "active": false,
           "updated_at": "2021-05-18T19:00:46Z",
           "created_at": "2021-05-18T19:00:46Z",
-          "actions": [{ "field": "assignee_id", "value": "current_user" }],
+          "actions": [
+            {
+              "field": "assignee_id",
+              "value": "current_user"
+            }
+          ],
           "conditions": {
             "all": [
-              { "field": "update_type", "operator": "is", "value": "Change" },
-              { "field": "current_via_id", "operator": "is", "value": "4" },
-              { "field": "assignee_id", "operator": "is", "value": "" },
-              { "field": "role", "operator": "is_not", "value": "end_user" }
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Change"
+              },
+              {
+                "field": "current_via_id",
+                "operator": "is",
+                "value": "4"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": ""
+              },
+              {
+                "field": "role",
+                "operator": "is_not",
+                "value": "end_user"
+              }
             ],
             "any": []
           },
@@ -3374,7 +4552,16 @@
               ]
             }
           ],
-          "conditions": { "all": [{ "field": "update_type", "operator": "is", "value": "Create" }], "any": [] },
+          "conditions": {
+            "all": [
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Create"
+              }
+            ],
+            "any": []
+          },
           "description": null,
           "position": 2,
           "raw_title": "Notify all agents of received request",
@@ -3399,11 +4586,31 @@
           ],
           "conditions": {
             "all": [
-              { "field": "update_type", "operator": "is", "value": "Create" },
-              { "field": "status", "operator": "is_not", "value": "solved" },
-              { "field": "ticket_is_public", "operator": "is", "value": "public" },
-              { "field": "comment_is_public", "operator": "is", "value": true },
-              { "field": "role", "operator": "is", "value": "end_user" }
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Create"
+              },
+              {
+                "field": "status",
+                "operator": "is_not",
+                "value": "solved"
+              },
+              {
+                "field": "ticket_is_public",
+                "operator": "is",
+                "value": "public"
+              },
+              {
+                "field": "comment_is_public",
+                "operator": "is",
+                "value": true
+              },
+              {
+                "field": "role",
+                "operator": "is",
+                "value": "end_user"
+              }
             ],
             "any": []
           },
@@ -3431,9 +4638,21 @@
           ],
           "conditions": {
             "all": [
-              { "field": "update_type", "operator": "is", "value": "Create" },
-              { "field": "ticket_is_public", "operator": "is", "value": "public" },
-              { "field": "role", "operator": "is", "value": "agent" }
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Create"
+              },
+              {
+                "field": "ticket_is_public",
+                "operator": "is",
+                "value": "public"
+              },
+              {
+                "field": "role",
+                "operator": "is",
+                "value": "agent"
+              }
             ],
             "any": []
           },
@@ -3461,8 +4680,16 @@
           ],
           "conditions": {
             "all": [
-              { "field": "update_type", "operator": "is", "value": "Change" },
-              { "field": "comment_is_public", "operator": "is", "value": true }
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Change"
+              },
+              {
+                "field": "comment_is_public",
+                "operator": "is",
+                "value": true
+              }
             ],
             "any": []
           },
@@ -3490,11 +4717,31 @@
           ],
           "conditions": {
             "all": [
-              { "field": "comment_is_public", "operator": "is", "value": "not_relevant" },
-              { "field": "assignee_id", "operator": "is_not", "value": "current_user" },
-              { "field": "assignee_id", "operator": "is_not", "value": "requester_id" },
-              { "field": "assignee_id", "operator": "not_changed", "value": null },
-              { "field": "status", "operator": "not_value_previous", "value": "solved" }
+              {
+                "field": "comment_is_public",
+                "operator": "is",
+                "value": "not_relevant"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is_not",
+                "value": "current_user"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is_not",
+                "value": "requester_id"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "not_changed",
+                "value": null
+              },
+              {
+                "field": "status",
+                "operator": "not_value_previous",
+                "value": "solved"
+              }
             ],
             "any": []
           },
@@ -3522,8 +4769,16 @@
           ],
           "conditions": {
             "all": [
-              { "field": "assignee_id", "operator": "changed", "value": null },
-              { "field": "assignee_id", "operator": "is_not", "value": "current_user" }
+              {
+                "field": "assignee_id",
+                "operator": "changed",
+                "value": null
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is_not",
+                "value": "current_user"
+              }
             ],
             "any": []
           },
@@ -3551,9 +4806,21 @@
           ],
           "conditions": {
             "all": [
-              { "field": "assignee_id", "operator": "is_not", "value": "current_user" },
-              { "field": "status", "operator": "value_previous", "value": "solved" },
-              { "field": "status", "operator": "is_not", "value": "closed" }
+              {
+                "field": "assignee_id",
+                "operator": "is_not",
+                "value": "current_user"
+              },
+              {
+                "field": "status",
+                "operator": "value_previous",
+                "value": "solved"
+              },
+              {
+                "field": "status",
+                "operator": "is_not",
+                "value": "closed"
+              }
             ],
             "any": []
           },
@@ -3581,12 +4848,28 @@
           ],
           "conditions": {
             "all": [
-              { "field": "group_id", "operator": "is_not", "value": "" },
-              { "field": "assignee_id", "operator": "is", "value": "" }
+              {
+                "field": "group_id",
+                "operator": "is_not",
+                "value": ""
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": ""
+              }
             ],
             "any": [
-              { "field": "group_id", "operator": "changed", "value": "" },
-              { "field": "assignee_id", "operator": "changed", "value": "" }
+              {
+                "field": "group_id",
+                "operator": "changed",
+                "value": ""
+              },
+              {
+                "field": "assignee_id",
+                "operator": "changed",
+                "value": ""
+              }
             ]
           },
           "description": null,
@@ -3613,8 +4896,16 @@
           "conditions": {
             "all": [],
             "any": [
-              { "field": "update_type", "operator": "is", "value": "Create" },
-              { "field": "update_type", "operator": "is", "value": "Change" }
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Create"
+              },
+              {
+                "field": "update_type",
+                "operator": "is",
+                "value": "Change"
+              }
             ]
           },
           "description": null,
@@ -3641,11 +4932,31 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              }
             ]
           },
           {
@@ -3656,10 +4967,24 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -3669,17 +4994,53 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3690,15 +5051,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3709,17 +5098,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3730,17 +5155,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3751,14 +5212,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500421645662", "title": "myBrand", "enabled": true },
-              { "value": "1900025376085", "title": "test org 123", "enabled": true },
-              { "value": "1500508294122", "title": "test org 124", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500421645662",
+                "title": "myBrand",
+                "enabled": true
+              },
+              {
+                "value": "1900025376085",
+                "title": "test org 123",
+                "enabled": true
+              },
+              {
+                "value": "1500508294122",
+                "title": "test org 124",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3769,44 +5254,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3817,44 +5446,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3864,9 +5637,19 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com", "enabled": true }
+              {
+                "value": "support@myBrand.zendesk.com",
+                "title": "support@myBrand.zendesk.com",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3877,10 +5660,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -3890,10 +5689,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "public", "title": "Ticket has public comments", "enabled": true },
-              { "value": "private", "title": "Ticket has no public comments", "enabled": true }
+              {
+                "value": "public",
+                "title": "Ticket has public comments",
+                "enabled": true
+              },
+              {
+                "value": "private",
+                "title": "Ticket has no public comments",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3903,11 +5716,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true },
-              { "value": "not_relevant", "title": "Present (public or private)", "enabled": true },
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              },
+              {
+                "value": "not_relevant",
+                "title": "Present (public or private)",
+                "enabled": true
+              },
               {
                 "value": "requester_can_see_comment",
                 "title": "Present, and requester can see the comment",
@@ -3923,10 +5754,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -3937,13 +5784,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "4", "title": "(agent)", "enabled": true },
-              { "value": "0", "title": "(end-user)", "enabled": true },
-              { "value": "2", "title": "(admin)", "enabled": true }
+              {
+                "value": "4",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "0",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "(admin)",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3954,13 +5821,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1", "title": "English (United States)", "enabled": true },
-              { "value": "30", "title": "Hebrew", "enabled": true },
-              { "value": "2", "title": "Spanish", "enabled": true }
+              {
+                "value": "1",
+                "title": "English (United States)",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Hebrew",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "Spanish",
+                "enabled": true
+              }
             ]
           },
           {
@@ -3971,183 +5858,783 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "American Samoa", "title": "(GMT-11:00) American Samoa", "enabled": true },
+              {
+                "value": "American Samoa",
+                "title": "(GMT-11:00) American Samoa",
+                "enabled": true
+              },
               {
                 "value": "International Date Line West",
                 "title": "(GMT-11:00) International Date Line West",
                 "enabled": true
               },
-              { "value": "Midway Island", "title": "(GMT-11:00) Midway Island", "enabled": true },
-              { "value": "Hawaii", "title": "(GMT-10:00) Hawaii", "enabled": true },
-              { "value": "Alaska", "title": "(GMT-09:00) Alaska", "enabled": true },
+              {
+                "value": "Midway Island",
+                "title": "(GMT-11:00) Midway Island",
+                "enabled": true
+              },
+              {
+                "value": "Hawaii",
+                "title": "(GMT-10:00) Hawaii",
+                "enabled": true
+              },
+              {
+                "value": "Alaska",
+                "title": "(GMT-09:00) Alaska",
+                "enabled": true
+              },
               {
                 "value": "Pacific Time (US & Canada)",
                 "title": "(GMT-08:00) Pacific Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Tijuana", "title": "(GMT-08:00) Tijuana", "enabled": true },
-              { "value": "Arizona", "title": "(GMT-07:00) Arizona", "enabled": true },
-              { "value": "Chihuahua", "title": "(GMT-07:00) Chihuahua", "enabled": true },
-              { "value": "Mazatlan", "title": "(GMT-07:00) Mazatlan", "enabled": true },
+              {
+                "value": "Tijuana",
+                "title": "(GMT-08:00) Tijuana",
+                "enabled": true
+              },
+              {
+                "value": "Arizona",
+                "title": "(GMT-07:00) Arizona",
+                "enabled": true
+              },
+              {
+                "value": "Chihuahua",
+                "title": "(GMT-07:00) Chihuahua",
+                "enabled": true
+              },
+              {
+                "value": "Mazatlan",
+                "title": "(GMT-07:00) Mazatlan",
+                "enabled": true
+              },
               {
                 "value": "Mountain Time (US & Canada)",
                 "title": "(GMT-07:00) Mountain Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Central America", "title": "(GMT-06:00) Central America", "enabled": true },
+              {
+                "value": "Central America",
+                "title": "(GMT-06:00) Central America",
+                "enabled": true
+              },
               {
                 "value": "Central Time (US & Canada)",
                 "title": "(GMT-06:00) Central Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Guadalajara", "title": "(GMT-06:00) Guadalajara", "enabled": true },
-              { "value": "Mexico City", "title": "(GMT-06:00) Mexico City", "enabled": true },
-              { "value": "Monterrey", "title": "(GMT-06:00) Monterrey", "enabled": true },
-              { "value": "Saskatchewan", "title": "(GMT-06:00) Saskatchewan", "enabled": true },
-              { "value": "Bogota", "title": "(GMT-05:00) Bogota", "enabled": true },
+              {
+                "value": "Guadalajara",
+                "title": "(GMT-06:00) Guadalajara",
+                "enabled": true
+              },
+              {
+                "value": "Mexico City",
+                "title": "(GMT-06:00) Mexico City",
+                "enabled": true
+              },
+              {
+                "value": "Monterrey",
+                "title": "(GMT-06:00) Monterrey",
+                "enabled": true
+              },
+              {
+                "value": "Saskatchewan",
+                "title": "(GMT-06:00) Saskatchewan",
+                "enabled": true
+              },
+              {
+                "value": "Bogota",
+                "title": "(GMT-05:00) Bogota",
+                "enabled": true
+              },
               {
                 "value": "Eastern Time (US & Canada)",
                 "title": "(GMT-05:00) Eastern Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Indiana (East)", "title": "(GMT-05:00) Indiana (East)", "enabled": true },
-              { "value": "Lima", "title": "(GMT-05:00) Lima", "enabled": true },
-              { "value": "Quito", "title": "(GMT-05:00) Quito", "enabled": true },
-              { "value": "Atlantic Time (Canada)", "title": "(GMT-04:00) Atlantic Time (Canada)", "enabled": true },
-              { "value": "Caracas", "title": "(GMT-04:00) Caracas", "enabled": true },
-              { "value": "Georgetown", "title": "(GMT-04:00) Georgetown", "enabled": true },
-              { "value": "La Paz", "title": "(GMT-04:00) La Paz", "enabled": true },
-              { "value": "Puerto Rico", "title": "(GMT-04:00) Puerto Rico", "enabled": true },
-              { "value": "Newfoundland", "title": "(GMT-03:30) Newfoundland", "enabled": true },
-              { "value": "Brasilia", "title": "(GMT-03:00) Brasilia", "enabled": true },
-              { "value": "Buenos Aires", "title": "(GMT-03:00) Buenos Aires", "enabled": true },
-              { "value": "Greenland", "title": "(GMT-03:00) Greenland", "enabled": true },
-              { "value": "Montevideo", "title": "(GMT-03:00) Montevideo", "enabled": true },
-              { "value": "Santiago", "title": "(GMT-03:00) Santiago", "enabled": true },
-              { "value": "Mid-Atlantic", "title": "(GMT-02:00) Mid-Atlantic", "enabled": true },
-              { "value": "Azores", "title": "(GMT-01:00) Azores", "enabled": true },
-              { "value": "Cape Verde Is.", "title": "(GMT-01:00) Cape Verde Is.", "enabled": true },
-              { "value": "Dublin", "title": "(GMT+00:00) Dublin", "enabled": true },
-              { "value": "Edinburgh", "title": "(GMT+00:00) Edinburgh", "enabled": true },
-              { "value": "Lisbon", "title": "(GMT+00:00) Lisbon", "enabled": true },
-              { "value": "London", "title": "(GMT+00:00) London", "enabled": true },
-              { "value": "Monrovia", "title": "(GMT+00:00) Monrovia", "enabled": true },
-              { "value": "UTC", "title": "(GMT+00:00) UTC", "enabled": true },
-              { "value": "Amsterdam", "title": "(GMT+01:00) Amsterdam", "enabled": true },
-              { "value": "Belgrade", "title": "(GMT+01:00) Belgrade", "enabled": true },
-              { "value": "Berlin", "title": "(GMT+01:00) Berlin", "enabled": true },
-              { "value": "Bern", "title": "(GMT+01:00) Bern", "enabled": true },
-              { "value": "Bratislava", "title": "(GMT+01:00) Bratislava", "enabled": true },
-              { "value": "Brussels", "title": "(GMT+01:00) Brussels", "enabled": true },
-              { "value": "Budapest", "title": "(GMT+01:00) Budapest", "enabled": true },
-              { "value": "Casablanca", "title": "(GMT+01:00) Casablanca", "enabled": true },
-              { "value": "Copenhagen", "title": "(GMT+01:00) Copenhagen", "enabled": true },
-              { "value": "Ljubljana", "title": "(GMT+01:00) Ljubljana", "enabled": true },
-              { "value": "Madrid", "title": "(GMT+01:00) Madrid", "enabled": true },
-              { "value": "Oslo", "title": "(GMT+01:00) Oslo", "enabled": true },
-              { "value": "Paris", "title": "(GMT+01:00) Paris", "enabled": true },
-              { "value": "Prague", "title": "(GMT+01:00) Prague", "enabled": true },
-              { "value": "Rome", "title": "(GMT+01:00) Rome", "enabled": true },
-              { "value": "Sarajevo", "title": "(GMT+01:00) Sarajevo", "enabled": true },
-              { "value": "Skopje", "title": "(GMT+01:00) Skopje", "enabled": true },
-              { "value": "Stockholm", "title": "(GMT+01:00) Stockholm", "enabled": true },
-              { "value": "Vienna", "title": "(GMT+01:00) Vienna", "enabled": true },
-              { "value": "Warsaw", "title": "(GMT+01:00) Warsaw", "enabled": true },
-              { "value": "West Central Africa", "title": "(GMT+01:00) West Central Africa", "enabled": true },
-              { "value": "Zagreb", "title": "(GMT+01:00) Zagreb", "enabled": true },
-              { "value": "Athens", "title": "(GMT+02:00) Athens", "enabled": true },
-              { "value": "Bucharest", "title": "(GMT+02:00) Bucharest", "enabled": true },
-              { "value": "Cairo", "title": "(GMT+02:00) Cairo", "enabled": true },
-              { "value": "Harare", "title": "(GMT+02:00) Harare", "enabled": true },
-              { "value": "Helsinki", "title": "(GMT+02:00) Helsinki", "enabled": true },
-              { "value": "Jerusalem", "title": "(GMT+02:00) Jerusalem", "enabled": true },
-              { "value": "Kaliningrad", "title": "(GMT+02:00) Kaliningrad", "enabled": true },
-              { "value": "Kyev", "title": "(GMT+02:00) Kyev", "enabled": true },
-              { "value": "Kyiv", "title": "(GMT+02:00) Kyiv", "enabled": true },
-              { "value": "Pretoria", "title": "(GMT+02:00) Pretoria", "enabled": true },
-              { "value": "Riga", "title": "(GMT+02:00) Riga", "enabled": true },
-              { "value": "Sofia", "title": "(GMT+02:00) Sofia", "enabled": true },
-              { "value": "Tallinn", "title": "(GMT+02:00) Tallinn", "enabled": true },
-              { "value": "Vilnius", "title": "(GMT+02:00) Vilnius", "enabled": true },
-              { "value": "Baghdad", "title": "(GMT+03:00) Baghdad", "enabled": true },
-              { "value": "Istanbul", "title": "(GMT+03:00) Istanbul", "enabled": true },
-              { "value": "Kuwait", "title": "(GMT+03:00) Kuwait", "enabled": true },
-              { "value": "Minsk", "title": "(GMT+03:00) Minsk", "enabled": true },
-              { "value": "Moscow", "title": "(GMT+03:00) Moscow", "enabled": true },
-              { "value": "Nairobi", "title": "(GMT+03:00) Nairobi", "enabled": true },
-              { "value": "Riyadh", "title": "(GMT+03:00) Riyadh", "enabled": true },
-              { "value": "St. Petersburg", "title": "(GMT+03:00) St. Petersburg", "enabled": true },
-              { "value": "Tehran", "title": "(GMT+03:30) Tehran", "enabled": true },
-              { "value": "Abu Dhabi", "title": "(GMT+04:00) Abu Dhabi", "enabled": true },
-              { "value": "Baku", "title": "(GMT+04:00) Baku", "enabled": true },
-              { "value": "Muscat", "title": "(GMT+04:00) Muscat", "enabled": true },
-              { "value": "Samara", "title": "(GMT+04:00) Samara", "enabled": true },
-              { "value": "Tbilisi", "title": "(GMT+04:00) Tbilisi", "enabled": true },
-              { "value": "Volgograd", "title": "(GMT+04:00) Volgograd", "enabled": true },
-              { "value": "Yerevan", "title": "(GMT+04:00) Yerevan", "enabled": true },
-              { "value": "Kabul", "title": "(GMT+04:30) Kabul", "enabled": true },
-              { "value": "Ekaterinburg", "title": "(GMT+05:00) Ekaterinburg", "enabled": true },
-              { "value": "Islamabad", "title": "(GMT+05:00) Islamabad", "enabled": true },
-              { "value": "Karachi", "title": "(GMT+05:00) Karachi", "enabled": true },
-              { "value": "Tashkent", "title": "(GMT+05:00) Tashkent", "enabled": true },
-              { "value": "Chennai", "title": "(GMT+05:30) Chennai", "enabled": true },
-              { "value": "Kolkata", "title": "(GMT+05:30) Kolkata", "enabled": true },
-              { "value": "Mumbai", "title": "(GMT+05:30) Mumbai", "enabled": true },
-              { "value": "New Delhi", "title": "(GMT+05:30) New Delhi", "enabled": true },
-              { "value": "Sri Jayawardenepura", "title": "(GMT+05:30) Sri Jayawardenepura", "enabled": true },
-              { "value": "Kathmandu", "title": "(GMT+05:45) Kathmandu", "enabled": true },
-              { "value": "Almaty", "title": "(GMT+06:00) Almaty", "enabled": true },
-              { "value": "Astana", "title": "(GMT+06:00) Astana", "enabled": true },
-              { "value": "Dhaka", "title": "(GMT+06:00) Dhaka", "enabled": true },
-              { "value": "Urumqi", "title": "(GMT+06:00) Urumqi", "enabled": true },
-              { "value": "Rangoon", "title": "(GMT+06:30) Rangoon", "enabled": true },
-              { "value": "Bangkok", "title": "(GMT+07:00) Bangkok", "enabled": true },
-              { "value": "Hanoi", "title": "(GMT+07:00) Hanoi", "enabled": true },
-              { "value": "Jakarta", "title": "(GMT+07:00) Jakarta", "enabled": true },
-              { "value": "Krasnoyarsk", "title": "(GMT+07:00) Krasnoyarsk", "enabled": true },
-              { "value": "Novosibirsk", "title": "(GMT+07:00) Novosibirsk", "enabled": true },
-              { "value": "Beijing", "title": "(GMT+08:00) Beijing", "enabled": true },
-              { "value": "Chongqing", "title": "(GMT+08:00) Chongqing", "enabled": true },
-              { "value": "Hong Kong", "title": "(GMT+08:00) Hong Kong", "enabled": true },
-              { "value": "Irkutsk", "title": "(GMT+08:00) Irkutsk", "enabled": true },
-              { "value": "Kuala Lumpur", "title": "(GMT+08:00) Kuala Lumpur", "enabled": true },
-              { "value": "Perth", "title": "(GMT+08:00) Perth", "enabled": true },
-              { "value": "Singapore", "title": "(GMT+08:00) Singapore", "enabled": true },
-              { "value": "Taipei", "title": "(GMT+08:00) Taipei", "enabled": true },
-              { "value": "Ulaan Bataar", "title": "(GMT+08:00) Ulaanbataar", "enabled": true },
-              { "value": "Ulaanbaatar", "title": "(GMT+08:00) Ulaanbaatar", "enabled": true },
-              { "value": "Osaka", "title": "(GMT+09:00) Osaka", "enabled": true },
-              { "value": "Sapporo", "title": "(GMT+09:00) Sapporo", "enabled": true },
-              { "value": "Seoul", "title": "(GMT+09:00) Seoul", "enabled": true },
-              { "value": "Tokyo", "title": "(GMT+09:00) Tokyo", "enabled": true },
-              { "value": "Yakutsk", "title": "(GMT+09:00) Yakutsk", "enabled": true },
-              { "value": "Darwin", "title": "(GMT+09:30) Darwin", "enabled": true },
-              { "value": "Brisbane", "title": "(GMT+10:00) Brisbane", "enabled": true },
-              { "value": "Guam", "title": "(GMT+10:00) Guam", "enabled": true },
-              { "value": "Port Moresby", "title": "(GMT+10:00) Port Moresby", "enabled": true },
-              { "value": "Vladivostok", "title": "(GMT+10:00) Vladivostok", "enabled": true },
-              { "value": "Adelaide", "title": "(GMT+10:30) Adelaide", "enabled": true },
-              { "value": "Canberra", "title": "(GMT+11:00) Canberra", "enabled": true },
-              { "value": "Hobart", "title": "(GMT+11:00) Hobart", "enabled": true },
-              { "value": "Magadan", "title": "(GMT+11:00) Magadan", "enabled": true },
-              { "value": "Melbourne", "title": "(GMT+11:00) Melbourne", "enabled": true },
-              { "value": "New Caledonia", "title": "(GMT+11:00) New Caledonia", "enabled": true },
-              { "value": "Solomon Is.", "title": "(GMT+11:00) Solomon Is.", "enabled": true },
-              { "value": "Srednekolymsk", "title": "(GMT+11:00) Srednekolymsk", "enabled": true },
-              { "value": "Sydney", "title": "(GMT+11:00) Sydney", "enabled": true },
-              { "value": "Kamchatka", "title": "(GMT+12:00) Kamchatka", "enabled": true },
-              { "value": "Marshall Is.", "title": "(GMT+12:00) Marshall Is.", "enabled": true },
-              { "value": "Auckland", "title": "(GMT+13:00) Auckland", "enabled": true },
-              { "value": "Fiji", "title": "(GMT+13:00) Fiji", "enabled": true },
-              { "value": "Nuku'alofa", "title": "(GMT+13:00) Nuku'alofa", "enabled": true },
-              { "value": "Tokelau Is.", "title": "(GMT+13:00) Tokelau Is.", "enabled": true },
-              { "value": "Wellington", "title": "(GMT+13:00) Wellington", "enabled": true },
-              { "value": "Chatham Is.", "title": "(GMT+13:45) Chatham Is.", "enabled": true },
-              { "value": "Samoa", "title": "(GMT+14:00) Samoa", "enabled": true }
+              {
+                "value": "Indiana (East)",
+                "title": "(GMT-05:00) Indiana (East)",
+                "enabled": true
+              },
+              {
+                "value": "Lima",
+                "title": "(GMT-05:00) Lima",
+                "enabled": true
+              },
+              {
+                "value": "Quito",
+                "title": "(GMT-05:00) Quito",
+                "enabled": true
+              },
+              {
+                "value": "Atlantic Time (Canada)",
+                "title": "(GMT-04:00) Atlantic Time (Canada)",
+                "enabled": true
+              },
+              {
+                "value": "Caracas",
+                "title": "(GMT-04:00) Caracas",
+                "enabled": true
+              },
+              {
+                "value": "Georgetown",
+                "title": "(GMT-04:00) Georgetown",
+                "enabled": true
+              },
+              {
+                "value": "La Paz",
+                "title": "(GMT-04:00) La Paz",
+                "enabled": true
+              },
+              {
+                "value": "Puerto Rico",
+                "title": "(GMT-04:00) Puerto Rico",
+                "enabled": true
+              },
+              {
+                "value": "Newfoundland",
+                "title": "(GMT-03:30) Newfoundland",
+                "enabled": true
+              },
+              {
+                "value": "Brasilia",
+                "title": "(GMT-03:00) Brasilia",
+                "enabled": true
+              },
+              {
+                "value": "Buenos Aires",
+                "title": "(GMT-03:00) Buenos Aires",
+                "enabled": true
+              },
+              {
+                "value": "Greenland",
+                "title": "(GMT-03:00) Greenland",
+                "enabled": true
+              },
+              {
+                "value": "Montevideo",
+                "title": "(GMT-03:00) Montevideo",
+                "enabled": true
+              },
+              {
+                "value": "Santiago",
+                "title": "(GMT-03:00) Santiago",
+                "enabled": true
+              },
+              {
+                "value": "Mid-Atlantic",
+                "title": "(GMT-02:00) Mid-Atlantic",
+                "enabled": true
+              },
+              {
+                "value": "Azores",
+                "title": "(GMT-01:00) Azores",
+                "enabled": true
+              },
+              {
+                "value": "Cape Verde Is.",
+                "title": "(GMT-01:00) Cape Verde Is.",
+                "enabled": true
+              },
+              {
+                "value": "Dublin",
+                "title": "(GMT+00:00) Dublin",
+                "enabled": true
+              },
+              {
+                "value": "Edinburgh",
+                "title": "(GMT+00:00) Edinburgh",
+                "enabled": true
+              },
+              {
+                "value": "Lisbon",
+                "title": "(GMT+00:00) Lisbon",
+                "enabled": true
+              },
+              {
+                "value": "London",
+                "title": "(GMT+00:00) London",
+                "enabled": true
+              },
+              {
+                "value": "Monrovia",
+                "title": "(GMT+00:00) Monrovia",
+                "enabled": true
+              },
+              {
+                "value": "UTC",
+                "title": "(GMT+00:00) UTC",
+                "enabled": true
+              },
+              {
+                "value": "Amsterdam",
+                "title": "(GMT+01:00) Amsterdam",
+                "enabled": true
+              },
+              {
+                "value": "Belgrade",
+                "title": "(GMT+01:00) Belgrade",
+                "enabled": true
+              },
+              {
+                "value": "Berlin",
+                "title": "(GMT+01:00) Berlin",
+                "enabled": true
+              },
+              {
+                "value": "Bern",
+                "title": "(GMT+01:00) Bern",
+                "enabled": true
+              },
+              {
+                "value": "Bratislava",
+                "title": "(GMT+01:00) Bratislava",
+                "enabled": true
+              },
+              {
+                "value": "Brussels",
+                "title": "(GMT+01:00) Brussels",
+                "enabled": true
+              },
+              {
+                "value": "Budapest",
+                "title": "(GMT+01:00) Budapest",
+                "enabled": true
+              },
+              {
+                "value": "Casablanca",
+                "title": "(GMT+01:00) Casablanca",
+                "enabled": true
+              },
+              {
+                "value": "Copenhagen",
+                "title": "(GMT+01:00) Copenhagen",
+                "enabled": true
+              },
+              {
+                "value": "Ljubljana",
+                "title": "(GMT+01:00) Ljubljana",
+                "enabled": true
+              },
+              {
+                "value": "Madrid",
+                "title": "(GMT+01:00) Madrid",
+                "enabled": true
+              },
+              {
+                "value": "Oslo",
+                "title": "(GMT+01:00) Oslo",
+                "enabled": true
+              },
+              {
+                "value": "Paris",
+                "title": "(GMT+01:00) Paris",
+                "enabled": true
+              },
+              {
+                "value": "Prague",
+                "title": "(GMT+01:00) Prague",
+                "enabled": true
+              },
+              {
+                "value": "Rome",
+                "title": "(GMT+01:00) Rome",
+                "enabled": true
+              },
+              {
+                "value": "Sarajevo",
+                "title": "(GMT+01:00) Sarajevo",
+                "enabled": true
+              },
+              {
+                "value": "Skopje",
+                "title": "(GMT+01:00) Skopje",
+                "enabled": true
+              },
+              {
+                "value": "Stockholm",
+                "title": "(GMT+01:00) Stockholm",
+                "enabled": true
+              },
+              {
+                "value": "Vienna",
+                "title": "(GMT+01:00) Vienna",
+                "enabled": true
+              },
+              {
+                "value": "Warsaw",
+                "title": "(GMT+01:00) Warsaw",
+                "enabled": true
+              },
+              {
+                "value": "West Central Africa",
+                "title": "(GMT+01:00) West Central Africa",
+                "enabled": true
+              },
+              {
+                "value": "Zagreb",
+                "title": "(GMT+01:00) Zagreb",
+                "enabled": true
+              },
+              {
+                "value": "Athens",
+                "title": "(GMT+02:00) Athens",
+                "enabled": true
+              },
+              {
+                "value": "Bucharest",
+                "title": "(GMT+02:00) Bucharest",
+                "enabled": true
+              },
+              {
+                "value": "Cairo",
+                "title": "(GMT+02:00) Cairo",
+                "enabled": true
+              },
+              {
+                "value": "Harare",
+                "title": "(GMT+02:00) Harare",
+                "enabled": true
+              },
+              {
+                "value": "Helsinki",
+                "title": "(GMT+02:00) Helsinki",
+                "enabled": true
+              },
+              {
+                "value": "Jerusalem",
+                "title": "(GMT+02:00) Jerusalem",
+                "enabled": true
+              },
+              {
+                "value": "Kaliningrad",
+                "title": "(GMT+02:00) Kaliningrad",
+                "enabled": true
+              },
+              {
+                "value": "Kyev",
+                "title": "(GMT+02:00) Kyev",
+                "enabled": true
+              },
+              {
+                "value": "Kyiv",
+                "title": "(GMT+02:00) Kyiv",
+                "enabled": true
+              },
+              {
+                "value": "Pretoria",
+                "title": "(GMT+02:00) Pretoria",
+                "enabled": true
+              },
+              {
+                "value": "Riga",
+                "title": "(GMT+02:00) Riga",
+                "enabled": true
+              },
+              {
+                "value": "Sofia",
+                "title": "(GMT+02:00) Sofia",
+                "enabled": true
+              },
+              {
+                "value": "Tallinn",
+                "title": "(GMT+02:00) Tallinn",
+                "enabled": true
+              },
+              {
+                "value": "Vilnius",
+                "title": "(GMT+02:00) Vilnius",
+                "enabled": true
+              },
+              {
+                "value": "Baghdad",
+                "title": "(GMT+03:00) Baghdad",
+                "enabled": true
+              },
+              {
+                "value": "Istanbul",
+                "title": "(GMT+03:00) Istanbul",
+                "enabled": true
+              },
+              {
+                "value": "Kuwait",
+                "title": "(GMT+03:00) Kuwait",
+                "enabled": true
+              },
+              {
+                "value": "Minsk",
+                "title": "(GMT+03:00) Minsk",
+                "enabled": true
+              },
+              {
+                "value": "Moscow",
+                "title": "(GMT+03:00) Moscow",
+                "enabled": true
+              },
+              {
+                "value": "Nairobi",
+                "title": "(GMT+03:00) Nairobi",
+                "enabled": true
+              },
+              {
+                "value": "Riyadh",
+                "title": "(GMT+03:00) Riyadh",
+                "enabled": true
+              },
+              {
+                "value": "St. Petersburg",
+                "title": "(GMT+03:00) St. Petersburg",
+                "enabled": true
+              },
+              {
+                "value": "Tehran",
+                "title": "(GMT+03:30) Tehran",
+                "enabled": true
+              },
+              {
+                "value": "Abu Dhabi",
+                "title": "(GMT+04:00) Abu Dhabi",
+                "enabled": true
+              },
+              {
+                "value": "Baku",
+                "title": "(GMT+04:00) Baku",
+                "enabled": true
+              },
+              {
+                "value": "Muscat",
+                "title": "(GMT+04:00) Muscat",
+                "enabled": true
+              },
+              {
+                "value": "Samara",
+                "title": "(GMT+04:00) Samara",
+                "enabled": true
+              },
+              {
+                "value": "Tbilisi",
+                "title": "(GMT+04:00) Tbilisi",
+                "enabled": true
+              },
+              {
+                "value": "Volgograd",
+                "title": "(GMT+04:00) Volgograd",
+                "enabled": true
+              },
+              {
+                "value": "Yerevan",
+                "title": "(GMT+04:00) Yerevan",
+                "enabled": true
+              },
+              {
+                "value": "Kabul",
+                "title": "(GMT+04:30) Kabul",
+                "enabled": true
+              },
+              {
+                "value": "Ekaterinburg",
+                "title": "(GMT+05:00) Ekaterinburg",
+                "enabled": true
+              },
+              {
+                "value": "Islamabad",
+                "title": "(GMT+05:00) Islamabad",
+                "enabled": true
+              },
+              {
+                "value": "Karachi",
+                "title": "(GMT+05:00) Karachi",
+                "enabled": true
+              },
+              {
+                "value": "Tashkent",
+                "title": "(GMT+05:00) Tashkent",
+                "enabled": true
+              },
+              {
+                "value": "Chennai",
+                "title": "(GMT+05:30) Chennai",
+                "enabled": true
+              },
+              {
+                "value": "Kolkata",
+                "title": "(GMT+05:30) Kolkata",
+                "enabled": true
+              },
+              {
+                "value": "Mumbai",
+                "title": "(GMT+05:30) Mumbai",
+                "enabled": true
+              },
+              {
+                "value": "New Delhi",
+                "title": "(GMT+05:30) New Delhi",
+                "enabled": true
+              },
+              {
+                "value": "Sri Jayawardenepura",
+                "title": "(GMT+05:30) Sri Jayawardenepura",
+                "enabled": true
+              },
+              {
+                "value": "Kathmandu",
+                "title": "(GMT+05:45) Kathmandu",
+                "enabled": true
+              },
+              {
+                "value": "Almaty",
+                "title": "(GMT+06:00) Almaty",
+                "enabled": true
+              },
+              {
+                "value": "Astana",
+                "title": "(GMT+06:00) Astana",
+                "enabled": true
+              },
+              {
+                "value": "Dhaka",
+                "title": "(GMT+06:00) Dhaka",
+                "enabled": true
+              },
+              {
+                "value": "Urumqi",
+                "title": "(GMT+06:00) Urumqi",
+                "enabled": true
+              },
+              {
+                "value": "Rangoon",
+                "title": "(GMT+06:30) Rangoon",
+                "enabled": true
+              },
+              {
+                "value": "Bangkok",
+                "title": "(GMT+07:00) Bangkok",
+                "enabled": true
+              },
+              {
+                "value": "Hanoi",
+                "title": "(GMT+07:00) Hanoi",
+                "enabled": true
+              },
+              {
+                "value": "Jakarta",
+                "title": "(GMT+07:00) Jakarta",
+                "enabled": true
+              },
+              {
+                "value": "Krasnoyarsk",
+                "title": "(GMT+07:00) Krasnoyarsk",
+                "enabled": true
+              },
+              {
+                "value": "Novosibirsk",
+                "title": "(GMT+07:00) Novosibirsk",
+                "enabled": true
+              },
+              {
+                "value": "Beijing",
+                "title": "(GMT+08:00) Beijing",
+                "enabled": true
+              },
+              {
+                "value": "Chongqing",
+                "title": "(GMT+08:00) Chongqing",
+                "enabled": true
+              },
+              {
+                "value": "Hong Kong",
+                "title": "(GMT+08:00) Hong Kong",
+                "enabled": true
+              },
+              {
+                "value": "Irkutsk",
+                "title": "(GMT+08:00) Irkutsk",
+                "enabled": true
+              },
+              {
+                "value": "Kuala Lumpur",
+                "title": "(GMT+08:00) Kuala Lumpur",
+                "enabled": true
+              },
+              {
+                "value": "Perth",
+                "title": "(GMT+08:00) Perth",
+                "enabled": true
+              },
+              {
+                "value": "Singapore",
+                "title": "(GMT+08:00) Singapore",
+                "enabled": true
+              },
+              {
+                "value": "Taipei",
+                "title": "(GMT+08:00) Taipei",
+                "enabled": true
+              },
+              {
+                "value": "Ulaan Bataar",
+                "title": "(GMT+08:00) Ulaanbataar",
+                "enabled": true
+              },
+              {
+                "value": "Ulaanbaatar",
+                "title": "(GMT+08:00) Ulaanbaatar",
+                "enabled": true
+              },
+              {
+                "value": "Osaka",
+                "title": "(GMT+09:00) Osaka",
+                "enabled": true
+              },
+              {
+                "value": "Sapporo",
+                "title": "(GMT+09:00) Sapporo",
+                "enabled": true
+              },
+              {
+                "value": "Seoul",
+                "title": "(GMT+09:00) Seoul",
+                "enabled": true
+              },
+              {
+                "value": "Tokyo",
+                "title": "(GMT+09:00) Tokyo",
+                "enabled": true
+              },
+              {
+                "value": "Yakutsk",
+                "title": "(GMT+09:00) Yakutsk",
+                "enabled": true
+              },
+              {
+                "value": "Darwin",
+                "title": "(GMT+09:30) Darwin",
+                "enabled": true
+              },
+              {
+                "value": "Brisbane",
+                "title": "(GMT+10:00) Brisbane",
+                "enabled": true
+              },
+              {
+                "value": "Guam",
+                "title": "(GMT+10:00) Guam",
+                "enabled": true
+              },
+              {
+                "value": "Port Moresby",
+                "title": "(GMT+10:00) Port Moresby",
+                "enabled": true
+              },
+              {
+                "value": "Vladivostok",
+                "title": "(GMT+10:00) Vladivostok",
+                "enabled": true
+              },
+              {
+                "value": "Adelaide",
+                "title": "(GMT+10:30) Adelaide",
+                "enabled": true
+              },
+              {
+                "value": "Canberra",
+                "title": "(GMT+11:00) Canberra",
+                "enabled": true
+              },
+              {
+                "value": "Hobart",
+                "title": "(GMT+11:00) Hobart",
+                "enabled": true
+              },
+              {
+                "value": "Magadan",
+                "title": "(GMT+11:00) Magadan",
+                "enabled": true
+              },
+              {
+                "value": "Melbourne",
+                "title": "(GMT+11:00) Melbourne",
+                "enabled": true
+              },
+              {
+                "value": "New Caledonia",
+                "title": "(GMT+11:00) New Caledonia",
+                "enabled": true
+              },
+              {
+                "value": "Solomon Is.",
+                "title": "(GMT+11:00) Solomon Is.",
+                "enabled": true
+              },
+              {
+                "value": "Srednekolymsk",
+                "title": "(GMT+11:00) Srednekolymsk",
+                "enabled": true
+              },
+              {
+                "value": "Sydney",
+                "title": "(GMT+11:00) Sydney",
+                "enabled": true
+              },
+              {
+                "value": "Kamchatka",
+                "title": "(GMT+12:00) Kamchatka",
+                "enabled": true
+              },
+              {
+                "value": "Marshall Is.",
+                "title": "(GMT+12:00) Marshall Is.",
+                "enabled": true
+              },
+              {
+                "value": "Auckland",
+                "title": "(GMT+13:00) Auckland",
+                "enabled": true
+              },
+              {
+                "value": "Fiji",
+                "title": "(GMT+13:00) Fiji",
+                "enabled": true
+              },
+              {
+                "value": "Nuku'alofa",
+                "title": "(GMT+13:00) Nuku'alofa",
+                "enabled": true
+              },
+              {
+                "value": "Tokelau Is.",
+                "title": "(GMT+13:00) Tokelau Is.",
+                "enabled": true
+              },
+              {
+                "value": "Wellington",
+                "title": "(GMT+13:00) Wellington",
+                "enabled": true
+              },
+              {
+                "value": "Chatham Is.",
+                "title": "(GMT+13:45) Chatham Is.",
+                "enabled": true
+              },
+              {
+                "value": "Samoa",
+                "title": "(GMT+14:00) Samoa",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4158,13 +6645,33 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4175,14 +6682,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4193,13 +6724,33 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4210,8 +6761,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4222,12 +6781,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Before", "terminal": false },
-              { "value": "less_than_equal", "title": "Before or on", "terminal": false },
-              { "value": "greater_than", "title": "After", "terminal": false },
-              { "value": "greater_than_equal", "title": "After or on", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Before",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "After",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4238,12 +6821,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4254,8 +6861,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4266,14 +6881,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500001753322", "title": "Choice1", "enabled": true },
-              { "value": "1500001753342", "title": "another choice", "enabled": true },
-              { "value": "1500001753362", "title": "bla", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500001753322",
+                "title": "Choice1",
+                "enabled": true
+              },
+              {
+                "value": "1500001753342",
+                "title": "another choice",
+                "enabled": true
+              },
+              {
+                "value": "1500001753362",
+                "title": "bla",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4284,8 +6923,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4296,8 +6943,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4308,8 +6963,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4320,8 +6983,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4332,8 +7003,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4344,8 +7023,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4356,8 +7043,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4368,8 +7063,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4380,8 +7083,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4392,8 +7103,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4404,8 +7123,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4416,8 +7143,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4428,8 +7163,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4440,8 +7183,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4452,8 +7203,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4464,8 +7223,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4476,8 +7243,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4488,8 +7263,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4500,8 +7283,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4512,8 +7303,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4524,8 +7323,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4536,12 +7343,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4552,8 +7383,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4563,10 +7402,24 @@
             "group": "requester",
             "nullable": true,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Checked", "enabled": true },
-              { "value": "false", "title": "Unchecked", "enabled": true }
+              {
+                "value": "true",
+                "title": "Checked",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Unchecked",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4577,15 +7430,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1900000066065", "title": "123", "enabled": true },
-              { "value": "1900000066085", "title": "v1", "enabled": true },
-              { "value": "1900000066105", "title": "v2", "enabled": true },
-              { "value": "1900000066125", "title": "v3", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1900000066065",
+                "title": "123",
+                "enabled": true
+              },
+              {
+                "value": "1900000066085",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "1900000066105",
+                "title": "v2",
+                "enabled": true
+              },
+              {
+                "value": "1900000066125",
+                "title": "v3",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4596,8 +7477,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4608,8 +7497,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4620,8 +7517,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4632,8 +7537,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4644,8 +7557,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4656,12 +7577,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4672,12 +7617,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           }
         ],
@@ -4690,11 +7659,31 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4705,10 +7694,24 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -4718,17 +7721,53 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4739,15 +7778,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4758,17 +7825,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4779,17 +7882,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4800,14 +7939,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500421645662", "title": "myBrand", "enabled": true },
-              { "value": "1900025376085", "title": "test org 123", "enabled": true },
-              { "value": "1500508294122", "title": "test org 124", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500421645662",
+                "title": "myBrand",
+                "enabled": true
+              },
+              {
+                "value": "1900025376085",
+                "title": "test org 123",
+                "enabled": true
+              },
+              {
+                "value": "1500508294122",
+                "title": "test org 124",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4818,44 +7981,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4866,44 +8173,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4913,9 +8364,19 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com", "enabled": true }
+              {
+                "value": "support@myBrand.zendesk.com",
+                "title": "support@myBrand.zendesk.com",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4926,10 +8387,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4939,10 +8416,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "public", "title": "Ticket has public comments", "enabled": true },
-              { "value": "private", "title": "Ticket has no public comments", "enabled": true }
+              {
+                "value": "public",
+                "title": "Ticket has public comments",
+                "enabled": true
+              },
+              {
+                "value": "private",
+                "title": "Ticket has no public comments",
+                "enabled": true
+              }
             ]
           },
           {
@@ -4952,11 +8443,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true },
-              { "value": "not_relevant", "title": "Present (public or private)", "enabled": true },
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              },
+              {
+                "value": "not_relevant",
+                "title": "Present (public or private)",
+                "enabled": true
+              },
               {
                 "value": "requester_can_see_comment",
                 "title": "Present, and requester can see the comment",
@@ -4972,10 +8481,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -4986,13 +8511,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "4", "title": "(agent)", "enabled": true },
-              { "value": "0", "title": "(end-user)", "enabled": true },
-              { "value": "2", "title": "(admin)", "enabled": true }
+              {
+                "value": "4",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "0",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "(admin)",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5003,13 +8548,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1", "title": "English (United States)", "enabled": true },
-              { "value": "30", "title": "Hebrew", "enabled": true },
-              { "value": "2", "title": "Spanish", "enabled": true }
+              {
+                "value": "1",
+                "title": "English (United States)",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Hebrew",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "Spanish",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5020,183 +8585,783 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "American Samoa", "title": "(GMT-11:00) American Samoa", "enabled": true },
+              {
+                "value": "American Samoa",
+                "title": "(GMT-11:00) American Samoa",
+                "enabled": true
+              },
               {
                 "value": "International Date Line West",
                 "title": "(GMT-11:00) International Date Line West",
                 "enabled": true
               },
-              { "value": "Midway Island", "title": "(GMT-11:00) Midway Island", "enabled": true },
-              { "value": "Hawaii", "title": "(GMT-10:00) Hawaii", "enabled": true },
-              { "value": "Alaska", "title": "(GMT-09:00) Alaska", "enabled": true },
+              {
+                "value": "Midway Island",
+                "title": "(GMT-11:00) Midway Island",
+                "enabled": true
+              },
+              {
+                "value": "Hawaii",
+                "title": "(GMT-10:00) Hawaii",
+                "enabled": true
+              },
+              {
+                "value": "Alaska",
+                "title": "(GMT-09:00) Alaska",
+                "enabled": true
+              },
               {
                 "value": "Pacific Time (US & Canada)",
                 "title": "(GMT-08:00) Pacific Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Tijuana", "title": "(GMT-08:00) Tijuana", "enabled": true },
-              { "value": "Arizona", "title": "(GMT-07:00) Arizona", "enabled": true },
-              { "value": "Chihuahua", "title": "(GMT-07:00) Chihuahua", "enabled": true },
-              { "value": "Mazatlan", "title": "(GMT-07:00) Mazatlan", "enabled": true },
+              {
+                "value": "Tijuana",
+                "title": "(GMT-08:00) Tijuana",
+                "enabled": true
+              },
+              {
+                "value": "Arizona",
+                "title": "(GMT-07:00) Arizona",
+                "enabled": true
+              },
+              {
+                "value": "Chihuahua",
+                "title": "(GMT-07:00) Chihuahua",
+                "enabled": true
+              },
+              {
+                "value": "Mazatlan",
+                "title": "(GMT-07:00) Mazatlan",
+                "enabled": true
+              },
               {
                 "value": "Mountain Time (US & Canada)",
                 "title": "(GMT-07:00) Mountain Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Central America", "title": "(GMT-06:00) Central America", "enabled": true },
+              {
+                "value": "Central America",
+                "title": "(GMT-06:00) Central America",
+                "enabled": true
+              },
               {
                 "value": "Central Time (US & Canada)",
                 "title": "(GMT-06:00) Central Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Guadalajara", "title": "(GMT-06:00) Guadalajara", "enabled": true },
-              { "value": "Mexico City", "title": "(GMT-06:00) Mexico City", "enabled": true },
-              { "value": "Monterrey", "title": "(GMT-06:00) Monterrey", "enabled": true },
-              { "value": "Saskatchewan", "title": "(GMT-06:00) Saskatchewan", "enabled": true },
-              { "value": "Bogota", "title": "(GMT-05:00) Bogota", "enabled": true },
+              {
+                "value": "Guadalajara",
+                "title": "(GMT-06:00) Guadalajara",
+                "enabled": true
+              },
+              {
+                "value": "Mexico City",
+                "title": "(GMT-06:00) Mexico City",
+                "enabled": true
+              },
+              {
+                "value": "Monterrey",
+                "title": "(GMT-06:00) Monterrey",
+                "enabled": true
+              },
+              {
+                "value": "Saskatchewan",
+                "title": "(GMT-06:00) Saskatchewan",
+                "enabled": true
+              },
+              {
+                "value": "Bogota",
+                "title": "(GMT-05:00) Bogota",
+                "enabled": true
+              },
               {
                 "value": "Eastern Time (US & Canada)",
                 "title": "(GMT-05:00) Eastern Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Indiana (East)", "title": "(GMT-05:00) Indiana (East)", "enabled": true },
-              { "value": "Lima", "title": "(GMT-05:00) Lima", "enabled": true },
-              { "value": "Quito", "title": "(GMT-05:00) Quito", "enabled": true },
-              { "value": "Atlantic Time (Canada)", "title": "(GMT-04:00) Atlantic Time (Canada)", "enabled": true },
-              { "value": "Caracas", "title": "(GMT-04:00) Caracas", "enabled": true },
-              { "value": "Georgetown", "title": "(GMT-04:00) Georgetown", "enabled": true },
-              { "value": "La Paz", "title": "(GMT-04:00) La Paz", "enabled": true },
-              { "value": "Puerto Rico", "title": "(GMT-04:00) Puerto Rico", "enabled": true },
-              { "value": "Newfoundland", "title": "(GMT-03:30) Newfoundland", "enabled": true },
-              { "value": "Brasilia", "title": "(GMT-03:00) Brasilia", "enabled": true },
-              { "value": "Buenos Aires", "title": "(GMT-03:00) Buenos Aires", "enabled": true },
-              { "value": "Greenland", "title": "(GMT-03:00) Greenland", "enabled": true },
-              { "value": "Montevideo", "title": "(GMT-03:00) Montevideo", "enabled": true },
-              { "value": "Santiago", "title": "(GMT-03:00) Santiago", "enabled": true },
-              { "value": "Mid-Atlantic", "title": "(GMT-02:00) Mid-Atlantic", "enabled": true },
-              { "value": "Azores", "title": "(GMT-01:00) Azores", "enabled": true },
-              { "value": "Cape Verde Is.", "title": "(GMT-01:00) Cape Verde Is.", "enabled": true },
-              { "value": "Dublin", "title": "(GMT+00:00) Dublin", "enabled": true },
-              { "value": "Edinburgh", "title": "(GMT+00:00) Edinburgh", "enabled": true },
-              { "value": "Lisbon", "title": "(GMT+00:00) Lisbon", "enabled": true },
-              { "value": "London", "title": "(GMT+00:00) London", "enabled": true },
-              { "value": "Monrovia", "title": "(GMT+00:00) Monrovia", "enabled": true },
-              { "value": "UTC", "title": "(GMT+00:00) UTC", "enabled": true },
-              { "value": "Amsterdam", "title": "(GMT+01:00) Amsterdam", "enabled": true },
-              { "value": "Belgrade", "title": "(GMT+01:00) Belgrade", "enabled": true },
-              { "value": "Berlin", "title": "(GMT+01:00) Berlin", "enabled": true },
-              { "value": "Bern", "title": "(GMT+01:00) Bern", "enabled": true },
-              { "value": "Bratislava", "title": "(GMT+01:00) Bratislava", "enabled": true },
-              { "value": "Brussels", "title": "(GMT+01:00) Brussels", "enabled": true },
-              { "value": "Budapest", "title": "(GMT+01:00) Budapest", "enabled": true },
-              { "value": "Casablanca", "title": "(GMT+01:00) Casablanca", "enabled": true },
-              { "value": "Copenhagen", "title": "(GMT+01:00) Copenhagen", "enabled": true },
-              { "value": "Ljubljana", "title": "(GMT+01:00) Ljubljana", "enabled": true },
-              { "value": "Madrid", "title": "(GMT+01:00) Madrid", "enabled": true },
-              { "value": "Oslo", "title": "(GMT+01:00) Oslo", "enabled": true },
-              { "value": "Paris", "title": "(GMT+01:00) Paris", "enabled": true },
-              { "value": "Prague", "title": "(GMT+01:00) Prague", "enabled": true },
-              { "value": "Rome", "title": "(GMT+01:00) Rome", "enabled": true },
-              { "value": "Sarajevo", "title": "(GMT+01:00) Sarajevo", "enabled": true },
-              { "value": "Skopje", "title": "(GMT+01:00) Skopje", "enabled": true },
-              { "value": "Stockholm", "title": "(GMT+01:00) Stockholm", "enabled": true },
-              { "value": "Vienna", "title": "(GMT+01:00) Vienna", "enabled": true },
-              { "value": "Warsaw", "title": "(GMT+01:00) Warsaw", "enabled": true },
-              { "value": "West Central Africa", "title": "(GMT+01:00) West Central Africa", "enabled": true },
-              { "value": "Zagreb", "title": "(GMT+01:00) Zagreb", "enabled": true },
-              { "value": "Athens", "title": "(GMT+02:00) Athens", "enabled": true },
-              { "value": "Bucharest", "title": "(GMT+02:00) Bucharest", "enabled": true },
-              { "value": "Cairo", "title": "(GMT+02:00) Cairo", "enabled": true },
-              { "value": "Harare", "title": "(GMT+02:00) Harare", "enabled": true },
-              { "value": "Helsinki", "title": "(GMT+02:00) Helsinki", "enabled": true },
-              { "value": "Jerusalem", "title": "(GMT+02:00) Jerusalem", "enabled": true },
-              { "value": "Kaliningrad", "title": "(GMT+02:00) Kaliningrad", "enabled": true },
-              { "value": "Kyev", "title": "(GMT+02:00) Kyev", "enabled": true },
-              { "value": "Kyiv", "title": "(GMT+02:00) Kyiv", "enabled": true },
-              { "value": "Pretoria", "title": "(GMT+02:00) Pretoria", "enabled": true },
-              { "value": "Riga", "title": "(GMT+02:00) Riga", "enabled": true },
-              { "value": "Sofia", "title": "(GMT+02:00) Sofia", "enabled": true },
-              { "value": "Tallinn", "title": "(GMT+02:00) Tallinn", "enabled": true },
-              { "value": "Vilnius", "title": "(GMT+02:00) Vilnius", "enabled": true },
-              { "value": "Baghdad", "title": "(GMT+03:00) Baghdad", "enabled": true },
-              { "value": "Istanbul", "title": "(GMT+03:00) Istanbul", "enabled": true },
-              { "value": "Kuwait", "title": "(GMT+03:00) Kuwait", "enabled": true },
-              { "value": "Minsk", "title": "(GMT+03:00) Minsk", "enabled": true },
-              { "value": "Moscow", "title": "(GMT+03:00) Moscow", "enabled": true },
-              { "value": "Nairobi", "title": "(GMT+03:00) Nairobi", "enabled": true },
-              { "value": "Riyadh", "title": "(GMT+03:00) Riyadh", "enabled": true },
-              { "value": "St. Petersburg", "title": "(GMT+03:00) St. Petersburg", "enabled": true },
-              { "value": "Tehran", "title": "(GMT+03:30) Tehran", "enabled": true },
-              { "value": "Abu Dhabi", "title": "(GMT+04:00) Abu Dhabi", "enabled": true },
-              { "value": "Baku", "title": "(GMT+04:00) Baku", "enabled": true },
-              { "value": "Muscat", "title": "(GMT+04:00) Muscat", "enabled": true },
-              { "value": "Samara", "title": "(GMT+04:00) Samara", "enabled": true },
-              { "value": "Tbilisi", "title": "(GMT+04:00) Tbilisi", "enabled": true },
-              { "value": "Volgograd", "title": "(GMT+04:00) Volgograd", "enabled": true },
-              { "value": "Yerevan", "title": "(GMT+04:00) Yerevan", "enabled": true },
-              { "value": "Kabul", "title": "(GMT+04:30) Kabul", "enabled": true },
-              { "value": "Ekaterinburg", "title": "(GMT+05:00) Ekaterinburg", "enabled": true },
-              { "value": "Islamabad", "title": "(GMT+05:00) Islamabad", "enabled": true },
-              { "value": "Karachi", "title": "(GMT+05:00) Karachi", "enabled": true },
-              { "value": "Tashkent", "title": "(GMT+05:00) Tashkent", "enabled": true },
-              { "value": "Chennai", "title": "(GMT+05:30) Chennai", "enabled": true },
-              { "value": "Kolkata", "title": "(GMT+05:30) Kolkata", "enabled": true },
-              { "value": "Mumbai", "title": "(GMT+05:30) Mumbai", "enabled": true },
-              { "value": "New Delhi", "title": "(GMT+05:30) New Delhi", "enabled": true },
-              { "value": "Sri Jayawardenepura", "title": "(GMT+05:30) Sri Jayawardenepura", "enabled": true },
-              { "value": "Kathmandu", "title": "(GMT+05:45) Kathmandu", "enabled": true },
-              { "value": "Almaty", "title": "(GMT+06:00) Almaty", "enabled": true },
-              { "value": "Astana", "title": "(GMT+06:00) Astana", "enabled": true },
-              { "value": "Dhaka", "title": "(GMT+06:00) Dhaka", "enabled": true },
-              { "value": "Urumqi", "title": "(GMT+06:00) Urumqi", "enabled": true },
-              { "value": "Rangoon", "title": "(GMT+06:30) Rangoon", "enabled": true },
-              { "value": "Bangkok", "title": "(GMT+07:00) Bangkok", "enabled": true },
-              { "value": "Hanoi", "title": "(GMT+07:00) Hanoi", "enabled": true },
-              { "value": "Jakarta", "title": "(GMT+07:00) Jakarta", "enabled": true },
-              { "value": "Krasnoyarsk", "title": "(GMT+07:00) Krasnoyarsk", "enabled": true },
-              { "value": "Novosibirsk", "title": "(GMT+07:00) Novosibirsk", "enabled": true },
-              { "value": "Beijing", "title": "(GMT+08:00) Beijing", "enabled": true },
-              { "value": "Chongqing", "title": "(GMT+08:00) Chongqing", "enabled": true },
-              { "value": "Hong Kong", "title": "(GMT+08:00) Hong Kong", "enabled": true },
-              { "value": "Irkutsk", "title": "(GMT+08:00) Irkutsk", "enabled": true },
-              { "value": "Kuala Lumpur", "title": "(GMT+08:00) Kuala Lumpur", "enabled": true },
-              { "value": "Perth", "title": "(GMT+08:00) Perth", "enabled": true },
-              { "value": "Singapore", "title": "(GMT+08:00) Singapore", "enabled": true },
-              { "value": "Taipei", "title": "(GMT+08:00) Taipei", "enabled": true },
-              { "value": "Ulaan Bataar", "title": "(GMT+08:00) Ulaanbataar", "enabled": true },
-              { "value": "Ulaanbaatar", "title": "(GMT+08:00) Ulaanbaatar", "enabled": true },
-              { "value": "Osaka", "title": "(GMT+09:00) Osaka", "enabled": true },
-              { "value": "Sapporo", "title": "(GMT+09:00) Sapporo", "enabled": true },
-              { "value": "Seoul", "title": "(GMT+09:00) Seoul", "enabled": true },
-              { "value": "Tokyo", "title": "(GMT+09:00) Tokyo", "enabled": true },
-              { "value": "Yakutsk", "title": "(GMT+09:00) Yakutsk", "enabled": true },
-              { "value": "Darwin", "title": "(GMT+09:30) Darwin", "enabled": true },
-              { "value": "Brisbane", "title": "(GMT+10:00) Brisbane", "enabled": true },
-              { "value": "Guam", "title": "(GMT+10:00) Guam", "enabled": true },
-              { "value": "Port Moresby", "title": "(GMT+10:00) Port Moresby", "enabled": true },
-              { "value": "Vladivostok", "title": "(GMT+10:00) Vladivostok", "enabled": true },
-              { "value": "Adelaide", "title": "(GMT+10:30) Adelaide", "enabled": true },
-              { "value": "Canberra", "title": "(GMT+11:00) Canberra", "enabled": true },
-              { "value": "Hobart", "title": "(GMT+11:00) Hobart", "enabled": true },
-              { "value": "Magadan", "title": "(GMT+11:00) Magadan", "enabled": true },
-              { "value": "Melbourne", "title": "(GMT+11:00) Melbourne", "enabled": true },
-              { "value": "New Caledonia", "title": "(GMT+11:00) New Caledonia", "enabled": true },
-              { "value": "Solomon Is.", "title": "(GMT+11:00) Solomon Is.", "enabled": true },
-              { "value": "Srednekolymsk", "title": "(GMT+11:00) Srednekolymsk", "enabled": true },
-              { "value": "Sydney", "title": "(GMT+11:00) Sydney", "enabled": true },
-              { "value": "Kamchatka", "title": "(GMT+12:00) Kamchatka", "enabled": true },
-              { "value": "Marshall Is.", "title": "(GMT+12:00) Marshall Is.", "enabled": true },
-              { "value": "Auckland", "title": "(GMT+13:00) Auckland", "enabled": true },
-              { "value": "Fiji", "title": "(GMT+13:00) Fiji", "enabled": true },
-              { "value": "Nuku'alofa", "title": "(GMT+13:00) Nuku'alofa", "enabled": true },
-              { "value": "Tokelau Is.", "title": "(GMT+13:00) Tokelau Is.", "enabled": true },
-              { "value": "Wellington", "title": "(GMT+13:00) Wellington", "enabled": true },
-              { "value": "Chatham Is.", "title": "(GMT+13:45) Chatham Is.", "enabled": true },
-              { "value": "Samoa", "title": "(GMT+14:00) Samoa", "enabled": true }
+              {
+                "value": "Indiana (East)",
+                "title": "(GMT-05:00) Indiana (East)",
+                "enabled": true
+              },
+              {
+                "value": "Lima",
+                "title": "(GMT-05:00) Lima",
+                "enabled": true
+              },
+              {
+                "value": "Quito",
+                "title": "(GMT-05:00) Quito",
+                "enabled": true
+              },
+              {
+                "value": "Atlantic Time (Canada)",
+                "title": "(GMT-04:00) Atlantic Time (Canada)",
+                "enabled": true
+              },
+              {
+                "value": "Caracas",
+                "title": "(GMT-04:00) Caracas",
+                "enabled": true
+              },
+              {
+                "value": "Georgetown",
+                "title": "(GMT-04:00) Georgetown",
+                "enabled": true
+              },
+              {
+                "value": "La Paz",
+                "title": "(GMT-04:00) La Paz",
+                "enabled": true
+              },
+              {
+                "value": "Puerto Rico",
+                "title": "(GMT-04:00) Puerto Rico",
+                "enabled": true
+              },
+              {
+                "value": "Newfoundland",
+                "title": "(GMT-03:30) Newfoundland",
+                "enabled": true
+              },
+              {
+                "value": "Brasilia",
+                "title": "(GMT-03:00) Brasilia",
+                "enabled": true
+              },
+              {
+                "value": "Buenos Aires",
+                "title": "(GMT-03:00) Buenos Aires",
+                "enabled": true
+              },
+              {
+                "value": "Greenland",
+                "title": "(GMT-03:00) Greenland",
+                "enabled": true
+              },
+              {
+                "value": "Montevideo",
+                "title": "(GMT-03:00) Montevideo",
+                "enabled": true
+              },
+              {
+                "value": "Santiago",
+                "title": "(GMT-03:00) Santiago",
+                "enabled": true
+              },
+              {
+                "value": "Mid-Atlantic",
+                "title": "(GMT-02:00) Mid-Atlantic",
+                "enabled": true
+              },
+              {
+                "value": "Azores",
+                "title": "(GMT-01:00) Azores",
+                "enabled": true
+              },
+              {
+                "value": "Cape Verde Is.",
+                "title": "(GMT-01:00) Cape Verde Is.",
+                "enabled": true
+              },
+              {
+                "value": "Dublin",
+                "title": "(GMT+00:00) Dublin",
+                "enabled": true
+              },
+              {
+                "value": "Edinburgh",
+                "title": "(GMT+00:00) Edinburgh",
+                "enabled": true
+              },
+              {
+                "value": "Lisbon",
+                "title": "(GMT+00:00) Lisbon",
+                "enabled": true
+              },
+              {
+                "value": "London",
+                "title": "(GMT+00:00) London",
+                "enabled": true
+              },
+              {
+                "value": "Monrovia",
+                "title": "(GMT+00:00) Monrovia",
+                "enabled": true
+              },
+              {
+                "value": "UTC",
+                "title": "(GMT+00:00) UTC",
+                "enabled": true
+              },
+              {
+                "value": "Amsterdam",
+                "title": "(GMT+01:00) Amsterdam",
+                "enabled": true
+              },
+              {
+                "value": "Belgrade",
+                "title": "(GMT+01:00) Belgrade",
+                "enabled": true
+              },
+              {
+                "value": "Berlin",
+                "title": "(GMT+01:00) Berlin",
+                "enabled": true
+              },
+              {
+                "value": "Bern",
+                "title": "(GMT+01:00) Bern",
+                "enabled": true
+              },
+              {
+                "value": "Bratislava",
+                "title": "(GMT+01:00) Bratislava",
+                "enabled": true
+              },
+              {
+                "value": "Brussels",
+                "title": "(GMT+01:00) Brussels",
+                "enabled": true
+              },
+              {
+                "value": "Budapest",
+                "title": "(GMT+01:00) Budapest",
+                "enabled": true
+              },
+              {
+                "value": "Casablanca",
+                "title": "(GMT+01:00) Casablanca",
+                "enabled": true
+              },
+              {
+                "value": "Copenhagen",
+                "title": "(GMT+01:00) Copenhagen",
+                "enabled": true
+              },
+              {
+                "value": "Ljubljana",
+                "title": "(GMT+01:00) Ljubljana",
+                "enabled": true
+              },
+              {
+                "value": "Madrid",
+                "title": "(GMT+01:00) Madrid",
+                "enabled": true
+              },
+              {
+                "value": "Oslo",
+                "title": "(GMT+01:00) Oslo",
+                "enabled": true
+              },
+              {
+                "value": "Paris",
+                "title": "(GMT+01:00) Paris",
+                "enabled": true
+              },
+              {
+                "value": "Prague",
+                "title": "(GMT+01:00) Prague",
+                "enabled": true
+              },
+              {
+                "value": "Rome",
+                "title": "(GMT+01:00) Rome",
+                "enabled": true
+              },
+              {
+                "value": "Sarajevo",
+                "title": "(GMT+01:00) Sarajevo",
+                "enabled": true
+              },
+              {
+                "value": "Skopje",
+                "title": "(GMT+01:00) Skopje",
+                "enabled": true
+              },
+              {
+                "value": "Stockholm",
+                "title": "(GMT+01:00) Stockholm",
+                "enabled": true
+              },
+              {
+                "value": "Vienna",
+                "title": "(GMT+01:00) Vienna",
+                "enabled": true
+              },
+              {
+                "value": "Warsaw",
+                "title": "(GMT+01:00) Warsaw",
+                "enabled": true
+              },
+              {
+                "value": "West Central Africa",
+                "title": "(GMT+01:00) West Central Africa",
+                "enabled": true
+              },
+              {
+                "value": "Zagreb",
+                "title": "(GMT+01:00) Zagreb",
+                "enabled": true
+              },
+              {
+                "value": "Athens",
+                "title": "(GMT+02:00) Athens",
+                "enabled": true
+              },
+              {
+                "value": "Bucharest",
+                "title": "(GMT+02:00) Bucharest",
+                "enabled": true
+              },
+              {
+                "value": "Cairo",
+                "title": "(GMT+02:00) Cairo",
+                "enabled": true
+              },
+              {
+                "value": "Harare",
+                "title": "(GMT+02:00) Harare",
+                "enabled": true
+              },
+              {
+                "value": "Helsinki",
+                "title": "(GMT+02:00) Helsinki",
+                "enabled": true
+              },
+              {
+                "value": "Jerusalem",
+                "title": "(GMT+02:00) Jerusalem",
+                "enabled": true
+              },
+              {
+                "value": "Kaliningrad",
+                "title": "(GMT+02:00) Kaliningrad",
+                "enabled": true
+              },
+              {
+                "value": "Kyev",
+                "title": "(GMT+02:00) Kyev",
+                "enabled": true
+              },
+              {
+                "value": "Kyiv",
+                "title": "(GMT+02:00) Kyiv",
+                "enabled": true
+              },
+              {
+                "value": "Pretoria",
+                "title": "(GMT+02:00) Pretoria",
+                "enabled": true
+              },
+              {
+                "value": "Riga",
+                "title": "(GMT+02:00) Riga",
+                "enabled": true
+              },
+              {
+                "value": "Sofia",
+                "title": "(GMT+02:00) Sofia",
+                "enabled": true
+              },
+              {
+                "value": "Tallinn",
+                "title": "(GMT+02:00) Tallinn",
+                "enabled": true
+              },
+              {
+                "value": "Vilnius",
+                "title": "(GMT+02:00) Vilnius",
+                "enabled": true
+              },
+              {
+                "value": "Baghdad",
+                "title": "(GMT+03:00) Baghdad",
+                "enabled": true
+              },
+              {
+                "value": "Istanbul",
+                "title": "(GMT+03:00) Istanbul",
+                "enabled": true
+              },
+              {
+                "value": "Kuwait",
+                "title": "(GMT+03:00) Kuwait",
+                "enabled": true
+              },
+              {
+                "value": "Minsk",
+                "title": "(GMT+03:00) Minsk",
+                "enabled": true
+              },
+              {
+                "value": "Moscow",
+                "title": "(GMT+03:00) Moscow",
+                "enabled": true
+              },
+              {
+                "value": "Nairobi",
+                "title": "(GMT+03:00) Nairobi",
+                "enabled": true
+              },
+              {
+                "value": "Riyadh",
+                "title": "(GMT+03:00) Riyadh",
+                "enabled": true
+              },
+              {
+                "value": "St. Petersburg",
+                "title": "(GMT+03:00) St. Petersburg",
+                "enabled": true
+              },
+              {
+                "value": "Tehran",
+                "title": "(GMT+03:30) Tehran",
+                "enabled": true
+              },
+              {
+                "value": "Abu Dhabi",
+                "title": "(GMT+04:00) Abu Dhabi",
+                "enabled": true
+              },
+              {
+                "value": "Baku",
+                "title": "(GMT+04:00) Baku",
+                "enabled": true
+              },
+              {
+                "value": "Muscat",
+                "title": "(GMT+04:00) Muscat",
+                "enabled": true
+              },
+              {
+                "value": "Samara",
+                "title": "(GMT+04:00) Samara",
+                "enabled": true
+              },
+              {
+                "value": "Tbilisi",
+                "title": "(GMT+04:00) Tbilisi",
+                "enabled": true
+              },
+              {
+                "value": "Volgograd",
+                "title": "(GMT+04:00) Volgograd",
+                "enabled": true
+              },
+              {
+                "value": "Yerevan",
+                "title": "(GMT+04:00) Yerevan",
+                "enabled": true
+              },
+              {
+                "value": "Kabul",
+                "title": "(GMT+04:30) Kabul",
+                "enabled": true
+              },
+              {
+                "value": "Ekaterinburg",
+                "title": "(GMT+05:00) Ekaterinburg",
+                "enabled": true
+              },
+              {
+                "value": "Islamabad",
+                "title": "(GMT+05:00) Islamabad",
+                "enabled": true
+              },
+              {
+                "value": "Karachi",
+                "title": "(GMT+05:00) Karachi",
+                "enabled": true
+              },
+              {
+                "value": "Tashkent",
+                "title": "(GMT+05:00) Tashkent",
+                "enabled": true
+              },
+              {
+                "value": "Chennai",
+                "title": "(GMT+05:30) Chennai",
+                "enabled": true
+              },
+              {
+                "value": "Kolkata",
+                "title": "(GMT+05:30) Kolkata",
+                "enabled": true
+              },
+              {
+                "value": "Mumbai",
+                "title": "(GMT+05:30) Mumbai",
+                "enabled": true
+              },
+              {
+                "value": "New Delhi",
+                "title": "(GMT+05:30) New Delhi",
+                "enabled": true
+              },
+              {
+                "value": "Sri Jayawardenepura",
+                "title": "(GMT+05:30) Sri Jayawardenepura",
+                "enabled": true
+              },
+              {
+                "value": "Kathmandu",
+                "title": "(GMT+05:45) Kathmandu",
+                "enabled": true
+              },
+              {
+                "value": "Almaty",
+                "title": "(GMT+06:00) Almaty",
+                "enabled": true
+              },
+              {
+                "value": "Astana",
+                "title": "(GMT+06:00) Astana",
+                "enabled": true
+              },
+              {
+                "value": "Dhaka",
+                "title": "(GMT+06:00) Dhaka",
+                "enabled": true
+              },
+              {
+                "value": "Urumqi",
+                "title": "(GMT+06:00) Urumqi",
+                "enabled": true
+              },
+              {
+                "value": "Rangoon",
+                "title": "(GMT+06:30) Rangoon",
+                "enabled": true
+              },
+              {
+                "value": "Bangkok",
+                "title": "(GMT+07:00) Bangkok",
+                "enabled": true
+              },
+              {
+                "value": "Hanoi",
+                "title": "(GMT+07:00) Hanoi",
+                "enabled": true
+              },
+              {
+                "value": "Jakarta",
+                "title": "(GMT+07:00) Jakarta",
+                "enabled": true
+              },
+              {
+                "value": "Krasnoyarsk",
+                "title": "(GMT+07:00) Krasnoyarsk",
+                "enabled": true
+              },
+              {
+                "value": "Novosibirsk",
+                "title": "(GMT+07:00) Novosibirsk",
+                "enabled": true
+              },
+              {
+                "value": "Beijing",
+                "title": "(GMT+08:00) Beijing",
+                "enabled": true
+              },
+              {
+                "value": "Chongqing",
+                "title": "(GMT+08:00) Chongqing",
+                "enabled": true
+              },
+              {
+                "value": "Hong Kong",
+                "title": "(GMT+08:00) Hong Kong",
+                "enabled": true
+              },
+              {
+                "value": "Irkutsk",
+                "title": "(GMT+08:00) Irkutsk",
+                "enabled": true
+              },
+              {
+                "value": "Kuala Lumpur",
+                "title": "(GMT+08:00) Kuala Lumpur",
+                "enabled": true
+              },
+              {
+                "value": "Perth",
+                "title": "(GMT+08:00) Perth",
+                "enabled": true
+              },
+              {
+                "value": "Singapore",
+                "title": "(GMT+08:00) Singapore",
+                "enabled": true
+              },
+              {
+                "value": "Taipei",
+                "title": "(GMT+08:00) Taipei",
+                "enabled": true
+              },
+              {
+                "value": "Ulaan Bataar",
+                "title": "(GMT+08:00) Ulaanbataar",
+                "enabled": true
+              },
+              {
+                "value": "Ulaanbaatar",
+                "title": "(GMT+08:00) Ulaanbaatar",
+                "enabled": true
+              },
+              {
+                "value": "Osaka",
+                "title": "(GMT+09:00) Osaka",
+                "enabled": true
+              },
+              {
+                "value": "Sapporo",
+                "title": "(GMT+09:00) Sapporo",
+                "enabled": true
+              },
+              {
+                "value": "Seoul",
+                "title": "(GMT+09:00) Seoul",
+                "enabled": true
+              },
+              {
+                "value": "Tokyo",
+                "title": "(GMT+09:00) Tokyo",
+                "enabled": true
+              },
+              {
+                "value": "Yakutsk",
+                "title": "(GMT+09:00) Yakutsk",
+                "enabled": true
+              },
+              {
+                "value": "Darwin",
+                "title": "(GMT+09:30) Darwin",
+                "enabled": true
+              },
+              {
+                "value": "Brisbane",
+                "title": "(GMT+10:00) Brisbane",
+                "enabled": true
+              },
+              {
+                "value": "Guam",
+                "title": "(GMT+10:00) Guam",
+                "enabled": true
+              },
+              {
+                "value": "Port Moresby",
+                "title": "(GMT+10:00) Port Moresby",
+                "enabled": true
+              },
+              {
+                "value": "Vladivostok",
+                "title": "(GMT+10:00) Vladivostok",
+                "enabled": true
+              },
+              {
+                "value": "Adelaide",
+                "title": "(GMT+10:30) Adelaide",
+                "enabled": true
+              },
+              {
+                "value": "Canberra",
+                "title": "(GMT+11:00) Canberra",
+                "enabled": true
+              },
+              {
+                "value": "Hobart",
+                "title": "(GMT+11:00) Hobart",
+                "enabled": true
+              },
+              {
+                "value": "Magadan",
+                "title": "(GMT+11:00) Magadan",
+                "enabled": true
+              },
+              {
+                "value": "Melbourne",
+                "title": "(GMT+11:00) Melbourne",
+                "enabled": true
+              },
+              {
+                "value": "New Caledonia",
+                "title": "(GMT+11:00) New Caledonia",
+                "enabled": true
+              },
+              {
+                "value": "Solomon Is.",
+                "title": "(GMT+11:00) Solomon Is.",
+                "enabled": true
+              },
+              {
+                "value": "Srednekolymsk",
+                "title": "(GMT+11:00) Srednekolymsk",
+                "enabled": true
+              },
+              {
+                "value": "Sydney",
+                "title": "(GMT+11:00) Sydney",
+                "enabled": true
+              },
+              {
+                "value": "Kamchatka",
+                "title": "(GMT+12:00) Kamchatka",
+                "enabled": true
+              },
+              {
+                "value": "Marshall Is.",
+                "title": "(GMT+12:00) Marshall Is.",
+                "enabled": true
+              },
+              {
+                "value": "Auckland",
+                "title": "(GMT+13:00) Auckland",
+                "enabled": true
+              },
+              {
+                "value": "Fiji",
+                "title": "(GMT+13:00) Fiji",
+                "enabled": true
+              },
+              {
+                "value": "Nuku'alofa",
+                "title": "(GMT+13:00) Nuku'alofa",
+                "enabled": true
+              },
+              {
+                "value": "Tokelau Is.",
+                "title": "(GMT+13:00) Tokelau Is.",
+                "enabled": true
+              },
+              {
+                "value": "Wellington",
+                "title": "(GMT+13:00) Wellington",
+                "enabled": true
+              },
+              {
+                "value": "Chatham Is.",
+                "title": "(GMT+13:45) Chatham Is.",
+                "enabled": true
+              },
+              {
+                "value": "Samoa",
+                "title": "(GMT+14:00) Samoa",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5207,13 +9372,33 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5224,14 +9409,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5242,13 +9451,33 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5259,8 +9488,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5271,12 +9508,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Before", "terminal": false },
-              { "value": "less_than_equal", "title": "Before or on", "terminal": false },
-              { "value": "greater_than", "title": "After", "terminal": false },
-              { "value": "greater_than_equal", "title": "After or on", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Before",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "After",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5287,12 +9548,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5303,8 +9588,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5315,14 +9608,38 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500001753322", "title": "Choice1", "enabled": true },
-              { "value": "1500001753342", "title": "another choice", "enabled": true },
-              { "value": "1500001753362", "title": "bla", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500001753322",
+                "title": "Choice1",
+                "enabled": true
+              },
+              {
+                "value": "1500001753342",
+                "title": "another choice",
+                "enabled": true
+              },
+              {
+                "value": "1500001753362",
+                "title": "bla",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5333,8 +9650,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5345,8 +9670,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5357,8 +9690,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5369,8 +9710,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5381,8 +9730,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5393,8 +9750,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5405,8 +9770,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5417,8 +9790,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5429,8 +9810,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5441,8 +9830,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5453,8 +9850,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5465,8 +9870,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5477,8 +9890,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5489,8 +9910,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5501,8 +9930,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5513,8 +9950,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5525,8 +9970,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5537,8 +9990,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5549,8 +10010,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5561,8 +10030,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5573,8 +10050,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5585,12 +10070,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5601,8 +10110,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5612,10 +10129,24 @@
             "group": "requester",
             "nullable": true,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Checked", "enabled": true },
-              { "value": "false", "title": "Unchecked", "enabled": true }
+              {
+                "value": "true",
+                "title": "Checked",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Unchecked",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5626,15 +10157,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1900000066065", "title": "123", "enabled": true },
-              { "value": "1900000066085", "title": "v1", "enabled": true },
-              { "value": "1900000066105", "title": "v2", "enabled": true },
-              { "value": "1900000066125", "title": "v3", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1900000066065",
+                "title": "123",
+                "enabled": true
+              },
+              {
+                "value": "1900000066085",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "1900000066105",
+                "title": "v2",
+                "enabled": true
+              },
+              {
+                "value": "1900000066125",
+                "title": "v3",
+                "enabled": true
+              }
             ]
           },
           {
@@ -5645,8 +10204,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5657,8 +10224,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5669,8 +10244,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5681,8 +10264,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5693,8 +10284,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5705,12 +10304,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           },
           {
@@ -5721,12 +10344,36 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ]
           }
         ]
@@ -5735,7 +10382,9 @@
   },
   {
     "url": "/api/v2/views",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "views": [
         {
@@ -5752,28 +10401,74 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "status", "title": "Status", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "status",
+              "title": "Status",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "type", "title": "Type" },
-              { "id": "priority", "title": "Priority" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "type",
+                "title": "Type"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "type", "title": "Type" },
-              { "id": "priority", "title": "Priority" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "type",
+                "title": "Type"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "less_than", "value": "solved" },
-              { "field": "assignee_id", "operator": "is", "value": "current_user" }
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": "current_user"
+              }
             ],
             "any": []
           },
@@ -5796,27 +10491,69 @@
             "sort_by": "created",
             "sort_order": "desc",
             "group": null,
-            "sort": { "id": "created", "title": "Requested", "order": "desc" },
+            "sort": {
+              "id": "created",
+              "title": "Requested",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "assignee_id", "operator": "is", "value": "" },
-              { "field": "status", "operator": "less_than", "value": "solved" }
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": ""
+              },
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              }
             ],
             "any": []
           },
@@ -5838,25 +10575,72 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "assignee", "title": "Assignee", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "assignee",
+              "title": "Assignee",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "updated", "title": "Updated" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "updated",
+                "title": "Updated"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "updated", "title": "Updated" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "updated",
+                "title": "Updated"
+              }
             ],
             "custom_fields": []
           },
-          "conditions": { "all": [{ "field": "status", "operator": "less_than", "value": "solved" }], "any": [] },
+          "conditions": {
+            "all": [
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              }
+            ],
+            "any": []
+          },
           "restriction": null,
           "watchable": false,
           "raw_title": "{{zd.all_unsolved_tickets}}"
@@ -5875,30 +10659,82 @@
             "group_order": "asc",
             "sort_by": "updated",
             "sort_order": "desc",
-            "group": { "id": "status", "title": "Status", "order": "asc" },
-            "sort": { "id": "updated", "title": "Updated", "order": "desc" },
+            "group": {
+              "id": "status",
+              "title": "Status",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "updated",
+              "title": "Updated",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "updated_at", "operator": "less_than", "value": "24" },
-              { "field": "status", "operator": "less_than", "value": "closed" }
+              {
+                "field": "updated_at",
+                "operator": "less_than",
+                "value": "24"
+              },
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "closed"
+              }
             ],
             "any": []
           },
@@ -5920,28 +10756,74 @@
             "group_order": "asc",
             "sort_by": "assignee",
             "sort_order": "desc",
-            "group": { "id": "due_date", "title": "Due date", "order": "asc" },
-            "sort": { "id": "assignee", "title": "Assignee", "order": "desc" },
+            "group": {
+              "id": "due_date",
+              "title": "Due date",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "assignee",
+              "title": "Assignee",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "due_date", "title": "Due date" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "due_date",
+                "title": "Due date"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "due_date", "title": "Due date" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "due_date",
+                "title": "Due date"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "less_than", "value": "solved" },
-              { "field": "type", "operator": "is", "value": "task" }
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              },
+              {
+                "field": "type",
+                "operator": "is",
+                "value": "task"
+              }
             ],
             "any": []
           },
@@ -5963,28 +10845,74 @@
             "group_order": "asc",
             "sort_by": "assignee",
             "sort_order": "desc",
-            "group": { "id": "due_date", "title": "Due date", "order": "asc" },
-            "sort": { "id": "assignee", "title": "Assignee", "order": "desc" },
+            "group": {
+              "id": "due_date",
+              "title": "Due date",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "assignee",
+              "title": "Assignee",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "due_date", "title": "Due date" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "due_date",
+                "title": "Due date"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "due_date", "title": "Due date" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "due_date",
+                "title": "Due date"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "less_than", "value": "solved" },
-              { "field": "due_at", "operator": "greater_than", "value": "0" }
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              },
+              {
+                "field": "due_at",
+                "operator": "greater_than",
+                "value": "0"
+              }
             ],
             "any": []
           },
@@ -6006,29 +10934,79 @@
             "group_order": "desc",
             "sort_by": "created",
             "sort_order": "desc",
-            "group": { "id": "group", "title": "Group", "order": "desc" },
-            "sort": { "id": "created", "title": "Requested", "order": "desc" },
+            "group": {
+              "id": "group",
+              "title": "Group",
+              "order": "desc"
+            },
+            "sort": {
+              "id": "created",
+              "title": "Requested",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "less_than", "value": "solved" },
-              { "field": "assignee_id", "operator": "is", "value": "" },
-              { "field": "group_id", "operator": "is", "value": "current_groups" }
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              },
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": ""
+              },
+              {
+                "field": "group_id",
+                "operator": "is",
+                "value": "current_groups"
+              }
             ],
             "any": []
           },
@@ -6050,27 +11028,80 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "updated", "title": "Updated", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "updated",
+              "title": "Updated",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" },
-              { "id": "assignee", "title": "Assignee" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              }
             ],
             "custom_fields": []
           },
-          "conditions": { "all": [{ "field": "status", "operator": "is", "value": "pending" }], "any": [] },
+          "conditions": {
+            "all": [
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "pending"
+              }
+            ],
+            "any": []
+          },
           "restriction": null,
           "watchable": true,
           "raw_title": "{{zd.pending_tickets}}"
@@ -6089,27 +11120,80 @@
             "group_order": "asc",
             "sort_by": "solved",
             "sort_order": "desc",
-            "group": { "id": "assignee", "title": "Assignee", "order": "asc" },
-            "sort": { "id": "solved", "title": "Solved", "order": "desc" },
+            "group": {
+              "id": "assignee",
+              "title": "Assignee",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "solved",
+              "title": "Solved",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "solved", "title": "Solved" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "solved",
+                "title": "Solved"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "solved", "title": "Solved" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "solved",
+                "title": "Solved"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "custom_fields": []
           },
-          "conditions": { "all": [{ "field": "status", "operator": "is", "value": "solved" }], "any": [] },
+          "conditions": {
+            "all": [
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "solved"
+              }
+            ],
+            "any": []
+          },
           "restriction": null,
           "watchable": false,
           "raw_title": "{{zd.recently_solved_tickets}}"
@@ -6128,26 +11212,66 @@
             "group_order": "desc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "group", "title": "Group", "order": "desc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "group",
+              "title": "Group",
+              "order": "desc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "status", "title": "Status" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "status",
+                "title": "Status"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "status", "title": "Status" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "status",
+                "title": "Status"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "less_than", "value": "solved" },
-              { "field": "group_id", "operator": "is", "value": "current_groups" }
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              },
+              {
+                "field": "group_id",
+                "operator": "is",
+                "value": "current_groups"
+              }
             ],
             "any": []
           },
@@ -6169,39 +11293,107 @@
             "group_order": "desc",
             "sort_by": null,
             "sort_order": "desc",
-            "group": { "id": "submitter", "title": "Submitter", "order": "desc" },
+            "group": {
+              "id": "submitter",
+              "title": "Submitter",
+              "order": "desc"
+            },
             "sort": null,
             "columns": [
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "subject", "title": "Subject" },
-              { "id": "created", "title": "Requested" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "attributes_match", "title": "Skill match" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "attributes_match",
+                "title": "Skill match"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "fields": [
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "subject", "title": "Subject" },
-              { "id": "created", "title": "Requested" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "attributes_match", "title": "Skill match" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "attributes_match",
+                "title": "Skill match"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "type", "operator": "is", "value": "problem" },
-              { "field": "brand_id", "operator": "is_not", "value": "1500000550682" }
+              {
+                "field": "type",
+                "operator": "is",
+                "value": "problem"
+              },
+              {
+                "field": "brand_id",
+                "operator": "is_not",
+                "value": "1500000550682"
+              }
             ],
             "any": [
-              { "field": "requester_id", "operator": "is_not", "value": "assignee_id" },
-              { "field": "organization_id", "operator": "is_not", "value": "1900025376085" }
+              {
+                "field": "requester_id",
+                "operator": "is_not",
+                "value": "assignee_id"
+              },
+              {
+                "field": "organization_id",
+                "operator": "is_not",
+                "value": "1900025376085"
+              }
             ]
           },
-          "restriction": { "type": "Group", "id": 1500002894482, "ids": [1500002894482] },
+          "restriction": {
+            "type": "Group",
+            "id": 1500002894482,
+            "ids": [
+              1500002894482
+            ]
+          },
           "watchable": false,
           "raw_title": "Custom view 123"
         },
@@ -6220,27 +11412,69 @@
             "sort_by": "created",
             "sort_order": "desc",
             "group": null,
-            "sort": { "id": "created", "title": "Requested", "order": "desc" },
+            "sort": {
+              "id": "created",
+              "title": "Requested",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "group", "title": "Group" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "group",
+                "title": "Group"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "assignee_id", "operator": "is", "value": "" },
-              { "field": "status", "operator": "less_than", "value": "solved" }
+              {
+                "field": "assignee_id",
+                "operator": "is",
+                "value": ""
+              },
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              }
             ],
             "any": []
           },
@@ -6262,25 +11496,72 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "assignee", "title": "Assignee", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "assignee",
+              "title": "Assignee",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "updated", "title": "Updated" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "updated",
+                "title": "Updated"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "created", "title": "Requested" },
-              { "id": "priority", "title": "Priority" },
-              { "id": "updated", "title": "Updated" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "priority",
+                "title": "Priority"
+              },
+              {
+                "id": "updated",
+                "title": "Updated"
+              }
             ],
             "custom_fields": []
           },
-          "conditions": { "all": [{ "field": "status", "operator": "less_than", "value": "solved" }], "any": [] },
+          "conditions": {
+            "all": [
+              {
+                "field": "status",
+                "operator": "less_than",
+                "value": "solved"
+              }
+            ],
+            "any": []
+          },
           "restriction": null,
           "watchable": false,
           "raw_title": "Copy of All unsolved tickets"
@@ -6299,39 +11580,107 @@
             "group_order": "desc",
             "sort_by": null,
             "sort_order": "desc",
-            "group": { "id": "submitter", "title": "Submitter", "order": "desc" },
+            "group": {
+              "id": "submitter",
+              "title": "Submitter",
+              "order": "desc"
+            },
             "sort": null,
             "columns": [
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "subject", "title": "Subject" },
-              { "id": "created", "title": "Requested" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "attributes_match", "title": "Skill match" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "attributes_match",
+                "title": "Skill match"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "fields": [
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "subject", "title": "Subject" },
-              { "id": "created", "title": "Requested" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "attributes_match", "title": "Skill match" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "created",
+                "title": "Requested"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "attributes_match",
+                "title": "Skill match"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "custom_fields": []
           },
           "conditions": {
             "all": [
-              { "field": "type", "operator": "is", "value": "problem" },
-              { "field": "brand_id", "operator": "is_not", "value": "1500000550682" }
+              {
+                "field": "type",
+                "operator": "is",
+                "value": "problem"
+              },
+              {
+                "field": "brand_id",
+                "operator": "is_not",
+                "value": "1500000550682"
+              }
             ],
             "any": [
-              { "field": "requester_id", "operator": "is_not", "value": "assignee_id" },
-              { "field": "organization_id", "operator": "is_not", "value": "1900025376085" }
+              {
+                "field": "requester_id",
+                "operator": "is_not",
+                "value": "assignee_id"
+              },
+              {
+                "field": "organization_id",
+                "operator": "is_not",
+                "value": "1900025376085"
+              }
             ]
           },
-          "restriction": { "type": "Group", "id": 1500002894482, "ids": [1500002894482] },
+          "restriction": {
+            "type": "Group",
+            "id": 1500002894482,
+            "ids": [
+              1500002894482
+            ]
+          },
           "watchable": false,
           "raw_title": "Custom view 1234"
         },
@@ -6349,31 +11698,81 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "requester", "title": "Requester", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "requester",
+              "title": "Requester",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "requester", "title": "Requester" },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
               {
                 "id": 1500009152922,
                 "title": "zip code with validation",
                 "type": "regexp",
                 "url": "https://myBrand.zendesk.com/api/v2/ticket_fields/1500009152922.json"
               },
-              { "id": "brand", "title": "Brand" },
-              { "id": "updated_by_type", "title": "Updater" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "brand",
+                "title": "Brand"
+              },
+              {
+                "id": "updated_by_type",
+                "title": "Updater"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "assignee", "title": "Assignee" },
-              { "id": "satisfaction_score", "title": "Satisfaction" },
-              { "id": "requester", "title": "Requester" },
-              { "id": "brand", "title": "Brand" },
-              { "id": "updated_by_type", "title": "Updater" },
-              { "id": "sla_next_breach_at", "title": "Next SLA breach" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "assignee",
+                "title": "Assignee"
+              },
+              {
+                "id": "satisfaction_score",
+                "title": "Satisfaction"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
+              {
+                "id": "brand",
+                "title": "Brand"
+              },
+              {
+                "id": "updated_by_type",
+                "title": "Updater"
+              },
+              {
+                "id": "sla_next_breach_at",
+                "title": "Next SLA breach"
+              }
             ],
             "custom_fields": [
               {
@@ -6386,15 +11785,37 @@
           },
           "conditions": {
             "all": [
-              { "field": "status", "operator": "is", "value": "open" },
-              { "field": "brand_id", "operator": "is", "value": "1500000550682" }
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "open"
+              },
+              {
+                "field": "brand_id",
+                "operator": "is",
+                "value": "1500000550682"
+              }
             ],
             "any": [
-              { "field": "priority", "operator": "is_not", "value": "low" },
-              { "field": "custom_fields_1500009152882", "operator": "includes", "value": "v1" }
+              {
+                "field": "priority",
+                "operator": "is_not",
+                "value": "low"
+              },
+              {
+                "field": "custom_fields_1500009152882",
+                "operator": "includes",
+                "value": "v1"
+              }
             ]
           },
-          "restriction": { "type": "Group", "id": 1500002894482, "ids": [1500002894482] },
+          "restriction": {
+            "type": "Group",
+            "id": 1500002894482,
+            "ids": [
+              1500002894482
+            ]
+          },
           "watchable": false,
           "raw_title": "Test"
         },
@@ -6412,11 +11833,25 @@
             "group_order": "asc",
             "sort_by": "nice_id",
             "sort_order": "desc",
-            "group": { "id": "requester", "title": "Requester", "order": "asc" },
-            "sort": { "id": "ticket_id", "title": "ID", "order": "desc" },
+            "group": {
+              "id": "requester",
+              "title": "Requester",
+              "order": "asc"
+            },
+            "sort": {
+              "id": "ticket_id",
+              "title": "ID",
+              "order": "desc"
+            },
             "columns": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" },
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              },
               {
                 "id": 1500009152922,
                 "title": "zip code with validation",
@@ -6425,8 +11860,14 @@
               }
             ],
             "fields": [
-              { "id": "subject", "title": "Subject" },
-              { "id": "requester", "title": "Requester" }
+              {
+                "id": "subject",
+                "title": "Subject"
+              },
+              {
+                "id": "requester",
+                "title": "Requester"
+              }
             ],
             "custom_fields": [
               {
@@ -6438,13 +11879,33 @@
             ]
           },
           "conditions": {
-            "all": [{ "field": "status", "operator": "is", "value": "open" }],
+            "all": [
+              {
+                "field": "status",
+                "operator": "is",
+                "value": "open"
+              }
+            ],
             "any": [
-              { "field": "priority", "operator": "is_not", "value": "low" },
-              { "field": "custom_fields_1500009152882", "operator": "includes", "value": "v1" }
+              {
+                "field": "priority",
+                "operator": "is_not",
+                "value": "low"
+              },
+              {
+                "field": "custom_fields_1500009152882",
+                "operator": "includes",
+                "value": "v1"
+              }
             ]
           },
-          "restriction": { "type": "Group", "id": 1500002894482, "ids": [1500002894482] },
+          "restriction": {
+            "type": "Group",
+            "id": 1500002894482,
+            "ids": [
+              1500002894482
+            ]
+          },
           "watchable": false,
           "raw_title": "Test2"
         }
@@ -6456,7 +11917,9 @@
   },
   {
     "url": "/api/v2/apps/owned",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "apps": [
         {
@@ -6484,7 +11947,9 @@
           "framework_version": "2.0",
           "featured": false,
           "promoted": false,
-          "products": ["support"],
+          "products": [
+            "support"
+          ],
           "categories": [],
           "version": "1.0",
           "marketing_only": false,
@@ -6521,11 +11986,25 @@
         "all": [
           {
             "title": "Brand",
-            "values": { "type": "list", "list": [{ "value": 1500000550682, "title": "myBrand" }] },
+            "values": {
+              "type": "list",
+              "list": [
+                {
+                  "value": 1500000550682,
+                  "title": "myBrand"
+                }
+              ]
+            },
             "value": "brand_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Brand",
@@ -6536,19 +12015,46 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 1500000859362, "title": "Default Ticket Form" },
-                { "value": 1500002488461, "title": "Form 6436" },
-                { "value": 1500002488481, "title": "Form 11" },
-                { "value": 1900000172165, "title": "Form 13" },
-                { "value": 1500002488501, "title": "Form 12" },
-                { "value": 1900000882985, "title": "Demo ticket form" },
-                { "value": 1900000911005, "title": "Amazing ticket form" }
+                {
+                  "value": 1500000859362,
+                  "title": "Default Ticket Form"
+                },
+                {
+                  "value": 1500002488461,
+                  "title": "Form 6436"
+                },
+                {
+                  "value": 1500002488481,
+                  "title": "Form 11"
+                },
+                {
+                  "value": 1900000172165,
+                  "title": "Form 13"
+                },
+                {
+                  "value": 1500002488501,
+                  "title": "Form 12"
+                },
+                {
+                  "value": 1900000882985,
+                  "title": "Demo ticket form"
+                },
+                {
+                  "value": 1900000911005,
+                  "title": "Amazing ticket form"
+                }
               ]
             },
             "value": "ticket_form_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Ticket form",
@@ -6559,17 +12065,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "-" },
-                { "value": 1, "title": "Question" },
-                { "value": 2, "title": "Incident" },
-                { "value": 3, "title": "Problem" },
-                { "value": 4, "title": "Task" }
+                {
+                  "value": 0,
+                  "title": "-"
+                },
+                {
+                  "value": 1,
+                  "title": "Question"
+                },
+                {
+                  "value": 2,
+                  "title": "Incident"
+                },
+                {
+                  "value": 3,
+                  "title": "Problem"
+                },
+                {
+                  "value": 4,
+                  "title": "Task"
+                }
               ]
             },
             "value": "ticket_type_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Ticket type",
@@ -6580,17 +12107,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500002894482, "title": "Support" },
-                { "value": 4415660742295, "title": "Support2" },
-                { "value": 4415700870423, "title": "Support4" },
-                { "value": 4415704834327, "title": "Support5" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500002894482,
+                  "title": "Support"
+                },
+                {
+                  "value": 4415660742295,
+                  "title": "Support2"
+                },
+                {
+                  "value": 4415700870423,
+                  "title": "Support4"
+                },
+                {
+                  "value": 4415704834327,
+                  "title": "Support5"
+                }
               ]
             },
             "value": "group_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Group",
@@ -6601,20 +12149,50 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": "requester_id", "title": "(requester)" },
-                { "value": "current_user", "title": "(current user)" },
-                { "value": 1911534269745, "title": "Person4" },
-                { "value": 1508591419201, "title": "Person1" },
-                { "value": 1520622229002, "title": "Person3" },
-                { "value": 1508485810561, "title": "Person2" },
-                { "value": 1523341727741, "title": "myBrand Dev" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": "requester_id",
+                  "title": "(requester)"
+                },
+                {
+                  "value": "current_user",
+                  "title": "(current user)"
+                },
+                {
+                  "value": 1911534269745,
+                  "title": "Person4"
+                },
+                {
+                  "value": 1508591419201,
+                  "title": "Person1"
+                },
+                {
+                  "value": 1520622229002,
+                  "title": "Person3"
+                },
+                {
+                  "value": 1508485810561,
+                  "title": "Person2"
+                },
+                {
+                  "value": 1523341727741,
+                  "title": "myBrand Dev"
+                }
               ]
             },
             "value": "assignee_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Assignee",
@@ -6625,19 +12203,46 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "assignee_id", "title": "(assignee)" },
-                { "value": "current_user", "title": "(current user)" },
-                { "value": 1911534269745, "title": "Person4" },
-                { "value": 1508591419201, "title": "Person1" },
-                { "value": 1520622229002, "title": "Person3" },
-                { "value": 1508485810561, "title": "Person2" },
-                { "value": 1523341727741, "title": "myBrand Dev" }
+                {
+                  "value": "assignee_id",
+                  "title": "(assignee)"
+                },
+                {
+                  "value": "current_user",
+                  "title": "(current user)"
+                },
+                {
+                  "value": 1911534269745,
+                  "title": "Person4"
+                },
+                {
+                  "value": 1508591419201,
+                  "title": "Person1"
+                },
+                {
+                  "value": 1520622229002,
+                  "title": "Person3"
+                },
+                {
+                  "value": 1508485810561,
+                  "title": "Person2"
+                },
+                {
+                  "value": 1523341727741,
+                  "title": "myBrand Dev"
+                }
               ]
             },
             "value": "requester_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Requester",
@@ -6648,16 +12253,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500421645662, "title": "myBrand" },
-                { "value": 1900025376085, "title": "test org 123" },
-                { "value": 1500508294122, "title": "test org 124" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500421645662,
+                  "title": "myBrand"
+                },
+                {
+                  "value": 1900025376085,
+                  "title": "test org 123"
+                },
+                {
+                  "value": 1500508294122,
+                  "title": "test org 124"
+                }
               ]
             },
             "value": "organization_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Organization",
@@ -6665,11 +12288,21 @@
           },
           {
             "title": "Tags",
-            "values": { "type": "text", "css_class": "large", "list": [] },
+            "values": {
+              "type": "text",
+              "css_class": "large",
+              "list": []
+            },
             "value": "current_tags",
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following" },
-              { "value": "not_includes", "title": "Contains none of the following" }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following"
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Tags",
@@ -6680,46 +12313,154 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "Web form" },
-                { "value": 4, "title": "Email" },
-                { "value": 29, "title": "Chat" },
-                { "value": 30, "title": "Twitter" },
-                { "value": 26, "title": "Twitter DM" },
-                { "value": 23, "title": "Twitter Like" },
-                { "value": 33, "title": "Voicemail" },
-                { "value": 34, "title": "Phone call (incoming)" },
-                { "value": 35, "title": "Phone call (outgoing)" },
-                { "value": 44, "title": "CTI voicemail" },
-                { "value": 45, "title": "CTI phone call (incoming)" },
-                { "value": 46, "title": "CTI phone call (outgoing)" },
-                { "value": 57, "title": "Text" },
-                { "value": 16, "title": "Get Satisfaction" },
-                { "value": 48, "title": "Web Widget" },
-                { "value": 49, "title": "Mobile SDK" },
-                { "value": 56, "title": "Mobile" },
-                { "value": 50, "title": "Help Center post" },
-                { "value": 5, "title": "Web service (API)" },
-                { "value": 8, "title": "Automation" },
-                { "value": 24, "title": "Forum topic" },
-                { "value": 27, "title": "Closed ticket" },
-                { "value": 31, "title": "Ticket sharing" },
-                { "value": 38, "title": "Facebook Post" },
-                { "value": 41, "title": "Facebook Private Message" },
-                { "value": 54, "title": "Satisfaction Prediction" },
-                { "value": 67, "title": "Answer Bot for Web Widget" },
-                { "value": 55, "title": "Channel Integrations" },
-                { "value": 73, "title": "WeChat" },
-                { "value": 72, "title": "LINE" },
-                { "value": 74, "title": "WhatsApp" },
-                { "value": 78, "title": "Facebook Messenger" },
-                { "value": 88, "title": "Twitter Direct Message" },
-                { "value": 86, "title": "Instagram Direct" }
+                {
+                  "value": 0,
+                  "title": "Web form"
+                },
+                {
+                  "value": 4,
+                  "title": "Email"
+                },
+                {
+                  "value": 29,
+                  "title": "Chat"
+                },
+                {
+                  "value": 30,
+                  "title": "Twitter"
+                },
+                {
+                  "value": 26,
+                  "title": "Twitter DM"
+                },
+                {
+                  "value": 23,
+                  "title": "Twitter Like"
+                },
+                {
+                  "value": 33,
+                  "title": "Voicemail"
+                },
+                {
+                  "value": 34,
+                  "title": "Phone call (incoming)"
+                },
+                {
+                  "value": 35,
+                  "title": "Phone call (outgoing)"
+                },
+                {
+                  "value": 44,
+                  "title": "CTI voicemail"
+                },
+                {
+                  "value": 45,
+                  "title": "CTI phone call (incoming)"
+                },
+                {
+                  "value": 46,
+                  "title": "CTI phone call (outgoing)"
+                },
+                {
+                  "value": 57,
+                  "title": "Text"
+                },
+                {
+                  "value": 16,
+                  "title": "Get Satisfaction"
+                },
+                {
+                  "value": 48,
+                  "title": "Web Widget"
+                },
+                {
+                  "value": 49,
+                  "title": "Mobile SDK"
+                },
+                {
+                  "value": 56,
+                  "title": "Mobile"
+                },
+                {
+                  "value": 50,
+                  "title": "Help Center post"
+                },
+                {
+                  "value": 5,
+                  "title": "Web service (API)"
+                },
+                {
+                  "value": 8,
+                  "title": "Automation"
+                },
+                {
+                  "value": 24,
+                  "title": "Forum topic"
+                },
+                {
+                  "value": 27,
+                  "title": "Closed ticket"
+                },
+                {
+                  "value": 31,
+                  "title": "Ticket sharing"
+                },
+                {
+                  "value": 38,
+                  "title": "Facebook Post"
+                },
+                {
+                  "value": 41,
+                  "title": "Facebook Private Message"
+                },
+                {
+                  "value": 54,
+                  "title": "Satisfaction Prediction"
+                },
+                {
+                  "value": 67,
+                  "title": "Answer Bot for Web Widget"
+                },
+                {
+                  "value": 55,
+                  "title": "Channel Integrations"
+                },
+                {
+                  "value": 73,
+                  "title": "WeChat"
+                },
+                {
+                  "value": 72,
+                  "title": "LINE"
+                },
+                {
+                  "value": 74,
+                  "title": "WhatsApp"
+                },
+                {
+                  "value": 78,
+                  "title": "Facebook Messenger"
+                },
+                {
+                  "value": 88,
+                  "title": "Twitter Direct Message"
+                },
+                {
+                  "value": 86,
+                  "title": "Instagram Direct"
+                }
               ]
             },
             "value": "via_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Channel",
@@ -6730,46 +12471,154 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "Web form" },
-                { "value": 4, "title": "Email" },
-                { "value": 29, "title": "Chat" },
-                { "value": 30, "title": "Twitter" },
-                { "value": 26, "title": "Twitter DM" },
-                { "value": 23, "title": "Twitter Like" },
-                { "value": 33, "title": "Voicemail" },
-                { "value": 34, "title": "Phone call (incoming)" },
-                { "value": 35, "title": "Phone call (outgoing)" },
-                { "value": 44, "title": "CTI voicemail" },
-                { "value": 45, "title": "CTI phone call (incoming)" },
-                { "value": 46, "title": "CTI phone call (outgoing)" },
-                { "value": 57, "title": "Text" },
-                { "value": 16, "title": "Get Satisfaction" },
-                { "value": 48, "title": "Web Widget" },
-                { "value": 49, "title": "Mobile SDK" },
-                { "value": 56, "title": "Mobile" },
-                { "value": 50, "title": "Help Center post" },
-                { "value": 5, "title": "Web service (API)" },
-                { "value": 8, "title": "Automation" },
-                { "value": 24, "title": "Forum topic" },
-                { "value": 27, "title": "Closed ticket" },
-                { "value": 31, "title": "Ticket sharing" },
-                { "value": 38, "title": "Facebook Post" },
-                { "value": 41, "title": "Facebook Private Message" },
-                { "value": 54, "title": "Satisfaction Prediction" },
-                { "value": 67, "title": "Answer Bot for Web Widget" },
-                { "value": 55, "title": "Channel Integrations" },
-                { "value": 73, "title": "WeChat" },
-                { "value": 72, "title": "LINE" },
-                { "value": 74, "title": "WhatsApp" },
-                { "value": 78, "title": "Facebook Messenger" },
-                { "value": 88, "title": "Twitter Direct Message" },
-                { "value": 86, "title": "Instagram Direct" }
+                {
+                  "value": 0,
+                  "title": "Web form"
+                },
+                {
+                  "value": 4,
+                  "title": "Email"
+                },
+                {
+                  "value": 29,
+                  "title": "Chat"
+                },
+                {
+                  "value": 30,
+                  "title": "Twitter"
+                },
+                {
+                  "value": 26,
+                  "title": "Twitter DM"
+                },
+                {
+                  "value": 23,
+                  "title": "Twitter Like"
+                },
+                {
+                  "value": 33,
+                  "title": "Voicemail"
+                },
+                {
+                  "value": 34,
+                  "title": "Phone call (incoming)"
+                },
+                {
+                  "value": 35,
+                  "title": "Phone call (outgoing)"
+                },
+                {
+                  "value": 44,
+                  "title": "CTI voicemail"
+                },
+                {
+                  "value": 45,
+                  "title": "CTI phone call (incoming)"
+                },
+                {
+                  "value": 46,
+                  "title": "CTI phone call (outgoing)"
+                },
+                {
+                  "value": 57,
+                  "title": "Text"
+                },
+                {
+                  "value": 16,
+                  "title": "Get Satisfaction"
+                },
+                {
+                  "value": 48,
+                  "title": "Web Widget"
+                },
+                {
+                  "value": 49,
+                  "title": "Mobile SDK"
+                },
+                {
+                  "value": 56,
+                  "title": "Mobile"
+                },
+                {
+                  "value": 50,
+                  "title": "Help Center post"
+                },
+                {
+                  "value": 5,
+                  "title": "Web service (API)"
+                },
+                {
+                  "value": 8,
+                  "title": "Automation"
+                },
+                {
+                  "value": 24,
+                  "title": "Forum topic"
+                },
+                {
+                  "value": 27,
+                  "title": "Closed ticket"
+                },
+                {
+                  "value": 31,
+                  "title": "Ticket sharing"
+                },
+                {
+                  "value": 38,
+                  "title": "Facebook Post"
+                },
+                {
+                  "value": 41,
+                  "title": "Facebook Private Message"
+                },
+                {
+                  "value": 54,
+                  "title": "Satisfaction Prediction"
+                },
+                {
+                  "value": 67,
+                  "title": "Answer Bot for Web Widget"
+                },
+                {
+                  "value": 55,
+                  "title": "Channel Integrations"
+                },
+                {
+                  "value": 73,
+                  "title": "WeChat"
+                },
+                {
+                  "value": 72,
+                  "title": "LINE"
+                },
+                {
+                  "value": 74,
+                  "title": "WhatsApp"
+                },
+                {
+                  "value": 78,
+                  "title": "Facebook Messenger"
+                },
+                {
+                  "value": 88,
+                  "title": "Twitter Direct Message"
+                },
+                {
+                  "value": 86,
+                  "title": "Instagram Direct"
+                }
               ]
             },
             "value": "current_via_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Update via",
@@ -6782,10 +12631,20 @@
               "label": {
                 "default": "html_block You can add and remove support addresses in your account's email <a href=\"/settings/email\">settings</a>."
               },
-              "list": [{ "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com" }]
+              "list": [
+                {
+                  "value": "support@myBrand.zendesk.com",
+                  "title": "support@myBrand.zendesk.com"
+                }
+              ]
             },
             "value": "recipient",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "ticket",
             "title_for_field": "Received at",
             "output_key": null
@@ -6795,12 +12654,23 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "public", "title": "Ticket has public comments" },
-                { "value": "private", "title": "Ticket has no public comments" }
+                {
+                  "value": "public",
+                  "title": "Ticket has public comments"
+                },
+                {
+                  "value": "private",
+                  "title": "Ticket has no public comments"
+                }
               ]
             },
             "value": "ticket_is_public",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "ticket",
             "title_for_field": "Privacy",
             "output_key": null
@@ -6809,15 +12679,30 @@
             "title": "Created",
             "values": {
               "type": "datetime",
-              "labels": { "default": "YYYY-MM-DD hh:mm", "integer": " days" },
+              "labels": {
+                "default": "YYYY-MM-DD hh:mm",
+                "integer": " days"
+              },
               "list": []
             },
             "value": "exact_created_at",
             "operators": [
-              { "value": "less_than", "title": "Before" },
-              { "value": "less_than_equal", "title": "Before or on" },
-              { "value": "greater_than", "title": "After" },
-              { "value": "greater_than_equal", "title": "After or on" }
+              {
+                "value": "less_than",
+                "title": "Before"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on"
+              },
+              {
+                "value": "greater_than",
+                "title": "After"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Created",
@@ -6828,15 +12713,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 4, "title": "(agent)" },
-                { "value": 0, "title": "(end-user)" },
-                { "value": 2, "title": "(admin)" }
+                {
+                  "value": 4,
+                  "title": "(agent)"
+                },
+                {
+                  "value": 0,
+                  "title": "(end-user)"
+                },
+                {
+                  "value": 2,
+                  "title": "(admin)"
+                }
               ]
             },
             "value": "requester_role",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "Role",
@@ -6847,15 +12747,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1900006462685, "title": "Component A" },
-                { "value": 1900006462705, "title": "Component B" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1900006462685,
+                  "title": "Component A"
+                },
+                {
+                  "value": 1900006462705,
+                  "title": "Component B"
+                }
               ]
             },
             "value": "ticket_fields_1900004086785",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Product components",
@@ -6866,16 +12781,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500020384301, "title": "Free" },
-                { "value": 1500020384321, "title": "Paying" },
-                { "value": 1500020384341, "title": "Enterprise" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500020384301,
+                  "title": "Free"
+                },
+                {
+                  "value": 1500020384321,
+                  "title": "Paying"
+                },
+                {
+                  "value": 1500020384341,
+                  "title": "Enterprise"
+                }
               ]
             },
             "value": "ticket_fields_1500012620641",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Customer Tier",
@@ -6886,15 +12819,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500015072702, "title": "v1" },
-                { "value": 1500015072722, "title": "v2" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500015072702,
+                  "title": "v1"
+                },
+                {
+                  "value": 1500015072722,
+                  "title": "v2"
+                }
               ]
             },
             "value": "ticket_fields_1500009152882",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "agent dropdown 643 for agent",
@@ -6902,11 +12850,20 @@
           },
           {
             "title": "another text 3425",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.another_text_3425",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "another text 3425",
@@ -6924,12 +12881,30 @@
             },
             "value": "requester.custom_fields.date6436",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" },
-              { "value": "less_than", "title": "Before" },
-              { "value": "less_than_equal", "title": "Before or on" },
-              { "value": "greater_than", "title": "After" },
-              { "value": "greater_than_equal", "title": "After or on" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              },
+              {
+                "value": "less_than",
+                "title": "Before"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on"
+              },
+              {
+                "value": "greater_than",
+                "title": "After"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on"
+              }
             ],
             "group": "requester",
             "title_for_field": "date6436",
@@ -6937,15 +12912,36 @@
           },
           {
             "title": "decimal 765 field",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.decimal_765_field",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "decimal 765 field",
@@ -6953,11 +12949,20 @@
           },
           {
             "title": "description 123",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.description_123",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "description 123",
@@ -6968,16 +12973,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500001753322, "title": "Choice1" },
-                { "value": 1500001753342, "title": "another choice" },
-                { "value": 1500001753362, "title": "bla" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500001753322,
+                  "title": "Choice1"
+                },
+                {
+                  "value": 1500001753342,
+                  "title": "another choice"
+                },
+                {
+                  "value": 1500001753362,
+                  "title": "bla"
+                }
               ]
             },
             "value": "requester.custom_fields.dropdown_25",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "dropdown 25",
@@ -6985,11 +13008,20 @@
           },
           {
             "title": "f201",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f201",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f201",
@@ -6997,11 +13029,20 @@
           },
           {
             "title": "f202",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f202",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f202",
@@ -7009,11 +13050,20 @@
           },
           {
             "title": "f203",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f203",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f203",
@@ -7021,11 +13071,20 @@
           },
           {
             "title": "f204",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f204",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f204",
@@ -7033,11 +13092,20 @@
           },
           {
             "title": "f205",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f205",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f205",
@@ -7045,11 +13113,20 @@
           },
           {
             "title": "f206",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f206",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f206",
@@ -7057,11 +13134,20 @@
           },
           {
             "title": "f207",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f207",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f207",
@@ -7069,11 +13155,20 @@
           },
           {
             "title": "f208",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f208",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f208",
@@ -7081,11 +13176,20 @@
           },
           {
             "title": "f209",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f209",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f209",
@@ -7093,11 +13197,20 @@
           },
           {
             "title": "f210",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f210",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f210",
@@ -7105,11 +13218,20 @@
           },
           {
             "title": "f211",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f211",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f211",
@@ -7117,11 +13239,20 @@
           },
           {
             "title": "f212",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f212",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f212",
@@ -7129,11 +13260,20 @@
           },
           {
             "title": "f213",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f213",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f213",
@@ -7141,11 +13281,20 @@
           },
           {
             "title": "f214",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f214",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f214",
@@ -7153,11 +13302,20 @@
           },
           {
             "title": "f215",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f215",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f215",
@@ -7165,11 +13323,20 @@
           },
           {
             "title": "f216",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f216",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f216",
@@ -7177,11 +13344,20 @@
           },
           {
             "title": "f217",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f217",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f217",
@@ -7189,11 +13365,20 @@
           },
           {
             "title": "f218",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f218",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f218",
@@ -7201,11 +13386,20 @@
           },
           {
             "title": "f219",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f219",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f219",
@@ -7213,11 +13407,20 @@
           },
           {
             "title": "f220",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f220",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f220",
@@ -7225,11 +13428,20 @@
           },
           {
             "title": "multi75",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.modified_multi75_key",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "multi75",
@@ -7237,15 +13449,36 @@
           },
           {
             "title": "numeric65",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.numeric65",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "numeric65",
@@ -7253,11 +13486,20 @@
           },
           {
             "title": "regex 6546",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.regex_6546",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "regex 6546",
@@ -7268,12 +13510,23 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "true", "title": "Checked" },
-                { "value": "false", "title": "Unchecked" }
+                {
+                  "value": "true",
+                  "title": "Checked"
+                },
+                {
+                  "value": "false",
+                  "title": "Unchecked"
+                }
               ]
             },
             "value": "requester.custom_fields.this_is_a_checkbox",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "requester",
             "title_for_field": "this is a checkbox 32",
             "output_key": "1500001315942"
@@ -7283,17 +13536,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1900000066065, "title": "123" },
-                { "value": 1900000066085, "title": "v1" },
-                { "value": 1900000066105, "title": "v2" },
-                { "value": 1900000066125, "title": "v3" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1900000066065,
+                  "title": "123"
+                },
+                {
+                  "value": 1900000066085,
+                  "title": "v1"
+                },
+                {
+                  "value": 1900000066105,
+                  "title": "v2"
+                },
+                {
+                  "value": 1900000066125,
+                  "title": "v3"
+                }
               ]
             },
             "value": "organization.custom_fields.dropdown_26",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "dropdown 26",
@@ -7301,11 +13575,20 @@
           },
           {
             "title": "org_field301",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field301",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field301",
@@ -7313,11 +13596,20 @@
           },
           {
             "title": "org_field302",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field302",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field302",
@@ -7325,11 +13617,20 @@
           },
           {
             "title": "org_field305",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field305",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field305",
@@ -7337,11 +13638,20 @@
           },
           {
             "title": "org_field306",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field306",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field306",
@@ -7349,11 +13659,20 @@
           },
           {
             "title": "org_field307",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field307",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field307",
@@ -7361,15 +13680,36 @@
           },
           {
             "title": "org_field_n403",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field_n403",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field_n403",
@@ -7377,15 +13717,36 @@
           },
           {
             "title": "org_field_n404",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field_n404",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field_n404",
@@ -7395,11 +13756,25 @@
         "any": [
           {
             "title": "Brand",
-            "values": { "type": "list", "list": [{ "value": 1500000550682, "title": "myBrand" }] },
+            "values": {
+              "type": "list",
+              "list": [
+                {
+                  "value": 1500000550682,
+                  "title": "myBrand"
+                }
+              ]
+            },
             "value": "brand_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Brand",
@@ -7410,19 +13785,46 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 1500000859362, "title": "Default Ticket Form" },
-                { "value": 1500002488461, "title": "Form 6436" },
-                { "value": 1500002488481, "title": "Form 11" },
-                { "value": 1900000172165, "title": "Form 13" },
-                { "value": 1500002488501, "title": "Form 12" },
-                { "value": 1900000882985, "title": "Demo ticket form" },
-                { "value": 1900000911005, "title": "Amazing ticket form" }
+                {
+                  "value": 1500000859362,
+                  "title": "Default Ticket Form"
+                },
+                {
+                  "value": 1500002488461,
+                  "title": "Form 6436"
+                },
+                {
+                  "value": 1500002488481,
+                  "title": "Form 11"
+                },
+                {
+                  "value": 1900000172165,
+                  "title": "Form 13"
+                },
+                {
+                  "value": 1500002488501,
+                  "title": "Form 12"
+                },
+                {
+                  "value": 1900000882985,
+                  "title": "Demo ticket form"
+                },
+                {
+                  "value": 1900000911005,
+                  "title": "Amazing ticket form"
+                }
               ]
             },
             "value": "ticket_form_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Ticket form",
@@ -7433,17 +13835,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "-" },
-                { "value": 1, "title": "Question" },
-                { "value": 2, "title": "Incident" },
-                { "value": 3, "title": "Problem" },
-                { "value": 4, "title": "Task" }
+                {
+                  "value": 0,
+                  "title": "-"
+                },
+                {
+                  "value": 1,
+                  "title": "Question"
+                },
+                {
+                  "value": 2,
+                  "title": "Incident"
+                },
+                {
+                  "value": 3,
+                  "title": "Problem"
+                },
+                {
+                  "value": 4,
+                  "title": "Task"
+                }
               ]
             },
             "value": "ticket_type_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Ticket type",
@@ -7454,17 +13877,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500002894482, "title": "Support" },
-                { "value": 4415660742295, "title": "Support2" },
-                { "value": 4415700870423, "title": "Support4" },
-                { "value": 4415704834327, "title": "Support5" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500002894482,
+                  "title": "Support"
+                },
+                {
+                  "value": 4415660742295,
+                  "title": "Support2"
+                },
+                {
+                  "value": 4415700870423,
+                  "title": "Support4"
+                },
+                {
+                  "value": 4415704834327,
+                  "title": "Support5"
+                }
               ]
             },
             "value": "group_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Group",
@@ -7475,20 +13919,50 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": "requester_id", "title": "(requester)" },
-                { "value": "current_user", "title": "(current user)" },
-                { "value": 1911534269745, "title": "Person4" },
-                { "value": 1508591419201, "title": "Person1" },
-                { "value": 1520622229002, "title": "Person3" },
-                { "value": 1508485810561, "title": "Person2" },
-                { "value": 1523341727741, "title": "myBrand Dev" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": "requester_id",
+                  "title": "(requester)"
+                },
+                {
+                  "value": "current_user",
+                  "title": "(current user)"
+                },
+                {
+                  "value": 1911534269745,
+                  "title": "Person4"
+                },
+                {
+                  "value": 1508591419201,
+                  "title": "Person1"
+                },
+                {
+                  "value": 1520622229002,
+                  "title": "Person3"
+                },
+                {
+                  "value": 1508485810561,
+                  "title": "Person2"
+                },
+                {
+                  "value": 1523341727741,
+                  "title": "myBrand Dev"
+                }
               ]
             },
             "value": "assignee_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Assignee",
@@ -7499,19 +13973,46 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "assignee_id", "title": "(assignee)" },
-                { "value": "current_user", "title": "(current user)" },
-                { "value": 1911534269745, "title": "Person4" },
-                { "value": 1508591419201, "title": "Person1" },
-                { "value": 1520622229002, "title": "Person3" },
-                { "value": 1508485810561, "title": "Person2" },
-                { "value": 1523341727741, "title": "myBrand Dev" }
+                {
+                  "value": "assignee_id",
+                  "title": "(assignee)"
+                },
+                {
+                  "value": "current_user",
+                  "title": "(current user)"
+                },
+                {
+                  "value": 1911534269745,
+                  "title": "Person4"
+                },
+                {
+                  "value": 1508591419201,
+                  "title": "Person1"
+                },
+                {
+                  "value": 1520622229002,
+                  "title": "Person3"
+                },
+                {
+                  "value": 1508485810561,
+                  "title": "Person2"
+                },
+                {
+                  "value": 1523341727741,
+                  "title": "myBrand Dev"
+                }
               ]
             },
             "value": "requester_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Requester",
@@ -7522,16 +14023,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500421645662, "title": "myBrand" },
-                { "value": 1900025376085, "title": "test org 123" },
-                { "value": 1500508294122, "title": "test org 124" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500421645662,
+                  "title": "myBrand"
+                },
+                {
+                  "value": 1900025376085,
+                  "title": "test org 123"
+                },
+                {
+                  "value": 1500508294122,
+                  "title": "test org 124"
+                }
               ]
             },
             "value": "organization_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Organization",
@@ -7539,11 +14058,21 @@
           },
           {
             "title": "Tags",
-            "values": { "type": "text", "css_class": "large", "list": [] },
+            "values": {
+              "type": "text",
+              "css_class": "large",
+              "list": []
+            },
             "value": "current_tags",
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following" },
-              { "value": "not_includes", "title": "Contains none of the following" }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following"
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Tags",
@@ -7554,46 +14083,154 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "Web form" },
-                { "value": 4, "title": "Email" },
-                { "value": 29, "title": "Chat" },
-                { "value": 30, "title": "Twitter" },
-                { "value": 26, "title": "Twitter DM" },
-                { "value": 23, "title": "Twitter Like" },
-                { "value": 33, "title": "Voicemail" },
-                { "value": 34, "title": "Phone call (incoming)" },
-                { "value": 35, "title": "Phone call (outgoing)" },
-                { "value": 44, "title": "CTI voicemail" },
-                { "value": 45, "title": "CTI phone call (incoming)" },
-                { "value": 46, "title": "CTI phone call (outgoing)" },
-                { "value": 57, "title": "Text" },
-                { "value": 16, "title": "Get Satisfaction" },
-                { "value": 48, "title": "Web Widget" },
-                { "value": 49, "title": "Mobile SDK" },
-                { "value": 56, "title": "Mobile" },
-                { "value": 50, "title": "Help Center post" },
-                { "value": 5, "title": "Web service (API)" },
-                { "value": 8, "title": "Automation" },
-                { "value": 24, "title": "Forum topic" },
-                { "value": 27, "title": "Closed ticket" },
-                { "value": 31, "title": "Ticket sharing" },
-                { "value": 38, "title": "Facebook Post" },
-                { "value": 41, "title": "Facebook Private Message" },
-                { "value": 54, "title": "Satisfaction Prediction" },
-                { "value": 67, "title": "Answer Bot for Web Widget" },
-                { "value": 55, "title": "Channel Integrations" },
-                { "value": 73, "title": "WeChat" },
-                { "value": 72, "title": "LINE" },
-                { "value": 74, "title": "WhatsApp" },
-                { "value": 78, "title": "Facebook Messenger" },
-                { "value": 88, "title": "Twitter Direct Message" },
-                { "value": 86, "title": "Instagram Direct" }
+                {
+                  "value": 0,
+                  "title": "Web form"
+                },
+                {
+                  "value": 4,
+                  "title": "Email"
+                },
+                {
+                  "value": 29,
+                  "title": "Chat"
+                },
+                {
+                  "value": 30,
+                  "title": "Twitter"
+                },
+                {
+                  "value": 26,
+                  "title": "Twitter DM"
+                },
+                {
+                  "value": 23,
+                  "title": "Twitter Like"
+                },
+                {
+                  "value": 33,
+                  "title": "Voicemail"
+                },
+                {
+                  "value": 34,
+                  "title": "Phone call (incoming)"
+                },
+                {
+                  "value": 35,
+                  "title": "Phone call (outgoing)"
+                },
+                {
+                  "value": 44,
+                  "title": "CTI voicemail"
+                },
+                {
+                  "value": 45,
+                  "title": "CTI phone call (incoming)"
+                },
+                {
+                  "value": 46,
+                  "title": "CTI phone call (outgoing)"
+                },
+                {
+                  "value": 57,
+                  "title": "Text"
+                },
+                {
+                  "value": 16,
+                  "title": "Get Satisfaction"
+                },
+                {
+                  "value": 48,
+                  "title": "Web Widget"
+                },
+                {
+                  "value": 49,
+                  "title": "Mobile SDK"
+                },
+                {
+                  "value": 56,
+                  "title": "Mobile"
+                },
+                {
+                  "value": 50,
+                  "title": "Help Center post"
+                },
+                {
+                  "value": 5,
+                  "title": "Web service (API)"
+                },
+                {
+                  "value": 8,
+                  "title": "Automation"
+                },
+                {
+                  "value": 24,
+                  "title": "Forum topic"
+                },
+                {
+                  "value": 27,
+                  "title": "Closed ticket"
+                },
+                {
+                  "value": 31,
+                  "title": "Ticket sharing"
+                },
+                {
+                  "value": 38,
+                  "title": "Facebook Post"
+                },
+                {
+                  "value": 41,
+                  "title": "Facebook Private Message"
+                },
+                {
+                  "value": 54,
+                  "title": "Satisfaction Prediction"
+                },
+                {
+                  "value": 67,
+                  "title": "Answer Bot for Web Widget"
+                },
+                {
+                  "value": 55,
+                  "title": "Channel Integrations"
+                },
+                {
+                  "value": 73,
+                  "title": "WeChat"
+                },
+                {
+                  "value": 72,
+                  "title": "LINE"
+                },
+                {
+                  "value": 74,
+                  "title": "WhatsApp"
+                },
+                {
+                  "value": 78,
+                  "title": "Facebook Messenger"
+                },
+                {
+                  "value": 88,
+                  "title": "Twitter Direct Message"
+                },
+                {
+                  "value": 86,
+                  "title": "Instagram Direct"
+                }
               ]
             },
             "value": "via_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Channel",
@@ -7604,46 +14241,154 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 0, "title": "Web form" },
-                { "value": 4, "title": "Email" },
-                { "value": 29, "title": "Chat" },
-                { "value": 30, "title": "Twitter" },
-                { "value": 26, "title": "Twitter DM" },
-                { "value": 23, "title": "Twitter Like" },
-                { "value": 33, "title": "Voicemail" },
-                { "value": 34, "title": "Phone call (incoming)" },
-                { "value": 35, "title": "Phone call (outgoing)" },
-                { "value": 44, "title": "CTI voicemail" },
-                { "value": 45, "title": "CTI phone call (incoming)" },
-                { "value": 46, "title": "CTI phone call (outgoing)" },
-                { "value": 57, "title": "Text" },
-                { "value": 16, "title": "Get Satisfaction" },
-                { "value": 48, "title": "Web Widget" },
-                { "value": 49, "title": "Mobile SDK" },
-                { "value": 56, "title": "Mobile" },
-                { "value": 50, "title": "Help Center post" },
-                { "value": 5, "title": "Web service (API)" },
-                { "value": 8, "title": "Automation" },
-                { "value": 24, "title": "Forum topic" },
-                { "value": 27, "title": "Closed ticket" },
-                { "value": 31, "title": "Ticket sharing" },
-                { "value": 38, "title": "Facebook Post" },
-                { "value": 41, "title": "Facebook Private Message" },
-                { "value": 54, "title": "Satisfaction Prediction" },
-                { "value": 67, "title": "Answer Bot for Web Widget" },
-                { "value": 55, "title": "Channel Integrations" },
-                { "value": 73, "title": "WeChat" },
-                { "value": 72, "title": "LINE" },
-                { "value": 74, "title": "WhatsApp" },
-                { "value": 78, "title": "Facebook Messenger" },
-                { "value": 88, "title": "Twitter Direct Message" },
-                { "value": 86, "title": "Instagram Direct" }
+                {
+                  "value": 0,
+                  "title": "Web form"
+                },
+                {
+                  "value": 4,
+                  "title": "Email"
+                },
+                {
+                  "value": 29,
+                  "title": "Chat"
+                },
+                {
+                  "value": 30,
+                  "title": "Twitter"
+                },
+                {
+                  "value": 26,
+                  "title": "Twitter DM"
+                },
+                {
+                  "value": 23,
+                  "title": "Twitter Like"
+                },
+                {
+                  "value": 33,
+                  "title": "Voicemail"
+                },
+                {
+                  "value": 34,
+                  "title": "Phone call (incoming)"
+                },
+                {
+                  "value": 35,
+                  "title": "Phone call (outgoing)"
+                },
+                {
+                  "value": 44,
+                  "title": "CTI voicemail"
+                },
+                {
+                  "value": 45,
+                  "title": "CTI phone call (incoming)"
+                },
+                {
+                  "value": 46,
+                  "title": "CTI phone call (outgoing)"
+                },
+                {
+                  "value": 57,
+                  "title": "Text"
+                },
+                {
+                  "value": 16,
+                  "title": "Get Satisfaction"
+                },
+                {
+                  "value": 48,
+                  "title": "Web Widget"
+                },
+                {
+                  "value": 49,
+                  "title": "Mobile SDK"
+                },
+                {
+                  "value": 56,
+                  "title": "Mobile"
+                },
+                {
+                  "value": 50,
+                  "title": "Help Center post"
+                },
+                {
+                  "value": 5,
+                  "title": "Web service (API)"
+                },
+                {
+                  "value": 8,
+                  "title": "Automation"
+                },
+                {
+                  "value": 24,
+                  "title": "Forum topic"
+                },
+                {
+                  "value": 27,
+                  "title": "Closed ticket"
+                },
+                {
+                  "value": 31,
+                  "title": "Ticket sharing"
+                },
+                {
+                  "value": 38,
+                  "title": "Facebook Post"
+                },
+                {
+                  "value": 41,
+                  "title": "Facebook Private Message"
+                },
+                {
+                  "value": 54,
+                  "title": "Satisfaction Prediction"
+                },
+                {
+                  "value": 67,
+                  "title": "Answer Bot for Web Widget"
+                },
+                {
+                  "value": 55,
+                  "title": "Channel Integrations"
+                },
+                {
+                  "value": 73,
+                  "title": "WeChat"
+                },
+                {
+                  "value": 72,
+                  "title": "LINE"
+                },
+                {
+                  "value": 74,
+                  "title": "WhatsApp"
+                },
+                {
+                  "value": 78,
+                  "title": "Facebook Messenger"
+                },
+                {
+                  "value": 88,
+                  "title": "Twitter Direct Message"
+                },
+                {
+                  "value": 86,
+                  "title": "Instagram Direct"
+                }
               ]
             },
             "value": "current_via_id",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Update via",
@@ -7656,10 +14401,20 @@
               "label": {
                 "default": "html_block You can add and remove support addresses in your account's email <a href=\"/settings/email\">settings</a>."
               },
-              "list": [{ "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com" }]
+              "list": [
+                {
+                  "value": "support@myBrand.zendesk.com",
+                  "title": "support@myBrand.zendesk.com"
+                }
+              ]
             },
             "value": "recipient",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "ticket",
             "title_for_field": "Received at",
             "output_key": null
@@ -7669,12 +14424,23 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "public", "title": "Ticket has public comments" },
-                { "value": "private", "title": "Ticket has no public comments" }
+                {
+                  "value": "public",
+                  "title": "Ticket has public comments"
+                },
+                {
+                  "value": "private",
+                  "title": "Ticket has no public comments"
+                }
               ]
             },
             "value": "ticket_is_public",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "ticket",
             "title_for_field": "Privacy",
             "output_key": null
@@ -7683,15 +14449,30 @@
             "title": "Created",
             "values": {
               "type": "datetime",
-              "labels": { "default": "YYYY-MM-DD hh:mm", "integer": " days" },
+              "labels": {
+                "default": "YYYY-MM-DD hh:mm",
+                "integer": " days"
+              },
               "list": []
             },
             "value": "exact_created_at",
             "operators": [
-              { "value": "less_than", "title": "Before" },
-              { "value": "less_than_equal", "title": "Before or on" },
-              { "value": "greater_than", "title": "After" },
-              { "value": "greater_than_equal", "title": "After or on" }
+              {
+                "value": "less_than",
+                "title": "Before"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on"
+              },
+              {
+                "value": "greater_than",
+                "title": "After"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Created",
@@ -7702,15 +14483,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": 4, "title": "(agent)" },
-                { "value": 0, "title": "(end-user)" },
-                { "value": 2, "title": "(admin)" }
+                {
+                  "value": 4,
+                  "title": "(agent)"
+                },
+                {
+                  "value": 0,
+                  "title": "(end-user)"
+                },
+                {
+                  "value": 2,
+                  "title": "(admin)"
+                }
               ]
             },
             "value": "requester_role",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "Role",
@@ -7721,15 +14517,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1900006462685, "title": "Component A" },
-                { "value": 1900006462705, "title": "Component B" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1900006462685,
+                  "title": "Component A"
+                },
+                {
+                  "value": 1900006462705,
+                  "title": "Component B"
+                }
               ]
             },
             "value": "ticket_fields_1900004086785",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Product components",
@@ -7740,16 +14551,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500020384301, "title": "Free" },
-                { "value": 1500020384321, "title": "Paying" },
-                { "value": 1500020384341, "title": "Enterprise" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500020384301,
+                  "title": "Free"
+                },
+                {
+                  "value": 1500020384321,
+                  "title": "Paying"
+                },
+                {
+                  "value": 1500020384341,
+                  "title": "Enterprise"
+                }
               ]
             },
             "value": "ticket_fields_1500012620641",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "Customer Tier",
@@ -7760,15 +14589,30 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500015072702, "title": "v1" },
-                { "value": 1500015072722, "title": "v2" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500015072702,
+                  "title": "v1"
+                },
+                {
+                  "value": 1500015072722,
+                  "title": "v2"
+                }
               ]
             },
             "value": "ticket_fields_1500009152882",
             "operators": [
-              { "value": "includes", "title": "Includes" },
-              { "value": "not_includes", "title": "Does not include" }
+              {
+                "value": "includes",
+                "title": "Includes"
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include"
+              }
             ],
             "group": "ticket",
             "title_for_field": "agent dropdown 643 for agent",
@@ -7776,11 +14620,20 @@
           },
           {
             "title": "another text 3425",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.another_text_3425",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "another text 3425",
@@ -7798,12 +14651,30 @@
             },
             "value": "requester.custom_fields.date6436",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" },
-              { "value": "less_than", "title": "Before" },
-              { "value": "less_than_equal", "title": "Before or on" },
-              { "value": "greater_than", "title": "After" },
-              { "value": "greater_than_equal", "title": "After or on" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              },
+              {
+                "value": "less_than",
+                "title": "Before"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on"
+              },
+              {
+                "value": "greater_than",
+                "title": "After"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on"
+              }
             ],
             "group": "requester",
             "title_for_field": "date6436",
@@ -7811,15 +14682,36 @@
           },
           {
             "title": "decimal 765 field",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.decimal_765_field",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "decimal 765 field",
@@ -7827,11 +14719,20 @@
           },
           {
             "title": "description 123",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.description_123",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "description 123",
@@ -7842,16 +14743,34 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1500001753322, "title": "Choice1" },
-                { "value": 1500001753342, "title": "another choice" },
-                { "value": 1500001753362, "title": "bla" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1500001753322,
+                  "title": "Choice1"
+                },
+                {
+                  "value": 1500001753342,
+                  "title": "another choice"
+                },
+                {
+                  "value": 1500001753362,
+                  "title": "bla"
+                }
               ]
             },
             "value": "requester.custom_fields.dropdown_25",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "dropdown 25",
@@ -7859,11 +14778,20 @@
           },
           {
             "title": "f201",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f201",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f201",
@@ -7871,11 +14799,20 @@
           },
           {
             "title": "f202",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f202",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f202",
@@ -7883,11 +14820,20 @@
           },
           {
             "title": "f203",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f203",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f203",
@@ -7895,11 +14841,20 @@
           },
           {
             "title": "f204",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f204",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f204",
@@ -7907,11 +14862,20 @@
           },
           {
             "title": "f205",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f205",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f205",
@@ -7919,11 +14883,20 @@
           },
           {
             "title": "f206",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f206",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f206",
@@ -7931,11 +14904,20 @@
           },
           {
             "title": "f207",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f207",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f207",
@@ -7943,11 +14925,20 @@
           },
           {
             "title": "f208",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f208",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f208",
@@ -7955,11 +14946,20 @@
           },
           {
             "title": "f209",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f209",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f209",
@@ -7967,11 +14967,20 @@
           },
           {
             "title": "f210",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f210",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f210",
@@ -7979,11 +14988,20 @@
           },
           {
             "title": "f211",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f211",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f211",
@@ -7991,11 +15009,20 @@
           },
           {
             "title": "f212",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f212",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f212",
@@ -8003,11 +15030,20 @@
           },
           {
             "title": "f213",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f213",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f213",
@@ -8015,11 +15051,20 @@
           },
           {
             "title": "f214",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f214",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f214",
@@ -8027,11 +15072,20 @@
           },
           {
             "title": "f215",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f215",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f215",
@@ -8039,11 +15093,20 @@
           },
           {
             "title": "f216",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f216",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f216",
@@ -8051,11 +15114,20 @@
           },
           {
             "title": "f217",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f217",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f217",
@@ -8063,11 +15135,20 @@
           },
           {
             "title": "f218",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f218",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f218",
@@ -8075,11 +15156,20 @@
           },
           {
             "title": "f219",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f219",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f219",
@@ -8087,11 +15177,20 @@
           },
           {
             "title": "f220",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.f220",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "f220",
@@ -8099,11 +15198,20 @@
           },
           {
             "title": "multi75",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.modified_multi75_key",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "multi75",
@@ -8111,15 +15219,36 @@
           },
           {
             "title": "numeric65",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.numeric65",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "numeric65",
@@ -8127,11 +15256,20 @@
           },
           {
             "title": "regex 6546",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "requester.custom_fields.regex_6546",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "requester",
             "title_for_field": "regex 6546",
@@ -8142,12 +15280,23 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": "true", "title": "Checked" },
-                { "value": "false", "title": "Unchecked" }
+                {
+                  "value": "true",
+                  "title": "Checked"
+                },
+                {
+                  "value": "false",
+                  "title": "Unchecked"
+                }
               ]
             },
             "value": "requester.custom_fields.this_is_a_checkbox",
-            "operators": [{ "value": "is", "title": "Is" }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is"
+              }
+            ],
             "group": "requester",
             "title_for_field": "this is a checkbox 32",
             "output_key": "1500001315942"
@@ -8157,17 +15306,38 @@
             "values": {
               "type": "list",
               "list": [
-                { "value": null, "title": "-" },
-                { "value": 1900000066065, "title": "123" },
-                { "value": 1900000066085, "title": "v1" },
-                { "value": 1900000066105, "title": "v2" },
-                { "value": 1900000066125, "title": "v3" }
+                {
+                  "value": null,
+                  "title": "-"
+                },
+                {
+                  "value": 1900000066065,
+                  "title": "123"
+                },
+                {
+                  "value": 1900000066085,
+                  "title": "v1"
+                },
+                {
+                  "value": 1900000066105,
+                  "title": "v2"
+                },
+                {
+                  "value": 1900000066125,
+                  "title": "v3"
+                }
               ]
             },
             "value": "organization.custom_fields.dropdown_26",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "dropdown 26",
@@ -8175,11 +15345,20 @@
           },
           {
             "title": "org_field301",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field301",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field301",
@@ -8187,11 +15366,20 @@
           },
           {
             "title": "org_field302",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field302",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field302",
@@ -8199,11 +15387,20 @@
           },
           {
             "title": "org_field305",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field305",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field305",
@@ -8211,11 +15408,20 @@
           },
           {
             "title": "org_field306",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field306",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field306",
@@ -8223,11 +15429,20 @@
           },
           {
             "title": "org_field307",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field307",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field307",
@@ -8235,15 +15450,36 @@
           },
           {
             "title": "org_field_n403",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field_n403",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field_n403",
@@ -8251,15 +15487,36 @@
           },
           {
             "title": "org_field_n404",
-            "values": { "type": "text", "list": [] },
+            "values": {
+              "type": "text",
+              "list": []
+            },
             "value": "organization.custom_fields.org_field_n404",
             "operators": [
-              { "value": "is", "title": "Is" },
-              { "value": "less_than", "title": "Less than" },
-              { "value": "less_than_equal", "title": "Less than or equal to" },
-              { "value": "greater_than", "title": "Greater than" },
-              { "value": "greater_than_equal", "title": "Greater than or equal to" },
-              { "value": "is_not", "title": "Is not" }
+              {
+                "value": "is",
+                "title": "Is"
+              },
+              {
+                "value": "less_than",
+                "title": "Less than"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to"
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not"
+              }
             ],
             "group": "organization",
             "title_for_field": "org_field_n404",
@@ -8271,12 +15528,23 @@
   },
   {
     "url": "/api/v2/trigger_categories",
-    "params": { "page[size]": "100" },
-    "queryParams": { "page[after]": "eyJvIjoicG9zaXRpb24saWQiLCJ2IjoiYVFNQUFBQUFBQUFBYVgwaEVEOWRBUUFBIn0=" },
+    "params": {
+      "page[size]": "100"
+    },
+    "queryParams": {
+      "page[after]": "eyJvIjoicG9zaXRpb24saWQiLCJ2IjoiYVFNQUFBQUFBQUFBYVgwaEVEOWRBUUFBIn0="
+    },
     "response": {
       "trigger_categories": [],
-      "meta": { "has_more": false, "after_cursor": null, "before_cursor": null },
-      "links": { "prev": null, "next": null }
+      "meta": {
+        "has_more": false,
+        "after_cursor": null,
+        "before_cursor": null
+      },
+      "links": {
+        "prev": null,
+        "next": null
+      }
     }
   },
   {
@@ -8292,10 +15560,26 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "open", "title": "Open", "enabled": true },
-              { "value": "pending", "title": "Pending", "enabled": true },
-              { "value": "solved", "title": "Solved", "enabled": true },
-              { "value": "closed", "title": "Closed", "enabled": true }
+              {
+                "value": "open",
+                "title": "Open",
+                "enabled": true
+              },
+              {
+                "value": "pending",
+                "title": "Pending",
+                "enabled": true
+              },
+              {
+                "value": "solved",
+                "title": "Solved",
+                "enabled": true
+              },
+              {
+                "value": "closed",
+                "title": "Closed",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8305,7 +15589,13 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -8315,14 +15605,46 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "default_ticket_form", "title": "(default form)", "enabled": true },
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "default_ticket_form",
+                "title": "(default form)",
+                "enabled": true
+              },
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8333,10 +15655,26 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8347,10 +15685,26 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8361,11 +15715,31 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8376,14 +15750,46 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8418,12 +15824,36 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8434,9 +15864,21 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "1500001035461", "title": "Schedule 3", "enabled": true },
-              { "value": "1500001036042", "title": "Schedule 2", "enabled": true },
-              { "value": "1900000004365", "title": "New schedule", "enabled": true }
+              {
+                "value": "1500001035461",
+                "title": "Schedule 3",
+                "enabled": true
+              },
+              {
+                "value": "1500001036042",
+                "title": "Schedule 2",
+                "enabled": true
+              },
+              {
+                "value": "1900000004365",
+                "title": "New schedule",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8447,16 +15889,56 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "requester_and_ccs", "title": "(requester and CCs)", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "all_agents", "title": "(all non-restricted agents)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "requester_and_ccs",
+                "title": "(requester and CCs)",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "all_agents",
+                "title": "(all non-restricted agents)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8467,11 +15949,31 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "group_id", "title": "(assigned group)", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "group_id",
+                "title": "(assigned group)",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8482,7 +15984,12 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "1900000033645", "title": "Slack integration Endpoint", "enabled": true, "format": "json" }
+              {
+                "value": "1900000033645",
+                "title": "Slack integration Endpoint",
+                "enabled": true,
+                "format": "json"
+              }
             ]
           },
           {
@@ -8501,9 +16008,21 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "1", "title": "English", "enabled": true },
-              { "value": "30", "title": "עִבְרִית (Hebrew)", "enabled": true },
-              { "value": "2", "title": "Español", "enabled": true }
+              {
+                "value": "1",
+                "title": "English",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "עִבְרִית (Hebrew)",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "Español",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8514,13 +16033,40 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "group_id", "title": "(assigned group)", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "group_id",
+                "title": "(assigned group)",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ],
-            "metadata": { "phone_numbers": [{ "value": 1500000205802, "title": "+1 (510) 650-1859" }] }
+            "metadata": {
+              "phone_numbers": [
+                {
+                  "value": 1500000205802,
+                  "title": "+1 (510) 650-1859"
+                }
+              ]
+            }
           },
           {
             "title": "Text user",
@@ -8530,16 +16076,55 @@
             "nullable": false,
             "repeatable": false,
             "values": [
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ],
-            "metadata": { "phone_numbers": [{ "value": 1500000205802, "title": "+1 (510) 650-1859" }] }
+            "metadata": {
+              "phone_numbers": [
+                {
+                  "value": 1500000205802,
+                  "title": "+1 (510) 650-1859"
+                }
+              ]
+            }
           },
           {
             "title": "Product components",
@@ -8549,8 +16134,16 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8561,9 +16154,21 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8574,8 +16179,16 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8618,10 +16231,26 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500001753322", "title": "Choice1", "enabled": true },
-              { "value": "1500001753342", "title": "another choice", "enabled": true },
-              { "value": "1500001753362", "title": "bla", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500001753322",
+                "title": "Choice1",
+                "enabled": true
+              },
+              {
+                "value": "1500001753342",
+                "title": "another choice",
+                "enabled": true
+              },
+              {
+                "value": "1500001753362",
+                "title": "bla",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8816,8 +16445,16 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "true", "title": "Checked", "enabled": true },
-              { "value": "false", "title": "Unchecked", "enabled": true }
+              {
+                "value": "true",
+                "title": "Checked",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Unchecked",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8828,11 +16465,31 @@
             "nullable": true,
             "repeatable": false,
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1900000066065", "title": "123", "enabled": true },
-              { "value": "1900000066085", "title": "v1", "enabled": true },
-              { "value": "1900000066105", "title": "v2", "enabled": true },
-              { "value": "1900000066125", "title": "v3", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1900000066065",
+                "title": "123",
+                "enabled": true
+              },
+              {
+                "value": "1900000066085",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "1900000066105",
+                "title": "v2",
+                "enabled": true
+              },
+              {
+                "value": "1900000066125",
+                "title": "v3",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8901,23 +16558,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "new", "title": "New", "enabled": true },
-              { "value": "open", "title": "Open", "enabled": true },
-              { "value": "pending", "title": "Pending", "enabled": true },
-              { "value": "solved", "title": "Solved", "enabled": true },
-              { "value": "closed", "title": "Closed", "enabled": true }
+              {
+                "value": "new",
+                "title": "New",
+                "enabled": true
+              },
+              {
+                "value": "open",
+                "title": "Open",
+                "enabled": true
+              },
+              {
+                "value": "pending",
+                "title": "Pending",
+                "enabled": true
+              },
+              {
+                "value": "solved",
+                "title": "Solved",
+                "enabled": true
+              },
+              {
+                "value": "closed",
+                "title": "Closed",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8928,11 +16645,31 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              }
             ]
           },
           {
@@ -8943,16 +16680,54 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -8962,23 +16737,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -8989,21 +16824,73 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9014,23 +16901,83 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9041,21 +16988,73 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9066,24 +17065,88 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9094,23 +17157,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9121,20 +17244,68 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500421645662", "title": "myBrand", "enabled": true },
-              { "value": "1900025376085", "title": "test org 123", "enabled": true },
-              { "value": "1500508294122", "title": "test org 124", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500421645662",
+                "title": "myBrand",
+                "enabled": true
+              },
+              {
+                "value": "1900025376085",
+                "title": "test org 123",
+                "enabled": true
+              },
+              {
+                "value": "1500508294122",
+                "title": "test org 124",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9145,8 +17316,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9157,44 +17336,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9205,44 +17528,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9252,9 +17719,19 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com", "enabled": true }
+              {
+                "value": "support@myBrand.zendesk.com",
+                "title": "support@myBrand.zendesk.com",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9264,10 +17741,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "Create", "title": "Created", "enabled": true },
-              { "value": "Change", "title": "Updated", "enabled": true }
+              {
+                "value": "Create",
+                "title": "Created",
+                "enabled": true
+              },
+              {
+                "value": "Change",
+                "title": "Updated",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9278,10 +17769,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9291,10 +17798,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "public", "title": "Ticket has public comments", "enabled": true },
-              { "value": "private", "title": "Ticket has no public comments", "enabled": true }
+              {
+                "value": "public",
+                "title": "Ticket has public comments",
+                "enabled": true
+              },
+              {
+                "value": "private",
+                "title": "Ticket has no public comments",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9304,11 +17825,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true },
-              { "value": "not_relevant", "title": "Present (public or private)", "enabled": true },
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              },
+              {
+                "value": "not_relevant",
+                "title": "Present (public or private)",
+                "enabled": true
+              },
               {
                 "value": "requester_can_see_comment",
                 "title": "Present, and requester can see the comment",
@@ -9324,10 +17863,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9338,9 +17893,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9351,9 +17918,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9364,9 +17943,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9377,9 +17968,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9389,10 +17992,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Yes", "enabled": true },
-              { "value": "false", "title": "No", "enabled": true }
+              {
+                "value": "true",
+                "title": "Yes",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "No",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9402,10 +18019,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Yes", "enabled": true },
-              { "value": "false", "title": "No", "enabled": true }
+              {
+                "value": "true",
+                "title": "Yes",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "No",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9416,13 +18047,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500001035461", "title": "Schedule 3", "enabled": true },
-              { "value": "1500001036042", "title": "Schedule 2", "enabled": true },
-              { "value": "1900000004365", "title": "New schedule", "enabled": true }
+              {
+                "value": "1500001035461",
+                "title": "Schedule 3",
+                "enabled": true
+              },
+              {
+                "value": "1500001036042",
+                "title": "Schedule 2",
+                "enabled": true
+              },
+              {
+                "value": "1900000004365",
+                "title": "New schedule",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9432,11 +18083,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "1500001035461", "title": "Schedule 3", "enabled": true },
-              { "value": "1500001036042", "title": "Schedule 2", "enabled": true },
-              { "value": "1900000004365", "title": "New schedule", "enabled": true }
+              {
+                "value": "1500001035461",
+                "title": "Schedule 3",
+                "enabled": true
+              },
+              {
+                "value": "1500001036042",
+                "title": "Schedule 2",
+                "enabled": true
+              },
+              {
+                "value": "1900000004365",
+                "title": "New schedule",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9446,10 +18115,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Present", "enabled": true },
-              { "value": "false", "title": "Not present", "enabled": true }
+              {
+                "value": "true",
+                "title": "Present",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Not present",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9460,13 +18143,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "4", "title": "(agent)", "enabled": true },
-              { "value": "0", "title": "(end-user)", "enabled": true },
-              { "value": "2", "title": "(admin)", "enabled": true }
+              {
+                "value": "4",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "0",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "(admin)",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9477,13 +18180,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1", "title": "English (United States)", "enabled": true },
-              { "value": "30", "title": "Hebrew", "enabled": true },
-              { "value": "2", "title": "Spanish", "enabled": true }
+              {
+                "value": "1",
+                "title": "English (United States)",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Hebrew",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "Spanish",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9494,9 +18217,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9507,9 +18242,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9519,8 +18266,20 @@
             "group": "requester",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
-            "values": [{ "value": "true", "title": "true", "enabled": true }]
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
+            "values": [
+              {
+                "value": "true",
+                "title": "true",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Time zone",
@@ -9530,183 +18289,783 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "American Samoa", "title": "(GMT-11:00) American Samoa", "enabled": true },
+              {
+                "value": "American Samoa",
+                "title": "(GMT-11:00) American Samoa",
+                "enabled": true
+              },
               {
                 "value": "International Date Line West",
                 "title": "(GMT-11:00) International Date Line West",
                 "enabled": true
               },
-              { "value": "Midway Island", "title": "(GMT-11:00) Midway Island", "enabled": true },
-              { "value": "Hawaii", "title": "(GMT-10:00) Hawaii", "enabled": true },
-              { "value": "Alaska", "title": "(GMT-09:00) Alaska", "enabled": true },
+              {
+                "value": "Midway Island",
+                "title": "(GMT-11:00) Midway Island",
+                "enabled": true
+              },
+              {
+                "value": "Hawaii",
+                "title": "(GMT-10:00) Hawaii",
+                "enabled": true
+              },
+              {
+                "value": "Alaska",
+                "title": "(GMT-09:00) Alaska",
+                "enabled": true
+              },
               {
                 "value": "Pacific Time (US & Canada)",
                 "title": "(GMT-08:00) Pacific Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Tijuana", "title": "(GMT-08:00) Tijuana", "enabled": true },
-              { "value": "Arizona", "title": "(GMT-07:00) Arizona", "enabled": true },
-              { "value": "Chihuahua", "title": "(GMT-07:00) Chihuahua", "enabled": true },
-              { "value": "Mazatlan", "title": "(GMT-07:00) Mazatlan", "enabled": true },
+              {
+                "value": "Tijuana",
+                "title": "(GMT-08:00) Tijuana",
+                "enabled": true
+              },
+              {
+                "value": "Arizona",
+                "title": "(GMT-07:00) Arizona",
+                "enabled": true
+              },
+              {
+                "value": "Chihuahua",
+                "title": "(GMT-07:00) Chihuahua",
+                "enabled": true
+              },
+              {
+                "value": "Mazatlan",
+                "title": "(GMT-07:00) Mazatlan",
+                "enabled": true
+              },
               {
                 "value": "Mountain Time (US & Canada)",
                 "title": "(GMT-07:00) Mountain Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Central America", "title": "(GMT-06:00) Central America", "enabled": true },
+              {
+                "value": "Central America",
+                "title": "(GMT-06:00) Central America",
+                "enabled": true
+              },
               {
                 "value": "Central Time (US & Canada)",
                 "title": "(GMT-06:00) Central Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Guadalajara", "title": "(GMT-06:00) Guadalajara", "enabled": true },
-              { "value": "Mexico City", "title": "(GMT-06:00) Mexico City", "enabled": true },
-              { "value": "Monterrey", "title": "(GMT-06:00) Monterrey", "enabled": true },
-              { "value": "Saskatchewan", "title": "(GMT-06:00) Saskatchewan", "enabled": true },
-              { "value": "Bogota", "title": "(GMT-05:00) Bogota", "enabled": true },
+              {
+                "value": "Guadalajara",
+                "title": "(GMT-06:00) Guadalajara",
+                "enabled": true
+              },
+              {
+                "value": "Mexico City",
+                "title": "(GMT-06:00) Mexico City",
+                "enabled": true
+              },
+              {
+                "value": "Monterrey",
+                "title": "(GMT-06:00) Monterrey",
+                "enabled": true
+              },
+              {
+                "value": "Saskatchewan",
+                "title": "(GMT-06:00) Saskatchewan",
+                "enabled": true
+              },
+              {
+                "value": "Bogota",
+                "title": "(GMT-05:00) Bogota",
+                "enabled": true
+              },
               {
                 "value": "Eastern Time (US & Canada)",
                 "title": "(GMT-05:00) Eastern Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Indiana (East)", "title": "(GMT-05:00) Indiana (East)", "enabled": true },
-              { "value": "Lima", "title": "(GMT-05:00) Lima", "enabled": true },
-              { "value": "Quito", "title": "(GMT-05:00) Quito", "enabled": true },
-              { "value": "Atlantic Time (Canada)", "title": "(GMT-04:00) Atlantic Time (Canada)", "enabled": true },
-              { "value": "Caracas", "title": "(GMT-04:00) Caracas", "enabled": true },
-              { "value": "Georgetown", "title": "(GMT-04:00) Georgetown", "enabled": true },
-              { "value": "La Paz", "title": "(GMT-04:00) La Paz", "enabled": true },
-              { "value": "Puerto Rico", "title": "(GMT-04:00) Puerto Rico", "enabled": true },
-              { "value": "Newfoundland", "title": "(GMT-03:30) Newfoundland", "enabled": true },
-              { "value": "Brasilia", "title": "(GMT-03:00) Brasilia", "enabled": true },
-              { "value": "Buenos Aires", "title": "(GMT-03:00) Buenos Aires", "enabled": true },
-              { "value": "Greenland", "title": "(GMT-03:00) Greenland", "enabled": true },
-              { "value": "Montevideo", "title": "(GMT-03:00) Montevideo", "enabled": true },
-              { "value": "Santiago", "title": "(GMT-03:00) Santiago", "enabled": true },
-              { "value": "Mid-Atlantic", "title": "(GMT-02:00) Mid-Atlantic", "enabled": true },
-              { "value": "Azores", "title": "(GMT-01:00) Azores", "enabled": true },
-              { "value": "Cape Verde Is.", "title": "(GMT-01:00) Cape Verde Is.", "enabled": true },
-              { "value": "Dublin", "title": "(GMT+00:00) Dublin", "enabled": true },
-              { "value": "Edinburgh", "title": "(GMT+00:00) Edinburgh", "enabled": true },
-              { "value": "Lisbon", "title": "(GMT+00:00) Lisbon", "enabled": true },
-              { "value": "London", "title": "(GMT+00:00) London", "enabled": true },
-              { "value": "Monrovia", "title": "(GMT+00:00) Monrovia", "enabled": true },
-              { "value": "UTC", "title": "(GMT+00:00) UTC", "enabled": true },
-              { "value": "Amsterdam", "title": "(GMT+01:00) Amsterdam", "enabled": true },
-              { "value": "Belgrade", "title": "(GMT+01:00) Belgrade", "enabled": true },
-              { "value": "Berlin", "title": "(GMT+01:00) Berlin", "enabled": true },
-              { "value": "Bern", "title": "(GMT+01:00) Bern", "enabled": true },
-              { "value": "Bratislava", "title": "(GMT+01:00) Bratislava", "enabled": true },
-              { "value": "Brussels", "title": "(GMT+01:00) Brussels", "enabled": true },
-              { "value": "Budapest", "title": "(GMT+01:00) Budapest", "enabled": true },
-              { "value": "Casablanca", "title": "(GMT+01:00) Casablanca", "enabled": true },
-              { "value": "Copenhagen", "title": "(GMT+01:00) Copenhagen", "enabled": true },
-              { "value": "Ljubljana", "title": "(GMT+01:00) Ljubljana", "enabled": true },
-              { "value": "Madrid", "title": "(GMT+01:00) Madrid", "enabled": true },
-              { "value": "Oslo", "title": "(GMT+01:00) Oslo", "enabled": true },
-              { "value": "Paris", "title": "(GMT+01:00) Paris", "enabled": true },
-              { "value": "Prague", "title": "(GMT+01:00) Prague", "enabled": true },
-              { "value": "Rome", "title": "(GMT+01:00) Rome", "enabled": true },
-              { "value": "Sarajevo", "title": "(GMT+01:00) Sarajevo", "enabled": true },
-              { "value": "Skopje", "title": "(GMT+01:00) Skopje", "enabled": true },
-              { "value": "Stockholm", "title": "(GMT+01:00) Stockholm", "enabled": true },
-              { "value": "Vienna", "title": "(GMT+01:00) Vienna", "enabled": true },
-              { "value": "Warsaw", "title": "(GMT+01:00) Warsaw", "enabled": true },
-              { "value": "West Central Africa", "title": "(GMT+01:00) West Central Africa", "enabled": true },
-              { "value": "Zagreb", "title": "(GMT+01:00) Zagreb", "enabled": true },
-              { "value": "Athens", "title": "(GMT+02:00) Athens", "enabled": true },
-              { "value": "Bucharest", "title": "(GMT+02:00) Bucharest", "enabled": true },
-              { "value": "Cairo", "title": "(GMT+02:00) Cairo", "enabled": true },
-              { "value": "Harare", "title": "(GMT+02:00) Harare", "enabled": true },
-              { "value": "Helsinki", "title": "(GMT+02:00) Helsinki", "enabled": true },
-              { "value": "Jerusalem", "title": "(GMT+02:00) Jerusalem", "enabled": true },
-              { "value": "Kaliningrad", "title": "(GMT+02:00) Kaliningrad", "enabled": true },
-              { "value": "Kyev", "title": "(GMT+02:00) Kyev", "enabled": true },
-              { "value": "Kyiv", "title": "(GMT+02:00) Kyiv", "enabled": true },
-              { "value": "Pretoria", "title": "(GMT+02:00) Pretoria", "enabled": true },
-              { "value": "Riga", "title": "(GMT+02:00) Riga", "enabled": true },
-              { "value": "Sofia", "title": "(GMT+02:00) Sofia", "enabled": true },
-              { "value": "Tallinn", "title": "(GMT+02:00) Tallinn", "enabled": true },
-              { "value": "Vilnius", "title": "(GMT+02:00) Vilnius", "enabled": true },
-              { "value": "Baghdad", "title": "(GMT+03:00) Baghdad", "enabled": true },
-              { "value": "Istanbul", "title": "(GMT+03:00) Istanbul", "enabled": true },
-              { "value": "Kuwait", "title": "(GMT+03:00) Kuwait", "enabled": true },
-              { "value": "Minsk", "title": "(GMT+03:00) Minsk", "enabled": true },
-              { "value": "Moscow", "title": "(GMT+03:00) Moscow", "enabled": true },
-              { "value": "Nairobi", "title": "(GMT+03:00) Nairobi", "enabled": true },
-              { "value": "Riyadh", "title": "(GMT+03:00) Riyadh", "enabled": true },
-              { "value": "St. Petersburg", "title": "(GMT+03:00) St. Petersburg", "enabled": true },
-              { "value": "Tehran", "title": "(GMT+03:30) Tehran", "enabled": true },
-              { "value": "Abu Dhabi", "title": "(GMT+04:00) Abu Dhabi", "enabled": true },
-              { "value": "Baku", "title": "(GMT+04:00) Baku", "enabled": true },
-              { "value": "Muscat", "title": "(GMT+04:00) Muscat", "enabled": true },
-              { "value": "Samara", "title": "(GMT+04:00) Samara", "enabled": true },
-              { "value": "Tbilisi", "title": "(GMT+04:00) Tbilisi", "enabled": true },
-              { "value": "Volgograd", "title": "(GMT+04:00) Volgograd", "enabled": true },
-              { "value": "Yerevan", "title": "(GMT+04:00) Yerevan", "enabled": true },
-              { "value": "Kabul", "title": "(GMT+04:30) Kabul", "enabled": true },
-              { "value": "Ekaterinburg", "title": "(GMT+05:00) Ekaterinburg", "enabled": true },
-              { "value": "Islamabad", "title": "(GMT+05:00) Islamabad", "enabled": true },
-              { "value": "Karachi", "title": "(GMT+05:00) Karachi", "enabled": true },
-              { "value": "Tashkent", "title": "(GMT+05:00) Tashkent", "enabled": true },
-              { "value": "Chennai", "title": "(GMT+05:30) Chennai", "enabled": true },
-              { "value": "Kolkata", "title": "(GMT+05:30) Kolkata", "enabled": true },
-              { "value": "Mumbai", "title": "(GMT+05:30) Mumbai", "enabled": true },
-              { "value": "New Delhi", "title": "(GMT+05:30) New Delhi", "enabled": true },
-              { "value": "Sri Jayawardenepura", "title": "(GMT+05:30) Sri Jayawardenepura", "enabled": true },
-              { "value": "Kathmandu", "title": "(GMT+05:45) Kathmandu", "enabled": true },
-              { "value": "Almaty", "title": "(GMT+06:00) Almaty", "enabled": true },
-              { "value": "Astana", "title": "(GMT+06:00) Astana", "enabled": true },
-              { "value": "Dhaka", "title": "(GMT+06:00) Dhaka", "enabled": true },
-              { "value": "Urumqi", "title": "(GMT+06:00) Urumqi", "enabled": true },
-              { "value": "Rangoon", "title": "(GMT+06:30) Rangoon", "enabled": true },
-              { "value": "Bangkok", "title": "(GMT+07:00) Bangkok", "enabled": true },
-              { "value": "Hanoi", "title": "(GMT+07:00) Hanoi", "enabled": true },
-              { "value": "Jakarta", "title": "(GMT+07:00) Jakarta", "enabled": true },
-              { "value": "Krasnoyarsk", "title": "(GMT+07:00) Krasnoyarsk", "enabled": true },
-              { "value": "Novosibirsk", "title": "(GMT+07:00) Novosibirsk", "enabled": true },
-              { "value": "Beijing", "title": "(GMT+08:00) Beijing", "enabled": true },
-              { "value": "Chongqing", "title": "(GMT+08:00) Chongqing", "enabled": true },
-              { "value": "Hong Kong", "title": "(GMT+08:00) Hong Kong", "enabled": true },
-              { "value": "Irkutsk", "title": "(GMT+08:00) Irkutsk", "enabled": true },
-              { "value": "Kuala Lumpur", "title": "(GMT+08:00) Kuala Lumpur", "enabled": true },
-              { "value": "Perth", "title": "(GMT+08:00) Perth", "enabled": true },
-              { "value": "Singapore", "title": "(GMT+08:00) Singapore", "enabled": true },
-              { "value": "Taipei", "title": "(GMT+08:00) Taipei", "enabled": true },
-              { "value": "Ulaan Bataar", "title": "(GMT+08:00) Ulaanbataar", "enabled": true },
-              { "value": "Ulaanbaatar", "title": "(GMT+08:00) Ulaanbaatar", "enabled": true },
-              { "value": "Osaka", "title": "(GMT+09:00) Osaka", "enabled": true },
-              { "value": "Sapporo", "title": "(GMT+09:00) Sapporo", "enabled": true },
-              { "value": "Seoul", "title": "(GMT+09:00) Seoul", "enabled": true },
-              { "value": "Tokyo", "title": "(GMT+09:00) Tokyo", "enabled": true },
-              { "value": "Yakutsk", "title": "(GMT+09:00) Yakutsk", "enabled": true },
-              { "value": "Darwin", "title": "(GMT+09:30) Darwin", "enabled": true },
-              { "value": "Brisbane", "title": "(GMT+10:00) Brisbane", "enabled": true },
-              { "value": "Guam", "title": "(GMT+10:00) Guam", "enabled": true },
-              { "value": "Port Moresby", "title": "(GMT+10:00) Port Moresby", "enabled": true },
-              { "value": "Vladivostok", "title": "(GMT+10:00) Vladivostok", "enabled": true },
-              { "value": "Adelaide", "title": "(GMT+10:30) Adelaide", "enabled": true },
-              { "value": "Canberra", "title": "(GMT+11:00) Canberra", "enabled": true },
-              { "value": "Hobart", "title": "(GMT+11:00) Hobart", "enabled": true },
-              { "value": "Magadan", "title": "(GMT+11:00) Magadan", "enabled": true },
-              { "value": "Melbourne", "title": "(GMT+11:00) Melbourne", "enabled": true },
-              { "value": "New Caledonia", "title": "(GMT+11:00) New Caledonia", "enabled": true },
-              { "value": "Solomon Is.", "title": "(GMT+11:00) Solomon Is.", "enabled": true },
-              { "value": "Srednekolymsk", "title": "(GMT+11:00) Srednekolymsk", "enabled": true },
-              { "value": "Sydney", "title": "(GMT+11:00) Sydney", "enabled": true },
-              { "value": "Kamchatka", "title": "(GMT+12:00) Kamchatka", "enabled": true },
-              { "value": "Marshall Is.", "title": "(GMT+12:00) Marshall Is.", "enabled": true },
-              { "value": "Auckland", "title": "(GMT+13:00) Auckland", "enabled": true },
-              { "value": "Fiji", "title": "(GMT+13:00) Fiji", "enabled": true },
-              { "value": "Nuku'alofa", "title": "(GMT+13:00) Nuku'alofa", "enabled": true },
-              { "value": "Tokelau Is.", "title": "(GMT+13:00) Tokelau Is.", "enabled": true },
-              { "value": "Wellington", "title": "(GMT+13:00) Wellington", "enabled": true },
-              { "value": "Chatham Is.", "title": "(GMT+13:45) Chatham Is.", "enabled": true },
-              { "value": "Samoa", "title": "(GMT+14:00) Samoa", "enabled": true }
+              {
+                "value": "Indiana (East)",
+                "title": "(GMT-05:00) Indiana (East)",
+                "enabled": true
+              },
+              {
+                "value": "Lima",
+                "title": "(GMT-05:00) Lima",
+                "enabled": true
+              },
+              {
+                "value": "Quito",
+                "title": "(GMT-05:00) Quito",
+                "enabled": true
+              },
+              {
+                "value": "Atlantic Time (Canada)",
+                "title": "(GMT-04:00) Atlantic Time (Canada)",
+                "enabled": true
+              },
+              {
+                "value": "Caracas",
+                "title": "(GMT-04:00) Caracas",
+                "enabled": true
+              },
+              {
+                "value": "Georgetown",
+                "title": "(GMT-04:00) Georgetown",
+                "enabled": true
+              },
+              {
+                "value": "La Paz",
+                "title": "(GMT-04:00) La Paz",
+                "enabled": true
+              },
+              {
+                "value": "Puerto Rico",
+                "title": "(GMT-04:00) Puerto Rico",
+                "enabled": true
+              },
+              {
+                "value": "Newfoundland",
+                "title": "(GMT-03:30) Newfoundland",
+                "enabled": true
+              },
+              {
+                "value": "Brasilia",
+                "title": "(GMT-03:00) Brasilia",
+                "enabled": true
+              },
+              {
+                "value": "Buenos Aires",
+                "title": "(GMT-03:00) Buenos Aires",
+                "enabled": true
+              },
+              {
+                "value": "Greenland",
+                "title": "(GMT-03:00) Greenland",
+                "enabled": true
+              },
+              {
+                "value": "Montevideo",
+                "title": "(GMT-03:00) Montevideo",
+                "enabled": true
+              },
+              {
+                "value": "Santiago",
+                "title": "(GMT-03:00) Santiago",
+                "enabled": true
+              },
+              {
+                "value": "Mid-Atlantic",
+                "title": "(GMT-02:00) Mid-Atlantic",
+                "enabled": true
+              },
+              {
+                "value": "Azores",
+                "title": "(GMT-01:00) Azores",
+                "enabled": true
+              },
+              {
+                "value": "Cape Verde Is.",
+                "title": "(GMT-01:00) Cape Verde Is.",
+                "enabled": true
+              },
+              {
+                "value": "Dublin",
+                "title": "(GMT+00:00) Dublin",
+                "enabled": true
+              },
+              {
+                "value": "Edinburgh",
+                "title": "(GMT+00:00) Edinburgh",
+                "enabled": true
+              },
+              {
+                "value": "Lisbon",
+                "title": "(GMT+00:00) Lisbon",
+                "enabled": true
+              },
+              {
+                "value": "London",
+                "title": "(GMT+00:00) London",
+                "enabled": true
+              },
+              {
+                "value": "Monrovia",
+                "title": "(GMT+00:00) Monrovia",
+                "enabled": true
+              },
+              {
+                "value": "UTC",
+                "title": "(GMT+00:00) UTC",
+                "enabled": true
+              },
+              {
+                "value": "Amsterdam",
+                "title": "(GMT+01:00) Amsterdam",
+                "enabled": true
+              },
+              {
+                "value": "Belgrade",
+                "title": "(GMT+01:00) Belgrade",
+                "enabled": true
+              },
+              {
+                "value": "Berlin",
+                "title": "(GMT+01:00) Berlin",
+                "enabled": true
+              },
+              {
+                "value": "Bern",
+                "title": "(GMT+01:00) Bern",
+                "enabled": true
+              },
+              {
+                "value": "Bratislava",
+                "title": "(GMT+01:00) Bratislava",
+                "enabled": true
+              },
+              {
+                "value": "Brussels",
+                "title": "(GMT+01:00) Brussels",
+                "enabled": true
+              },
+              {
+                "value": "Budapest",
+                "title": "(GMT+01:00) Budapest",
+                "enabled": true
+              },
+              {
+                "value": "Casablanca",
+                "title": "(GMT+01:00) Casablanca",
+                "enabled": true
+              },
+              {
+                "value": "Copenhagen",
+                "title": "(GMT+01:00) Copenhagen",
+                "enabled": true
+              },
+              {
+                "value": "Ljubljana",
+                "title": "(GMT+01:00) Ljubljana",
+                "enabled": true
+              },
+              {
+                "value": "Madrid",
+                "title": "(GMT+01:00) Madrid",
+                "enabled": true
+              },
+              {
+                "value": "Oslo",
+                "title": "(GMT+01:00) Oslo",
+                "enabled": true
+              },
+              {
+                "value": "Paris",
+                "title": "(GMT+01:00) Paris",
+                "enabled": true
+              },
+              {
+                "value": "Prague",
+                "title": "(GMT+01:00) Prague",
+                "enabled": true
+              },
+              {
+                "value": "Rome",
+                "title": "(GMT+01:00) Rome",
+                "enabled": true
+              },
+              {
+                "value": "Sarajevo",
+                "title": "(GMT+01:00) Sarajevo",
+                "enabled": true
+              },
+              {
+                "value": "Skopje",
+                "title": "(GMT+01:00) Skopje",
+                "enabled": true
+              },
+              {
+                "value": "Stockholm",
+                "title": "(GMT+01:00) Stockholm",
+                "enabled": true
+              },
+              {
+                "value": "Vienna",
+                "title": "(GMT+01:00) Vienna",
+                "enabled": true
+              },
+              {
+                "value": "Warsaw",
+                "title": "(GMT+01:00) Warsaw",
+                "enabled": true
+              },
+              {
+                "value": "West Central Africa",
+                "title": "(GMT+01:00) West Central Africa",
+                "enabled": true
+              },
+              {
+                "value": "Zagreb",
+                "title": "(GMT+01:00) Zagreb",
+                "enabled": true
+              },
+              {
+                "value": "Athens",
+                "title": "(GMT+02:00) Athens",
+                "enabled": true
+              },
+              {
+                "value": "Bucharest",
+                "title": "(GMT+02:00) Bucharest",
+                "enabled": true
+              },
+              {
+                "value": "Cairo",
+                "title": "(GMT+02:00) Cairo",
+                "enabled": true
+              },
+              {
+                "value": "Harare",
+                "title": "(GMT+02:00) Harare",
+                "enabled": true
+              },
+              {
+                "value": "Helsinki",
+                "title": "(GMT+02:00) Helsinki",
+                "enabled": true
+              },
+              {
+                "value": "Jerusalem",
+                "title": "(GMT+02:00) Jerusalem",
+                "enabled": true
+              },
+              {
+                "value": "Kaliningrad",
+                "title": "(GMT+02:00) Kaliningrad",
+                "enabled": true
+              },
+              {
+                "value": "Kyev",
+                "title": "(GMT+02:00) Kyev",
+                "enabled": true
+              },
+              {
+                "value": "Kyiv",
+                "title": "(GMT+02:00) Kyiv",
+                "enabled": true
+              },
+              {
+                "value": "Pretoria",
+                "title": "(GMT+02:00) Pretoria",
+                "enabled": true
+              },
+              {
+                "value": "Riga",
+                "title": "(GMT+02:00) Riga",
+                "enabled": true
+              },
+              {
+                "value": "Sofia",
+                "title": "(GMT+02:00) Sofia",
+                "enabled": true
+              },
+              {
+                "value": "Tallinn",
+                "title": "(GMT+02:00) Tallinn",
+                "enabled": true
+              },
+              {
+                "value": "Vilnius",
+                "title": "(GMT+02:00) Vilnius",
+                "enabled": true
+              },
+              {
+                "value": "Baghdad",
+                "title": "(GMT+03:00) Baghdad",
+                "enabled": true
+              },
+              {
+                "value": "Istanbul",
+                "title": "(GMT+03:00) Istanbul",
+                "enabled": true
+              },
+              {
+                "value": "Kuwait",
+                "title": "(GMT+03:00) Kuwait",
+                "enabled": true
+              },
+              {
+                "value": "Minsk",
+                "title": "(GMT+03:00) Minsk",
+                "enabled": true
+              },
+              {
+                "value": "Moscow",
+                "title": "(GMT+03:00) Moscow",
+                "enabled": true
+              },
+              {
+                "value": "Nairobi",
+                "title": "(GMT+03:00) Nairobi",
+                "enabled": true
+              },
+              {
+                "value": "Riyadh",
+                "title": "(GMT+03:00) Riyadh",
+                "enabled": true
+              },
+              {
+                "value": "St. Petersburg",
+                "title": "(GMT+03:00) St. Petersburg",
+                "enabled": true
+              },
+              {
+                "value": "Tehran",
+                "title": "(GMT+03:30) Tehran",
+                "enabled": true
+              },
+              {
+                "value": "Abu Dhabi",
+                "title": "(GMT+04:00) Abu Dhabi",
+                "enabled": true
+              },
+              {
+                "value": "Baku",
+                "title": "(GMT+04:00) Baku",
+                "enabled": true
+              },
+              {
+                "value": "Muscat",
+                "title": "(GMT+04:00) Muscat",
+                "enabled": true
+              },
+              {
+                "value": "Samara",
+                "title": "(GMT+04:00) Samara",
+                "enabled": true
+              },
+              {
+                "value": "Tbilisi",
+                "title": "(GMT+04:00) Tbilisi",
+                "enabled": true
+              },
+              {
+                "value": "Volgograd",
+                "title": "(GMT+04:00) Volgograd",
+                "enabled": true
+              },
+              {
+                "value": "Yerevan",
+                "title": "(GMT+04:00) Yerevan",
+                "enabled": true
+              },
+              {
+                "value": "Kabul",
+                "title": "(GMT+04:30) Kabul",
+                "enabled": true
+              },
+              {
+                "value": "Ekaterinburg",
+                "title": "(GMT+05:00) Ekaterinburg",
+                "enabled": true
+              },
+              {
+                "value": "Islamabad",
+                "title": "(GMT+05:00) Islamabad",
+                "enabled": true
+              },
+              {
+                "value": "Karachi",
+                "title": "(GMT+05:00) Karachi",
+                "enabled": true
+              },
+              {
+                "value": "Tashkent",
+                "title": "(GMT+05:00) Tashkent",
+                "enabled": true
+              },
+              {
+                "value": "Chennai",
+                "title": "(GMT+05:30) Chennai",
+                "enabled": true
+              },
+              {
+                "value": "Kolkata",
+                "title": "(GMT+05:30) Kolkata",
+                "enabled": true
+              },
+              {
+                "value": "Mumbai",
+                "title": "(GMT+05:30) Mumbai",
+                "enabled": true
+              },
+              {
+                "value": "New Delhi",
+                "title": "(GMT+05:30) New Delhi",
+                "enabled": true
+              },
+              {
+                "value": "Sri Jayawardenepura",
+                "title": "(GMT+05:30) Sri Jayawardenepura",
+                "enabled": true
+              },
+              {
+                "value": "Kathmandu",
+                "title": "(GMT+05:45) Kathmandu",
+                "enabled": true
+              },
+              {
+                "value": "Almaty",
+                "title": "(GMT+06:00) Almaty",
+                "enabled": true
+              },
+              {
+                "value": "Astana",
+                "title": "(GMT+06:00) Astana",
+                "enabled": true
+              },
+              {
+                "value": "Dhaka",
+                "title": "(GMT+06:00) Dhaka",
+                "enabled": true
+              },
+              {
+                "value": "Urumqi",
+                "title": "(GMT+06:00) Urumqi",
+                "enabled": true
+              },
+              {
+                "value": "Rangoon",
+                "title": "(GMT+06:30) Rangoon",
+                "enabled": true
+              },
+              {
+                "value": "Bangkok",
+                "title": "(GMT+07:00) Bangkok",
+                "enabled": true
+              },
+              {
+                "value": "Hanoi",
+                "title": "(GMT+07:00) Hanoi",
+                "enabled": true
+              },
+              {
+                "value": "Jakarta",
+                "title": "(GMT+07:00) Jakarta",
+                "enabled": true
+              },
+              {
+                "value": "Krasnoyarsk",
+                "title": "(GMT+07:00) Krasnoyarsk",
+                "enabled": true
+              },
+              {
+                "value": "Novosibirsk",
+                "title": "(GMT+07:00) Novosibirsk",
+                "enabled": true
+              },
+              {
+                "value": "Beijing",
+                "title": "(GMT+08:00) Beijing",
+                "enabled": true
+              },
+              {
+                "value": "Chongqing",
+                "title": "(GMT+08:00) Chongqing",
+                "enabled": true
+              },
+              {
+                "value": "Hong Kong",
+                "title": "(GMT+08:00) Hong Kong",
+                "enabled": true
+              },
+              {
+                "value": "Irkutsk",
+                "title": "(GMT+08:00) Irkutsk",
+                "enabled": true
+              },
+              {
+                "value": "Kuala Lumpur",
+                "title": "(GMT+08:00) Kuala Lumpur",
+                "enabled": true
+              },
+              {
+                "value": "Perth",
+                "title": "(GMT+08:00) Perth",
+                "enabled": true
+              },
+              {
+                "value": "Singapore",
+                "title": "(GMT+08:00) Singapore",
+                "enabled": true
+              },
+              {
+                "value": "Taipei",
+                "title": "(GMT+08:00) Taipei",
+                "enabled": true
+              },
+              {
+                "value": "Ulaan Bataar",
+                "title": "(GMT+08:00) Ulaanbataar",
+                "enabled": true
+              },
+              {
+                "value": "Ulaanbaatar",
+                "title": "(GMT+08:00) Ulaanbaatar",
+                "enabled": true
+              },
+              {
+                "value": "Osaka",
+                "title": "(GMT+09:00) Osaka",
+                "enabled": true
+              },
+              {
+                "value": "Sapporo",
+                "title": "(GMT+09:00) Sapporo",
+                "enabled": true
+              },
+              {
+                "value": "Seoul",
+                "title": "(GMT+09:00) Seoul",
+                "enabled": true
+              },
+              {
+                "value": "Tokyo",
+                "title": "(GMT+09:00) Tokyo",
+                "enabled": true
+              },
+              {
+                "value": "Yakutsk",
+                "title": "(GMT+09:00) Yakutsk",
+                "enabled": true
+              },
+              {
+                "value": "Darwin",
+                "title": "(GMT+09:30) Darwin",
+                "enabled": true
+              },
+              {
+                "value": "Brisbane",
+                "title": "(GMT+10:00) Brisbane",
+                "enabled": true
+              },
+              {
+                "value": "Guam",
+                "title": "(GMT+10:00) Guam",
+                "enabled": true
+              },
+              {
+                "value": "Port Moresby",
+                "title": "(GMT+10:00) Port Moresby",
+                "enabled": true
+              },
+              {
+                "value": "Vladivostok",
+                "title": "(GMT+10:00) Vladivostok",
+                "enabled": true
+              },
+              {
+                "value": "Adelaide",
+                "title": "(GMT+10:30) Adelaide",
+                "enabled": true
+              },
+              {
+                "value": "Canberra",
+                "title": "(GMT+11:00) Canberra",
+                "enabled": true
+              },
+              {
+                "value": "Hobart",
+                "title": "(GMT+11:00) Hobart",
+                "enabled": true
+              },
+              {
+                "value": "Magadan",
+                "title": "(GMT+11:00) Magadan",
+                "enabled": true
+              },
+              {
+                "value": "Melbourne",
+                "title": "(GMT+11:00) Melbourne",
+                "enabled": true
+              },
+              {
+                "value": "New Caledonia",
+                "title": "(GMT+11:00) New Caledonia",
+                "enabled": true
+              },
+              {
+                "value": "Solomon Is.",
+                "title": "(GMT+11:00) Solomon Is.",
+                "enabled": true
+              },
+              {
+                "value": "Srednekolymsk",
+                "title": "(GMT+11:00) Srednekolymsk",
+                "enabled": true
+              },
+              {
+                "value": "Sydney",
+                "title": "(GMT+11:00) Sydney",
+                "enabled": true
+              },
+              {
+                "value": "Kamchatka",
+                "title": "(GMT+12:00) Kamchatka",
+                "enabled": true
+              },
+              {
+                "value": "Marshall Is.",
+                "title": "(GMT+12:00) Marshall Is.",
+                "enabled": true
+              },
+              {
+                "value": "Auckland",
+                "title": "(GMT+13:00) Auckland",
+                "enabled": true
+              },
+              {
+                "value": "Fiji",
+                "title": "(GMT+13:00) Fiji",
+                "enabled": true
+              },
+              {
+                "value": "Nuku'alofa",
+                "title": "(GMT+13:00) Nuku'alofa",
+                "enabled": true
+              },
+              {
+                "value": "Tokelau Is.",
+                "title": "(GMT+13:00) Tokelau Is.",
+                "enabled": true
+              },
+              {
+                "value": "Wellington",
+                "title": "(GMT+13:00) Wellington",
+                "enabled": true
+              },
+              {
+                "value": "Chatham Is.",
+                "title": "(GMT+13:45) Chatham Is.",
+                "enabled": true
+              },
+              {
+                "value": "Samoa",
+                "title": "(GMT+14:00) Samoa",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9717,17 +19076,53 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "agent", "title": "(agent)", "enabled": true },
-              { "value": "end_user", "title": "(end-user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "agent",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "end_user",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9738,15 +19133,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9757,16 +19180,48 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9777,15 +19232,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9796,8 +19279,16 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -9808,14 +19299,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9826,21 +19349,66 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false, "format": "date" },
-              { "value": "is_not", "title": "Is not", "terminal": false, "format": "date" },
-              { "value": "present", "title": "Present", "terminal": true, "format": "date" },
-              { "value": "not_present", "title": "Not present", "terminal": true, "format": "date" },
-              { "value": "less_than", "title": "Before", "terminal": false, "format": "date" },
-              { "value": "less_than_equal", "title": "Before or on", "terminal": false, "format": "date" },
-              { "value": "greater_than", "title": "After", "terminal": false, "format": "date" },
-              { "value": "greater_than_equal", "title": "After or on", "terminal": false, "format": "date" },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true,
+                "format": "date"
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true,
+                "format": "date"
+              },
+              {
+                "value": "less_than",
+                "title": "Before",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "greater_than",
+                "title": "After",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on",
+                "terminal": false,
+                "format": "date"
+              },
               {
                 "value": "within_previous_n_days",
                 "title": "Is within the previous",
                 "terminal": false,
                 "format": "integer"
               },
-              { "value": "within_next_n_days", "title": "Is within the next", "terminal": false, "format": "integer" }
+              {
+                "value": "within_next_n_days",
+                "title": "Is within the next",
+                "terminal": false,
+                "format": "integer"
+              }
             ]
           },
           {
@@ -9851,14 +19419,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -9869,14 +19469,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9887,16 +19519,48 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500001753322", "title": "Choice1", "enabled": true },
-              { "value": "1500001753342", "title": "another choice", "enabled": true },
-              { "value": "1500001753362", "title": "bla", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500001753322",
+                "title": "Choice1",
+                "enabled": true
+              },
+              {
+                "value": "1500001753342",
+                "title": "another choice",
+                "enabled": true
+              },
+              {
+                "value": "1500001753362",
+                "title": "bla",
+                "enabled": true
+              }
             ]
           },
           {
@@ -9907,14 +19571,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9925,14 +19621,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9943,14 +19671,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9961,14 +19721,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9979,14 +19771,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -9997,14 +19821,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10015,14 +19871,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10033,14 +19921,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10051,14 +19971,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10069,14 +20021,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10087,14 +20071,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10105,14 +20121,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10123,14 +20171,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10141,14 +20221,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10159,14 +20271,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10177,14 +20321,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10195,14 +20371,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10213,14 +20421,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10231,14 +20471,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10249,14 +20521,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10267,14 +20571,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10285,14 +20621,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -10303,14 +20671,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10320,10 +20720,24 @@
             "group": "requester",
             "nullable": true,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Checked", "enabled": true },
-              { "value": "false", "title": "Unchecked", "enabled": true }
+              {
+                "value": "true",
+                "title": "Checked",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Unchecked",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10334,17 +20748,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1900000066065", "title": "123", "enabled": true },
-              { "value": "1900000066085", "title": "v1", "enabled": true },
-              { "value": "1900000066105", "title": "v2", "enabled": true },
-              { "value": "1900000066125", "title": "v3", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1900000066065",
+                "title": "123",
+                "enabled": true
+              },
+              {
+                "value": "1900000066085",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "1900000066105",
+                "title": "v2",
+                "enabled": true
+              },
+              {
+                "value": "1900000066125",
+                "title": "v3",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10355,14 +20805,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10373,14 +20855,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10391,14 +20905,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10409,14 +20955,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10427,14 +21005,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10445,14 +21055,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -10463,14 +21105,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           }
         ],
@@ -10483,23 +21157,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "new", "title": "New", "enabled": true },
-              { "value": "open", "title": "Open", "enabled": true },
-              { "value": "pending", "title": "Pending", "enabled": true },
-              { "value": "solved", "title": "Solved", "enabled": true },
-              { "value": "closed", "title": "Closed", "enabled": true }
+              {
+                "value": "new",
+                "title": "New",
+                "enabled": true
+              },
+              {
+                "value": "open",
+                "title": "Open",
+                "enabled": true
+              },
+              {
+                "value": "pending",
+                "title": "Pending",
+                "enabled": true
+              },
+              {
+                "value": "solved",
+                "title": "Solved",
+                "enabled": true
+              },
+              {
+                "value": "closed",
+                "title": "Closed",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10510,11 +21244,31 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10525,16 +21279,54 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
-            "values": [{ "value": "1500000550682", "title": "myBrand", "enabled": true }]
+            "values": [
+              {
+                "value": "1500000550682",
+                "title": "myBrand",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Form",
@@ -10544,23 +21336,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500000859362", "title": "Default Ticket Form", "enabled": true },
-              { "value": "1500002488461", "title": "Form 6436", "enabled": true },
-              { "value": "1500002488481", "title": "Form 11", "enabled": true },
-              { "value": "1900000172165", "title": "Form 13", "enabled": true },
-              { "value": "1500002488501", "title": "Form 12", "enabled": true },
-              { "value": "1900000882985", "title": "Demo ticket form", "enabled": true },
-              { "value": "1900000911005", "title": "Amazing ticket form", "enabled": true }
+              {
+                "value": "1500000859362",
+                "title": "Default Ticket Form",
+                "enabled": true
+              },
+              {
+                "value": "1500002488461",
+                "title": "Form 6436",
+                "enabled": true
+              },
+              {
+                "value": "1500002488481",
+                "title": "Form 11",
+                "enabled": true
+              },
+              {
+                "value": "1900000172165",
+                "title": "Form 13",
+                "enabled": true
+              },
+              {
+                "value": "1500002488501",
+                "title": "Form 12",
+                "enabled": true
+              },
+              {
+                "value": "1900000882985",
+                "title": "Demo ticket form",
+                "enabled": true
+              },
+              {
+                "value": "1900000911005",
+                "title": "Amazing ticket form",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10571,21 +21423,73 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "question", "title": "Question", "enabled": true },
-              { "value": "incident", "title": "Incident", "enabled": true },
-              { "value": "problem", "title": "Problem", "enabled": true },
-              { "value": "task", "title": "Task", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "question",
+                "title": "Question",
+                "enabled": true
+              },
+              {
+                "value": "incident",
+                "title": "Incident",
+                "enabled": true
+              },
+              {
+                "value": "problem",
+                "title": "Problem",
+                "enabled": true
+              },
+              {
+                "value": "task",
+                "title": "Task",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10596,23 +21500,83 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "low", "title": "Low", "enabled": true },
-              { "value": "normal", "title": "Normal", "enabled": true },
-              { "value": "high", "title": "High", "enabled": true },
-              { "value": "urgent", "title": "Urgent", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "low",
+                "title": "Low",
+                "enabled": true
+              },
+              {
+                "value": "normal",
+                "title": "Normal",
+                "enabled": true
+              },
+              {
+                "value": "high",
+                "title": "High",
+                "enabled": true
+              },
+              {
+                "value": "urgent",
+                "title": "Urgent",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10623,21 +21587,73 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500002894482", "title": "Support", "enabled": true },
-              { "value": "4415660742295", "title": "Support2", "enabled": true },
-              { "value": "4415700870423", "title": "Support4", "enabled": true },
-              { "value": "4415704834327", "title": "Support5", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500002894482",
+                "title": "Support",
+                "enabled": true
+              },
+              {
+                "value": "4415660742295",
+                "title": "Support2",
+                "enabled": true
+              },
+              {
+                "value": "4415700870423",
+                "title": "Support4",
+                "enabled": true
+              },
+              {
+                "value": "4415704834327",
+                "title": "Support5",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10648,24 +21664,88 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "requester_id", "title": "(requester)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "requester_id",
+                "title": "(requester)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10676,23 +21756,83 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "assignee_id", "title": "(assignee)", "enabled": true },
-              { "value": "current_user", "title": "(current user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "assignee_id",
+                "title": "(assignee)",
+                "enabled": true
+              },
+              {
+                "value": "current_user",
+                "title": "(current user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10703,20 +21843,68 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "changed", "title": "Changed", "terminal": true },
-              { "value": "value", "title": "Changed to", "terminal": false },
-              { "value": "value_previous", "title": "Changed from", "terminal": false },
-              { "value": "not_changed", "title": "Not changed", "terminal": true },
-              { "value": "not_value", "title": "Not changed to", "terminal": false },
-              { "value": "not_value_previous", "title": "Not changed from", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "changed",
+                "title": "Changed",
+                "terminal": true
+              },
+              {
+                "value": "value",
+                "title": "Changed to",
+                "terminal": false
+              },
+              {
+                "value": "value_previous",
+                "title": "Changed from",
+                "terminal": false
+              },
+              {
+                "value": "not_changed",
+                "title": "Not changed",
+                "terminal": true
+              },
+              {
+                "value": "not_value",
+                "title": "Not changed to",
+                "terminal": false
+              },
+              {
+                "value": "not_value_previous",
+                "title": "Not changed from",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500421645662", "title": "myBrand", "enabled": true },
-              { "value": "1900025376085", "title": "test org 123", "enabled": true },
-              { "value": "1500508294122", "title": "test org 124", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500421645662",
+                "title": "myBrand",
+                "enabled": true
+              },
+              {
+                "value": "1900025376085",
+                "title": "test org 123",
+                "enabled": true
+              },
+              {
+                "value": "1500508294122",
+                "title": "test org 124",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10727,8 +21915,16 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10739,44 +21935,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10787,44 +22127,188 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "0", "title": "Web form", "enabled": true },
-              { "value": "4", "title": "Email", "enabled": true },
-              { "value": "29", "title": "Chat", "enabled": true },
-              { "value": "30", "title": "Twitter", "enabled": true },
-              { "value": "26", "title": "Twitter DM", "enabled": true },
-              { "value": "23", "title": "Twitter Like", "enabled": true },
-              { "value": "33", "title": "Voicemail", "enabled": true },
-              { "value": "34", "title": "Phone call (incoming)", "enabled": true },
-              { "value": "35", "title": "Phone call (outgoing)", "enabled": true },
-              { "value": "44", "title": "CTI voicemail", "enabled": true },
-              { "value": "45", "title": "CTI phone call (incoming)", "enabled": true },
-              { "value": "46", "title": "CTI phone call (outgoing)", "enabled": true },
-              { "value": "57", "title": "Text", "enabled": true },
-              { "value": "16", "title": "Get Satisfaction", "enabled": true },
-              { "value": "48", "title": "Web Widget", "enabled": true },
-              { "value": "49", "title": "Mobile SDK", "enabled": true },
-              { "value": "56", "title": "Mobile", "enabled": true },
-              { "value": "50", "title": "Help Center post", "enabled": true },
-              { "value": "5", "title": "Web service (API)", "enabled": true },
-              { "value": "8", "title": "Automation", "enabled": true },
-              { "value": "24", "title": "Forum topic", "enabled": true },
-              { "value": "27", "title": "Closed ticket", "enabled": true },
-              { "value": "31", "title": "Ticket sharing", "enabled": true },
-              { "value": "38", "title": "Facebook Post", "enabled": true },
-              { "value": "41", "title": "Facebook Private Message", "enabled": true },
-              { "value": "54", "title": "Satisfaction Prediction", "enabled": true },
-              { "value": "67", "title": "Answer Bot for Web Widget", "enabled": true },
-              { "value": "55", "title": "Channel Integrations", "enabled": true },
-              { "value": "73", "title": "WeChat", "enabled": true },
-              { "value": "72", "title": "LINE", "enabled": true },
-              { "value": "74", "title": "WhatsApp", "enabled": true },
-              { "value": "78", "title": "Facebook Messenger", "enabled": true },
-              { "value": "88", "title": "Twitter Direct Message", "enabled": true },
-              { "value": "86", "title": "Instagram Direct", "enabled": true }
+              {
+                "value": "0",
+                "title": "Web form",
+                "enabled": true
+              },
+              {
+                "value": "4",
+                "title": "Email",
+                "enabled": true
+              },
+              {
+                "value": "29",
+                "title": "Chat",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Twitter",
+                "enabled": true
+              },
+              {
+                "value": "26",
+                "title": "Twitter DM",
+                "enabled": true
+              },
+              {
+                "value": "23",
+                "title": "Twitter Like",
+                "enabled": true
+              },
+              {
+                "value": "33",
+                "title": "Voicemail",
+                "enabled": true
+              },
+              {
+                "value": "34",
+                "title": "Phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "35",
+                "title": "Phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "44",
+                "title": "CTI voicemail",
+                "enabled": true
+              },
+              {
+                "value": "45",
+                "title": "CTI phone call (incoming)",
+                "enabled": true
+              },
+              {
+                "value": "46",
+                "title": "CTI phone call (outgoing)",
+                "enabled": true
+              },
+              {
+                "value": "57",
+                "title": "Text",
+                "enabled": true
+              },
+              {
+                "value": "16",
+                "title": "Get Satisfaction",
+                "enabled": true
+              },
+              {
+                "value": "48",
+                "title": "Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "49",
+                "title": "Mobile SDK",
+                "enabled": true
+              },
+              {
+                "value": "56",
+                "title": "Mobile",
+                "enabled": true
+              },
+              {
+                "value": "50",
+                "title": "Help Center post",
+                "enabled": true
+              },
+              {
+                "value": "5",
+                "title": "Web service (API)",
+                "enabled": true
+              },
+              {
+                "value": "8",
+                "title": "Automation",
+                "enabled": true
+              },
+              {
+                "value": "24",
+                "title": "Forum topic",
+                "enabled": true
+              },
+              {
+                "value": "27",
+                "title": "Closed ticket",
+                "enabled": true
+              },
+              {
+                "value": "31",
+                "title": "Ticket sharing",
+                "enabled": true
+              },
+              {
+                "value": "38",
+                "title": "Facebook Post",
+                "enabled": true
+              },
+              {
+                "value": "41",
+                "title": "Facebook Private Message",
+                "enabled": true
+              },
+              {
+                "value": "54",
+                "title": "Satisfaction Prediction",
+                "enabled": true
+              },
+              {
+                "value": "67",
+                "title": "Answer Bot for Web Widget",
+                "enabled": true
+              },
+              {
+                "value": "55",
+                "title": "Channel Integrations",
+                "enabled": true
+              },
+              {
+                "value": "73",
+                "title": "WeChat",
+                "enabled": true
+              },
+              {
+                "value": "72",
+                "title": "LINE",
+                "enabled": true
+              },
+              {
+                "value": "74",
+                "title": "WhatsApp",
+                "enabled": true
+              },
+              {
+                "value": "78",
+                "title": "Facebook Messenger",
+                "enabled": true
+              },
+              {
+                "value": "88",
+                "title": "Twitter Direct Message",
+                "enabled": true
+              },
+              {
+                "value": "86",
+                "title": "Instagram Direct",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10834,9 +22318,19 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "support@myBrand.zendesk.com", "title": "support@myBrand.zendesk.com", "enabled": true }
+              {
+                "value": "support@myBrand.zendesk.com",
+                "title": "support@myBrand.zendesk.com",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10846,10 +22340,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "Create", "title": "Created", "enabled": true },
-              { "value": "Change", "title": "Updated", "enabled": true }
+              {
+                "value": "Create",
+                "title": "Created",
+                "enabled": true
+              },
+              {
+                "value": "Change",
+                "title": "Updated",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10860,10 +22368,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10873,10 +22397,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "public", "title": "Ticket has public comments", "enabled": true },
-              { "value": "private", "title": "Ticket has no public comments", "enabled": true }
+              {
+                "value": "public",
+                "title": "Ticket has public comments",
+                "enabled": true
+              },
+              {
+                "value": "private",
+                "title": "Ticket has no public comments",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10886,11 +22424,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Public", "enabled": true },
-              { "value": "false", "title": "Private", "enabled": true },
-              { "value": "not_relevant", "title": "Present (public or private)", "enabled": true },
+              {
+                "value": "true",
+                "title": "Public",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Private",
+                "enabled": true
+              },
+              {
+                "value": "not_relevant",
+                "title": "Present (public or private)",
+                "enabled": true
+              },
               {
                 "value": "requester_can_see_comment",
                 "title": "Present, and requester can see the comment",
@@ -10906,10 +22462,26 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes", "title": "Contains none of the following words", "terminal": false },
-              { "value": "is", "title": "Contains the following string", "terminal": false },
-              { "value": "is_not", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "includes",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10920,9 +22492,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10933,9 +22517,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10946,9 +22542,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10959,9 +22567,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -10971,10 +22591,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Yes", "enabled": true },
-              { "value": "false", "title": "No", "enabled": true }
+              {
+                "value": "true",
+                "title": "Yes",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "No",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10984,10 +22618,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Yes", "enabled": true },
-              { "value": "false", "title": "No", "enabled": true }
+              {
+                "value": "true",
+                "title": "Yes",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "No",
+                "enabled": true
+              }
             ]
           },
           {
@@ -10998,13 +22646,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1500001035461", "title": "Schedule 3", "enabled": true },
-              { "value": "1500001036042", "title": "Schedule 2", "enabled": true },
-              { "value": "1900000004365", "title": "New schedule", "enabled": true }
+              {
+                "value": "1500001035461",
+                "title": "Schedule 3",
+                "enabled": true
+              },
+              {
+                "value": "1500001036042",
+                "title": "Schedule 2",
+                "enabled": true
+              },
+              {
+                "value": "1900000004365",
+                "title": "New schedule",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11014,11 +22682,29 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "1500001035461", "title": "Schedule 3", "enabled": true },
-              { "value": "1500001036042", "title": "Schedule 2", "enabled": true },
-              { "value": "1900000004365", "title": "New schedule", "enabled": true }
+              {
+                "value": "1500001035461",
+                "title": "Schedule 3",
+                "enabled": true
+              },
+              {
+                "value": "1500001036042",
+                "title": "Schedule 2",
+                "enabled": true
+              },
+              {
+                "value": "1900000004365",
+                "title": "New schedule",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11028,10 +22714,24 @@
             "group": "ticket",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Present", "enabled": true },
-              { "value": "false", "title": "Not present", "enabled": true }
+              {
+                "value": "true",
+                "title": "Present",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Not present",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11042,13 +22742,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "4", "title": "(agent)", "enabled": true },
-              { "value": "0", "title": "(end-user)", "enabled": true },
-              { "value": "2", "title": "(admin)", "enabled": true }
+              {
+                "value": "4",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "0",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "(admin)",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11059,13 +22779,33 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "1", "title": "English (United States)", "enabled": true },
-              { "value": "30", "title": "Hebrew", "enabled": true },
-              { "value": "2", "title": "Spanish", "enabled": true }
+              {
+                "value": "1",
+                "title": "English (United States)",
+                "enabled": true
+              },
+              {
+                "value": "30",
+                "title": "Hebrew",
+                "enabled": true
+              },
+              {
+                "value": "2",
+                "title": "Spanish",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11076,9 +22816,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11089,9 +22841,21 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "is", "title": "Is", "terminal": false }
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11101,8 +22865,20 @@
             "group": "requester",
             "nullable": false,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
-            "values": [{ "value": "true", "title": "true", "enabled": true }]
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
+            "values": [
+              {
+                "value": "true",
+                "title": "true",
+                "enabled": true
+              }
+            ]
           },
           {
             "title": "Time zone",
@@ -11112,183 +22888,783 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "American Samoa", "title": "(GMT-11:00) American Samoa", "enabled": true },
+              {
+                "value": "American Samoa",
+                "title": "(GMT-11:00) American Samoa",
+                "enabled": true
+              },
               {
                 "value": "International Date Line West",
                 "title": "(GMT-11:00) International Date Line West",
                 "enabled": true
               },
-              { "value": "Midway Island", "title": "(GMT-11:00) Midway Island", "enabled": true },
-              { "value": "Hawaii", "title": "(GMT-10:00) Hawaii", "enabled": true },
-              { "value": "Alaska", "title": "(GMT-09:00) Alaska", "enabled": true },
+              {
+                "value": "Midway Island",
+                "title": "(GMT-11:00) Midway Island",
+                "enabled": true
+              },
+              {
+                "value": "Hawaii",
+                "title": "(GMT-10:00) Hawaii",
+                "enabled": true
+              },
+              {
+                "value": "Alaska",
+                "title": "(GMT-09:00) Alaska",
+                "enabled": true
+              },
               {
                 "value": "Pacific Time (US & Canada)",
                 "title": "(GMT-08:00) Pacific Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Tijuana", "title": "(GMT-08:00) Tijuana", "enabled": true },
-              { "value": "Arizona", "title": "(GMT-07:00) Arizona", "enabled": true },
-              { "value": "Chihuahua", "title": "(GMT-07:00) Chihuahua", "enabled": true },
-              { "value": "Mazatlan", "title": "(GMT-07:00) Mazatlan", "enabled": true },
+              {
+                "value": "Tijuana",
+                "title": "(GMT-08:00) Tijuana",
+                "enabled": true
+              },
+              {
+                "value": "Arizona",
+                "title": "(GMT-07:00) Arizona",
+                "enabled": true
+              },
+              {
+                "value": "Chihuahua",
+                "title": "(GMT-07:00) Chihuahua",
+                "enabled": true
+              },
+              {
+                "value": "Mazatlan",
+                "title": "(GMT-07:00) Mazatlan",
+                "enabled": true
+              },
               {
                 "value": "Mountain Time (US & Canada)",
                 "title": "(GMT-07:00) Mountain Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Central America", "title": "(GMT-06:00) Central America", "enabled": true },
+              {
+                "value": "Central America",
+                "title": "(GMT-06:00) Central America",
+                "enabled": true
+              },
               {
                 "value": "Central Time (US & Canada)",
                 "title": "(GMT-06:00) Central Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Guadalajara", "title": "(GMT-06:00) Guadalajara", "enabled": true },
-              { "value": "Mexico City", "title": "(GMT-06:00) Mexico City", "enabled": true },
-              { "value": "Monterrey", "title": "(GMT-06:00) Monterrey", "enabled": true },
-              { "value": "Saskatchewan", "title": "(GMT-06:00) Saskatchewan", "enabled": true },
-              { "value": "Bogota", "title": "(GMT-05:00) Bogota", "enabled": true },
+              {
+                "value": "Guadalajara",
+                "title": "(GMT-06:00) Guadalajara",
+                "enabled": true
+              },
+              {
+                "value": "Mexico City",
+                "title": "(GMT-06:00) Mexico City",
+                "enabled": true
+              },
+              {
+                "value": "Monterrey",
+                "title": "(GMT-06:00) Monterrey",
+                "enabled": true
+              },
+              {
+                "value": "Saskatchewan",
+                "title": "(GMT-06:00) Saskatchewan",
+                "enabled": true
+              },
+              {
+                "value": "Bogota",
+                "title": "(GMT-05:00) Bogota",
+                "enabled": true
+              },
               {
                 "value": "Eastern Time (US & Canada)",
                 "title": "(GMT-05:00) Eastern Time (US & Canada)",
                 "enabled": true
               },
-              { "value": "Indiana (East)", "title": "(GMT-05:00) Indiana (East)", "enabled": true },
-              { "value": "Lima", "title": "(GMT-05:00) Lima", "enabled": true },
-              { "value": "Quito", "title": "(GMT-05:00) Quito", "enabled": true },
-              { "value": "Atlantic Time (Canada)", "title": "(GMT-04:00) Atlantic Time (Canada)", "enabled": true },
-              { "value": "Caracas", "title": "(GMT-04:00) Caracas", "enabled": true },
-              { "value": "Georgetown", "title": "(GMT-04:00) Georgetown", "enabled": true },
-              { "value": "La Paz", "title": "(GMT-04:00) La Paz", "enabled": true },
-              { "value": "Puerto Rico", "title": "(GMT-04:00) Puerto Rico", "enabled": true },
-              { "value": "Newfoundland", "title": "(GMT-03:30) Newfoundland", "enabled": true },
-              { "value": "Brasilia", "title": "(GMT-03:00) Brasilia", "enabled": true },
-              { "value": "Buenos Aires", "title": "(GMT-03:00) Buenos Aires", "enabled": true },
-              { "value": "Greenland", "title": "(GMT-03:00) Greenland", "enabled": true },
-              { "value": "Montevideo", "title": "(GMT-03:00) Montevideo", "enabled": true },
-              { "value": "Santiago", "title": "(GMT-03:00) Santiago", "enabled": true },
-              { "value": "Mid-Atlantic", "title": "(GMT-02:00) Mid-Atlantic", "enabled": true },
-              { "value": "Azores", "title": "(GMT-01:00) Azores", "enabled": true },
-              { "value": "Cape Verde Is.", "title": "(GMT-01:00) Cape Verde Is.", "enabled": true },
-              { "value": "Dublin", "title": "(GMT+00:00) Dublin", "enabled": true },
-              { "value": "Edinburgh", "title": "(GMT+00:00) Edinburgh", "enabled": true },
-              { "value": "Lisbon", "title": "(GMT+00:00) Lisbon", "enabled": true },
-              { "value": "London", "title": "(GMT+00:00) London", "enabled": true },
-              { "value": "Monrovia", "title": "(GMT+00:00) Monrovia", "enabled": true },
-              { "value": "UTC", "title": "(GMT+00:00) UTC", "enabled": true },
-              { "value": "Amsterdam", "title": "(GMT+01:00) Amsterdam", "enabled": true },
-              { "value": "Belgrade", "title": "(GMT+01:00) Belgrade", "enabled": true },
-              { "value": "Berlin", "title": "(GMT+01:00) Berlin", "enabled": true },
-              { "value": "Bern", "title": "(GMT+01:00) Bern", "enabled": true },
-              { "value": "Bratislava", "title": "(GMT+01:00) Bratislava", "enabled": true },
-              { "value": "Brussels", "title": "(GMT+01:00) Brussels", "enabled": true },
-              { "value": "Budapest", "title": "(GMT+01:00) Budapest", "enabled": true },
-              { "value": "Casablanca", "title": "(GMT+01:00) Casablanca", "enabled": true },
-              { "value": "Copenhagen", "title": "(GMT+01:00) Copenhagen", "enabled": true },
-              { "value": "Ljubljana", "title": "(GMT+01:00) Ljubljana", "enabled": true },
-              { "value": "Madrid", "title": "(GMT+01:00) Madrid", "enabled": true },
-              { "value": "Oslo", "title": "(GMT+01:00) Oslo", "enabled": true },
-              { "value": "Paris", "title": "(GMT+01:00) Paris", "enabled": true },
-              { "value": "Prague", "title": "(GMT+01:00) Prague", "enabled": true },
-              { "value": "Rome", "title": "(GMT+01:00) Rome", "enabled": true },
-              { "value": "Sarajevo", "title": "(GMT+01:00) Sarajevo", "enabled": true },
-              { "value": "Skopje", "title": "(GMT+01:00) Skopje", "enabled": true },
-              { "value": "Stockholm", "title": "(GMT+01:00) Stockholm", "enabled": true },
-              { "value": "Vienna", "title": "(GMT+01:00) Vienna", "enabled": true },
-              { "value": "Warsaw", "title": "(GMT+01:00) Warsaw", "enabled": true },
-              { "value": "West Central Africa", "title": "(GMT+01:00) West Central Africa", "enabled": true },
-              { "value": "Zagreb", "title": "(GMT+01:00) Zagreb", "enabled": true },
-              { "value": "Athens", "title": "(GMT+02:00) Athens", "enabled": true },
-              { "value": "Bucharest", "title": "(GMT+02:00) Bucharest", "enabled": true },
-              { "value": "Cairo", "title": "(GMT+02:00) Cairo", "enabled": true },
-              { "value": "Harare", "title": "(GMT+02:00) Harare", "enabled": true },
-              { "value": "Helsinki", "title": "(GMT+02:00) Helsinki", "enabled": true },
-              { "value": "Jerusalem", "title": "(GMT+02:00) Jerusalem", "enabled": true },
-              { "value": "Kaliningrad", "title": "(GMT+02:00) Kaliningrad", "enabled": true },
-              { "value": "Kyev", "title": "(GMT+02:00) Kyev", "enabled": true },
-              { "value": "Kyiv", "title": "(GMT+02:00) Kyiv", "enabled": true },
-              { "value": "Pretoria", "title": "(GMT+02:00) Pretoria", "enabled": true },
-              { "value": "Riga", "title": "(GMT+02:00) Riga", "enabled": true },
-              { "value": "Sofia", "title": "(GMT+02:00) Sofia", "enabled": true },
-              { "value": "Tallinn", "title": "(GMT+02:00) Tallinn", "enabled": true },
-              { "value": "Vilnius", "title": "(GMT+02:00) Vilnius", "enabled": true },
-              { "value": "Baghdad", "title": "(GMT+03:00) Baghdad", "enabled": true },
-              { "value": "Istanbul", "title": "(GMT+03:00) Istanbul", "enabled": true },
-              { "value": "Kuwait", "title": "(GMT+03:00) Kuwait", "enabled": true },
-              { "value": "Minsk", "title": "(GMT+03:00) Minsk", "enabled": true },
-              { "value": "Moscow", "title": "(GMT+03:00) Moscow", "enabled": true },
-              { "value": "Nairobi", "title": "(GMT+03:00) Nairobi", "enabled": true },
-              { "value": "Riyadh", "title": "(GMT+03:00) Riyadh", "enabled": true },
-              { "value": "St. Petersburg", "title": "(GMT+03:00) St. Petersburg", "enabled": true },
-              { "value": "Tehran", "title": "(GMT+03:30) Tehran", "enabled": true },
-              { "value": "Abu Dhabi", "title": "(GMT+04:00) Abu Dhabi", "enabled": true },
-              { "value": "Baku", "title": "(GMT+04:00) Baku", "enabled": true },
-              { "value": "Muscat", "title": "(GMT+04:00) Muscat", "enabled": true },
-              { "value": "Samara", "title": "(GMT+04:00) Samara", "enabled": true },
-              { "value": "Tbilisi", "title": "(GMT+04:00) Tbilisi", "enabled": true },
-              { "value": "Volgograd", "title": "(GMT+04:00) Volgograd", "enabled": true },
-              { "value": "Yerevan", "title": "(GMT+04:00) Yerevan", "enabled": true },
-              { "value": "Kabul", "title": "(GMT+04:30) Kabul", "enabled": true },
-              { "value": "Ekaterinburg", "title": "(GMT+05:00) Ekaterinburg", "enabled": true },
-              { "value": "Islamabad", "title": "(GMT+05:00) Islamabad", "enabled": true },
-              { "value": "Karachi", "title": "(GMT+05:00) Karachi", "enabled": true },
-              { "value": "Tashkent", "title": "(GMT+05:00) Tashkent", "enabled": true },
-              { "value": "Chennai", "title": "(GMT+05:30) Chennai", "enabled": true },
-              { "value": "Kolkata", "title": "(GMT+05:30) Kolkata", "enabled": true },
-              { "value": "Mumbai", "title": "(GMT+05:30) Mumbai", "enabled": true },
-              { "value": "New Delhi", "title": "(GMT+05:30) New Delhi", "enabled": true },
-              { "value": "Sri Jayawardenepura", "title": "(GMT+05:30) Sri Jayawardenepura", "enabled": true },
-              { "value": "Kathmandu", "title": "(GMT+05:45) Kathmandu", "enabled": true },
-              { "value": "Almaty", "title": "(GMT+06:00) Almaty", "enabled": true },
-              { "value": "Astana", "title": "(GMT+06:00) Astana", "enabled": true },
-              { "value": "Dhaka", "title": "(GMT+06:00) Dhaka", "enabled": true },
-              { "value": "Urumqi", "title": "(GMT+06:00) Urumqi", "enabled": true },
-              { "value": "Rangoon", "title": "(GMT+06:30) Rangoon", "enabled": true },
-              { "value": "Bangkok", "title": "(GMT+07:00) Bangkok", "enabled": true },
-              { "value": "Hanoi", "title": "(GMT+07:00) Hanoi", "enabled": true },
-              { "value": "Jakarta", "title": "(GMT+07:00) Jakarta", "enabled": true },
-              { "value": "Krasnoyarsk", "title": "(GMT+07:00) Krasnoyarsk", "enabled": true },
-              { "value": "Novosibirsk", "title": "(GMT+07:00) Novosibirsk", "enabled": true },
-              { "value": "Beijing", "title": "(GMT+08:00) Beijing", "enabled": true },
-              { "value": "Chongqing", "title": "(GMT+08:00) Chongqing", "enabled": true },
-              { "value": "Hong Kong", "title": "(GMT+08:00) Hong Kong", "enabled": true },
-              { "value": "Irkutsk", "title": "(GMT+08:00) Irkutsk", "enabled": true },
-              { "value": "Kuala Lumpur", "title": "(GMT+08:00) Kuala Lumpur", "enabled": true },
-              { "value": "Perth", "title": "(GMT+08:00) Perth", "enabled": true },
-              { "value": "Singapore", "title": "(GMT+08:00) Singapore", "enabled": true },
-              { "value": "Taipei", "title": "(GMT+08:00) Taipei", "enabled": true },
-              { "value": "Ulaan Bataar", "title": "(GMT+08:00) Ulaanbataar", "enabled": true },
-              { "value": "Ulaanbaatar", "title": "(GMT+08:00) Ulaanbaatar", "enabled": true },
-              { "value": "Osaka", "title": "(GMT+09:00) Osaka", "enabled": true },
-              { "value": "Sapporo", "title": "(GMT+09:00) Sapporo", "enabled": true },
-              { "value": "Seoul", "title": "(GMT+09:00) Seoul", "enabled": true },
-              { "value": "Tokyo", "title": "(GMT+09:00) Tokyo", "enabled": true },
-              { "value": "Yakutsk", "title": "(GMT+09:00) Yakutsk", "enabled": true },
-              { "value": "Darwin", "title": "(GMT+09:30) Darwin", "enabled": true },
-              { "value": "Brisbane", "title": "(GMT+10:00) Brisbane", "enabled": true },
-              { "value": "Guam", "title": "(GMT+10:00) Guam", "enabled": true },
-              { "value": "Port Moresby", "title": "(GMT+10:00) Port Moresby", "enabled": true },
-              { "value": "Vladivostok", "title": "(GMT+10:00) Vladivostok", "enabled": true },
-              { "value": "Adelaide", "title": "(GMT+10:30) Adelaide", "enabled": true },
-              { "value": "Canberra", "title": "(GMT+11:00) Canberra", "enabled": true },
-              { "value": "Hobart", "title": "(GMT+11:00) Hobart", "enabled": true },
-              { "value": "Magadan", "title": "(GMT+11:00) Magadan", "enabled": true },
-              { "value": "Melbourne", "title": "(GMT+11:00) Melbourne", "enabled": true },
-              { "value": "New Caledonia", "title": "(GMT+11:00) New Caledonia", "enabled": true },
-              { "value": "Solomon Is.", "title": "(GMT+11:00) Solomon Is.", "enabled": true },
-              { "value": "Srednekolymsk", "title": "(GMT+11:00) Srednekolymsk", "enabled": true },
-              { "value": "Sydney", "title": "(GMT+11:00) Sydney", "enabled": true },
-              { "value": "Kamchatka", "title": "(GMT+12:00) Kamchatka", "enabled": true },
-              { "value": "Marshall Is.", "title": "(GMT+12:00) Marshall Is.", "enabled": true },
-              { "value": "Auckland", "title": "(GMT+13:00) Auckland", "enabled": true },
-              { "value": "Fiji", "title": "(GMT+13:00) Fiji", "enabled": true },
-              { "value": "Nuku'alofa", "title": "(GMT+13:00) Nuku'alofa", "enabled": true },
-              { "value": "Tokelau Is.", "title": "(GMT+13:00) Tokelau Is.", "enabled": true },
-              { "value": "Wellington", "title": "(GMT+13:00) Wellington", "enabled": true },
-              { "value": "Chatham Is.", "title": "(GMT+13:45) Chatham Is.", "enabled": true },
-              { "value": "Samoa", "title": "(GMT+14:00) Samoa", "enabled": true }
+              {
+                "value": "Indiana (East)",
+                "title": "(GMT-05:00) Indiana (East)",
+                "enabled": true
+              },
+              {
+                "value": "Lima",
+                "title": "(GMT-05:00) Lima",
+                "enabled": true
+              },
+              {
+                "value": "Quito",
+                "title": "(GMT-05:00) Quito",
+                "enabled": true
+              },
+              {
+                "value": "Atlantic Time (Canada)",
+                "title": "(GMT-04:00) Atlantic Time (Canada)",
+                "enabled": true
+              },
+              {
+                "value": "Caracas",
+                "title": "(GMT-04:00) Caracas",
+                "enabled": true
+              },
+              {
+                "value": "Georgetown",
+                "title": "(GMT-04:00) Georgetown",
+                "enabled": true
+              },
+              {
+                "value": "La Paz",
+                "title": "(GMT-04:00) La Paz",
+                "enabled": true
+              },
+              {
+                "value": "Puerto Rico",
+                "title": "(GMT-04:00) Puerto Rico",
+                "enabled": true
+              },
+              {
+                "value": "Newfoundland",
+                "title": "(GMT-03:30) Newfoundland",
+                "enabled": true
+              },
+              {
+                "value": "Brasilia",
+                "title": "(GMT-03:00) Brasilia",
+                "enabled": true
+              },
+              {
+                "value": "Buenos Aires",
+                "title": "(GMT-03:00) Buenos Aires",
+                "enabled": true
+              },
+              {
+                "value": "Greenland",
+                "title": "(GMT-03:00) Greenland",
+                "enabled": true
+              },
+              {
+                "value": "Montevideo",
+                "title": "(GMT-03:00) Montevideo",
+                "enabled": true
+              },
+              {
+                "value": "Santiago",
+                "title": "(GMT-03:00) Santiago",
+                "enabled": true
+              },
+              {
+                "value": "Mid-Atlantic",
+                "title": "(GMT-02:00) Mid-Atlantic",
+                "enabled": true
+              },
+              {
+                "value": "Azores",
+                "title": "(GMT-01:00) Azores",
+                "enabled": true
+              },
+              {
+                "value": "Cape Verde Is.",
+                "title": "(GMT-01:00) Cape Verde Is.",
+                "enabled": true
+              },
+              {
+                "value": "Dublin",
+                "title": "(GMT+00:00) Dublin",
+                "enabled": true
+              },
+              {
+                "value": "Edinburgh",
+                "title": "(GMT+00:00) Edinburgh",
+                "enabled": true
+              },
+              {
+                "value": "Lisbon",
+                "title": "(GMT+00:00) Lisbon",
+                "enabled": true
+              },
+              {
+                "value": "London",
+                "title": "(GMT+00:00) London",
+                "enabled": true
+              },
+              {
+                "value": "Monrovia",
+                "title": "(GMT+00:00) Monrovia",
+                "enabled": true
+              },
+              {
+                "value": "UTC",
+                "title": "(GMT+00:00) UTC",
+                "enabled": true
+              },
+              {
+                "value": "Amsterdam",
+                "title": "(GMT+01:00) Amsterdam",
+                "enabled": true
+              },
+              {
+                "value": "Belgrade",
+                "title": "(GMT+01:00) Belgrade",
+                "enabled": true
+              },
+              {
+                "value": "Berlin",
+                "title": "(GMT+01:00) Berlin",
+                "enabled": true
+              },
+              {
+                "value": "Bern",
+                "title": "(GMT+01:00) Bern",
+                "enabled": true
+              },
+              {
+                "value": "Bratislava",
+                "title": "(GMT+01:00) Bratislava",
+                "enabled": true
+              },
+              {
+                "value": "Brussels",
+                "title": "(GMT+01:00) Brussels",
+                "enabled": true
+              },
+              {
+                "value": "Budapest",
+                "title": "(GMT+01:00) Budapest",
+                "enabled": true
+              },
+              {
+                "value": "Casablanca",
+                "title": "(GMT+01:00) Casablanca",
+                "enabled": true
+              },
+              {
+                "value": "Copenhagen",
+                "title": "(GMT+01:00) Copenhagen",
+                "enabled": true
+              },
+              {
+                "value": "Ljubljana",
+                "title": "(GMT+01:00) Ljubljana",
+                "enabled": true
+              },
+              {
+                "value": "Madrid",
+                "title": "(GMT+01:00) Madrid",
+                "enabled": true
+              },
+              {
+                "value": "Oslo",
+                "title": "(GMT+01:00) Oslo",
+                "enabled": true
+              },
+              {
+                "value": "Paris",
+                "title": "(GMT+01:00) Paris",
+                "enabled": true
+              },
+              {
+                "value": "Prague",
+                "title": "(GMT+01:00) Prague",
+                "enabled": true
+              },
+              {
+                "value": "Rome",
+                "title": "(GMT+01:00) Rome",
+                "enabled": true
+              },
+              {
+                "value": "Sarajevo",
+                "title": "(GMT+01:00) Sarajevo",
+                "enabled": true
+              },
+              {
+                "value": "Skopje",
+                "title": "(GMT+01:00) Skopje",
+                "enabled": true
+              },
+              {
+                "value": "Stockholm",
+                "title": "(GMT+01:00) Stockholm",
+                "enabled": true
+              },
+              {
+                "value": "Vienna",
+                "title": "(GMT+01:00) Vienna",
+                "enabled": true
+              },
+              {
+                "value": "Warsaw",
+                "title": "(GMT+01:00) Warsaw",
+                "enabled": true
+              },
+              {
+                "value": "West Central Africa",
+                "title": "(GMT+01:00) West Central Africa",
+                "enabled": true
+              },
+              {
+                "value": "Zagreb",
+                "title": "(GMT+01:00) Zagreb",
+                "enabled": true
+              },
+              {
+                "value": "Athens",
+                "title": "(GMT+02:00) Athens",
+                "enabled": true
+              },
+              {
+                "value": "Bucharest",
+                "title": "(GMT+02:00) Bucharest",
+                "enabled": true
+              },
+              {
+                "value": "Cairo",
+                "title": "(GMT+02:00) Cairo",
+                "enabled": true
+              },
+              {
+                "value": "Harare",
+                "title": "(GMT+02:00) Harare",
+                "enabled": true
+              },
+              {
+                "value": "Helsinki",
+                "title": "(GMT+02:00) Helsinki",
+                "enabled": true
+              },
+              {
+                "value": "Jerusalem",
+                "title": "(GMT+02:00) Jerusalem",
+                "enabled": true
+              },
+              {
+                "value": "Kaliningrad",
+                "title": "(GMT+02:00) Kaliningrad",
+                "enabled": true
+              },
+              {
+                "value": "Kyev",
+                "title": "(GMT+02:00) Kyev",
+                "enabled": true
+              },
+              {
+                "value": "Kyiv",
+                "title": "(GMT+02:00) Kyiv",
+                "enabled": true
+              },
+              {
+                "value": "Pretoria",
+                "title": "(GMT+02:00) Pretoria",
+                "enabled": true
+              },
+              {
+                "value": "Riga",
+                "title": "(GMT+02:00) Riga",
+                "enabled": true
+              },
+              {
+                "value": "Sofia",
+                "title": "(GMT+02:00) Sofia",
+                "enabled": true
+              },
+              {
+                "value": "Tallinn",
+                "title": "(GMT+02:00) Tallinn",
+                "enabled": true
+              },
+              {
+                "value": "Vilnius",
+                "title": "(GMT+02:00) Vilnius",
+                "enabled": true
+              },
+              {
+                "value": "Baghdad",
+                "title": "(GMT+03:00) Baghdad",
+                "enabled": true
+              },
+              {
+                "value": "Istanbul",
+                "title": "(GMT+03:00) Istanbul",
+                "enabled": true
+              },
+              {
+                "value": "Kuwait",
+                "title": "(GMT+03:00) Kuwait",
+                "enabled": true
+              },
+              {
+                "value": "Minsk",
+                "title": "(GMT+03:00) Minsk",
+                "enabled": true
+              },
+              {
+                "value": "Moscow",
+                "title": "(GMT+03:00) Moscow",
+                "enabled": true
+              },
+              {
+                "value": "Nairobi",
+                "title": "(GMT+03:00) Nairobi",
+                "enabled": true
+              },
+              {
+                "value": "Riyadh",
+                "title": "(GMT+03:00) Riyadh",
+                "enabled": true
+              },
+              {
+                "value": "St. Petersburg",
+                "title": "(GMT+03:00) St. Petersburg",
+                "enabled": true
+              },
+              {
+                "value": "Tehran",
+                "title": "(GMT+03:30) Tehran",
+                "enabled": true
+              },
+              {
+                "value": "Abu Dhabi",
+                "title": "(GMT+04:00) Abu Dhabi",
+                "enabled": true
+              },
+              {
+                "value": "Baku",
+                "title": "(GMT+04:00) Baku",
+                "enabled": true
+              },
+              {
+                "value": "Muscat",
+                "title": "(GMT+04:00) Muscat",
+                "enabled": true
+              },
+              {
+                "value": "Samara",
+                "title": "(GMT+04:00) Samara",
+                "enabled": true
+              },
+              {
+                "value": "Tbilisi",
+                "title": "(GMT+04:00) Tbilisi",
+                "enabled": true
+              },
+              {
+                "value": "Volgograd",
+                "title": "(GMT+04:00) Volgograd",
+                "enabled": true
+              },
+              {
+                "value": "Yerevan",
+                "title": "(GMT+04:00) Yerevan",
+                "enabled": true
+              },
+              {
+                "value": "Kabul",
+                "title": "(GMT+04:30) Kabul",
+                "enabled": true
+              },
+              {
+                "value": "Ekaterinburg",
+                "title": "(GMT+05:00) Ekaterinburg",
+                "enabled": true
+              },
+              {
+                "value": "Islamabad",
+                "title": "(GMT+05:00) Islamabad",
+                "enabled": true
+              },
+              {
+                "value": "Karachi",
+                "title": "(GMT+05:00) Karachi",
+                "enabled": true
+              },
+              {
+                "value": "Tashkent",
+                "title": "(GMT+05:00) Tashkent",
+                "enabled": true
+              },
+              {
+                "value": "Chennai",
+                "title": "(GMT+05:30) Chennai",
+                "enabled": true
+              },
+              {
+                "value": "Kolkata",
+                "title": "(GMT+05:30) Kolkata",
+                "enabled": true
+              },
+              {
+                "value": "Mumbai",
+                "title": "(GMT+05:30) Mumbai",
+                "enabled": true
+              },
+              {
+                "value": "New Delhi",
+                "title": "(GMT+05:30) New Delhi",
+                "enabled": true
+              },
+              {
+                "value": "Sri Jayawardenepura",
+                "title": "(GMT+05:30) Sri Jayawardenepura",
+                "enabled": true
+              },
+              {
+                "value": "Kathmandu",
+                "title": "(GMT+05:45) Kathmandu",
+                "enabled": true
+              },
+              {
+                "value": "Almaty",
+                "title": "(GMT+06:00) Almaty",
+                "enabled": true
+              },
+              {
+                "value": "Astana",
+                "title": "(GMT+06:00) Astana",
+                "enabled": true
+              },
+              {
+                "value": "Dhaka",
+                "title": "(GMT+06:00) Dhaka",
+                "enabled": true
+              },
+              {
+                "value": "Urumqi",
+                "title": "(GMT+06:00) Urumqi",
+                "enabled": true
+              },
+              {
+                "value": "Rangoon",
+                "title": "(GMT+06:30) Rangoon",
+                "enabled": true
+              },
+              {
+                "value": "Bangkok",
+                "title": "(GMT+07:00) Bangkok",
+                "enabled": true
+              },
+              {
+                "value": "Hanoi",
+                "title": "(GMT+07:00) Hanoi",
+                "enabled": true
+              },
+              {
+                "value": "Jakarta",
+                "title": "(GMT+07:00) Jakarta",
+                "enabled": true
+              },
+              {
+                "value": "Krasnoyarsk",
+                "title": "(GMT+07:00) Krasnoyarsk",
+                "enabled": true
+              },
+              {
+                "value": "Novosibirsk",
+                "title": "(GMT+07:00) Novosibirsk",
+                "enabled": true
+              },
+              {
+                "value": "Beijing",
+                "title": "(GMT+08:00) Beijing",
+                "enabled": true
+              },
+              {
+                "value": "Chongqing",
+                "title": "(GMT+08:00) Chongqing",
+                "enabled": true
+              },
+              {
+                "value": "Hong Kong",
+                "title": "(GMT+08:00) Hong Kong",
+                "enabled": true
+              },
+              {
+                "value": "Irkutsk",
+                "title": "(GMT+08:00) Irkutsk",
+                "enabled": true
+              },
+              {
+                "value": "Kuala Lumpur",
+                "title": "(GMT+08:00) Kuala Lumpur",
+                "enabled": true
+              },
+              {
+                "value": "Perth",
+                "title": "(GMT+08:00) Perth",
+                "enabled": true
+              },
+              {
+                "value": "Singapore",
+                "title": "(GMT+08:00) Singapore",
+                "enabled": true
+              },
+              {
+                "value": "Taipei",
+                "title": "(GMT+08:00) Taipei",
+                "enabled": true
+              },
+              {
+                "value": "Ulaan Bataar",
+                "title": "(GMT+08:00) Ulaanbataar",
+                "enabled": true
+              },
+              {
+                "value": "Ulaanbaatar",
+                "title": "(GMT+08:00) Ulaanbaatar",
+                "enabled": true
+              },
+              {
+                "value": "Osaka",
+                "title": "(GMT+09:00) Osaka",
+                "enabled": true
+              },
+              {
+                "value": "Sapporo",
+                "title": "(GMT+09:00) Sapporo",
+                "enabled": true
+              },
+              {
+                "value": "Seoul",
+                "title": "(GMT+09:00) Seoul",
+                "enabled": true
+              },
+              {
+                "value": "Tokyo",
+                "title": "(GMT+09:00) Tokyo",
+                "enabled": true
+              },
+              {
+                "value": "Yakutsk",
+                "title": "(GMT+09:00) Yakutsk",
+                "enabled": true
+              },
+              {
+                "value": "Darwin",
+                "title": "(GMT+09:30) Darwin",
+                "enabled": true
+              },
+              {
+                "value": "Brisbane",
+                "title": "(GMT+10:00) Brisbane",
+                "enabled": true
+              },
+              {
+                "value": "Guam",
+                "title": "(GMT+10:00) Guam",
+                "enabled": true
+              },
+              {
+                "value": "Port Moresby",
+                "title": "(GMT+10:00) Port Moresby",
+                "enabled": true
+              },
+              {
+                "value": "Vladivostok",
+                "title": "(GMT+10:00) Vladivostok",
+                "enabled": true
+              },
+              {
+                "value": "Adelaide",
+                "title": "(GMT+10:30) Adelaide",
+                "enabled": true
+              },
+              {
+                "value": "Canberra",
+                "title": "(GMT+11:00) Canberra",
+                "enabled": true
+              },
+              {
+                "value": "Hobart",
+                "title": "(GMT+11:00) Hobart",
+                "enabled": true
+              },
+              {
+                "value": "Magadan",
+                "title": "(GMT+11:00) Magadan",
+                "enabled": true
+              },
+              {
+                "value": "Melbourne",
+                "title": "(GMT+11:00) Melbourne",
+                "enabled": true
+              },
+              {
+                "value": "New Caledonia",
+                "title": "(GMT+11:00) New Caledonia",
+                "enabled": true
+              },
+              {
+                "value": "Solomon Is.",
+                "title": "(GMT+11:00) Solomon Is.",
+                "enabled": true
+              },
+              {
+                "value": "Srednekolymsk",
+                "title": "(GMT+11:00) Srednekolymsk",
+                "enabled": true
+              },
+              {
+                "value": "Sydney",
+                "title": "(GMT+11:00) Sydney",
+                "enabled": true
+              },
+              {
+                "value": "Kamchatka",
+                "title": "(GMT+12:00) Kamchatka",
+                "enabled": true
+              },
+              {
+                "value": "Marshall Is.",
+                "title": "(GMT+12:00) Marshall Is.",
+                "enabled": true
+              },
+              {
+                "value": "Auckland",
+                "title": "(GMT+13:00) Auckland",
+                "enabled": true
+              },
+              {
+                "value": "Fiji",
+                "title": "(GMT+13:00) Fiji",
+                "enabled": true
+              },
+              {
+                "value": "Nuku'alofa",
+                "title": "(GMT+13:00) Nuku'alofa",
+                "enabled": true
+              },
+              {
+                "value": "Tokelau Is.",
+                "title": "(GMT+13:00) Tokelau Is.",
+                "enabled": true
+              },
+              {
+                "value": "Wellington",
+                "title": "(GMT+13:00) Wellington",
+                "enabled": true
+              },
+              {
+                "value": "Chatham Is.",
+                "title": "(GMT+13:45) Chatham Is.",
+                "enabled": true
+              },
+              {
+                "value": "Samoa",
+                "title": "(GMT+14:00) Samoa",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11299,17 +23675,53 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              }
             ],
             "values": [
-              { "value": "agent", "title": "(agent)", "enabled": true },
-              { "value": "end_user", "title": "(end-user)", "enabled": true },
-              { "value": "1911534269745", "title": "Person4", "enabled": true },
-              { "value": "1508591419201", "title": "Person1", "enabled": true },
-              { "value": "1520622229002", "title": "Person3", "enabled": true },
-              { "value": "1508485810561", "title": "Person2", "enabled": true },
-              { "value": "1523341727741", "title": "myBrand Dev", "enabled": true }
+              {
+                "value": "agent",
+                "title": "(agent)",
+                "enabled": true
+              },
+              {
+                "value": "end_user",
+                "title": "(end-user)",
+                "enabled": true
+              },
+              {
+                "value": "1911534269745",
+                "title": "Person4",
+                "enabled": true
+              },
+              {
+                "value": "1508591419201",
+                "title": "Person1",
+                "enabled": true
+              },
+              {
+                "value": "1520622229002",
+                "title": "Person3",
+                "enabled": true
+              },
+              {
+                "value": "1508485810561",
+                "title": "Person2",
+                "enabled": true
+              },
+              {
+                "value": "1523341727741",
+                "title": "myBrand Dev",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11320,15 +23732,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "component_a", "title": "Component A", "enabled": true },
-              { "value": "component_b", "title": "Component B", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "component_a",
+                "title": "Component A",
+                "enabled": true
+              },
+              {
+                "value": "component_b",
+                "title": "Component B",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11339,16 +23779,48 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "free", "title": "Free", "enabled": true },
-              { "value": "paying", "title": "Paying", "enabled": true },
-              { "value": "enterprise", "title": "Enterprise", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "free",
+                "title": "Free",
+                "enabled": true
+              },
+              {
+                "value": "paying",
+                "title": "Paying",
+                "enabled": true
+              },
+              {
+                "value": "enterprise",
+                "title": "Enterprise",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11359,15 +23831,43 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "includes", "title": "Includes", "terminal": false },
-              { "value": "not_includes", "title": "Does not include", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "includes",
+                "title": "Includes",
+                "terminal": false
+              },
+              {
+                "value": "not_includes",
+                "title": "Does not include",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "v1", "title": "v1", "enabled": true },
-              { "value": "v2_modified", "title": "v2", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "v1",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "v2_modified",
+                "title": "v2",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11378,8 +23878,16 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -11390,14 +23898,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11408,21 +23948,66 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false, "format": "date" },
-              { "value": "is_not", "title": "Is not", "terminal": false, "format": "date" },
-              { "value": "present", "title": "Present", "terminal": true, "format": "date" },
-              { "value": "not_present", "title": "Not present", "terminal": true, "format": "date" },
-              { "value": "less_than", "title": "Before", "terminal": false, "format": "date" },
-              { "value": "less_than_equal", "title": "Before or on", "terminal": false, "format": "date" },
-              { "value": "greater_than", "title": "After", "terminal": false, "format": "date" },
-              { "value": "greater_than_equal", "title": "After or on", "terminal": false, "format": "date" },
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true,
+                "format": "date"
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true,
+                "format": "date"
+              },
+              {
+                "value": "less_than",
+                "title": "Before",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Before or on",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "greater_than",
+                "title": "After",
+                "terminal": false,
+                "format": "date"
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "After or on",
+                "terminal": false,
+                "format": "date"
+              },
               {
                 "value": "within_previous_n_days",
                 "title": "Is within the previous",
                 "terminal": false,
                 "format": "integer"
               },
-              { "value": "within_next_n_days", "title": "Is within the next", "terminal": false, "format": "integer" }
+              {
+                "value": "within_next_n_days",
+                "title": "Is within the next",
+                "terminal": false,
+                "format": "integer"
+              }
             ]
           },
           {
@@ -11433,14 +24018,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -11451,14 +24068,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11469,16 +24118,48 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1500001753322", "title": "Choice1", "enabled": true },
-              { "value": "1500001753342", "title": "another choice", "enabled": true },
-              { "value": "1500001753362", "title": "bla", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1500001753322",
+                "title": "Choice1",
+                "enabled": true
+              },
+              {
+                "value": "1500001753342",
+                "title": "another choice",
+                "enabled": true
+              },
+              {
+                "value": "1500001753362",
+                "title": "bla",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11489,14 +24170,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11507,14 +24220,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11525,14 +24270,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11543,14 +24320,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11561,14 +24370,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11579,14 +24420,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11597,14 +24470,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11615,14 +24520,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11633,14 +24570,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11651,14 +24620,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11669,14 +24670,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11687,14 +24720,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11705,14 +24770,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11723,14 +24820,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11741,14 +24870,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11759,14 +24920,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11777,14 +24970,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11795,14 +25020,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11813,14 +25070,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11831,14 +25120,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11849,14 +25170,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11867,14 +25220,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -11885,14 +25270,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11902,10 +25319,24 @@
             "group": "requester",
             "nullable": true,
             "repeatable": false,
-            "operators": [{ "value": "is", "title": "Is", "terminal": false }],
+            "operators": [
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              }
+            ],
             "values": [
-              { "value": "true", "title": "Checked", "enabled": true },
-              { "value": "false", "title": "Unchecked", "enabled": true }
+              {
+                "value": "true",
+                "title": "Checked",
+                "enabled": true
+              },
+              {
+                "value": "false",
+                "title": "Unchecked",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11916,17 +25347,53 @@
             "nullable": true,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ],
             "values": [
-              { "value": "__NULL__", "title": "-", "enabled": true },
-              { "value": "1900000066065", "title": "123", "enabled": true },
-              { "value": "1900000066085", "title": "v1", "enabled": true },
-              { "value": "1900000066105", "title": "v2", "enabled": true },
-              { "value": "1900000066125", "title": "v3", "enabled": true }
+              {
+                "value": "__NULL__",
+                "title": "-",
+                "enabled": true
+              },
+              {
+                "value": "1900000066065",
+                "title": "123",
+                "enabled": true
+              },
+              {
+                "value": "1900000066085",
+                "title": "v1",
+                "enabled": true
+              },
+              {
+                "value": "1900000066105",
+                "title": "v2",
+                "enabled": true
+              },
+              {
+                "value": "1900000066125",
+                "title": "v3",
+                "enabled": true
+              }
             ]
           },
           {
@@ -11937,14 +25404,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11955,14 +25454,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11973,14 +25504,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -11991,14 +25554,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -12009,14 +25604,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true },
-              { "value": "includes_words", "title": "Contains at least one of the following words", "terminal": false },
-              { "value": "not_includes_words", "title": "Contains none of the following words", "terminal": false },
-              { "value": "includes_string", "title": "Contains the following string", "terminal": false },
-              { "value": "not_includes_string", "title": "Does not contain the following string", "terminal": false }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              },
+              {
+                "value": "includes_words",
+                "title": "Contains at least one of the following words",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_words",
+                "title": "Contains none of the following words",
+                "terminal": false
+              },
+              {
+                "value": "includes_string",
+                "title": "Contains the following string",
+                "terminal": false
+              },
+              {
+                "value": "not_includes_string",
+                "title": "Does not contain the following string",
+                "terminal": false
+              }
             ]
           },
           {
@@ -12027,14 +25654,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           },
           {
@@ -12045,14 +25704,46 @@
             "nullable": false,
             "repeatable": false,
             "operators": [
-              { "value": "is", "title": "Is", "terminal": false },
-              { "value": "less_than", "title": "Less than", "terminal": false },
-              { "value": "less_than_equal", "title": "Less than or equal to", "terminal": false },
-              { "value": "greater_than", "title": "Greater than", "terminal": false },
-              { "value": "greater_than_equal", "title": "Greater than or equal to", "terminal": false },
-              { "value": "is_not", "title": "Is not", "terminal": false },
-              { "value": "present", "title": "Present", "terminal": true },
-              { "value": "not_present", "title": "Not present", "terminal": true }
+              {
+                "value": "is",
+                "title": "Is",
+                "terminal": false
+              },
+              {
+                "value": "less_than",
+                "title": "Less than",
+                "terminal": false
+              },
+              {
+                "value": "less_than_equal",
+                "title": "Less than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "greater_than",
+                "title": "Greater than",
+                "terminal": false
+              },
+              {
+                "value": "greater_than_equal",
+                "title": "Greater than or equal to",
+                "terminal": false
+              },
+              {
+                "value": "is_not",
+                "title": "Is not",
+                "terminal": false
+              },
+              {
+                "value": "present",
+                "title": "Present",
+                "terminal": true
+              },
+              {
+                "value": "not_present",
+                "title": "Not present",
+                "terminal": true
+              }
             ]
           }
         ]
@@ -12061,16 +25752,22 @@
   },
   {
     "url": "/api/v2/webhooks",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
-      "meta": { "has_more": false },
+      "meta": {
+        "has_more": false
+      },
       "webhooks": [
         {
           "id": "01FTBADQMTH2C95HAE0FTSXNN5",
           "name": "test",
           "description": "",
           "status": "active",
-          "subscriptions": ["conditional_ticket_events"],
+          "subscriptions": [
+            "conditional_ticket_events"
+          ],
           "created_at": "2022-01-26T13:50:25Z",
           "created_by": "1523341727741",
           "updated_at": "2022-01-26T13:53:11Z",
@@ -12078,7 +25775,10 @@
           "endpoint": "https://example.com/status/200",
           "http_method": "GET",
           "request_format": "json",
-          "authentication": { "type": "bearer_token", "add_position": "header" }
+          "authentication": {
+            "type": "bearer_token",
+            "add_position": "header"
+          }
         }
       ]
     }
@@ -12124,7 +25824,9 @@
           "suspended": false,
           "default_group_id": 4414969685139,
           "report_csv": true,
-          "user_fields": { "userfield1": null }
+          "user_fields": {
+            "userfield1": null
+          }
         }
       ],
       "next_page": null,
@@ -12134,7 +25836,11 @@
   },
   {
     "url": "/api/v2/help_center/categories/7243705734931/articles",
-    "params": { "include": "translations", "sort_by": "updated_at", "page[size]": "100" },
+    "params": {
+      "include": "translations",
+      "sort_by": "updated_at",
+      "page[size]": "100"
+    },
     "response": {
       "count": 1,
       "next_page": null,
@@ -12195,7 +25901,10 @@
   },
   {
     "url": "/api/v2/help_center/categories",
-    "params": { "include": "translations", "page[size]": "100" },
+    "params": {
+      "include": "translations",
+      "page[size]": "100"
+    },
     "response": {
       "categories": [
         {
@@ -12275,7 +25984,9 @@
   },
   {
     "url": "/api/v2/help_center/user_segments",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "user_segments": [
         {
@@ -12307,7 +26018,10 @@
         {
           "id": 7243702759187,
           "user_type": "staff",
-          "group_ids": [6120409509651, 6120315606419],
+          "group_ids": [
+            6120409509651,
+            6120315606419
+          ],
           "organization_ids": [],
           "tags": [],
           "or_tags": [],
@@ -12321,23 +26035,37 @@
           "id": 7243628455955,
           "user_type": "signed_in_users",
           "group_ids": [],
-          "organization_ids": [6121341780755, 6121380831635],
+          "organization_ids": [
+            6121341780755,
+            6121380831635
+          ],
           "tags": [],
           "or_tags": [],
           "created_at": "2022-06-24T10:23:36Z",
           "updated_at": "2022-06-24T10:23:41Z",
           "built_in": false,
-          "added_user_ids": [1534261810821],
+          "added_user_ids": [
+            1534261810821
+          ],
           "name": "VIP Customers"
         }
       ]
     },
-    "meta": { "has_more": false, "after_cursor": null, "before_cursor": null },
-    "links": { "prev": null, "next": null }
+    "meta": {
+      "has_more": false,
+      "after_cursor": null,
+      "before_cursor": null
+    },
+    "links": {
+      "prev": null,
+      "next": null
+    }
   },
   {
     "url": "/api/v2/guide/permission_groups",
-    "params": { "per_page": "100" },
+    "params": {
+      "per_page": "100"
+    },
     "response": {
       "count": 1,
       "page_count": 1,
@@ -12360,7 +26088,10 @@
   },
   {
     "url": "/api/v2/help_center/sections",
-    "params": { "include": "translations", "page[size]": "100" },
+    "params": {
+      "include": "translations",
+      "page[size]": "100"
+    },
     "response": {
       "sections": [
         {
@@ -12584,7 +26315,9 @@
   },
   {
     "url": "/hc/api/internal/general_settings",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": {
       "help_center": {
         "settings": {
@@ -12725,11 +26458,22 @@
   },
   {
     "url": "/hc/api/internal/help_center_translations",
-    "params": { "page[size]": "100" },
+    "params": {
+      "page[size]": "100"
+    },
     "response": [
-      { "locale": "ar", "name": "c" },
-      { "locale": "en-us", "name": "Eden-test" },
-      { "locale": "he", "name": "test" }
+      {
+        "locale": "ar",
+        "name": "c"
+      },
+      {
+        "locale": "en-us",
+        "name": "Eden-test"
+      },
+      {
+        "locale": "he",
+        "name": "test"
+      }
     ],
     "headers": {
       "date": "Sun, 13 Nov 2022 15:41:43 GMT",
@@ -12792,7 +26536,11 @@
         "id": "0ce55de8ee341aacf08dc245316a0fb3",
         "status": "pending",
         "errors": null,
-        "data": { "download": { "url": "https://download.theme.url.for.test" } }
+        "data": {
+          "download": {
+            "url": "https://download.theme.url.for.test"
+          }
+        }
       }
     },
     "page": 1,
@@ -12808,7 +26556,12 @@
   {
     "url": "/api/v2/guide/theming/jobs/0ce55de8ee341aacf08dc245316a0fb3",
     "response": {
-      "job": { "id": "0ce55de8ee341aacf08dc245316a0fb3", "status": "completed", "errors": null, "data": null }
+      "job": {
+        "id": "0ce55de8ee341aacf08dc245316a0fb3",
+        "status": "completed",
+        "errors": null,
+        "data": null
+      }
     }
   }
 ]


### PR DESCRIPTION
This type seems to have been migrated to the new type of pagination

---

Ran fetch before and after the change, made sure the results are identical

---

_Release Notes_: 

Zendesk:
migrate dynamic_content_item fetching to use the new pagination system

---
_User Notifications_: 
None