### PR TITLE
SALTO-4227: NS: SDF Loader shouldn't set attributes from the existing instance

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -1062,22 +1062,52 @@ describe('Netsuite adapter E2E with real account', () => {
         expect(loadedFeaturesInstance).toEqual(fetchedFeaturesInstance)
       })
 
-      it('should load existing folders correctly', async () => {
-        expect(findElement(loadedElements, topLevelFolder.elemID)).toEqual(alignInactiveFields(topLevelFolder))
-        expect(findElement(loadedElements, innerFolder.elemID)).toEqual(alignInactiveFields(innerFolder))
+      it('should load existing folder with default attributes when attributes were not passed', async () => {
+        expect(findElement(loadedElements, topLevelFolder.elemID)).toEqual(
+          alignInactiveFields(
+            new InstanceElement(
+              topLevelFolder.elemID.name,
+              additionalTypes[FOLDER],
+              {
+                bundleable: false,
+                isinactive: false,
+                isprivate: false,
+                path: '/SuiteScripts',
+              },
+              ['netsuite', 'FileCabinet', 'SuiteScripts', 'SuiteScripts'],
+              {
+                [CORE_ANNOTATIONS.ALIAS]: 'SuiteScripts',
+              },
+            ),
+          ),
+        )
       })
 
-      it('should load existing file with new content', async () => {
-        const loadedExistingFile = findElement(loadedElements, existingFileInstance.elemID) as InstanceElement
-        const loadedContent = loadedExistingFile.value.content
-        delete loadedExistingFile.value.content
-        delete existingFileInstance.value.content
-        expect(loadedExistingFile).toEqual(alignInactiveFields(existingFileInstance))
-        expect(loadedContent).toEqual(
-          new StaticFile({
-            filepath: 'netsuite/FileCabinet/SuiteScripts/b/existing.js',
-            content: Buffer.from('console.log("Hello Back!")'),
-          }),
+      it('should load existing file with default attributes when attributes were not passed, and with its new content', async () => {
+        expect(findElement(loadedElements, existingFileInstance.elemID)).toEqual(
+          alignInactiveFields(
+            new InstanceElement(
+              existingFileInstance.elemID.name,
+              additionalTypes[FILE],
+              {
+                availablewithoutlogin: false,
+                bundleable: false,
+                generateurltimestamp: false,
+                hideinbundle: false,
+                isinactive: false,
+                path: '/SuiteScripts/b/existing.js',
+                content: new StaticFile({
+                  filepath: 'netsuite/FileCabinet/SuiteScripts/b/existing.js',
+                  content: Buffer.from('console.log("Hello Back!")'),
+                }),
+              },
+              ['netsuite', 'FileCabinet', 'SuiteScripts', 'b', 'existing.js'],
+              {
+                [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(innerFolder.elemID)],
+                [CORE_ANNOTATIONS.ALIAS]: 'existing.js',
+              },
+            ),
+          ),
         )
       })
 

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -408,7 +408,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         ...fileCabinetContent,
         ...(this.userConfig.fetch.addBundles !== false ? bundlesCustomInfo : []),
       ]
-      const elements = await createElements(elementsToCreate, this.elementsSource, this.getElemIdFunc)
+      const elements = await createElements(elementsToCreate, this.getElemIdFunc)
       const [standardInstances, types] = _.partition(elements, isInstanceElement)
       const [objectTypes, otherTypes] = _.partition(types, isObjectType)
       const [customRecordTypes, standardTypes] = _.partition(objectTypes, isCustomRecordType)

--- a/packages/netsuite-adapter/src/client/sdf_parser.ts
+++ b/packages/netsuite-adapter/src/client/sdf_parser.ts
@@ -122,31 +122,25 @@ const convertToFileCustomizationInfo = ({
   xmlContent,
   path,
   fileContent,
-  hadMissingAttributes,
 }: {
   xmlContent: string
   path: string[]
   fileContent: Buffer
-  hadMissingAttributes: boolean
 }): FileCustomizationInfo => ({
   ...convertToCustomizationInfo(xmlContent),
   path,
   fileContent,
-  hadMissingAttributes,
 })
 
 const convertToFolderCustomizationInfo = ({
   xmlContent,
   path,
-  hadMissingAttributes,
 }: {
   xmlContent: string
   path: string[]
-  hadMissingAttributes: boolean
 }): FolderCustomizationInfo => ({
   ...convertToCustomizationInfo(xmlContent),
   path,
-  hadMissingAttributes,
 })
 
 export const convertToXmlContent = (customizationInfo: CustomizationInfo): string =>
@@ -232,7 +226,6 @@ const transformFiles = (
       xmlContent: xmlContent?.toString() ?? DEFAULT_FILE_ATTRIBUTES,
       path: filePathParts.slice(1),
       fileContent,
-      hadMissingAttributes: xmlContent === undefined,
     })
   }
 
@@ -252,7 +245,6 @@ const transformFolders = (
     return convertToFolderCustomizationInfo({
       xmlContent: xmlContent.toString(),
       path: folderPathParts.slice(1, -2),
-      hadMissingAttributes: false,
     })
   }
 
@@ -283,7 +275,6 @@ const transformFoldersWithoutAttributes = (
         convertToFolderCustomizationInfo({
           xmlContent: DEFAULT_FOLDER_ATTRIBUTES,
           path,
-          hadMissingAttributes: true,
         }),
       )
       .value()

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -46,12 +46,10 @@ export interface TemplateCustomTypeInfo extends CustomTypeInfo {
 export interface FileCustomizationInfo extends CustomizationInfo {
   path: string[]
   fileContent: Buffer
-  hadMissingAttributes?: boolean
 }
 
 export interface FolderCustomizationInfo extends CustomizationInfo {
   path: string[]
-  hadMissingAttributes?: boolean
 }
 
 export type FileCabinetCustomizationInfo = FileCustomizationInfo | FolderCustomizationInfo

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -41,7 +41,6 @@ const loadElementsFromFolder = async (
   const customizationInfos = await parseSdfProjectDir(baseDir)
   const elements = await createElements(
     customizationInfos.filter(custInfo => !TYPES_TO_SKIP.includes(custInfo.typeName)),
-    elementsSource,
     getElemIdFunc,
   )
   await filtersRunner.onFetch(elements)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -214,7 +214,6 @@ describe('Adapter', () => {
 
   describe('fetch', () => {
     it('should fetch all types and instances that are not in fetch.exclude', async () => {
-      const mockElementsSource = buildElementsSourceFromElements([])
       const folderCustomizationInfo: FolderCustomizationInfo = {
         typeName: FOLDER,
         values: {},
@@ -276,40 +275,25 @@ describe('Adapter', () => {
       )
       expect(isObjectType(customFieldType)).toBeTruthy()
       expect(elements).toContainEqual(
-        await createInstanceElement(
-          customTypeInfo,
-          customFieldType as ObjectType,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        ),
+        await createInstanceElement(customTypeInfo, customFieldType as ObjectType, mockGetElemIdFunc),
       )
 
       const file = elements.find(element => element.elemID.isEqual(new ElemID(NETSUITE, FILE)))
       expect(isObjectType(file)).toBeTruthy()
       expect(elements).toContainEqual(
-        await createInstanceElement(fileCustomizationInfo, file as ObjectType, mockElementsSource, mockGetElemIdFunc),
+        await createInstanceElement(fileCustomizationInfo, file as ObjectType, mockGetElemIdFunc),
       )
 
       const folder = elements.find(element => element.elemID.isEqual(new ElemID(NETSUITE, FOLDER)))
       expect(isObjectType(folder)).toBeTruthy()
       expect(elements).toContainEqual(
-        await createInstanceElement(
-          folderCustomizationInfo,
-          folder as ObjectType,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        ),
+        await createInstanceElement(folderCustomizationInfo, folder as ObjectType, mockGetElemIdFunc),
       )
 
       const featuresType = elements.find(element => element.elemID.isEqual(new ElemID(NETSUITE, CONFIG_FEATURES)))
       expect(isObjectType(featuresType)).toBeTruthy()
       expect(elements).toContainEqual(
-        await createInstanceElement(
-          featuresCustomTypeInfo,
-          featuresType as ObjectType,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        ),
+        await createInstanceElement(featuresCustomTypeInfo, featuresType as ObjectType, mockGetElemIdFunc),
       )
 
       expect(suiteAppImportFileCabinetMock).not.toHaveBeenCalled()

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1151,7 +1151,6 @@ describe('sdf client', () => {
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
           fileContent: 'dummy file content',
-          hadMissingAttributes: false,
         },
         {
           typeName: 'folder',
@@ -1159,7 +1158,6 @@ describe('sdf client', () => {
             description: 'folder description',
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
-          hadMissingAttributes: false,
         },
         {
           typeName: 'folder',
@@ -1170,7 +1168,6 @@ describe('sdf client', () => {
             isprivate: 'F',
           },
           path: ['Templates'],
-          hadMissingAttributes: true,
         },
         {
           typeName: 'folder',
@@ -1181,7 +1178,6 @@ describe('sdf client', () => {
             isprivate: 'F',
           },
           path: ['Templates', 'E-mail Templates'],
-          hadMissingAttributes: true,
         },
       ])
       expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
@@ -1283,7 +1279,6 @@ describe('sdf client', () => {
             description: 'folder description',
           },
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
-          hadMissingAttributes: false,
         },
       ])
       expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })

--- a/packages/netsuite-adapter/test/client/sdf_parser.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_parser.test.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash'
 import {
   OBJECTS_DIR,
   convertToFeaturesXmlContent,
@@ -23,7 +22,6 @@ import {
   parseObjectsDir,
   parseSdfProjectDir,
 } from '../../src/client/sdf_parser'
-import { isFileCustomizationInfo, isFolderCustomizationInfo } from '../../src/client/utils'
 import {
   MOCK_FEATURES_XML,
   MOCK_FILE_ATTRS_PATH,
@@ -111,64 +109,58 @@ describe('sdf parser', () => {
         MOCK_FOLDER_ATTRS_PATH,
         MOCK_FILE_WITHOUT_ATTRIBUTES_PATH,
       ])
-      const [objectsWithoutAttributes, objectsWithAttributes] = _.partition(objects, obj => obj.hadMissingAttributes)
-      expect(objectsWithAttributes).toEqual([
-        {
-          fileContent: 'dummy file content',
-          path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
-          typeName: 'file',
-          values: {
-            description: 'file description',
+      expect(objects).toEqual(
+        expect.arrayContaining([
+          {
+            fileContent: 'dummy file content',
+            path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
+            typeName: 'file',
+            values: {
+              description: 'file description',
+            },
           },
-          hadMissingAttributes: false,
-        },
-        {
-          path: ['Templates', 'E-mail Templates', 'InnerFolder'],
-          typeName: 'folder',
-          values: {
-            description: 'folder description',
+          {
+            path: ['Templates', 'E-mail Templates', 'InnerFolder'],
+            typeName: 'folder',
+            values: {
+              description: 'folder description',
+            },
           },
-          hadMissingAttributes: false,
-        },
-      ])
-      expect(objectsWithoutAttributes).toEqual([
-        {
-          fileContent: 'console.log("Hello World!")',
-          hadMissingAttributes: true,
-          path: ['Templates', 'E-mail Templates', 'InnerFolder', 'test.js'],
-          typeName: 'file',
-          values: {
-            availablewithoutlogin: 'F',
-            bundleable: 'F',
-            description: '',
-            generateurltimestamp: 'F',
-            hideinbundle: 'F',
-            isinactive: 'F',
+          {
+            fileContent: 'console.log("Hello World!")',
+            path: ['Templates', 'E-mail Templates', 'InnerFolder', 'test.js'],
+            typeName: 'file',
+            values: {
+              availablewithoutlogin: 'F',
+              bundleable: 'F',
+              description: '',
+              generateurltimestamp: 'F',
+              hideinbundle: 'F',
+              isinactive: 'F',
+            },
           },
-        },
-        {
-          typeName: 'folder',
-          values: {
-            bundleable: 'F',
-            description: '',
-            isinactive: 'F',
-            isprivate: 'F',
+          {
+            typeName: 'folder',
+            values: {
+              bundleable: 'F',
+              description: '',
+              isinactive: 'F',
+              isprivate: 'F',
+            },
+            path: ['Templates'],
           },
-          path: ['Templates'],
-          hadMissingAttributes: true,
-        },
-        {
-          typeName: 'folder',
-          values: {
-            bundleable: 'F',
-            description: '',
-            isinactive: 'F',
-            isprivate: 'F',
+          {
+            typeName: 'folder',
+            values: {
+              bundleable: 'F',
+              description: '',
+              isinactive: 'F',
+              isprivate: 'F',
+            },
+            path: ['Templates', 'E-mail Templates'],
           },
-          path: ['Templates', 'E-mail Templates'],
-          hadMissingAttributes: true,
-        },
-      ])
+        ]),
+      )
       expect(readFileMock).toHaveBeenCalledTimes(4)
       expect(readFileMock).toHaveBeenCalledWith(`/projectPath/src/FileCabinet${MOCK_FILE_PATH}`)
       expect(readFileMock).toHaveBeenCalledWith(`/projectPath/src/FileCabinet${MOCK_FILE_ATTRS_PATH}`)
@@ -198,94 +190,86 @@ describe('sdf parser', () => {
   })
   describe('parseSdfProjectDir', () => {
     it('should parse', async () => {
-      const [fileCabinetWithoutAttributes, objects] = _.partition(
-        await parseSdfProjectDir('/projectPath'),
-        obj => (isFileCustomizationInfo(obj) || isFolderCustomizationInfo(obj)) && obj.hadMissingAttributes,
+      const parsedContent = await parseSdfProjectDir('/projectPath')
+      expect(parsedContent).toEqual(
+        expect.arrayContaining([
+          {
+            fileContent: MOCK_TEMPLATE_CONTENT,
+            fileExtension: 'html',
+            scriptId: 'a',
+            typeName: 'addressForm',
+            values: {
+              '@_filename': 'a.xml',
+            },
+          },
+          {
+            scriptId: 'b',
+            typeName: 'addressForm',
+            values: {
+              '@_filename': 'b.xml',
+            },
+          },
+          {
+            fileContent: 'dummy file content',
+            path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
+            typeName: 'file',
+            values: {
+              description: 'file description',
+            },
+          },
+          {
+            path: ['Templates', 'E-mail Templates', 'InnerFolder'],
+            typeName: 'folder',
+            values: {
+              description: 'folder description',
+            },
+          },
+          {
+            typeName: 'companyFeatures',
+            values: {
+              feature: [
+                {
+                  id: 'SUITEAPPCONTROLCENTER',
+                  status: 'ENABLED',
+                },
+              ],
+            },
+          },
+          {
+            fileContent: 'console.log("Hello World!")',
+            path: ['Templates', 'E-mail Templates', 'InnerFolder', 'test.js'],
+            typeName: 'file',
+            values: {
+              availablewithoutlogin: 'F',
+              bundleable: 'F',
+              description: '',
+              generateurltimestamp: 'F',
+              hideinbundle: 'F',
+              isinactive: 'F',
+            },
+          },
+          {
+            typeName: 'folder',
+            values: {
+              bundleable: 'F',
+              description: '',
+              isinactive: 'F',
+              isprivate: 'F',
+            },
+            path: ['Templates'],
+          },
+          {
+            typeName: 'folder',
+            values: {
+              bundleable: 'F',
+              description: '',
+              isinactive: 'F',
+              isprivate: 'F',
+            },
+            path: ['Templates', 'E-mail Templates'],
+          },
+        ]),
       )
-      expect(objects).toEqual([
-        {
-          fileContent: MOCK_TEMPLATE_CONTENT,
-          fileExtension: 'html',
-          scriptId: 'a',
-          typeName: 'addressForm',
-          values: {
-            '@_filename': 'a.xml',
-          },
-        },
-        {
-          scriptId: 'b',
-          typeName: 'addressForm',
-          values: {
-            '@_filename': 'b.xml',
-          },
-        },
-        {
-          fileContent: 'dummy file content',
-          path: ['Templates', 'E-mail Templates', 'InnerFolder', 'content.html'],
-          typeName: 'file',
-          values: {
-            description: 'file description',
-          },
-          hadMissingAttributes: false,
-        },
-        {
-          path: ['Templates', 'E-mail Templates', 'InnerFolder'],
-          typeName: 'folder',
-          values: {
-            description: 'folder description',
-          },
-          hadMissingAttributes: false,
-        },
-        {
-          typeName: 'companyFeatures',
-          values: {
-            feature: [
-              {
-                id: 'SUITEAPPCONTROLCENTER',
-                status: 'ENABLED',
-              },
-            ],
-          },
-        },
-      ])
-      expect(fileCabinetWithoutAttributes).toEqual([
-        {
-          fileContent: 'console.log("Hello World!")',
-          hadMissingAttributes: true,
-          path: ['Templates', 'E-mail Templates', 'InnerFolder', 'test.js'],
-          typeName: 'file',
-          values: {
-            availablewithoutlogin: 'F',
-            bundleable: 'F',
-            description: '',
-            generateurltimestamp: 'F',
-            hideinbundle: 'F',
-            isinactive: 'F',
-          },
-        },
-        {
-          typeName: 'folder',
-          values: {
-            bundleable: 'F',
-            description: '',
-            isinactive: 'F',
-            isprivate: 'F',
-          },
-          path: ['Templates'],
-          hadMissingAttributes: true,
-        },
-        {
-          typeName: 'folder',
-          values: {
-            bundleable: 'F',
-            description: '',
-            isinactive: 'F',
-            isprivate: 'F',
-          },
-          path: ['Templates', 'E-mail Templates'],
-          hadMissingAttributes: true,
-        },
-      ])
     })
   })
   describe('convertToXmlContent', () => {

--- a/packages/netsuite-adapter/test/transformer.test.ts
+++ b/packages/netsuite-adapter/test/transformer.test.ts
@@ -15,7 +15,6 @@
  */
 import {
   BuiltinTypes,
-  CORE_ANNOTATIONS,
   ElemID,
   InstanceElement,
   ObjectType,
@@ -23,7 +22,7 @@ import {
   ServiceIds,
   StaticFile,
 } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements, naclCase } from '@salto-io/adapter-utils'
+import { naclCase } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { createInstanceElement, getLookUpName, toCustomizationInfo } from '../src/transformer'
 import {
@@ -39,7 +38,6 @@ import {
   FOLDER,
   PATH,
   CONFIG_FEATURES,
-  WORKFLOW,
   BUNDLE,
 } from '../src/constants'
 import {
@@ -237,10 +235,9 @@ describe('Transformer', () => {
   const bundle = bundleType().type
 
   describe('createInstanceElement', () => {
-    const mockElementsSource = buildElementsSourceFromElements([])
     const transformCustomFieldRecord = (custInfo: CustomTypeInfo): Promise<InstanceElement> => {
       const customFieldType = entitycustomfield
-      return createInstanceElement(custInfo, customFieldType, mockElementsSource, mockGetElemIdFunc)
+      return createInstanceElement(custInfo, customFieldType, mockGetElemIdFunc)
     }
 
     it('should create instance name correctly', async () => {
@@ -260,12 +257,7 @@ describe('Transformer', () => {
 
     it('should transform nested attributes', async () => {
       const customRecordTypeXmlContent = CUST_INFOS.WITH_NESTED_ATTRIBUTE
-      const result = await createInstanceElement(
-        customRecordTypeXmlContent,
-        customrecordtype,
-        mockElementsSource,
-        mockGetElemIdFunc,
-      )
+      const result = await createInstanceElement(customRecordTypeXmlContent, customrecordtype, mockGetElemIdFunc)
       expect(result.value[SCRIPT_ID]).toEqual('customrecord_my_script_id')
       const { customrecordcustomfields } = result.value
       expect(customrecordcustomfields).toBeDefined()
@@ -370,12 +362,7 @@ describe('Transformer', () => {
         fileContent: emailTemplateContent,
         fileExtension: 'html',
       } as TemplateCustomTypeInfo
-      const result = await createInstanceElement(
-        emailTemplateCustomizationInfo,
-        emailtemplate,
-        mockElementsSource,
-        mockGetElemIdFunc,
-      )
+      const result = await createInstanceElement(emailTemplateCustomizationInfo, emailtemplate, mockGetElemIdFunc)
       expect(result.value).toEqual({
         name: 'email template name',
         [SCRIPT_ID]: 'custemailtmpl_my_script_id',
@@ -395,12 +382,7 @@ describe('Transformer', () => {
           [SCRIPT_ID]: 'custemailtmpl_my_script_id',
         },
       } as CustomTypeInfo
-      const result = await createInstanceElement(
-        emailTemplateCustomizationInfo,
-        emailtemplate,
-        mockElementsSource,
-        mockGetElemIdFunc,
-      )
+      const result = await createInstanceElement(emailTemplateCustomizationInfo, emailtemplate, mockGetElemIdFunc)
       expect(result.value).toEqual({
         name: 'email template name',
         [SCRIPT_ID]: 'custemailtmpl_my_script_id',
@@ -415,7 +397,7 @@ describe('Transformer', () => {
           id: '4321',
         },
       } as CustomizationInfo
-      const result = await createInstanceElement(bundleCustomizationInfo, bundle, mockElementsSource, mockGetElemIdFunc)
+      const result = await createInstanceElement(bundleCustomizationInfo, bundle, mockGetElemIdFunc)
       expect(result.elemID.name).toEqual(`${BUNDLE}_${bundleCustomizationInfo.values.id}`)
     })
 
@@ -438,12 +420,12 @@ describe('Transformer', () => {
       }
 
       it('should create instance name correctly for file instance', async () => {
-        const result = await createInstanceElement(fileCustomizationInfo, file, mockElementsSource, mockGetElemIdFunc)
+        const result = await createInstanceElement(fileCustomizationInfo, file, mockGetElemIdFunc)
         expect(result.elemID.name).toEqual(`${NAME_FROM_GET_ELEM_ID}${naclCase(fileCustomizationInfo.path.join('/'))}`)
       })
 
       it('should create instance path correctly for file instance', async () => {
-        const result = await createInstanceElement(fileCustomizationInfo, file, mockElementsSource, mockGetElemIdFunc)
+        const result = await createInstanceElement(fileCustomizationInfo, file, mockGetElemIdFunc)
         expect(result.path).toEqual([
           NETSUITE,
           FILE_CABINET_PATH,
@@ -457,12 +439,7 @@ describe('Transformer', () => {
       it('should create instance path correctly for file instance when it has . prefix', async () => {
         const fileCustomizationInfoWithDotPrefix = _.clone(fileCustomizationInfo)
         fileCustomizationInfoWithDotPrefix.path = ['Templates', 'E-mail Templates', '.hiddenFolder', '..hiddenFile.xml']
-        const result = await createInstanceElement(
-          fileCustomizationInfoWithDotPrefix,
-          file,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        )
+        const result = await createInstanceElement(fileCustomizationInfoWithDotPrefix, file, mockGetElemIdFunc)
         expect(result.path).toEqual([
           NETSUITE,
           FILE_CABINET_PATH,
@@ -474,12 +451,7 @@ describe('Transformer', () => {
       })
 
       it('should create instance path correctly for folder instance', async () => {
-        const result = await createInstanceElement(
-          folderCustomizationInfo,
-          folder,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        )
+        const result = await createInstanceElement(folderCustomizationInfo, folder, mockGetElemIdFunc)
         expect(result.path).toEqual([
           NETSUITE,
           FILE_CABINET_PATH,
@@ -493,12 +465,7 @@ describe('Transformer', () => {
       it('should create instance path correctly for folder instance when it has . prefix', async () => {
         const folderCustomizationInfoWithDotPrefix = _.clone(folderCustomizationInfo)
         folderCustomizationInfoWithDotPrefix.path = ['Templates', 'E-mail Templates', '.hiddenFolder']
-        const result = await createInstanceElement(
-          folderCustomizationInfoWithDotPrefix,
-          folder,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        )
+        const result = await createInstanceElement(folderCustomizationInfoWithDotPrefix, folder, mockGetElemIdFunc)
         expect(result.path).toEqual([
           NETSUITE,
           FILE_CABINET_PATH,
@@ -510,118 +477,18 @@ describe('Transformer', () => {
       })
 
       it('should transform path field correctly', async () => {
-        const result = await createInstanceElement(fileCustomizationInfo, file, mockElementsSource, mockGetElemIdFunc)
+        const result = await createInstanceElement(fileCustomizationInfo, file, mockGetElemIdFunc)
         expect(result.value[PATH]).toEqual('/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html')
       })
 
       it('should set file content in the content field for file instance', async () => {
-        const result = await createInstanceElement(fileCustomizationInfo, file, mockElementsSource, mockGetElemIdFunc)
+        const result = await createInstanceElement(fileCustomizationInfo, file, mockGetElemIdFunc)
         expect(result.value.content).toEqual(
           new StaticFile({
             filepath: `${NETSUITE}/${FILE_CABINET_PATH}/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html`,
             content: Buffer.from('dummy file content'),
           }),
         )
-      })
-
-      describe('when missing attributes', () => {
-        const defaultFolder: FolderCustomizationInfo = {
-          typeName: FOLDER,
-          values: {
-            description: '',
-            bundleable: 'F',
-            isinactive: 'F',
-            isprivate: 'F',
-          },
-          path: ['Templates', 'E-mail Templates', 'Inner EmailTemplates Folder'],
-          hadMissingAttributes: true,
-        }
-        const defaultFile: FileCustomizationInfo = {
-          typeName: FILE,
-          values: {
-            description: '',
-            availablewithoutlogin: 'F',
-            bundleable: 'F',
-            generateurltimestamp: 'F',
-            hideinbundle: 'F',
-            isinactive: 'F',
-          },
-          path: ['Templates', 'E-mail Templates', 'Inner EmailTemplates Folder', 'content.html'],
-          fileContent: Buffer.from('other content'),
-          hadMissingAttributes: true,
-        }
-
-        it('should return folder with default attributes', async () => {
-          const result = await createInstanceElement(defaultFolder, folder, mockElementsSource, mockGetElemIdFunc)
-          expect(result.value).toEqual({
-            bundleable: false,
-            isinactive: false,
-            isprivate: false,
-            path: '/Templates/E-mail Templates/Inner EmailTemplates Folder',
-          })
-        })
-        it('should return file with default attributes', async () => {
-          const result = await createInstanceElement(defaultFile, file, mockElementsSource, mockGetElemIdFunc)
-          expect(result.value).toEqual({
-            availablewithoutlogin: false,
-            bundleable: false,
-            generateurltimestamp: false,
-            hideinbundle: false,
-            isinactive: false,
-            path: '/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
-            content: new StaticFile({
-              filepath: `${NETSUITE}/${FILE_CABINET_PATH}/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html`,
-              content: Buffer.from('other content'),
-            }),
-          })
-        })
-        it('should return existing folder instance if exists', async () => {
-          const existingFolderInstance = await createInstanceElement(
-            folderCustomizationInfo,
-            folder,
-            mockElementsSource,
-            mockGetElemIdFunc,
-          )
-          const result = await createInstanceElement(
-            defaultFolder,
-            folder,
-            buildElementsSourceFromElements([existingFolderInstance]),
-            mockGetElemIdFunc,
-          )
-          expect(result.value).toEqual({
-            description: 'folder description',
-            path: '/Templates/E-mail Templates/Inner EmailTemplates Folder',
-          })
-        })
-        it('should return existing file instance if exists with new content', async () => {
-          const existingFileInstance = await createInstanceElement(
-            fileCustomizationInfo,
-            file,
-            mockElementsSource,
-            mockGetElemIdFunc,
-          )
-          existingFileInstance.annotate({
-            [CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]: [
-              new ReferenceExpression(new ElemID(NETSUITE, WORKFLOW, 'instance', 'customworkflow1', SCRIPT_ID)),
-            ],
-          })
-          const result = await createInstanceElement(
-            defaultFile,
-            file,
-            buildElementsSourceFromElements([existingFileInstance]),
-            mockGetElemIdFunc,
-          )
-          expect(result.value).toEqual({
-            description: 'file description',
-            path: '/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html',
-            content: new StaticFile({
-              filepath: `${NETSUITE}/${FILE_CABINET_PATH}/Templates/E-mail Templates/Inner EmailTemplates Folder/content.html`,
-              content: Buffer.from('other content'),
-            }),
-          })
-          // should delete generated dependencies
-          expect(result.annotations).toEqual({})
-        })
       })
     })
 
@@ -634,12 +501,7 @@ describe('Transformer', () => {
         },
       }
       it('should create features instance correctly', async () => {
-        const result = await createInstanceElement(
-          featuresCustomizationInfo,
-          companyFeatures,
-          mockElementsSource,
-          mockGetElemIdFunc,
-        )
+        const result = await createInstanceElement(featuresCustomizationInfo, companyFeatures, mockGetElemIdFunc)
         expect(result.elemID.getFullName()).toEqual(`netsuite.${CONFIG_FEATURES}.instance`)
         expect(result.value).toEqual({
           feature: [{ id: 'TEST', label: 'test', status: 'ENABLED' }],


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
SALTO-4227: NS: SDF Loader shouldn't set attributes from the existing instance

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
