### PR TITLE
SALTO-5797: fix jira E2E for scriptRunner

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -191,7 +191,7 @@ export const createInstances = (
   const scriptedField = new InstanceElement(
     randomString,
     findType(SCRIPTED_FIELD_TYPE, fetchedElements),
-    createScriptedFieldValues(randomString, fetchedElements),
+    createScriptedFieldValues(randomString),
   )
   const scriptRunnerListeners = new InstanceElement(
     randomString,

--- a/packages/jira-adapter/e2e_test/instances/cloud/scriptrunner/scripted_fields.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/scriptrunner/scripted_fields.ts
@@ -13,20 +13,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ElemID, Values, Element } from '@salto-io/adapter-api'
-import { createReference } from '../../../utils'
-import { ISSUE_TYPE_NAME, JIRA } from '../../../../src/constants'
+import { Values } from '@salto-io/adapter-api'
 
-export const createScriptedFieldValues = (name: string, allElements: Element[]): Values => ({
+// TODO update to reflect new scripted field
+export const createScriptedFieldValues = (name: string): Values => ({
   name,
-  projectKeys: [createReference(new ElemID(JIRA, 'Project', 'instance', 'Test_Project@s'), allElements)],
-  issueTypes: [
-    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Story'), allElements),
-    createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
-  ],
   scriptedFieldType: 'DATE_FIELD',
   codeToRun: 'issue.projectObject.key == XYZ17',
-  searchTerm: `ComplexName${name}`,
-  enabled: true,
-  itemLocation: 'atl.jira.view.issue.right.context',
+  description: 'Description of the scripted field',
 })


### PR DESCRIPTION
Changed the ScriptedFields to meet the new structure
---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None