### PR TITLE
SALTO-5722: allow filtering instances by type, status and group names in Okta

### DIFF
--- a/packages/okta-adapter/config_doc.md
+++ b/packages/okta-adapter/config_doc.md
@@ -90,9 +90,11 @@ okta {
 
 ## Fetch entry criteria
 
-| Name | Default when undefined | Description                                                                |
-| ---- | ---------------------- | -------------------------------------------------------------------------- |
-| name | .\*                    | A regex used to filter instances by matching the regex to their name value |
+| Name   | Default when undefined | Description                                                                                                         |
+| ------ | ---------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| name   | .\*                    | A regex used to filter instances by matching the regex to their name value. Groups will be filtered by profile.name |
+| type   | .\*                    | A regex used to filter instances by matching the regex to their type value                                          |
+| status | .\*                    | A regex used to filter instances by matching the regex to their status value                                        |
 
 ### Deploy configuration options
 

--- a/packages/okta-adapter/src/fetch_criteria.ts
+++ b/packages/okta-adapter/src/fetch_criteria.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 import { elements as elementUtils } from '@salto-io/adapter-components'
+import { GROUP_TYPE_NAME } from './constants'
+
+const oktaNameCriterion: elementUtils.query.QueryCriterion = ({ instance, value }): boolean =>
+  instance.elemID.typeName === GROUP_TYPE_NAME
+    ? elementUtils.query.fieldCriterionCreator('profile.name')({ instance, value })
+    : elementUtils.query.nameCriterion({ instance, value })
 
 export default {
-  name: elementUtils.query.nameCriterion,
+  name: oktaNameCriterion,
+  type: elementUtils.query.fieldCriterionCreator('type'),
+  status: elementUtils.query.fieldCriterionCreator('status'),
 }

--- a/packages/okta-adapter/test/fetch_criteria.test.ts
+++ b/packages/okta-adapter/test/fetch_criteria.test.ts
@@ -15,6 +15,7 @@
  */
 import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import fetchCriteria from '../src/fetch_criteria'
+import { GROUP_TYPE_NAME } from '../src/constants'
 
 describe('fetch_criteria', () => {
   describe('name', () => {
@@ -25,6 +26,41 @@ describe('fetch_criteria', () => {
 
       expect(fetchCriteria.name({ instance, value: '.ame' })).toBeTruthy()
       expect(fetchCriteria.name({ instance, value: 'ame' })).toBeFalsy()
+    })
+    it('should match group profile.name field', () => {
+      const instance = new InstanceElement(
+        'instance',
+        new ObjectType({ elemID: new ElemID('adapter', GROUP_TYPE_NAME) }),
+        {
+          type: 'OKTA_GROUP',
+          profile: { name: 'name' },
+        },
+      )
+
+      expect(fetchCriteria.name({ instance, value: '.ame' })).toBeTruthy()
+      expect(fetchCriteria.name({ instance, value: 'ame' })).toBeFalsy()
+    })
+  })
+  describe('type', () => {
+    it('should match element type', () => {
+      const instance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        name: 'name',
+        type: 'SAML_2_0',
+      })
+
+      expect(fetchCriteria.type({ instance, value: 'SAML_._0' })).toBeTruthy()
+      expect(fetchCriteria.type({ instance, value: 'OIDC' })).toBeFalsy()
+    })
+  })
+  describe('status', () => {
+    it('should match element status', () => {
+      const instance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        name: 'name',
+        status: 'ACTIVE',
+      })
+
+      expect(fetchCriteria.status({ instance, value: 'ACTIVE' })).toBeTruthy()
+      expect(fetchCriteria.status({ instance, value: 'INACTIVE' })).toBeFalsy()
     })
   })
 })


### PR DESCRIPTION
Allow filtering by type, status, group

---

Added originally to support the option to exclude the "Everyone" group

---
_Release Notes_: 

_Okta_adapter_:
- Allow filtering instances using fetch criteria by type, status, and group names. For example, to exclude all inactive apps, use:
```
okta = {
  fetch = {
    ...
    exclude = [
      {
        type = "Application"
        criteria = {
          status = "INACTIVE"
        }
      }
    ]
  }
}
```

---
_User Notifications_: 
None 