### PR TITLE
SALTO-5779: Modify network zone to inactive to make E2E pass

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -170,8 +170,10 @@ const createInstancesForDeploy = (types: ObjectType[], testSuffix: string): Inst
       name: createName('policyRule'),
       conditions: {
         network: {
-          connection: 'ZONE',
-          include: [new ReferenceExpression(zoneInstance.elemID, zoneInstance)],
+          connection: 'ANYWHERE',
+          // TODO SALTO-5780 - return reference to zone once resolved
+          // connection: 'ZONE',
+          // include: [new ReferenceExpression(zoneInstance.elemID, zoneInstance)],
         },
         riskScore: { level: 'ANY' },
       },

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -133,7 +133,8 @@ export const mockDefaultValues: Record<string, Values> = {
   [NETWORK_ZONE_TYPE_NAME]: {
     type: 'IP',
     name: 'myNewZone',
-    status: 'ACTIVE',
+    // TODO SALTO-5779 change to ACTIVE
+    status: 'INACTIVE',
     usage: 'POLICY',
     system: false,
     gateways: [


### PR DESCRIPTION
Changing mock element so the E2E can pass until a I'll add a full fix

---

_Additional context for reviewer_

---
_Release Notes_: 
None 

---
_User Notifications_: 
None
