### PR TITLE
SALTO-5279: Cleaning up organization settings filter

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -110,7 +110,7 @@ import createMissingInstalledPackagesInstancesFilter from './filters/create_miss
 import metadataInstancesAliasesFilter from './filters/metadata_instances_aliases'
 import formulaDepsFilter from './filters/formula_deps'
 import removeUnixTimeZeroFilter from './filters/remove_unix_time_zero'
-import organizationWideDefaults from './filters/organization_wide_sharing_defaults'
+import organizationWideDefaults from './filters/organization_settings'
 import centralizeTrackingInfoFilter from './filters/centralize_tracking_info'
 import changedAtSingletonFilter from './filters/changed_at_singleton'
 import importantValuesFilter from './filters/important_values_filter'

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -151,7 +151,7 @@ const createOrganizationInstance = (
     ],
   )
 
-const FILTER_NAME = 'organizationWideSharingDefaults'
+const FILTER_NAME = 'organizationSettings'
 export const WARNING_MESSAGE = 'Failed to fetch OrganizationSettings.'
 
 const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
@@ -160,7 +160,6 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,
-    filterName: FILTER_NAME,
     fetchFilterFunc: async (elements) => {
       // SALTO-4821
       if (config.fetchProfile.metadataQuery.isFetchWithChangesDetection()) {

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -24,9 +24,8 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { RemoteFilterCreator } from '../filter'
-import { ensureSafeFilterFetch, queryClient } from './utils'
+import { ensureSafeFilterFetch, queryClient, safeApiName } from './utils'
 import {
-  apiName,
   getSObjectFieldElement,
   getTypePath,
 } from '../transformers/transformer'
@@ -75,7 +74,11 @@ const enrichTypeWithFields = async (
   fieldsToIgnore: Set<string>,
   fetchProfile: FetchProfile,
 ): Promise<void> => {
-  const typeApiName = await apiName(type)
+  const typeApiName = await safeApiName(type)
+  if (typeApiName === undefined) {
+    log.error('Failed getting OrganizationSettings API name.')
+    return
+  }
   const describeSObjectsResult = await client.describeSObjects([typeApiName])
   if (
     describeSObjectsResult.errors.length !== 0 ||

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -726,11 +726,14 @@ export const ensureSafeFilterFetch =
   }: {
     fetchFilterFunc: Required<Filter>['onFetch']
     warningMessage: string
-    filterName: keyof OptionalFeatures
     config: FilterContext
+    filterName?: keyof OptionalFeatures
   }): Required<Filter>['onFetch'] =>
   async (elements) => {
-    if (!config.fetchProfile.isFeatureEnabled(filterName)) {
+    if (
+      filterName !== undefined &&
+      !config.fetchProfile.isFeatureEnabled(filterName)
+    ) {
       log.debug('skipping %s filter due to configuration', filterName)
       return undefined
     }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -123,7 +123,6 @@ export type OptionalFeatures = {
   toolingDepsOfCurrentNamespace?: boolean
   useLabelAsAlias?: boolean
   fixRetrieveFilePaths?: boolean
-  organizationWideSharingDefaults?: boolean
   extendedCustomFieldInformation?: boolean
   importantValues?: boolean
   hideTypesFolder?: boolean
@@ -832,7 +831,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
     fixRetrieveFilePaths: { refType: BuiltinTypes.BOOLEAN },
-    organizationWideSharingDefaults: { refType: BuiltinTypes.BOOLEAN },
     extendedCustomFieldInformation: { refType: BuiltinTypes.BOOLEAN },
     importantValues: { refType: BuiltinTypes.BOOLEAN },
     hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { CORE_ANNOTATIONS, Element, ElemID } from '@salto-io/adapter-api'
-import filterCreator from '../../src/filters/organization_wide_sharing_defaults'
+import filterCreator from '../../src/filters/organization_settings'
 import mockAdapter from '../adapter'
 import * as filterUtilsModule from '../../src/filters/utils'
 import {


### PR DESCRIPTION
In preparation for fetching supported API versions.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.