### PR TITLE
SALTO-5293 hide types by default, avoid requiring client config

### DIFF
--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -32,7 +32,7 @@ export type UserConfig<
   }>,
   TDeploy extends UserDeployConfig = UserDeployConfig,
 > = {
-  client: TClient
+  client?: TClient
   fetch: TFetch
   deploy?: TDeploy
 }
@@ -104,7 +104,7 @@ export const adapterConfigFromConfig = <
 ): Co & UserConfig<TCustomNameMappingOptions> => {
   // TODO extend validations SALTO-5584
   validateClientConfig('client', config?.value?.client)
-  const client = mergeWithDefaultConfig(defaultConfig.client, config?.value?.client)
+  const client = mergeWithDefaultConfig(defaultConfig.client ?? {}, config?.value?.client)
 
   const fetch = _.defaults({}, config?.value?.fetch, defaultConfig.fetch)
 

--- a/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
+++ b/packages/adapter-components/test/adapter-wrapper/adapter.test.ts
@@ -81,7 +81,6 @@ const getMockFunction = (method: HTTPMethod, mockAxiosAdapter: MockAdapter): Moc
 }
 
 const DEFAULT_CONFIG: UserConfig = {
-  client: {},
   fetch: {
     ...INCLUDE_ALL_CONFIG,
   },

--- a/packages/adapter-components/test/filters/common_filters.test.ts
+++ b/packages/adapter-components/test/filters/common_filters.test.ts
@@ -41,7 +41,6 @@ describe('common filters', () => {
       const filters = createCommonFilters({
         referenceRules: [],
         config: {
-          client: {},
           fetch: {
             ...INCLUDE_ALL_CONFIG,
           },

--- a/packages/confluence-adapter/src/config.ts
+++ b/packages/confluence-adapter/src/config.ts
@@ -28,8 +28,8 @@ export type UserConfig = definitions.UserConfig<
 >
 
 export const DEFAULT_CONFIG: UserConfig = {
-  client: {},
   fetch: {
     ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
   },
 }

--- a/packages/google-workspace-adapter/src/config.ts
+++ b/packages/google-workspace-adapter/src/config.ts
@@ -28,8 +28,8 @@ export type UserConfig = definitions.UserConfig<
 >
 
 export const DEFAULT_CONFIG: UserConfig = {
-  client: {},
   fetch: {
     ...elements.query.INCLUDE_ALL_CONFIG,
+    hideTypes: true,
   },
 }

--- a/packages/intercom-adapter/src/config.ts
+++ b/packages/intercom-adapter/src/config.ts
@@ -28,9 +28,9 @@ export type UserConfig = definitions.UserConfig<
 >
 
 export const DEFAULT_CONFIG: UserConfig = {
-  client: {},
   fetch: {
     include: [{ type: elements.query.ALL_TYPES }],
     exclude: [{ type: 'company' }],
+    hideTypes: true,
   },
 }

--- a/packages/serviceplaceholder-adapter/src/config.ts
+++ b/packages/serviceplaceholder-adapter/src/config.ts
@@ -31,8 +31,9 @@ export type UserConfig = definitions.UserConfig<
 >
 
 export const DEFAULT_CONFIG: UserConfig = {
-  client: {},
   fetch: {
     ...elements.query.INCLUDE_ALL_CONFIG,
+    // TODO hideTypes should be true when the adapter is ready. for development, it helps to set to false
+    hideTypes: true,
   },
 }


### PR DESCRIPTION
minor improvements to the user defaults to clean up the resulting env and config


---
_Release Notes_: 
None

---
_User Notifications_: 
None