### PR TITLE
SALTO-5639 allow removing restriction field in views

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -266,7 +266,14 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
   },
   view__restriction: {
     transformation: {
-      fieldTypeOverrides: [{ fieldName: 'id', fieldType: 'unknown' }],
+      fieldTypeOverrides: [
+        { fieldName: 'id', fieldType: 'unknown' },
+        {
+          fieldName: 'type',
+          fieldType: 'string',
+          restrictions: { enforce_value: true, values: ['Group', 'User'] },
+        },
+      ],
     },
   },
   trigger: {

--- a/packages/zendesk-adapter/src/filters/view.ts
+++ b/packages/zendesk-adapter/src/filters/view.ts
@@ -44,6 +44,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
               .map((c: Values) => c.id)
               .filter(values.isDefined) ?? [],
         },
+        restriction: instance.value.restriction ?? null,
         // copying raw_title to title means that title might now be a dynamic content token
         // and not a raw string. Since the title field is hidden, this should be safe
         title: instance.value.raw_title,
@@ -53,7 +54,9 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
   },
   onDeploy: async changes => {
     await applyforInstanceChangesOfType(changes, [VIEW_TYPE_NAME], (instance: InstanceElement) => {
-      instance.value = _.omit(instance.value, ['all', 'any', 'output'])
+      const baseValuesToOmit = ['all', 'any', 'output']
+      const valuesToOmit = instance.value.restriction === null ? [...baseValuesToOmit, 'restriction'] : baseValuesToOmit
+      instance.value = _.omit(instance.value, valuesToOmit)
       return instance
     })
   },

--- a/packages/zendesk-adapter/src/filters/view.ts
+++ b/packages/zendesk-adapter/src/filters/view.ts
@@ -32,6 +32,7 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
     await applyforInstanceChangesOfType(changes, [VIEW_TYPE_NAME], (instance: InstanceElement) => {
       instance.value = {
         ...instance.value,
+        restriction: instance.value.restriction ?? null,
         all: (instance.value.conditions.all ?? []).map((e: Values) => ({ ...e, value: valToString(e.value) })),
         any: (instance.value.conditions.any ?? []).map((e: Values) => ({ ...e, value: valToString(e.value) })),
         output: {
@@ -44,7 +45,6 @@ const filterCreator: FilterCreator = ({ config, client }) => ({
               .map((c: Values) => c.id)
               .filter(values.isDefined) ?? [],
         },
-        restriction: instance.value.restriction ?? null,
         // copying raw_title to title means that title might now be a dynamic content token
         // and not a raw string. Since the title field is hidden, this should be safe
         title: instance.value.raw_title,

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -133,7 +133,7 @@ describe('views filter', () => {
     filter = filterCreator(createFilterCreatorParams({})) as FilterType
   })
 
-  describe('preDeploy', () => {
+  describe('preDeploy addition', () => {
     const clonedView = view.clone()
     beforeEach(async () => {
       const change = toChange({ after: clonedView })
@@ -182,8 +182,21 @@ describe('views filter', () => {
       expect(clonedView.value.raw_title).toEqual(clonedView.value.title)
     })
   })
+  describe('preDeploy modification', () => {
+    const clonedViewBefore = view.clone()
+    const clonedViewAfter = view.clone()
+    delete clonedViewAfter.value.restriction
+    beforeEach(async () => {
+      const change = toChange({ before: clonedViewBefore, after: clonedViewAfter })
+      await filter?.preDeploy([change])
+    })
 
-  describe('onDeploy', () => {
+    it('should add restriction field as null', async () => {
+      expect(clonedViewAfter.value.restriction).toEqual(null)
+    })
+  })
+
+  describe('onDeploy addition', () => {
     const clonedView = view.clone()
     beforeEach(async () => {
       clonedView.value.any = view.value.conditions.any
@@ -207,6 +220,23 @@ describe('views filter', () => {
     })
     it('should keep execution', async () => {
       expect(clonedView.value.execution).toBeDefined()
+    })
+  })
+  describe('onDeploy modification', () => {
+    const clonedViewBefore = view.clone()
+    const {
+      value: { restriction, ...viewWithoutRestriction },
+      ...restOfView
+    } = clonedViewBefore
+    const viewAfter = { ...restOfView, value: viewWithoutRestriction } as InstanceElement
+
+    beforeEach(async () => {
+      const change = toChange({ before: clonedViewBefore, after: viewAfter })
+      await filter?.onDeploy([change])
+    })
+
+    it('should remove restriction field', async () => {
+      expect(viewAfter.value.restriction).toBeUndefined()
     })
   })
 

--- a/packages/zendesk-adapter/test/filters/view.test.ts
+++ b/packages/zendesk-adapter/test/filters/view.test.ts
@@ -224,19 +224,15 @@ describe('views filter', () => {
   })
   describe('onDeploy modification', () => {
     const clonedViewBefore = view.clone()
-    const {
-      value: { restriction, ...viewWithoutRestriction },
-      ...restOfView
-    } = clonedViewBefore
-    const viewAfter = { ...restOfView, value: viewWithoutRestriction } as InstanceElement
-
+    const clonedViewAfter = view.clone()
+    clonedViewAfter.value.restriction = null
     beforeEach(async () => {
-      const change = toChange({ before: clonedViewBefore, after: viewAfter })
+      const change = toChange({ before: clonedViewBefore, after: clonedViewAfter })
       await filter?.onDeploy([change])
     })
 
     it('should remove restriction field', async () => {
-      expect(viewAfter.value.restriction).toBeUndefined()
+      expect(clonedViewAfter.value.restriction).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
When removing the restriction field in views, it must be set to null for the service to understand that it was on purpose.

---

When changing restrictions on views to "all agents", Zendesk sets the field to null. We should exhibit the same behavior as the service.

---
_Release Notes_: _None_

---
_User Notifications_: _None_