### PR TITLE
SALTO-5721: Consolidate missing ref strategies between okta and jira

### DIFF
--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -110,7 +110,7 @@ export type MissingReferenceStrategy = {
 
 export type MissingReferenceStrategyName = 'typeAndValue'
 
-export const MissingReferenceStrategyLookup: Record<MissingReferenceStrategyName, MissingReferenceStrategy> = {
+export const missingReferenceStrategyLookup: Record<MissingReferenceStrategyName, MissingReferenceStrategy> = {
   typeAndValue: {
     create: ({ value, adapter, typeName }) => {
       if (!_.isString(typeName) || !value) {
@@ -193,7 +193,9 @@ export class FieldReferenceResolver<T extends string> {
     this.serializationStrategy = ReferenceSerializationStrategyLookup[def.serializationStrategy ?? 'fullValue']
     this.sourceTransformation = ReferenceSourceTransformationLookup[def.sourceTransformation ?? 'exact']
     this.target = def.target ? { ...def.target, lookup: this.serializationStrategy.lookup } : undefined
-    this.missingRefStrategy = def.missingRefStrategy ? MissingReferenceStrategyLookup[def.missingRefStrategy] : undefined
+    this.missingRefStrategy = def.missingRefStrategy
+      ? missingReferenceStrategyLookup[def.missingRefStrategy]
+      : undefined
   }
 
   static create<S extends string>(def: FieldReferenceDefinition<S>): FieldReferenceResolver<S> {

--- a/packages/adapter-components/test/references/field_references.test.ts
+++ b/packages/adapter-components/test/references/field_references.test.ts
@@ -431,11 +431,12 @@ describe('Field references', () => {
       expect(folders[0].value.parent_id).not.toBeInstanceOf(ReferenceExpression)
       expect(folders[0].value.parent_id).toEqual('invalid')
     })
-    it('should not create missing reference if enableMissingReference is false (or not specified)', async () => {
+    it('should create missing reference if missingRefStrategy provided', async () => {
       const triggerWithMissingReference = elements.filter(
         e => isInstanceElement(e) && e.elemID.name === 'trigger2',
       )[0] as InstanceElement
-      expect(triggerWithMissingReference.value.ticket_field_id).not.toBeInstanceOf(ReferenceExpression)
+      expect(triggerWithMissingReference.value.ticket_field_id).toBeInstanceOf(ReferenceExpression)
+      expect(triggerWithMissingReference.value.ticket_field_id.elemID.name).toEqual('missing_3111')
     })
     describe("'exact' validation strategy", () => {
       const referee = new InstanceElement('referee', ticketFieldType, { id: '1234' })

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -26,7 +26,7 @@ const filter: FilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async (elements: Element[]) => {
     const fixedDefs = referencesRules.map(def =>
-      config.fetch.enableMissingReferences ? def : _.omit(def, 'jiraMissingRefStrategy'),
+      config.fetch.enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
     await referenceUtils.addReferences({
       elements,

--- a/packages/jira-adapter/src/filters/layouts/create_references_layouts.ts
+++ b/packages/jira-adapter/src/filters/layouts/create_references_layouts.ts
@@ -28,7 +28,7 @@ const filter: FilterCreator = ({ config }) => ({
   onFetch: async elements => {
     const layouts = elements.filter(isInstanceElement).filter(e => supportedLayouts.includes(e.elemID.typeName))
     const fixedDefs = referencesRules.map(def =>
-      config.fetch.enableMissingReferences ? def : _.omit(def, 'jiraMissingRefStrategy'),
+      config.fetch.enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
     await referenceUtils.addReferences({
       elements: layouts,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -91,22 +91,6 @@ import {
 const { awu } = collections.asynciterable
 const { neighborContextGetter, basicLookUp } = referenceUtils
 
-type jiraMissingReferenceStrategyName = referenceUtils.MissingReferenceStrategyName
-
-export const JiraMissingReferenceStrategyLookup: Record<
-  jiraMissingReferenceStrategyName,
-  referenceUtils.MissingReferenceStrategy
-> = {
-  typeAndValue: {
-    create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value) {
-        return undefined
-      }
-      return referenceUtils.createMissingInstance(adapter, typeName, value)
-    },
-  },
-}
-
 const neighborContextFunc = (args: {
   contextFieldName: string
   levelsUp?: number
@@ -215,19 +199,15 @@ const JiraReferenceSerializationStrategyLookup: Record<
 
 type JiraFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<ReferenceContextStrategyName> & {
   jiraSerializationStrategy?: JiraReferenceSerializationStrategyName
-  jiraMissingRefStrategy?: jiraMissingReferenceStrategyName
 }
 export class JiraFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<ReferenceContextStrategyName> {
   constructor(def: JiraFieldReferenceDefinition) {
-    super({ src: def.src, sourceTransformation: def.sourceTransformation ?? 'asString' })
+    super({ src: def.src, sourceTransformation: def.sourceTransformation ?? 'asString', missingRefStrategy: def.missingRefStrategy })
     this.serializationStrategy =
       JiraReferenceSerializationStrategyLookup[
         def.jiraSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
       ]
     this.target = def.target ? { ...def.target, lookup: this.serializationStrategy.lookup } : undefined
-    this.missingRefStrategy = def.jiraMissingRefStrategy
-      ? JiraMissingReferenceStrategyLookup[def.jiraMissingRefStrategy]
-      : undefined
   }
 }
 
@@ -249,25 +229,25 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'fieldConfigurationId', parentTypes: ['FieldConfigurationIssueTypeItem'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'FieldConfiguration' },
   },
   {
     src: { field: 'screenSchemeId', parentTypes: ['IssueTypeScreenSchemeItem'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'ScreenScheme' },
   },
   {
     src: { field: 'defaultIssueTypeId', parentTypes: [ISSUE_TYPE_SCHEMA_NAME] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'issueTypeIds', parentTypes: [ISSUE_TYPE_SCHEMA_NAME, 'CustomFieldContext'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
@@ -278,55 +258,55 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'id', parentTypes: ['WorkflowStatus'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'statusReference', parentTypes: ['WorkflowReferenceStatus'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'statusReference', parentTypes: ['WorkflowStatusAndPort'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'issueTypeId', parentTypes: ['StatusMappingDTO'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'projectId', parentTypes: ['StatusMappingDTO'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'oldStatusReference', parentTypes: ['StatusMigration'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'newStatusReference', parentTypes: ['StatusMigration'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'roleIds', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
     src: { field: 'roleId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
@@ -337,193 +317,193 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'fieldId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'sourceFieldKey', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'targetFieldKey', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'webhookId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: WEBHOOK_TYPE },
   },
   {
     src: { field: 'field', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'denyUserCustomFields', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'groupCustomFields', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'groupIds', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     jiraSerializationStrategy: 'groupId',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'statusIds', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'previousStatusIds', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'fromStatusId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'toStatusId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'screenId', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: SCREEN_TYPE_NAME },
   },
   {
     src: { field: 'date1FieldKey', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'date2FieldKey', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'fieldKey', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'fieldsRequired', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'groupsExemptFromValidation', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
     jiraSerializationStrategy: 'groupId',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'customIssueEventId', parentTypes: ['WorkflowTransitions'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_EVENT_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['TransitionScreenDetails'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
     src: { field: 'to', parentTypes: ['Transition'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'from', parentTypes: ['Transition'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['TransitionFrom'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['ProjectRoleConfig'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'ProjectRole' },
   },
   {
     src: { field: 'fieldId', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'destinationFieldId', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'sourceFieldId', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'date1', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'date2', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'fieldIds', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'fieldId', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'id', parentTypes: ['StatusRef'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
@@ -541,73 +521,73 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'id', parentTypes: ['ProjectPermission'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Project' },
   },
   {
     src: { field: 'id', parentTypes: ['ProjectRolePermission'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'ProjectRole' },
   },
   {
     src: { field: 'filterId', parentTypes: ['Board'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Filter' },
   },
   {
     src: { field: 'workflowScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'WorkflowScheme' },
   },
   {
     src: { field: 'issueTypeScreenScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'IssueTypeScreenScheme' },
   },
   {
     src: { field: 'fieldConfigurationScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'FieldConfigurationScheme' },
   },
   {
     src: { field: 'issueTypeScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_SCHEMA_NAME },
   },
   {
     src: { field: 'permissionScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'PermissionScheme' },
   },
   {
     src: { field: 'notificationScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'NotificationScheme' },
   },
   {
     src: { field: 'issueSecurityScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'SecurityScheme' },
   },
   {
     src: { field: 'priorityScheme', parentTypes: ['Project'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PRIORITY_SCHEME_TYPE_NAME },
   },
   {
     src: { field: 'fields', parentTypes: ['ScreenableTab'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
@@ -618,37 +598,37 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'projectId', parentTypes: ['Board_location', SCRIPT_RUNNER_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Project' },
   },
   {
     src: { field: 'projectKeyOrId', parentTypes: ['Board_location'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Project' },
   },
   {
     src: { field: 'edit', parentTypes: ['ScreenTypes'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
     src: { field: 'create', parentTypes: ['ScreenTypes'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
     src: { field: 'view', parentTypes: ['ScreenTypes'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
     src: { field: 'default', parentTypes: ['ScreenTypes'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
@@ -664,13 +644,13 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'workflow', parentTypes: ['WorkflowSchemeItem'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_CONFIGURATION_TYPE },
   },
   {
     src: { field: 'defaultWorkflow', parentTypes: ['WorkflowScheme'] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: WORKFLOW_CONFIGURATION_TYPE },
   },
   {
@@ -681,115 +661,115 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'statusId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'newStatusId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'issueTypeId', parentTypes: ['StatusMapping'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'field', parentTypes: [BOARD_ESTIMATION_TYPE, MAIL_LIST_TYPE_NAME] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'timeTracking', parentTypes: [BOARD_ESTIMATION_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'rankCustomFieldId', parentTypes: ['BoardConfiguration_ranking'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'statusCategory', parentTypes: [STATUS_TYPE_NAME] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'StatusCategory' },
   },
   {
     src: { field: 'defaultLevel', parentTypes: [SECURITY_SCHEME_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: SECURITY_LEVEL_TYPE },
   },
   {
     src: { field: 'projectId', parentTypes: [AUTOMATION_PROJECT_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'statuses', parentTypes: ['BoardConfiguration_columnConfig_columns'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['PostFunctionEvent'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'IssueEvent' },
   },
   {
     src: { field: 'eventType', parentTypes: ['NotificationSchemeEvent'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'IssueEvent' },
   },
   {
     src: { field: 'fieldId', parentTypes: ['ConditionConfiguration'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Field' },
   },
   {
     src: { field: 'groups', parentTypes: ['ConditionConfiguration'] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'group', parentTypes: ['ConditionConfiguration', MAIL_LIST_TYPE_NAME] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['ConditionStatus'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Status' },
   },
   {
     src: { field: 'id', parentTypes: ['ConditionProjectRole'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'ProjectRole' },
   },
   {
     src: { field: 'groups', parentTypes: ['ApplicationRole'] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'defaultGroups', parentTypes: ['ApplicationRole'] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
@@ -801,13 +781,13 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'name', parentTypes: ['GroupName'] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'groupName', parentTypes: [SCRIPT_RUNNER_TYPE] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
@@ -833,7 +813,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'linkTypeId', parentTypes: [SCRIPT_RUNNER_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_LINK_TYPE_NAME },
   },
   {
@@ -923,7 +903,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'fieldValue', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { typeContext: 'parentFieldId' },
   },
   {
@@ -969,13 +949,13 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'optionIds', parentTypes: ['PriorityScheme'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Priority' },
   },
   {
     src: { field: 'defaultOptionId', parentTypes: ['PriorityScheme'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Priority' },
   },
   {
@@ -986,25 +966,25 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'groups', parentTypes: ['UserFilter'] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'roleIds', parentTypes: ['UserFilter'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
     src: { field: 'roleId', parentTypes: [SCRIPT_RUNNER_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
     src: { field: 'FIELD_ROLE_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
@@ -1023,231 +1003,231 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     // for DC
     src: { field: 'groupIds', parentTypes: ['CustomFieldContextDefaultValue'] },
     serializationStrategy: 'nameWithPath',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     // for DC
     src: { field: 'groupId', parentTypes: ['CustomFieldContextDefaultValue'] },
     serializationStrategy: 'nameWithPath',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'projectId', parentTypes: ['CustomFieldContextDefaultValue'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'FIELD_RESOLUTION_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: RESOLUTION_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_EVENT_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_EVENT_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_TARGET_ISSUE_TYPE', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_TARGET_FIELD_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_SOURCE_FIELD_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_TARGET_PROJECT', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     jiraSerializationStrategy: 'key',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'FIELD_SELECTED_FIELDS', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_SECURITY_LEVEL_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: SECURITY_LEVEL_TYPE },
   },
   {
     src: { field: 'FIELD_BOARD_ID', parentTypes: [POST_FUNCTION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: BOARD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_STATUS_ID', parentTypes: [CONDITION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_LINKED_ISSUE_RESOLUTION', parentTypes: [CONDITION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: RESOLUTION_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_PROJECT_ROLE_IDS', parentTypes: [CONDITION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   {
     src: { field: 'FIELD_GROUP_NAMES', parentTypes: [CONDITION_CONFIGURATION] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'RESOLUTION_FIELD_NAME', parentTypes: [CONDITION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: RESOLUTION_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_LINKED_ISSUE_STATUS', parentTypes: [CONDITION_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_TEXT_FIELD', parentTypes: [CONDITION_CONFIGURATION, VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_USER_IN_FIELDS', parentTypes: [CONDITION_CONFIGURATION, VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_REQUIRED_FIELDS', parentTypes: [CONDITION_CONFIGURATION, VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_FIELD_IDS', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'FIELD_FORM_FIELD', parentTypes: [VALIDATOR_CONFIGURATION] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'linkType', parentTypes: [DIRECTED_LINK_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_LINK_TYPE_NAME },
   },
   {
     src: { field: 'field', parentTypes: [MAIL_LIST_TYPE_NAME] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'role', parentTypes: [MAIL_LIST_TYPE_NAME] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
   // ScriptRunner
   {
     src: { field: 'projects', parentTypes: [SCRIPT_RUNNER_LISTENER_TYPE] },
     jiraSerializationStrategy: 'key',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'projectKeys', parentTypes: [SCRIPTED_FIELD_TYPE] },
     jiraSerializationStrategy: 'key',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'issueTypes', parentTypes: [SCRIPTED_FIELD_TYPE] },
     serializationStrategy: 'name',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'projectId', parentTypes: [REQUEST_FORM_TYPE, ISSUE_VIEW_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'extraDefinerId', parentTypes: [ISSUE_LAYOUT_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Screen' },
   },
   {
     src: { field: 'key', parentTypes: ['issueLayoutItem'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'affectedFields', parentTypes: ['Behavior__config'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'projects', parentTypes: [BEHAVIOR_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'issueTypes', parentTypes: [BEHAVIOR_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ISSUE_TYPE_NAME },
   },
   {
     src: { field: 'notifications_group@b', parentTypes: [SCRIPT_RUNNER_SETTINGS_TYPE] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'excluded_notifications_groups@b', parentTypes: [SCRIPT_RUNNER_SETTINGS_TYPE] },
     jiraSerializationStrategy: 'groupStrategyByOriginalName',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'entities', parentTypes: [SCRIPT_FRAGMENT_TYPE] },
     jiraSerializationStrategy: 'key',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
@@ -1266,67 +1246,67 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
       ],
     },
     jiraSerializationStrategy: 'key',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {
     src: { field: 'ticketTypeIds', parentTypes: [PORTAL_GROUP_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: REQUEST_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['RequestType__workflowStatuses'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: STATUS_TYPE_NAME },
   },
   {
     src: { field: 'columns', parentTypes: [QUEUE_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'calendarId', parentTypes: ['SLA__config__goals', 'SLA__config__goals__subGoals'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: CALENDAR_TYPE },
   },
   {
     src: { field: 'extraDefinerId', parentTypes: [REQUEST_FORM_TYPE, ISSUE_VIEW_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: REQUEST_TYPE_NAME },
   },
   {
     src: { field: 'jiraField', parentTypes: ['Question'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {
     src: { field: 'parentObjectTypeId', parentTypes: [OBJECT_TYPE_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
   {
     src: { field: 'objectType', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
   {
     src: { field: 'typeValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
   {
     src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { typeContext: 'referenceTypeTypeName' },
   },
   {
@@ -1342,7 +1322,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'portalRequestTypeIds', parentTypes: ['FormPortal'] },
     serializationStrategy: 'id',
-    jiraMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: REQUEST_TYPE_NAME },
   },
   {

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -202,7 +202,11 @@ type JiraFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<Refe
 }
 export class JiraFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<ReferenceContextStrategyName> {
   constructor(def: JiraFieldReferenceDefinition) {
-    super({ src: def.src, sourceTransformation: def.sourceTransformation ?? 'asString', missingRefStrategy: def.missingRefStrategy })
+    super({
+      src: def.src,
+      sourceTransformation: def.sourceTransformation ?? 'asString',
+      missingRefStrategy: def.missingRefStrategy,
+    })
     this.serializationStrategy =
       JiraReferenceSerializationStrategyLookup[
         def.jiraSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'

--- a/packages/okta-adapter/src/filters/field_references.ts
+++ b/packages/okta-adapter/src/filters/field_references.ts
@@ -27,7 +27,7 @@ const filter: FilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async (elements: Element[]) => {
     const fixedDefs = referencesRules.map(def =>
-      config[FETCH_CONFIG].enableMissingReferences ? def : _.omit(def, 'oktaMissingRefStrategy'),
+      config[FETCH_CONFIG].enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
     await referenceUtils.addReferences({
       elements,

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash'
 import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
@@ -40,20 +39,6 @@ import {
 import { resolveUserSchemaRef } from './filters/expression_language'
 
 const { awu } = collections.asynciterable
-
-export const OktaMissingReferenceStrategyLookup: Record<
-  referenceUtils.MissingReferenceStrategyName,
-  referenceUtils.MissingReferenceStrategy
-> = {
-  typeAndValue: {
-    create: ({ value, adapter, typeName }) => {
-      if (!_.isString(typeName) || !value) {
-        return undefined
-      }
-      return referenceUtils.createMissingInstance(adapter, typeName, value)
-    },
-  },
-}
 
 type OktaReferenceSerializationStrategyName = 'key' | 'mappingRuleId'
 const OktaReferenceSerializationStrategyLookup: Record<
@@ -103,7 +88,6 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
 
 type OktaFieldReferenceDefinition = referenceUtils.FieldReferenceDefinition<ReferenceContextStrategyName> & {
   oktaSerializationStrategy?: OktaReferenceSerializationStrategyName
-  oktaMissingRefStrategy?: referenceUtils.MissingReferenceStrategyName
 }
 
 export class OktaFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<ReferenceContextStrategyName> {
@@ -113,9 +97,6 @@ export class OktaFieldReferenceResolver extends referenceUtils.FieldReferenceRes
       OktaReferenceSerializationStrategyLookup[
         def.oktaSerializationStrategy ?? def.serializationStrategy ?? 'fullValue'
       ]
-    this.missingRefStrategy = def.oktaMissingRefStrategy
-      ? OktaMissingReferenceStrategyLookup[def.oktaMissingRefStrategy]
-      : undefined
   }
 }
 
@@ -143,19 +124,19 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'groupIds', parentTypes: ['GroupRuleGroupAssignment'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'include', parentTypes: ['UserTypeCondition'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: USERTYPE_TYPE_NAME },
   },
   {
     src: { field: 'exclude', parentTypes: ['UserTypeCondition'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: USERTYPE_TYPE_NAME },
   },
   {
@@ -181,55 +162,55 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'id', parentTypes: ['IdpPolicyRuleActionProvider'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: IDENTITY_PROVIDER_TYPE_NAME },
   },
   {
     src: { field: 'profileEnrollment', parentTypes: [APPLICATION_TYPE_NAME] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROFILE_ENROLLMENT_POLICY_TYPE_NAME },
   },
   {
     src: { field: 'accessPolicy', parentTypes: [APPLICATION_TYPE_NAME] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: ACCESS_POLICY_TYPE_NAME },
   },
   {
     src: { field: 'targetGroupIds', parentTypes: ['ProfileEnrollmentPolicyRuleAction'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'inlineHookId', parentTypes: ['PreRegistrationInlineHook'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: INLINE_HOOK_TYPE_NAME },
   },
   {
     src: { field: 'key', parentTypes: ['MultifactorEnrollmentPolicyAuthenticatorSettings'] },
     oktaSerializationStrategy: 'key',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: AUTHENTICATOR_TYPE_NAME },
   },
   {
     src: { field: 'behaviors', parentTypes: ['RiskPolicyRuleCondition'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: BEHAVIOR_RULE_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['AppAndInstanceConditionEvaluatorAppOrInstance'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: APPLICATION_TYPE_NAME },
   },
   {
     src: { field: 'enabledGroup', parentTypes: ['BrowserPlugin'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
@@ -240,55 +221,55 @@ export const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'id', parentTypes: ['ProfileMappingSource'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { typeContext: 'profileMappingName' },
   },
   {
     src: { field: 'appInstanceId', parentTypes: ['AuthenticatorSettings'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: APPLICATION_TYPE_NAME },
   },
   {
     src: { field: 'id', parentTypes: ['Group__source'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: APPLICATION_TYPE_NAME },
   },
   {
     src: { field: 'include', parentTypes: ['DeviceCondition'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'DeviceAssurance' },
   },
   {
     src: { field: 'emailDomainId', parentTypes: ['Brand'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'EmailDomain' },
   },
   {
     src: { field: 'appInstanceId', parentTypes: ['DefaultApp'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: APPLICATION_TYPE_NAME },
   },
   {
     src: { field: 'brandId', parentTypes: ['Domain'] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: BRAND_TYPE_NAME },
   },
   {
     src: { field: 'userGroupId', parentTypes: [GROUP_PUSH_TYPE_NAME] },
     serializationStrategy: 'id',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
   },
   {
     src: { field: 'groupPushRule', parentTypes: [GROUP_PUSH_TYPE_NAME] },
     oktaSerializationStrategy: 'mappingRuleId',
-    oktaMissingRefStrategy: 'typeAndValue',
+    missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_PUSH_RULE_TYPE_NAME },
   },
 ]


### PR DESCRIPTION
Consolidate missing ref strategies between okta and jira and allow reusing missing ref strategies for other adapters


---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None