### PR TITLE
SALTO-3080 Fetch guide theme with references

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     ],
     "nohoist": [
       "salto-vscode/**",
-      "**/@salto-io/rocksdb/**"
+      "**/@salto-io/rocksdb/**",
+      "**/acorn-walk"
     ]
   },
   "resolutions": {

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -125,10 +125,10 @@ zendesk {
 
 ## Themes reference options
 
-| Name                                                                              | Default when undefined           | Description                                                             |
-| --------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- |
-| enableReferenceLookup                                                             | false                            | When enabled, references will be extracted from Themes files            |
-| [javascriptReferenceLookupStrategy](#themes-javascript-reference-lookup-strategy) | { enableReferenceLookup: false } | Configuration for defining reference parsing and extraction from Themes |
+| Name                                                                              | Default when undefined | Description                                                             |
+| --------------------------------------------------------------------------------- | ---------------------- | ----------------------------------------------------------------------- |
+| enableReferenceLookup                                                             | false                  | When enabled, references will be extracted from Themes files            |
+| [javascriptReferenceLookupStrategy](#themes-javascript-reference-lookup-strategy) | undefined              | Configuration for defining reference parsing and extraction from Themes |
 
 ## Themes Javascript Reference Lookup Strategy
 

--- a/packages/zendesk-adapter/config_doc.md
+++ b/packages/zendesk-adapter/config_doc.md
@@ -88,19 +88,19 @@ zendesk {
 
 ## Fetch configuration options
 
-| Name                               | Default when undefined             | Description                                                                                                                                                            |
-| ---------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [include](#fetch-entry-options)    | [{ type = ".*" }]                  | List of entries to determine what instances to include in the fetch                                                                                                    |
-| [exclude](#fetch-entry-options)    | []                                 | List of entries to determine what instances to exclude in the fetch                                                                                                    |
-| [guide]                            | undefined (Guide will be disabled) | Configuration for defining which brands will be included in Zendesk Guide fetch                                                                                        |
-| [resolveOrganizationIDs]           | false                              | When enabled, organization IDs will be replaced with organization names                                                                                                |
-| [resolveUserIDs]                   | true                               | When enabled, user IDs will be replaced with user emails                                                                                                               |
-| includeAuditDetails                | false                              | When enabled, changed_by information will be added to instances                                                                                                        |
-| handleIdenticalAttachmentConflicts | false                              | When enabled, one attachment will be kept from each set of identical attachments (having the same hash) associated with the same article                               |
-| extractReferencesFromFreeText      | false                              | When enabled, convert ids in zendesk links in string values to salto references                                                                                        |
-| convertJsonIdsToReferences         | false                              | When enabled, If a field is a json with an 'id' field, convert its value to a reference                                                                                |
-| omitInactive                       | true                               | When enabled, Inactive instances will be omitted from the fetch. This option support default value and specific types can be overridden using the customizations field |
-| omitTicketStatusTicketField        | false                              | When enabled, Custom Ticket Status will be omitted from the fetch.                                                                                                     |
+| Name                                  | Default when undefined             | Description                                                                                                                                                            |
+| ------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [include](#fetch-entry-options)       | [{ type = ".*" }]                  | List of entries to determine what instances to include in the fetch                                                                                                    |
+| [exclude](#fetch-entry-options)       | []                                 | List of entries to determine what instances to exclude in the fetch                                                                                                    |
+| [guide](#guide-configuration-options) | undefined (Guide will be disabled) | Configuration for defining options for Zendesk Guide fetch                                                                                                             |
+| [resolveOrganizationIDs]              | false                              | When enabled, organization IDs will be replaced with organization names                                                                                                |
+| [resolveUserIDs]                      | true                               | When enabled, user IDs will be replaced with user emails                                                                                                               |
+| includeAuditDetails                   | false                              | When enabled, changed_by information will be added to instances                                                                                                        |
+| handleIdenticalAttachmentConflicts    | false                              | When enabled, one attachment will be kept from each set of identical attachments (having the same hash) associated with the same article                               |
+| extractReferencesFromFreeText         | false                              | When enabled, convert ids in zendesk links in string values to salto references                                                                                        |
+| convertJsonIdsToReferences            | false                              | When enabled, If a field is a json with an 'id' field, convert its value to a reference                                                                                |
+| omitInactive                          | true                               | When enabled, Inactive instances will be omitted from the fetch. This option support default value and specific types can be overridden using the customizations field |
+| omitTicketStatusTicketField           | false                              | When enabled, Custom Ticket Status will be omitted from the fetch.                                                                                                     |
 
 ## Fetch entry options
 
@@ -108,6 +108,35 @@ zendesk {
 | --------------------------------- | ---------------------- | --------------------------------------------------------------- |
 | type                              | ""                     | A regex of the Salto type name to include in the entry          |
 | [criteria](#fetch-entry-criteria) |                        | A List of criteria to filter specific instance of certain types |
+
+## Guide configuration options
+
+| Name                                    | Default when undefined                 | Description                                                                     |
+| --------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| brands                                  | []                                     | Configuration for defining which brands will be included in Zendesk Guide fetch |
+| [themes](#themes-configuration-options) | undefined (Themes will not be fetched) | Configuration for defining fetching of Zendesk Guide Themes                     |
+
+## Themes configuration options
+
+| Name                                          | Default when undefined           | Description                                                             |
+| --------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- |
+| brands                                        | []                               | Configuration for defining which brands will have their Themes fetched  |
+| [referenceOptions](#themes-reference-options) | { enableReferenceLookup: false } | Configuration for defining reference parsing and extraction from Themes |
+
+## Themes reference options
+
+| Name                                                                              | Default when undefined           | Description                                                             |
+| --------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------- |
+| enableReferenceLookup                                                             | false                            | When enabled, references will be extracted from Themes files            |
+| [javascriptReferenceLookupStrategy](#themes-javascript-reference-lookup-strategy) | { enableReferenceLookup: false } | Configuration for defining reference parsing and extraction from Themes |
+
+## Themes Javascript Reference Lookup Strategy
+
+| Name               | Default when undefined | Description                                                                                                                                                                                                                                                                                                                                                                                  |
+| ------------------ | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| strategy           | `varNamePrefix`        | The reference strategy for Javascript files - either `varNamePrefix` or `numericValues`.                                                                                                                                                                                                                                                                                                     |
+| prefix             | `PREFIX_`              | When matched with the `varNamePrefix` option, parses only variable definitions that are prefixed by `prefix`, and tries to match all digit sequences within the variable initialization as references. For example, with the default value, the Javascript line `var PREFIX_my_article_id = 12345` will extract the digit `12345`, but `var my_article_id = 12345` will not extract anything |
+| minimumDigitAmount | undefined              | When matched with the `numericValues` option, extracts all digits sequences with at least `minimumDigitAmount` digits - and tries to match them as references                                                                                                                                                                                                                                |
 
 ### Deploy configuration options
 

--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -309,6 +309,10 @@ describe('Zendesk adapter E2E', () => {
         name,
         idsToElements: {},
         matchBrandSubdomain: () => brand,
+        config: {
+          javascriptStrategy: 'greedy',
+          javascriptDigitAmount: 6,
+        },
       })
       const { content } = root.files['manifest_json@v']
       expect(isStaticFile(content)).toBeTruthy()

--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -200,7 +200,12 @@ const usedConfig = {
     exclude: [],
     guide: {
       brands: ['.*'],
-      themesForBrands: ['.*'],
+      themes: {
+        brands: ['.*'],
+        referenceOptions: {
+          enableReferenceLookup: false,
+        },
+      },
     },
   },
   [API_DEFINITIONS_CONFIG]: {
@@ -308,10 +313,15 @@ describe('Zendesk adapter E2E', () => {
         currentBrandName: brand.value.name,
         name,
         idsToElements: {},
-        matchBrandSubdomain: () => brand,
+        matchBrandSubdomain: (url: string) => (url === brand.value.brand_url ? brand : undefined),
         config: {
-          javascriptStrategy: 'greedy',
-          javascriptDigitAmount: 6,
+          referenceOptions: {
+            enableReferenceLookup: true,
+            javascriptReferenceLookupStrategy: {
+              strategy: 'numericValues',
+              minimumDigitAmount: 6,
+            },
+          },
         },
       })
       const { content } = root.files['manifest_json@v']
@@ -1064,7 +1074,12 @@ describe('Zendesk adapter E2E', () => {
             exclude: [],
             guide: {
               brands: ['.*'],
-              themesForBrands: ['.*'],
+              themes: {
+                brands: ['.*'],
+                referenceOptions: {
+                  enableReferenceLookup: false,
+                },
+              },
             },
           },
           [API_DEFINITIONS_CONFIG]: {

--- a/packages/zendesk-adapter/package.json
+++ b/packages/zendesk-adapter/package.json
@@ -41,6 +41,8 @@
     "@salto-io/logging": "0.3.55",
     "@salto-io/lowerdash": "0.3.55",
     "@salto-io/parser": "0.3.55",
+    "acorn": "^8.11.3",
+    "acorn-walk": "^8.3.2",
     "domhandler": "^4.2.2",
     "form-data": "^4.0.0",
     "htmlparser2": "^7.2.0",

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -73,15 +73,21 @@ export type IdLocator = {
   type: string[]
 }
 
-export type Themes =
-  | {
-      javascriptStrategy: 'greedy'
-      javascriptDigitAmount: number
-    }
-  | {
-      javascriptStrategy: 'prefix'
-      javascriptPrefix: string
-    }
+export type Themes = {
+  brands?: string[]
+  referenceOptions: {
+    enableReferenceLookup: boolean
+    javascriptReferenceLookupStrategy?:
+      | {
+          strategy: 'numericValues'
+          minimumDigitAmount: number
+        }
+      | {
+          strategy: 'varNamePrefix'
+          prefix: string
+        }
+  }
+}
 
 export type Guide = {
   brands: string[]
@@ -2849,23 +2855,58 @@ const IdLocatorType = createMatchingObjectType<IdLocator>({
   },
 })
 
+const ThemesReferenceJavascriptReferenceLookupStrategyType = createMatchingObjectType<
+  Themes['referenceOptions']['javascriptReferenceLookupStrategy']
+>({
+  elemID: new ElemID(ZENDESK, 'ThemesReferenceJavascriptReferenceLookupStrategyType'),
+  fields: {
+    strategy: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: true,
+      },
+    },
+    minimumDigitAmount: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: {
+        _required: true,
+      },
+    },
+    prefix: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: true,
+      },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
+const ThemesReferenceType = createMatchingObjectType<Themes['referenceOptions']>({
+  elemID: new ElemID(ZENDESK, 'ThemeType-referenceOptions'),
+  fields: {
+    enableReferenceLookup: {
+      refType: BuiltinTypes.BOOLEAN,
+      annotations: {
+        _required: true,
+      },
+    },
+    javascriptReferenceLookupStrategy: {
+      refType: ThemesReferenceJavascriptReferenceLookupStrategyType,
+    },
+  },
+})
+
 const ThemesType = createMatchingObjectType<Themes>({
   elemID: new ElemID(ZENDESK, 'ThemeType'),
   fields: {
-    javascriptStrategy: {
-      refType: BuiltinTypes.STRING,
-      annotations: {
-        _required: true,
-      },
+    brands: {
+      refType: new ListType(BuiltinTypes.STRING),
     },
-    javascriptPrefix: {
-      refType: BuiltinTypes.STRING,
-      annotations: {
-        _required: true,
-      },
-    },
-    javascriptDigitAmount: {
-      refType: BuiltinTypes.NUMBER,
+    referenceOptions: {
+      refType: ThemesReferenceType,
       annotations: {
         _required: true,
       },
@@ -3171,7 +3212,9 @@ export const validateGuideTypesConfig = (adapterApiConfig: configUtils.AdapterAp
 export const isGuideEnabled = (fetchConfig: ZendeskFetchConfig): boolean => fetchConfig.guide?.brands !== undefined
 
 export const isGuideThemesEnabled = (fetchConfig: ZendeskFetchConfig): boolean =>
-  fetchConfig.guide?.themesForBrands !== undefined && fetchConfig.guide?.themesForBrands.length > 0
+  (fetchConfig.guide?.themes?.brands !== undefined && fetchConfig.guide?.themes?.brands.length > 0) ||
+  // Deprecated
+  (fetchConfig.guide?.themesForBrands !== undefined && fetchConfig.guide?.themesForBrands.length > 0)
 
 export const validateOmitInactiveConfig = (
   omitInactiveConfig: OmitInactiveConfig | undefined,

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -92,6 +92,7 @@ export type Themes = {
 export type Guide = {
   brands: string[]
   themes?: Themes
+  // Deprecated
   themesForBrands?: string[]
 }
 
@@ -2929,6 +2930,7 @@ const GuideType = createMatchingObjectType<Guide>({
     themes: {
       refType: ThemesType,
     },
+    // Deprecated
     themesForBrands: {
       refType: new ListType(BuiltinTypes.STRING),
     },

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -73,8 +73,19 @@ export type IdLocator = {
   type: string[]
 }
 
+export type Themes =
+  | {
+      javascriptStrategy: 'greedy'
+      javascriptDigitAmount: number
+    }
+  | {
+      javascriptStrategy: 'prefix'
+      javascriptPrefix: string
+    }
+
 export type Guide = {
   brands: string[]
+  themes?: Themes
   themesForBrands?: string[]
 }
 
@@ -2838,6 +2849,33 @@ const IdLocatorType = createMatchingObjectType<IdLocator>({
   },
 })
 
+const ThemesType = createMatchingObjectType<Themes>({
+  elemID: new ElemID(ZENDESK, 'ThemeType'),
+  fields: {
+    javascriptStrategy: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: true,
+      },
+    },
+    javascriptPrefix: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: true,
+      },
+    },
+    javascriptDigitAmount: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: {
+        _required: true,
+      },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 const GuideType = createMatchingObjectType<Guide>({
   elemID: new ElemID(ZENDESK, 'GuideType'),
   fields: {
@@ -2846,6 +2884,9 @@ const GuideType = createMatchingObjectType<Guide>({
       annotations: {
         _required: true,
       },
+    },
+    themes: {
+      refType: ThemesType,
     },
     themesForBrands: {
       refType: new ListType(BuiltinTypes.STRING),

--- a/packages/zendesk-adapter/src/filters/guide_theme.ts
+++ b/packages/zendesk-adapter/src/filters/guide_theme.ts
@@ -86,6 +86,9 @@ const createTemplateExpression = ({
   matchBrandSubdomain: (url: string) => InstanceElement | undefined
   config: Themes
 }): string | TemplateExpression => {
+  if (config.referenceOptions.enableReferenceLookup === false) {
+    return content
+  }
   try {
     let createTemplateExpressionFunc: TemplateEngineCreator
     if (filePath.endsWith('.hbs')) {
@@ -104,7 +107,7 @@ const createTemplateExpression = ({
         matchBrandSubdomain,
         enableMissingReferences: false, // Starting with false, to gain confidence in the feature
       },
-      config,
+      config.referenceOptions.javascriptReferenceLookupStrategy,
     )
   } catch (e) {
     log.warn('Error parsing references in file %s, %o', filePath, e)
@@ -359,8 +362,9 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
             idsToElements,
             matchBrandSubdomain,
             config: config[FETCH_CONFIG].guide?.themes || {
-              javascriptStrategy: 'greedy',
-              javascriptDigitAmount: 6,
+              referenceOptions: {
+                enableReferenceLookup: false,
+              },
             },
           })
           theme.value.root = themeElements

--- a/packages/zendesk-adapter/src/filters/template_engines/creator.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/creator.ts
@@ -1,0 +1,161 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InstanceElement, TemplateExpression } from '@salto-io/adapter-api'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
+import { Themes } from '../../config'
+import { parseHandlebarPotentialReferences } from './handlebar_parser'
+import { parseHtmlPotentialReferences } from './html_parser'
+import { extractDomainsAndFieldsFromScripts, extractGreedyIdsFromScripts } from './javascript_extractor'
+import { parsePotentialReferencesByPrefix } from './javascript_parser'
+import { PotentialReference, TemplateEngineOptions } from './types'
+
+export type TemplateEngineCreator = (
+  content: string,
+  options: TemplateEngineOptions,
+  config: Themes,
+) => string | TemplateExpression
+
+const extractOrParseByStrategy = (
+  scripts: PotentialReference<string>[],
+  idsToElements: Record<string, InstanceElement>,
+  themes: Themes,
+): PotentialReference<string | TemplateExpression>[] => {
+  if (themes.javascriptStrategy === 'greedy') {
+    return scripts.map(script => ({
+      value: extractGreedyIdsFromScripts(idsToElements, script.value, themes.javascriptDigitAmount),
+      loc: script.loc,
+    }))
+  }
+  if (themes.javascriptStrategy === 'prefix') {
+    return scripts.flatMap(script => {
+      const parsedScripts = parsePotentialReferencesByPrefix(script.value, idsToElements, themes.javascriptPrefix)
+      return parsedScripts.map(parsedScript => ({
+        value: parsedScript.value,
+        loc: { start: script.loc.start + parsedScript.loc.start, end: script.loc.start + parsedScript.loc.end },
+      }))
+    })
+  }
+  return scripts
+}
+
+const extractDomainsAndFieldsAfterStrategy = (
+  script: PotentialReference<string | TemplateExpression>,
+  idsToElements: Record<string, InstanceElement>,
+  matchBrandSubdomain: (url: string) => InstanceElement | undefined,
+): PotentialReference<string | TemplateExpression> => {
+  if (typeof script.value === 'string') {
+    return {
+      value: extractDomainsAndFieldsFromScripts(idsToElements, matchBrandSubdomain, script.value),
+      loc: script.loc,
+    }
+  }
+  return {
+    value: createTemplateExpression({
+      parts: script.value.parts.flatMap(part => {
+        if (typeof part === 'string') {
+          const templatedString = extractDomainsAndFieldsFromScripts(idsToElements, matchBrandSubdomain, part)
+          return typeof templatedString === 'string' ? templatedString : templatedString.parts
+        }
+        return part
+      }),
+    }),
+    loc: script.loc,
+  }
+}
+
+const javascriptReferencesByConfig = (
+  scripts: PotentialReference<string>[],
+  idsToElements: Record<string, InstanceElement>,
+  matchBrandSubdomain: (url: string) => InstanceElement | undefined,
+  themes?: Themes,
+): PotentialReference<string | TemplateExpression>[] => {
+  if (themes === undefined) {
+    return scripts
+  }
+  return extractOrParseByStrategy(scripts, idsToElements, themes).flatMap(script =>
+    extractDomainsAndFieldsAfterStrategy(script, idsToElements, matchBrandSubdomain),
+  )
+}
+
+const mergeDistinctReferences = (
+  content: string,
+  references: PotentialReference<string | TemplateExpression>[],
+): string | TemplateExpression => {
+  const sortedReferences = references.sort((a, b) => a.loc.start - b.loc.start)
+  const mergedReferences: (string | TemplateExpression)[] = []
+  let lastEnd = 0
+  sortedReferences.forEach(reference => {
+    if (reference.loc.start > lastEnd) {
+      mergedReferences.push(content.slice(lastEnd, reference.loc.start))
+    }
+    mergedReferences.push(reference.value)
+    lastEnd = reference.loc.end
+  })
+  if (lastEnd < content.length) {
+    mergedReferences.push(content.slice(lastEnd))
+  }
+  const templateParts = mergedReferences.flatMap(part => (typeof part === 'string' ? part : part.parts))
+  const templateExpression = createTemplateExpression({
+    parts: templateParts,
+  })
+  return templateExpression.parts.every(part => typeof part === 'string')
+    ? templateExpression.parts.join('')
+    : templateExpression
+}
+
+export const createHandlebarTemplateExpression: TemplateEngineCreator = (
+  content,
+  { matchBrandSubdomain, idsToElements, enableMissingReferences },
+  config,
+) => {
+  const handlebarReferences = parseHandlebarPotentialReferences(content, idsToElements)
+  const { urls, scripts } = parseHtmlPotentialReferences(content, {
+    matchBrandSubdomain,
+    idsToElements,
+    enableMissingReferences,
+  })
+  const javascriptReferences = javascriptReferencesByConfig(scripts, idsToElements, matchBrandSubdomain, config)
+  return mergeDistinctReferences(content, [...handlebarReferences, ...urls, ...javascriptReferences])
+}
+
+export const createHtmlTemplateExpression: TemplateEngineCreator = (
+  content,
+  { matchBrandSubdomain, idsToElements, enableMissingReferences },
+  config,
+) => {
+  const { urls, scripts } = parseHtmlPotentialReferences(content, {
+    matchBrandSubdomain,
+    idsToElements,
+    enableMissingReferences,
+  })
+  const javascriptReferences = javascriptReferencesByConfig(scripts, idsToElements, matchBrandSubdomain, config)
+  return mergeDistinctReferences(content, [...urls, ...javascriptReferences])
+}
+
+export const createJavascriptTemplateExpression: TemplateEngineCreator = (
+  content,
+  { matchBrandSubdomain, idsToElements },
+  config,
+) => {
+  const javascriptReferences = javascriptReferencesByConfig(
+    [{ value: content, loc: { start: 0, end: content.length } }],
+    idsToElements,
+    matchBrandSubdomain,
+    config,
+  )
+  return mergeDistinctReferences(content, javascriptReferences)
+}

--- a/packages/zendesk-adapter/src/filters/template_engines/html_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/html_parser.ts
@@ -13,11 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstanceElement, TemplateExpression } from '@salto-io/adapter-api'
+import { TemplateExpression } from '@salto-io/adapter-api'
 import { extractTemplate } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { Element } from 'domhandler'
-import { hasChildren, isTag, isText, Node } from 'domhandler'
+import { Element, hasChildren, isTag, isText, Node } from 'domhandler'
 import { DomHandler, Parser } from 'htmlparser2'
 import { extractTemplateFromUrl, URL_REGEX } from '../article/utils'
 import { PotentialReference, TemplateEngineOptions } from './types'

--- a/packages/zendesk-adapter/src/filters/template_engines/html_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/html_parser.ts
@@ -16,10 +16,11 @@
 import { InstanceElement, TemplateExpression } from '@salto-io/adapter-api'
 import { extractTemplate } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
+import { Element } from 'domhandler'
 import { hasChildren, isTag, isText, Node } from 'domhandler'
 import { DomHandler, Parser } from 'htmlparser2'
 import { extractTemplateFromUrl, URL_REGEX } from '../article/utils'
-import { PotentialReference } from './types'
+import { PotentialReference, TemplateEngineOptions } from './types'
 
 const log = logger(module)
 
@@ -49,25 +50,69 @@ const ELEMENTS_WITH_URLS: { [key: string]: string } = {
  */
 export const parseUrlPotentialReferencesFromString = (
   content: string,
-  {
-    matchBrandSubdomain,
-    instancesById,
-    enableMissingReferences,
-  }: {
-    matchBrandSubdomain: (url: string) => InstanceElement | undefined
-    instancesById: Record<string, InstanceElement>
-    enableMissingReferences?: boolean
-  },
+  { matchBrandSubdomain, idsToElements, enableMissingReferences }: TemplateEngineOptions,
 ): string | TemplateExpression =>
   extractTemplate(content, [URL_REGEX, HELP_CENTER_URL], expression => {
     if (expression.match(URL_REGEX)) {
       const urlBrandInstance = matchBrandSubdomain(expression)
       return urlBrandInstance !== undefined
-        ? extractTemplateFromUrl({ url: expression, urlBrandInstance, instancesById, enableMissingReferences })
+        ? extractTemplateFromUrl({
+            url: expression,
+            urlBrandInstance,
+            instancesById: idsToElements,
+            enableMissingReferences,
+          })
         : expression
     }
-    return extractTemplateFromUrl({ url: expression, instancesById, enableMissingReferences })
+    return extractTemplateFromUrl({ url: expression, instancesById: idsToElements, enableMissingReferences })
   })
+
+// Function to extract the location of an attribute value in the content
+// htmlparser2 does not provide the location of the attribute value in a node
+const updateUrlLocations = (urls: PotentialReference<string>[], content: string): PotentialReference<string>[] =>
+  urls.map(({ loc, value }) => {
+    const start = loc.start + content.substring(loc.start, loc.end).indexOf(value)
+    return { value, loc: { start, end: start + value.length } }
+  })
+
+const parseUrlTag = (node: Element): PotentialReference<string> | undefined => {
+  if (node.name in ELEMENTS_WITH_URLS) {
+    const urlAttr = ELEMENTS_WITH_URLS[node.name]
+    if (!node.startIndex || !node.endIndex) {
+      log.error('Missing start or end index for node %o', node)
+      return undefined
+    }
+    if (node.attribs[urlAttr]) {
+      return { value: node.attribs[urlAttr], loc: { start: node.startIndex, end: node.endIndex } }
+    }
+    if (node.attribs[`ng-${urlAttr}`]) {
+      // Support AngularJS ng-href and ng-src
+      return {
+        value: node.attribs[`ng-${urlAttr}`],
+        loc: { start: node.startIndex, end: node.endIndex },
+      }
+    }
+  }
+  return undefined
+}
+
+const parseScriptTag = (node: Element): PotentialReference<string> | undefined => {
+  if (node.name === 'script') {
+    // Assumes the first text child of a script tag is the script content
+    const scriptContent = node.children.find(child => isText(child))
+    if (scriptContent && isText(scriptContent)) {
+      if (!scriptContent.startIndex || !scriptContent.endIndex) {
+        log.error('Missing start or end index for node %o', node)
+        return undefined
+      }
+      return {
+        value: scriptContent.data,
+        loc: { start: scriptContent.startIndex, end: scriptContent.endIndex },
+      }
+    }
+  }
+  return undefined
+}
 
 // Function to parse HTML and extract URLs from tags
 export const parseTagsFromHtml = (
@@ -83,27 +128,13 @@ export const parseTagsFromHtml = (
         const traverse = (nodes: Node[]): void => {
           nodes.forEach(node => {
             if (isTag(node)) {
-              if (node.name in ELEMENTS_WITH_URLS) {
-                const urlAttr = ELEMENTS_WITH_URLS[node.name]
-                if (node.attribs[urlAttr]) {
-                  urls.push({ value: node.attribs[urlAttr], loc: { start: node.startIndex, end: node.endIndex } })
-                } else if (node.attribs[`ng-${urlAttr}`]) {
-                  // Support AngularJS ng-href and ng-src
-                  urls.push({
-                    value: node.attribs[`ng-${urlAttr}`],
-                    loc: { start: node.startIndex, end: node.endIndex },
-                  })
-                }
+              const url = parseUrlTag(node)
+              if (url) {
+                urls.push(url)
               }
-              if (node.name === 'script') {
-                // Assumes the first text child of a script tag is the script content
-                const scriptContent = node.children.find(child => isText(child))
-                if (scriptContent && isText(scriptContent)) {
-                  scripts.push({
-                    value: scriptContent.data,
-                    loc: { start: scriptContent.startIndex, end: scriptContent.endIndex },
-                  })
-                }
+              const script = parseScriptTag(node)
+              if (script) {
+                scripts.push(script)
               }
             }
             if (hasChildren(node)) {
@@ -121,27 +152,19 @@ export const parseTagsFromHtml = (
   parser.write(htmlContent)
   parser.end()
 
-  return { urls, scripts }
+  return { urls: updateUrlLocations(urls, htmlContent), scripts }
 }
 
 export const parseHtmlPotentialReferences = (
   content: string,
-  {
-    matchBrandSubdomain,
-    instancesById,
-    enableMissingReferences,
-  }: {
-    matchBrandSubdomain: (url: string) => InstanceElement | undefined
-    instancesById: Record<string, InstanceElement>
-    enableMissingReferences?: boolean
-  },
+  { matchBrandSubdomain, idsToElements, enableMissingReferences }: TemplateEngineOptions,
 ): { urls: PotentialReference<string | TemplateExpression>[]; scripts: PotentialReference<string>[] } => {
   const { urls, scripts } = parseTagsFromHtml(content)
   return {
     urls: urls.map(url => ({
       value: parseUrlPotentialReferencesFromString(url.value, {
         matchBrandSubdomain,
-        instancesById,
+        idsToElements,
         enableMissingReferences,
       }),
       loc: url.loc,

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
@@ -18,7 +18,7 @@ import { extractTemplate } from '@salto-io/adapter-utils'
 import { DOMAIN_REGEX } from '../utils'
 import { extractIdIfElementExists } from './utils'
 
-export const extractGreedyIdsFromScripts = (
+export const extractNumericValueIdsFromScripts = (
   idsToElements: Record<string, InstanceElement>,
   script: string,
   digitAmount: number,

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
@@ -16,23 +16,16 @@
 import { InstanceElement, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
 import { extractTemplate } from '@salto-io/adapter-utils'
 import { DOMAIN_REGEX } from '../utils'
-
-const extractIdIfElementExists = (
-  idsToElements: Record<string, InstanceElement>,
-  expression: string,
-): string | ReferenceExpression => {
-  const element = idsToElements[expression]
-  if (element !== undefined) {
-    return new ReferenceExpression(element.elemID, element)
-  }
-  return expression
-}
+import { extractIdIfElementExists } from './utils'
 
 export const extractGreedyIdsFromScripts = (
   idsToElements: Record<string, InstanceElement>,
   script: string,
+  digitAmount: number,
 ): string | TemplateExpression =>
-  extractTemplate(script, [/(\d{6,})/], expression => extractIdIfElementExists(idsToElements, expression))
+  extractTemplate(script, [new RegExp(`(\\d{${digitAmount},})`)], expression =>
+    extractIdIfElementExists(idsToElements, expression),
+  )
 
 export const extractDomainsAndFieldsFromScripts = (
   idsToElements: Record<string, InstanceElement>,

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_extractor.ts
@@ -15,15 +15,58 @@
  */
 import { InstanceElement, ReferenceExpression, TemplateExpression } from '@salto-io/adapter-api'
 import { extractTemplate } from '@salto-io/adapter-utils'
+import { DOMAIN_REGEX } from '../utils'
+
+const extractIdIfElementExists = (
+  idsToElements: Record<string, InstanceElement>,
+  expression: string,
+): string | ReferenceExpression => {
+  const element = idsToElements[expression]
+  if (element !== undefined) {
+    return new ReferenceExpression(element.elemID, element)
+  }
+  return expression
+}
 
 export const extractGreedyIdsFromScripts = (
   idsToElements: Record<string, InstanceElement>,
   script: string,
 ): string | TemplateExpression =>
-  extractTemplate(script, [/(\d{6,})/], expression => {
-    const element = idsToElements[expression]
-    if (element !== undefined) {
-      return new ReferenceExpression(element.elemID, element)
-    }
-    return expression
-  })
+  extractTemplate(script, [/(\d{6,})/], expression => extractIdIfElementExists(idsToElements, expression))
+
+export const extractDomainsAndFieldsFromScripts = (
+  idsToElements: Record<string, InstanceElement>,
+  matchBrandSubdomain: (url: string) => InstanceElement | undefined,
+  script: string,
+): string | TemplateExpression => {
+  const locators = [
+    {
+      locatorRegex: /(request_custom_fields_\d+)/,
+      elementFunc: (expression: string) => {
+        const potentialId = expression.match(/(\d+)/)
+        if (potentialId === null) {
+          return expression
+        }
+        return ['request_custom_fields_', extractIdIfElementExists(idsToElements, potentialId[0])]
+      },
+    },
+    {
+      locatorRegex: DOMAIN_REGEX,
+      elementFunc: (expression: string) => {
+        const element = matchBrandSubdomain(expression)
+        if (element !== undefined) {
+          return new ReferenceExpression(element.elemID, element)
+        }
+        return expression
+      },
+    },
+  ]
+  return extractTemplate(
+    script,
+    locators.map(locator => locator.locatorRegex),
+    expression => {
+      const locator = locators.find(loc => expression.match(loc.locatorRegex) !== null)
+      return locator !== undefined ? locator.elementFunc(expression) : expression
+    },
+  )
+}

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
@@ -1,0 +1,55 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { CallExpression, parse, VariableDeclaration } from 'acorn'
+import { simple as walkSimple } from 'acorn-walk'
+
+const matchVariableDeclarationWithPrefix = (node: VariableDeclaration, prefix: string, matches: string[]): void => {
+  node.declarations.forEach(declarationNode => {
+    if (
+      declarationNode.id.type === 'Identifier' &&
+      declarationNode.id.name.startsWith(prefix) &&
+      declarationNode.init &&
+      declarationNode.init.type === 'Literal' &&
+      typeof declarationNode.init.value === 'string'
+    ) {
+      matches.push(declarationNode.init.value)
+    }
+  })
+}
+const matchJQuerySelector = (node: CallExpression, matches: string[]): void => {
+  const { callee } = node
+  if (callee.type === 'Identifier' && callee.name === '$' && node.arguments.length === 1) {
+    const selectorArg = node.arguments[0]
+    if (selectorArg && selectorArg.type === 'Literal' && typeof selectorArg.value === 'string') {
+      matches.push(selectorArg.value)
+    }
+  }
+}
+export const parsePotentialReferencesByPrefix = (content: string, prefix: string): string[] => {
+  const ast = parse(content, { ecmaVersion: 2020, locations: true })
+  const matches: string[] = []
+
+  walkSimple(ast, {
+    VariableDeclaration(node) {
+      matchVariableDeclarationWithPrefix(node, prefix, matches)
+    },
+    CallExpression(node) {
+      matchJQuerySelector(node, matches)
+    },
+  })
+
+  return matches
+}

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
@@ -13,34 +13,54 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { CallExpression, parse, VariableDeclaration } from 'acorn'
+import { InstanceElement, TemplateExpression, TemplatePart } from '@salto-io/adapter-api'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { CallExpression, parse, SourceLocation, VariableDeclaration } from 'acorn'
 import { simple as walkSimple } from 'acorn-walk'
+import { PotentialReference } from './types'
+import { extractIdIfElementExists, findLineStartIndexes, sourceLocationToIndexRange } from './utils'
 
-const matchVariableDeclarationWithPrefix = (node: VariableDeclaration, prefix: string, matches: string[]): void => {
+const log = logger(module)
+
+const matchVariableDeclarationWithPrefix = (
+  node: VariableDeclaration,
+  prefix: string,
+  matches: { value: string; loc: SourceLocation }[],
+): void => {
   node.declarations.forEach(declarationNode => {
     if (
       declarationNode.id.type === 'Identifier' &&
       declarationNode.id.name.startsWith(prefix) &&
       declarationNode.init &&
       declarationNode.init.type === 'Literal' &&
-      typeof declarationNode.init.value === 'string'
+      ['string', 'number'].includes(typeof declarationNode.init.value)
     ) {
-      matches.push(declarationNode.init.value)
+      if (declarationNode.init.loc === undefined || declarationNode.init.loc === null) {
+        log.warn('Could not find location for variable declaration')
+      } else if (declarationNode.init.value) {
+        matches.push({ value: declarationNode.init.value.toString(), loc: declarationNode.init.loc })
+      }
     }
   })
 }
-const matchJQuerySelector = (node: CallExpression, matches: string[]): void => {
+const matchJQuerySelector = (node: CallExpression, matches: { value: string; loc: SourceLocation }[]): void => {
   const { callee } = node
   if (callee.type === 'Identifier' && callee.name === '$' && node.arguments.length === 1) {
     const selectorArg = node.arguments[0]
     if (selectorArg && selectorArg.type === 'Literal' && typeof selectorArg.value === 'string') {
-      matches.push(selectorArg.value)
+      if (selectorArg.loc === undefined || selectorArg.loc === null) {
+        log.warn('Could not find location for jQuery selector')
+      } else {
+        matches.push({ value: selectorArg.value, loc: selectorArg.loc })
+      }
     }
   }
 }
-export const parsePotentialReferencesByPrefix = (content: string, prefix: string): string[] => {
+
+const parsePotentialExpressions = (content: string, prefix: string): { value: string; loc: SourceLocation }[] => {
+  const matches: { value: string; loc: SourceLocation }[] = []
   const ast = parse(content, { ecmaVersion: 2020, locations: true })
-  const matches: string[] = []
 
   walkSimple(ast, {
     VariableDeclaration(node) {
@@ -52,4 +72,22 @@ export const parsePotentialReferencesByPrefix = (content: string, prefix: string
   })
 
   return matches
+}
+
+export const parsePotentialReferencesByPrefix = (
+  content: string,
+  idsToElements: Record<string, InstanceElement>,
+  prefix: string,
+): PotentialReference<TemplateExpression>[] => {
+  const expressionToTemplateParts = (expression: string): TemplatePart[] =>
+    expression.split(/(\d+)/).map(id => extractIdIfElementExists(idsToElements, id))
+  const expressionMatches = parsePotentialExpressions(content, prefix)
+
+  const newlineIndexes = findLineStartIndexes(content)
+  return expressionMatches.map(expression => ({
+    value: createTemplateExpression({
+      parts: expressionToTemplateParts(expression.value),
+    }),
+    loc: sourceLocationToIndexRange(newlineIndexes, expression.loc),
+  }))
 }

--- a/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/javascript_parser.ts
@@ -39,7 +39,10 @@ const matchVariableDeclarationWithPrefix = (
       if (declarationNode.init.loc === undefined || declarationNode.init.loc === null) {
         log.warn('Could not find location for variable declaration')
       } else if (declarationNode.init.value) {
-        matches.push({ value: declarationNode.init.value.toString(), loc: declarationNode.init.loc })
+        matches.push({
+          value: (declarationNode.init.raw ?? declarationNode.init.value).toString(),
+          loc: declarationNode.init.loc,
+        })
       }
     }
   })
@@ -52,7 +55,7 @@ const matchJQuerySelector = (node: CallExpression, matches: { value: string; loc
       if (selectorArg.loc === undefined || selectorArg.loc === null) {
         log.warn('Could not find location for jQuery selector')
       } else {
-        matches.push({ value: selectorArg.value, loc: selectorArg.loc })
+        matches.push({ value: selectorArg.raw ?? selectorArg.value, loc: selectorArg.loc })
       }
     }
   }

--- a/packages/zendesk-adapter/src/filters/template_engines/types.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/types.ts
@@ -13,10 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { SourceLocation } from '@handlebars/parser/types/ast'
-import { TemplateExpression } from '@salto-io/adapter-api'
+import { InstanceElement, TemplateExpression } from '@salto-io/adapter-api'
 
 export type PotentialReference<T extends string | TemplateExpression> = {
   value: T
-  loc: SourceLocation | { start: number | null; end: number | null }
+  loc: { start: number; end: number }
+}
+
+export type TemplateEngineOptions = {
+  matchBrandSubdomain: (url: string) => InstanceElement | undefined
+  idsToElements: Record<string, InstanceElement>
+  enableMissingReferences?: boolean
 }

--- a/packages/zendesk-adapter/src/filters/template_engines/utils.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/utils.ts
@@ -20,9 +20,9 @@ import { SourceLocation as AcornLocation } from 'acorn'
 export const findLineStartIndexes = (input: string, pos = 0, indexes = [0]): number[] => {
   const index = input.indexOf('\n', pos)
   if (index === -1) {
-    // If the last character is not a newline, add the start index of the last line
-    if (indexes[indexes.length - 1] !== input.length) {
-      return [...indexes, input.length]
+    // If the last character is a newline, remove the last wrong start index
+    if (input.endsWith('\n')) {
+      indexes.pop() // Removes the last element
     }
     return indexes
   }
@@ -40,11 +40,11 @@ export const sourceLocationToIndexRange = (
 
 export const extractIdIfElementExists = (
   idsToElements: Record<string, InstanceElement>,
-  expression: string,
+  id: string,
 ): string | ReferenceExpression => {
-  const element = idsToElements[expression]
+  const element = idsToElements[id]
   if (element !== undefined) {
     return new ReferenceExpression(element.elemID, element)
   }
-  return expression
+  return id
 }

--- a/packages/zendesk-adapter/src/filters/template_engines/utils.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/utils.ts
@@ -1,0 +1,50 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SourceLocation as HandlebarLocation } from '@handlebars/parser/types/ast'
+import { InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
+import { SourceLocation as AcornLocation } from 'acorn'
+
+export const findLineStartIndexes = (input: string, pos = 0, indexes = [0]): number[] => {
+  const index = input.indexOf('\n', pos)
+  if (index === -1) {
+    // If the last character is not a newline, add the start index of the last line
+    if (indexes[indexes.length - 1] !== input.length) {
+      return [...indexes, input.length]
+    }
+    return indexes
+  }
+  return findLineStartIndexes(input, index + 1, [...indexes, index + 1])
+}
+
+export const sourceLocationToIndexRange = (
+  newlineIndexes: number[],
+  loc: HandlebarLocation | AcornLocation,
+): { start: number; end: number } => {
+  const start = newlineIndexes[loc.start.line - 1] + loc.start.column
+  const end = newlineIndexes[loc.end.line - 1] + loc.end.column
+  return { start, end }
+}
+
+export const extractIdIfElementExists = (
+  idsToElements: Record<string, InstanceElement>,
+  expression: string,
+): string | ReferenceExpression => {
+  const element = idsToElements[expression]
+  if (element !== undefined) {
+    return new ReferenceExpression(element.elemID, element)
+  }
+  return expression
+}

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -143,9 +143,9 @@ export const isCorrectConditions = (value: unknown, typeName: string): value is 
 const getBrandsForFilter = (
   elements: InstanceElement[],
   fetchConfig: ZendeskFetchConfig,
-  filter: 'brands' | 'themesForBrands',
+  filter: 'brands' | 'themesForBrands' | 'themes.brands',
 ): InstanceElement[] => {
-  const brandsRegexList = fetchConfig.guide?.[filter] ?? []
+  const brandsRegexList: string[] = _.get(fetchConfig.guide, filter, [])
   return elements
     .filter(instance => instance.elemID.typeName === BRAND_TYPE_NAME)
     .filter(brandInstance => brandInstance.value.has_help_center)
@@ -158,7 +158,10 @@ export const getBrandsForGuide = (elements: InstanceElement[], fetchConfig: Zend
 export const getBrandsForGuideThemes = (
   elements: InstanceElement[],
   fetchConfig: ZendeskFetchConfig,
-): InstanceElement[] => getBrandsForFilter(elements, fetchConfig, 'themesForBrands')
+): InstanceElement[] => {
+  const themesSelector = fetchConfig.guide?.themesForBrands ? 'themesForBrands' : 'themes.brands'
+  return getBrandsForFilter(elements, fetchConfig, themesSelector)
+}
 
 export const matchBrand = (url: string, brands: Record<string, InstanceElement>): InstanceElement | undefined => {
   const urlSubdomain = url.match(DOMAIN_REGEX)?.pop()

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -1904,7 +1904,12 @@ describe('adapter', () => {
             exclude: [],
             guide: {
               brands: ['.WithGuide'],
-              themesForBrands: ['my.'],
+              themes: {
+                brands: ['my.'],
+                referenceOptions: {
+                  enableReferenceLookup: false,
+                },
+              },
             },
           },
         })

--- a/packages/zendesk-adapter/test/filters/guide_theme_settings.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_theme_settings.test.ts
@@ -84,7 +84,15 @@ describe('filterCreator', () => {
 
         beforeEach(() => {
           const config = { ...DEFAULT_CONFIG }
-          config[FETCH_CONFIG].guide = { brands: ['.*'], themesForBrands: [] }
+          config[FETCH_CONFIG].guide = {
+            brands: ['.*'],
+            themes: {
+              brands: [],
+              referenceOptions: {
+                enableReferenceLookup: false,
+              },
+            },
+          }
           filter = filterCreator(createFilterCreatorParams({ config }))
         })
 
@@ -99,7 +107,15 @@ describe('filterCreator', () => {
 
       beforeEach(() => {
         const config = { ...DEFAULT_CONFIG }
-        config[FETCH_CONFIG].guide = { brands: ['.*'], themesForBrands: ['.*'] }
+        config[FETCH_CONFIG].guide = {
+          brands: ['.*'],
+          themes: {
+            brands: ['.*'],
+            referenceOptions: {
+              enableReferenceLookup: false,
+            },
+          },
+        }
         filter = filterCreator(createFilterCreatorParams({ config }))
       })
 
@@ -132,7 +148,15 @@ describe('filterCreator', () => {
     beforeEach(() => {
       jest.resetAllMocks()
       const config = { ...DEFAULT_CONFIG }
-      config[FETCH_CONFIG].guide = { brands: ['.*'], themesForBrands: ['.*'] }
+      config[FETCH_CONFIG].guide = {
+        brands: ['.*'],
+        themes: {
+          brands: ['.*'],
+          referenceOptions: {
+            enableReferenceLookup: false,
+          },
+        },
+      }
       filter = filterCreator(createFilterCreatorParams({ config }))
       mockPublish = jest.spyOn(PublishModule, 'publish')
     })

--- a/packages/zendesk-adapter/test/filters/template_engines/creator.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/creator.test.ts
@@ -1,0 +1,199 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { Themes } from '../../../src/config'
+import { ARTICLE_TYPE_NAME, BRAND_TYPE_NAME, ZENDESK } from '../../../src/constants'
+import {
+  createHandlebarTemplateExpression,
+  createHtmlTemplateExpression,
+  createJavascriptTemplateExpression,
+} from '../../../src/filters/template_engines/creator'
+
+describe('create template expression from files', () => {
+  let config: Themes
+  const article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
+    id: 12345,
+  })
+  const brand = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
+    id: 654321,
+    brand_url: 'https://brand.com',
+  })
+  const javascriptContent = `
+    $(document).ready(function() {
+      $('.request_custom_fields_12345').hide(); //hidden checkbox to make attachment required
+    })
+    var PREFIX_article_id_friend = 12345
+    var without_a_prefix = 12345
+    var PREFIX_full_article = 'https://brand.com/article/12345'`
+
+  const expectedJavascriptContent = (strategy: 'greedy' | 'prefix'): (ReferenceExpression | string)[] => {
+    const greedyJavascriptContent = [
+      `
+    var without_a_prefix = `,
+      new ReferenceExpression(article.elemID, article),
+      `
+    var PREFIX_full_article = '`,
+    ]
+    const prefixJavascriptContent = [
+      `
+    var without_a_prefix = 12345
+    var PREFIX_full_article = '`,
+    ]
+    const innerContent = strategy === 'greedy' ? greedyJavascriptContent : prefixJavascriptContent
+    return [
+      `
+    $(document).ready(function() {
+      $('.request_custom_fields_`,
+      new ReferenceExpression(article.elemID, article),
+      `').hide(); //hidden checkbox to make attachment required
+    })
+    var PREFIX_article_id_friend = `,
+      new ReferenceExpression(article.elemID, article),
+      ...innerContent,
+      new ReferenceExpression(brand.elemID, brand),
+      '/article/',
+      new ReferenceExpression(article.elemID, article),
+      "'",
+    ]
+  }
+
+  const content = `
+    <body>
+      <script>
+        ${javascriptContent}
+      </script>
+
+      <div class="container">
+        <a href="https://brand.com/requests/new?ticket_form_id=12345">{{dc 'submit_a_request'}}</a>
+        {{#is article.id 12345}}
+          <span>{{date article.created_at timeago=true}}</span>
+          <a href="{{help_center.url}}/articles/12345">{{dc 'contact_support'}}</a>
+        {{/is}}
+        {{#is article.id 12345}}
+          <span>{{date article.created_at timeago=true}}</span>
+        {{/is}}
+      </div>
+    </body>
+    `
+
+  const matchBrandSubdomain = (url: string): InstanceElement | undefined => {
+    if (url.includes('https://brand.com')) {
+      return brand
+    }
+    return undefined
+  }
+
+  describe.each(['greedy', 'prefix'])('with %s javascript strategy', strategyString => {
+    const strategy = strategyString as 'greedy' | 'prefix'
+    beforeEach(() => {
+      config =
+        strategy === 'greedy'
+          ? {
+              javascriptStrategy: 'greedy',
+              javascriptDigitAmount: 5,
+            }
+          : {
+              javascriptStrategy: 'prefix',
+              javascriptPrefix: 'PREFIX_',
+            }
+    })
+    describe('createHandlebarTemplateExpression', () => {
+      it('should create a template expression from handlebar, html and javascript references', () => {
+        const options = { matchBrandSubdomain, idsToElements: { 12345: article, 654321: brand } }
+        const template = createHandlebarTemplateExpression(content, options, config)
+        expect(template).toEqual({
+          parts: [
+            `
+    <body>
+      <script>
+        ${expectedJavascriptContent(strategy)[0]}`,
+            ...expectedJavascriptContent(strategy).slice(1, -1),
+            expect.stringContaining(`</script>
+
+      <div class="container">
+        <a href="`),
+            new ReferenceExpression(brand.elemID, brand),
+            '/requests/new?ticket_form_id=',
+            new ReferenceExpression(article.elemID, article),
+            `">{{dc 'submit_a_request'}}</a>
+        {{#is article.id `,
+            new ReferenceExpression(article.elemID, article),
+            `}}
+          <span>{{date article.created_at timeago=true}}</span>
+          <a href="{{help_center.url}}/articles/`,
+            new ReferenceExpression(article.elemID, article),
+            `">{{dc 'contact_support'}}</a>
+        {{/is}}
+        {{#is article.id `,
+            new ReferenceExpression(article.elemID, article),
+            `}}
+          <span>{{date article.created_at timeago=true}}</span>
+        {{/is}}
+      </div>
+    </body>
+    `,
+          ],
+        })
+      })
+    })
+
+    describe('createHtmlTemplateExpression', () => {
+      it('should create a template expression from html references', () => {
+        const options = { matchBrandSubdomain, idsToElements: { 12345: article, 654321: brand } }
+        const template = createHtmlTemplateExpression(content, options, config)
+        expect(template).toEqual({
+          parts: [
+            `
+    <body>
+      <script>
+        ${expectedJavascriptContent(strategy)[0]}`,
+            ...expectedJavascriptContent(strategy).slice(1, -1),
+            expect.stringContaining(`</script>
+
+      <div class="container">
+        <a href="`),
+            new ReferenceExpression(brand.elemID, brand),
+            '/requests/new?ticket_form_id=',
+            new ReferenceExpression(article.elemID, article),
+            `">{{dc 'submit_a_request'}}</a>
+        {{#is article.id 12345}}
+          <span>{{date article.created_at timeago=true}}</span>
+          <a href="{{help_center.url}}/articles/`,
+            new ReferenceExpression(article.elemID, article),
+            `">{{dc 'contact_support'}}</a>
+        {{/is}}
+        {{#is article.id 12345}}
+          <span>{{date article.created_at timeago=true}}</span>
+        {{/is}}
+      </div>
+    </body>
+    `,
+          ],
+        })
+      })
+    })
+
+    describe('createJavascriptTemplateExpression', () => {
+      it('should create a template expression from javascript references', () => {
+        const options = { matchBrandSubdomain, idsToElements: { 12345: article, 654321: brand } }
+        const template = createJavascriptTemplateExpression(javascriptContent, options, config)
+        expect(template).toEqual({
+          parts: expectedJavascriptContent(strategy),
+        })
+      })
+    })
+  })
+})

--- a/packages/zendesk-adapter/test/filters/template_engines/creator.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/creator.test.ts
@@ -23,7 +23,7 @@ import {
 } from '../../../src/filters/template_engines/creator'
 
 describe('create template expression from files', () => {
-  let config: Themes
+  let config: Themes['referenceOptions']['javascriptReferenceLookupStrategy']
   const article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
     id: 12345,
   })
@@ -39,7 +39,7 @@ describe('create template expression from files', () => {
     var without_a_prefix = 12345
     var PREFIX_full_article = 'https://brand.com/article/12345'`
 
-  const expectedJavascriptContent = (strategy: 'greedy' | 'prefix'): (ReferenceExpression | string)[] => {
+  const expectedJavascriptContent = (strategy: 'numericValues' | 'varNamePrefix'): (ReferenceExpression | string)[] => {
     const greedyJavascriptContent = [
       `
     var without_a_prefix = `,
@@ -52,7 +52,7 @@ describe('create template expression from files', () => {
     var without_a_prefix = 12345
     var PREFIX_full_article = '`,
     ]
-    const innerContent = strategy === 'greedy' ? greedyJavascriptContent : prefixJavascriptContent
+    const innerContent = strategy === 'numericValues' ? greedyJavascriptContent : prefixJavascriptContent
     return [
       `
     $(document).ready(function() {
@@ -96,18 +96,18 @@ describe('create template expression from files', () => {
     return undefined
   }
 
-  describe.each(['greedy', 'prefix'])('with %s javascript strategy', strategyString => {
-    const strategy = strategyString as 'greedy' | 'prefix'
+  describe.each(['numericValues', 'varNamePrefix'])('with %s javascript strategy', strategyString => {
+    const strategy = strategyString as 'numericValues' | 'varNamePrefix'
     beforeEach(() => {
       config =
-        strategy === 'greedy'
+        strategy === 'numericValues'
           ? {
-              javascriptStrategy: 'greedy',
-              javascriptDigitAmount: 5,
+              strategy: 'numericValues',
+              minimumDigitAmount: 5,
             }
           : {
-              javascriptStrategy: 'prefix',
-              javascriptPrefix: 'PREFIX_',
+              strategy: 'varNamePrefix',
+              prefix: 'PREFIX_',
             }
     })
     describe('createHandlebarTemplateExpression', () => {

--- a/packages/zendesk-adapter/test/filters/template_engines/html_parser.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/html_parser.test.ts
@@ -34,22 +34,22 @@ describe('parseTagsFromHtml', () => {
         {
           value: 'https://example.com',
           loc: {
-            end: 46,
-            start: 7,
+            end: 35,
+            start: 16,
           },
         },
         {
           value: 'https://example.com/image.jpg',
           loc: {
-            end: 106,
-            start: 54,
+            end: 93,
+            start: 64,
           },
         },
         {
           value: 'https://example.com/styles.css',
           loc: {
-            end: 174,
-            start: 114,
+            end: 156,
+            start: 126,
           },
         },
       ])
@@ -88,7 +88,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
   let urlBrandInstance: InstanceElement
   let matchBrandSubdomain: (url: string) => InstanceElement | undefined
   let article: InstanceElement
-  let instancesById: Record<string, InstanceElement>
+  let idsToElements: Record<string, InstanceElement>
   beforeEach(() => {
     urlBrandInstance = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
       id: 1,
@@ -98,7 +98,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
     article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
       id: 222552,
     })
-    instancesById = {
+    idsToElements = {
       [urlBrandInstance.value.id]: urlBrandInstance,
       [article.value.id]: article,
     }
@@ -106,7 +106,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
 
   it('should extract URL references from a string', () => {
     const content = 'This is a string with a URL reference: {{help_center.url}}/hc/en-us/articles/222552'
-    const result = parseUrlPotentialReferencesFromString(content, { matchBrandSubdomain, instancesById })
+    const result = parseUrlPotentialReferencesFromString(content, { matchBrandSubdomain, idsToElements })
     expect(result).toEqual({
       parts: [
         'This is a string with a URL reference: {{help_center.url}}/hc/en-us/articles/',
@@ -118,7 +118,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
   it('should extract URL references from a string with multiple references', () => {
     const content =
       'This is a string with multiple URL references: https://some.domain.com/hc/en-us/articles/222552 and {{help_center.url}}/hc/en-us/articles/222552'
-    const result = parseUrlPotentialReferencesFromString(content, { matchBrandSubdomain, instancesById })
+    const result = parseUrlPotentialReferencesFromString(content, { matchBrandSubdomain, idsToElements })
     expect(result).toEqual({
       parts: [
         'This is a string with multiple URL references: ',
@@ -142,7 +142,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
     )
     const result = parseUrlPotentialReferencesFromString(content, {
       matchBrandSubdomain,
-      instancesById,
+      idsToElements,
       enableMissingReferences: true,
     })
     expect(result).toEqual({
@@ -157,7 +157,7 @@ describe('parseUrlPotentialReferencesFromString', () => {
     const content = 'This is a string with a missing URL reference: {{help_center.url}}/hc/en-us/articles/360001234568'
     const result = parseUrlPotentialReferencesFromString(content, {
       matchBrandSubdomain,
-      instancesById,
+      idsToElements,
       enableMissingReferences: false,
     })
     expect(result).toEqual(
@@ -170,7 +170,7 @@ describe('parseHtmlPotentialReferences', () => {
   let urlBrandInstance: InstanceElement
   let matchBrandSubdomain: (url: string) => InstanceElement | undefined
   let article: InstanceElement
-  let instancesById: Record<string, InstanceElement>
+  let idsToElements: Record<string, InstanceElement>
   beforeEach(() => {
     urlBrandInstance = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
       id: 1,
@@ -180,7 +180,7 @@ describe('parseHtmlPotentialReferences', () => {
     article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
       id: 222552,
     })
-    instancesById = {
+    idsToElements = {
       [urlBrandInstance.value.id]: urlBrandInstance,
       [article.value.id]: article,
     }
@@ -192,21 +192,21 @@ describe('parseHtmlPotentialReferences', () => {
       <img src="{{help_center.url}}/image.jpg" alt="Image">
       <link href="{{help_center.url}}/styles.css" rel="stylesheet">
     `
-    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, instancesById })
+    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, idsToElements })
     expect(result.urls).toEqual([
       {
         value: {
           parts: ['{{help_center.url}}/hc/en-us/articles/', new ReferenceExpression(article.elemID, article)],
         },
-        loc: { start: 7, end: 71 },
+        loc: { start: 16, end: 60 },
       },
       {
         value: '{{help_center.url}}/image.jpg',
-        loc: { start: 79, end: 131 },
+        loc: { start: 89, end: 118 },
       },
       {
         value: '{{help_center.url}}/styles.css',
-        loc: { start: 139, end: 199 },
+        loc: { start: 151, end: 181 },
       },
     ])
   })
@@ -216,17 +216,17 @@ describe('parseHtmlPotentialReferences', () => {
       <a ng-href="{{help_center.url}}/hc/en-us/articles/222552">Link 1</a>
       <img ng-src="{{help_center.url}}/image.jpg" alt="Image">
     `
-    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, instancesById })
+    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, idsToElements })
     expect(result.urls).toEqual([
       {
         value: {
           parts: ['{{help_center.url}}/hc/en-us/articles/', new ReferenceExpression(article.elemID, article)],
         },
-        loc: { start: 7, end: 74 },
+        loc: { start: 19, end: 63 },
       },
       {
         value: '{{help_center.url}}/image.jpg',
-        loc: { start: 82, end: 137 },
+        loc: { start: 95, end: 124 },
       },
     ])
   })
@@ -252,7 +252,7 @@ describe('parseHtmlPotentialReferences', () => {
     )
     const result = parseHtmlPotentialReferences(htmlContent, {
       matchBrandSubdomain,
-      instancesById,
+      idsToElements,
       enableMissingReferences: true,
     })
     expect(result.urls).toEqual([
@@ -263,7 +263,7 @@ describe('parseHtmlPotentialReferences', () => {
             new ReferenceExpression(missingArticle.elemID, missingArticle),
           ],
         },
-        loc: { start: 7, end: 77 },
+        loc: { start: 16, end: 66 },
       },
       {
         value: {
@@ -273,7 +273,7 @@ describe('parseHtmlPotentialReferences', () => {
             new ReferenceExpression(missingBrandArticle.elemID, missingBrandArticle),
           ],
         },
-        loc: { start: 85, end: 165 },
+        loc: { start: 94, end: 154 },
       },
     ])
   })
@@ -284,7 +284,7 @@ describe('parseHtmlPotentialReferences', () => {
         const someVar = 'some value';
       </script>
     `
-    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, instancesById })
+    const result = parseHtmlPotentialReferences(htmlContent, { matchBrandSubdomain, idsToElements })
     expect(result.scripts).toEqual([
       {
         value: expect.stringMatching(/\s+const someVar = 'some value';\s+/),

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
@@ -17,10 +17,10 @@ import { InstanceElement, ObjectType, ElemID, ReferenceExpression } from '@salto
 import { ZENDESK, ARTICLE_TYPE_NAME, SECTION_TYPE_NAME, BRAND_TYPE_NAME } from '../../../src/constants'
 import {
   extractDomainsAndFieldsFromScripts,
-  extractGreedyIdsFromScripts,
+  extractNumericValueIdsFromScripts,
 } from '../../../src/filters/template_engines/javascript_extractor'
 
-describe('extractGreedyIdsFromScripts', () => {
+describe('extractNumericValueIdsFromScripts', () => {
   const article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
     id: 123456,
   })
@@ -40,7 +40,7 @@ describe('extractGreedyIdsFromScripts', () => {
       const id2 = 789012;
       // More script code
     `
-    const result = extractGreedyIdsFromScripts(idsToElements, script, 6)
+    const result = extractNumericValueIdsFromScripts(idsToElements, script, 6)
     expect(result).toEqual({
       parts: [
         expect.stringMatching(/\s+\/\/ Some script code\s+const id1 = /),
@@ -59,7 +59,7 @@ describe('extractGreedyIdsFromScripts', () => {
       const id2 = 'some id?';
       // More script code
     `
-    const result = extractGreedyIdsFromScripts(idsToElements, script, 6)
+    const result = extractNumericValueIdsFromScripts(idsToElements, script, 6)
     expect(result).toEqual(script)
   })
 })

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
@@ -14,8 +14,11 @@
  * limitations under the License.
  */
 import { InstanceElement, ObjectType, ElemID, ReferenceExpression } from '@salto-io/adapter-api'
-import { ZENDESK, ARTICLE_TYPE_NAME, SECTION_TYPE_NAME } from '../../../src/constants'
-import { extractGreedyIdsFromScripts } from '../../../src/filters/template_engines/javascript_extractor'
+import { ZENDESK, ARTICLE_TYPE_NAME, SECTION_TYPE_NAME, BRAND_TYPE_NAME } from '../../../src/constants'
+import {
+  extractDomainsAndFieldsFromScripts,
+  extractGreedyIdsFromScripts,
+} from '../../../src/filters/template_engines/javascript_extractor'
 
 describe('extractGreedyIdsFromScripts', () => {
   const article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
@@ -57,6 +60,61 @@ describe('extractGreedyIdsFromScripts', () => {
       // More script code
     `
     const result = extractGreedyIdsFromScripts(idsToElements, script)
+    expect(result).toEqual(script)
+  })
+})
+
+describe('extractDomainsAndFieldsFromScripts', () => {
+  const article = new InstanceElement('article', new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TYPE_NAME) }), {
+    id: 123456,
+  })
+  const section = new InstanceElement('section', new ObjectType({ elemID: new ElemID(ZENDESK, SECTION_TYPE_NAME) }), {
+    id: 789012,
+  })
+
+  const idsToElements = {
+    '123456': article,
+    '789012': section,
+  }
+
+  const brand = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) }), {
+    id: 654321,
+    brand_url: 'https://brand.com',
+  })
+
+  const matchBrandSubdomain = (url: string): InstanceElement | undefined => {
+    if (url === 'https://brand.com') {
+      return brand
+    }
+    return undefined
+  }
+
+  it('should return a TemplateExpression with references from the script', () => {
+    const script = `
+      // Some script code
+      const request_custom_fields_123456 = 'some value';
+      const brandDomain = 'https://brand.com/';
+      // More script code
+    `
+    const result = extractDomainsAndFieldsFromScripts(idsToElements, matchBrandSubdomain, script)
+    expect(result).toEqual({
+      parts: [
+        expect.stringMatching(/\s+\/\/ Some script code\s+const request_custom_fields_/),
+        new ReferenceExpression(article.elemID, article),
+        expect.stringMatching(/ = 'some value';\s+const brandDomain = /),
+        new ReferenceExpression(brand.elemID, brand),
+        expect.stringMatching(/\/';\s+\/\/ More script code\s+/),
+      ],
+    })
+  })
+
+  it('should return the input if no potential IDs are found', () => {
+    const script = `
+      // Some script code
+      const request_custom_fields_654321 = 'some value';
+      // More script code
+    `
+    const result = extractDomainsAndFieldsFromScripts(idsToElements, matchBrandSubdomain, script)
     expect(result).toEqual(script)
   })
 })

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
@@ -40,7 +40,7 @@ describe('extractGreedyIdsFromScripts', () => {
       const id2 = 789012;
       // More script code
     `
-    const result = extractGreedyIdsFromScripts(idsToElements, script)
+    const result = extractGreedyIdsFromScripts(idsToElements, script, 6)
     expect(result).toEqual({
       parts: [
         expect.stringMatching(/\s+\/\/ Some script code\s+const id1 = /),
@@ -59,7 +59,7 @@ describe('extractGreedyIdsFromScripts', () => {
       const id2 = 'some id?';
       // More script code
     `
-    const result = extractGreedyIdsFromScripts(idsToElements, script)
+    const result = extractGreedyIdsFromScripts(idsToElements, script, 6)
     expect(result).toEqual(script)
   })
 })

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_extractor.test.ts
@@ -83,7 +83,7 @@ describe('extractDomainsAndFieldsFromScripts', () => {
   })
 
   const matchBrandSubdomain = (url: string): InstanceElement | undefined => {
-    if (url === 'https://brand.com') {
+    if (url.includes('https://brand.com')) {
       return brand
     }
     return undefined

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_parser.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_parser.test.ts
@@ -1,0 +1,51 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { parsePotentialReferencesByPrefix } from '../../../src/filters/template_engines/javascript_parser'
+
+describe('parsePotentialReferencesByPrefix', () => {
+  it('should return an array of initial assignments to variable definitions with the given prefix', () => {
+    const code = `
+        const myVar1 = "hello";
+        let myVar2 = "world";
+        const otherVar = "test";
+      `
+    const prefix = 'myVar'
+    const result = parsePotentialReferencesByPrefix(code, prefix)
+    expect(result).toEqual(['hello', 'world'])
+  })
+
+  it('should return an empty array if no variables or assignments with the given prefix are found', () => {
+    const code = `
+        const otherVar1 = "hello";
+        let otherVar2 = "world";
+        const anotherVar = "test";
+      `
+    const prefix = 'myVar'
+    const result = parsePotentialReferencesByPrefix(code, prefix)
+    expect(result).toEqual([])
+  })
+
+  it('should find literal selectors in jQuery-like expressions', () => {
+    const code = `
+      $('goodbye').addClass('myClass');
+      const myVar3 = $('space_123').text();
+      $(myVar3).val()
+    `
+    const prefix = 'notRelevantHere'
+    const result = parsePotentialReferencesByPrefix(code, prefix)
+    expect(result).toEqual(['goodbye', 'space_123'])
+  })
+})

--- a/packages/zendesk-adapter/test/filters/template_engines/javascript_parser.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/javascript_parser.test.ts
@@ -29,11 +29,11 @@ describe('parsePotentialReferencesByPrefix', () => {
     expect(result).toEqual([
       {
         loc: { start: 24, end: 31 },
-        value: { parts: ['hello'] },
+        value: { parts: ['"hello"'] },
       },
       {
         loc: { start: 54, end: 61 },
-        value: { parts: ['world'] },
+        value: { parts: ['"world"'] },
       },
     ])
   })
@@ -60,11 +60,11 @@ describe('parsePotentialReferencesByPrefix', () => {
     expect(result).toEqual([
       {
         loc: { start: 9, end: 18 },
-        value: { parts: ['goodbye'] },
+        value: { parts: ["'goodbye'"] },
       },
       {
         loc: { start: 64, end: 75 },
-        value: { parts: ['space_123'] },
+        value: { parts: ["'space_123'"] },
       },
     ])
   })
@@ -87,11 +87,11 @@ describe('parsePotentialReferencesByPrefix', () => {
     expect(result).toEqual([
       {
         loc: { start: 28, end: 56 },
-        value: { parts: ['catch_', new ReferenceExpression(article.elemID, article), '_miss_1144226'] },
+        value: { parts: ["'catch_", new ReferenceExpression(article.elemID, article), "_miss_1144226'"] },
       },
       {
         loc: { start: 66, end: 94 },
-        value: { parts: ['catch_', new ReferenceExpression(article.elemID, article), '_miss_1144226'] },
+        value: { parts: ["'catch_", new ReferenceExpression(article.elemID, article), "_miss_1144226'"] },
       },
     ])
   })

--- a/packages/zendesk-adapter/test/filters/template_engines/utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/template_engines/utils.test.ts
@@ -1,0 +1,52 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { SourceLocation } from '@handlebars/parser/types/ast'
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import {
+  extractIdIfElementExists,
+  findLineStartIndexes,
+  sourceLocationToIndexRange,
+} from '../../../src/filters/template_engines/utils'
+
+describe('findLineStartIndexes', () => {
+  it('should return the start indexes of each line in the input', () => {
+    expect(findLineStartIndexes('a\nb\nc')).toEqual([0, 2, 4])
+    expect(findLineStartIndexes('a\nb\nc\n')).toEqual([0, 2, 4])
+    expect(findLineStartIndexes('\n')).toEqual([0])
+    expect(findLineStartIndexes('')).toEqual([0])
+  })
+})
+
+describe('sourceLocationToIndexRange', () => {
+  it('should convert a Handlebar location to a range of indexes in a string', () => {
+    const newlineIndexes = [0, 2, 4, 5]
+    const loc = { start: { line: 2, column: 1 }, end: { line: 3, column: 1 } } as SourceLocation
+    expect(sourceLocationToIndexRange(newlineIndexes, loc)).toEqual({ start: 3, end: 5 })
+  })
+})
+
+describe('extractIdIfElementExists', () => {
+  it('should return a reference expression if the element exists', () => {
+    const element = new InstanceElement('elem', new ObjectType({ elemID: new ElemID('', 'test') }))
+    const idsToElements = { elem: element }
+    expect(extractIdIfElementExists(idsToElements, 'elem')).toEqual(new ReferenceExpression(element.elemID, element))
+  })
+
+  it('should return the id if the element does not exist', () => {
+    const idsToElements = {}
+    expect(extractIdIfElementExists(idsToElements, 'elem')).toEqual('elem')
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -4208,6 +4208,11 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"
+  integrity sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==
+
 acorn@^7.1.1:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.2.0.tgz#17ea7e40d7c8640ff54a694c889c26f31704effe"
@@ -4217,6 +4222,11 @@ acorn@^7.4.0:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+
+acorn@^8.11.3:
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 acorn@^8.2.4, acorn@^8.5.0, acorn@^8.7.1:
   version "8.8.1"


### PR DESCRIPTION
Add support to fetch template static files in Zendesk guide themes

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
