### PR TITLE
Salto 5781 remove object count from object types

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectType.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectType.ts
@@ -21,7 +21,6 @@ import { JIRA } from '../../../../src/constants'
 export const createObjectTypeValues = (name: string, allElements: Element[]): Values => ({
   name,
   type: 0,
-  objectCount: 0,
   inherited: true,
   abstractObjectType: false,
   parentObjectTypeInherited: true,

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2296,7 +2296,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'updated' },
         { fieldName: 'globalId' },
         { fieldName: 'workspaceId' },
-        { fieldName: 'objectCount'},
+        { fieldName: 'objectCount' },
       ],
       extendsParentId: false,
       serviceUrl: '/jira/servicedesk/assets/object-schema/{objectSchemaId}?typeId={id}',

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -2281,9 +2281,6 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   ObjectTypes: {
     request: {
       url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/{AssetsSchemaId}/objecttypes/flat',
-      queryParams: {
-        includeObjectCounts: 'true',
-      },
     },
     transformation: {
       dataField: '.',
@@ -2299,6 +2296,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'updated' },
         { fieldName: 'globalId' },
         { fieldName: 'workspaceId' },
+        { fieldName: 'objectCount'},
       ],
       extendsParentId: false,
       serviceUrl: '/jira/servicedesk/assets/object-schema/{objectSchemaId}?typeId={id}',


### PR DESCRIPTION
In this PR I removed object count field from objectType instances (requested by @liorn )

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* objectTypes will have no field called objectCount. 

---
_User Notifications_: 
_Jira Adapter:_
* objectTypes will have no field called objectCount. 
