### PR TITLE
SALTO-5611 add references to add_skills, set_skills, and remove_skills in trigger actions

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -72,6 +72,9 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   locale_id: 'locale',
   via_id: 'channel',
   current_via_id: 'channel',
+  add_skills: 'routing_attribute_value',
+  set_skills: 'routing_attribute_value',
+  remove_skills: 'routing_attribute_value',
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {
@@ -905,6 +908,18 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
     target: { typeContext: 'neighborField' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
+  {
+  src: {
+    field: 'value',
+    parentTypes: [
+      'trigger__actions',
+    ],
+  },
+  serializationStrategy: 'idString',
+  target: { typeContext: 'allowlistedNeighborField' },
+  zendeskMissingRefStrategy: 'typeAndValue',
+},
+
   // only one of these applies in a given instance
   {
     src: { field: 'value' },

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -909,16 +909,14 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
     zendeskMissingRefStrategy: 'typeAndValue',
   },
   {
-  src: {
-    field: 'value',
-    parentTypes: [
-      'trigger__actions',
-    ],
+    src: {
+      field: 'value',
+      parentTypes: ['trigger__actions'],
+    },
+    serializationStrategy: 'idString',
+    target: { typeContext: 'allowlistedNeighborField' },
+    zendeskMissingRefStrategy: 'typeAndValue',
   },
-  serializationStrategy: 'idString',
-  target: { typeContext: 'allowlistedNeighborField' },
-  zendeskMissingRefStrategy: 'typeAndValue',
-},
 
   // only one of these applies in a given instance
   {

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -293,8 +293,8 @@ export type ReferenceContextStrategyName =
   | 'neighborParentType'
 export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
-  // We use allow lists because there are types we don't support (such organizarion or requester)
-  // and they'll as false positives
+  // We use allow lists because there are types we don't support (such as organization or requester)
+  // and they'll end up being false positives
   allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: allowListLookupType }),
   allowlistedNeighborSubject: neighborContextFunc({
     contextFieldName: 'subject',


### PR DESCRIPTION
Add missing reference to skills in trigger actions

---

---
_Release Notes_: 
Zendesk:
- Add reference to skills in trigger actions
---
_User Notifications_:  _None_