### PR TITLE
SALTO-5384: enable deployment with null user

### DIFF
--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -40,6 +40,7 @@ export const VALID_USER_VALUES = [
   'agent',
   'end_user',
   '',
+  '__NULL__',
 ]
 export const MISSING_USERS_DOC_LINK =
   'https://help.salto.io/en/articles/6955302-element-references-users-which-don-t-exist-in-target-environment-zendesk'


### PR DESCRIPTION
enable deployment with null user

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* enable deployment of `__NULL__` as user

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
