### PR TITLE
SALTO-5537: exclude fields with unresolved references in forms

### DIFF
--- a/packages/lowerdash/test/collections/asynciterable.test.ts
+++ b/packages/lowerdash/test/collections/asynciterable.test.ts
@@ -39,6 +39,7 @@ const {
   keyByAsync,
   iterateTogether,
   flatMapAsync,
+  partitionAsync,
 } = asynciterable
 type BeforeAfter<T> = collections.asynciterable.BeforeAfter<T>
 
@@ -324,6 +325,15 @@ describe('asynciterable', () => {
     })
   })
 
+  describe('partitionAsync', () => {
+    it('should return two iterables, one with the elements that passed the predicate and one with the ones that did not', async () => {
+      expect(await partitionAsync(toAsyncIterable([1, 2, 3, 4, 5, 6]), n => n % 2 === 0)).toEqual([
+        [2, 4, 6],
+        [1, 3, 5],
+      ])
+    })
+  })
+
   describe('iterateTogether', () => {
     let firstIter: AsyncIterable<number>
     let secondIter: AsyncIterable<number>
@@ -487,6 +497,13 @@ describe('asynciterable', () => {
           A: [{ key: 'A' }],
         })
       })
+      it('should forward the partition function to partitionAsync', async () => {
+        expect(await awu([1, 2, 3, 4, 5, 6]).partition(num => num > 4)).toEqual([
+          [5, 6],
+          [1, 2, 3, 4],
+        ])
+      })
+
       it('should delete copies from list when uniquifying', async () => {
         expect(
           await awu([1, 2, 3, 5, 4, 6, 6, 4, 3, 7, 2, 1])

--- a/packages/netsuite-adapter/src/custom_references/index.ts
+++ b/packages/netsuite-adapter/src/custom_references/index.ts
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 import { permissionsHandler } from './weak_references/permissions_references'
+import { fieldsHandler } from './weak_references/fields_references'
 
 export const customReferenceHandlers = {
   permissionsReferences: permissionsHandler,
+  fieldsReferences: fieldsHandler,
 }

--- a/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
@@ -1,0 +1,196 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeError,
+  ElemID,
+  FixElementsFunc,
+  GetCustomReferencesFunc,
+  InstanceElement,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+  ReferenceInfo,
+  Value,
+  isInstanceElement,
+  isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { WeakReferencesHandler } from '@salto-io/adapter-components'
+import { collections, values } from '@salto-io/lowerdash'
+import { TransformFunc, WALK_NEXT_STEP, transformElement, walkOnValue } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { ADDRESS_FORM, ENTRY_FORM, PERMISSIONS, TRANSACTION_FORM } from '../../constants'
+import { captureServiceIdInfo } from '../../service_id_info'
+
+const { awu } = collections.asynciterable
+
+const formTypes = new Set([ADDRESS_FORM, ENTRY_FORM, TRANSACTION_FORM])
+
+const GENERATED_DEPENDENCIES = '_generated_dependencies'
+
+export const getPermissionsListPath = (): string[] => [PERMISSIONS, 'permission']
+
+const getFieldReferences = (formInstance: InstanceElement): Record<string, ReferenceExpression> => {
+  const referencesRecord: Record<string, ReferenceExpression> = {}
+  walkOnValue({
+    elemId: formInstance.elemID,
+    value: formInstance.value,
+    func: ({ path, value }) => {
+      if (!values.isPlainRecord(value)) {
+        return WALK_NEXT_STEP.SKIP
+      }
+      if (isReferenceExpression(value.id)) {
+        referencesRecord[path.getFullName()] = value.id
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  // eslint-disable-next-line no-underscore-dangle
+  const generatedDependencies = formInstance.annotations[GENERATED_DEPENDENCIES]
+  if (Array.isArray(generatedDependencies)) {
+    generatedDependencies.forEach((dep, index) => {
+      if (values.isPlainRecord(dep) && isReferenceExpression(dep.reference)) {
+        referencesRecord[formInstance.elemID.createNestedID(GENERATED_DEPENDENCIES, index.toString()).getFullName()] =
+          dep.reference
+      }
+    })
+  }
+  return referencesRecord
+}
+
+const getWeakElementReferences = (formInstance: InstanceElement): ReferenceInfo[] => {
+  const fieldsReferences = getFieldReferences(formInstance)
+  return Object.entries(fieldsReferences).flatMap(([path, referenceElement]) => ({
+    source: ElemID.fromFullName(path),
+    target: referenceElement.elemID,
+    type: 'weak' as const,
+  }))
+}
+
+const isFormInstanceElement = (element: Value): element is InstanceElement =>
+  isInstanceElement(element) && formTypes.has(element.elemID.typeName)
+
+const getFieldsReferences: GetCustomReferencesFunc = async elements =>
+  elements.filter(isFormInstanceElement).flatMap(getWeakElementReferences)
+
+const checkIfUnresolvedGeneratedDependency = (value: string, generatedDependencies: Set<string>): boolean => {
+  const capture = captureServiceIdInfo(value)[0]
+  return capture ? generatedDependencies.has(capture.serviceId) : false
+}
+
+const isUnresolvedReference = async (
+  ref: ReferenceExpression,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<boolean> => (await elementsSource.get(ref.elemID.createTopLevelParentID().parent)) === undefined
+
+const getUnresolvedGeneratedDependencies = async (
+  form: InstanceElement,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<string[]> =>
+  awu(form.annotations[GENERATED_DEPENDENCIES])
+    .filter(values.isPlainRecord)
+    .map(dep => dep.reference)
+    .filter(isReferenceExpression)
+    // TODO: see how to do this without this lint disable
+    // eslint-disable-next-line no-return-await, @typescript-eslint/return-await
+    .filter(async ref => await isUnresolvedReference(ref, elementsSource))
+    .map(ref => ref.elemID.createTopLevelParentID().parent.name)
+    .toArray()
+
+const getPathsToRemove = async (form: InstanceElement, elementsSource: ReadOnlyElementsSource): Promise<string[]> => {
+  // TODO: why doesn't the transformElement change the value in the fixedForm?
+  const pathsToRemove: string[] = []
+
+  const unresolvedGeneratedDependencies = new Set<string>(
+    await getUnresolvedGeneratedDependencies(form, elementsSource),
+  )
+
+  const transformPathsToRemove: TransformFunc = async ({ value, path }) => {
+    if (!values.isPlainRecord(value)) {
+      return value
+    }
+    const { id } = value
+    if (isReferenceExpression(id) && (await isUnresolvedReference(id, elementsSource))) {
+      if (path) {
+        pathsToRemove.push(form.elemID.getRelativePath(path).join('.'))
+      }
+      return undefined
+    }
+    if (_.isString(id) && checkIfUnresolvedGeneratedDependency(id, unresolvedGeneratedDependencies)) {
+      if (path) {
+        pathsToRemove.push(form.elemID.getRelativePath(path).join('.'))
+      }
+      return undefined
+    }
+    return value
+  }
+
+  await transformElement({
+    element: form,
+    transformFunc: transformPathsToRemove,
+    elementsSource,
+  })
+
+  return pathsToRemove
+}
+const getFixedElements = async (
+  form: InstanceElement,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<InstanceElement | undefined> => {
+  const fixedForm = form.clone()
+
+  const pathsToRemove = await getPathsToRemove(fixedForm, elementsSource)
+
+  if (pathsToRemove.length === 0) {
+    return undefined
+  }
+
+  pathsToRemove.forEach(path => _.unset(fixedForm.value, path))
+  fixedForm.annotations[GENERATED_DEPENDENCIES] = []
+
+  return fixedForm
+}
+
+const removeUnresolvedFieldElements: WeakReferencesHandler<{
+  elementsSource: ReadOnlyElementsSource
+}>['removeWeakReferences'] =
+  ({ elementsSource }): FixElementsFunc =>
+  async elements => {
+    const fixedForms = await awu(elements)
+      .filter(isFormInstanceElement)
+      .map(form => getFixedElements(form, elementsSource))
+      .filter(values.isDefined)
+      .toArray()
+
+    const formErrors: ChangeError[] = fixedForms.map(form => ({
+      elemID: form.elemID,
+      severity: 'Info',
+      message: 'Deploying without all referenced fields',
+      detailedMessage:
+        'This form is referencing a few fields that do not exist in the target environment. As a result, it will be deployed without those references.',
+    }))
+
+    return {
+      fixedElements: fixedForms,
+      errors: formErrors,
+    }
+  }
+
+export const fieldsHandler: WeakReferencesHandler<{
+  elementsSource: ReadOnlyElementsSource
+}> = {
+  findWeakReferences: getFieldsReferences,
+  removeWeakReferences: removeUnresolvedFieldElements,
+}

--- a/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
@@ -146,7 +146,7 @@ const getFixedPermissionField = async (
   )
 }
 
-const getFixedElementsAndUpdatedPaths = async (
+const getFixedElements = async (
   roleOrCustomRecordType: InstanceElement | ObjectType,
   elementsSource: ReadOnlyElementsSource,
   permissionType: RoleOrCustomRecordType,
@@ -189,7 +189,7 @@ const removeUnresolvedPermissionElements: WeakReferencesHandler<{
     const fixedRoles = await awu(elements)
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === ROLE)
-      .map(role => getFixedElementsAndUpdatedPaths(role, elementsSource, ROLE))
+      .map(role => getFixedElements(role, elementsSource, ROLE))
       .filter(values.isDefined)
       .toArray()
 
@@ -206,7 +206,7 @@ const removeUnresolvedPermissionElements: WeakReferencesHandler<{
     const fixedCustomRecordTypes = await awu(elements)
       .filter(isObjectType)
       .filter(isCustomRecordType)
-      .map(custRecordType => getFixedElementsAndUpdatedPaths(custRecordType, elementsSource, CUSTOM_RECORD_TYPE))
+      .map(custRecordType => getFixedElements(custRecordType, elementsSource, CUSTOM_RECORD_TYPE))
       .filter(values.isDefined)
       .toArray()
 

--- a/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/permissions_references.ts
@@ -146,7 +146,7 @@ const getFixedPermissionField = async (
   )
 }
 
-const getFixedElements = async (
+const getFixedElement = async (
   roleOrCustomRecordType: InstanceElement | ObjectType,
   elementsSource: ReadOnlyElementsSource,
   permissionType: RoleOrCustomRecordType,
@@ -189,7 +189,7 @@ const removeUnresolvedPermissionElements: WeakReferencesHandler<{
     const fixedRoles = await awu(elements)
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === ROLE)
-      .map(role => getFixedElements(role, elementsSource, ROLE))
+      .map(role => getFixedElement(role, elementsSource, ROLE))
       .filter(values.isDefined)
       .toArray()
 
@@ -206,7 +206,7 @@ const removeUnresolvedPermissionElements: WeakReferencesHandler<{
     const fixedCustomRecordTypes = await awu(elements)
       .filter(isObjectType)
       .filter(isCustomRecordType)
-      .map(custRecordType => getFixedElements(custRecordType, elementsSource, CUSTOM_RECORD_TYPE))
+      .map(custRecordType => getFixedElement(custRecordType, elementsSource, CUSTOM_RECORD_TYPE))
       .filter(values.isDefined)
       .toArray()
 

--- a/packages/netsuite-adapter/test/custom_references/weak_references/fields_references.test.ts
+++ b/packages/netsuite-adapter/test/custom_references/weak_references/fields_references.test.ts
@@ -13,9 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ElemID, InstanceElement, ObjectType, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { GENERATED_DEPENDENCIES, fieldsHandler } from '../../../src/custom_references/weak_references/fields_references'
+import { fieldsHandler } from '../../../src/custom_references/weak_references/fields_references'
 import { NETSUITE, SCRIPT_ID, TRANSACTION_FORM } from '../../../src/constants'
 import { transactionFormType } from '../../../src/autogen/types/standard_types/transactionForm'
 
@@ -93,7 +100,7 @@ describe('permissions_references', () => {
     },
     [NETSUITE, TRANSACTION_FORM, 'form2'],
     {
-      [GENERATED_DEPENDENCIES]: [
+      [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [
         {
           reference: new ReferenceExpression(inst2.elemID.createNestedID(SCRIPT_ID), inst2.value.scriptid, inst2),
         },
@@ -146,12 +153,12 @@ describe('permissions_references', () => {
           type: 'weak',
         },
         {
-          source: form2.elemID.createNestedID(GENERATED_DEPENDENCIES, '0'),
+          source: form2.elemID.createNestedID(CORE_ANNOTATIONS.GENERATED_DEPENDENCIES, '0'),
           target: instance2.elemID.createNestedID(SCRIPT_ID),
           type: 'weak',
         },
         {
-          source: form2.elemID.createNestedID(GENERATED_DEPENDENCIES, '1'),
+          source: form2.elemID.createNestedID(CORE_ANNOTATIONS.GENERATED_DEPENDENCIES, '1'),
           target: instance3.elemID.createNestedID(SCRIPT_ID),
           type: 'weak',
         },
@@ -240,8 +247,10 @@ describe('permissions_references', () => {
       expect(fixedForm.value.parentField.field2).toBeUndefined()
       expect(fixedForm.value.parentField.field3.id).toEqual(form2.value.parentField.field3.id)
       expect(fixedForm.value.parentField.field3.index).toEqual(0)
-      expect(fixedForm.annotations[GENERATED_DEPENDENCIES].length).toEqual(1)
-      expect(fixedForm.annotations[GENERATED_DEPENDENCIES][0]).toEqual(form2.annotations[GENERATED_DEPENDENCIES][1])
+      expect(fixedForm.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES].length).toEqual(1)
+      expect(fixedForm.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES][0]).toEqual(
+        form2.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES][1],
+      )
     })
     it('should do nothing if all references are valid', async () => {
       const clonedForm2 = form2.clone()

--- a/packages/netsuite-adapter/test/custom_references/weak_references/fields_references.test.ts
+++ b/packages/netsuite-adapter/test/custom_references/weak_references/fields_references.test.ts
@@ -1,0 +1,256 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, isInstanceElement } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { GENERATED_DEPENDENCIES, fieldsHandler } from '../../../src/custom_references/weak_references/fields_references'
+import { NETSUITE, SCRIPT_ID, TRANSACTION_FORM } from '../../../src/constants'
+import { transactionFormType } from '../../../src/autogen/types/standard_types/transactionForm'
+
+describe('permissions_references', () => {
+  let instance1: InstanceElement
+  let instance2: InstanceElement
+  let instance3: InstanceElement
+  let form1: InstanceElement
+  let form2: InstanceElement
+
+  const inst1 = new InstanceElement(
+    'instance1',
+    new ObjectType({
+      elemID: new ElemID(NETSUITE, 'instance1'),
+    }),
+    {
+      [SCRIPT_ID]: 'instance1',
+    },
+  )
+
+  const inst2 = new InstanceElement(
+    'instance2',
+    new ObjectType({
+      elemID: new ElemID(NETSUITE, 'instance2'),
+    }),
+    {
+      [SCRIPT_ID]: 'instance2',
+    },
+  )
+
+  const inst3 = new InstanceElement(
+    'instance3',
+    new ObjectType({
+      elemID: new ElemID(NETSUITE, 'instance3'),
+    }),
+    {
+      [SCRIPT_ID]: 'instance3',
+    },
+  )
+
+  const form1Instance = new InstanceElement('form1', transactionFormType().type, {
+    [SCRIPT_ID]: 'form1',
+    field1: {
+      id: new ReferenceExpression(inst1.elemID.createNestedID(SCRIPT_ID), inst1.value.scriptid, inst1),
+    },
+    stringId: {
+      id: 'some string id',
+    },
+    parentField: {
+      field2: {
+        id: new ReferenceExpression(inst2.elemID.createNestedID(SCRIPT_ID), inst2.value.scriptid, inst2),
+        index: 0,
+      },
+    },
+  })
+
+  const form2Instance = new InstanceElement(
+    'form2',
+    transactionFormType().type,
+    {
+      [SCRIPT_ID]: 'form2',
+      field1: {
+        id: new ReferenceExpression(inst1.elemID.createNestedID(SCRIPT_ID), inst1.value.scriptid, inst1),
+      },
+      parentField: {
+        field2: {
+          id: '[type=transactionbodycustomfield, scriptid=instance2]',
+          index: 0,
+        },
+        field3: {
+          id: '[type=transactionbodycustomfield, scriptid=instance3]',
+          index: 1,
+        },
+      },
+    },
+    [NETSUITE, TRANSACTION_FORM, 'form2'],
+    {
+      [GENERATED_DEPENDENCIES]: [
+        {
+          reference: new ReferenceExpression(inst2.elemID.createNestedID(SCRIPT_ID), inst2.value.scriptid, inst2),
+        },
+        {
+          reference: new ReferenceExpression(inst3.elemID.createNestedID(SCRIPT_ID), inst3.value.scriptid, inst3),
+        },
+        {
+          invalid: 'irrelevent generated dependency',
+        },
+      ],
+    },
+  )
+
+  const AdapterConfigType = new ObjectType({
+    elemID: new ElemID('adapter'),
+    isSettings: true,
+  })
+  const adapterConfig = new InstanceElement(ElemID.CONFIG_NAME, AdapterConfigType)
+
+  beforeEach(() => {
+    instance1 = inst1.clone()
+    instance2 = inst2.clone()
+    instance3 = inst3.clone()
+    form1 = form1Instance.clone()
+    form2 = form2Instance.clone()
+  })
+
+  describe('findWeakReferences', () => {
+    it('should return weak references for fields', async () => {
+      const references = await fieldsHandler.findWeakReferences([form1], adapterConfig)
+      expect(references).toEqual([
+        {
+          source: form1.elemID.createNestedID('field1'),
+          target: instance1.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+        {
+          source: form1.elemID.createNestedID('parentField', 'field2'),
+          target: instance2.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+      ])
+    })
+    it('should return weak references for generated permissions', async () => {
+      const references = await fieldsHandler.findWeakReferences([form2], adapterConfig)
+      expect(references).toEqual([
+        {
+          source: form2.elemID.createNestedID('field1'),
+          target: instance1.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+        {
+          source: form2.elemID.createNestedID(GENERATED_DEPENDENCIES, '0'),
+          target: instance2.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+        {
+          source: form2.elemID.createNestedID(GENERATED_DEPENDENCIES, '1'),
+          target: instance3.elemID.createNestedID(SCRIPT_ID),
+          type: 'weak',
+        },
+      ])
+    })
+  })
+
+  describe('removeWeakReferences', () => {
+    describe('should remove the invalid references and keep valid ones', () => {
+      it('should remove top level field reference', async () => {
+        const clonedForm1 = form1.clone()
+        const elementsSource = buildElementsSourceFromElements([instance2])
+        const fixes = await fieldsHandler.removeWeakReferences({ elementsSource })([form1])
+        expect(clonedForm1).toEqual(form1)
+
+        expect(fixes.errors.length).toEqual(1)
+
+        expect(fixes.errors).toEqual([
+          {
+            elemID: form1.elemID.createNestedID('field1'),
+            severity: 'Info',
+            message: 'Deploying without all referenced fields',
+            detailedMessage:
+              'This form1.field1 is referencing a field that does not exist in the target environment. As a result, it will be deployed without this field.',
+          },
+        ])
+
+        expect(fixes.fixedElements).toHaveLength(1)
+        const fixedElement = fixes.fixedElements[0]
+        expect(isInstanceElement(fixedElement) && fixedElement.elemID.typeName === TRANSACTION_FORM).toBeTruthy()
+        const fixedForm = fixedElement as InstanceElement
+        expect(fixedForm.value.field1).toBeUndefined()
+        expect(fixedForm.value.parentField.field2).toEqual(form1.value.parentField.field2)
+        expect(fixedForm.value.stringId).toEqual(form1.value.stringId)
+      })
+      it('should remove inner field reference', async () => {
+        const clonedForm1 = form1.clone()
+        const elementsSource = buildElementsSourceFromElements([instance1])
+        const fixes = await fieldsHandler.removeWeakReferences({ elementsSource })([form1])
+        expect(clonedForm1).toEqual(form1)
+
+        expect(fixes.errors.length).toEqual(1)
+
+        expect(fixes.errors).toEqual([
+          {
+            elemID: form1.elemID.createNestedID('parentField', 'field2'),
+            severity: 'Info',
+            message: 'Deploying without all referenced fields',
+            detailedMessage:
+              'This form1.parentField.field2 is referencing a field that does not exist in the target environment. As a result, it will be deployed without this field.',
+          },
+        ])
+
+        expect(fixes.fixedElements).toHaveLength(1)
+        const fixedElement = fixes.fixedElements[0]
+        expect(isInstanceElement(fixedElement) && fixedElement.elemID.typeName === TRANSACTION_FORM).toBeTruthy()
+        const fixedForm = fixedElement as InstanceElement
+        expect(fixedForm.value.field1).toEqual(form1.value.field1)
+        expect(fixedForm.value.parentField).toEqual({})
+        expect(fixedForm.value.stringId).toEqual(form1.value.stringId)
+      })
+    })
+    it('should remove generated references and their related fields', async () => {
+      const clonedForm2 = form2.clone()
+      const elementsSource = buildElementsSourceFromElements([instance1, instance3])
+      const fixes = await fieldsHandler.removeWeakReferences({ elementsSource })([form2])
+      expect(clonedForm2).toEqual(form2)
+
+      expect(fixes.errors.length).toEqual(1)
+
+      expect(fixes.errors).toEqual([
+        {
+          elemID: form2.elemID.createNestedID('parentField', 'field2'),
+          severity: 'Info',
+          message: 'Deploying without all referenced fields',
+          detailedMessage:
+            'This form2.parentField.field2 is referencing a field that does not exist in the target environment. As a result, it will be deployed without this field.',
+        },
+      ])
+
+      expect(fixes.fixedElements).toHaveLength(1)
+      const fixedElement = fixes.fixedElements[0]
+      expect(isInstanceElement(fixedElement) && fixedElement.elemID.typeName === TRANSACTION_FORM).toBeTruthy()
+      const fixedForm = fixedElement as InstanceElement
+      expect(fixedForm.value.field1).toEqual(form2.value.field1)
+      expect(fixedForm.value.parentField.field2).toBeUndefined()
+      expect(fixedForm.value.parentField.field3.id).toEqual(form2.value.parentField.field3.id)
+      expect(fixedForm.value.parentField.field3.index).toEqual(0)
+      expect(fixedForm.annotations[GENERATED_DEPENDENCIES].length).toEqual(1)
+      expect(fixedForm.annotations[GENERATED_DEPENDENCIES][0]).toEqual(form2.annotations[GENERATED_DEPENDENCIES][1])
+    })
+    it('should do nothing if all references are valid', async () => {
+      const clonedForm2 = form2.clone()
+      const elementsSource = buildElementsSourceFromElements([instance1, instance2, instance3])
+      const fixes = await fieldsHandler.removeWeakReferences({ elementsSource })([form2])
+      expect(clonedForm2).toEqual(form2)
+
+      expect(fixes.errors).toEqual([])
+      expect(fixes.fixedElements).toEqual([])
+    })
+  })
+})


### PR DESCRIPTION
_Define the references in forms to be weak references.
Making it possible to deploy a form to a target environment that doesn't have all the referenced fields without adding all those fields to the deployment._

---

_Jira ticket: https://salto-io.atlassian.net/browse/SALTO-5537_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
