### PR TITLE
SALTO-5707 pass context correctly

### DIFF
--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -134,7 +134,14 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
     // order of precedence in case of overlaps: pagination defaults < endpoint < resource-specific request
     const mergedEndpointDef = _.merge({}, clientArgs, mergedRequestDef.endpoint)
 
-    const extractorCreator = (context: ContextParams): ItemExtractor => createExtractor({ ...requestDef, context }, typeName)
+    const extractorCreator = (context: ContextParams): ItemExtractor =>
+      createExtractor(
+        {
+          ...requestDef,
+          context: { ...requestDef.context, context },
+        },
+        typeName,
+      )
 
     const callArgs = mergedEndpointDef.omitBody
       ? _.pick(mergedEndpointDef, ['queryArgs', 'headers'])

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -134,7 +134,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
     // order of precedence in case of overlaps: pagination defaults < endpoint < resource-specific request
     const mergedEndpointDef = _.merge({}, clientArgs, mergedRequestDef.endpoint)
 
-    const extractor = createExtractor(requestDef, typeName)
+    const extractorCreator = (context: ContextParams): ItemExtractor => createExtractor({ ...requestDef, context }, typeName)
 
     const callArgs = mergedEndpointDef.omitBody
       ? _.pick(mergedEndpointDef, ['queryArgs', 'headers'])
@@ -158,7 +158,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
     })
 
     const itemsWithContext = pagesWithContext
-      .map(({ context, pages }) => ({ items: extractor(pages), context }))
+      .map(({ context, pages }) => ({ items: extractorCreator(context)(pages), context }))
       .flatMap(({ items, context }) => items.flatMap(item => ({ ...item, context })))
     return itemsWithContext.filter(item => {
       if (!lowerdashValues.isPlainRecord(item.value)) {


### PR DESCRIPTION
pass the relevant request's context to the transformation

will add unittests together with the rest of the missing coverage for this logic


---
_Release Notes_: 
None

---
_User Notifications_: 
None