### PR TITLE
SALTO-5671 allow creation of dynamic content whose placeholder and title are different

### DIFF
--- a/packages/zendesk-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content.ts
@@ -89,7 +89,6 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     // name -> {{dc.name}}
     const nameToPlaceholder = (name: string): string => `{{dc.${name}}}`
 
-    
     const isAdditionOfAlteredDynamicContentItem = (change: Change<InstanceElement>): boolean =>
       isAdditionChange(change) &&
       getChangeData(change).elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME &&
@@ -110,7 +109,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       log.trace('Successfully created dynamic content item with placeholder %o', newPlaceholder)
 
       // must add ID before the modification change
-      addId({response, change: clonedAdditionChange, apiDefinitions: config.apiDefinitions})
+      addId({ response, change: clonedAdditionChange, apiDefinitions: config.apiDefinitions })
       const afterChangeData = getChangeData(change)
       afterChangeData.value.id = getChangeData(clonedAdditionChange).value.id
       try {
@@ -131,7 +130,10 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
             clonedChangeData.elemID.getFullName(),
             modificationError,
           )
-          return { message: `Failed to create dynamic content item: ${(modificationError as Error).message}`, severity: 'Error' }
+          return {
+            message: `Failed to create dynamic content item: ${(modificationError as Error).message}`,
+            severity: 'Error',
+          }
         } catch (removalError) {
           log.error(
             'Unable to remove dynamic content item %s after failed modification: %o',

--- a/packages/zendesk-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content.ts
@@ -28,11 +28,7 @@ import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { addIdsToChildrenUponAddition, deployChange, deployChanges, deployChangesByGroups } from '../deployment'
 import { API_DEFINITIONS_CONFIG } from '../config'
-import {
-  applyforInstanceChangesOfType,
-  placeholderToName,
-  nameToPlaceholder,
-} from './utils'
+import { applyforInstanceChangesOfType, placeholderToName, nameToPlaceholder } from './utils'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../constants'
 
 const log = logger(module)

--- a/packages/zendesk-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content.ts
@@ -28,7 +28,11 @@ import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { addIdsToChildrenUponAddition, deployChange, deployChanges, deployChangesByGroups } from '../deployment'
 import { API_DEFINITIONS_CONFIG } from '../config'
-import { applyforInstanceChangesOfType, placeholderToTitle as placeholderToName, titleToPlaceholder as nameToPlaceholder } from './utils'
+import {
+  applyforInstanceChangesOfType,
+  placeholderToTitle as placeholderToName,
+  titleToPlaceholder as nameToPlaceholder,
+} from './utils'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../constants'
 
 const log = logger(module)
@@ -94,7 +98,16 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         log.debug('Creating dynamic content item with placeholder %s', newAdditionChange.value.placeholder)
         await deployChange({ action: 'add', data: { after: newAdditionChange } }, client, config.apiDefinitions)
       } catch (additionError) {
-        return { appliedChanges: [], errors: [{elemID: changeData.elemID, message: `Failed to create dynamic content item: ${additionError}`, severity: 'Error'}] }
+        return {
+          appliedChanges: [],
+          errors: [
+            {
+              elemID: changeData.elemID,
+              message: `Failed to create dynamic content item: ${additionError}`,
+              severity: 'Error',
+            },
+          ],
+        }
       }
       try {
         await deployChange(
@@ -110,19 +123,18 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
           return {
             appliedChanges: [],
             errors: [
-              { elemID: changeData.elemID, 
-                message: 'Unable to modify name of dynamic content item, please modify it in the Zendesk UI and fetch.', 
-                severity: 'Warning'
-              }
+              {
+                elemID: changeData.elemID,
+                message: 'Unable to modify name of dynamic content item, please modify it in the Zendesk UI and fetch.',
+                severity: 'Warning',
+              },
             ],
           }
         }
         log.warn('Unable to modify dynamic content item %s, but removal was successful: %s', modificationError)
         return {
           appliedChanges: [],
-          errors: [
-            { message: `Failed to create dynamic content item: ${modificationError}`, severity: 'Error' }
-          ],
+          errors: [{ message: `Failed to create dynamic content item: ${modificationError}`, severity: 'Error' }],
         }
       }
       log.trace('Successfully created dynamic content item %s', changeData.elemID.name)

--- a/packages/zendesk-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content.ts
@@ -30,8 +30,8 @@ import { addIdsToChildrenUponAddition, deployChange, deployChanges, deployChange
 import { API_DEFINITIONS_CONFIG } from '../config'
 import {
   applyforInstanceChangesOfType,
-  placeholderToTitle as placeholderToName,
-  titleToPlaceholder as nameToPlaceholder,
+  placeholderToName,
+  nameToPlaceholder,
 } from './utils'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../constants'
 

--- a/packages/zendesk-adapter/src/filters/dynamic_content.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content.ts
@@ -30,7 +30,7 @@ import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { addIdsToChildrenUponAddition, deployChange, deployChanges, deployChangesByGroups } from '../deployment'
 import { API_DEFINITIONS_CONFIG } from '../config'
-import { applyforInstanceChangesOfType, placeholderToName, nameToPlaceholder } from './utils'
+import { applyforInstanceChangesOfType } from './utils'
 import { DYNAMIC_CONTENT_ITEM_TYPE_NAME } from '../constants'
 
 const log = logger(module)
@@ -83,6 +83,13 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       change => getChangeData(change).elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME,
     )
 
+    // {{dc.name}} -> name
+    const placeholderToName = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
+
+    // name -> {{dc.name}}
+    const nameToPlaceholder = (name: string): string => `{{dc.${name}}}`
+
+    
     const isAdditionOfAlteredDynamicContentItem = (change: Change<InstanceElement>): boolean =>
       isAdditionChange(change) &&
       getChangeData(change).elemID.typeName === DYNAMIC_CONTENT_ITEM_TYPE_NAME &&

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -66,8 +66,10 @@ export type SubjectCondition = {
 const TYPES_WITH_SUBJECT_CONDITIONS = ['routing_attribute_value']
 export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
+// {{dc.name}} -> name
 export const placeholderToName = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
 
+// name: bla here-there::everywhere -> {{dc.name_bla_here-there-everywhere}}
 export const nameToPlaceholder = (name: string): string => {
   const cleanedName = name.replace(/:?\s+/g, '_').replace(/::/g, '-').replace(/\s/g, '_')
   return `{{dc.${cleanedName.toLowerCase()}}}`

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -69,9 +69,7 @@ export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 export const placeholderToTitle = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
 
 export const titleToPlaceholder = (title: string): string => {
-  const cleanedTitle = title.replace(/:?\s+/g, '_')
-                            .replace(/::/g, '-')
-                            .replace(/\s/g, '_')
+  const cleanedTitle = title.replace(/:?\s+/g, '_').replace(/::/g, '-').replace(/\s/g, '_')
   return `{{dc.${cleanedTitle.toLowerCase()}}}`
 }
 export const applyforInstanceChangesOfType = async (

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -66,6 +66,10 @@ export type SubjectCondition = {
 const TYPES_WITH_SUBJECT_CONDITIONS = ['routing_attribute_value']
 export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
+export const placeholderToTitle = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
+
+export const titleToPlaceholder = (title: string): string => `{{dc.${title.toLowerCase()}}}`
+
 export const applyforInstanceChangesOfType = async (
   changes: Change<ChangeDataType>[],
   typeNames: string[],

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -68,8 +68,12 @@ export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
 export const placeholderToTitle = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
 
-export const titleToPlaceholder = (title: string): string => `{{dc.${title.toLowerCase()}}}`
-
+export const titleToPlaceholder = (title: string): string => {
+  const cleanedTitle = title.replace(/:?\s+/g, '_')
+                            .replace(/::/g, '-')
+                            .replace(/\s/g, '_')
+  return `{{dc.${cleanedTitle.toLowerCase()}}}`
+}
 export const applyforInstanceChangesOfType = async (
   changes: Change<ChangeDataType>[],
   typeNames: string[],

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -66,11 +66,11 @@ export type SubjectCondition = {
 const TYPES_WITH_SUBJECT_CONDITIONS = ['routing_attribute_value']
 export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
-export const placeholderToTitle = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
+export const placeholderToName = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
 
-export const titleToPlaceholder = (title: string): string => {
-  const cleanedTitle = title.replace(/:?\s+/g, '_').replace(/::/g, '-').replace(/\s/g, '_')
-  return `{{dc.${cleanedTitle.toLowerCase()}}}`
+export const nameToPlaceholder = (name: string): string => {
+  const cleanedName = name.replace(/:?\s+/g, '_').replace(/::/g, '-').replace(/\s/g, '_')
+  return `{{dc.${cleanedName.toLowerCase()}}}`
 }
 export const applyforInstanceChangesOfType = async (
   changes: Change<ChangeDataType>[],

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -66,14 +66,6 @@ export type SubjectCondition = {
 const TYPES_WITH_SUBJECT_CONDITIONS = ['routing_attribute_value']
 export const DOMAIN_REGEX = /(https:\/\/[^/]+)/
 
-// {{dc.name}} -> name
-export const placeholderToName = (placeholder: string): string => placeholder.substring(5, placeholder.length - 2)
-
-// name: bla here-there::everywhere -> {{dc.name_bla_here-there-everywhere}}
-export const nameToPlaceholder = (name: string): string => {
-  const cleanedName = name.replace(/:?\s+/g, '_').replace(/::/g, '-').replace(/\s/g, '_')
-  return `{{dc.${cleanedName.toLowerCase()}}}`
-}
 export const applyforInstanceChangesOfType = async (
   changes: Change<ChangeDataType>[],
   typeNames: string[],

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -187,6 +187,8 @@ describe('dynamic content filter', () => {
     const resolvedParent = new InstanceElement('parent', parentObjType, {
       default_locale_id: 1,
       name: 'parent',
+      title: 'parent',
+      placeholder: '{{dc.parent}}',
       [VARIANTS_FIELD_NAME]: [
         { content: 'abc', locale_id: 1, active: true, default: true },
         { content: 'abc', locale_id: 2, active: true, default: false },
@@ -296,23 +298,6 @@ describe('dynamic content filter', () => {
         beforeElements.map((e, i) => ({ action: 'modify', data: { before: e, after: afterElements[i] } })),
       )
     })
-    it('should return error if deployChange failed', async () => {
-      const clonedResolvedParent = resolvedParent.clone()
-      mockDeployChange.mockImplementation(async () => {
-        throw new Error('err')
-      })
-      const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith({
-        change: { action: 'add', data: { after: clonedResolvedParent } },
-        client: expect.anything(),
-        endpointDetails: expect.anything(),
-        undefined,
-      })
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.appliedChanges).toHaveLength(0)
-    })
     it('should create the correct changes when creating a new change where title is different from the placeholder', async () => {
       // deploy changes the change itself so we need to clone it
       const clonedDifferentTitleAndPlaceholder = differentTitleAndPlaceholder.clone()
@@ -329,6 +314,24 @@ describe('dynamic content filter', () => {
         action: 'modify',
         data: { after: clonedDifferentTitleAndPlaceholder, before: differentTitleAndPlaceholder },
       })
+    })
+    // This test must be last because it changes the mock implementation!
+    it('should return error if deployChange failed', async () => {
+      const clonedResolvedParent = resolvedParent.clone()
+      mockDeployChange.mockImplementation(async () => {
+        throw new Error('err')
+      })
+      const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
+      expect(mockDeployChange).toHaveBeenCalledTimes(1)
+      expect(mockDeployChange).toHaveBeenCalledWith({
+        change: { action: 'add', data: { after: clonedResolvedParent } },
+        client: expect.anything(),
+        endpointDetails: expect.anything(),
+        undefined,
+      })
+      expect(res.leftoverChanges).toHaveLength(0)
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.appliedChanges).toHaveLength(0)
     })
   })
 })

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -41,7 +41,7 @@ jest.mock('@salto-io/adapter-components', () => {
   }
 })
 
-describe('dynmaic content filter', () => {
+describe('dynamic content filter', () => {
   type FilterType = filterUtils.FilterWith<'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   const parentTypeName = DYNAMIC_CONTENT_ITEM_TYPE_NAME

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -28,7 +28,6 @@ import filterCreator, {
   DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME,
   VARIANTS_FIELD_NAME,
 } from '../../src/filters/dynamic_content'
-import { placeholderToTitle } from '../../src/filters/utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -209,9 +208,7 @@ describe('dynmaic content filter', () => {
       default_locale_id: 1,
       title: 'differentTitleAndPlaceholder',
       placeholder: '{{dc.placeholder}}',
-      [VARIANTS_FIELD_NAME]: [
-        { content: 'abc', locale_id: 1, active: true, default: true },
-      ],
+      [VARIANTS_FIELD_NAME]: [{ content: 'abc', locale_id: 1, active: true, default: true }],
     })
 
     it('should pass the correct params to deployChange when we add both parent and children', async () => {
@@ -324,8 +321,14 @@ describe('dynmaic content filter', () => {
       expect(res.leftoverChanges).toHaveLength(0)
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(2)
-      expect(res.deployResult.appliedChanges[0]).toEqual({ action: 'add', data: { after: differentTitleAndPlaceholder }})
-      expect(res.deployResult.appliedChanges[1]).toEqual({ action: 'modify', data: { after: clonedDifferentTitleAndPlaceholder, before: differentTitleAndPlaceholder }})
+      expect(res.deployResult.appliedChanges[0]).toEqual({
+        action: 'add',
+        data: { after: differentTitleAndPlaceholder },
+      })
+      expect(res.deployResult.appliedChanges[1]).toEqual({
+        action: 'modify',
+        data: { after: clonedDifferentTitleAndPlaceholder, before: differentTitleAndPlaceholder },
+      })
     })
   })
 })

--- a/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
+++ b/packages/zendesk-adapter/test/filters/dynamic_content.test.ts
@@ -28,6 +28,7 @@ import filterCreator, {
   DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME,
   VARIANTS_FIELD_NAME,
 } from '../../src/filters/dynamic_content'
+import ZendeskClient from '../../src/client/client'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -44,6 +45,7 @@ jest.mock('@salto-io/adapter-components', () => {
 describe('dynamic content filter', () => {
   type FilterType = filterUtils.FilterWith<'deploy' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
+  let client: ZendeskClient
   const parentTypeName = DYNAMIC_CONTENT_ITEM_TYPE_NAME
   const childTypeName = DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME
   const parentObjType = new ObjectType({
@@ -109,7 +111,11 @@ describe('dynamic content filter', () => {
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+
+    filter = filterCreator(createFilterCreatorParams({ client })) as FilterType
   })
 
   describe('preDeploy', () => {
@@ -184,179 +190,292 @@ describe('dynamic content filter', () => {
     })
   })
   describe('deploy', () => {
-    const resolvedParent = new InstanceElement('parent', parentObjType, {
-      default_locale_id: 1,
-      name: 'parent',
-      placeholder: '{{dc.parent}}',
-      [VARIANTS_FIELD_NAME]: [
-        { content: 'abc', locale_id: 1, active: true, default: true },
-        { content: 'abc', locale_id: 2, active: true, default: false },
-      ],
-    })
-    const child1Resolved = new InstanceElement('child1', childObjType, {
-      content: 'abc',
-      locale_id: 1,
-      active: true,
-      default: true,
-    })
-    const child2Resolved = new InstanceElement('child2', childObjType, {
-      content: 'abc',
-      locale_id: 2,
-      active: true,
-      default: false,
-    })
-    const differentNameAndPlaceholder = new InstanceElement('differentNameAndPlaceholder', parentObjType, {
-      default_locale_id: 1,
-      name: 'differentNameAndPlaceholder',
-      placeholder: '{{dc.placeholder}}',
-      [VARIANTS_FIELD_NAME]: [{ content: 'abc', locale_id: 1, active: true, default: true }],
-    })
-
-    it('should pass the correct params to deployChange when we add both parent and children', async () => {
-      const clonedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
-      mockDeployChange.mockImplementation(async () => ({
-        item: {
-          id: 11,
-          variants: [
-            { id: 22, locale_id: 1 },
-            { id: 33, locale_id: 2 },
-          ],
-        },
-      }))
-      const res = await filter.deploy(clonedElements.map(e => ({ action: 'add', data: { after: e } })))
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith({
-        change: { action: 'add', data: { after: clonedElements[0] } },
-        client: expect.anything(),
-        endpointDetails: expect.anything(),
-        undefined,
+    describe('dynamic content item types and variant changes', () => {
+      const resolvedParent = new InstanceElement('parent', parentObjType, {
+        default_locale_id: 1,
+        name: 'parent',
+        placeholder: '{{dc.parent}}',
+        [VARIANTS_FIELD_NAME]: [
+          { content: 'abc', locale_id: 1, active: true, default: true },
+          { content: 'abc', locale_id: 2, active: true, default: false },
+        ],
       })
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(0)
-      const expectedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
-      expectedElements[0].value.id = 11
-      expectedElements[1].value.id = 22
-      expectedElements[2].value.id = 33
-      expect(res.deployResult.appliedChanges).toHaveLength(3)
-      expect(res.deployResult.appliedChanges).toEqual(
-        expectedElements.map(e => ({ action: 'add', data: { after: e } })),
-      )
-    })
-    it('should pass the correct params to deployChange when we remove both parent and children', async () => {
-      const clonedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
-      clonedElements[0].value.id = 11
-      clonedElements[1].value.id = 22
-      clonedElements[2].value.id = 33
-      mockDeployChange.mockImplementation(async () => ({}))
-      const res = await filter.deploy(clonedElements.map(e => ({ action: 'remove', data: { before: e } })))
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith({
-        change: { action: 'remove', data: { before: clonedElements[0] } },
-        client: expect.anything(),
-        endpointDetails: expect.anything(),
-        undefined,
+      const child1Resolved = new InstanceElement('child1', childObjType, {
+        content: 'abc',
+        locale_id: 1,
+        active: true,
+        default: true,
       })
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(0)
-      expect(res.deployResult.appliedChanges).toHaveLength(3)
-      expect(res.deployResult.appliedChanges).toEqual(
-        clonedElements.map(e => ({ action: 'remove', data: { before: e } })),
-      )
-    })
-    it('should pass the correct params to deployChange when we modify both parent and children', async () => {
-      const beforeElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
-      beforeElements[0].value.id = 11
-      beforeElements[1].value.id = 22
-      beforeElements[2].value.id = 33
-      const afterElements = beforeElements
-        .map(e => e.clone())
-        .map(e => {
-          e.value.name = `${e.value.name}-edited`
-          return e
+      const child2Resolved = new InstanceElement('child2', childObjType, {
+        content: 'abc',
+        locale_id: 2,
+        active: true,
+        default: false,
+      })
+      it('should pass the correct params to deployChange when we add both parent and children', async () => {
+        const clonedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
+        mockDeployChange.mockImplementation(async () => ({
+          item: {
+            id: 11,
+            variants: [
+              { id: 22, locale_id: 1 },
+              { id: 33, locale_id: 2 },
+            ],
+          },
+        }))
+        const res = await filter.deploy(clonedElements.map(e => ({ action: 'add', data: { after: e } })))
+        expect(mockDeployChange).toHaveBeenCalledTimes(1)
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedElements[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          undefined,
         })
-      mockDeployChange.mockImplementation(async () => ({}))
-      const res = await filter.deploy(
-        beforeElements.map((e, i) => ({
-          action: 'modify',
-          data: { before: e, after: afterElements[i] },
-        })),
-      )
-      expect(mockDeployChange).toHaveBeenCalledTimes(3)
-      beforeElements.forEach((e, i) => {
-        expect(mockDeployChange).toHaveBeenNthCalledWith(i + 1, {
-          change: { action: 'modify', data: { before: e, after: afterElements[i] } },
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        const expectedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
+        expectedElements[0].value.id = 11
+        expectedElements[1].value.id = 22
+        expectedElements[2].value.id = 33
+        expect(res.deployResult.appliedChanges).toHaveLength(3)
+        expect(res.deployResult.appliedChanges).toEqual(
+          expectedElements.map(e => ({ action: 'add', data: { after: e } })),
+        )
+      })
+      it('should pass the correct params to deployChange when we remove both parent and children', async () => {
+        const clonedElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
+        clonedElements[0].value.id = 11
+        clonedElements[1].value.id = 22
+        clonedElements[2].value.id = 33
+        mockDeployChange.mockImplementation(async () => ({}))
+        const res = await filter.deploy(clonedElements.map(e => ({ action: 'remove', data: { before: e } })))
+        expect(mockDeployChange).toHaveBeenCalledTimes(1)
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'remove', data: { before: clonedElements[0] } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          undefined,
+        })
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(3)
+        expect(res.deployResult.appliedChanges).toEqual(
+          clonedElements.map(e => ({ action: 'remove', data: { before: e } })),
+        )
+      })
+      it('should pass the correct params to deployChange when we modify both parent and children', async () => {
+        const beforeElements = [resolvedParent, child1Resolved, child2Resolved].map(e => e.clone())
+        beforeElements[0].value.id = 11
+        beforeElements[1].value.id = 22
+        beforeElements[2].value.id = 33
+        const afterElements = beforeElements
+          .map(e => e.clone())
+          .map(e => {
+            e.value.name = `${e.value.name}-edited`
+            return e
+          })
+        mockDeployChange.mockImplementation(async () => ({}))
+        const res = await filter.deploy(
+          beforeElements.map((e, i) => ({
+            action: 'modify',
+            data: { before: e, after: afterElements[i] },
+          })),
+        )
+        expect(mockDeployChange).toHaveBeenCalledTimes(3)
+        beforeElements.forEach((e, i) => {
+          expect(mockDeployChange).toHaveBeenNthCalledWith(i + 1, {
+            change: { action: 'modify', data: { before: e, after: afterElements[i] } },
+            client: expect.anything(),
+            endpointDetails: expect.anything(),
+            fieldsToOmit: undefined,
+          })
+        })
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(3)
+        expect(res.deployResult.appliedChanges).toEqual(
+          beforeElements.map((e, i) => ({ action: 'modify', data: { before: e, after: afterElements[i] } })),
+        )
+      })
+      it('should return error if deployChange failed', async () => {
+        const clonedResolvedParent = resolvedParent.clone()
+        mockDeployChange.mockImplementation(async () => {
+          throw new Error('err')
+        })
+        const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(1)
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: { action: 'add', data: { after: clonedResolvedParent } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          undefined,
+        })
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(1)
+        expect(res.deployResult.appliedChanges).toHaveLength(0)
+      })
+    })
+    describe('deploy of dynamic content item with a different placeholder than the name', () => {
+      const differentNameAndPlaceholder = new InstanceElement('dynamicContentItem', parentObjType, {
+        default_locale_id: 1,
+        name: 'differentNameAndPlaceholder',
+        placeholder: '{{dc.placeholder}}',
+        [VARIANTS_FIELD_NAME]: [{ content: 'abc', locale_id: 1, active: true, default: true }],
+      })
+      const sameNameAndPlaceholder = new InstanceElement('dynamicContentItem', parentObjType, {
+        default_locale_id: 1,
+        name: 'placeholder',
+        placeholder: '{{dc.placeholder}}',
+        [VARIANTS_FIELD_NAME]: [{ content: 'abc', locale_id: 1, active: true, default: true }],
+      })
+
+      it('should create the correct changes when creating a new change where name is different from the placeholder', async () => {
+        mockDeployChange.mockImplementation(async args => args.change)
+        const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(2)
+        expect(mockDeployChange).toHaveBeenNthCalledWith(1, {
+          change: { action: 'add', data: { after: sameNameAndPlaceholder } },
           client: expect.anything(),
           endpointDetails: expect.anything(),
           fieldsToOmit: undefined,
         })
+        expect(mockDeployChange).toHaveBeenNthCalledWith(2, {
+          change: {
+            action: 'modify',
+            data: {
+              before: sameNameAndPlaceholder,
+              after: differentNameAndPlaceholder,
+            },
+          },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(1)
+        expect(res.deployResult.appliedChanges[0]).toEqual({
+          action: 'add',
+          data: { after: differentNameAndPlaceholder },
+        })
       })
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(0)
-      expect(res.deployResult.appliedChanges).toHaveLength(3)
-      expect(res.deployResult.appliedChanges).toEqual(
-        beforeElements.map((e, i) => ({ action: 'modify', data: { before: e, after: afterElements[i] } })),
-      )
-    })
-    it('should create the correct changes when creating a new change where name is different from the placeholder', async () => {
-      // deploy changes the change itself so we need to clone it
-      const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(0)
-      expect(res.deployResult.appliedChanges).toHaveLength(1)
-      expect(res.deployResult.appliedChanges[0]).toEqual({
-        action: 'add',
-        data: { after: differentNameAndPlaceholder },
-      })
-    })
-    it('should return a failure when the addition fails', async () => {
-      const clonedDifferentNameAndPlaceholder = differentNameAndPlaceholder.clone()
-      mockDeployChange.mockImplementation(async () => {
-        throw new Error('err')
-      })
-      const res = await filter.deploy([{ action: 'add', data: { after: clonedDifferentNameAndPlaceholder } }])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.appliedChanges).toHaveLength(0)
-    })
-    it('should return a failure when the modification fails but the addition succeeded', async () => {
-      mockDeployChange.mockImplementation(async change => {
-        if (change.action === 'add') {
-          return { item: { id: 11 } }
-        }
-        throw new Error('err')
-      })
-      const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith({
-        change: { action: 'add', data: { after: differentNameAndPlaceholder } },
-        client: expect.anything(),
-        endpointDetails: expect.anything(),
-        fieldsToOmit: undefined,
-      })
+      it('should return a failure when the addition fails', async () => {
+        mockDeployChange.mockImplementation(async () => {
+          throw new Error('Failed to create dynamic content item')
+        })
 
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.appliedChanges).toHaveLength(0)
-    })
-    // This test must be last because it changes the mock implementation!
-    it('should return error if deployChange failed', async () => {
-      const clonedResolvedParent = resolvedParent.clone()
-      mockDeployChange.mockImplementation(async () => {
-        throw new Error('err')
+        const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(1)
+        expect(mockDeployChange).toHaveBeenCalledWith({
+          change: {
+            action: 'add',
+            data: {
+              after: sameNameAndPlaceholder,
+            },
+          },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.appliedChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(1)
+        expect(res.deployResult.errors[0].severity).toEqual('Error')
+        expect(res.deployResult.errors[0].message).toContain('Failed to create dynamic content item')
       })
-      const res = await filter.deploy([{ action: 'add', data: { after: clonedResolvedParent } }])
-      expect(mockDeployChange).toHaveBeenCalledTimes(1)
-      expect(mockDeployChange).toHaveBeenCalledWith({
-        change: { action: 'add', data: { after: clonedResolvedParent } },
-        client: expect.anything(),
-        endpointDetails: expect.anything(),
-        undefined,
+      it('should return a warning when the addition succeeds, modification fails, and deletion fails', async () => {
+        mockDeployChange.mockImplementation(async args => {
+          if (args.change.action === 'add') {
+            // return valid deploy response
+            return args.change
+          }
+          if (args.change.action === 'modify') {
+            throw new Error('Failed to modify dynamic content item')
+          } else {
+            // removal change
+            throw new Error(
+              'Unable to modify name of dynamic content item, please modify it in the Zendesk UI and fetch with regenerate salto ids.',
+            )
+          }
+        })
+        const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(3)
+        expect(mockDeployChange).toHaveBeenNthCalledWith(1, {
+          change: { action: 'add', data: { after: sameNameAndPlaceholder } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+        expect(mockDeployChange).toHaveBeenNthCalledWith(2, {
+          change: {
+            action: 'modify',
+            data: {
+              before: sameNameAndPlaceholder,
+              after: differentNameAndPlaceholder,
+            },
+          },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+        expect(mockDeployChange).toHaveBeenNthCalledWith(3, {
+          change: { action: 'remove', data: { before: sameNameAndPlaceholder } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(1)
+        expect(res.deployResult.errors[0].severity).toEqual('Warning')
+        expect(res.deployResult.errors[0].message).toEqual(
+          'Unable to modify name of dynamic content item, please modify it in the Zendesk UI and fetch with regenerate salto ids.',
+        )
+        expect(res.deployResult.appliedChanges).toHaveLength(0)
       })
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.appliedChanges).toHaveLength(0)
+      it('should return a failure when addition succeeds, modification fails, and deletion succeeds', async () => {
+        mockDeployChange.mockImplementation(async args => {
+          if (args.change.action === 'add' || args.change.action === 'remove') {
+            // return valid deploy response
+            return args.change
+          }
+          // modify
+          throw new Error('Failed to modify dynamic content item')
+        })
+        const res = await filter.deploy([{ action: 'add', data: { after: differentNameAndPlaceholder } }])
+        expect(mockDeployChange).toHaveBeenCalledTimes(3)
+        expect(mockDeployChange).toHaveBeenNthCalledWith(1, {
+          change: { action: 'add', data: { after: sameNameAndPlaceholder } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+        expect(mockDeployChange).toHaveBeenNthCalledWith(2, {
+          change: {
+            action: 'modify',
+            data: {
+              before: sameNameAndPlaceholder,
+              after: differentNameAndPlaceholder,
+            },
+          },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+        expect(mockDeployChange).toHaveBeenNthCalledWith(3, {
+          change: { action: 'remove', data: { before: sameNameAndPlaceholder } },
+          client: expect.anything(),
+          endpointDetails: expect.anything(),
+          fieldsToOmit: undefined,
+        })
+
+        expect(res.leftoverChanges).toHaveLength(0)
+        expect(res.deployResult.errors).toHaveLength(1)
+        expect(res.deployResult.errors[0].severity).toEqual('Error')
+        expect(res.deployResult.errors[0].message).toContain('Failed to create dynamic content item')
+        expect(res.deployResult.appliedChanges).toHaveLength(0)
+      })
     })
   })
 })


### PR DESCRIPTION
When creating dynamic content, Zendesk automatically takes the title and creates the placeholder from it, regardless of what was sent as a placeholder. To overcome this, we create two changes, one that creates the dynamic content item with a title that will translate to the placeholder we expect, and a second to modify the title to the final expected title.

---


---
_Release Notes_: 
Zendesk:
* Allow adding dynamic content items whose placeholders and titles are different

---
_User Notifications_:  _None_