### PR TITLE
SALTO-5275: Fix Okta E2E

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -40,6 +40,7 @@ import {
   buildElementsSourceFromElements,
   detailedCompare,
   getParents,
+  inspectValue,
   naclCase,
   safeJsonStringify,
 } from '@salto-io/adapter-utils'
@@ -505,7 +506,16 @@ describe('Okta adapter E2E', () => {
         const instance = elements.filter(isInstanceElement).find(e => e.elemID.isEqual(deployedInstance.elemID))
         expect(instance).toBeDefined()
         // Omit '_links' as this field is hidden
-        expect(isEqualValues(_.omit(instance?.value, '_links'), deployedInstance.value)).toBeTruthy()
+        const originalValue = _.omit(instance?.value, '_links')
+        const isEqualResult = isEqualValues(originalValue, deployedInstance.value)
+        if (!isEqualResult) {
+          log.error('Received unexpected result when deploying instance: %s. Deployed value: %s , Recieved value after fetch: %s',
+          deployedInstance.elemID.getFullName(),
+          inspectValue(deployedInstance.value, { depth: 7 }),
+          inspectValue(originalValue, { depth: 7 })
+          )
+        }
+        expect(isEqualResult).toBeTruthy()
       })
     })
   })

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -509,10 +509,11 @@ describe('Okta adapter E2E', () => {
         const originalValue = _.omit(instance?.value, '_links')
         const isEqualResult = isEqualValues(originalValue, deployedInstance.value)
         if (!isEqualResult) {
-          log.error('Received unexpected result when deploying instance: %s. Deployed value: %s , Recieved value after fetch: %s',
-          deployedInstance.elemID.getFullName(),
-          inspectValue(deployedInstance.value, { depth: 7 }),
-          inspectValue(originalValue, { depth: 7 })
+          log.error(
+            'Received unexpected result when deploying instance: %s. Deployed value: %s , Received value after fetch: %s',
+            deployedInstance.elemID.getFullName(),
+            inspectValue(deployedInstance.value, { depth: 7 }),
+            inspectValue(originalValue, { depth: 7 }),
           )
         }
         expect(isEqualResult).toBeTruthy()

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -111,7 +111,6 @@ export const mockDefaultValues: Record<string, Values> = {
         slo: {
           enabled: false,
         },
-        signOnMode: 'SAML_2_0',
       },
       manualProvisioning: false,
       implicitAssignment: false,


### PR DESCRIPTION
Looks like Okta changed back SAML app structure after changing it back in november (https://github.com/salto-io/salto/pull/5075)

also added some logs for easier debugging next time

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None