### PR TITLE
Improving coverage in adapter-api

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -65,7 +65,6 @@ const StandardBuiltinTypes = {
 const restrictionType = new ObjectType({
   elemID: new ElemID(GLOBAL_ADAPTER, BUILTIN_TYPE_NAMES.RESTRICTION),
   fields: {
-    // eslint-disable-next-line camelcase
     enforce_value: {
       refType: new TypeReference(StandardBuiltinTypes.BOOLEAN.elemID, StandardBuiltinTypes.BOOLEAN),
     },
@@ -170,7 +169,7 @@ export const BuiltinTypes = {
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export const isServiceId = (type: any): boolean => type.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] ?? false
+export const isServiceId = (type: any): boolean => _.has(type, `annotations.${CORE_ANNOTATIONS.SERVICE_ID}`)
 
 export const BuiltinTypesByFullName: Record<string, PrimitiveType> = _.keyBy(Object.values(BuiltinTypes), builtinType =>
   builtinType.elemID.getFullName(),

--- a/packages/adapter-api/test/adapter.test.ts
+++ b/packages/adapter-api/test/adapter.test.ts
@@ -1,0 +1,137 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID } from '../src/element_id'
+import {
+  DependencyError,
+  isAdapterSuccessInstallResult,
+  isDependencyError,
+  isUnresolvedReferenceError,
+  setPartialFetchData,
+  toServiceIdsString,
+  UnresolvedReferenceError,
+} from '../src/adapter'
+
+describe('adapter', () => {
+  describe('setPartialFetchData', () => {
+    it('should return value when isPartial is true', () => {
+      const result = setPartialFetchData(true, [])
+      expect(result).toEqual({ isPartial: true, deletedElements: [] })
+    })
+
+    it('should return undefined when isPartial is false', () => {
+      const result = setPartialFetchData(false, [])
+      expect(result).toBeUndefined()
+    })
+  })
+
+  describe('isDependencyError', () => {
+    it('should return true for a dependency error', () => {
+      const result = isDependencyError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error with causeID',
+        detailedMessage: '',
+        causeID: new ElemID('adapter', 'cause'),
+      } as DependencyError)
+      expect(result).toEqual(true)
+    })
+
+    it('should return false for a non-dependency error', () => {
+      const result = isDependencyError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error without causeID',
+        detailedMessage: '',
+      })
+      expect(result).toEqual(false)
+    })
+  })
+
+  describe('isUnresolvedReferenceError', () => {
+    it('should return true for an unresolved reference error', () => {
+      const result = isUnresolvedReferenceError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error with causeID',
+        detailedMessage: '',
+        type: 'unresolvedReferences',
+        unresolvedElemIds: [],
+      } as UnresolvedReferenceError)
+      expect(result).toEqual(true)
+    })
+
+    it('should return false when no type is defined', () => {
+      const result = isUnresolvedReferenceError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error with causeID',
+        detailedMessage: '',
+        unresolvedElemIds: [],
+      } as UnresolvedReferenceError)
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when no unresolvedElemIds are defined', () => {
+      const result = isUnresolvedReferenceError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error with causeID',
+        detailedMessage: '',
+        type: 'unresolvedReferences',
+      } as UnresolvedReferenceError)
+      expect(result).toEqual(false)
+    })
+
+    it('should return false for a generic ChangeError', () => {
+      const result = isUnresolvedReferenceError({
+        elemID: new ElemID('adapter'),
+        severity: 'Error',
+        message: 'Error with causeID',
+        detailedMessage: '',
+      })
+      expect(result).toEqual(false)
+    })
+  })
+
+  describe('isAdapterSuccessInstallResult', () => {
+    it('should return true for successful result', () => {
+      const result = isAdapterSuccessInstallResult({
+        success: true,
+        installedVersion: 'version',
+      })
+      expect(result).toEqual(true)
+    })
+
+    it('should return false for unsuccessful result', () => {
+      const result = isAdapterSuccessInstallResult({
+        success: false,
+        errors: [],
+      })
+      expect(result).toEqual(false)
+    })
+  })
+
+  describe('toServiceIdsString', () => {
+    it('should return a sorted service IDs string', () => {
+      const result = toServiceIdsString({
+        service3: 'my service',
+        service1: 'my other service',
+        service10: "someone else's service",
+      })
+      expect(result).toEqual("service1,my other service,service10,someone else's service,service3,my service")
+    })
+  })
+})

--- a/packages/adapter-api/test/builtins.test.ts
+++ b/packages/adapter-api/test/builtins.test.ts
@@ -13,31 +13,44 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Values } from '../src/values'
-import { CORE_ANNOTATIONS, getRestriction, createRestriction } from '../src/builtins'
+import { CORE_ANNOTATIONS, getRestriction, createRestriction, isServiceId } from '../src/builtins'
 
 describe('builtins', () => {
   describe('getRestriction', () => {
-    let result: ReturnType<typeof getRestriction>
-    describe('when element has restriction', () => {
-      let annotations: Values
-      beforeEach(() => {
-        annotations = {
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ min: 10 }),
-        }
-        result = getRestriction({ annotations })
-      })
-      it('should a reference to the restriction', () => {
-        expect(result).toBe(annotations[CORE_ANNOTATIONS.RESTRICTION])
-      })
+    it('should a reference to the restriction when element has restriction', () => {
+      const annotations = {
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ min: 10 }),
+      }
+      const result = getRestriction({ annotations })
+      expect(result).toBe(annotations[CORE_ANNOTATIONS.RESTRICTION])
     })
-    describe('when element has no restriction', () => {
-      beforeEach(() => {
-        result = getRestriction({ annotations: {} })
+
+    it('should return an empty object when element has no restriction', () => {
+      const result = getRestriction({ annotations: {} })
+      expect(result).toEqual({})
+    })
+  })
+
+  describe('isServiceId', () => {
+    it('should return true when service ID is present', () => {
+      const result = isServiceId({
+        annotations: {
+          _service_id: 'ID',
+        },
       })
-      it('should return an empty object', () => {
-        expect(result).toEqual({})
+      expect(result).toEqual(true)
+    })
+
+    it('should return false when service ID is missing', () => {
+      const result = isServiceId({
+        annotations: {},
       })
+      expect(result).toEqual(false)
+    })
+
+    it('should return false when annotations are missing', () => {
+      const result = isServiceId({})
+      expect(result).toEqual(false)
     })
   })
 })

--- a/packages/adapter-api/test/comparison.test.ts
+++ b/packages/adapter-api/test/comparison.test.ts
@@ -1,0 +1,277 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID } from '../src/element_id'
+import { ReferenceExpression, StaticFile } from '../src/values'
+import { areReferencesEqual, compareSpecialValues, isEqualValues, shouldResolve } from '../src/comparison'
+
+describe('comparisons', () => {
+  describe('shouldResolve', () => {
+    it('should return true for non reference expressions', () => {
+      const result = shouldResolve({})
+      expect(result).toEqual(true)
+    })
+
+    it('should return true for non base elements', () => {
+      const result = shouldResolve(
+        new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'someInstance', 'nested')),
+      )
+      expect(result).toEqual(true)
+    })
+
+    it('should return true for vars', () => {
+      const result = shouldResolve(new ReferenceExpression(new ElemID('adapter', 'someType', 'var')))
+      expect(result).toEqual(true)
+    })
+
+    it('should return false for top level elements', () => {
+      const result = shouldResolve(new ReferenceExpression(new ElemID('adapter', 'someType')))
+      expect(result).toEqual(false)
+    })
+  })
+
+  describe('areReferencesEqual', () => {
+    const firstValue = 'first value'
+    const secondValue = 'second value'
+
+    let firstVisitedReferences: Set<string>
+    let secondVisitedReferences: Set<string>
+
+    beforeEach(() => {
+      firstVisitedReferences = new Set<string>()
+      secondVisitedReferences = new Set<string>()
+    })
+
+    describe('compare by value', () => {
+      const compareOptions = {
+        compareByValue: true,
+      }
+
+      it('should recurse when both are resolved references', () => {
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first'), firstValue),
+          second: new ReferenceExpression(
+            new ElemID('adapter', 'someType', 'instance', 'parent', 'second'),
+            secondValue,
+          ),
+          firstVisitedReferences,
+          secondVisitedReferences,
+          compareOptions,
+        })
+        expect(result).toEqual({
+          returnCode: 'recurse',
+          returnValue: {
+            firstValue,
+            secondValue,
+          },
+        })
+      })
+
+      it('should recurse when first is a resolved reference and second is a value', () => {
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first'), firstValue),
+          second: secondValue,
+          firstVisitedReferences,
+          secondVisitedReferences,
+          compareOptions,
+        })
+        expect(result).toEqual({
+          returnCode: 'recurse',
+          returnValue: {
+            firstValue,
+            secondValue,
+          },
+        })
+      })
+
+      it('should recurse when first is a value and second is a resolved reference', () => {
+        const result = areReferencesEqual({
+          first: firstValue,
+          second: new ReferenceExpression(
+            new ElemID('adapter', 'someType', 'instance', 'parent', 'second'),
+            secondValue,
+          ),
+          firstVisitedReferences,
+          secondVisitedReferences,
+          compareOptions,
+        })
+        expect(result).toEqual({
+          returnCode: 'recurse',
+          returnValue: {
+            firstValue,
+            secondValue,
+          },
+        })
+      })
+
+      it('should return false when both are values', () => {
+        const result = areReferencesEqual({
+          first: firstValue,
+          second: secondValue,
+          firstVisitedReferences,
+          secondVisitedReferences,
+          compareOptions,
+        })
+        expect(result).toEqual({
+          returnCode: 'return',
+          returnValue: false,
+        })
+      })
+
+      it('should recurse with undefined value for visited element', () => {
+        firstVisitedReferences.add('adapter.someType.instance.parent.first')
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first')),
+          second: secondValue,
+          firstVisitedReferences,
+          secondVisitedReferences,
+          compareOptions,
+        })
+        expect(result).toEqual({
+          returnCode: 'recurse',
+          returnValue: {
+            firstValue: undefined,
+            secondValue,
+          },
+        })
+      })
+    })
+
+    describe('compare by reference', () => {
+      it('should return true when references are equal', () => {
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'element')),
+          second: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'element')),
+          firstVisitedReferences,
+          secondVisitedReferences,
+        })
+        expect(result).toEqual({
+          returnCode: 'return',
+          returnValue: true,
+        })
+      })
+
+      it('should return false when references are different', () => {
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first')),
+          second: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'second')),
+          firstVisitedReferences,
+          secondVisitedReferences,
+        })
+        expect(result).toEqual({
+          returnCode: 'return',
+          returnValue: false,
+        })
+      })
+
+      it('should return false when first is a reference and second is a value', () => {
+        const result = areReferencesEqual({
+          first: new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first')),
+          second: secondValue,
+          firstVisitedReferences,
+          secondVisitedReferences,
+        })
+        expect(result).toEqual({
+          returnCode: 'return',
+          returnValue: false,
+        })
+      })
+    })
+  })
+
+  describe('compareSpecialValues', () => {
+    describe('compare by value', () => {
+      const options = {
+        compareByValue: true,
+      }
+
+      it('should return true for static files with identical content and different paths', () => {
+        const result = compareSpecialValues(
+          new StaticFile({
+            filepath: 'path/to/file',
+            hash: 'hash',
+          }),
+          new StaticFile({
+            filepath: 'path/to/file2',
+            hash: 'hash',
+          }),
+          options,
+        )
+        expect(result).toEqual(true)
+      })
+
+      it('should return true for resolved references with the same value', () => {
+        const result = compareSpecialValues(
+          new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'first'), 42),
+          new ReferenceExpression(new ElemID('adapter', 'someType', 'instance', 'parent', 'second'), 42),
+          options,
+        )
+        expect(result).toEqual(true)
+      })
+    })
+
+    describe('compare by reference', () => {
+      it('should return true for identical strings', () => {
+        const result = compareSpecialValues('abcd123', 'abcd123')
+        expect(result).toEqual(true)
+      })
+
+      it('should return true for strings that differ only by newline type', () => {
+        const result = compareSpecialValues('abcd\n123', 'abcd\r\n123')
+        expect(result).toEqual(true)
+      })
+
+      it('should return true for static files with identical content paths', () => {
+        const result = compareSpecialValues(
+          new StaticFile({
+            filepath: 'path/to/file',
+            hash: 'hash',
+          }),
+          new StaticFile({
+            filepath: 'path/to/file',
+            hash: 'hash',
+          }),
+        )
+        expect(result).toEqual(true)
+      })
+
+      it('should return true for references to the same element', () => {
+        const result = compareSpecialValues(
+          new ReferenceExpression(new ElemID('adapter', 'someType'), 42),
+          new ReferenceExpression(new ElemID('adapter', 'someType')),
+        )
+        expect(result).toEqual(true)
+      })
+
+      it('should return undefined for mismatched types', () => {
+        const result = compareSpecialValues('abcd123', 42)
+        expect(result).toBeUndefined()
+      })
+
+      it('should return false for type and reference', () => {
+        const result = compareSpecialValues(new ReferenceExpression(new ElemID('adapter', 'someType')), 42)
+        expect(result).toEqual(false)
+      })
+    })
+  })
+
+  describe('isEqualValues', () => {
+    it('should return true for equal values', () => {
+      const result = isEqualValues(42, 42)
+      expect(result).toEqual(true)
+    })
+  })
+})


### PR DESCRIPTION
Coverage dropped a bit lately in the SFDC adapter so making up for it a bit here.

---

Note that the implementation of `isServiceId` in `packages/adapter-api/src/builtins.ts` changed because the UT picked up on it not actually returning a boolean...

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
