### PR TITLE
SALTO-4094: Deploy priority instance for policy

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -151,7 +151,6 @@ export const mockDefaultValues: Record<string, Values> = {
   [PROFILE_ENROLLMENT_RULE_TYPE_NAME]: {
     status: 'ACTIVE',
     name: 'Catch-all Rule',
-    priority: 99,
     system: true,
     type: 'PROFILE_ENROLLMENT',
   },

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -37,7 +37,6 @@ export const mockDefaultValues: Record<string, Values> = {
   [ACCESS_POLICY_RULE_TYPE_NAME]: {
     status: 'ACTIVE',
     name: 'authentication rule',
-    priority: 0,
     system: false,
     conditions: {
       network: { connection: 'ANYWHERE' },

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -88,15 +88,23 @@ import profileMappingPropertiesFilter from './filters/profile_mapping_properties
 import profileMappingAdditionFilter from './filters/profile_mapping_addition'
 import profileMappingRemovalFilter from './filters/profile_mapping_removal'
 import omitAuthenticatorMappingFilter from './filters/omit_authenticator_mapping'
+import policyRulePrioritiesFilter from './filters/policy_rule_priority'
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import groupPushPathFilter from './filters/group_push_path'
 import renameDefaultAccessPolicy from './filters/rename_default_access_policy'
-import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'
+import {
+  APP_LOGO_TYPE_NAME,
+  BRAND_LOGO_TYPE_NAME,
+  FAV_ICON_TYPE_NAME,
+  OKTA,
+  POLICY_RULE_PRIORITY_TYPE_NAMES,
+} from './constants'
 import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
 import { isClassicEngineOrg } from './utils'
 import { createFixElementFunctions } from './fix_elements'
+import { weakReferenceHandlers } from './weak_references'
 
 const { awu } = collections.asynciterable
 
@@ -131,6 +139,7 @@ const DEFAULT_FILTERS = [
   brandThemeFilesFilter,
   fieldReferencesFilter,
   // should run after fieldReferencesFilter
+  policyRulePrioritiesFilter,
   addAliasFilter,
   // should run after fieldReferencesFilter and userFilter
   unorderedListsFilter,
@@ -148,7 +157,12 @@ const DEFAULT_FILTERS = [
   defaultDeployFilter,
 ]
 
-const SKIP_RESOLVE_TYPE_NAMES = [APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME]
+const SKIP_RESOLVE_TYPE_NAMES = [
+  APP_LOGO_TYPE_NAME,
+  BRAND_LOGO_TYPE_NAME,
+  FAV_ICON_TYPE_NAME,
+  ...POLICY_RULE_PRIORITY_TYPE_NAMES,
+]
 
 export interface OktaAdapterParams {
   filterCreators?: FilterCreator[]
@@ -215,7 +229,10 @@ export default class OktaAdapter implements AdapterOperations {
         filterCreators,
         objects.concatObjects,
       )
-    this.fixElementsFunc = combineElementFixers(createFixElementFunctions({ client, config }))
+    this.fixElementsFunc = combineElementFixers([
+      ...createFixElementFunctions({ client, config }),
+      ...Object.values(weakReferenceHandlers).map(handler => handler.removeWeakReferences({ elementsSource })),
+    ])
   }
 
   @logDuration('generating types from swagger')

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -104,7 +104,6 @@ import { getLookUpName } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances } from './user_utils'
 import { isClassicEngineOrg } from './utils'
 import { createFixElementFunctions } from './fix_elements'
-import { weakReferenceHandlers } from './weak_references'
 
 const { awu } = collections.asynciterable
 
@@ -229,10 +228,7 @@ export default class OktaAdapter implements AdapterOperations {
         filterCreators,
         objects.concatObjects,
       )
-    this.fixElementsFunc = combineElementFixers([
-      ...createFixElementFunctions({ client, config }),
-      ...Object.values(weakReferenceHandlers).map(handler => handler.removeWeakReferences({ elementsSource })),
-    ])
+    this.fixElementsFunc = combineElementFixers(createFixElementFunctions({ client, config, elementsSource }))
   }
 
   @logDuration('generating types from swagger')

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -16,7 +16,12 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter, Values } from '@salto-io/adapter-api'
-import { client as clientUtils, combineCustomReferenceGetters, config as configUtils, definitions } from '@salto-io/adapter-components'
+import {
+  client as clientUtils,
+  combineCustomReferenceGetters,
+  config as configUtils,
+  definitions,
+} from '@salto-io/adapter-components'
 import OktaClient from './client/client'
 import OktaAdapter from './adapter'
 import {

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter, Values } from '@salto-io/adapter-api'
-import { client as clientUtils, config as configUtils, definitions } from '@salto-io/adapter-components'
+import { client as clientUtils, combineCustomReferenceGetters, config as configUtils, definitions } from '@salto-io/adapter-components'
 import OktaClient from './client/client'
 import OktaAdapter from './adapter'
 import {
@@ -43,6 +43,7 @@ import {
 import { createConnection } from './client/connection'
 import { validateOktaBaseUrl } from './utils'
 import { getAdminUrl } from './client/admin'
+import { weakReferenceHandlers } from './weak_references'
 
 const log = logger(module)
 const { validateCredentials } = clientUtils
@@ -159,4 +160,7 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  getCustomReferences: combineCustomReferenceGetters(
+    _.mapValues(weakReferenceHandlers, handler => handler.findWeakReferences),
+  ),
 }

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -305,6 +305,7 @@ const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
 }
 const getPoliceyRulePriorityConfig = (): OktaSwaggerApiConfig['types'] => {
   const policyRulePrioritiesConfig = POLICY_RULE_PRIORITY_TYPE_NAMES.map(typeName => ({
+    // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator only for additions and modifications
     [typeName]: {
       deployRequests: {
         add: { url: '', method: 'put' },
@@ -1813,13 +1814,6 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
     },
   },
   GroupMembership: {
-    // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator only for additions and modifications
-    deployRequests: {
-      add: { url: '', method: 'put' },
-      modify: { url: '', method: 'put' },
-    },
-  },
-  PolicyRulePriorities: {
     // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator only for additions and modifications
     deployRequests: {
       add: { url: '', method: 'put' },

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -37,6 +37,7 @@ import {
   AUTOMATION_TYPE_NAME,
   AUTHENTICATOR_TYPE_NAME,
   DEVICE_ASSURANCE,
+  POLICY_RULE_PRIORITY_TYPE_NAMES,
 } from './constants'
 import { DEFAULT_CONVERT_USERS_IDS_VALUE, DEFAULT_GET_USERS_STRATEGY } from './user_utils'
 import { DEFAULT_APP_URLS_VALIDATOR_VALUE } from './change_validators/app_urls'
@@ -301,6 +302,17 @@ const getPolicyConfig = (): OktaSwaggerApiConfig['types'] => {
     }
   })
   return Object.assign({}, ...policiesConfig)
+}
+const getPoliceyRulePriorityConfig = (): OktaSwaggerApiConfig['types'] => {
+  const policyRulePrioritiesConfig = POLICY_RULE_PRIORITY_TYPE_NAMES.map(typeName => ({
+    [typeName]: {
+      deployRequests: {
+        add: { url: '', method: 'put' },
+        modify: { url: '', method: 'put' },
+      },
+    },
+  }))
+  return Object.assign({}, ...policyRulePrioritiesConfig)
 }
 
 const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
@@ -1345,6 +1357,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
     },
   },
   ...getPolicyConfig(),
+  ...getPoliceyRulePriorityConfig(),
   api__v1__behaviors: {
     request: {
       url: '/api/v1/behaviors',
@@ -1800,6 +1813,13 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
     },
   },
   GroupMembership: {
+    // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator only for additions and modifications
+    deployRequests: {
+      add: { url: '', method: 'put' },
+      modify: { url: '', method: 'put' },
+    },
+  },
+  PolicyRulePriorities: {
     // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator only for additions and modifications
     deployRequests: {
       add: { url: '', method: 'put' },

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -44,6 +44,13 @@ export const MFA_RULE_TYPE_NAME = 'MultifactorEnrollmentPolicyRule'
 export const SIGN_ON_RULE_TYPE_NAME = 'OktaSignOnPolicyRule'
 export const PASSWORD_RULE_TYPE_NAME = 'PasswordPolicyRule'
 export const AUTHORIZATION_POLICY_RULE = 'AuthorizationServerPolicyRule'
+export const ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME = 'AccessPolicyRulePriority'
+export const PROFILE_ENROLLMENT_RULE_PRIORITY_TYPE_NAME = 'ProfileEnrollmentPolicyRulePriority'
+export const AUTHORIZATION_POLICY_RULE_PRIORITY_TYPE_NAME = 'AuthorizationServerPolicyRulePriority'
+export const IDP_RULE_PRIORITY_TYPE_NAME = 'IdentityProviderPolicyRulePriority'
+export const MFA_RULE_PRIORITY_TYPE_NAME = 'MultifactorEnrollmentPolicyRulePriority'
+export const SIGN_ON_RULE_PRIORITY_TYPE_NAME = 'OktaSignOnPolicyRulePriority'
+export const PASSWORD_RULE_PRIORITY_TYPE_NAME = 'PasswordPolicyRulePriority'
 export const AUTOMATION_TYPE_NAME = 'Automation'
 export const AUTOMATION_RULE_TYPE_NAME = 'AutomationRule'
 export const ACTIVE_STATUS = 'ACTIVE'
@@ -63,6 +70,15 @@ export const POLICY_RULE_TYPE_NAMES = [
   SIGN_ON_RULE_TYPE_NAME,
   PASSWORD_RULE_TYPE_NAME,
   PROFILE_ENROLLMENT_RULE_TYPE_NAME,
+]
+export const POLICY_RULE_PRIORITY_TYPE_NAMES = [
+  ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
+  IDP_RULE_PRIORITY_TYPE_NAME,
+  MFA_RULE_PRIORITY_TYPE_NAME,
+  SIGN_ON_RULE_PRIORITY_TYPE_NAME,
+  PASSWORD_RULE_PRIORITY_TYPE_NAME,
+  PROFILE_ENROLLMENT_RULE_PRIORITY_TYPE_NAME,
+  AUTHORIZATION_POLICY_RULE_PRIORITY_TYPE_NAME,
 ]
 export const CUSTOM_NAME_FIELD = 'customName'
 export const LINKS_FIELD = '_links'

--- a/packages/okta-adapter/src/filters/default_rule_deployment.ts
+++ b/packages/okta-adapter/src/filters/default_rule_deployment.ts
@@ -122,6 +122,20 @@ const deployDefaultPolicy = async (
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'defaultPolicyRuleDeployment',
+  preDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+      .filter(
+        change =>
+          [PROFILE_ENROLLMENT_RULE_TYPE_NAME].includes(getChangeData(change).elemID.typeName) &&
+          getChangeData(change).value.system === true,
+      )
+      .map(change => getChangeData(change))
+      .forEach(instance => {
+        instance.value.priority = 99
+      })
+  },
   deploy: async changes => {
     const [relevantChanges, leftoverChanges] = _.partition(
       changes,
@@ -142,6 +156,20 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       leftoverChanges,
       deployResult,
     }
+  },
+  onDeploy: async changes => {
+    changes
+      .filter(isInstanceChange)
+      .filter(isAdditionChange)
+      .filter(
+        change =>
+          [PROFILE_ENROLLMENT_RULE_TYPE_NAME].includes(getChangeData(change).elemID.typeName) &&
+          getChangeData(change).value.system === true,
+      )
+      .map(change => getChangeData(change))
+      .forEach(instance => {
+        delete instance.value.priority
+      })
   },
 })
 

--- a/packages/okta-adapter/src/filters/policy_rule_priority.ts
+++ b/packages/okta-adapter/src/filters/policy_rule_priority.ts
@@ -27,12 +27,12 @@ import {
   isInstanceElement,
   isModificationChange,
   isReferenceExpression,
-  ElemIdGetter,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { getParents, invertNaclCase, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
-import { fetch, elements as adapterElements, config as configUtils } from '@salto-io/adapter-components'
+import { fetch, elements as adapterElements } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import {
   ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
@@ -57,15 +57,14 @@ import {
 } from '../constants'
 import { deployChanges } from '../deployment'
 import OktaClient from '../client/client'
-import { API_DEFINITIONS_CONFIG, OktaConfig } from '../config'
+import { OktaConfig } from '../config'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 const { createUrl } = fetch.resource
-const { toBasicInstance } = adapterElements
-const { getTransformationConfigByType } = configUtils
-
 const ALL_SUPPORTED_POLICY_NAMES = POLICY_TYPE_NAMES.concat([AUTHORIZATION_POLICY])
 const ALL_SUPPORTED_POLICY_RULE_NAMES = POLICY_RULE_TYPE_NAMES.concat([AUTHORIZATION_POLICY_RULE])
+// Automation is not included in the list of supported policy rules because it is not supported
 const POLICY_NAME_TO_PRIORITY_NAME: Record<string, string> = {
   [ACCESS_POLICY_TYPE_NAME]: ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
   [IDP_POLICY_TYPE_NAME]: IDP_RULE_PRIORITY_TYPE_NAME,
@@ -89,27 +88,18 @@ const createPriorityType = (typeName: string): ObjectType =>
         annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
       },
     },
-    path: undefined,
-    annotations: {
-      [CORE_ANNOTATIONS.CREATABLE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: true,
-      [CORE_ANNOTATIONS.DELETABLE]: true,
-    },
+    path: [OKTA, adapterElements.TYPES_PATH, typeName],
   })
 
 const createPolicyRulePriorityInstance = ({
   rules,
   type,
   policy,
-  getElemIdFunc,
-  config,
 }: {
   rules: InstanceElement[]
   type: ObjectType
   policy: InstanceElement
-  getElemIdFunc?: ElemIdGetter
-  config: OktaConfig
-}): Promise<InstanceElement> => {
+}): InstanceElement => {
   const name = naclCase(`${invertNaclCase(policy.elemID.name)}_priority`)
   const defaultRule = rules.find(rule => rule.value.system === true)
   const value = {
@@ -121,16 +111,8 @@ const createPolicyRulePriorityInstance = ({
   const fullValue = defaultRule
     ? { ...value, defaultRule: new ReferenceExpression(defaultRule.elemID, defaultRule) }
     : value
-
-  return toBasicInstance({
-    entry: fullValue,
-    type,
-    transformationConfigByType: getTransformationConfigByType(config[API_DEFINITIONS_CONFIG].types),
-    transformationDefaultConfig: config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
-    parent: policy,
-    defaultName: name,
-    nestedPath: [...(policy.path ?? []).slice(2, (policy.path ?? []).length - 1), pathNaclCase(name)],
-    getElemIdFunc,
+  return new InstanceElement(name, type, fullValue, [...(policy.path ?? []).slice(0, -1), pathNaclCase(name)], {
+    [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(policy.elemID, policy),
   })
 }
 
@@ -150,56 +132,77 @@ const deployPriorityChange = async ({
 }: {
   client: OktaClient
   priority: number
-  rule: ReferenceExpression
+  rule: InstanceElement
   config: OktaConfig
 }): Promise<void> => {
-  const { id } = rule.value.value
-  const { type } = rule.value.value
-  const policy = getParents(rule.value)[0].value
+  const { id } = rule.value
+  const { type } = rule.value
+  const policy = getParents(rule).find(parent => ALL_SUPPORTED_POLICY_NAMES.includes(parent.elemID.typeName))?.value
+  if (policy === undefined) {
+    throw new Error('Failed to deploy priority change due to missing policy')
+  }
   const policyId = policy.value.id
   const policyTypeName = policy.elemID.typeName
-  const data = { priority: setPriority(policyTypeName, priority), type, name: rule.value.value.name }
+  const data = { priority: setPriority(policyTypeName, priority), type, name: rule.value.name }
   const typeDefinition = config.apiDefinitions.types[rule.elemID.typeName]
   const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests.modify : undefined
   const deployUrl = deployRequest?.url
   if (deployUrl === undefined) {
     throw new Error('Failed to deploy priority change due to missing url')
   }
-  const url = createUrl({ instance: rule.value, url: deployUrl, additionalUrlVars: { ruleId: id, policyId } })
+  const url = createUrl({ instance: rule, url: deployUrl, additionalUrlVars: { ruleId: id, policyId } })
 
   await client.put({ url, data })
 }
 
-/* Manages the priorities of policyRules within each Policy
- * by generating an InstanceElement for the policyRules priorities.
+/*
+ * Manages the priorities of policy rules within each Policy by generating an InstanceElement
+ * for the policy rules' priorities. Each priority instance contains the policy rules sorted
+ * by their priority, including the default rule. The default rule is always set to be last.
+ * In deployment, we deploy the priorities, not the policy rules themselves.
  */
-const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
+const filter: FilterCreator = ({ config, client }) => ({
   name: 'policyRulePrioritiesFilter',
   onFetch: async elements => {
     const instances = elements.filter(isInstanceElement)
-    const policyNameToInstance = _.keyBy(
-      instances.filter(e => ALL_SUPPORTED_POLICY_NAMES.includes(e.elemID.typeName)),
-      inst => inst.elemID.getFullName(),
-    )
     const policiesRules = instances.filter(instance =>
       ALL_SUPPORTED_POLICY_RULE_NAMES.includes(instance.elemID.typeName),
     )
-    const policiesToPoliciesRules = _.groupBy(policiesRules.filter(rule => isReferenceExpression(getParents(rule)[0])), rule =>
-      // AuthorizationServerPolicyRule has two parents. 
-      getParents(rule)[0].elemID.getFullName(),
+    const policyAndrules = Object.values(
+      policiesRules.reduce(
+        (acc, rule) => {
+          // Autorization policy rules has more than one parent
+          const policy = getParents(rule).find(parent =>
+            ALL_SUPPORTED_POLICY_NAMES.includes(parent.elemID.typeName),
+          )?.value
+          if (policy === undefined) {
+            log.warn('Policy not found for rule %s', rule.elemID.getFullName())
+            return acc
+          }
+          const policyName = policy.elemID.getFullName()
+          if (!acc[policyName]) {
+            acc[policyName] = { policy, rules: [] }
+          }
+          acc[policyName].rules.push(rule)
+          return acc
+        },
+        {} as {
+          [key: string]: {
+            policy: InstanceElement
+            rules: InstanceElement[]
+          }
+        },
+      ),
     )
     const priorityTypes = POLICY_RULE_PRIORITY_TYPE_NAMES.map(name => createPriorityType(name))
     priorityTypes.forEach(type => elements.push(type))
     const priorityNameToPriorityType = _.keyBy(priorityTypes, type => type.elemID.typeName)
-    await awu(Object.entries(policiesToPoliciesRules)).forEach(async ([policyName, rules]) => {
-      const type =
-        priorityNameToPriorityType[POLICY_NAME_TO_PRIORITY_NAME[policyNameToInstance[policyName].elemID.typeName]]
-      const priorityInstance = await createPolicyRulePriorityInstance({
+    await awu(policyAndrules).forEach(async ({ policy, rules }) => {
+      const type = priorityNameToPriorityType[POLICY_NAME_TO_PRIORITY_NAME[policy.elemID.typeName]]
+      const priorityInstance = createPolicyRulePriorityInstance({
         rules,
         type,
-        policy: policyNameToInstance[policyName],
-        getElemIdFunc,
-        config,
+        policy,
       })
       elements.push(priorityInstance)
     })
@@ -221,12 +224,12 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
             await deployPriorityChange({
               client,
               priority,
-              rule,
+              rule: rule.value,
               config,
             })
           })
       }
-      if (isModificationChange(change)) {
+      if (isModificationChange(change) && instance.value.priorities !== undefined) {
         const positionsBefore = change.data.before.value.priorities.filter(isReferenceExpression)
         await awu(instance.value.priorities)
           .filter(isReferenceExpression)
@@ -235,7 +238,7 @@ const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
               await deployPriorityChange({
                 client,
                 priority,
-                rule,
+                rule: rule.value,
                 config,
               })
             }

--- a/packages/okta-adapter/src/filters/policy_rule_priority.ts
+++ b/packages/okta-adapter/src/filters/policy_rule_priority.ts
@@ -1,0 +1,249 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ListType,
+  ObjectType,
+  ReferenceExpression,
+  getChangeData,
+  isAdditionChange,
+  isInstanceChange,
+  isInstanceElement,
+  isModificationChange,
+  isReferenceExpression,
+  ElemIdGetter,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { getParents, invertNaclCase, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
+import { fetch, elements as adapterElements, config as configUtils } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
+import {
+  ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
+  ACCESS_POLICY_TYPE_NAME,
+  AUTHORIZATION_POLICY,
+  AUTHORIZATION_POLICY_RULE,
+  AUTHORIZATION_POLICY_RULE_PRIORITY_TYPE_NAME,
+  IDP_POLICY_TYPE_NAME,
+  IDP_RULE_PRIORITY_TYPE_NAME,
+  MFA_POLICY_TYPE_NAME,
+  MFA_RULE_PRIORITY_TYPE_NAME,
+  OKTA,
+  PASSWORD_POLICY_TYPE_NAME,
+  PASSWORD_RULE_PRIORITY_TYPE_NAME,
+  POLICY_RULE_PRIORITY_TYPE_NAMES,
+  POLICY_RULE_TYPE_NAMES,
+  POLICY_TYPE_NAMES,
+  PROFILE_ENROLLMENT_POLICY_TYPE_NAME,
+  PROFILE_ENROLLMENT_RULE_PRIORITY_TYPE_NAME,
+  SIGN_ON_POLICY_TYPE_NAME,
+  SIGN_ON_RULE_PRIORITY_TYPE_NAME,
+} from '../constants'
+import { deployChanges } from '../deployment'
+import OktaClient from '../client/client'
+import { API_DEFINITIONS_CONFIG, OktaConfig } from '../config'
+
+const { awu } = collections.asynciterable
+const { createUrl } = fetch.resource
+const { toBasicInstance } = adapterElements
+const { getTransformationConfigByType } = configUtils
+
+const ALL_SUPPORTED_POLICY_NAMES = POLICY_TYPE_NAMES.concat([AUTHORIZATION_POLICY])
+const ALL_SUPPORTED_POLICY_RULE_NAMES = POLICY_RULE_TYPE_NAMES.concat([AUTHORIZATION_POLICY_RULE])
+const POLICY_NAME_TO_PRIORITY_NAME: Record<string, string> = {
+  [ACCESS_POLICY_TYPE_NAME]: ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
+  [IDP_POLICY_TYPE_NAME]: IDP_RULE_PRIORITY_TYPE_NAME,
+  [MFA_POLICY_TYPE_NAME]: MFA_RULE_PRIORITY_TYPE_NAME,
+  [SIGN_ON_POLICY_TYPE_NAME]: SIGN_ON_RULE_PRIORITY_TYPE_NAME,
+  [PASSWORD_POLICY_TYPE_NAME]: PASSWORD_RULE_PRIORITY_TYPE_NAME,
+  [PROFILE_ENROLLMENT_POLICY_TYPE_NAME]: PROFILE_ENROLLMENT_RULE_PRIORITY_TYPE_NAME,
+  [AUTHORIZATION_POLICY]: AUTHORIZATION_POLICY_RULE_PRIORITY_TYPE_NAME,
+}
+
+const createPriorityType = (typeName: string): ObjectType =>
+  new ObjectType({
+    elemID: new ElemID(OKTA, typeName),
+    fields: {
+      priorities: {
+        refType: new ListType(BuiltinTypes.NUMBER),
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+      defaultValue: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+    },
+    path: undefined,
+    annotations: {
+      [CORE_ANNOTATIONS.CREATABLE]: true,
+      [CORE_ANNOTATIONS.UPDATABLE]: true,
+      [CORE_ANNOTATIONS.DELETABLE]: true,
+    },
+  })
+
+const createPolicyRulePriorityInstance = ({
+  rules,
+  type,
+  policy,
+  getElemIdFunc,
+  config,
+}: {
+  rules: InstanceElement[]
+  type: ObjectType
+  policy: InstanceElement
+  getElemIdFunc?: ElemIdGetter
+  config: OktaConfig
+}): Promise<InstanceElement> => {
+  const name = naclCase(`${invertNaclCase(policy.elemID.name)}_priority`)
+  const defaultRule = rules.find(rule => rule.value.system === true)
+  const value = {
+    priorities: rules
+      .filter(rule => rule.value.system !== true)
+      .sort((a, b) => a.value.priority - b.value.priority)
+      .map(inst => new ReferenceExpression(inst.elemID, inst)),
+  }
+  const fullValue = defaultRule
+    ? { ...value, defaultRule: new ReferenceExpression(defaultRule.elemID, defaultRule) }
+    : value
+
+  return toBasicInstance({
+    entry: fullValue,
+    type,
+    transformationConfigByType: getTransformationConfigByType(config[API_DEFINITIONS_CONFIG].types),
+    transformationDefaultConfig: config[API_DEFINITIONS_CONFIG].typeDefaults.transformation,
+    parent: policy,
+    defaultName: name,
+    nestedPath: [...(policy.path ?? []).slice(2, (policy.path ?? []).length - 1), pathNaclCase(name)],
+    getElemIdFunc,
+  })
+}
+
+// For AccessPolicy, the priority index starts from 1, while for others it starts from 0.
+const setPriority = (typeName: string, priority: number): number => {
+  if (typeName === ACCESS_POLICY_TYPE_NAME) {
+    return priority
+  }
+  return priority + 1
+}
+
+const deployPriorityChange = async ({
+  client,
+  priority,
+  rule,
+  config,
+}: {
+  client: OktaClient
+  priority: number
+  rule: ReferenceExpression
+  config: OktaConfig
+}): Promise<void> => {
+  const { id } = rule.value.value
+  const { type } = rule.value.value
+  const policy = getParents(rule.value)[0].value
+  const policyId = policy.value.id
+  const policyTypeName = policy.elemID.typeName
+  const data = { priority: setPriority(policyTypeName, priority), type, name: rule.value.value.name }
+  const typeDefinition = config.apiDefinitions.types[rule.elemID.typeName]
+  const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests.modify : undefined
+  const deployUrl = deployRequest?.url
+  if (deployUrl === undefined) {
+    throw new Error('Failed to deploy priority change due to missing url')
+  }
+  const url = createUrl({ instance: rule.value, url: deployUrl, additionalUrlVars: { ruleId: id, policyId } })
+
+  await client.put({ url, data })
+}
+
+/* Manages the priorities of policyRules within each Policy
+ * by generating an InstanceElement for the policyRules priorities.
+ */
+const filter: FilterCreator = ({ config, client, getElemIdFunc }) => ({
+  name: 'policyRulePrioritiesFilter',
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    const policyNameToInstance = _.keyBy(
+      instances.filter(e => ALL_SUPPORTED_POLICY_NAMES.includes(e.elemID.typeName)),
+      inst => inst.elemID.getFullName(),
+    )
+    const policiesRules = instances.filter(instance =>
+      ALL_SUPPORTED_POLICY_RULE_NAMES.includes(instance.elemID.typeName),
+    )
+    const policiesToPoliciesRules = _.groupBy(policiesRules.filter(rule => isReferenceExpression(getParents(rule)[0])), rule =>
+      // AuthorizationServerPolicyRule has two parents. 
+      getParents(rule)[0].elemID.getFullName(),
+    )
+    const priorityTypes = POLICY_RULE_PRIORITY_TYPE_NAMES.map(name => createPriorityType(name))
+    priorityTypes.forEach(type => elements.push(type))
+    const priorityNameToPriorityType = _.keyBy(priorityTypes, type => type.elemID.typeName)
+    await awu(Object.entries(policiesToPoliciesRules)).forEach(async ([policyName, rules]) => {
+      const type =
+        priorityNameToPriorityType[POLICY_NAME_TO_PRIORITY_NAME[policyNameToInstance[policyName].elemID.typeName]]
+      const priorityInstance = await createPolicyRulePriorityInstance({
+        rules,
+        type,
+        policy: policyNameToInstance[policyName],
+        getElemIdFunc,
+        config,
+      })
+      elements.push(priorityInstance)
+    })
+    // Remove priority field from the policy rules
+    policiesRules.forEach(rule => {
+      delete rule.value.priority
+    })
+  },
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(changes, change =>
+      POLICY_RULE_PRIORITY_TYPE_NAMES.includes(getChangeData(change).elemID.typeName),
+    )
+    const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change => {
+      const instance = getChangeData(change)
+      if (isAdditionChange(change)) {
+        await awu(instance.value.priorities)
+          .filter(isReferenceExpression)
+          .forEach(async (rule, priority) => {
+            await deployPriorityChange({
+              client,
+              priority,
+              rule,
+              config,
+            })
+          })
+      }
+      if (isModificationChange(change)) {
+        const positionsBefore = change.data.before.value.priorities.filter(isReferenceExpression)
+        await awu(instance.value.priorities)
+          .filter(isReferenceExpression)
+          .forEach(async (rule, priority) => {
+            if (positionsBefore[priority]?.elemID.getFullName() !== rule.elemID.getFullName()) {
+              await deployPriorityChange({
+                client,
+                priority,
+                rule,
+                config,
+              })
+            }
+          })
+      }
+    })
+    return { deployResult, leftoverChanges }
+  },
+})
+
+export default filter

--- a/packages/okta-adapter/src/filters/policy_rule_priority.ts
+++ b/packages/okta-adapter/src/filters/policy_rule_priority.ts
@@ -177,7 +177,7 @@ const filter: FilterCreator = ({ config, client }) => ({
       policiesRules.reduce(
         (acc, rule) => {
           const policy = getParentPolicy(rule)
-          if (policy === undefined) {
+          if (!isInstanceElement(policy)) {
             log.warn('Policy not found for rule %s', rule.elemID.getFullName())
             return acc
           }

--- a/packages/okta-adapter/src/fix_elements/index.ts
+++ b/packages/okta-adapter/src/fix_elements/index.ts
@@ -16,5 +16,11 @@
 import { FixElementsFunc } from '@salto-io/adapter-api'
 import { omitMissingUsersHandler } from './missing_users'
 import { FixElementsArgs } from './types'
+import { weakReferenceHandlers } from '../weak_references'
 
-export const createFixElementFunctions = (args: FixElementsArgs): FixElementsFunc[] => [omitMissingUsersHandler(args)]
+export const createFixElementFunctions = (args: FixElementsArgs): FixElementsFunc[] => [
+  omitMissingUsersHandler(args),
+  ...Object.values(weakReferenceHandlers).map(handler =>
+    handler.removeWeakReferences({ elementsSource: args.elementsSource }),
+  ),
+]

--- a/packages/okta-adapter/src/fix_elements/types.ts
+++ b/packages/okta-adapter/src/fix_elements/types.ts
@@ -13,13 +13,14 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { FixElementsFunc } from '@salto-io/adapter-api'
+import { FixElementsFunc, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import OktaClient from '../client/client'
 import { OktaConfig } from '../config'
 
 export type FixElementsArgs = {
   client: OktaClient
   config: OktaConfig
+  elementsSource: ReadOnlyElementsSource
 }
 
 export type FixElementsHandler = (args: FixElementsArgs) => FixElementsFunc

--- a/packages/okta-adapter/src/weak_references/index.ts
+++ b/packages/okta-adapter/src/weak_references/index.ts
@@ -1,0 +1,21 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { WeakReferencesHandler } from './weak_references_handler'
+import { policyRulePrioritiesHandler } from './policy_rule_priorities'
+
+export const weakReferenceHandlers: Record<string, WeakReferencesHandler> = {
+  policyRulePrioritiesHandler,
+}

--- a/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
+++ b/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
@@ -60,8 +60,9 @@ const getPolicyPriorityReferences: GetCustomReferencesFunc = async elements =>
     .flatMap(getFieldReferences)
     .toArray()
 
-/**
- * Remove invalid rules (not references or missing references) from policyPriority.
+/*
+ * Since we can implement a priority order for a portion of the rules.
+ * We removing invalid rules (those not referenced or missing references) from policyPriority.
  */
 const removeMissingPolicyRulePriorities: WeakReferencesHandler['removeWeakReferences'] =
   ({ elementsSource }) =>
@@ -97,9 +98,8 @@ const removeMissingPolicyRulePriorities: WeakReferencesHandler['removeWeakRefere
     const errors = fixedElements.map(instance => ({
       elemID: instance.elemID.createNestedID('priorities'),
       severity: 'Info' as const,
-      message: `${instance.elemID.typeName} will be deployed without priorities defined on non-existing fields`,
-      detailedMessage:
-        'This policy priority has priorities which use rules which no longer exist. It will be deployed without them.',
+      message: `Deploying ${instance.elemID.typeName} without all attached priorities for rules.`,
+      detailedMessage: `This ${instance.elemID.typeName} is attached to some rules that do not exist in the target environment. It will be deployed without referencing these.`,
     }))
     return { fixedElements, errors }
   }

--- a/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
+++ b/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
@@ -30,11 +30,11 @@ const { awu } = collections.asynciterable
 
 const log = logger(module)
 
-const getFieldReferences = async (instance: InstanceElement): Promise<ReferenceInfo[]> => {
+const markRuleAsWeakReference = async (instance: InstanceElement): Promise<ReferenceInfo[]> => {
   const { priorities } = instance.value
   if (priorities === undefined || !Array.isArray(priorities)) {
     // priorities can be undefined if the policy has no custom rules
-    log.debug(
+    log.trace(
       `priorities value is undefined or not an array in instance ${instance.elemID.getFullName()}, hence not calculating rules weak references`,
     )
     return []
@@ -57,7 +57,7 @@ const getPolicyPriorityReferences: GetCustomReferencesFunc = async elements =>
   awu(elements)
     .filter(isInstanceElement)
     .filter(instance => POLICY_RULE_PRIORITY_TYPE_NAMES.includes(instance.elemID.typeName))
-    .flatMap(getFieldReferences)
+    .flatMap(markRuleAsWeakReference)
     .toArray()
 
 /*

--- a/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
+++ b/packages/okta-adapter/src/weak_references/policy_rule_priorities.ts
@@ -1,0 +1,110 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  GetCustomReferencesFunc,
+  InstanceElement,
+  ReferenceInfo,
+  isInstanceElement,
+  isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { POLICY_RULE_PRIORITY_TYPE_NAMES } from '../constants'
+import { WeakReferencesHandler } from './weak_references_handler'
+
+const { awu } = collections.asynciterable
+
+const log = logger(module)
+
+const getFieldReferences = async (instance: InstanceElement): Promise<ReferenceInfo[]> => {
+  const { priorities } = instance.value
+  if (priorities === undefined || !Array.isArray(priorities)) {
+    // priorities can be undefined if the policy has no custom rules
+    log.debug(
+      `priorities value is undefined or not an array in instance ${instance.elemID.getFullName()}, hence not calculating rules weak references`,
+    )
+    return []
+  }
+
+  return awu(priorities)
+    .map(async (rule, index) =>
+      isReferenceExpression(rule)
+        ? { source: instance.elemID.createNestedID(index.toString()), target: rule.elemID, type: 'weak' as const }
+        : undefined,
+    )
+    .filter(values.isDefined)
+    .toArray()
+}
+
+/**
+ * Marks each rule reference in policyPriority as a weak reference.
+ */
+const getPolicyPriorityReferences: GetCustomReferencesFunc = async elements =>
+  awu(elements)
+    .filter(isInstanceElement)
+    .filter(instance => POLICY_RULE_PRIORITY_TYPE_NAMES.includes(instance.elemID.typeName))
+    .flatMap(getFieldReferences)
+    .toArray()
+
+/**
+ * Remove invalid rules (not references or missing references) from policyPriority.
+ */
+const removeMissingPolicyRulePriorities: WeakReferencesHandler['removeWeakReferences'] =
+  ({ elementsSource }) =>
+  async elements => {
+    const fixedElements = await awu(elements)
+      .filter(isInstanceElement)
+      .filter(instance => POLICY_RULE_PRIORITY_TYPE_NAMES.includes(instance.elemID.typeName))
+      .map(async instance => {
+        const { priorities } = instance.value
+        if (priorities === undefined) {
+          return undefined
+        }
+        const fixedInstance = instance.clone()
+        fixedInstance.value.priorities = await awu(priorities)
+          .filter(
+            async rule =>
+              rule !== undefined &&
+              isReferenceExpression(rule) &&
+              // eslint-disable-next-line no-return-await
+              (await elementsSource.has(rule.elemID)),
+          )
+          .toArray()
+
+        if (fixedInstance.value.priorities.length === instance.value.priorities.length) {
+          return undefined
+        }
+
+        return fixedInstance
+      })
+      .filter(values.isDefined)
+      .toArray()
+
+    const errors = fixedElements.map(instance => ({
+      elemID: instance.elemID.createNestedID('priorities'),
+      severity: 'Info' as const,
+      message: `${instance.elemID.typeName} will be deployed without priorities defined on non-existing fields`,
+      detailedMessage:
+        'This policy priority has priorities which use rules which no longer exist. It will be deployed without them.',
+    }))
+    return { fixedElements, errors }
+  }
+
+export const policyRulePrioritiesHandler: WeakReferencesHandler = {
+  findWeakReferences: getPolicyPriorityReferences,
+  removeWeakReferences: removeMissingPolicyRulePriorities,
+}

--- a/packages/okta-adapter/src/weak_references/weak_references_handler.ts
+++ b/packages/okta-adapter/src/weak_references/weak_references_handler.ts
@@ -1,0 +1,21 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { WeakReferencesHandler as ComponentsWeakReferencesHandler } from '@salto-io/adapter-components'
+
+export type WeakReferencesHandler = ComponentsWeakReferencesHandler<{
+  elementsSource: ReadOnlyElementsSource
+}>

--- a/packages/okta-adapter/test/filters/policy_rule_priority.test.ts
+++ b/packages/okta-adapter/test/filters/policy_rule_priority.test.ts
@@ -1,0 +1,409 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { filterUtils, elements as elementUtils, client as clientUtils } from '@salto-io/adapter-components'
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  isInstanceElement,
+  isObjectType,
+  toChange,
+} from '@salto-io/adapter-api'
+import { MockInterface } from '@salto-io/test-utils'
+import policyRulePrioritiesFilter from '../../src/filters/policy_rule_priority'
+import {
+  ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME,
+  ACCESS_POLICY_RULE_TYPE_NAME,
+  ACCESS_POLICY_TYPE_NAME,
+  AUTHORIZATION_POLICY,
+  OKTA,
+} from '../../src/constants'
+import { getFilterParams, mockClient } from '../utils'
+import OktaClient from '../../src/client/client'
+import { DEFAULT_CONFIG, OktaConfig } from '../../src/config'
+
+const createPolicyRuleInstance = (
+  id: number,
+  isSystem: boolean,
+  type: ObjectType,
+  parent: InstanceElement,
+): InstanceElement =>
+  new InstanceElement(
+    `accessPolicyRule${id.toString()}`,
+    type,
+    {
+      id,
+      system: isSystem,
+      name: `accessPolicyRule${id.toString()}`,
+      priority: id,
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)],
+    },
+  )
+
+describe('policyRulePrioritiesFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy'>
+  let filter: FilterType
+  let client: OktaClient
+  const accessPolicyType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_TYPE_NAME) })
+  let elements: InstanceElement[]
+  const accessPolicyInstance = new InstanceElement(
+    'accessPolicyInstance',
+    accessPolicyType,
+    {
+      name: 'accessPolicyInstance',
+      id: 4,
+    },
+    [OKTA, elementUtils.RECORDS_PATH, ACCESS_POLICY_TYPE_NAME, 'accessPolicyInstance', 'accessPolicyInstance'],
+  )
+  const accessPolicyRuleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
+  const accessPolicyRuleInstanceOne = createPolicyRuleInstance(1, false, accessPolicyRuleType, accessPolicyInstance)
+  const accessPolicyRuleInstanceTwo = createPolicyRuleInstance(2, false, accessPolicyRuleType, accessPolicyInstance)
+  const accessPolicyRuleInstanceThree = createPolicyRuleInstance(3, false, accessPolicyRuleType, accessPolicyInstance)
+  const accessPolicyRuleInstanceFourDefault = createPolicyRuleInstance(
+    4,
+    true,
+    accessPolicyRuleType,
+    accessPolicyInstance,
+  )
+  describe('fetch', () => {
+    beforeEach(() => {
+      filter = policyRulePrioritiesFilter(getFilterParams({})) as typeof filter
+      elements = [
+        accessPolicyInstance,
+        accessPolicyRuleInstanceOne,
+        accessPolicyRuleInstanceTwo,
+        accessPolicyRuleInstanceThree,
+        accessPolicyRuleInstanceFourDefault,
+      ]
+    })
+    it('should add AccessPolicyRulePriority instance and type to the elements', async () => {
+      await filter.onFetch(elements)
+      const priorityInstances = elements
+        .filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityInstances[0]).toBeDefined()
+      expect(priorityInstances[0].elemID.name).toEqual('accessPolicyInstance_priority')
+      expect(priorityInstances[0].value.priorities).toEqual([
+        new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+        new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+        new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+      ])
+      expect(priorityInstances[0].value.defaultRule).toEqual(
+        new ReferenceExpression(accessPolicyRuleInstanceFourDefault.elemID, accessPolicyRuleInstanceFourDefault),
+      )
+      const priorityType = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityType).toBeDefined()
+      expect(priorityInstances[0].path).toEqual([
+        OKTA,
+        elementUtils.RECORDS_PATH,
+        ACCESS_POLICY_TYPE_NAME,
+        'accessPolicyInstance',
+        'accessPolicyInstance_priority',
+      ])
+    })
+    it("should add AccessPolicyRulePriority instance and type to the elements when it doesn't have default rule", async () => {
+      elements = [
+        accessPolicyInstance,
+        accessPolicyRuleInstanceOne,
+        accessPolicyRuleInstanceTwo,
+        accessPolicyRuleInstanceThree,
+      ]
+      await filter.onFetch(elements)
+      const priorityInstances = elements
+        .filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityInstances[0]).toBeDefined()
+      expect(priorityInstances[0].elemID.name).toEqual('accessPolicyInstance_priority')
+      expect(priorityInstances[0].value.priorities).toEqual([
+        new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+        new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+        new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+      ])
+      expect(priorityInstances[0].value.defaultRule).toBeUndefined()
+      const priorityType = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityType).toBeDefined()
+      expect(priorityInstances[0].path).toEqual([
+        OKTA,
+        elementUtils.RECORDS_PATH,
+        ACCESS_POLICY_TYPE_NAME,
+        'accessPolicyInstance',
+        'accessPolicyInstance_priority',
+      ])
+    })
+    it('should add AccessPolicyRulePriority instance and type to the elements when access policy has no path', async () => {
+      accessPolicyInstance.path = undefined
+      elements = [
+        accessPolicyInstance,
+        accessPolicyRuleInstanceOne,
+        accessPolicyRuleInstanceTwo,
+        accessPolicyRuleInstanceThree,
+      ]
+      await filter.onFetch(elements)
+      const priorityInstances = elements
+        .filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityInstances[0]).toBeDefined()
+      expect(priorityInstances[0].elemID.name).toEqual('accessPolicyInstance_priority')
+      expect(priorityInstances[0].value.priorities).toEqual([
+        new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+        new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+        new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+      ])
+      expect(priorityInstances[0].value.defaultRule).toBeUndefined()
+      const priorityType = elements
+        .filter(isObjectType)
+        .find(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityType).toBeDefined()
+      expect(priorityInstances[0].path).toEqual(['accessPolicyInstance_priority'])
+    })
+    it('should not add AccessPolicyRulePriority instance if there is no parent AccessPolicy', async () => {
+      const elementsWithoutAccessPolicy = elements.map(instance => {
+        const instanceWithoutAccessPolicy = instance.clone()
+        instanceWithoutAccessPolicy.annotations[CORE_ANNOTATIONS.PARENT] = undefined
+        return instanceWithoutAccessPolicy
+      })
+
+      await filter.onFetch(elementsWithoutAccessPolicy)
+      const priorityInstances = elementsWithoutAccessPolicy
+        .filter(isInstanceElement)
+        .filter(e => e.elemID.typeName === ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME)
+      expect(priorityInstances).toHaveLength(0)
+    })
+  })
+  describe('deploy', () => {
+    let connection: MockInterface<clientUtils.APIConnection>
+    let accessPolicyPriorityInstance: InstanceElement
+    const accessPolicyRulePriorityType = new ObjectType({
+      elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME),
+    })
+    beforeEach(() => {
+      const { client: cli, connection: conn } = mockClient()
+      client = cli
+      connection = conn
+      filter = policyRulePrioritiesFilter(getFilterParams({ client })) as typeof filter
+      accessPolicyPriorityInstance = new InstanceElement(
+        'accessPolicyPriorityInstance',
+        accessPolicyRulePriorityType,
+        {
+          priorities: [
+            new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+            new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+            new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+          ],
+          defaultRule: new ReferenceExpression(
+            accessPolicyRuleInstanceFourDefault.elemID,
+            accessPolicyRuleInstanceFourDefault,
+          ),
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(accessPolicyInstance.elemID, accessPolicyInstance)],
+        },
+      )
+      connection.put.mockResolvedValueOnce({ status: 200, data: {} })
+    })
+    it('should apply order when adding accessPolicyPriorityInstance', async () => {
+      const changes = [toChange({ after: accessPolicyPriorityInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(3)
+    })
+    it('should apply order when adding AuthorizationServerPolicyRulePriorityInstance', async () => {
+      const authorizationServerPolicyType = new ObjectType({ elemID: new ElemID(OKTA, AUTHORIZATION_POLICY) })
+      const authorizationServerPolicyInstance = new InstanceElement(
+        'authorizationServerPolicyInstance',
+        authorizationServerPolicyType,
+        {
+          name: 'authorizationServerPolicyInstance',
+          id: 4,
+        },
+        [
+          OKTA,
+          elementUtils.RECORDS_PATH,
+          AUTHORIZATION_POLICY,
+          'authorizationServerPolicyInstance',
+          'authorizationServerPolicyInstance',
+        ],
+      )
+      const authorizationServerPolicyRuleType = new ObjectType({
+        elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME),
+      })
+      const authorizationServerPolicyRuleInstanceOne = createPolicyRuleInstance(
+        1,
+        false,
+        authorizationServerPolicyRuleType,
+        authorizationServerPolicyInstance,
+      )
+      const authorizationServerPolicyRuleInstanceTwo = createPolicyRuleInstance(
+        2,
+        false,
+        authorizationServerPolicyRuleType,
+        authorizationServerPolicyInstance,
+      )
+      const authorizationServerPolicyRuleInstanceThree = createPolicyRuleInstance(
+        3,
+        false,
+        authorizationServerPolicyRuleType,
+        authorizationServerPolicyInstance,
+      )
+      const authorizationServerPolicyRuleInstanceFourDefault = createPolicyRuleInstance(
+        4,
+        true,
+        authorizationServerPolicyRuleType,
+        authorizationServerPolicyInstance,
+      )
+      const authorizationServerPolicyRulePriorityType = new ObjectType({
+        elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME),
+      })
+      const authorizationServerPolicyPriorityInstance = new InstanceElement(
+        'authorizationServerPolicyPriorityInstance',
+        authorizationServerPolicyRulePriorityType,
+        {
+          priorities: [
+            new ReferenceExpression(
+              authorizationServerPolicyRuleInstanceOne.elemID,
+              authorizationServerPolicyRuleInstanceOne,
+            ),
+            new ReferenceExpression(
+              authorizationServerPolicyRuleInstanceTwo.elemID,
+              authorizationServerPolicyRuleInstanceTwo,
+            ),
+            new ReferenceExpression(
+              authorizationServerPolicyRuleInstanceThree.elemID,
+              authorizationServerPolicyRuleInstanceThree,
+            ),
+          ],
+          defaultRule: new ReferenceExpression(
+            authorizationServerPolicyRuleInstanceFourDefault.elemID,
+            authorizationServerPolicyRuleInstanceFourDefault,
+          ),
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [
+            new ReferenceExpression(authorizationServerPolicyInstance.elemID, authorizationServerPolicyInstance),
+          ],
+        },
+      )
+      const changes = [toChange({ after: authorizationServerPolicyPriorityInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(3)
+    })
+    it('should call API only for changed positions when modifing', async () => {
+      const accessPolicyPriorityInstanceAfter = accessPolicyPriorityInstance.clone()
+      accessPolicyPriorityInstanceAfter.value.priorities = [
+        new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+        new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+        new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+      ]
+      const changes = [toChange({ before: accessPolicyPriorityInstance, after: accessPolicyPriorityInstanceAfter })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(2)
+    })
+    it('should change order when adding another rule and change order', async () => {
+      const accessPolicyRuleInstanceFive = createPolicyRuleInstance(
+        5,
+        false,
+        accessPolicyRuleType,
+        accessPolicyInstance,
+      )
+      const accessPolicyPriorityInstanceAfter = accessPolicyPriorityInstance.clone()
+      accessPolicyPriorityInstanceAfter.value.priorities = [
+        new ReferenceExpression(accessPolicyRuleInstanceTwo.elemID, accessPolicyRuleInstanceTwo),
+        new ReferenceExpression(accessPolicyRuleInstanceOne.elemID, accessPolicyRuleInstanceOne),
+        new ReferenceExpression(accessPolicyRuleInstanceThree.elemID, accessPolicyRuleInstanceThree),
+        new ReferenceExpression(accessPolicyRuleInstanceFive.elemID, accessPolicyRuleInstanceFive),
+      ]
+      const changes = [toChange({ before: accessPolicyPriorityInstance, after: accessPolicyPriorityInstanceAfter })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(0)
+      expect(res.deployResult.appliedChanges).toHaveLength(1)
+      expect(connection.put).toHaveBeenCalledTimes(3)
+    })
+    it('should throw when deployUrl is not defined', async () => {
+      const config = {
+        ...DEFAULT_CONFIG,
+        apiDefinitions: {
+          types: {
+            [ACCESS_POLICY_RULE_TYPE_NAME]: {
+              deployRequests: {
+                modify: {
+                  url: undefined,
+                },
+              },
+            },
+          },
+        },
+      } as unknown as OktaConfig
+      filter = policyRulePrioritiesFilter(getFilterParams({ client, config })) as typeof filter
+      const changes = [toChange({ after: accessPolicyPriorityInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0].message).toEqual('Failed to deploy priority change due to missing url')
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+    it('should throw when there are no deployRequest', async () => {
+      const config = {
+        ...DEFAULT_CONFIG,
+        apiDefinitions: {
+          types: {
+            [ACCESS_POLICY_RULE_TYPE_NAME]: {},
+          },
+        },
+      } as unknown as OktaConfig
+      filter = policyRulePrioritiesFilter(getFilterParams({ client, config })) as typeof filter
+      const changes = [toChange({ after: accessPolicyPriorityInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0].message).toEqual('Failed to deploy priority change due to missing url')
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.put).toHaveBeenCalledTimes(0)
+    })
+    it('should throw when there are no parent policy', async () => {
+      filter = policyRulePrioritiesFilter(getFilterParams({ client })) as typeof filter
+      accessPolicyRuleInstanceTwo.annotations[CORE_ANNOTATIONS.PARENT] = []
+      const changes = [toChange({ after: accessPolicyPriorityInstance })]
+      const res = await filter.deploy(changes)
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0].message).toEqual('Failed to deploy priority change due to missing policy')
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      expect(connection.put).toHaveBeenCalledTimes(1) // call for rule1
+    })
+  })
+})

--- a/packages/okta-adapter/test/fix_elements/missing_users.test.ts
+++ b/packages/okta-adapter/test/fix_elements/missing_users.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 import { ElemID, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import OktaClient from '../../src/client/client'
 import * as userUtilsModule from '../../src/user_utils'
 import { ACCESS_POLICY_RULE_TYPE_NAME, GROUP_PUSH_TYPE_NAME, GROUP_RULE_TYPE_NAME, OKTA } from '../../src/constants'
@@ -65,6 +66,7 @@ describe('missing_users', () => {
   )
   const groupPushInstance = new InstanceElement('foo', pushGroupType, { notUsersKnownPath: [NOT_EXIST_USER] })
   const missingUsersHandlerInput = [accessPolicyInstance, groupRuleInstance, groupPushInstance]
+  const elementsSource = buildElementsSourceFromElements([])
   beforeEach(() => {
     jest.clearAllMocks()
   })
@@ -74,7 +76,9 @@ describe('missing_users', () => {
       [FETCH_CONFIG]: {},
     } as OktaConfig
     it('should return empty fixElements list and empty errors list', async () => {
-      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient, elementsSource })(
+        missingUsersHandlerInput,
+      )
       expect(result.errors).toHaveLength(0)
       expect(result.fixedElements).toHaveLength(0)
       expect(mockGetUsers).not.toHaveBeenCalled()
@@ -88,7 +92,9 @@ describe('missing_users', () => {
       [FETCH_CONFIG]: {},
     } as OktaConfig
     it('should return empty fixElements list and empty errors list', async () => {
-      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient, elementsSource })(
+        missingUsersHandlerInput,
+      )
       expect(result.errors).toHaveLength(0)
       expect(result.fixedElements).toHaveLength(0)
       expect(mockGetUsers).not.toHaveBeenCalled()
@@ -102,7 +108,9 @@ describe('missing_users', () => {
       [FETCH_CONFIG]: {},
     } as OktaConfig
     it('should return fixElements list and errors list correctly', async () => {
-      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient })(missingUsersHandlerInput)
+      const result = await omitMissingUsersHandler({ config: mockConfig, client: mockClient, elementsSource })(
+        missingUsersHandlerInput,
+      )
       expect(result.errors).toHaveLength(2)
       expect(result.errors).toEqual([
         expect.objectContaining({
@@ -141,6 +149,7 @@ If you continue, they will be omitted. Learn more: ${userUtilsModule.OMIT_MISSIN
             },
           } as OktaConfig,
           client: mockClient,
+          elementsSource,
         })(missingUsersHandlerInput)
         expect(mockGetUsers.mock.calls[0][1]).toEqual({
           userIds: expect.arrayContaining(ALL_MOCK_USERS),

--- a/packages/okta-adapter/test/weak_references/policy_rule_priorities.test.ts
+++ b/packages/okta-adapter/test/weak_references/policy_rule_priorities.test.ts
@@ -1,0 +1,145 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BuiltinTypes,
+  ElemID,
+  InstanceElement,
+  ListType,
+  ObjectType,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { OKTA, ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME, ACCESS_POLICY_RULE_TYPE_NAME } from '../../src/constants'
+import { policyRulePrioritiesHandler } from '../../src/weak_references/policy_rule_priorities'
+import { createConfigInstance } from '../utils'
+import { DEFAULT_CONFIG } from '../../src/config'
+
+describe('policyRulePrioritiesHandler', () => {
+  const ruleType = new ObjectType({
+    elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME),
+    fields: {
+      id: { refType: BuiltinTypes.STRING },
+      name: { refType: BuiltinTypes.STRING },
+    },
+  })
+  let ruleInstance: InstanceElement
+  const policyRulePriorityType = new ObjectType({
+    elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_PRIORITY_TYPE_NAME),
+    fields: {
+      priorities: {
+        refType: new ListType(BuiltinTypes.STRING),
+      },
+    },
+  })
+  let policyRulePriorityInstance: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  const adapterConfig = createConfigInstance(DEFAULT_CONFIG)
+
+  beforeEach(() => {
+    ruleInstance = new InstanceElement('rule1', ruleType, { id: 'ruleId', name: 'rule1' })
+    elementsSource = buildElementsSourceFromElements([ruleInstance])
+
+    policyRulePriorityInstance = new InstanceElement('policyRulePriorityInstance', policyRulePriorityType, {
+      priorities: [
+        'priority1',
+        new ReferenceExpression(new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME, 'instance', 'rule1')),
+        new ReferenceExpression(new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME, 'instance', 'rule2')),
+      ],
+    })
+  })
+  describe('findWeakReferences', () => {
+    it('should return weak references rules', async () => {
+      const references = await policyRulePrioritiesHandler.findWeakReferences(
+        [policyRulePriorityInstance],
+        adapterConfig,
+      )
+
+      expect(references).toEqual([
+        { source: policyRulePriorityInstance.elemID.createNestedID('1'), target: ruleInstance.elemID, type: 'weak' },
+        {
+          source: policyRulePriorityInstance.elemID.createNestedID('2'),
+          target: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME, 'instance', 'rule2'),
+          type: 'weak',
+        },
+      ])
+    })
+
+    it('should do nothing if received invalid policyRulePriorityInstance', async () => {
+      policyRulePriorityInstance.value.priorities = 'invalid'
+      const references = await policyRulePrioritiesHandler.findWeakReferences(
+        [policyRulePriorityInstance],
+        adapterConfig,
+      )
+
+      expect(references).toEqual([])
+    })
+
+    it('should do nothing if there are no priorities', async () => {
+      delete policyRulePriorityInstance.value.priorities
+      const references = await policyRulePrioritiesHandler.findWeakReferences(
+        [policyRulePriorityInstance],
+        adapterConfig,
+      )
+
+      expect(references).toEqual([])
+    })
+  })
+
+  describe('removeWeakReferences', () => {
+    it('should remove the invalid rules', async () => {
+      const fixes = await policyRulePrioritiesHandler.removeWeakReferences({ elementsSource })([
+        policyRulePriorityInstance,
+      ])
+
+      expect(fixes.errors).toEqual([
+        {
+          elemID: policyRulePriorityInstance.elemID.createNestedID('priorities'),
+          severity: 'Info',
+          message: 'Deploying AccessPolicyRulePriority without all attached priorities for rules.',
+          detailedMessage:
+            'This AccessPolicyRulePriority is attached to some rules that do not exist in the target environment. It will be deployed without referencing these.',
+        },
+      ])
+
+      expect(fixes.fixedElements).toHaveLength(1)
+      expect((fixes.fixedElements[0] as InstanceElement).value.priorities).toEqual([
+        new ReferenceExpression(new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME, 'instance', 'rule1')),
+      ])
+    })
+    it('should do nothing if there are no priorities', async () => {
+      delete policyRulePriorityInstance.value.priorities
+      const fixes = await policyRulePrioritiesHandler.removeWeakReferences({ elementsSource })([
+        policyRulePriorityInstance,
+      ])
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+
+    it('should do nothing if all priorities are valid', async () => {
+      policyRulePriorityInstance.value.priorities = [
+        new ReferenceExpression(new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME, 'instance', 'rule1')),
+      ]
+      const fixes = await policyRulePrioritiesHandler.removeWeakReferences({ elementsSource })([
+        policyRulePriorityInstance,
+      ])
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
In this PR:
1. I added a filter that fetches and deploys policy rules priories into an instance.
2. Added a weak reference mechanism to allow deploying order without all the instances in it.  

---

_Additional context for reviewer_
1. **I will add tests after first review when the tech design will be approve.** 
3. View of the nacl:
![image](https://github.com/salto-io/salto/assets/63644199/316b3d5a-b0f8-4235-babb-026c71aca289)

4. View of the element tree
![image](https://github.com/salto-io/salto/assets/63644199/c4cc9e83-7e07-4d07-adc6-d31d1c64368d)
@shir-reifenberg I don't think that the priority should actually be inside its own folder. WDYT?

---
_Release Notes_: 
_Okta Adapter:_
* New instances responsible for policy rules priorities were added. 

---
_User Notifications_: 
_Okta Adapter:_
* New instances responsible for policy rules priorities were added. 