### PR TITLE
SALTO-5745 - Salesforce: When duplicate file props are retrieved, keep the most up-to-date one

### DIFF
--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -854,7 +854,7 @@ const pickFromDuplicates = (
   duplicateProperties: ReadonlyArray<FileProperties>,
 ): FileProperties | undefined =>
   _(duplicateProperties)
-    .sortBy((prop) => prop.lastModifiedDate)
+    .sortBy((prop) => new Date(prop.lastModifiedDate))
     .last()
 
 const removeDuplicateFileProps = (

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -849,6 +849,14 @@ export const getChangedAtSingletonInstance = async (
 export const isCustomType = (element: Element): element is ObjectType =>
   isObjectType(element) &&
   ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(apiNameSync(element) ?? '')
+
+const pickFromDuplicates = (
+  duplicateProperties: ReadonlyArray<FileProperties>,
+): FileProperties | undefined =>
+  _(duplicateProperties)
+    .sortBy((prop) => prop.lastModifiedDate)
+    .last()
+
 const removeDuplicateFileProps = (
   files: FileProperties[],
 ): FileProperties[] => {
@@ -862,7 +870,7 @@ const removeDuplicateFileProps = (
       props,
     )
   })
-  return uniques.concat(duplicates.map((props) => props[0]))
+  return uniques.concat(duplicates.map(pickFromDuplicates).filter(isDefined))
 }
 export const listMetadataObjects = async (
   client: SalesforceClient,

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2008,18 +2008,33 @@ public class MyClass${index} {
       it('should fetch only the element once', async () => {
         mockMetadataType({ xmlName: 'Test2' }, { valueTypeFields: [] }, [
           {
-            props: { fullName: 'Test' },
+            props: {
+              fullName: 'Test',
+              lastModifiedDate: '2024-04-09',
+              id: 'olderInstance',
+            },
             values: { fullName: 'Test' },
           },
           {
-            props: { fullName: 'Test' },
+            props: {
+              fullName: 'Test',
+              lastModifiedDate: '2024-04-10',
+              id: 'newerInstance',
+            },
             values: { fullName: 'Test' },
           },
         ])
         const { elements: result } = await adapter.fetch(mockFetchOpts)
         const testInstances = findElements(result, 'Test2', 'Test')
         expect(connection.metadata.read).toHaveBeenCalled()
-        expect(testInstances).toHaveLength(1)
+        expect(testInstances).toEqual([
+          expect.objectContaining({
+            value: {
+              fullName: 'Test',
+              internalId: 'newerInstance',
+            },
+          }),
+        ])
       })
     })
 


### PR DESCRIPTION
This keeps the state file consistent across fetches.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A