### PR TITLE
SALTO-5704: Allow using transformation in recurseInto

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
@@ -13,7 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { TransformDefinition } from '../shared'
+import { types } from '@salto-io/lowerdash'
+import { ContextParams, TransformDefinition } from '../shared'
 
 export type DependsOnDefinition = {
   parentTypeName: string
@@ -32,9 +33,11 @@ export type Condition = ConditionByField | ConditionByContext
 
 export const isConditionByField = (condition: Condition): condition is ConditionByField => 'fromField' in condition
 
-type RecurseIntoContextParamDefinition = {
-  fromField: string // TODO replace with transformation config to align
-}
+type RecurseIntoContextParamDefinition<TContext = ContextParams> = types.OneOf<{
+  fromField: string,
+  transformation: TransformDefinition<TContext, string> & { single?: true } // set single to true as transform func should return a single string
+}>
+
 type RecurseIntoContext = {
   args: Record<string, RecurseIntoContextParamDefinition>
 }

--- a/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
@@ -34,7 +34,7 @@ export type Condition = ConditionByField | ConditionByContext
 export const isConditionByField = (condition: Condition): condition is ConditionByField => 'fromField' in condition
 
 type RecurseIntoContextParamDefinition<TContext = ContextParams> = types.OneOf<{
-  fromField: string,
+  fromField: string
   transformation: TransformDefinition<TContext, string> & { single?: true } // set single to true as transform func should return a single string
 }>
 

--- a/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
@@ -35,7 +35,7 @@ export const isConditionByField = (condition: Condition): condition is Condition
 
 type RecurseIntoContextParamDefinition<TContext = ContextParams> = types.OneOf<{
   fromField: string
-  transformation: TransformDefinition<TContext, string> & { single?: true } // set single to true as transform func should return a single string
+  transformation: TransformDefinition<TContext, string | string[]>
 }>
 
 type RecurseIntoContext = {

--- a/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/dependencies.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { types } from '@salto-io/lowerdash'
 import { ContextParams, TransformDefinition } from '../shared'
 
 export type DependsOnDefinition = {
@@ -33,10 +32,7 @@ export type Condition = ConditionByField | ConditionByContext
 
 export const isConditionByField = (condition: Condition): condition is ConditionByField => 'fromField' in condition
 
-type RecurseIntoContextParamDefinition<TContext = ContextParams> = types.OneOf<{
-  fromField: string
-  transformation: TransformDefinition<TContext, string | string[]>
-}>
+type RecurseIntoContextParamDefinition<TContext = ContextParams> = TransformDefinition<TContext, unknown>
 
 type RecurseIntoContext = {
   args: Record<string, RecurseIntoContextParamDefinition>

--- a/packages/adapter-components/src/fetch/resource/subresources.ts
+++ b/packages/adapter-components/src/fetch/resource/subresources.ts
@@ -37,7 +37,7 @@ const extractRecurseIntoContext = (
     const transformedItem = transformer(item)
     if (Array.isArray(transformedItem)) {
       return transformedItem.map(({ value }) => value)
-    } 
+    }
     return transformedItem?.value
   })
   return context

--- a/packages/adapter-components/src/fetch/resource/subresources.ts
+++ b/packages/adapter-components/src/fetch/resource/subresources.ts
@@ -15,16 +15,41 @@
  */
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
 import { FetchResourceDefinition } from '../../definitions/system/fetch/resource'
 import { TypeFetcherCreator, ValueGeneratedItem } from '../types'
 import { shouldRecurseIntoEntry } from '../../elements/instance_elements' // TODO move
 import { createValueTransformer } from '../utils'
+import { RecurseIntoDefinition } from '../../definitions/system/fetch/dependencies'
 
 const log = logger(module)
 
 type NestedResourceFetcher = (
   item: ValueGeneratedItem,
 ) => Promise<Record<string, ValueGeneratedItem[] | ValueGeneratedItem>>
+
+const extractRecurseIntoContext = (
+  item: ValueGeneratedItem,
+  recurseIntoDef: RecurseIntoDefinition,
+): Record<string, string | string[]> => {
+  const { args: contextArgs } = recurseIntoDef.context
+  const context = _.mapValues(contextArgs, contextDef => {
+    if (contextDef.fromField !== undefined) {
+      return _.get(item.value, contextDef.fromField)
+    }
+    const transformer = createValueTransformer(contextDef.transformation)
+    return collections.array
+      .makeArray(transformer(item))
+      .map(transformedItem => transformedItem.value)
+      .flatMap(value => {
+        if (_.isObject(value)) {
+          return Object.values(value).flatMap(val => collections.array.makeArray(val))
+        }
+        return value
+      })
+  })
+  return context
+}
 
 // TODO remove the old code when possible - originally called getExtraFieldValues
 export const recurseIntoSubresources =
@@ -44,13 +69,7 @@ export const recurseIntoSubresources =
           Object.entries(def.recurseInto ?? {})
             .filter(([_fieldName, { conditions }]) => shouldRecurseIntoEntry(item.value, item.context, conditions))
             .map(async ([fieldName, recurseDef]) => {
-              const nestedRequestContext = _.mapValues(recurseDef.context.args, contextDef => {
-                if (contextDef.fromField !== undefined) {
-                  return _.get(item.value, contextDef.fromField)
-                }
-                const transformer = createValueTransformer({ ...contextDef.transformation, single: true }) // transformer should return a single string value
-                return _.get(transformer(item), 'value')
-              })
+              const nestedRequestContext = extractRecurseIntoContext(item, recurseDef)
               // TODO avoid crashing if fails on sub-element (SALTO-5427)
               const typeFetcher = typeFetcherCreator({
                 typeName: recurseDef.typeName,

--- a/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
+++ b/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
@@ -174,7 +174,7 @@ describe('createAdapter', () => {
                     context: {
                       args: {
                         parent_id: {
-                          fromField: 'id',
+                          root: 'id',
                         },
                       },
                     },

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -152,7 +152,7 @@ describe('fetch', () => {
                         context: {
                           args: {
                             parent_id: {
-                              fromField: 'id',
+                              root: 'id',
                             },
                           },
                         },
@@ -163,7 +163,7 @@ describe('fetch', () => {
                         context: {
                           args: {
                             parent_id: {
-                              fromField: 'id',
+                              root: 'id',
                             },
                           },
                         },

--- a/packages/adapter-components/test/fetch/resource/subresources.test.ts
+++ b/packages/adapter-components/test/fetch/resource/subresources.test.ts
@@ -36,11 +36,13 @@ describe('subresources', () => {
           recurseInto: {
             mySubType: {
               typeName: 'mySubType',
-              context: { args: { 
-                id: { root: 'id' },
-                domain: { adjust: () => ({ value: ['custom'] }) },
-                context: { root: 'nested', pick: ['nestedId'], single: true },
-              } },
+              context: {
+                args: {
+                  id: { root: 'id' },
+                  domain: { adjust: () => ({ value: ['custom'] }) },
+                  context: { root: 'nested', pick: ['nestedId'], single: true },
+                },
+              },
             },
           },
         },

--- a/packages/adapter-components/test/fetch/resource/subresources.test.ts
+++ b/packages/adapter-components/test/fetch/resource/subresources.test.ts
@@ -1,0 +1,119 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { recurseIntoSubresources } from '../../../src/fetch/resource/subresources'
+import { FetchResourceDefinition } from '../../../src/definitions/system/fetch/resource'
+import { TypeFetcherCreator } from '../../../src/fetch/types'
+
+describe('subresources', () => {
+  describe('recurseIntoSubresources', () => {
+    const typeFetcherCreator: TypeFetcherCreator = jest.fn().mockImplementation(() => ({
+      fetch: jest.fn().mockResolvedValue({ success: true }),
+      done: jest.fn().mockReturnValue(true),
+      getItems: jest.fn().mockReturnValue([{ typeName: 'mySubType', value: { test: 'test' }, context: {} }]),
+    }))
+
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it('should extract request arg from field using fromField', async () => {
+      const def: Record<string, FetchResourceDefinition> = {
+        myType: {
+          directFetch: false,
+          recurseInto: {
+            mySubType: {
+              typeName: 'mySubType',
+              context: { args: { id: { fromField: 'id' }, name: { fromField: 'name' } } },
+            },
+          },
+        },
+        mySubType: { directFetch: false },
+      }
+
+      const recurseIntoFunc = recurseIntoSubresources({
+        def: def.myType,
+        typeFetcherCreator,
+        contextResources: {},
+      })
+      const myTypeValue = { id: '123', name: 'parent' }
+      await recurseIntoFunc({ typeName: 'myType', value: myTypeValue, context: {} })
+      expect(typeFetcherCreator).toHaveBeenCalledWith({ typeName: 'mySubType', context: { id: '123', name: 'parent' } })
+    })
+    it('should extract request arg from using recurseInto transformation', async () => {
+      const def: Record<string, FetchResourceDefinition> = {
+        myType: {
+          directFetch: false,
+          recurseInto: {
+            mySubType: {
+              typeName: 'mySubType',
+              context: { args: { id: { transformation: { root: 'nested', pick: ['id', 'nestedId'] } } } },
+            },
+          },
+        },
+        mySubType: { directFetch: false },
+      }
+
+      const recurseIntoFunc = recurseIntoSubresources({
+        def: def.myType,
+        typeFetcherCreator,
+        contextResources: {},
+      })
+      const myTypeValueA = { id: '123', nested: { id: '234', nestedId: '345' } }
+      await recurseIntoFunc({ typeName: 'myType', value: myTypeValueA, context: {} })
+      expect(typeFetcherCreator).toHaveBeenNthCalledWith(1, { typeName: 'mySubType', context: { id: ['234', '345'] } })
+
+      const myTypeValueB = { id: '123', nested: { id: ['234', '456'], nestedId: '345' } }
+      await recurseIntoFunc({ typeName: 'myType', value: myTypeValueB, context: {} })
+      expect(typeFetcherCreator).toHaveBeenNthCalledWith(2, {
+        typeName: 'mySubType',
+        context: { id: ['234', '456', '345'] },
+      })
+    })
+    it('should extract request arg from using recurseInto transformation with adjust function', async () => {
+      const def: Record<string, FetchResourceDefinition> = {
+        myType: {
+          directFetch: false,
+          recurseInto: {
+            mySubType: {
+              typeName: 'mySubType',
+              context: {
+                args: {
+                  id: { transformation: { adjust: () => ({ value: ['custom'] }) } },
+                  name: { fromField: 'name' },
+                },
+              },
+            },
+          },
+        },
+        mySubType: { directFetch: false },
+      }
+
+      const recurseIntoFunc = recurseIntoSubresources({
+        def: def.myType,
+        typeFetcherCreator,
+        contextResources: {},
+      })
+
+      const myTypeValue = { id: '123', name: 'foo' }
+      await recurseIntoFunc({ typeName: 'myType', value: myTypeValue, context: {} })
+      expect(typeFetcherCreator).toHaveBeenNthCalledWith(1, {
+        typeName: 'mySubType',
+        context: { id: ['custom'], name: 'foo' },
+      })
+    })
+  })
+})

--- a/packages/serviceplaceholder-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/fetch/fetch.ts
@@ -108,7 +108,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
           context: {
             args: {
               parent_id: {
-                fromField: 'id',
+                root: 'id',
               },
             },
           },


### PR DESCRIPTION
Allow passing transformation for recurseInto in order to adjust values before using in recurse into

---

_Additional context for reviewer_

---
_Release Notes_: 
None 

---
_User Notifications_: 
None
