### PR TITLE
SALTO-4730: Do not suggest to exclude types with many instances in allowReferenceTo

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -794,8 +794,10 @@ const filterTypesWithManyInstances = async ({
   const heavyTypesSuggestions: ConfigChangeSuggestion[] = []
 
   // Creates a lists of typeNames and changeSuggestions for types with too many instances
-  await awu(Object.keys(validChangesFetchSettings)).forEach(
-    async (typeName) => {
+  await awu(Object.entries(validChangesFetchSettings))
+    // Do not handle types that are in `allowReferenceTo`
+    .filter(([, setting]) => setting.isBase)
+    .forEach(async ([typeName]) => {
       const instancesCount = await client.countInstances(typeName)
       if (instancesCount > maxInstancesPerType) {
         typesToFilter.push(typeName)
@@ -807,8 +809,7 @@ const filterTypesWithManyInstances = async ({
           }),
         )
       }
-    },
-  )
+    })
 
   return {
     filteredChangesFetchSettings: _.omit(

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -795,7 +795,6 @@ const filterTypesWithManyInstances = async ({
 
   // Creates a lists of typeNames and changeSuggestions for types with too many instances
   await awu(Object.entries(validChangesFetchSettings))
-    // Do not handle types that are in `allowReferenceTo`
     .filter(([, setting]) => setting.isBase)
     .forEach(async ([typeName]) => {
       const instancesCount = await client.countInstances(typeName)

--- a/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_instances.test.ts
@@ -264,6 +264,7 @@ describe('Custom Object Instances filter', () => {
         getElemIdFunc: mockGetElemIdFunc,
       },
     }))
+    jest.spyOn(client, 'countInstances')
     setMockQueryResults(TestCustomRecords, false)
   })
 
@@ -2331,6 +2332,12 @@ describe('Custom Object Instances filter', () => {
             expect(elements).toSatisfyAny(
               (element) =>
                 element?.value?.[CUSTOM_OBJECT_ID_FIELD] === refToInstanceId,
+            )
+          })
+          it('should not count types in allowReferenceTo', () => {
+            expect(client.countInstances).toHaveBeenCalledWith(testTypeName)
+            expect(client.countInstances).not.toHaveBeenCalledWith(
+              refToTypeName,
             )
           })
         })


### PR DESCRIPTION
Do not suggest to exclude types with many instances in allowReferenceTo.

---

_Release Notes_: 
Salesforce Adapter:
- Do not suggest to exclude types with many instances that are under `allowReferenceTo`.

---
_User Notifications_: 
_None_
