### PR TITLE
SALTO-5793: Add TypeValueMulti References in ObjectTypeAttribute

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
@@ -21,7 +21,7 @@ import { JIRA } from '../../../../src/constants'
 export const createObjectTypeAttributeValues = (name: string, allElements: Element[]): Values => ({
   name,
   objectType: createReference(new ElemID(JIRA, 'ObjectType', 'instance', 'testSchema_Hardware_Assets@us'), allElements),
-  type: 0,
+  type: 7,
   editable: true,
   sortable: true,
   summable: false,
@@ -33,5 +33,9 @@ export const createObjectTypeAttributeValues = (name: string, allElements: Eleme
   includeChildObjectTypes: false,
   uniqueAttribute: false,
   options: '',
-  defaultTypeId: 0,
+  defaultTypeId: -1,
+  typeValueMulti: [
+    createReference(new ElemID(JIRA, 'ObjectSchemaStatus', 'instance', 'testSchema__Disposed'), allElements),
+    createReference(new ElemID(JIRA, 'ObjectSchemaStatus', 'instance', 'testSchema__Missing'), allElements),
+  ]
 })

--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/objectTypeAttribute.ts
@@ -37,5 +37,5 @@ export const createObjectTypeAttributeValues = (name: string, allElements: Eleme
   typeValueMulti: [
     createReference(new ElemID(JIRA, 'ObjectSchemaStatus', 'instance', 'testSchema__Disposed'), allElements),
     createReference(new ElemID(JIRA, 'ObjectSchemaStatus', 'instance', 'testSchema__Missing'), allElements),
-  ]
+  ],
 })

--- a/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/assets/attribute_deploy_filter.ts
@@ -160,7 +160,7 @@ const deployAttributeChanges = async ({
       additionalUrlVars,
     })
     if (isAdditionOrModificationChange(change)) {
-      const data = _.omit(instance.value, ['objectType', 'typeValue', 'additionalValue'])
+      const data = _.omit(instance.value, ['objectType', 'typeValue', 'additionalValue', 'typeValueMulti'])
       const url = `gateway/api/jsm/assets/workspace/${workspaceId}/v1/objecttypeattribute/${instance.value.id}/configure`
       await client.put({
         url,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -78,6 +78,7 @@ import {
   DELETE_LINK_TYPES,
   OBJECT_SCHEMA_TYPE,
   OBJECT_TYPE_ICON_TYPE,
+  OBJECT_SCHEMA_STATUS_TYPE,
 } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
@@ -1339,6 +1340,22 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'iconId', parentTypes: [OBJECT_TYPE_TYPE] },
     serializationStrategy: 'id',
     target: { type: OBJECT_TYPE_ICON_TYPE },
+  },
+  // typeValueMulti in ObjectTypeAttribute can be of different types. 
+  {
+    src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: STATUS_TYPE_NAME },
+  },
+  {
+    src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: OBJECT_SCHEMA_STATUS_TYPE },
+  },
+  {
+    src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'groupStrategyByOriginalName',
+    target: { type: GROUP_TYPE_NAME },
   },
 ]
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1357,6 +1357,13 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'groupStrategyByOriginalName',
     target: { type: GROUP_TYPE_NAME },
   },
+  // Hack to handle missing references when the type is unknown
+  {
+    src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: 'UnknownType' },
+  },
 ]
 
 const lookupNameFuncs: GetLookupNameFunc[] = [

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1341,7 +1341,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     target: { type: OBJECT_TYPE_ICON_TYPE },
   },
-  // typeValueMulti in ObjectTypeAttribute can be of different types. 
+  // typeValueMulti in ObjectTypeAttribute can be of different types.
   {
     src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',


### PR DESCRIPTION
Added support for reference expression in TypeValueMulti field 

---

_Additional context for reviewer_
| Status | ObjectSchemaStatus | Group |
|--------|--------------------|-------|
| <img width="1728" alt="Screenshot 2024-04-14 at 12 27 08" src="https://github.com/salto-io/salto/assets/63644199/73558e74-f5ce-4c7e-8ddb-7e0142f1dd9f"> | <img width="1728" alt="Screenshot 2024-04-14 at 12 27 59" src="https://github.com/salto-io/salto/assets/63644199/cda0c718-7233-4378-84f2-5e93e2ee64e5"> | <img width="1728" alt="Screenshot 2024-04-14 at 12 28 26" src="https://github.com/salto-io/salto/assets/63644199/5c3a9877-fef6-45fe-9f68-239e8dc7c52f"> |


---
_Release Notes_: 
_Jira Adapter:_
* Fixed bug SALTO-5793 by added references from objectTypeAttribute to statuses, objectSchemaStatuses and groups. 

---
_User Notifications_: 
_Jira Adapter:_
* In the nacl `objectTypeAttribute` the field `TypeValueMulti` changed from string to referenceExpression. 
