### PR TITLE
SALTO-5599 Fix multiline regex to support $ before a reference

### DIFF
--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -50,7 +50,14 @@ export const TOKEN_TYPES = {
 
 const WORD_PART = '[a-zA-Z_][\\w.@]*'
 const NEWLINE_CHARS = '\r\n\u2028\u2029'
-const MULTILINE_CONTENT = new RegExp(`.*\\\\\\$\\{.*[${NEWLINE_CHARS}]|.*?(?=\\$\\{)|.*[${NEWLINE_CHARS}]`)
+// In multiline strings, we want to match content till a reference expression, so next token matches the reference.
+// to do this we use a lookahead that finds the '${', but matches the string without it. the next token should catch the full ${<reference>} expression.
+// But, if the origin string contains something like ${<some text> {<reference>}}, the $ will be escaped by us and we get \${<some text> {<reference>}}
+// So, we need to distinguish between '${' and '\${', and the first alternative in the regex actually checks for a '${' preceded by at least one char that isn't \
+// The second alternative checks for strings containing '\${', and stops right after, to avoid including real references that comes after
+// The third alternative matches any other string, till a new line.
+const MULTILINE_CONTENT = new RegExp(`.*?[^\\\\](?=\\$\\{)|.*\\\\\\$\\{|.*[${NEWLINE_CHARS}]`)
+const ALL_TILL_NEW_LINE = new RegExp(`.*[${NEWLINE_CHARS}]`)
 // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
 // We accept unicode newline characters because the string dump code does not treat them as newlines so they can appear
 // in a single line string
@@ -109,7 +116,7 @@ export const rules: Record<string, moo.Rules> = {
   mergeConflict: {
     [TOKEN_TYPES.MERGE_CONFLICT_MID]: '=======',
     [TOKEN_TYPES.MERGE_CONFLICT_END]: { match: '>>>>>>>', pop: 1 },
-    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: MULTILINE_CONTENT, lineBreaks: true },
+    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: ALL_TILL_NEW_LINE, lineBreaks: true },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
 }

--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -116,7 +116,7 @@ export const rules: Record<string, moo.Rules> = {
   mergeConflict: {
     [TOKEN_TYPES.MERGE_CONFLICT_MID]: '=======',
     [TOKEN_TYPES.MERGE_CONFLICT_END]: { match: '>>>>>>>', pop: 1 },
-    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: /.*[${NEWLINE_CHARS}]/, lineBreaks: true },
+    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: MULTILINE_CONTENT, lineBreaks: true },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
 }

--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -52,12 +52,12 @@ const WORD_PART = '[a-zA-Z_][\\w.@]*'
 const NEWLINE_CHARS = '\r\n\u2028\u2029'
 // In multiline strings, we want to match content till a reference expression, so next token matches the reference.
 // to do this we use a lookahead that finds the '${', but matches the string without it. the next token should catch the full ${<reference>} expression.
-// But, if the origin string contains something like ${<some text> {<reference>}}, the $ will be escaped by us and we get \${<some text> {<reference>}}
-// So, we need to distinguish between '${' and '\${', and the first alternative in the regex actually checks for a '${' preceded by at least one char that isn't \
+// But, if the origin string contains something like ${<some text> {<reference>}}, the $ will be escaped by us, and we get \${<some text> {<reference>}}
+// So, we need to distinguish between '${' and '\${'.
+// The first alternative in the regex actually checks for a '${' preceded by at least one char that isn't \
 // The second alternative checks for strings containing '\${', and stops right after, to avoid including real references that comes after
-// The third alternative matches any other string, till a new line.
+// The third alternative matches any other string, until a new line.
 const MULTILINE_CONTENT = new RegExp(`.*?[^\\\\](?=\\$\\{)|.*\\\\\\$\\{|.*[${NEWLINE_CHARS}]`)
-const ALL_TILL_NEW_LINE = new RegExp(`.*[${NEWLINE_CHARS}]`)
 // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
 // We accept unicode newline characters because the string dump code does not treat them as newlines so they can appear
 // in a single line string
@@ -116,7 +116,7 @@ export const rules: Record<string, moo.Rules> = {
   mergeConflict: {
     [TOKEN_TYPES.MERGE_CONFLICT_MID]: '=======',
     [TOKEN_TYPES.MERGE_CONFLICT_END]: { match: '>>>>>>>', pop: 1 },
-    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: ALL_TILL_NEW_LINE, lineBreaks: true },
+    [TOKEN_TYPES.CONFLICT_CONTENT]: { match: /.*[${NEWLINE_CHARS}]/, lineBreaks: true },
     [TOKEN_TYPES.ERROR]: moo.error,
   },
 }

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -36,8 +36,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { registerTestFunction, registerThrowingFunction } from '../utils'
-import { Functions } from '../../src/parser/functions'
-import { SourceRange, parse, SourceMap, tokenizeContent, ParseResult } from '../../src/parser'
+import { Functions, SourceRange, parse, SourceMap, tokenizeContent, ParseResult } from '../../src/parser'
 import { LexerErrorTokenReachedError } from '../../src/parser/internal/native/lexer'
 
 const { awu } = collections.asynciterable
@@ -230,6 +229,10 @@ describe('Salto parser', () => {
 multiline
 template {{$\{te@mp.late.instance.multiline_stuff@us}}}
 value
+'''
+        complex = '''
+multiline
+\${{$\{te@mp.late.instance.multiline_stuff@us}}} and {{$\{te@mp.late.instance.multiline_stuff@us}}}\${{$\{te@mp.late.instance.multiline_stuff@us}}}{{$\{te@mp.late.instance.multiline_stuff@us}}} hello
 '''
       }
       
@@ -731,6 +734,29 @@ value
             elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
           }),
           '}}\nvalue',
+        ])
+      })
+
+      it('should parse references to complex multiline template as TemplateExpression', () => {
+        expect(multilineRefObj.annotations.complex).toBeInstanceOf(TemplateExpression)
+        expect(multilineRefObj.annotations.complex.parts).toEqual([
+          'multiline\n${{',
+          expect.objectContaining({
+            elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
+          }),
+          '}} and {{',
+          expect.objectContaining({
+            elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
+          }),
+          '}}${{',
+          expect.objectContaining({
+            elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
+          }),
+          '}}{{',
+          expect.objectContaining({
+            elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
+          }),
+          '}} hello',
         ])
       })
     })

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -230,7 +230,7 @@ multiline
 template {{$\{te@mp.late.instance.multiline_stuff@us}}}
 value
 '''
-        complex = '''
+        escapedTemplateMarker = '''
 multiline
 \${{$\{te@mp.late.instance.multiline_stuff@us}}} and {{$\{te@mp.late.instance.multiline_stuff@us}}}\${{$\{te@mp.late.instance.multiline_stuff@us}}}{{$\{te@mp.late.instance.multiline_stuff@us}}} hello
 '''
@@ -737,9 +737,9 @@ multiline
         ])
       })
 
-      it('should parse references to complex multiline template as TemplateExpression', () => {
-        expect(multilineRefObj.annotations.complex).toBeInstanceOf(TemplateExpression)
-        expect(multilineRefObj.annotations.complex.parts).toEqual([
+      it('should parse references in multiline that exists on the same line as an escaped template marker as TemplateExpression', () => {
+        expect(multilineRefObj.annotations.escapedTemplateMarker).toBeInstanceOf(TemplateExpression)
+        expect(multilineRefObj.annotations.escapedTemplateMarker.parts).toEqual([
           'multiline\n${{',
           expect.objectContaining({
             elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),


### PR DESCRIPTION
Fix multiline regex to support $ before a reference
For example: "Cost:  ${{issue.Cost}} for year" - we should be able to escape the given $, and match the reference to cost

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
