### PR TITLE
SALTO-4094: Fetch priority instance for policy rules

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -87,6 +87,7 @@ import profileMappingPropertiesFilter from './filters/profile_mapping_properties
 import profileMappingAdditionFilter from './filters/profile_mapping_addition'
 import profileMappingRemovalFilter from './filters/profile_mapping_removal'
 import omitAuthenticatorMappingFilter from './filters/omit_authenticator_mapping'
+import policyRulePrioritiesFilter from './filters/policy_rule_priorities'
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import groupPushPathFilter from './filters/group_push_path'
@@ -125,6 +126,7 @@ const DEFAULT_FILTERS = [
   addImportantValues,
   accessPolicyRuleConstraintsFilter,
   defaultPolicyRuleDeployment,
+  policyRulePrioritiesFilter,
   schemaFieldsRemovalFilter,
   appLogoFilter,
   brandThemeFilesFilter,

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -48,6 +48,7 @@ export const AUTOMATION_TYPE_NAME = 'Automation'
 export const AUTOMATION_RULE_TYPE_NAME = 'AutomationRule'
 export const ACTIVE_STATUS = 'ACTIVE'
 export const INACTIVE_STATUS = 'INACTIVE'
+export const POLICY_RULE_PRIORITIES = 'PolicyRulePriorities'
 export const POLICY_TYPE_NAMES = [
   ACCESS_POLICY_TYPE_NAME,
   IDP_POLICY_TYPE_NAME,

--- a/packages/okta-adapter/src/filters/policy_rule_priorities.ts
+++ b/packages/okta-adapter/src/filters/policy_rule_priorities.ts
@@ -1,0 +1,98 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ListType,
+  ObjectType,
+  ReferenceExpression,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { getParent, hasValidParent, invertNaclCase, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { elements as adapterElements } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
+import { OKTA, POLICY_RULE_PRIORITIES, POLICY_RULE_TYPE_NAMES, POLICY_TYPE_NAMES } from '../constants'
+
+const createPrioritiesType = (): ObjectType =>
+  new ObjectType({
+    elemID: new ElemID(OKTA, POLICY_RULE_PRIORITIES),
+    fields: {
+      rules: {
+        refType: new ListType(BuiltinTypes.NUMBER),
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+    },
+    path: [OKTA, adapterElements.TYPES_PATH, POLICY_RULE_PRIORITIES],
+    annotations: {
+      [CORE_ANNOTATIONS.CREATABLE]: true,
+      [CORE_ANNOTATIONS.UPDATABLE]: true,
+      [CORE_ANNOTATIONS.DELETABLE]: true,
+    },
+  })
+
+const createPolicyRulePriorities = (
+  rules: InstanceElement[],
+  policyRulePrioritiesType: ObjectType,
+  policy: InstanceElement,
+): InstanceElement => {
+const name = naclCase(`${policy.elemID.typeName}_${invertNaclCase(policy.elemID.name)}_Priorities`)
+  return new InstanceElement(
+    name,
+    policyRulePrioritiesType,
+    {
+      rules: rules
+        .sort((a, b) => a.value.position - b.value.position)
+        .map(inst => new ReferenceExpression(inst.elemID, inst)),
+    },
+    [...(policy.path ?? []).slice(0, -1), pathNaclCase(name)],
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(policy.elemID, policy)],
+    },
+  )
+}
+
+/* Manages the priorities of policyRules within each Policy
+ * by generating an InstanceElement for the policyRules priorities.
+ */
+const filter: FilterCreator = () => ({
+  name: 'policyRulePrioritiesFilter',
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    const policyInstanceToName = _.keyBy(
+      instances.filter(e => POLICY_TYPE_NAMES.includes(e.elemID.typeName)),
+      inst => inst.elemID.getFullName(),
+    )
+    const policiesRules = instances.filter(instance => POLICY_RULE_TYPE_NAMES.includes(instance.elemID.typeName))
+    const policiesToRules = _.groupBy(policiesRules.filter(hasValidParent), rule =>
+      getParent(rule).elemID.getFullName(),
+    )
+    const prioritiesType = createPrioritiesType()
+    elements.push(prioritiesType)
+    Object.entries(policiesToRules).forEach(([policyName, rules]) => {
+      const prioritiesInstance = createPolicyRulePriorities(rules, prioritiesType, policyInstanceToName[policyName])
+      elements.push(prioritiesInstance)
+    })
+    // Remove priority field from the policy rules
+    policiesRules.forEach(rule => {
+      delete rule.value.priority
+    })
+  },
+})
+
+export default filter


### PR DESCRIPTION
In this PR I support fetching policy rules priories into an instance. 

---

_Additional context for reviewer_
1. **I will add tests after first review when the tech design will be approve.** 
2. View of the nacl:
![image](https://github.com/salto-io/salto/assets/63644199/27a1b2e9-10c9-472d-9a64-5a4d6e5b93d8)

3. View of the element tree
![image](https://github.com/salto-io/salto/assets/63644199/33c985fb-90df-44e1-97dc-88947611fda2)

4. Priority without rules will not have a priority rule instance
![image](https://github.com/salto-io/salto/assets/63644199/0e2eea1d-2e4b-451b-8299-5438eba91209)


---
_Release Notes_: 
_Okta Adapter:_
* New instances responsible for policy rules priorities were added. 

---
_User Notifications_: 
_Okta Adapter:_
* New instances responsible for policy rules priorities were added. 