### PR TITLE
SALTO-5686: Validate dynamic OS constraints on DeviceAssurancePolicy (Okta)

### DIFF
--- a/packages/okta-adapter/src/change_validators/dynamic_os_version_feature.ts
+++ b/packages/okta-adapter/src/change_validators/dynamic_os_version_feature.ts
@@ -28,6 +28,7 @@ const DYNAMIC_OS_VERSION_PATH_OPTIONS = [
   ['osVersion', 'dynamicVersionRequirement'],
   ['osVersionConstraints'],
   // support paths including additionalProperties for backward compatibility
+  // TODO - remove after SALTO-5332s
   ['osVersion', 'additionalProperties', 'dynamicVersionRequirement'],
   ['additionalProperties', 'osVersionConstraints'],
 ]

--- a/packages/okta-adapter/src/change_validators/dynamic_os_version_feature.ts
+++ b/packages/okta-adapter/src/change_validators/dynamic_os_version_feature.ts
@@ -1,0 +1,76 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { ChangeValidator, getChangeData, isInstanceChange, isAdditionOrModificationChange } from '@salto-io/adapter-api'
+import { DEVICE_ASSURANCE, FEATURE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+
+const DYNAMIC_OS_VERSION_FEATURE_NAME = 'Dynamic OS version compliance'
+
+const DYNAMIC_OS_VERSION_PATH_OPTIONS = [
+  ['osVersion', 'dynamicVersionRequirement'],
+  ['osVersionConstraints'],
+  // support paths including additionalProperties for backward compatibility
+  ['osVersion', 'additionalProperties', 'dynamicVersionRequirement'],
+  ['additionalProperties', 'osVersionConstraints'],
+]
+
+/**
+ * Device assurance policies only support defining dynamic OS constraints when Dynamic OS version compliance feature is enabled.
+ * The validaor verifies the feature is enabled in the account before attempting to deploy device assurance policies with dynamic OS constraints.
+ * source: https://developer.okta.com/docs/api/openapi/okta-management/management/tag/DeviceAssurance/
+ */
+export const dynamicOSVersionFeatureValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run dynamicOSVersionFeatureValidator because element source is undefined')
+    return []
+  }
+
+  const relevantDeviceAssuranceInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === DEVICE_ASSURANCE)
+    .filter(instance => DYNAMIC_OS_VERSION_PATH_OPTIONS.some(path => _.get(instance.value, path) !== undefined))
+
+  if (_.isEmpty(relevantDeviceAssuranceInstances)) {
+    return []
+  }
+
+  const dynamicOSVersionFeature = (await getInstancesFromElementSource(elementSource, [FEATURE_TYPE_NAME])).find(
+    instance => instance.value.name === DYNAMIC_OS_VERSION_FEATURE_NAME,
+  )
+
+  if (!dynamicOSVersionFeature) {
+    log.debug(`Failed to find ${DYNAMIC_OS_VERSION_FEATURE_NAME} feature, skipping dynamicOSVersionFeatureValidator`)
+    return []
+  }
+
+  if (dynamicOSVersionFeature.value.status === 'ENABLED') {
+    return []
+  }
+
+  return relevantDeviceAssuranceInstances.map(instance => ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: `${DYNAMIC_OS_VERSION_FEATURE_NAME} feature is not enabled in the account`,
+    detailedMessage: `This Device Assurance policy is using dynamic OS version constraints which requires the ${DYNAMIC_OS_VERSION_FEATURE_NAME} feature to be enabled in the account. To fix this error, enable this feature in your account, fetch your updated configuration through Salto and refresh this deployment.`,
+  }))
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -45,6 +45,7 @@ import {
   OktaConfig,
   PRIVATE_API_DEFINITIONS_CONFIG,
 } from '../config'
+import { dynamicOSVersionFeatureValidator } from './dynamic_os_version_feature'
 
 const { createCheckDeploymentBasedOnConfigValidator, getDefaultChangeValidators, createChangeValidator } =
   deployment.changeValidators
@@ -76,6 +77,7 @@ export default ({ client, config }: { client: OktaClient; config: OktaConfig }):
     appUrls: appUrlsValidator,
     profileMappingRemoval: profileMappingRemovalValidator,
     brandRemoval: brandRemovalValidator,
+    dynamicOSVersion: dynamicOSVersionFeatureValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1898,6 +1898,7 @@ export type ChangeValidatorName =
   | 'appUrls'
   | 'profileMappingRemoval'
   | 'brandRemoval'
+  | 'dynamicOSVersion'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -1926,6 +1927,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     appUrls: { refType: BuiltinTypes.BOOLEAN },
     profileMappingRemoval: { refType: BuiltinTypes.BOOLEAN },
     brandRemoval: { refType: BuiltinTypes.BOOLEAN },
+    dynamicOSVersion: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/test/change_validators/dynamic_os_version_feature.test.ts
+++ b/packages/okta-adapter/test/change_validators/dynamic_os_version_feature.test.ts
@@ -1,0 +1,135 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { dynamicOSVersionFeatureValidator } from '../../src/change_validators/dynamic_os_version_feature'
+import { OKTA, FEATURE_TYPE_NAME, DEVICE_ASSURANCE } from '../../src/constants'
+
+describe('dynamicOSVersionFeatureValidator', () => {
+  const message = 'Dynamic OS version compliance feature is not enabled in the account'
+  const detailedMessage =
+    'This Device Assurance policy is using dynamic OS version constraints which requires the Dynamic OS version compliance feature to be enabled in the account. To fix this error, enable this feature in your account, fetch your updated configuration through Salto and refresh this deployment.'
+  const deviceAssuranceType = new ObjectType({ elemID: new ElemID(OKTA, DEVICE_ASSURANCE) })
+  const featureType = new ObjectType({ elemID: new ElemID(OKTA, FEATURE_TYPE_NAME) })
+  const dynamicOSVersionFeature = new InstanceElement('a', featureType, {
+    type: 'self-service',
+    name: 'Dynamic OS version compliance',
+    status: 'DISABLED',
+  })
+  const randomFeature = new InstanceElement('b', featureType, {
+    type: 'self-service',
+    name: 'Random feature',
+    status: 'ENABLED',
+  })
+  const windowsAssuranceA = new InstanceElement('devicePolicy', deviceAssuranceType, {
+    platform: 'WINDOWS',
+    name: 'policiy',
+    osVersionConstraints: [{ majorVersionConstraint: 'WINDOWS_11', minimum: '10.0.22631.0' }],
+  })
+  const windowsAssuranceB = new InstanceElement('devicePolicyB', deviceAssuranceType, {
+    platform: 'WINDOWS',
+    name: 'policiy',
+    additionalProperties: {
+      osVersionConstraints: [{ majorVersionConstraint: 'WINDOWS_11', minimum: '10.0.22631.0' }],
+    },
+  })
+  const macOSAssuranceA = new InstanceElement('macOS', deviceAssuranceType, {
+    platform: 'MACOS',
+    name: 'mac policy',
+    osVersion: { dynamicVersionRequirement: { type: 'MINIMUM', distanceFromLatestMajor: 1 } },
+  })
+  const macOSAssuranceB = new InstanceElement('macOSB', deviceAssuranceType, {
+    platform: 'MACOS',
+    name: 'mac policy',
+    osVersion: { additionalProperties: { dynamicVersionRequirement: { type: 'MINIMUM', distanceFromLatestMajor: 1 } } },
+  })
+
+  it('should return an error when attempting to deploy device assurance policy with dynamic os constraints and the feature is disabled', async () => {
+    const elementSource = buildElementsSourceFromElements([
+      deviceAssuranceType,
+      featureType,
+      dynamicOSVersionFeature,
+      randomFeature,
+      windowsAssuranceA,
+      windowsAssuranceB,
+      macOSAssuranceA,
+      macOSAssuranceB,
+    ])
+    const changeErrors = await dynamicOSVersionFeatureValidator(
+      [
+        toChange({ after: windowsAssuranceA }),
+        toChange({ after: windowsAssuranceB }),
+        toChange({ before: macOSAssuranceA, after: macOSAssuranceA }),
+        toChange({ after: macOSAssuranceB }),
+      ],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(4)
+    expect(changeErrors).toEqual([
+      { elemID: windowsAssuranceA.elemID, severity: 'Error', message, detailedMessage },
+      { elemID: windowsAssuranceB.elemID, severity: 'Error', message, detailedMessage },
+      { elemID: macOSAssuranceA.elemID, severity: 'Error', message, detailedMessage },
+      { elemID: macOSAssuranceB.elemID, severity: 'Error', message, detailedMessage },
+    ])
+  })
+  it('should not return an error when attempting to deploy device assurance policy with dynamic os constraints and the feature is enabled', async () => {
+    const enabledFeature = dynamicOSVersionFeature.clone()
+    enabledFeature.value.status = 'ENABLED'
+    const elementSource = buildElementsSourceFromElements([
+      deviceAssuranceType,
+      featureType,
+      enabledFeature,
+      randomFeature,
+      windowsAssuranceA,
+      macOSAssuranceA,
+    ])
+    const changeErrors = await dynamicOSVersionFeatureValidator(
+      [toChange({ after: windowsAssuranceA }), toChange({ before: macOSAssuranceA, after: macOSAssuranceA })],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return an error when adding a device assurance policy with no dynamic os constraints and the feature is disabled', async () => {
+    const assuranceInsB = new InstanceElement('devicePolicy', deviceAssuranceType, {
+      platform: 'WINDOWS',
+      name: 'policiy',
+      osVersion: { minimum: '10.0.22631.0' },
+    })
+    const elementSource = buildElementsSourceFromElements([
+      deviceAssuranceType,
+      featureType,
+      dynamicOSVersionFeature,
+      randomFeature,
+      assuranceInsB,
+    ])
+    const changeErrors = await dynamicOSVersionFeatureValidator([toChange({ after: assuranceInsB })], elementSource)
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return an error when the feature is missing', async () => {
+    const elementSource = buildElementsSourceFromElements([
+      deviceAssuranceType,
+      featureType,
+      randomFeature,
+      windowsAssuranceA,
+      macOSAssuranceA,
+    ])
+    const changeErrors = await dynamicOSVersionFeatureValidator(
+      [toChange({ after: windowsAssuranceA }), toChange({ before: macOSAssuranceA, after: macOSAssuranceA })],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Add a validator to notify user when trying to deploy device assurance with dynamic os constraints and the feature is not enabled in the account.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Okta_adapter_:
- When deploying Device Assurance Policies with dynamic OS constraints, verify the dynamic OS feature is enabled in the target account

---
_User Notifications_: 
None