### PR TITLE
SALTO-5220: change createSkipParentsOfSkippedInstancesValidator error message

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/skip_parents_of_skipped_instances.ts
+++ b/packages/adapter-components/src/deployment/change_validators/skip_parents_of_skipped_instances.ts
@@ -62,8 +62,8 @@ export const createSkipParentsOfSkippedInstancesValidator =
           ({
             elemID: ref.elemID,
             severity: 'Error',
-            message: `${ref.elemID.getFullName()} depends on a skipped instance`,
-            detailedMessage: `${ref.elemID.getFullName()} depends on a skipped instance and therefore is also skipped`,
+            message: 'Element cannot be deployed due to an error in its dependency',
+            detailedMessage: `${ref.elemID.getFullName()} cannot be deployed due to an error in its dependency. Please resolve that error and try again.`,
           }) as ChangeError,
       )
       .value()


### PR DESCRIPTION
change createSkipParentsOfSkippedInstancesValidator error message

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
