### PR TITLE
SALTO-5747: recursiveNaclCase is not iterating inner value

### DIFF
--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -22,7 +22,7 @@ import {
   ReferenceExpression,
   Values,
 } from '@salto-io/adapter-api'
-import { TransformFuncSync, invertNaclCase, naclCase, transformValuesSync } from '@salto-io/adapter-utils'
+import { TransformFuncSync, invertNaclCase, mapKeysRecursive, naclCase, transformValuesSync } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { FetchApiDefinitionsOptions, InstanceFetchApiDefinitions } from '../../definitions/system/fetch'
 import { DefQuery, NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'
@@ -38,7 +38,7 @@ import { ElementAndResourceDefFinder } from '../../definitions/system/fetch/type
  */
 export const recursiveNaclCase = (value: Values, invert = false): Values => {
   const func = invert ? invertNaclCase : naclCase
-  return _.cloneDeepWith(value, val => (_.isPlainObject(val) ? _.mapKeys(val, (_v, k) => func(k)) : val))
+  return mapKeysRecursive(value, ({ key }) => func(key))
 }
 
 /**

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -22,7 +22,13 @@ import {
   ReferenceExpression,
   Values,
 } from '@salto-io/adapter-api'
-import { TransformFuncSync, invertNaclCase, mapKeysRecursive, naclCase, transformValuesSync } from '@salto-io/adapter-utils'
+import {
+  TransformFuncSync,
+  invertNaclCase,
+  mapKeysRecursive,
+  naclCase,
+  transformValuesSync,
+} from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { FetchApiDefinitionsOptions, InstanceFetchApiDefinitions } from '../../definitions/system/fetch'
 import { DefQuery, NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'

--- a/packages/adapter-components/test/fetch/element/instance_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_utils.test.ts
@@ -21,6 +21,7 @@ import {
   getInstanceCreationFunctions,
   createInstance,
   omitInstanceValues,
+  recursiveNaclCase,
 } from '../../../src/fetch/element/instance_utils'
 
 describe('instance utils', () => {
@@ -130,6 +131,48 @@ describe('instance utils', () => {
           defQuery,
         }),
       ).toEqual({ str: 'A', something: 'a' })
+    })
+  })
+  describe('recursiveNaclCase', () => {
+    describe('when invert is false', () => {
+      it('should nacl case all keys in object', () => {
+        const obj = {
+          id: 'abc',
+          'some.key': { val: 'a' },
+          arr: [{ $foo: 'a', bar: 'b' }],
+          innerObj: {
+            'i.n.n.e.r': 'a',
+          },
+        }
+        expect(recursiveNaclCase(obj)).toEqual({
+          id: 'abc',
+          'some_key@v': { val: 'a' },
+          arr: [{ '_foo@zc': 'a', bar: 'b' }],
+          innerObj: {
+            'i_n_n_e_r@v': 'a',
+          },
+        })
+      })
+    })
+    describe('when invert is true', () => {
+      it('should invert nacl case all keys in object', () => {
+        const obj = {
+          id: 'abc',
+          'some_key@v': { val: 'a' },
+          arr: [{ '_foo@zc': 'a', bar: 'b' }],
+          innerObj: {
+            'i_n_n_e_r@v': 'a',
+          },
+        }
+        expect(recursiveNaclCase(obj, true)).toEqual({
+          id: 'abc',
+          'some.key': { val: 'a' },
+          arr: [{ $foo: 'a', bar: 'b' }],
+          innerObj: {
+            'i.n.n.e.r': 'a',
+          },
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
recursiveNaclCase was only changing top level keys

---

The issue was that `cloneDeepWith` was not iterating through the value once it received the result from the customizer

---
_Release Notes_: 
None

---
_User Notifications_: 
None
