### PR TITLE
SALTO-5404: Set prettier to ignore json files under test folder

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+packages/*/test/*.json


### PR DESCRIPTION
We want to be able to define mock replies JSONs (like [this one](https://github.com/salto-io/salto/blob/main/packages/serviceplaceholder-adapter/test/fetch_mock_replies.json)) in a more concise format. Therefore, we should disable Prettier for JSON files located directly within test directories.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
