### PR TITLE
SALTO-5413: Validating views with custom status conditions

### DIFF
--- a/packages/zendesk-adapter/src/change_validator.ts
+++ b/packages/zendesk-adapter/src/change_validator.ts
@@ -86,6 +86,7 @@ import {
   immutableTypeAndKeyForUserFieldsValidator,
   localeModificationValidator,
   emptyAutomationOrderValidator,
+  viewCustomStatusConditionsValidator,
 } from './change_validators'
 import ZendeskClient from './client/client'
 import { ChangeValidatorName, ZendeskDeployConfig, ZendeskFetchConfig, ZendeskConfig } from './config'
@@ -187,6 +188,7 @@ export default ({
     immutableTypeAndKeyForUserFields: immutableTypeAndKeyForUserFieldsValidator,
     localeModification: localeModificationValidator,
     emptyAutomationOrder: emptyAutomationOrderValidator,
+    viewCustomStatusConditions: viewCustomStatusConditionsValidator,
     // *** Guide Order Validators ***
     childInOrder: childInOrderValidator,
     childrenReferences: childrenReferencesValidator,

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -88,3 +88,4 @@ export { inactiveTicketFormInViewValidator } from './inactive_ticket_forms_in_vi
 export { immutableTypeAndKeyForUserFieldsValidator } from './immutable_fields_in_user_fields'
 export { localeModificationValidator } from './locale'
 export { emptyAutomationOrderValidator } from './empty_automation_order'
+export { viewCustomStatusConditionsValidator } from './view_custom_status_conditions'

--- a/packages/zendesk-adapter/src/change_validators/view_custom_status_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/view_custom_status_conditions.ts
@@ -56,7 +56,7 @@ export const viewCustomStatusConditionsValidator: ChangeValidator = async (chang
         severity: 'Error',
         message: "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled",
         detailedMessage:
-          "To enable custom ticket status conditions, please ensure that the custom ticket statuses feature is turned on. To do so, please update the 'custom_statuses_enabled' setting to 'true' in the account_settings.",
+          "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled. To apply conditions on custom ticket statuses, please activate this feature first. For help see: https://support.zendesk.com/hc/en-us/articles/4412575841306-Activating-custom-ticket-statuses.",
       }),
     )
 }

--- a/packages/zendesk-adapter/src/change_validators/view_custom_status_conditions.ts
+++ b/packages/zendesk-adapter/src/change_validators/view_custom_status_conditions.ts
@@ -1,0 +1,62 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import {
+  ChangeError,
+  ChangeValidator,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { VIEW_TYPE_NAME } from '../constants'
+import { getAccountSettings, AccountSettingsInstance } from './utils'
+
+const log = logger(module)
+
+export const viewCustomStatusConditionsValidator: ChangeValidator = async (changes, elementSource) => {
+  let accountSettings: AccountSettingsInstance
+  try {
+    accountSettings = await getAccountSettings(elementSource)
+  } catch (e) {
+    log.error(`Failed to run viewCustomStatusConditionsValidator: ${e.message}`)
+    return []
+  }
+
+  if (accountSettings.value.tickets.custom_statuses_enabled === true) {
+    return []
+  }
+
+  return changes
+    .filter(isAdditionOrModificationChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === VIEW_TYPE_NAME)
+    .filter(instance =>
+      _.concat(instance.value?.conditions?.all, instance.value?.conditions?.any).some(
+        cond => cond?.field === 'custom_status_id',
+      ),
+    )
+    .map(
+      (instance): ChangeError => ({
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled",
+        detailedMessage:
+          "To enable custom ticket status conditions, please ensure that the custom ticket statuses feature is turned on. To do so, please update the 'custom_statuses_enabled' setting to 'true' in the account_settings.",
+      }),
+    )
+}

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2943,6 +2943,7 @@ export type ChangeValidatorName =
   | 'immutableTypeAndKeyForUserFields'
   | 'localeModification'
   | 'emptyAutomationOrder'
+  | 'viewCustomStatusConditions'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -3021,6 +3022,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     immutableTypeAndKeyForUserFields: { refType: BuiltinTypes.BOOLEAN },
     localeModification: { refType: BuiltinTypes.BOOLEAN },
     emptyAutomationOrder: { refType: BuiltinTypes.BOOLEAN },
+    viewCustomStatusConditions: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/test/change_validators/active_action_features.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/active_action_features.test.ts
@@ -42,7 +42,7 @@ const createTestInstance = (type: string, field?: string): InstanceElement =>
     ],
   })
 
-describe('deflectionActionValidator', () => {
+describe('activeActionFeaturesValidator', () => {
   let deflectionTrigger: InstanceElement
   let deflectionAutomation: InstanceElement
   let deflectionMacro: InstanceElement

--- a/packages/zendesk-adapter/test/change_validators/view_custom_status_conditions.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/view_custom_status_conditions.test.ts
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from 'lodash'
 import { Change, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { elementSource, RemoteElementSource } from '@salto-io/workspace'
 import { VIEW_TYPE_NAME, ZENDESK } from '../../src/constants'
@@ -35,27 +36,19 @@ const createElementSource = (customStatusesEnabled: boolean): RemoteElementSourc
   return createInMemoryElementSource([accountSetting])
 }
 
-const createConditions = (customConditions: number, standardConditions: number): {}[] => {
-  const conditions = []
-
-  for (let i = 0; i < customConditions; i += 1) {
-    conditions.push({
+const createConditions = (customConditions: number, standardConditions: number): {}[] =>
+  _.concat(
+    _.range(customConditions).map(i => ({
       field: 'custom_status_id',
       operator: 'includes',
       value: `custom_status_${i}`,
-    })
-  }
-
-  for (let i = 0; i < standardConditions; i += 1) {
-    conditions.push({
+    })),
+    _.range(standardConditions).map(i => ({
       field: 'status',
       operator: 'is',
       value: `status_${i}`,
-    })
-  }
-
-  return conditions
-}
+    })),
+  )
 
 const createInstance = (
   allCustomConditions: number,
@@ -106,7 +99,7 @@ describe('viewCustomStatusConditionsValidator', () => {
         severity: 'Error',
         message: "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled",
         detailedMessage:
-          "To enable custom ticket status conditions, please ensure that the custom ticket statuses feature is turned on. To do so, please update the 'custom_statuses_enabled' setting to 'true' in the account_settings.",
+          "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled. To apply conditions on custom ticket statuses, please activate this feature first. For help see: https://support.zendesk.com/hc/en-us/articles/4412575841306-Activating-custom-ticket-statuses.",
       })),
     )
   })

--- a/packages/zendesk-adapter/test/change_validators/view_custom_status_conditions.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/view_custom_status_conditions.test.ts
@@ -1,0 +1,121 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Change, ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { elementSource, RemoteElementSource } from '@salto-io/workspace'
+import { VIEW_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { ACCOUNT_SETTING_TYPE_NAME } from '../../src/filters/account_settings'
+import { viewCustomStatusConditionsValidator } from '../../src/change_validators'
+
+const { createInMemoryElementSource } = elementSource
+
+const createElementSource = (customStatusesEnabled: boolean): RemoteElementSource => {
+  const accountSetting = new InstanceElement(
+    '_config',
+    new ObjectType({ elemID: new ElemID(ZENDESK, ACCOUNT_SETTING_TYPE_NAME) }),
+    {
+      active_features: {},
+      tickets: {
+        custom_statuses_enabled: customStatusesEnabled,
+      },
+    },
+  )
+  return createInMemoryElementSource([accountSetting])
+}
+
+const createConditions = (customConditions: number, standardConditions: number): {}[] => {
+  const conditions = []
+
+  for (let i = 0; i < customConditions; i += 1) {
+    conditions.push({
+      field: 'custom_status_id',
+      operator: 'includes',
+      value: `custom_status_${i}`,
+    })
+  }
+
+  for (let i = 0; i < standardConditions; i += 1) {
+    conditions.push({
+      field: 'status',
+      operator: 'is',
+      value: `status_${i}`,
+    })
+  }
+
+  return conditions
+}
+
+const createInstance = (
+  allCustomConditions: number,
+  allStandardConditions: number,
+  anyCustomConditions: number,
+  anyStandardConditions: number,
+): InstanceElement =>
+  new InstanceElement(
+    `view_${allCustomConditions}_${allStandardConditions}_${anyCustomConditions}_${anyStandardConditions}`,
+    new ObjectType({ elemID: new ElemID(ZENDESK, VIEW_TYPE_NAME) }),
+    {
+      conditions: {
+        all: createConditions(allCustomConditions, allStandardConditions),
+        any: createConditions(anyCustomConditions, anyStandardConditions),
+      },
+    },
+  )
+
+const toChanges = (views: InstanceElement[]): Change[] => views.map(view => toChange({ after: view }))
+
+describe('viewCustomStatusConditionsValidator', () => {
+  it('should return nothing when custom statuses are enabled', async () => {
+    const tempElementSource = createElementSource(true)
+    const changes = toChanges([createInstance(0, 0, 0, 0), createInstance(1, 0, 1, 0), createInstance(3, 3, 3, 3)])
+
+    const errors = await viewCustomStatusConditionsValidator(changes, tempElementSource)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should return nothing when no custom status conditions are defined', async () => {
+    const tempElementSource = createElementSource(false)
+    const changes = toChanges([createInstance(0, 0, 0, 0), createInstance(0, 1, 0, 2)])
+
+    const errors = await viewCustomStatusConditionsValidator(changes, tempElementSource)
+    expect(errors).toHaveLength(0)
+  })
+
+  it('should return errors when custom statuses are disabled but used in conditions', async () => {
+    const tempElementSource = createElementSource(false)
+    const validViews = [createInstance(0, 0, 0, 0), createInstance(0, 1, 0, 2)]
+    const invalidViews = [createInstance(1, 0, 1, 0), createInstance(3, 3, 3, 3)]
+    const changes = toChanges(validViews.concat(invalidViews))
+
+    const errors = await viewCustomStatusConditionsValidator(changes, tempElementSource)
+    expect(errors).toMatchObject(
+      invalidViews.map(view => ({
+        elemID: view.elemID,
+        severity: 'Error',
+        message: "View includes a condition on field 'custom_status_id' but custom ticket statuses are disabled",
+        detailedMessage:
+          "To enable custom ticket status conditions, please ensure that the custom ticket statuses feature is turned on. To do so, please update the 'custom_statuses_enabled' setting to 'true' in the account_settings.",
+      })),
+    )
+  })
+
+  it('should return nothing when there are no account settings', async () => {
+    const tempElementSource = createInMemoryElementSource()
+    const changes = toChanges([createInstance(0, 0, 0, 0), createInstance(1, 0, 1, 0), createInstance(3, 3, 3, 3)])
+
+    const errors = await viewCustomStatusConditionsValidator(changes, tempElementSource)
+    expect(errors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Adding a new validator that emits errors when custom statuses are disabled for the account but used in view conditions.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Zendesk_:
- Added a new validator that emit errors when custom statuses are disabled for the account but used in view conditions.

---
_User Notifications_: 
None.
