### PR TITLE
SALTO-5728 Google WS omit domainAliases deploy when creating domain

### DIFF
--- a/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
@@ -90,11 +90,12 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   // add CV to inform the user that this fields are read-only
-                  omit: ['verified', 'isPrimary'],
+                  omit: ['verified', 'isPrimary', 'domainAliases'],
                 },
               },
+              // TODO - SALTO-5728 - we should deal with the domain aliases in a different request
               copyFromResponse: {
-                additional: { pick: ['verified', 'isPrimary'] },
+                additional: { pick: ['verified', 'isPrimary', 'domainAliases'] },
               },
             },
           ],


### PR DESCRIPTION
SALTO-5728 Google WS omit domainAliases deploy when creating domain
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none