### PR TITLE
Revert "Make fix-order-problems-in-workbooks run generically on XMLs"

### DIFF
--- a/packages/netsuite-adapter/src/filters/fix_order_problems_in_workbooks.ts
+++ b/packages/netsuite-adapter/src/filters/fix_order_problems_in_workbooks.ts
@@ -14,32 +14,70 @@
  * limitations under the License.
  */
 
+import {
+  Change,
+  ElemID,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  ReadOnlyElementsSource,
+  Value,
+  Values,
+} from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { parse } from 'fast-xml-parser'
 import { decode } from 'he'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import {
-  Change,
-  getChangeData,
-  InstanceElement,
-  isAdditionOrModificationChange,
-  isInstanceElement,
-  Values,
-} from '@salto-io/adapter-api'
-import { TransformFunc, resolvePath, transformValuesSync } from '@salto-io/adapter-utils'
-import { DATASET, SCRIPT_ID, WORKBOOK } from '../constants'
+import { DATASET, SCRIPT_ID, SOAP_SCRIPT_ID, WORKBOOK } from '../constants'
 import { LocalFilterCreator } from '../filter'
 import { ATTRIBUTE_PREFIX } from '../client/constants'
-import { DATASET_LINK, DATASET_LINKS, DATASETS, ROOT } from '../type_parsers/analytics_parsers/analytics_constants'
+import {
+  DATASET_LINK,
+  DATASET_LINKS,
+  DATASETS,
+  INNER_ARRAY_NAMES,
+  INNER_XML_TITLES,
+} from '../type_parsers/analytics_parsers/analytics_constants'
 import { addAdditionalDependency } from '../client/utils'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-const isStringArray = (val: unknown): val is string[] => Array.isArray(val) && _.every(val, _.isString)
+const addWorkbookToolsToRecord = (
+  instance: InstanceElement,
+  workbookToolsRecord: Record<string, Values>,
+  name: string,
+): void => {
+  if (Array.isArray(instance.value[name])) {
+    instance.value[name].forEach((tool: unknown) => {
+      if (values.isPlainObject(tool)) {
+        Object.values(tool)
+          .filter(values.isPlainObject)
+          .forEach((obj: Values) => {
+            if (_.isString(obj[SOAP_SCRIPT_ID])) {
+              workbookToolsRecord[obj[SOAP_SCRIPT_ID]] = obj
+            }
+          })
+      }
+    })
+  }
+}
 
-const isXmlContent = (val: unknown): val is string => _.isString(val) && val.startsWith(`<${ROOT}>`)
+const createRecordOfPivotsChartsAndDsLinks = async (
+  elementsSource: ReadOnlyElementsSource,
+  elemID: ElemID,
+): Promise<Record<string, Values>> => {
+  const oldWorkbookToolsRecord: Record<string, Values> = {}
+  const oldInstance = await elementsSource.get(elemID)
+  if (isInstanceElement(oldInstance)) {
+    INNER_ARRAY_NAMES.forEach(arrayName => {
+      addWorkbookToolsToRecord(oldInstance, oldWorkbookToolsRecord, arrayName)
+    })
+  }
+  return oldWorkbookToolsRecord
+}
 
 const isSameXmlValues = (xml1: string, xml2: string): boolean => {
   const values1 = parse(xml1, {
@@ -55,33 +93,45 @@ const isSameXmlValues = (xml1: string, xml2: string): boolean => {
   return _.isEqual(values1, values2)
 }
 
-const discardUnrelevantChanges = (
-  existingInstance: InstanceElement | undefined,
-  newInstance: InstanceElement,
-): void => {
-  const transformFunc: TransformFunc = ({ value, path }) => {
-    if (path === undefined) {
-      return value
-    }
-    if (path.name === DATASETS && isStringArray(value)) {
-      return value.sort()
-    }
-    if (!isInstanceElement(existingInstance) || !isXmlContent(value)) {
-      return value
-    }
-    const existingValue = resolvePath(existingInstance, path)
-    if (isXmlContent(existingValue) && isSameXmlValues(value, existingValue)) {
-      return existingValue
-    }
-    return value
-  }
+const getInnerXmlTitle = (workbookTool: Values): string | undefined =>
+  INNER_XML_TITLES.find(title => title in workbookTool)
 
-  newInstance.value = transformValuesSync({
-    values: newInstance.value,
-    type: newInstance.getTypeSync(),
-    strict: false,
-    pathID: newInstance.elemID,
-    transformFunc,
+const compareAndAssignInnerXmls = (newTool: Values, oldTool: Values): void => {
+  const innerXmlTitle = getInnerXmlTitle(newTool)
+  if (innerXmlTitle === undefined) {
+    return
+  }
+  const innerXmlNew = newTool[innerXmlTitle]
+  const innerXmlOld = oldTool[innerXmlTitle]
+  if (!_.isString(innerXmlNew) || !_.isString(innerXmlOld)) {
+    return
+  }
+  if (isSameXmlValues(innerXmlNew, innerXmlOld)) {
+    newTool[innerXmlTitle] = oldTool[innerXmlTitle]
+  }
+}
+
+const adjustWorkbookToolsOrder = (workbookTools: Value[], oldWorkbookToolsRecord: Record<string, Values>): void => {
+  workbookTools
+    .filter(values.isPlainObject)
+    .flatMap(obj => Object.values(obj))
+    .filter(values.isPlainRecord)
+    .forEach((workbookTool: Values) => {
+      if (_.isArray(workbookTool[DATASETS])) {
+        workbookTool[DATASETS].sort()
+      }
+      if (_.isString(workbookTool[SOAP_SCRIPT_ID]) && workbookTool[SOAP_SCRIPT_ID] in oldWorkbookToolsRecord) {
+        const oldWorkbookTool = oldWorkbookToolsRecord[workbookTool[SOAP_SCRIPT_ID]]
+        compareAndAssignInnerXmls(workbookTool, oldWorkbookTool)
+      }
+    })
+}
+
+const discardUnrelevantChanges = (newInstanceValues: Values, oldTools: Record<string, Values>): void => {
+  INNER_ARRAY_NAMES.forEach(arrName => {
+    if (Array.isArray(newInstanceValues[arrName])) {
+      adjustWorkbookToolsOrder(newInstanceValues[arrName], oldTools)
+    }
   })
 }
 
@@ -106,16 +156,18 @@ const getDatasetLinkList = (workbook: InstanceElement): Values[] =>
         .filter(values.isPlainObject)
     : []
 
+const isStringArray = (val: unknown): val is string[] => Array.isArray(val) && _.every(val, _.isString)
+
 const filterCreator: LocalFilterCreator = ({ elementsSource }) => ({
   name: 'fixOrderProblemsInWorkbooks',
   onFetch: async elements => {
-    await awu(elements)
-      .filter(elem => elem.elemID.typeName === WORKBOOK)
-      .filter(isInstanceElement)
-      .forEach(async instance => {
-        discardUnrelevantChanges(await elementsSource.get(instance.elemID), instance)
-      })
+    const workbooks = elements.filter(elem => elem.elemID.typeName === WORKBOOK).filter(isInstanceElement)
+    await awu(workbooks).forEach(async instance => {
+      const oldTools = await createRecordOfPivotsChartsAndDsLinks(elementsSource, instance.elemID)
+      discardUnrelevantChanges(instance.value, oldTools)
+    })
   },
+
   preDeploy: async (changes: Change[]) => {
     const changedDatasets = changes
       .filter(isAdditionOrModificationChange)

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
@@ -198,3 +198,7 @@ export type EmptyObject = {
 export const TValuesToIgnore = new Set(['workbook', 'dataSet', 'formula'])
 export const fieldsToOmitFromDefinition = [NAME]
 export const fieldsToOmitFromOriginal = [DEFINITION, TABLES, CHARTS, PIVOTS]
+
+export const INNER_ARRAY_NAMES = [PIVOTS, CHARTS, DATASET_LINKS]
+
+export const INNER_XML_TITLES = [DEFINITION, MAPPING]


### PR DESCRIPTION
This reverts commit ab1b350304c9c8328d44c7664764e8e0bbe9fc5e.

_Trying to fix the order problem with the inner XMLs in workbooks.
Reverting the commit that makes it generic for all the fields to see if the problem was there.
By reverting this commit,  we focusing in fixing specific fields we already know that could include XMLs._

---

_Additional context for reviewer_
The problem is xml values have changes in the order of fields which have no practical effect but changes the nacl in the fetch:
<img width="791" alt="image" src="https://github.com/salto-io/salto/assets/83573185/9aa8f3d5-6ec6-4e19-9ca1-33a3fa3f37e4">

reverted PR: https://github.com/salto-io/salto/pull/5476/files#diff-1668dd0cd14f8db2f240d8060131c2f53f983f2103078269809dd8060e534511

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
