### PR TITLE
SALTO-5498: [Zendesk] Replace `parent` field in `macro_attachment` object with `macros` field to accommodate multiple macros using the same attachment

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -875,13 +875,13 @@ export default class ZendeskAdapter implements AdapterOperations {
         deployConfig: this.userConfig[DEPLOY_CONFIG],
         typesDeployedViaParent: [
           'organization_field__custom_field_options',
-          'macro_attachment',
           BRAND_LOGO_TYPE_NAME,
           CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME,
         ],
         // article_attachment, guide themes additions, and locales are supported in a filter
         typesWithNoDeploy: [
           'tag',
+          'macro_attachment',
           ARTICLE_ATTACHMENT_TYPE_NAME,
           GUIDE_THEME_TYPE_NAME,
           THEME_SETTINGS_TYPE_NAME,

--- a/packages/zendesk-adapter/src/change_validators/child_parent/utils.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/utils.ts
@@ -35,7 +35,6 @@ export type ChildParentRelationship = {
 }
 
 const ADDITIONAL_CHILD_PARENT_RELATIONSHIPS: ChildParentRelationship[] = [
-  { parent: 'macro', child: 'macro_attachment', fieldName: 'attachments' },
   { parent: 'brand', child: 'brand_logo', fieldName: 'logo' },
   { parent: 'article', child: 'article_attachment', fieldName: 'attachments' },
 ]

--- a/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
@@ -30,17 +30,15 @@ import { MACRO_ATTACHMENT_TYPE_NAME } from '../filters/macro_attachments'
 const createDependencyChange = (
   change: { key: collections.set.SetId; change: Change<InstanceElement> },
   changes: { key: collections.set.SetId; change: Change<InstanceElement> }[],
-): DependencyChange[] => {
-  const { macros } = getChangeData(change.change).value
-
-  const macroChanges = changes.filter(
-    c =>
-      macros.find((macroRef: ReferenceExpression) => getChangeData(c.change).elemID === macroRef.value.elemID) !==
-      undefined,
-  )
-
-  return macroChanges.map(macroChange => dependencyChange('remove', change.key, macroChange.key))
-}
+): DependencyChange[] =>
+  changes
+    .filter(
+      c =>
+        getChangeData(change.change).value.find(
+          (macroRef: ReferenceExpression) => getChangeData(c.change).elemID === macroRef.value.elemID,
+        ) !== undefined,
+    )
+    .map(macroChange => dependencyChange('remove', change.key, macroChange.key))
 
 const isRelevantChange = (change: Change<InstanceElement>): boolean =>
   isInstanceChange(change) && getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME
@@ -55,6 +53,7 @@ export const macroAttachmentDependencyChanger: DependencyChanger = async changes
       isInstanceChange(change.change),
     )
 
-  const relevantChanges = instanceChanges.filter(({ change }) => isRelevantChange(change))
-  return relevantChanges.flatMap(change => createDependencyChange(change, instanceChanges))
+  return instanceChanges
+    .filter(({ change }) => isRelevantChange(change))
+    .flatMap(change => createDependencyChange(change, instanceChanges))
 }

--- a/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
@@ -31,22 +31,22 @@ const createDependencyChange = (
   change: { key: collections.set.SetId; change: Change<InstanceElement> },
   changes: { key: collections.set.SetId; change: Change<InstanceElement> }[],
 ): DependencyChange[] => {
-  const parents = getChangeData(change.change).value.macros
+  const { macros } = getChangeData(change.change).value
 
-  const parentChanges = changes.filter(
+  const macroChanges = changes.filter(
     c =>
-      parents.find((parent: ReferenceExpression) => getChangeData(c.change).elemID === parent.value.elemID) !==
+      macros.find((macroRef: ReferenceExpression) => getChangeData(c.change).elemID === macroRef.value.elemID) !==
       undefined,
   )
 
-  return parentChanges.map(parentChange => dependencyChange('remove', change.key, parentChange.key))
+  return macroChanges.map(macroChange => dependencyChange('remove', change.key, macroChange.key))
 }
 
 const isRelevantChange = (change: Change<InstanceElement>): boolean =>
   isInstanceChange(change) && getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME
 
 /**
- * Removed the dependency between a macro attachment instance and its parent, to avoid circular dependency
+ * Removed the dependency between a macro attachment instance and its macro, to avoid circular dependency
  */
 export const macroAttachmentDependencyChanger: DependencyChanger = async changes => {
   const instanceChanges = Array.from(changes.entries())

--- a/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/macro_attachment_change.ts
@@ -1,0 +1,60 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  Change,
+  dependencyChange,
+  DependencyChanger,
+  getChangeData,
+  InstanceElement,
+  isInstanceChange,
+  DependencyChange,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { collections } from '@salto-io/lowerdash'
+import { MACRO_ATTACHMENT_TYPE_NAME } from '../filters/macro_attachments'
+
+const createDependencyChange = (
+  change: { key: collections.set.SetId; change: Change<InstanceElement> },
+  changes: { key: collections.set.SetId; change: Change<InstanceElement> }[],
+): DependencyChange[] => {
+  const parents = getChangeData(change.change).value.macros
+
+  const parentChanges = changes.filter(
+    c =>
+      parents.find((parent: ReferenceExpression) => getChangeData(c.change).elemID === parent.value.elemID) !==
+      undefined,
+  )
+
+  return parentChanges.map(parentChange => dependencyChange('remove', change.key, parentChange.key))
+}
+
+const isRelevantChange = (change: Change<InstanceElement>): boolean =>
+  isInstanceChange(change) && getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME
+
+/**
+ * Removed the dependency between a macro attachment instance and its parent, to avoid circular dependency
+ */
+export const macroAttachmentDependencyChanger: DependencyChanger = async changes => {
+  const instanceChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter((change): change is deployment.dependency.ChangeWithKey<Change<InstanceElement>> =>
+      isInstanceChange(change.change),
+    )
+
+  const relevantChanges = instanceChanges.filter(({ change }) => isRelevantChange(change))
+  return relevantChanges.flatMap(change => createDependencyChange(change, instanceChanges))
+}

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -847,6 +847,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     target: { type: 'macro_attachment' },
   },
   {
+    src: { field: 'macros', parentTypes: ['macro_attachment'] },
+    serializationStrategy: 'id',
+    target: { type: 'macro' },
+  },
+  {
     src: { field: 'tag', parentTypes: FIELD_TYPE_NAMES },
     serializationStrategy: 'id',
     target: { type: 'tag' },

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -51,7 +51,6 @@ import { addId, deployChange, deployChanges } from '../deployment'
 import { getZendeskError } from '../errors'
 import { lookupFunc } from './field_references'
 import ZendeskClient from '../client/client'
-// import { createAdditionalParentChanges } from './utils'
 
 const { isDefined } = values
 const log = logger(module)
@@ -328,7 +327,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       relevantChanges,
       change => getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME,
     )
-    let additionalParentChanges: Change<InstanceElement>[] | undefined = []
+    let additionalParentChanges: Change<InstanceElement>[] | undefined
     if (parentChanges.length === 0 && childrenChanges.length > 0) {
       additionalParentChanges = childrenChanges
         .flatMap(childChange => {

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/* eslint-disable no-console */
-
 import _ from 'lodash'
 import Joi from 'joi'
 import FormData from 'form-data'
@@ -28,7 +26,6 @@ import {
   InstanceElement,
   isInstanceElement,
   isRemovalChange,
-  isRemovalOrModificationChange,
   isSaltoError,
   isStaticFile,
   ObjectType,
@@ -118,31 +115,6 @@ const replaceAttachmentId = (
     return instance ? new ReferenceExpression(instance.elemID, instance) : ref
   })
   return parentChange
-}
-
-const replaceMacroObject = (
-  change: Change<InstanceElement>,
-  fullNameToInstance: Record<string, InstanceElement>,
-): void => {
-  const instance = getChangeData(change)
-  const { macros } = instance.value
-  if (macros === undefined || !Array.isArray(macros) || macros.length === 0) {
-    return
-  }
-  if (isArrayOfRefExprToInstances(macros)) {
-    return
-  }
-  instance.value.macros = macros.map(ref => {
-    const instance2 = fullNameToInstance[ref.id]
-    return instance2 ? new ReferenceExpression(instance2.elemID, instance2) : ref
-  })
-
-  if (isRemovalOrModificationChange(change)) {
-    change.data.before.value.macros = macros.map(ref => {
-      const instance2 = fullNameToInstance[ref.id]
-      return instance2 ? new ReferenceExpression(instance2.elemID, instance2) : ref
-    })
-  }
 }
 
 const addAttachment = async (client: ZendeskClient, instance: InstanceElement): ReturnType<typeof client.post> => {
@@ -355,7 +327,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
       relevantChanges,
       change => getChangeData(change).elemID.typeName === MACRO_ATTACHMENT_TYPE_NAME,
     )
-    let additionalParentChanges: Change<InstanceElement>[] | undefined
+    let additionalParentChanges: Change<InstanceElement>[] | undefined = []
     if (parentChanges.length === 0 && childrenChanges.length > 0) {
       additionalParentChanges = childrenChanges
         .flatMap(childChange => {
@@ -388,11 +360,6 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         leftoverChanges,
       }
     }
-    const parentFullNameToInstance: Record<string, InstanceElement> = {}
-    ;[...parentChanges, ...additionalParentChanges].forEach(change => {
-      const instance = getChangeData(change)
-      parentFullNameToInstance[instance.value.id] = instance
-    })
     const childFullNameToInstance: Record<string, InstanceElement> = {}
     const resolvedChildrenChanges = await awu(childrenChanges)
       .map(change => resolveChangeElement(change, lookupFunc))
@@ -410,11 +377,6 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
         dataField: MACRO_ATTACHMENT_DATA_FIELD,
         addAlsoOnModification: true,
       })
-      // eslint-disable-next-line no-console
-      console.log('b4', instance)
-      replaceMacroObject(change, parentFullNameToInstance)
-      // eslint-disable-next-line no-console
-      console.log('after', instance)
       childFullNameToInstance[instance.elemID.getFullName()] = instance
     })
     if (!_.isEmpty(attachmentDeployResult.errors)) {

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -20,7 +20,6 @@ import {
   InstanceElement,
   isInstanceElement,
   StaticFile,
-  CORE_ANNOTATIONS,
   ReferenceExpression,
   ListType,
   BuiltinTypes,
@@ -135,6 +134,7 @@ describe('macro attachment filter', () => {
           encoding: 'binary',
           content,
         }),
+        macros: [new ReferenceExpression(macroInstance.elemID, macroInstance)],
       })
     })
     describe('invalid attachments response', () => {
@@ -308,9 +308,7 @@ describe('macro attachment filter', () => {
         ],
         [ATTACHMENTS_FIELD_NAME]: [new ReferenceExpression(attachmentInstance.elemID, attachmentInstance)],
       })
-      attachmentInstance.annotate({
-        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(macroInstance.elemID, macroInstance)],
-      })
+      attachmentInstance.value.macros = [new ReferenceExpression(macroInstance.elemID, macroInstance)]
     })
     it('should pass the correct params to deployChange and client on create', async () => {
       const clonedMacro = macroInstance.clone()
@@ -369,7 +367,7 @@ describe('macro attachment filter', () => {
       const clonedAttachment = attachmentInstance.clone()
       clonedAttachment.value.id = attachmentId
       clonedMacro.value[ATTACHMENTS_FIELD_NAME] = [new ReferenceExpression(clonedAttachment.elemID, clonedAttachment)]
-      clonedAttachment.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
+      clonedAttachment.value.macros = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
       const clonedBeforeMacro = clonedMacro.clone()
       const clonedAfterMacro = clonedMacro.clone()
       clonedAfterMacro.value.title = `${clonedAfterMacro.value.title}-edited`
@@ -438,7 +436,7 @@ describe('macro attachment filter', () => {
       const clonedAttachment = attachmentInstance.clone()
       clonedAttachment.value.id = attachmentId
       clonedMacro.value[ATTACHMENTS_FIELD_NAME] = [new ReferenceExpression(clonedAttachment.elemID, clonedAttachment)]
-      clonedAttachment.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
+      clonedAttachment.value.macros = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
       const clonedBeforeAttachment = clonedAttachment.clone()
       const clonedAfterAttachment = clonedAttachment.clone()
       clonedAfterAttachment.value.filename = `${clonedAfterAttachment.value.filename}-edited`
@@ -484,6 +482,19 @@ describe('macro attachment filter', () => {
       resolvedBeforeAttachment.value.content = content
       resolvedAfterAttachment.value.content = content
       resolvedAfterAttachment.value.id = newAttachmentId
+      // eslint-disable-next-line no-console
+      console.log('AFTER')
+      // eslint-disable-next-line no-console
+      console.log(resolvedAfterAttachment.value)
+      // eslint-disable-next-line no-console
+      console.log((res.deployResult.appliedChanges[0] as ModificationChange<InstanceElement>).data.after.value)
+      // eslint-disable-next-line no-console
+      console.log('BEFORE')
+      // eslint-disable-next-line no-console
+      console.log(resolvedBeforeAttachment.value)
+      // eslint-disable-next-line no-console
+      console.log((res.deployResult.appliedChanges[0] as ModificationChange<InstanceElement>).data.before.value)
+
       expect(res.deployResult.appliedChanges[0].action).toEqual('modify')
       expect((res.deployResult.appliedChanges[0] as ModificationChange<InstanceElement>).data.before.value).toEqual(
         resolvedBeforeAttachment.value,
@@ -498,7 +509,7 @@ describe('macro attachment filter', () => {
       const clonedAttachment = attachmentInstance.clone()
       clonedAttachment.value.id = attachmentId
       clonedMacro.value[ATTACHMENTS_FIELD_NAME] = [new ReferenceExpression(clonedAttachment.elemID, clonedAttachment)]
-      clonedAttachment.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
+      clonedAttachment.value.macros = [new ReferenceExpression(clonedMacro.elemID, clonedMacro)]
       mockDeployChange.mockImplementation(async () => ({ macro: { id: macroId } }))
       mockPost = jest.spyOn(client, 'post')
       mockPost.mockResolvedValueOnce({ status: 200 })


### PR DESCRIPTION
We found out that every macro attachment can be assigned to multiple macros, and that they are not hard-linked to their corresponding macros (i.e a macro can be deleted and the attachment will stay alive). Thus, a parent-child relationship doesn't make sense between the two object. In this PR, I removed the `parent` field and instead added a `macros` field, to which we add all macros that reference the attachment as `ReferencesExpression`s.

---

The change required some re-jigging of how we create attachment `nacls`, so i had to rewrite some of the code around that. 

---
_Release Notes_: 
Zendesk:
Replace `parent` field in `macro_attachment` object with `macros` field, so that we can now accommodate multiple macros using the same attachment

---
_User Notifications_: 
Zendesk:
Replace `parent` field in `macro_attachment` object with `macros` field, so that we can now accommodate multiple macros using the same attachment