### PR TITLE
SALTO-5796 Google workspace support cloud identity api for group labels

### DIFF
--- a/packages/adapter-components/src/definitions/system/deploy/deploy.ts
+++ b/packages/adapter-components/src/definitions/system/deploy/deploy.ts
@@ -24,7 +24,7 @@ export type ValueReferenceResolver = (args: { value: Values }) => Values
 export type DeployRequestCondition = ArgsWithCustomizer<
   boolean,
   {
-    // when true, the request will be sent even if the before and after values are equal
+    // when false, the request will be sent even if the before and after values are equal
     // default: true
     skipIfIdentical?: boolean
     // transformation to use on before and after of the change when comparing the values

--- a/packages/adapter-components/src/deployment/deploy/requester.ts
+++ b/packages/adapter-components/src/deployment/deploy/requester.ts
@@ -93,8 +93,8 @@ const createCheck = (conditionDef?: DeployRequestCondition): ((args: ChangeAndCo
     }
     const { typeName } = change.data.after.elemID
     return !isEqualValues(
-      transform({ value: change.data.before, typeName, context: args }),
-      transform({ value: change.data.after, typeName, context: args }),
+      transform({ value: change.data.before.value, typeName, context: args }),
+      transform({ value: change.data.after.value, typeName, context: args }),
     )
   }
 }

--- a/packages/google-workspace-adapter/src/adapter_creator.ts
+++ b/packages/google-workspace-adapter/src/adapter_creator.ts
@@ -24,6 +24,7 @@ import { PAGINATION } from './definitions/requests/pagination'
 import { REFERENCES } from './definitions/references'
 import { Options } from './definitions/types'
 import {
+  CLOUD_IDENTITY_APP_NAME,
   DIRECTORY_APP_NAME,
   GROUP_SETTINGS_APP_NAME,
   createFromOauthResponse,
@@ -80,6 +81,7 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
   initialClients: {
     main: undefined,
     groupSettings: createConnectionForApp(GROUP_SETTINGS_APP_NAME),
+    cloudIdentity: createConnectionForApp(CLOUD_IDENTITY_APP_NAME),
   },
   clientDefaults,
 })

--- a/packages/google-workspace-adapter/src/client/connection.ts
+++ b/packages/google-workspace-adapter/src/client/connection.ts
@@ -39,6 +39,9 @@ export const validateDirectoryCredentials = async ({
 // There is no endPoints for groupSettings that we can use to validate the credentials with.
 export const validateGroupSettingsCredentials = async (): Promise<AccountInfo> => ({ accountId: 'groupSettings' })
 
+// There is no endPoints for groupSettings that we can use to validate the credentials with.
+export const validateCloudIdentityCredentials = async (): Promise<AccountInfo> => ({ accountId: 'groupSettings' })
+
 const validateCredentialsPerApp: Record<
   string,
   ({
@@ -51,11 +54,13 @@ const validateCredentialsPerApp: Record<
 > = {
   directory: validateDirectoryCredentials,
   groupSettings: validateGroupSettingsCredentials,
+  cloudIdentity: validateCloudIdentityCredentials,
 }
 
 const baseUrlPerApp: Record<string, string> = {
   directory: 'https://admin.googleapis.com',
   groupSettings: 'https://www.googleapis.com',
+  cloudIdentity: 'https://cloudidentity.googleapis.com',
 }
 
 const isOauthCredentials = (cred: Credentials): cred is OauthAccessTokenCredentials => 'refreshToken' in cred

--- a/packages/google-workspace-adapter/src/client/connection.ts
+++ b/packages/google-workspace-adapter/src/client/connection.ts
@@ -37,10 +37,10 @@ export const validateDirectoryCredentials = async ({
 }
 
 // There is no endPoints for groupSettings that we can use to validate the credentials with.
-export const validateGroupSettingsCredentials = async (): Promise<AccountInfo> => ({ accountId: 'groupSettings' })
+export const validateGroupSettingsCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
 
 // There is no endPoints for groupSettings that we can use to validate the credentials with.
-export const validateCloudIdentityCredentials = async (): Promise<AccountInfo> => ({ accountId: 'groupSettings' })
+export const validateCloudIdentityCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
 
 const validateCredentialsPerApp: Record<
   string,

--- a/packages/google-workspace-adapter/src/client/oauth.ts
+++ b/packages/google-workspace-adapter/src/client/oauth.ts
@@ -28,10 +28,12 @@ import { ADAPTER_NAME } from '../constants'
 
 export const DIRECTORY_APP_NAME = 'directory'
 export const GROUP_SETTINGS_APP_NAME = 'groupSettings'
+export const CLOUD_IDENTITY_APP_NAME = 'cloudIdentity'
 
 const REQUIRED_OAUTH_SCOPES = [
   'https://www.googleapis.com/auth/userinfo.profile',
   'https://www.googleapis.com/auth/cloud-platform',
+  'https://www.googleapis.com/auth/admin.directory.customer',
   'https://www.googleapis.com/auth/admin.directory.rolemanagement',
   'https://www.googleapis.com/auth/admin.directory.group',
   'https://www.googleapis.com/auth/admin.directory.domain',

--- a/packages/google-workspace-adapter/src/client/oauth.ts
+++ b/packages/google-workspace-adapter/src/client/oauth.ts
@@ -31,6 +31,7 @@ export const GROUP_SETTINGS_APP_NAME = 'groupSettings'
 
 const REQUIRED_OAUTH_SCOPES = [
   'https://www.googleapis.com/auth/userinfo.profile',
+  'https://www.googleapis.com/auth/cloud-platform',
   'https://www.googleapis.com/auth/admin.directory.rolemanagement',
   'https://www.googleapis.com/auth/admin.directory.group',
   'https://www.googleapis.com/auth/admin.directory.domain',

--- a/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
@@ -137,7 +137,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   // add CV to inform the user that this fields are read-only
-                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings'],
+                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings', 'labels'],
                 },
               },
               copyFromResponse: {
@@ -153,6 +153,22 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   root: 'groupSettings',
+                },
+              },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/v1/groups/{id}',
+                  method: 'patch',
+                  queryArgs: {
+                    updateMask: 'labels',
+                  },
+                  client: 'cloudIdentity',
+                },
+                transformation: {
+                  root: 'labels',
+                  nestUnderField: 'labels',
                 },
               },
             },
@@ -176,7 +192,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   // add CV to inform the user that this fields are read-only
-                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings'],
+                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings', 'labels'],
                 },
               },
             },
@@ -189,6 +205,22 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   root: 'groupSettings',
+                },
+              },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/v1/groups/{id}',
+                  queryArgs: {
+                    updateMask: 'labels',
+                  },
+                  method: 'patch',
+                  client: 'cloudIdentity',
+                },
+                transformation: {
+                  root: 'labels',
+                  nestUnderField: 'labels',
                 },
               },
             },

--- a/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/google-workspace-adapter/src/definitions/deploy/deploy.ts
@@ -89,7 +89,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   method: 'post',
                 },
                 transformation: {
-                  // add CV to inform the user that this fields are read-only
+                  // add CV to inform the user that verified and isPrimary are read-only
                   omit: ['verified', 'isPrimary', 'domainAliases'],
                 },
               },
@@ -136,12 +136,13 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   method: 'post',
                 },
                 transformation: {
-                  // add CV to inform the user that this fields are read-only
-                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings', 'labels'],
+                  omit: ['groupSettings', 'labels'],
                 },
               },
-              copyFromResponse: {
-                additional: { pick: ['adminCreated', 'nonEditableAliases'] },
+              condition: {
+                transformForCheck: {
+                  omit: ['groupSettings', 'labels'],
+                },
               },
             },
             {
@@ -153,6 +154,11 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   root: 'groupSettings',
+                },
+              },
+              condition: {
+                transformForCheck: {
+                  pick: ['groupSettings'],
                 },
               },
             },
@@ -169,6 +175,11 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 transformation: {
                   root: 'labels',
                   nestUnderField: 'labels',
+                },
+              },
+              condition: {
+                transformForCheck: {
+                  pick: ['labels'],
                 },
               },
             },
@@ -191,8 +202,12 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   method: 'put',
                 },
                 transformation: {
-                  // add CV to inform the user that this fields are read-only
-                  omit: ['adminCreated', 'nonEditableAliases', 'groupSettings', 'labels'],
+                  omit: ['groupSettings', 'labels'],
+                },
+              },
+              condition: {
+                transformForCheck: {
+                  omit: ['groupSettings', 'labels'],
                 },
               },
             },
@@ -205,6 +220,11 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
                 transformation: {
                   root: 'groupSettings',
+                },
+              },
+              condition: {
+                transformForCheck: {
+                  pick: ['groupSettings'],
                 },
               },
             },
@@ -221,6 +241,11 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 transformation: {
                   root: 'labels',
                   nestUnderField: 'labels',
+                },
+              },
+              condition: {
+                transformForCheck: {
+                  pick: ['labels'],
                 },
               },
             },
@@ -457,7 +482,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   method: 'post',
                 },
                 transformation: {
-                  // add CV to inform the user that this fields are read-only
+                  // add CV to inform the user that this field are read-only
                   omit: ['resourceEmail'],
                   adjust: item => {
                     const { value } = item

--- a/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
@@ -187,6 +187,17 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
             },
           },
         },
+        labels: {
+          typeName: 'label',
+          single: true,
+          context: {
+            args: {
+              groupId: {
+                root: 'id',
+              },
+            },
+          },
+        },
       },
     },
     element: {
@@ -226,6 +237,19 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
       },
     },
+  },
+  label: {
+    requests: [
+      {
+        endpoint: {
+          path: '/v1/groups/{groupId}',
+          client: 'cloudIdentity',
+        },
+        transformation: {
+          root: 'labels',
+        },
+      },
+    ],
   },
   groupMember: {
     requests: [

--- a/packages/google-workspace-adapter/src/definitions/requests/clients.ts
+++ b/packages/google-workspace-adapter/src/definitions/requests/clients.ts
@@ -51,5 +51,20 @@ export const createClientDefinitions = (
         },
       },
     },
+    cloudIdentity: {
+      httpClient: clients.cloudIdentity,
+      endpoints: {
+        default: {
+          get: {
+            pagination: 'cursor',
+            // only readonly endpoint calls are allowed during fetch. we assume by default that GET endpoints are safe
+            readonly: true,
+          },
+          delete: {
+            omitBody: true,
+          },
+        },
+      },
+    },
   },
 })

--- a/packages/google-workspace-adapter/src/definitions/types.ts
+++ b/packages/google-workspace-adapter/src/definitions/types.ts
@@ -16,7 +16,7 @@
 import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
-export type ClientOptions = 'main' | 'groupSettings'
+export type ClientOptions = 'main' | 'groupSettings' | 'cloudIdentity'
 export type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = 'roleId' | 'orgUnitId' | 'buildingId' | 'email'


### PR DESCRIPTION
SALTO-5796 Google workspace support cloud identity api for group labels
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none
