### PR TITLE
SALTO-5735: Add requestType field in automaiton

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1895,13 +1895,8 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
       idFields: ['name', 'projectKey'],
       sourceTypeName: 'RequestType__values',
       dataField: 'values',
-      fieldsToOmit: [
-        { fieldName: '_expands' },
-        { fieldName: 'portalId' },
-        { fieldName: 'groupIds' },
-        { fieldName: 'serviceDeskId' },
-      ],
-      fieldsToHide: [{ fieldName: 'id' }, { fieldName: 'icon' }],
+      fieldsToOmit: [{ fieldName: '_expands' }, { fieldName: 'portalId' }, { fieldName: 'groupIds' }],
+      fieldsToHide: [{ fieldName: 'id' }, { fieldName: 'icon' }, { fieldName: 'serviceDeskId' }],
       serviceIdField: 'id',
     },
     deployRequests: {

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -120,9 +120,7 @@ const ASSET_COMPONENT_SCHEME = Joi.object({
   })
     .unknown(true)
     .required(),
-})
-  .unknown(true)
-  .required()
+}).unknown(true)
 
 export const isAssetComponent = createSchemeGuard<AssetComponent>(ASSET_COMPONENT_SCHEME)
 
@@ -136,6 +134,7 @@ type requestTypeComponent = {
 const REQUEST_TYPE_COMPONENT_SCHEME = Joi.object({
   value: Joi.object({
     requestType: Joi.required(),
+    serviceDesk: Joi.string().optional(),
   })
     .unknown(true)
     .required(),
@@ -385,12 +384,9 @@ const modifyComponentsPreDeploy = (instance: InstanceElement, config: JiraConfig
   if (config.fetch.enableJSM) {
     const requestTypeComponents: requestTypeComponent[] = instance.value.components.filter(isRequestTypeComponent)
     requestTypeComponents.forEach(component => {
-      try {
-        const requestType = component.value.requestType.value
-        component.value.serviceDesk = requestType.value.serviceDeskId
-      } catch (e) {
-        log.warn(`Failed to update detailed request type components for ${instance.elemID.getFullName()}`)
-      }
+      const requestType = component.value.requestType.value
+      component.value.serviceDesk = requestType.value.serviceDeskId
+      log.warn(`Failed to update detailed request type components for ${instance.elemID.getFullName()}`)
     })
   }
 }

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -368,16 +368,12 @@ const modifyComponentsPreDeploy = (instance: InstanceElement, config: JiraConfig
   if (config.fetch.enableJSM && (config.fetch.enableJsmExperimental || config.fetch.enableJSMPremium)) {
     const assetsComponents: AssetComponent[] = instance.value.components.filter(isAssetComponent)
     assetsComponents.forEach(component => {
-      try {
-        const schema = component.value.schemaId.value
-        component.value.schemaLabel = schema.value.name
-        component.value.workspaceId = schema.value.workspaceId
-        if (component.value.objectTypeId !== undefined) {
-          const objectType = component.value.objectTypeId.value
-          component.value.objectTypeLabel = objectType.value.name
-        }
-      } catch (e) {
-        log.warn(`Failed to update detailed assets components for ${instance.elemID.getFullName()}`)
+      const schema = component.value.schemaId.value
+      component.value.schemaLabel = schema.value.name
+      component.value.workspaceId = schema.value.workspaceId
+      if (component.value.objectTypeId !== undefined) {
+        const objectType = component.value.objectTypeId.value
+        component.value.objectTypeLabel = objectType.value.name
       }
     })
   }
@@ -386,7 +382,6 @@ const modifyComponentsPreDeploy = (instance: InstanceElement, config: JiraConfig
     requestTypeComponents.forEach(component => {
       const requestType = component.value.requestType.value
       component.value.serviceDesk = requestType.value.serviceDeskId
-      log.warn(`Failed to update detailed request type components for ${instance.elemID.getFullName()}`)
     })
   }
 }

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -183,6 +183,13 @@ export const createAutomationTypes = (): {
       schemaId: { refType: BuiltinTypes.STRING },
       objectTypeLabel: { refType: BuiltinTypes.STRING },
       objectTypeId: { refType: BuiltinTypes.STRING },
+      requestType: { refType: BuiltinTypes.STRING },
+      serviceDesk: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+        },
+      },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1326,6 +1326,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'requestType', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
     target: { type: REQUEST_TYPE_NAME },
   },
   {

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1324,6 +1324,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: OBJECT_SCHEMA_TYPE },
   },
   {
+    src: { field: 'requestType', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: REQUEST_TYPE_NAME },
+  },
+  {
     src: { field: 'portalRequestTypeIds', parentTypes: ['FormPortal'] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',

--- a/packages/jira-adapter/test/filters/request_type.test.ts
+++ b/packages/jira-adapter/test/filters/request_type.test.ts
@@ -163,6 +163,7 @@ describe('requestType filter', () => {
         }
         throw new Error('Err')
       })
+      connection.post.mockResolvedValueOnce({ status: 200, data: { serviceDeskId: '1010' } })
     })
     it('should deploy addition of a request type', async () => {
       const res = await filter.deploy([{ action: 'add', data: { after: requestTypeInstance } }])


### PR DESCRIPTION
In this PR I modified the requestType field in automation to be a reference and added required `serviceDesk` field with the correct value.  

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
_Jira Adapter:_
* for automation nacls: serviceDesk field will be removed and requestType field will be converted from string to reference expression. 