### PR TITLE
SALTO-5711: Sort group membership members

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -129,7 +129,7 @@ const DEFAULT_FILTERS = [
   fieldReferencesFilter,
   // should run after fieldReferencesFilter
   addAliasFilter,
-  // should run after fieldReferencesFilter
+  // should run after fieldReferencesFilter and userFilter
   unorderedListsFilter,
   // should run before appDeploymentFilter and after userSchemaFilter
   serviceUrlFilter,

--- a/packages/okta-adapter/src/filters/group_members.ts
+++ b/packages/okta-adapter/src/filters/group_members.ts
@@ -101,7 +101,7 @@ const createGroupMembershipInstance = async (
     : undefined
 }
 
-const isValidGroupMembershipInstance = (instance: InstanceElement): instance is GroupMembershipInstance =>
+export const isValidGroupMembershipInstance = (instance: InstanceElement): instance is GroupMembershipInstance =>
   Array.isArray(instance.value.members) && instance.value.members.every(m => _.isString(m))
 
 const deployGroupAssignment = async ({

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -81,10 +81,10 @@ const filterCreator: FilterCreator = () => ({
     instances
       .filter(instance => instance.elemID.typeName === PASSWORD_RULE_TYPE_NAME)
       .forEach(instance => orderPasswordPolicyRuleMethods(instance))
-    
+
     instances
       .filter(instance => instance.elemID.typeName === GROUP_MEMBERSHIP_TYPE_NAME)
-      .forEach(instance => sortGroupMembershipMembers(instance))
+      .forEach(instance => sortGroupMembershipMembers(instance)) // we assume user ids were already converted to emails
   },
 })
 

--- a/packages/okta-adapter/src/filters/unordered_lists.ts
+++ b/packages/okta-adapter/src/filters/unordered_lists.ts
@@ -24,7 +24,8 @@ import {
 import { setPath, resolvePath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
-import { GROUP_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME } from '../constants'
+import { GROUP_MEMBERSHIP_TYPE_NAME, GROUP_RULE_TYPE_NAME, PASSWORD_RULE_TYPE_NAME } from '../constants'
+import { isValidGroupMembershipInstance } from './group_members'
 
 const log = logger(module)
 
@@ -59,6 +60,12 @@ const orderPasswordPolicyRuleMethods = (instance: InstanceElement): void => {
   }
 }
 
+const sortGroupMembershipMembers = (instance: InstanceElement): void => {
+  if (isValidGroupMembershipInstance(instance)) {
+    instance.value.members = instance.value.members.sort()
+  }
+}
+
 /**
  * Sort lists whose order changes between fetches, to avoid unneeded noise.
  */
@@ -74,6 +81,10 @@ const filterCreator: FilterCreator = () => ({
     instances
       .filter(instance => instance.elemID.typeName === PASSWORD_RULE_TYPE_NAME)
       .forEach(instance => orderPasswordPolicyRuleMethods(instance))
+    
+    instances
+      .filter(instance => instance.elemID.typeName === GROUP_MEMBERSHIP_TYPE_NAME)
+      .forEach(instance => sortGroupMembershipMembers(instance))
   },
 })
 

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -16,7 +16,7 @@
 
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, PASSWORD_RULE_TYPE_NAME } from '../../src/constants'
+import { GROUP_MEMBERSHIP_TYPE_NAME, GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, PASSWORD_RULE_TYPE_NAME } from '../../src/constants'
 import unorderedListsFilter from '../../src/filters/unordered_lists'
 import { getFilterParams } from '../utils'
 
@@ -104,6 +104,15 @@ describe('unorderedListsFilter', () => {
           selfServiceUnlock: { access: 'DENY' },
         },
       })
+    })
+  })
+
+  describe('GroupMembership instances', () => {
+    const groupMembershipType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_MEMBERSHIP_TYPE_NAME) })
+    it('should sort group membership members list', async () => {
+      const inst = new InstanceElement('inst', groupMembershipType, { members: ['c', 'a', 'b'] })
+      await filter.onFetch([inst, groupMembershipType])
+      expect(inst.value.members).toEqual(['a', 'b', 'c'])
     })
   })
 })

--- a/packages/okta-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/okta-adapter/test/filters/unordered_lists.test.ts
@@ -16,7 +16,13 @@
 
 import { ObjectType, ElemID, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
-import { GROUP_MEMBERSHIP_TYPE_NAME, GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA, PASSWORD_RULE_TYPE_NAME } from '../../src/constants'
+import {
+  GROUP_MEMBERSHIP_TYPE_NAME,
+  GROUP_RULE_TYPE_NAME,
+  GROUP_TYPE_NAME,
+  OKTA,
+  PASSWORD_RULE_TYPE_NAME,
+} from '../../src/constants'
 import unorderedListsFilter from '../../src/filters/unordered_lists'
 import { getFilterParams } from '../utils'
 


### PR DESCRIPTION
To avoid comparison noise, we should sort group members
this must be done after user filter to avoid sorting based on internal ids 

---

No noise reduction is needed as this is behind an FF 

---

_Release Notes_: 
None

---
_User Notifications_: 

_Okta_adapter_:
- members list in GroupMembership instances will be sorted