### PR TITLE
SALTO-5808: fix notEnabledMissingReferencesValidator

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/not_enabled_missing_references.ts
+++ b/packages/zendesk-adapter/src/change_validators/not_enabled_missing_references.ts
@@ -94,7 +94,7 @@ export const notEnabledMissingReferencesValidator =
                   isReferenceExpression(part) &&
                   (!isResolvedReferenceExpression(part) || references.checkMissingRef(part.value))
                 ) {
-                  missingReferences.push(createMissingRefString(path, part.value))
+                  missingReferences.push(createMissingRefString(path, part))
                 }
               })
             }


### PR DESCRIPTION
fix notEnabledMissingReferencesValidator

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
