### PR TITLE
SALTO-5807: Add support for deleteMany for S3 dir store

### DIFF
--- a/packages/core/src/local-workspace/dir_store.ts
+++ b/packages/core/src/local-workspace/dir_store.ts
@@ -315,6 +315,12 @@ const buildLocalDirectoryStore = <T extends dirStore.ContentType>(
     getFullPath: filename => getAbsFileName(filename),
     isPathIncluded,
     exists: async (filename: string): Promise<boolean> => fileUtils.exists(getAbsFileName(filename)),
+    deleteMany: async (filePaths: string[]): Promise<void> => {
+      await withLimitedConcurrency(
+        filePaths.map(f => () => deleteFile(f)),
+        DELETE_CONCURRENCY,
+      )
+    },
   }
 }
 

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -94,6 +94,7 @@ const mockDirStore = <T extends dirStore.ContentType>(files: Record<string, T> =
     ),
     isPathIncluded: mockFunction<dirStore.DirectoryStore<T>['isPathIncluded']>(),
     exists: mockFunction<dirStore.DirectoryStore<T>['exists']>(),
+    deleteMany: mockFunction<dirStore.DirectoryStore<T>['deleteMany']>(),
   }
 }
 

--- a/packages/workspace/src/workspace/dir_store.ts
+++ b/packages/workspace/src/workspace/dir_store.ts
@@ -42,4 +42,5 @@ export type DirectoryStore<T extends ContentType> = {
   getFullPath(filename: string): string
   isPathIncluded(filePath: string): boolean
   exists: (filePath: string) => Promise<boolean>
+  deleteMany: (filePaths: string[]) => Promise<void>
 }

--- a/packages/workspace/src/workspace/static_files/common.ts
+++ b/packages/workspace/src/workspace/static_files/common.ts
@@ -62,4 +62,7 @@ export type StateStaticFilesSource = Pick<
   'getStaticFile' | 'persistStaticFile' | 'flush' | 'clear' | 'rename' | 'delete'
 >
 
-export type StateStaticFilesStore = Pick<DirectoryStore<Buffer>, 'get' | 'set' | 'list' | 'getFullPath' | 'flush'>
+export type StateStaticFilesStore = Pick<
+  DirectoryStore<Buffer>,
+  'get' | 'set' | 'list' | 'getFullPath' | 'flush' | 'deleteMany'
+>

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -325,6 +325,9 @@ export const mockDirStore = (
     exists: mockFunction<DirectoryStore<string>['exists']>().mockImplementation(async filename =>
       naclFiles.has(filename),
     ),
+    deleteMany: mockFunction<DirectoryStore<string>['deleteMany']>().mockImplementation(async filePaths => {
+      filePaths.forEach(filePath => naclFiles.delete(filePath))
+    }),
   }
 }
 

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -61,6 +61,7 @@ describe('Nacl Files Source', () => {
       getFullPath: filename => filename,
       isPathIncluded: jest.fn().mockResolvedValue(true),
       exists: jest.fn().mockResolvedValue(false),
+      deleteMany: jest.fn().mockResolvedValue(undefined),
     }
     mockedStaticFilesSource = mockStaticFilesSource()
   })

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -65,6 +65,7 @@ describe('Static Files', () => {
         getFullPath: mockFunction<DirectoryStore<Buffer>['getFullPath']>().mockImplementation(filename => filename),
         isPathIncluded: mockFunction<DirectoryStore<Buffer>['isPathIncluded']>().mockReturnValue(true),
         exists: mockFunction<DirectoryStore<Buffer>['exists']>().mockResolvedValue(true),
+        deleteMany: mockFunction<DirectoryStore<Buffer>['deleteMany']>(),
       }
       staticFilesSource = buildStaticFilesSource(mockDirStore, mockCacheStore)
     })

--- a/packages/workspace/test/workspace/static_files_sources/history_static_files_source.test.ts
+++ b/packages/workspace/test/workspace/static_files_sources/history_static_files_source.test.ts
@@ -41,6 +41,7 @@ describe('buildHistoryStateStaticFilesSource', () => {
       getFullPath: jest.fn(),
       isPathIncluded: jest.fn(),
       exists: jest.fn().mockResolvedValue(true),
+      deleteMany: jest.fn(),
     }
 
     staticFilesSource = buildHistoryStateStaticFilesSource(directoryStore)

--- a/packages/workspace/test/workspace/static_files_sources/override_static_files_source.test.ts
+++ b/packages/workspace/test/workspace/static_files_sources/override_static_files_source.test.ts
@@ -41,6 +41,7 @@ describe('buildOverrideStateStaticFilesSource', () => {
       getFullPath: jest.fn(),
       isPathIncluded: jest.fn(),
       exists: jest.fn().mockResolvedValue(true),
+      deleteMany: jest.fn(),
     }
 
     staticFilesSource = buildOverrideStateStaticFilesSource(directoryStore)


### PR DESCRIPTION
In this PR I added deleteMany interface to S3 dir store

---

_Additional context for reviewer_
1. We are sending a list as a parameter to the function since querying the object list costs money, whereas we can build the object suffix from the database.

---
_Release Notes_: 
_Core:_
* Added `deleteMany` abstraction to s3 dir store. 

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
