### PR TITLE
SALTO-5788 do not rely on types being loaded

### DIFF
--- a/packages/adapter-utils/src/additional_properties.ts
+++ b/packages/adapter-utils/src/additional_properties.ts
@@ -18,12 +18,12 @@ import {
   BuiltinTypes,
   CORE_ANNOTATIONS,
   Field,
-  isType,
   Element,
   ObjectType,
   Value,
   ReferenceExpression,
   isReferenceExpression,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -53,12 +53,12 @@ export const extractAdditionalPropertiesField = (objType: ObjectType, name: stri
     return new Field(objType, name, BuiltinTypes.UNKNOWN)
   }
   if (isAdditionalPropertiesAnnotation(additionalProperties)) {
-    const type = additionalProperties.refType.value
-    if (!isType(type)) {
+    const { elemID, value: type } = additionalProperties.refType
+    if (elemID.idType !== 'type') {
       log.warn('Additional properties annotations refType reference is not a type')
       return undefined
     }
-    return new Field(objType, name, type, additionalProperties.annotations)
+    return new Field(objType, name, new TypeReference(elemID, type), additionalProperties.annotations)
   }
   // case additionalProperties = false
   return undefined

--- a/packages/adapter-utils/test/additional_properties.test.ts
+++ b/packages/adapter-utils/test/additional_properties.test.ts
@@ -22,6 +22,7 @@ import {
   InstanceElement,
   ObjectType,
   ReferenceExpression,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import { extractAdditionalPropertiesField, setAdditionalPropertiesAnnotation } from '../src/additional_properties'
 
@@ -73,10 +74,10 @@ describe('additional_properties', () => {
       })
     })
     describe('when additional properties annotation is defining a type', () => {
-      it('should return undefined', () => {
+      it('should return the type', () => {
         const objType = baseObj.clone()
         const additionalPropertiesObjType = new ObjectType({
-          elemID: new ElemID('additionalProperties'),
+          elemID: new ElemID('adapter', 'additionalProperties'),
           fields: { field: { refType: BuiltinTypes.STRING } },
         })
         objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = {
@@ -85,6 +86,24 @@ describe('additional_properties', () => {
         }
         expect(extractAdditionalPropertiesField(objType, fieldName)).toEqual(
           new Field(objType, fieldName, additionalPropertiesObjType, { someUniqueAnnotation: 'unique' }),
+        )
+      })
+    })
+    describe('when additional properties annotation is defining a type but the type is not loaded', () => {
+      it('should return the type', () => {
+        const objType = baseObj.clone()
+        const additionalPropertiesObjType = new ObjectType({
+          elemID: new ElemID('adapter', 'additionalProperties'),
+          fields: { field: { refType: BuiltinTypes.STRING } },
+        })
+        objType.annotations[CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES] = {
+          refType: new ReferenceExpression(additionalPropertiesObjType.elemID),
+          annotations: { someUniqueAnnotation: 'unique' },
+        }
+        expect(extractAdditionalPropertiesField(objType, fieldName)).toEqual(
+          new Field(objType, fieldName, new TypeReference(new ElemID('adapter', 'additionalProperties')), {
+            someUniqueAnnotation: 'unique',
+          }),
         )
       })
     })

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -26,7 +26,7 @@ import {
   ReadOnlyElementsSource,
   toChange,
 } from '@salto-io/adapter-api'
-import { elements as elementUtils, resolveValues, client as clientUtils } from '@salto-io/adapter-components'
+import { elements as elementUtils, resolveValues } from '@salto-io/adapter-components'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import { buildElementsSourceFromElements, getParents, safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -263,7 +263,7 @@ each([
               progressReporter: nullProgressReporter,
             })
           } catch (e) {
-            if (e instanceof clientUtils.HTTPError && e.response?.status === 404) {
+            if (String(e).includes('status code 404')) {
               return {
                 errors: [],
                 appliedChanges: [],


### PR DESCRIPTION
Fix unintentional fallback to `additionalProperties = false` on loadWorkspace

---

will also check if there are other similar assumptions before merging, and try to add a UT

---
_Release Notes_: 
_Okta Adapter_:
* Fix issue that would cause false pending changes to remain after deploy

---
_User Notifications_: 
None