### PR TITLE
SALTO-5755: Expose a 'scrollingPagination' function within the infra pagination utils

### DIFF
--- a/packages/adapter-components/src/fetch/request/pagination/index.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/index.ts
@@ -22,6 +22,7 @@ export {
   pageOffsetPagination,
   noPagination,
   defaultPathChecker,
+  scrollingPagination,
   PathCheckerFunc,
   tokenPagination,
 } from './pagination_functions'

--- a/packages/adapter-components/src/fetch/request/pagination/pagination_functions.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/pagination_functions.ts
@@ -208,6 +208,32 @@ export const cursorPagination = ({
   return nextPageCursorPages
 }
 
+export const scrollingPagination = ({
+  scrollingParam,
+  stopCondition,
+}: {
+  scrollingParam: string
+  stopCondition?: (data: unknown) => boolean
+}): PaginationFunction => {
+  const nextPageScrollingPages: PaginationFunction = ({ currentParams, responseData }) => {
+    const scrollParam = _.get(responseData, scrollingParam)
+    if (typeof scrollParam !== 'string' || stopCondition?.(responseData)) {
+      return []
+    }
+    return [
+      _.merge({}, currentParams, {
+        queryParams: {
+          [scrollingParam]: scrollParam,
+          // This is a workaround to to handle our pagination mechanism which expects each pagination request to have a unique query param.
+          // It is not the case for the scrolling param - which is the same for all requests (until the stop condition is met).
+          timestamp: new Date().toISOString(),
+        },
+      }),
+    ]
+  }
+  return nextPageScrollingPages
+}
+
 /**
  * Make paginated requests using the link response header.
  * Only supports next pages under the same endpoint (and uses the same host).

--- a/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination_functions.test.ts
@@ -21,6 +21,7 @@ import {
   offsetAndLimitPagination,
   cursorHeaderPagination,
   tokenPagination,
+  scrollingPagination,
 } from '../../../../src/fetch/request/pagination/pagination_functions'
 
 describe('pagination functions', () => {
@@ -189,5 +190,47 @@ describe('pagination functions', () => {
       ).toEqual([{ queryParams: { pageToken: 'second' } }])
     })
   })
+
+  describe('scrollingPagination', () => {
+    describe('When the stop condition is not met', () => {
+      const paginate = scrollingPagination({ scrollingParam: 'scroll', stopCondition: () => false })
+      it('should calculate next pages', async () => {
+        expect(
+          paginate({
+            endpointIdentifier: { path: '/ep' },
+            currentParams: {},
+            responseData: { a: [{ x: 'y' }], scroll: 'next' },
+          }),
+        ).toEqual([{ queryParams: { scroll: 'next', timestamp: expect.any(String) } }])
+      })
+    })
+
+    describe('When the stop condition is met', () => {
+      const paginate = scrollingPagination({ scrollingParam: 'scroll', stopCondition: () => true })
+      it('should return no next page', async () => {
+        expect(
+          paginate({
+            endpointIdentifier: { path: '/ep' },
+            currentParams: {},
+            responseData: { a: [{ x: 'y' }], scroll: 'next' },
+          }),
+        ).toEqual([])
+      })
+    })
+
+    describe('When there is no scrolling param', () => {
+      const paginate = scrollingPagination({ scrollingParam: 'scroll', stopCondition: () => false })
+      it('should return no next page', async () => {
+        expect(
+          paginate({
+            endpointIdentifier: { path: '/ep' },
+            currentParams: {},
+            responseData: { a: [{ x: 'y' }] },
+          }),
+        ).toEqual([])
+      })
+    })
+  })
+
   // TODO extend tests for all pagination functions (can rely on previous tests)
 })


### PR DESCRIPTION
Intercom public API exposes a [scrolling API](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/scrollOverAllCompanies/) request, which offers better performance than using the standard [‘list’ endpoint](https://developers.intercom.com/docs/references/rest-api/api.intercom.io/Companies/listAllCompanies/). In this PR we add this scrolling mechanism as part of our pagination functions.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
