### PR TITLE
SALTO-5617: revert missing reference between workflow scheme to old workflow

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -654,13 +654,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'defaultWorkflow', parentTypes: ['WorkflowScheme'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_TYPE_NAME },
   },
   {
     src: { field: 'workflow', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_TYPE_NAME },
   },
   {


### PR DESCRIPTION
_revert missing reference between workflow scheme to old workflow_

---

_Additional context for reviewer_
* When turning on the new workflow flag it caused missing references to the old workflow in every workflowScheme object. It is because both types have a reference rule from workflowScheme to themself.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
