### PR TITLE
SALTO-5279: Validating SFDC flows do not use an unsupported API version

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -49,9 +49,10 @@ import instanceWithUnknownType from './change_validators/instance_with_unknown_t
 import artificialTypes from './change_validators/artificial_types'
 import taskOrEventFieldsModifications from './change_validators/task_or_event_fields_modifications'
 import newFieldsAndObjectsFLS from './change_validators/new_fields_and_objects_fls'
+import metadataTypes from './change_validators/metadata_types'
+import elementApiVersionValidator from './change_validators/element_api_version'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
-import metadataTypes from './change_validators/metadata_types'
 
 const { createChangeValidator, getDefaultChangeValidators } =
   deployment.changeValidators
@@ -108,6 +109,7 @@ export const changeValidators: Record<
   metadataTypes: () => metadataTypes,
   taskOrEventFieldsModifications: () => taskOrEventFieldsModifications,
   newFieldsAndObjectsFLS: (config) => newFieldsAndObjectsFLS(config),
+  elementApiVersion: () => elementApiVersionValidator,
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/element_api_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/element_api_version.ts
@@ -1,0 +1,58 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { ChangeValidator, ElemID, getChangeData } from '@salto-io/adapter-api'
+import {
+  FLOW_METADATA_TYPE,
+  ORGANIZATION_SETTINGS,
+  SALESFORCE,
+} from '../constants'
+import { LATEST_SUPPORTED_API_VERSION_FIELD } from '../filters/organization_settings'
+import { isInstanceOfTypeSync } from '../filters/utils'
+
+const log = logger(module)
+
+const VERSIONED_TYPES = [FLOW_METADATA_TYPE]
+
+const elementApiVersionValidator: ChangeValidator = async (
+  changes,
+  elementsSource,
+) => {
+  const orgSettings = await elementsSource?.get(
+    new ElemID(SALESFORCE, ORGANIZATION_SETTINGS, 'instance'),
+  )
+  const latestApiVersion =
+    orgSettings?.value[LATEST_SUPPORTED_API_VERSION_FIELD]
+
+  if (!_.isNumber(latestApiVersion)) {
+    log.error('Could not get the latest supported API version.')
+    return []
+  }
+
+  return changes
+    .map(getChangeData)
+    .filter(isInstanceOfTypeSync(...VERSIONED_TYPES))
+    .filter((instance) => instance.value.apiVersion > latestApiVersion)
+    .map((instance) => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Unsupported API version',
+      detailedMessage: `Element API version set to ${instance.value.apiVersion}, the maximum supported version is ${latestApiVersion}.`,
+    }))
+}
+
+export default elementApiVersionValidator

--- a/packages/salesforce-adapter/src/change_validators/element_api_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/element_api_version.ts
@@ -46,12 +46,16 @@ const elementApiVersionValidator: ChangeValidator = async (
   return changes
     .map(getChangeData)
     .filter(isInstanceOfTypeSync(...VERSIONED_TYPES))
-    .filter((instance) => instance.value.apiVersion > latestApiVersion)
+    .filter(
+      (instance) =>
+        _.isNumber(instance.value.apiVersion) &&
+        instance.value.apiVersion > latestApiVersion,
+    )
     .map((instance) => ({
       elemID: instance.elemID,
       severity: 'Error',
       message: 'Unsupported API version',
-      detailedMessage: `Element API version set to ${instance.value.apiVersion}, the maximum supported version is ${latestApiVersion}.`,
+      detailedMessage: `Element API version set to ${instance.value.apiVersion}, the maximum supported version is ${latestApiVersion}. You can change the element's API version to one that is supported.`,
     }))
 }
 

--- a/packages/salesforce-adapter/src/change_validators/element_api_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/element_api_version.ts
@@ -38,6 +38,11 @@ const elementApiVersionValidator: ChangeValidator = async (
   const latestApiVersion =
     orgSettings?.value[LATEST_SUPPORTED_API_VERSION_FIELD]
 
+  if (latestApiVersion === undefined) {
+    log.debug('Latest API version not found.')
+    return []
+  }
+
   if (!_.isNumber(latestApiVersion)) {
     log.error('Could not get the latest supported API version.')
     return []

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1184,4 +1184,11 @@ export default class SalesforceClient {
     log.trace('client.bulkLoadOperation result: %o', result)
     return flatValues(result)
   }
+
+  @mapToUserFriendlyErrorMessages
+  @logDecorator()
+  @requiresLogin()
+  public async request(request: string): Promise<unknown> {
+    return this.conn.request(request)
+  }
 }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1188,7 +1188,7 @@ export default class SalesforceClient {
   @mapToUserFriendlyErrorMessages
   @logDecorator()
   @requiresLogin()
-  public async request(request: string): Promise<unknown> {
-    return this.conn.request(request)
+  public async request(url: string): Promise<unknown> {
+    return this.conn.request(url)
   }
 }

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -135,6 +135,7 @@ export default interface Connection {
   limits(): Promise<Limits>
   identity(): Promise<IdentityInfo>
   instanceUrl: string
+  request(request: string): Promise<unknown>
 }
 
 type ArrayOrSingle<T> = T | T[]

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -43,7 +43,7 @@ import { FetchProfile } from '../types'
 const log = logger(module)
 
 const ORGANIZATION_SETTINGS_INSTANCE_NAME = 'OrganizationSettings'
-const latestSupportedApiVersionField = 'LatestSupportedApiVersion'
+export const LATEST_SUPPORTED_API_VERSION_FIELD = 'LatestSupportedApiVersion'
 
 /*
  * These fields are not multienv friendly
@@ -130,7 +130,7 @@ const createOrganizationType = (): ObjectType =>
   new ObjectType({
     elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
     fields: {
-      [latestSupportedApiVersionField]: {
+      [LATEST_SUPPORTED_API_VERSION_FIELD]: {
         refType: BuiltinTypes.NUMBER,
         annotations: {
           [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
@@ -186,7 +186,7 @@ const addLatestSupportedAPIVersion = async (
     return
   }
 
-  instance.value[latestSupportedApiVersionField] = latestVersion
+  instance.value[LATEST_SUPPORTED_API_VERSION_FIELD] = latestVersion
 }
 
 const FILTER_NAME = 'organizationSettings'

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -131,7 +131,10 @@ const createOrganizationType = (): ObjectType =>
     elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
     fields: {
       [latestSupportedApiVersionField]: {
-        refType: BuiltinTypes.HIDDEN_STRING,
+        refType: BuiltinTypes.NUMBER,
+        annotations: {
+          [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+        },
       },
     },
     annotations: {
@@ -174,9 +177,9 @@ const addLatestSupportedAPIVersion = async (
 
   const latestVersion = _(versions)
     .map((ver) => ver?.version)
-    .filter((ver) => typeof ver === 'string')
-    .filter((ver) => ver.length > 0)
-    .maxBy(parseInt)
+    .map(_.toNumber)
+    .filter(_.isFinite)
+    .max()
 
   if (latestVersion === undefined) {
     log.error('Could not get the latest supported API version.')

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -162,6 +162,7 @@ export type ChangeValidatorName =
   | 'metadataTypes'
   | 'taskOrEventFieldsModifications'
   | 'newFieldsAndObjectsFLS'
+  | 'elementApiVersion'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -879,6 +880,7 @@ const changeValidatorConfigType =
       metadataTypes: { refType: BuiltinTypes.BOOLEAN },
       taskOrEventFieldsModifications: { refType: BuiltinTypes.BOOLEAN },
       newFieldsAndObjectsFLS: { refType: BuiltinTypes.BOOLEAN },
+      elementApiVersion: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
@@ -1,0 +1,85 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  toChange,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ORGANIZATION_SETTINGS, SALESFORCE } from '../../src/constants'
+import { LATEST_SUPPORTED_API_VERSION_FIELD } from '../../src/filters/organization_settings'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import elementApiVersionValidator from '../../src/change_validators/element_api_version'
+
+const ELEMENTS_SOURCE = buildElementsSourceFromElements([
+  new InstanceElement(
+    ElemID.CONFIG_NAME,
+    new ObjectType({
+      elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
+    }),
+    {
+      [LATEST_SUPPORTED_API_VERSION_FIELD]: 50,
+    },
+  ),
+])
+
+const flowWithApiVersion = (apiVersion: number): InstanceElement =>
+  createInstanceElement({ fullName: 'flow1', apiVersion }, mockTypes.Flow)
+
+describe('Element API version validator', () => {
+  it('should return no errors for valid elements', async () => {
+    const change = toChange({
+      before: flowWithApiVersion(40),
+      after: flowWithApiVersion(50),
+    })
+    const errors = await elementApiVersionValidator([change], ELEMENTS_SOURCE)
+    expect(errors).toBeEmpty()
+  })
+
+  it('should return an error with unsupported API version', async () => {
+    const change = toChange({
+      after: flowWithApiVersion(51),
+    })
+    const errors = await elementApiVersionValidator([change], ELEMENTS_SOURCE)
+    expect(errors).toHaveLength(1)
+    const [error] = errors
+    expect(error.severity).toEqual('Error')
+    expect(error.detailedMessage).toInclude('50')
+    expect(error.detailedMessage).toInclude('51')
+  })
+
+  it('should return no errors for missing elements source', async () => {
+    const change = toChange({
+      after: flowWithApiVersion(51),
+    })
+    const errors = await elementApiVersionValidator([change])
+    expect(errors).toBeEmpty()
+  })
+
+  it('should return no errors when organization settings are missing', async () => {
+    const change = toChange({
+      after: flowWithApiVersion(51),
+    })
+    const errors = await elementApiVersionValidator(
+      [change],
+      buildElementsSourceFromElements([]),
+    )
+    expect(errors).toBeEmpty()
+  })
+})

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -510,6 +510,15 @@ export const mockSObjectDescribe = (
   fields: overrides.fields?.map(mockSObjectField) ?? [],
 })
 
+const mockRestResponses: Record<string, unknown> = {
+  '/services/data/': [
+    { version: '9.0' },
+    { version: '58.0' },
+    { version: '59.0' },
+    { version: '60.0' },
+  ],
+}
+
 export const mockJsforce: () => MockInterface<Connection> = () => ({
   login: mockFunction<Connection['login']>().mockImplementation(async () => ({
     id: '',
@@ -549,7 +558,6 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
       Soap['describeSObjects']
     >().mockResolvedValue([]),
   },
-
   describeGlobal: mockFunction<
     Connection['describeGlobal']
   >().mockResolvedValue({ sobjects: [] }),
@@ -577,6 +585,9 @@ export const mockJsforce: () => MockInterface<Connection> = () => ({
   },
   identity: mockFunction<Connection['identity']>().mockImplementation(
     async () => mockIdentity(''),
+  ),
+  request: mockFunction<Connection['request']>().mockImplementation(
+    async (req) => mockRestResponses[req],
   ),
   instanceUrl: MOCK_INSTANCE_URL,
 })

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -173,7 +173,7 @@ describe('organization-wide defaults filter', () => {
             DefaultContactAccess: 'ControlledByParent',
             DefaultLeadAccess: 'ReadEditTransfer',
             DefaultOpportunityAccess: 'None',
-            LatestSupportedApiVersion: '60.0',
+            LatestSupportedApiVersion: 60,
           },
         },
       ])

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -173,6 +173,7 @@ describe('organization-wide defaults filter', () => {
             DefaultContactAccess: 'ControlledByParent',
             DefaultLeadAccess: 'ReadEditTransfer',
             DefaultOpportunityAccess: 'None',
+            LatestSupportedApiVersion: '60.0',
           },
         },
       ])

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -23,7 +23,7 @@ import {
   ORGANIZATION_SETTINGS,
   SALESFORCE,
 } from '../../src/constants'
-import { defaultFilterContext } from '../utils'
+import { buildFilterContext } from '../utils'
 
 jest.mock('../../src/filters/utils', () => ({
   ...jest.requireActual('../../src/filters/utils'),
@@ -34,7 +34,11 @@ describe('organization-wide defaults filter', () => {
   const mockedFilterUtils = jest.mocked(filterUtilsModule)
   const { client, connection } = mockAdapter({})
   const filter = filterCreator({
-    config: defaultFilterContext,
+    config: buildFilterContext({
+      optionalFeatures: {
+        hideTypesFolder: true,
+      },
+    }),
     client,
   })
 

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -45,7 +45,10 @@ import {
 } from '../src/filters/custom_type_split'
 import { FilterContext } from '../src/filter'
 import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
-import { LastChangeDateOfTypesWithNestedInstances } from '../src/types'
+import {
+  LastChangeDateOfTypesWithNestedInstances,
+  OptionalFeatures,
+} from '../src/types'
 
 export const findElements = (
   elements: ReadonlyArray<Element>,
@@ -439,13 +442,19 @@ export const createCustomSettingsObject = (
   return obj
 }
 
-export const defaultFilterContext: FilterContext = {
+export const buildFilterContext = ({
+  optionalFeatures,
+}: {
+  optionalFeatures?: OptionalFeatures
+}): FilterContext => ({
   systemFields: SYSTEM_FIELDS,
-  fetchProfile: buildFetchProfile({ fetchParams: {} }),
+  fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures } }),
   elementsSource: buildElementsSourceFromElements([]),
   enumFieldPermissions: false,
   flsProfiles: [constants.ADMIN_PROFILE],
-}
+})
+
+export const defaultFilterContext: FilterContext = buildFilterContext({})
 
 export const mockFetchOpts: MockInterface<FetchOptions> = {
   progressReporter: { reportProgress: jest.fn() },


### PR DESCRIPTION
Adds the latest supported API versions to the organization settings as a hidden field and then validates flows do not use a later version.
We can easily add additional elements to this validation as needed.

---

_Additional context for reviewer_
Note the new field is hidden, so no need for release notes or notifications.

---
_Release Notes_: 
_Salesforce_:
* Added a new change validator which checks for flows with an unsupported API version.

---
_User Notifications_: 
None.
