### PR TITLE
SALTO-3041: Retrying SFDC requests on security policies timeout

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -141,6 +141,7 @@ const errorMessagesToRetry = [
   'UNABLE_TO_LOCK_ROW', // we saw this in both fetch and deploy
   'no healthy upstream',
   'upstream connect error or disconnect/reset before headers',
+  'security policies took too long to evaluate',
 ]
 
 type RateLimitBucketName = keyof ClientRateLimitConfig


### PR DESCRIPTION
Retrying SFDC requests on security policies timeout.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 

Salesforce:
- Retrying SFDC requests on "security policies took too long to evaluate".

---
_User Notifications_: 
None.
