### PR TITLE
SALTO-5672: Retrying SFDC requests on disconnect/reset before headers

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -140,6 +140,7 @@ const errorMessagesToRetry = [
   'Internal_Error',
   'UNABLE_TO_LOCK_ROW', // we saw this in both fetch and deploy
   'no healthy upstream',
+  'upstream connect error or disconnect/reset before headers',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
Retrying SFDC requests on disconnect/reset before headers.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 

_Salesforce_:
- Retrying SFDC requests on disconnect/reset before headers.

---
_User Notifications_: 
None.
