### PR TITLE
SALTO-5814 default service id field type if missing when replacing types during deploy

### DIFF
--- a/packages/adapter-components/src/deployment/placeholder_types.ts
+++ b/packages/adapter-components/src/deployment/placeholder_types.ts
@@ -15,7 +15,9 @@
  */
 import _ from 'lodash'
 import {
+  BuiltinTypes,
   Change,
+  Field,
   getChangeData,
   InstanceElement,
   isInstanceChange,
@@ -51,7 +53,8 @@ export const overrideInstanceTypeForDeploy = <Options extends FetchApiDefinition
   // make sure all service id fields are there even on additions (which might not have values for them)
   defQuery.query(typeName)?.resource?.serviceIDFields?.forEach(fieldName => {
     if (generatedType.type.fields[fieldName] === undefined) {
-      generatedType.type.fields[fieldName] = instance.getTypeSync().fields[fieldName]
+      generatedType.type.fields[fieldName] =
+        instance.getTypeSync().fields[fieldName] ?? new Field(generatedType.type, fieldName, BuiltinTypes.SERVICE_ID)
     }
   })
 

--- a/packages/adapter-components/test/deployment/placeholder_types.test.ts
+++ b/packages/adapter-components/test/deployment/placeholder_types.test.ts
@@ -23,6 +23,7 @@ import {
   getChangeData,
   Change,
   ListType,
+  Field,
 } from '@salto-io/adapter-api'
 import { SUBTYPES_PATH, TYPES_PATH } from '../../src/elements_deprecated'
 import { overrideInstanceTypeForDeploy, restoreInstanceTypeFromChange } from '../../src/deployment/placeholder_types'
@@ -157,6 +158,25 @@ describe('ducktype deployment functions', () => {
     it('should copy service id fields from type if they do not exist in the instance', () => {
       objType.fields.id = expectedType.fields.id
       delete instance.value.id
+      const instanceForDeploy = overrideInstanceTypeForDeploy({
+        instance,
+        defQuery: queryWithDefault<Pick<InstanceFetchApiDefinitions, 'element' | 'resource'>>({
+          default: {
+            resource: {
+              serviceIDFields: ['id'],
+            },
+          },
+          customizations: {
+            obj: {},
+          },
+        }),
+      })
+      expect(instanceForDeploy).toBeDefined()
+      expect(instanceForDeploy.refType.type).toEqual(expectedType)
+    })
+    it('should default to serviceid type if service id fields do not exist at all', () => {
+      delete instance.value.id
+      expectedType.fields.id = new Field(expectedType, 'id', BuiltinTypes.SERVICE_ID)
       const instanceForDeploy = overrideInstanceTypeForDeploy({
         instance,
         defQuery: queryWithDefault<Pick<InstanceFetchApiDefinitions, 'element' | 'resource'>>({


### PR DESCRIPTION
we create synthetic types during deploy in order to support creating the first instance of its type / other cases in ducktype adapters that might not have all fields defined accurately during fetch.
added a fallback in case a service id field does not exist at all (which happens when the first instance of its type is created)


---
_Release Notes_: 
None

---
_User Notifications_: 
None