### PR TITLE
SALTO-5807: Add the option to add an object to s3 with a tag

### DIFF
--- a/packages/core/test/workspace/local/s3_dir_store.test.ts
+++ b/packages/core/test/workspace/local/s3_dir_store.test.ts
@@ -206,6 +206,22 @@ describe('buildS3DirectoryStore', () => {
       expect(putObjectMock).toHaveBeenCalledTimes(1)
     })
   })
+  describe('set with tag', () => {
+    it('should write the file', async () => {
+      await directoryStore.set({ filename: 'a/b', buffer: Buffer.from('aaa') }, 'tag')
+
+      expect(putObjectMock).not.toHaveBeenCalled()
+
+      await directoryStore.flush()
+
+      expect(putObjectMock).toHaveBeenCalledWith({
+        Bucket: bucketName,
+        Key: 'baseDir/a/b',
+        Body: Buffer.from('aaa'),
+        Tagging: 'tag',
+      })
+    })
+  })
 
   describe('getFullPath', () => {
     it('should throw on unexpected error', async () => {

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -28,7 +28,7 @@ export type GetFileOptions = {
 export type DirectoryStore<T extends ContentType> = {
   list(): Promise<string[]>
   get(filename: string, options?: GetFileOptions): Promise<File<T> | undefined>
-  set(file: File<T>): Promise<void>
+  set(file: File<T>, tag?: string): Promise<void>
   delete(filename: string): Promise<void>
   clear(): Promise<void>
   rename(name: string): Promise<void>


### PR DESCRIPTION
Added the option to add 'tagging` when adding an object to S3. 

---

_Additional context for reviewer_
* We want to save changes in s3 for operation-changes. We decided that we will insert each operation change with a lifecycle rule of 30 days. In order to do so, I added this rule. 
* tag can be undefined.

---
_Release Notes_: 
_Core:_
* Added the support to add tagging to s3 objects when using s3_dir_store. 

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
