### PR TITLE
SALTO-5726: Improve SFDC non queryable fields warning

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -54,8 +54,8 @@ const createNonQueryableFieldsWarning = ({
 }): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Warning',
-  message: `The type of this instance (${apiNameSync(instance.getTypeSync())}) has inaccessible fields. Deploying the instance may be interpreted as deleting these fields.`,
-  detailedMessage: `The following fields were not readable/queryable by the user who last fetched this workspace. As a result, these fields are seen as empty, and when they are deployed their values will be erased in the target environment: ${fields.join(',')}`,
+  message: `The type of this instance (${apiNameSync(instance.getTypeSync())}) has inaccessible fields. Inaccessible fields might get deleted.`,
+  detailedMessage: `Some fields were not readable or queryable by the user who last fetched this workspace. As a result, these fields appear to have no value. Deploying these fields will cause their value in the service to be erased. The affected fields are: ${fields.join(',')}`,
 })
 
 /**

--- a/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
+++ b/packages/salesforce-adapter/src/change_validators/deleted_non_queryable_fields.ts
@@ -54,7 +54,7 @@ const createNonQueryableFieldsWarning = ({
 }): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Warning',
-  message: `The type of this instance (${apiNameSync(instance.getTypeSync())}) has inaccessible fields. Inaccessible fields might get deleted.`,
+  message: 'Inaccessible fields may lead to field deletion.',
   detailedMessage: `Some fields were not readable or queryable by the user who last fetched this workspace. As a result, these fields appear to have no value. Deploying these fields will cause their value in the service to be erased. The affected fields are: ${fields.join(',')}`,
 })
 

--- a/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/deleted_non_queryable_fields.test.ts
@@ -146,7 +146,7 @@ describe('deletedNonQueryableFields', () => {
           {
             elemID: getChangeData(changes[0]).elemID,
             severity: 'Warning',
-            message: expect.stringContaining('SomeType'),
+            message: 'Inaccessible fields may lead to field deletion.',
             detailedMessage: expect.stringContaining('SomeField'),
           },
         ])


### PR DESCRIPTION
Improving SFDC non queryable fields warning.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.