### PR TITLE
SALTO-5654: remove workflow missing reference to security level

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1086,6 +1086,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'FIELD_SECURITY_LEVEL_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
+    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: SECURITY_LEVEL_TYPE },
   },
   {

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -332,7 +332,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'issueSecurityLevelId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: SECURITY_LEVEL_TYPE },
   },
   {
@@ -1087,7 +1086,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'FIELD_SECURITY_LEVEL_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: SECURITY_LEVEL_TYPE },
   },
   {


### PR DESCRIPTION
_remove workflow missing reference to security level_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
