### PR TITLE
SALTO-5779: Deactivate NetworkZone before removal

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -133,8 +133,7 @@ export const mockDefaultValues: Record<string, Values> = {
   [NETWORK_ZONE_TYPE_NAME]: {
     type: 'IP',
     name: 'myNewZone',
-    // TODO SALTO-5779 change to ACTIVE
-    status: 'INACTIVE',
+    status: 'ACTIVE',
     usage: 'POLICY',
     system: false,
     gateways: [

--- a/packages/okta-adapter/src/deployment.ts
+++ b/packages/okta-adapter/src/deployment.ts
@@ -113,8 +113,12 @@ export const isActivationChange = ({ before, after }: { before: string; after: s
 export const isDeactivationChange = ({ before, after }: { before: string; after: string }): boolean =>
   before === ACTIVE_STATUS && after === INACTIVE_STATUS
 
+const isDeactivationModificationChange = (change: Change<InstanceElement>): boolean =>
+  isModificationChange(change) &&
+  isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })
+
 const DEACTIVATE_BEFORE_REMOVAL_TYPES = new Set([NETWORK_ZONE_TYPE_NAME])
-const shouldDeactiveBeforeRemoval = (change: Change<InstanceElement>): boolean =>
+const shouldDeactivateBeforeRemoval = (change: Change<InstanceElement>): boolean =>
   isRemovalChange(change) && DEACTIVATE_BEFORE_REMOVAL_TYPES.has(getChangeData(change).elemID.typeName)
 
 export const deployStatusChange = async (
@@ -214,13 +218,8 @@ export const defaultDeployWithStatus = async (
   queryParams?: Record<string, string>,
 ): Promise<deployment.ResponseResult> => {
   try {
-    if (
-      // If the instance is deactivated,
-      // we should first change the status as some instances can not be changed in status 'ACTIVE'
-      (isModificationChange(change) &&
-        isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) ||
-      shouldDeactiveBeforeRemoval(change)
-    ) {
+    // some changes can't be applied when status is ACTIVE, so we need to deactivate them first
+    if (isDeactivationModificationChange(change) || shouldDeactivateBeforeRemoval(change)) {
       await deployStatusChange(change, client, apiDefinitions, 'deactivate')
     }
     const response = await defaultDeployChange(change, client, apiDefinitions, fieldsToIgnore, queryParams)

--- a/packages/okta-adapter/src/deployment.ts
+++ b/packages/okta-adapter/src/deployment.ts
@@ -30,6 +30,7 @@ import {
   createSaltoElementError,
   isSaltoError,
   SaltoError,
+  isRemovalChange,
 } from '@salto-io/adapter-api'
 import {
   config as configUtils,
@@ -42,7 +43,7 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { values, collections } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
-import { ACTIVE_STATUS, INACTIVE_STATUS } from './constants'
+import { ACTIVE_STATUS, INACTIVE_STATUS, NETWORK_ZONE_TYPE_NAME } from './constants'
 import { OktaStatusActionName, OktaSwaggerApiConfig } from './config'
 
 const log = logger(module)
@@ -111,6 +112,10 @@ export const isActivationChange = ({ before, after }: { before: string; after: s
 
 export const isDeactivationChange = ({ before, after }: { before: string; after: string }): boolean =>
   before === ACTIVE_STATUS && after === INACTIVE_STATUS
+
+const DEACTIVATE_BEFORE_REMOVAL_TYPES = new Set([NETWORK_ZONE_TYPE_NAME])
+const shouldDeactiveBeforeRemoval = (change: Change<InstanceElement>): boolean =>
+  isRemovalChange(change) && DEACTIVATE_BEFORE_REMOVAL_TYPES.has(getChangeData(change).elemID.typeName)
 
 export const deployStatusChange = async (
   change: Change<InstanceElement>,
@@ -209,11 +214,12 @@ export const defaultDeployWithStatus = async (
   queryParams?: Record<string, string>,
 ): Promise<deployment.ResponseResult> => {
   try {
-    // If the instance is deactivated,
-    // we should first change the status as some instances can not be changed in status 'ACTIVE'
     if (
-      isModificationChange(change) &&
-      isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })
+      // If the instance is deactivated,
+      // we should first change the status as some instances can not be changed in status 'ACTIVE'
+      (isModificationChange(change) &&
+        isDeactivationChange({ before: change.data.before.value.status, after: change.data.after.value.status })) ||
+      shouldDeactiveBeforeRemoval(change)
     ) {
       await deployStatusChange(change, client, apiDefinitions, 'deactivate')
     }

--- a/packages/okta-adapter/test/deployment.test.ts
+++ b/packages/okta-adapter/test/deployment.test.ts
@@ -253,17 +253,9 @@ describe('deployment.ts', () => {
           data: {},
         })
         mockConnection.delete.mockResolvedValue({ status: 200, data: {} })
-        await defaultDeployWithStatus(
-          toChange({ before: zoneInstance }),
-          client,
-          DEFAULT_API_DEFINITIONS,
-          [],
-        )
+        await defaultDeployWithStatus(toChange({ before: zoneInstance }), client, DEFAULT_API_DEFINITIONS, [])
         expect(mockConnection.post).toHaveBeenCalledWith('/api/v1/zones/a/lifecycle/deactivate', {}, undefined)
-        expect(mockConnection.delete).toHaveBeenCalledWith(
-          '/api/v1/zones/a',
-          { data: undefined },
-        )
+        expect(mockConnection.delete).toHaveBeenCalledWith('/api/v1/zones/a', { data: undefined })
       })
     })
   })

--- a/packages/okta-adapter/test/deployment.test.ts
+++ b/packages/okta-adapter/test/deployment.test.ts
@@ -18,7 +18,7 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 import { ElemID, InstanceElement, ModificationChange, ObjectType, toChange } from '@salto-io/adapter-api'
 import { mockClient } from './utils'
 import OktaClient from '../src/client/client'
-import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, OKTA } from '../src/constants'
+import { GROUP_RULE_TYPE_NAME, GROUP_TYPE_NAME, NETWORK_ZONE_TYPE_NAME, OKTA } from '../src/constants'
 import { defaultDeployChange, defaultDeployWithStatus, deployStatusChange, getOktaError } from '../src/deployment'
 import { DEFAULT_API_DEFINITIONS, OktaSwaggerApiConfig } from '../src/config'
 
@@ -241,6 +241,28 @@ describe('deployment.ts', () => {
           '/api/v1/groups/rules/1',
           { id: '1', name: 'changed val' },
           undefined,
+        )
+      })
+    })
+    describe('removal changes', () => {
+      it('should deactivate change before removal for relevant changes', async () => {
+        const zoneType = new ObjectType({ elemID: new ElemID(OKTA, NETWORK_ZONE_TYPE_NAME) })
+        const zoneInstance = new InstanceElement('zone', zoneType, { id: 'a', name: 'zone', status: 'ACTIVE' })
+        mockConnection.post.mockResolvedValue({
+          status: 204,
+          data: {},
+        })
+        mockConnection.delete.mockResolvedValue({ status: 200, data: {} })
+        await defaultDeployWithStatus(
+          toChange({ before: zoneInstance }),
+          client,
+          DEFAULT_API_DEFINITIONS,
+          [],
+        )
+        expect(mockConnection.post).toHaveBeenCalledWith('/api/v1/zones/a/lifecycle/deactivate', {}, undefined)
+        expect(mockConnection.delete).toHaveBeenCalledWith(
+          '/api/v1/zones/a',
+          { data: undefined },
         )
       })
     })


### PR DESCRIPTION
Okta recently made a change and they no longer allow removing an active network zone
The solution is to deactivate the network zone before trying to delete it 

---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta_adapter_:

- Okta no longer allow to delete an active NetworkZone, Salto will no deactivate NetworkZone when trying to delete it
 
---
_User Notifications_: 
None
