### PR TITLE
SALTO-5703 convert create-check-deployment-based-on-config-validator to work with definitions

### DIFF
--- a/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
@@ -56,6 +56,7 @@ import { ElementQuery, createElementQuery } from '../../fetch/query'
 import {
   createChangeValidator,
   deployNotSupportedValidator,
+  createCheckDeploymentBasedOnDefinitionsValidator,
   getDefaultChangeValidators,
 } from '../../deployment/change_validators'
 import { generateOpenApiTypes } from '../../openapi/type_elements/type_elements'
@@ -145,6 +146,13 @@ export class AdapterImpl<
     this.changeValidators = {
       ...getDefaultChangeValidators(),
       ...(this.definitions.deploy?.instances === undefined ? { deployNotSupported: deployNotSupportedValidator } : {}),
+      ...(this.definitions.deploy !== undefined
+        ? {
+            createCheckDeploymentBasedOnDefinitions: createCheckDeploymentBasedOnDefinitionsValidator({
+              deployDefinitions: this.definitions.deploy,
+            }),
+          }
+        : {}),
       ...additionalChangeValidators,
     }
     // TODO combine with infra changers after SALTO-5571

--- a/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
@@ -145,14 +145,13 @@ export class AdapterImpl<
     this.configInstance = configInstance
     this.changeValidators = {
       ...getDefaultChangeValidators(),
-      ...(this.definitions.deploy?.instances === undefined ? { deployNotSupported: deployNotSupportedValidator } : {}),
-      ...(this.definitions.deploy !== undefined
-        ? {
+      ...(this.definitions.deploy?.instances === undefined
+        ? { deployNotSupported: deployNotSupportedValidator }
+        : {
             createCheckDeploymentBasedOnDefinitions: createCheckDeploymentBasedOnDefinitionsValidator({
               deployDefinitions: this.definitions.deploy,
             }),
-          }
-        : {}),
+          }),
       ...additionalChangeValidators,
     }
     // TODO combine with infra changers after SALTO-5571

--- a/packages/adapter-components/src/adapter-wrapper/adapter_creator.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter_creator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import _ from 'lodash'
-import { InstanceElement, Adapter, AdapterAuthentication } from '@salto-io/adapter-api'
+import { InstanceElement, Adapter, AdapterAuthentication, ChangeValidator } from '@salto-io/adapter-api'
 import { FilterCreationArgs, createCommonFilters } from '../filters/common_filters'
 import { createClient } from '../client/client_creator'
 import { AdapterImplConstructor } from './adapter/types'
@@ -77,6 +77,7 @@ export const createAdapter = <
     customizeFilterCreators?: (
       args: FilterCreationArgs<Options, Co>,
     ) => Record<string, AdapterFilterCreator<Co, FilterResult, {}, Options>>
+    additionalChangeValidators?: Record<string, ChangeValidator>
   }
   clientDefaults?: Partial<Omit<ClientDefaults<ClientRateLimitConfig>, 'pageSize'>>
   customConvertError?: ConvertError
@@ -124,6 +125,7 @@ export const createAdapter = <
           ),
           adapterName,
           configInstance: context.config,
+          additionalChangeValidators: operationsCustomizations.additionalChangeValidators,
         },
         adapterImpl ?? AdapterImpl,
       )

--- a/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_definitions.ts
+++ b/packages/adapter-components/src/deployment/change_validators/check_deployment_based_on_definitions.ts
@@ -40,12 +40,15 @@ const { awu } = collections.asynciterable
 const { makeArray } = collections.array
 
 const createChangeErrors = <Options extends APIDefinitionsOptions = {}>(
-  typeConfig: DefaultWithCustomizations<DeployableRequestDefinition<ResolveClientOptionsType<Options>>[], ActionName>,
+  typeRequestDefinition: DefaultWithCustomizations<
+    DeployableRequestDefinition<ResolveClientOptionsType<Options>>[],
+    ActionName
+  >,
   instanceElemID: ElemID,
   action: ActionName,
 ): ChangeError[] => {
-  const requestsByAction = makeArray(queryWithDefault(typeConfig).query(action))
-  if (requestsByAction.length === 0 || requestsByAction.every(req => req.request.endpoint === undefined)) {
+  const actionRequests = makeArray(queryWithDefault(typeRequestDefinition).query(action))
+  if (actionRequests.length === 0 || actionRequests.every(req => req.request.endpoint === undefined)) {
     return [
       {
         elemID: instanceElemID,
@@ -58,16 +61,17 @@ const createChangeErrors = <Options extends APIDefinitionsOptions = {}>(
   return []
 }
 
+// This is the new version of the createCheckDeploymentBasedOnConfigValidator CV that support definitions
 export const createCheckDeploymentBasedOnDefinitionsValidator = <Options extends APIDefinitionsOptions = {}>({
-  typesConfig,
+  deployDefinitions,
   typesDeployedViaParent = [],
   typesWithNoDeploy = [],
 }: {
-  typesConfig: DeployApiDefinitions<ResolveAdditionalActionType<Options>, ResolveClientOptionsType<Options>>
+  deployDefinitions: DeployApiDefinitions<ResolveAdditionalActionType<Options>, ResolveClientOptionsType<Options>>
   typesDeployedViaParent?: string[]
   typesWithNoDeploy?: string[]
 }): ChangeValidator => {
-  const typeConfigQuery = queryWithDefault(typesConfig.instances)
+  const typeConfigQuery = queryWithDefault(deployDefinitions.instances)
   return async changes =>
     awu(changes)
       .map(async (change: Change<Element>): Promise<(ChangeError | undefined)[]> => {

--- a/packages/adapter-components/src/deployment/change_validators/index.ts
+++ b/packages/adapter-components/src/deployment/change_validators/index.ts
@@ -16,6 +16,7 @@
 export { deployTypesNotSupportedValidator } from './deploy_types_not_supported'
 export { deployNotSupportedValidator } from './deploy_not_supported'
 export { createCheckDeploymentBasedOnConfigValidator } from './check_deployment_based_on_config'
+export { createCheckDeploymentBasedOnDefinitionsValidator } from './check_deployment_based_on_definitions'
 export { createSkipParentsOfSkippedInstancesValidator } from './skip_parents_of_skipped_instances'
 export { createOutgoingUnresolvedReferencesValidator } from './outgoing_unresolved_references'
 export { getDefaultChangeValidators } from './default_change_validators'

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment_based_on_definitions.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment_based_on_definitions.test.ts
@@ -26,7 +26,7 @@ import { DeployApiDefinitions } from '../../../src/definitions/system/deploy'
 
 describe('checkDeploymentBasedOnDefinitionsValidator', () => {
   let type: ObjectType
-  const typesConfig: DeployApiDefinitions<never, never> = {
+  const deployDefinitions: DeployApiDefinitions<never, never> = {
     instances: {
       customizations: {
         test: {
@@ -54,13 +54,15 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
   })
 
   it('should not return an error when the changed element is not an instance', async () => {
-    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([toChange({ after: type })])
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ deployDefinitions })([
+      toChange({ after: type }),
+    ])
     expect(errors).toEqual([])
   })
 
   it('should return an error when type does not support deploy', async () => {
     const instance = new InstanceElement('test2', new ObjectType({ elemID: new ElemID('dum', 'test2') }))
-    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ deployDefinitions })([
       toChange({ after: instance }),
     ])
     expect(errors).toEqual([
@@ -75,7 +77,7 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
 
   it('should return an error when type does not support specific method', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ deployDefinitions })([
       toChange({ before: instance }),
     ])
     expect(errors).toEqual([
@@ -90,7 +92,7 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
 
   it('should not return an error when operation is supported', async () => {
     const instance = new InstanceElement('test', type)
-    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ deployDefinitions })([
       toChange({ after: instance }),
     ])
     expect(errors).toEqual([])
@@ -106,7 +108,7 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
     const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
-      typesConfig,
+      deployDefinitions,
       typesDeployedViaParent: [childTypeName],
     })([toChange({ after: instance })])
     expect(errors).toEqual([])
@@ -122,7 +124,7 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
       { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
     )
     const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
-      typesConfig,
+      deployDefinitions,
       typesDeployedViaParent: [childTypeName],
     })([toChange({ before: instance })])
     expect(errors).toEqual([
@@ -138,7 +140,7 @@ describe('checkDeploymentBasedOnDefinitionsValidator', () => {
     const typeName = 'testChild'
     const instance = new InstanceElement('test', new ObjectType({ elemID: new ElemID('dum', typeName) }))
     const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
-      typesConfig,
+      deployDefinitions,
       typesDeployedViaParent: [],
       typesWithNoDeploy: [typeName],
     })([toChange({ after: instance })])

--- a/packages/adapter-components/test/deployment/change_validators/check_deployment_based_on_definitions.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/check_deployment_based_on_definitions.test.ts
@@ -1,0 +1,147 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  toChange,
+} from '@salto-io/adapter-api'
+import { createCheckDeploymentBasedOnDefinitionsValidator } from '../../../src/deployment/change_validators/check_deployment_based_on_definitions'
+import { DeployApiDefinitions } from '../../../src/definitions/system/deploy'
+
+describe('checkDeploymentBasedOnDefinitionsValidator', () => {
+  let type: ObjectType
+  const typesConfig: DeployApiDefinitions<never, never> = {
+    instances: {
+      customizations: {
+        test: {
+          requestsByAction: {
+            customizations: {
+              add: [
+                {
+                  request: {
+                    endpoint: {
+                      path: '/test',
+                      method: 'post',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        },
+      },
+    },
+    dependencies: [],
+  }
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID('dum', 'test') })
+  })
+
+  it('should not return an error when the changed element is not an instance', async () => {
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([toChange({ after: type })])
+    expect(errors).toEqual([])
+  })
+
+  it('should return an error when type does not support deploy', async () => {
+    const instance = new InstanceElement('test2', new ObjectType({ elemID: new ElemID('dum', 'test2') }))
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+      toChange({ after: instance }),
+    ])
+    expect(errors).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Operation not supported',
+        detailedMessage: `Salto does not support "add" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
+      },
+    ])
+  })
+
+  it('should return an error when type does not support specific method', async () => {
+    const instance = new InstanceElement('test', type)
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+      toChange({ before: instance }),
+    ])
+    expect(errors).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Operation not supported',
+        detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
+      },
+    ])
+  })
+
+  it('should not return an error when operation is supported', async () => {
+    const instance = new InstanceElement('test', type)
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({ typesConfig })([
+      toChange({ after: instance }),
+    ])
+    expect(errors).toEqual([])
+  })
+  it('should not return an error when operation deployed via parent and parent is supported', async () => {
+    const childTypeName = 'testChild'
+    const parentInst = new InstanceElement('parent', type)
+    const instance = new InstanceElement(
+      'test',
+      new ObjectType({ elemID: new ElemID('dum', childTypeName) }),
+      undefined,
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
+    )
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
+      typesConfig,
+      typesDeployedViaParent: [childTypeName],
+    })([toChange({ after: instance })])
+    expect(errors).toEqual([])
+  })
+  it('should return an error when operation deployed via parent and parent is not supported', async () => {
+    const childTypeName = 'testChild'
+    const parentInst = new InstanceElement('parent', type)
+    const instance = new InstanceElement(
+      'test',
+      new ObjectType({ elemID: new ElemID('dum', childTypeName) }),
+      undefined,
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parentInst.elemID, parentInst)] },
+    )
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
+      typesConfig,
+      typesDeployedViaParent: [childTypeName],
+    })([toChange({ before: instance })])
+    expect(errors).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Operation not supported',
+        detailedMessage: `Salto does not support "remove" of ${instance.elemID.getFullName()}. Please see your business app FAQ at https://help.salto.io/en/articles/6927118-supported-business-applications for a list of supported elements.`,
+      },
+    ])
+  })
+  it('should not return an error when operation deployed type in in the skipped list', async () => {
+    const typeName = 'testChild'
+    const instance = new InstanceElement('test', new ObjectType({ elemID: new ElemID('dum', typeName) }))
+    const errors = await createCheckDeploymentBasedOnDefinitionsValidator({
+      typesConfig,
+      typesDeployedViaParent: [],
+      typesWithNoDeploy: [typeName],
+    })([toChange({ after: instance })])
+    expect(errors).toEqual([])
+  })
+})

--- a/packages/google-workspace-adapter/src/adapter_creator.ts
+++ b/packages/google-workspace-adapter/src/adapter_creator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, createAdapter, credentials } from '@salto-io/adapter-components'
+import { client as clientUtils, createAdapter, credentials, deployment } from '@salto-io/adapter-components'
 import { Credentials, basicCredentialsType } from './auth'
 import { DEFAULT_CONFIG, UserConfig } from './config'
 import { createConnectionForApp } from './client/connection'
@@ -49,6 +49,8 @@ const clientDefaults = {
   retry: DEFAULT_RETRY_OPTS,
 }
 
+const { createCheckDeploymentBasedOnDefinitionsValidator } = deployment.changeValidators
+
 export const adapter = createAdapter<Credentials, Options, UserConfig>({
   adapterName: ADAPTER_NAME,
   authenticationMethods: {
@@ -77,6 +79,11 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
   operationsCustomizations: {
     connectionCreatorFromConfig: () => createConnectionForApp(DIRECTORY_APP_NAME),
     credentialsFromConfig: defaultCredentialsFromConfig,
+    additionalChangeValidators: {
+      createCheckDeploymentBasedOnConfig: createCheckDeploymentBasedOnDefinitionsValidator({
+        typesConfig: createDeployDefinitions(),
+      }),
+    },
   },
   initialClients: {
     main: undefined,

--- a/packages/google-workspace-adapter/src/adapter_creator.ts
+++ b/packages/google-workspace-adapter/src/adapter_creator.ts
@@ -22,7 +22,7 @@ import { ADAPTER_NAME } from './constants'
 import { createClientDefinitions, createDeployDefinitions, createFetchDefinitions } from './definitions'
 import { PAGINATION } from './definitions/requests/pagination'
 import { REFERENCES } from './definitions/references'
-import { Options } from './definitions/types'
+import { ClientOptions, Options } from './definitions/types'
 import {
   CLOUD_IDENTITY_APP_NAME,
   DIRECTORY_APP_NAME,
@@ -80,7 +80,9 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
     connectionCreatorFromConfig: () => createConnectionForApp(DIRECTORY_APP_NAME),
     credentialsFromConfig: defaultCredentialsFromConfig,
     additionalChangeValidators: {
-      createCheckDeploymentBasedOnConfig: createCheckDeploymentBasedOnDefinitionsValidator({
+      createCheckDeploymentBasedOnConfig: createCheckDeploymentBasedOnDefinitionsValidator<{
+        clientOptions: ClientOptions
+      }>({
         typesConfig: createDeployDefinitions(),
       }),
     },

--- a/packages/google-workspace-adapter/src/adapter_creator.ts
+++ b/packages/google-workspace-adapter/src/adapter_creator.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { InstanceElement } from '@salto-io/adapter-api'
-import { client as clientUtils, createAdapter, credentials, deployment } from '@salto-io/adapter-components'
+import { client as clientUtils, createAdapter, credentials } from '@salto-io/adapter-components'
 import { Credentials, basicCredentialsType } from './auth'
 import { DEFAULT_CONFIG, UserConfig } from './config'
 import { createConnectionForApp } from './client/connection'
@@ -22,7 +22,7 @@ import { ADAPTER_NAME } from './constants'
 import { createClientDefinitions, createDeployDefinitions, createFetchDefinitions } from './definitions'
 import { PAGINATION } from './definitions/requests/pagination'
 import { REFERENCES } from './definitions/references'
-import { ClientOptions, Options } from './definitions/types'
+import { Options } from './definitions/types'
 import {
   CLOUD_IDENTITY_APP_NAME,
   DIRECTORY_APP_NAME,
@@ -48,8 +48,6 @@ const clientDefaults = {
   maxRequestsPerMinute: RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
   retry: DEFAULT_RETRY_OPTS,
 }
-
-const { createCheckDeploymentBasedOnDefinitionsValidator } = deployment.changeValidators
 
 export const adapter = createAdapter<Credentials, Options, UserConfig>({
   adapterName: ADAPTER_NAME,
@@ -79,13 +77,6 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
   operationsCustomizations: {
     connectionCreatorFromConfig: () => createConnectionForApp(DIRECTORY_APP_NAME),
     credentialsFromConfig: defaultCredentialsFromConfig,
-    additionalChangeValidators: {
-      createCheckDeploymentBasedOnConfig: createCheckDeploymentBasedOnDefinitionsValidator<{
-        clientOptions: ClientOptions
-      }>({
-        typesConfig: createDeployDefinitions(),
-      }),
-    },
   },
   initialClients: {
     main: undefined,


### PR DESCRIPTION
SALTO-5703 convert create-check-deployment-based-on-config-validator to work with definitions
---

_Additional context for reviewer_
Also added the option to pass additional CV to the new createAdapter func and pass the new definitions CV to google WS adapter

---
_Release Notes_: 
none

---
_User Notifications_: 
none