### PR TITLE
SALTO-5744: Don't list nested elemIDs as missing dependencies if their parent is already a missing dependency 

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
+++ b/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
@@ -26,7 +26,7 @@ import {
   UnresolvedReferenceError,
   SaltoErrorType,
 } from '@salto-io/adapter-api'
-import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
+import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP, getIndependentElemIDs } from '@salto-io/adapter-utils'
 import { values, collections } from '@salto-io/lowerdash'
 
 const { awu } = collections.asynciterable
@@ -64,7 +64,7 @@ export const createOutgoingUnresolvedReferencesValidator =
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
       .map(async element => {
-        const unresolvedReferences = getOutgoingUnresolvedReferences(element, shouldIgnore)
+        const unresolvedReferences = getIndependentElemIDs(getOutgoingUnresolvedReferences(element, shouldIgnore))
 
         if (unresolvedReferences.length === 0) {
           return undefined

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1183,3 +1183,26 @@ export const validateReferenceExpression =
     }
     return true
   }
+
+/**
+ * For a list of ElemIDs, returns a list of ElemIDs that are not children of any other ElemID in the list.
+ */
+export const getIndependentElemIDs = (elemIDs: ElemID[]): ElemID[] => {
+  // The sort here is to make sure an elemID of inner path in list items
+  // will appear after the elemID of the item itself.
+  const sortedIDs = _.sortBy(elemIDs, id => id.getFullNameParts())
+  let lastId = sortedIDs[0]
+  const fullNamesToReturn = new Set(
+    sortedIDs
+      .filter(id => {
+        const skip = lastId.isParentOf(id)
+        if (!skip) {
+          lastId = id
+        }
+        return !skip
+      })
+      .map(id => id.getFullName()),
+  )
+  // filter the original list to avoid changing the list order
+  return elemIDs.filter(id => fullNamesToReturn.has(id.getFullName()))
+}

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -91,6 +91,7 @@ import {
   FILTER_FUNC_NEXT_STEP,
   transformValuesSync,
   TransformFuncSync,
+  getIndependentElemIDs,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -2802,6 +2803,31 @@ describe('Test utils.ts', () => {
     })
     it('should return true for a resolved reference expression', () => {
       expect(isResolvedReferenceExpression(new ReferenceExpression(inst.elemID, inst))).toBeTruthy()
+    })
+  })
+  describe('getIndependentElemIDs', () => {
+    it('should filter out any elemIDs that their parent is included in the list', () => {
+      const elemID = new ElemID('salto', 'type')
+      const fieldElemID = elemID.createNestedID('field', 'fieldA')
+      const anotherElemID = new ElemID('salto', 'anotherType')
+      const res = getIndependentElemIDs([fieldElemID, elemID, anotherElemID])
+      expect(res).toHaveLength(2)
+      expect(res).toEqual([elemID, anotherElemID])
+    })
+    it('should filter out nested instance path if the top level instance is in the list', () => {
+      const elemID = new ElemID('salto', 'type')
+      const instA = elemID.createNestedID('instance', 'inst')
+      const nested = instA.createNestedID('nested')
+      const res = getIndependentElemIDs([instA, elemID, nested])
+      expect(res).toHaveLength(2)
+      expect(res).toEqual([instA, elemID])
+    })
+    it('it should not filter out nested elemIDs if their parent is not included in the list', () => {
+      const elemID = new ElemID('salto', 'type')
+      const anotherElemID = new ElemID('salto', 'anotherType', 'field', 'nestedField')
+      const res = getIndependentElemIDs([elemID, anotherElemID])
+      expect(res).toHaveLength(2)
+      expect(res).toEqual([elemID, anotherElemID])
     })
   })
 })


### PR DESCRIPTION
This PR fix the redundancy in showing a missing dependency for a field when its parent type is also a missing dependency

---

2 main changes here - 
- Modify `getOutgoingUnresolvedReferences` to avoid including missing references to nested elements if their parent is already a missing reference. 
- Modify `listElementsDependenciesInWorkspace` to do the same when recursively listing dependencies to a specific elemID. This is done per element's dependency and not on the entire result to avoid omiting nested elements that are explicitly required without their parent.
note that changing `listElementsDependenciesInWorkspace` also changes `--listUnresolved`, so LMK if you think I should add a flag to avoid it.

---
_Release Notes_: 
None

---
_User Notifications_: 
None