### PR TITLE
Reverting isServiceId change

### DIFF
--- a/docs/syntax.md
+++ b/docs/syntax.md
@@ -6,6 +6,7 @@ The NaCl syntax allows defining configuration elements that usually describe bot
 Below is a document describing the syntax used to define these configuration elements
 
 This document describes the following topics:
+
 - [NaCl block types](#nacl-block-types)
 - [Primitive types and values](#primitive-types-and-values)
 - [Language features](#language-features)
@@ -15,6 +16,7 @@ This document describes the following topics:
 
 In the NaCl language there are several types of blocks. A block has one or more labels, followed by a scope that is marked with `{}`.
 The general block syntax is:
+
 ```HCL
 <label1> <label2> {
   <block content>
@@ -22,6 +24,7 @@ The general block syntax is:
 ```
 
 The following types of top level blocks are supported in NaCl:
+
 - [Type blocks](#type-blocks) - define types that are either user-defined types (in services that allow such customization) or Salto/adapter defined types that are used to describe the schema of configuration instances.
 - [Instance blocks](#instance-blocks) - hold actual configuration values.
 - [Settings blocks](#settings-types-and-instances) - A special case of types that allow only a single instance
@@ -31,6 +34,7 @@ The following types of top level blocks are supported in NaCl:
 
 Type blocks define or extend a type element in the configuration.
 Salto types have a few defining attributes:
+
 - A name that identifies the type
 - A type or category that describes what kind of value the type represents: `object`/`string`/`number`/`boolean`/`unknown` (most types are `object` types)
 - Annotation values - additional information about the type
@@ -38,6 +42,7 @@ Salto types have a few defining attributes:
 - Possible annotations that the type supports - defined under an `annotations` sub-block
 
 #### Syntax
+
 ```HCL
 type <type name> [is <type category>] {
   annotations {
@@ -54,6 +59,7 @@ type <type name> [is <type category>] {
 ```
 
 #### Example
+
 ```HCL
 type salto.address is string {
   // This defines a primitive string type with a possible label annotation
@@ -93,6 +99,7 @@ Instances are elements that hold configuration values.
 An instance structure is determined by its type, which must always be an object type.
 
 #### Syntax
+
 ```HCL
 <type name> <instance name> {
   <field name> = <value>
@@ -100,6 +107,7 @@ An instance structure is determined by its type, which must always be an object 
 ```
 
 #### Example
+
 ```HCL
 salto.office TLV {
   name = "Tel Aviv"
@@ -109,6 +117,7 @@ salto.office TLV {
 
 Instance values may include the fields specified by the instance's type as well as additional "untyped" values and a few built in annotations.
 All of these are written in the same way, for example
+
 ```HCL
 type salto.room {
   string name {
@@ -137,6 +146,7 @@ In order to define a type that supports only one instance, we use a block that i
 When defining an instance for a settings type, we use a block that is exactly the same as an [instance definition block](#instance-blocks), but we omit the instance name.
 
 #### Syntax
+
 ```HCL
 settings <type name> {
   // Definition of a settings type
@@ -159,6 +169,7 @@ settings <type name> {
 ```
 
 #### Example
+
 ```HCL
 settings salto.Security {
   number passwordExpiryDays {
@@ -178,6 +189,7 @@ salto.Security {
 Variables can be useful when a certain value repeats multiple times or when we want to extract a specific value from its element for documentation purposes.
 
 #### Syntax
+
 ```HCL
 vars {
   <variable name> = <value>
@@ -185,6 +197,7 @@ vars {
 ```
 
 #### Example
+
 ```HCL
 vars {
   text_field_length = 80
@@ -201,6 +214,7 @@ type salto.example {
 ```
 
 ## Primitive types and values
+
 The following types are supported in the language:
 | Name        | Example field definition | Example value  | Description
 |-------------|--------------------------|----------------|------------
@@ -214,16 +228,17 @@ The following types are supported in the language:
 | `json`      | json value {}            | "{ \"a\": 12 }"| A string value that expects the value to be in JSON format
 | `serviceid` | serviceid myid {}        | "ID"           | A string value that denotes an ID in the service (used by adapters to distinguish ID fields from other fields)
 
-
 ## Language features
 
 In addition to definition blocks, NaCl has several features relating to the configuration values it represents.
 These include:
+
 - [References](#references)
 - [Annotations](#annotations)
 - [Functions](#functions)
 
 ### References
+
 References in NaCl represent connections between configuration elements.
 These are useful to find direct and indirect relationships between configuration elements.
 References allow Salto to deploy changes in the correct order and it allows Salto users to perform more advanced analysis of the configuration.
@@ -231,7 +246,9 @@ References allow Salto to deploy changes in the correct order and it allows Salt
 References in NaCl are written as an [element ID](user_guide.md#salto-configuration-elements) and can be found anywhere a value can be written.
 
 #### Syntax
+
 The syntax of a reference is the same as the syntax of an element ID.
+
 ```HCL
 <service name>.<type name>
 <service name>.<type name>.field.<field name>
@@ -239,6 +256,7 @@ The syntax of a reference is the same as the syntax of an element ID.
 ```
 
 #### Examples
+
 ```HCL
 type salto.example {
   string field1 {
@@ -270,6 +288,7 @@ salto.example example_instance2 {
 ```
 
 ### Annotations
+
 Annotations are key-value pairs that represent important metadata about the block they are written in. Some are defined by Salto (built-in) and most are defined by service adapters (adapter-specific).
 
 Built-in annotations are available everywhere in Salto. Their names will always begin with `_` in order to distinguish them from adapter-specific annotations (adapters cannot define an annotation that starts with `_`).
@@ -277,6 +296,7 @@ Built-in annotations are available everywhere in Salto. Their names will always 
 Annotations can be of any primitive type, as well as complex types.
 
 Currently the following core annotations are supported:
+
 - [_required](#_required)
 - [_restriction](#_restriction)
 - [_hidden / _hidden_value](#_hidden--_hidden_value)
@@ -284,7 +304,7 @@ Currently the following core annotations are supported:
 - [_alias](#_alias)
 - [_generated_dependencies / _depends_on](#_generated_dependencies--_depends_on)
 - [_service_url](#_service_url)
-- [_is_service_id](#_is_service_id)
+- [_service_id](#_service_id)
 - [_created_by](#_created_by)
 - [_created_at](#_created_at)
 - [_changed_by](#_changed_by)
@@ -296,6 +316,7 @@ Currently the following core annotations are supported:
 - [_important_values / _self_important_values](#_important_values--_self_important_values)
 
 #### `_required`
+
 This annotation is used on field blocks to specify that an instance must contain a value for this field.
 Instances without a value for a required field will cause a validation warning.
 
@@ -305,7 +326,8 @@ Default: `false`
 
 Applicable to: Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example_type {
   string mandatory_field {
@@ -319,10 +341,12 @@ salto.example_type example_instance {
 ```
 
 #### `_restriction`
+
 This annotation is used on field blocks to specify restrictions on the values that are valid for this field.
 Instances with values that do not comply with these restrictions will cause a validation warning.
 
 Type:
+
 - enforce_value: `boolean` - when true, the restriction should be enforced and will create a validation warning, when false, the restriction is just a hint.
 - values: `list<string | number>` - a list of possible values, when this is specified, only these values are valid. The type of values is the list is determined by the type of the field.
 - min: `number` - relevant for number fields, specifies the minimum valid value (inclusive).
@@ -335,7 +359,8 @@ Default: `undefined`
 
 Applicable to: Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example_type {
   number restricted_num {
@@ -357,6 +382,7 @@ type salto.example_type {
 ```
 
 #### `_hidden` / `_hidden_value`
+
 These annotations are used to control which values appear in NaCl files and which are "hidden".
 hidden values are still part of the Salto element graph, but will not be represented in NaCl.
 
@@ -369,7 +395,8 @@ Default: `false`
 
 Applicable to: Fields, Types
 
-###### Example
+##### Example
+
 ```HCL
 type salto.hidden_number is number {
   _hidden_value = true
@@ -398,6 +425,7 @@ salto.example example_instance {
 ```
 
 #### `_parent`
+
 This is an annotation that can hold references to other elements to represent a parent-child relationship.
 
 Type: `List<reference>`
@@ -406,7 +434,8 @@ Default: `[]`
 
 Applicable to: Types, Instances
 
-###### Example
+##### Example
+
 ```HCL
 salto.example parent1 {
   name = "a parent configuration element"
@@ -442,7 +471,8 @@ Default: `undefined`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example_type_long_id {
   _alias = "Example Type"
@@ -458,6 +488,7 @@ salto.example_type_long_id example_instance_id_with_long_prefix {
 This annotation is used to define what are these elements' most important values. This list may be used in Salto enabled editors to highlight more important parts of the element, and index some of them for easy searchability. Important values are selected from annotations for types and from fields for instances. `_important_values` refer to fields in instances of the type whereas `_self_important_values` refers to fields of the type itself.
 
 Type: `Array` of objects of type:
+
 - value: `string` - A name of a field or annotation.
 - indexed: `boolean` - Specifies if the value should be indexed for easy searchability.
 - highlighted: `boolean` - Specifies if the value should be highlighted in the display.
@@ -466,7 +497,8 @@ Default: `undefined`
 
 Applicable to: Types
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   _important_values = [
@@ -486,8 +518,8 @@ type salto.example {
 }
 ```
 
-
 #### `_generated_dependencies` / `_depends_on`
+
 These are placeholders for additional references from one element to another.
 They are needed for cases where the dependency is not derived directly from the configuration.
 
@@ -500,7 +532,8 @@ Default: `[]`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   number field1 {
@@ -518,11 +551,13 @@ type salto.example {
 ```
 
 #### `_service_url`
+
 This is a hidden annotation (will not be seen in NaCl) that is used to store a URL for an element.
 Elements that have this annotation can support the "Go To Service" feature in Salto enabled editors.
 
-#### `_is_service_id`
-This boolean annotation is used to identify fields or types as ServiceId. a ServiceId is a value that denotes an ID in the service (used by adapters to distinguish ID fields from other fields). 
+#### `_service_id`
+
+This boolean annotation is used to identify fields or types as ServiceId. a ServiceId is a value that denotes an ID in the service (used by adapters to distinguish ID fields from other fields).
 
 Type: `boolean`
 
@@ -530,21 +565,22 @@ Default: `false`
 
 Applicable to: Types, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type serviceIdTypeExample {
-  _is_service_id = true
+  _service_id = true
 }
 
 type salto.example {
   string fieldWithServiceIdAnno {
-    _is_service_id = true
+    _service_id = true
   }
 }
 ```
 
-
 #### `_created_by`
+
 This is a hidden string annotation (will not be seen in NaCl) that is used to store a name of the user who created this element.
 
 Type: `string`
@@ -553,7 +589,8 @@ Default: `false`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   number field1 {
@@ -565,7 +602,9 @@ type salto.example {
   }
 }
 ```
+
 #### `_created_at`
+
 This is a hidden string annotation (will not be seen in NaCl) that is used to store the time the element was created.
 The time format is ISO-8601.
 
@@ -575,7 +614,8 @@ Default: `false`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   number field1 {
@@ -589,6 +629,7 @@ type salto.example {
 ```
 
 #### `_changed_by`
+
 This is a hidden string annotation (will not be seen in NaCl) that is used to store a name of the user who last changed this element.
 
 Type: `string`
@@ -597,7 +638,8 @@ Default: `false`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   number field1 {
@@ -611,6 +653,7 @@ type salto.example {
 ```
 
 #### `_changed_at`
+
 This is a hidden string annotation (will not be seen in NaCl) that is used to store the last time this element was changed.
 The time format is ISO-8601.
 
@@ -620,7 +663,8 @@ Default: `false`
 
 Applicable to: Types, Instances, Fields
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example {
   number field1 {
@@ -634,6 +678,7 @@ type salto.example {
 ```
 
 #### `_creatable`
+
 This is a hidden boolean annotation (will not be seen in NaCl) that is used to set whether creating instances of a type or certain value in it is supported.
 
 Type: `boolean`
@@ -643,7 +688,9 @@ Default: `true`
 Applicable to: Types, Fields
 
 ##### Example
+
 For the type:
+
 ```HCL
 type salto.example {
   number nonCreatableField {
@@ -657,6 +704,7 @@ type salto.example {
 ```
 
 The following new instance will be deployed without any error:
+
 ```HCL
 salto.example valid {
   creatableField = 1
@@ -664,6 +712,7 @@ salto.example valid {
 ```
 
 For the following new instance, a warning will be shown in the deploy preview:
+
 ```HCL
 salto.example invalid {
   creatableField = 1
@@ -672,6 +721,7 @@ salto.example invalid {
 ```
 
 #### `_updatable`
+
 This is a hidden boolean annotation (will not be seen in NaCl) that is used to set whether a modification of an instance or a certain value in an instance is supported.
 
 Type: `boolean`
@@ -680,8 +730,10 @@ Default: `true`
 
 Applicable to: Types, Fields
 
-###### Example
+##### Example
+
 For the types:
+
 ```HCL
 type salto.updatable {
   number nonUpdatableField {
@@ -701,6 +753,7 @@ type salto.notUpdatable {
 ```
 
 The following instance changes will be deployed without any error:
+
 ```HCL
 // before
 salto.updatable valid {
@@ -728,6 +781,7 @@ salto.updatable valid {
 ```
 
 For the following instance change, a warning will be shown to the user before deploying:
+
 ```HCL
 // before
 salto.updatable invalid {
@@ -743,6 +797,7 @@ salto.updatable invalid {
 ```
 
 For the following instance change, an error will be shown to the user on deploy and the change will not be deployed:
+
 ```HCL
 // before
 salto.notUpdatable invalid {
@@ -756,6 +811,7 @@ salto.notUpdatable invalid {
 ```
 
 #### `_deletable`
+
 This is a hidden boolean annotation (will not be seen in NaCl) that is used to set whether a deletion of an instance is supported.
 
 Type: `boolean`
@@ -764,8 +820,10 @@ Default: `true`
 
 Applicable to: Types
 
-###### Example
+##### Example
+
 For the types:
+
 ```HCL
 type salto.deletable {
   number someField {
@@ -781,6 +839,7 @@ type salto.notDeletable {
 ```
 
 The deletion of the following instance will be deployed without any error:
+
 ```HCL
 salto.deletable instance {
   someField = 2
@@ -788,6 +847,7 @@ salto.deletable instance {
 ```
 
 For the deletion of the following instance, an error will be shown to the user and the change will not be deployed:
+
 ```HCL
 salto.notDeletable instance {
   someField = 2
@@ -795,6 +855,7 @@ salto.notDeletable instance {
 ```
 
 #### `_additional_properties`
+
 This annotation can be used on types to specify whether the type allows additional properties.
 When it is set to false, values of this type may only contain the fields that this type allows, any additional value will cause a validation warning.
 
@@ -804,7 +865,8 @@ Default: `true`
 
 Applicable to: Types
 
-###### Example
+##### Example
+
 ```HCL
 type salto.example_type {
   number field {
@@ -819,8 +881,10 @@ salto.example_type example_instance {
 ```
 
 #### Adapter-specific annotations example
+
 Below we will use examples from the Salesforce adapter.
 In Salesforce it is possible to define custom types, these types have "label"s which are the names of these types as they show up in the salesforce UI. because of that, the Salto salesforce adapter supports a "label" annotation on custom types:
+
 ```HCL
 type salesforce.MyCustomLead__c {
   label = "My Custom Lead"
@@ -829,6 +893,7 @@ type salesforce.MyCustomLead__c {
 
 Annotations can also be complex.
 For example, when we create a custom field of type "Lookup" (which represent a relationship in salesforce), we can define a complex "filter" that chooses exactly which records in salesforce are the target of the relationship using the `lookupFilter` annotation:
+
 ```HCL
 type salesforce.MyCustomLead__c {
   salesforce.Lookup Case__c {
@@ -851,11 +916,13 @@ type salesforce.MyCustomLead__c {
 ### Functions
 
 Values in NaCl can be calculated using functions, function syntax in NaCl values is as follows:
+
 ```HCL
 <field name> = <function  name>(<parameter 1>, <parameter 2>, ...)
 ```
 
 In the example below, the value of the `logo` field in the instance would be the content of the `my_logo.png` file:
+
 ```HCL
 salto.example example_instance {
   logo = file("my_logo.png")
@@ -863,15 +930,17 @@ salto.example example_instance {
 ```
 
 Currently the following functions are available:
+
 - [file](#the-file-function)
 
 #### The `file` function
+
 Function signature: `file(path, encoding)`
 
 Arguments:
-  - `path`: The path of the file to load content from, relative to the `static-files` folder in the workspace.
-  - `encoding`: The encoding used to load the content of the file (default is `binary` - meaning, no encoding), this is usually useful for text files.
 
+- `path`: The path of the file to load content from, relative to the `static-files` folder in the workspace.
+- `encoding`: The encoding used to load the content of the file (default is `binary` - meaning, no encoding), this is usually useful for text files.
 
 ## Merge rules
 
@@ -879,6 +948,7 @@ Type and instance definitions may generally be split across multiple files / blo
 When parsing NaCl files, the Salto tools will load definitions from all files and merge them into one semantic element that contains the combination of all definition blocks.
 
 For example, the following two type definitions are equivalent:
+
 ```HCL
 type salto.test {
   string title {
@@ -890,7 +960,9 @@ type salto.test {
   }
 }
 ```
-and
+
+and:
+
 ```HCL
 type salto.test {
   string title {
@@ -901,6 +973,7 @@ type salto.test {
 ```
 
 The same goes from instance definitions, so the following definitions are equivalent:
+
 ```HCL
 salto.test my_test {
   title = "Sir"
@@ -910,7 +983,9 @@ salto.test my_test {
   name = "Configalot"
 }
 ```
-and
+
+and:
+
 ```HCL
 salto.test my_test {
   title = "Sir"
@@ -919,6 +994,7 @@ salto.test my_test {
 ```
 
 ### Value merging limitations
+
 When an instance is created it does not have to set values to all of the type fields.
 It's possible to create an instance in partial blocks, as long as:
 
@@ -950,6 +1026,7 @@ Note that `office` was set in both instance blocks but is still valid because `o
 In the above example, if we added a `name = "Salto TLV"` to the second office definition it would become invalid as it would attempt to define the primitive value of `name` in multiple blocks.
 
 The following example is **not valid** due to a conflicting definition of a list value:
+
 ```HCL
 salto employee john_doe {
   nicknames = ["Johnny"]
@@ -961,8 +1038,9 @@ salto employee john_doe {
 
 In the case of `settings` types the same rules apply, and since there are no instance name identifiers, all instance blocks of the same `settings` type will be merged into one.
 
-
 ### Type merging limitations
+
 When multiple type definitions have the same name we will attempt to merge them in the following way:
+
 - The type will contain field definitions from all blocks, as long as each field is defined once. if the same field name has more than one definition it will be considered an error.
 - Annotation values on the type itself will follow the same rules as [instance values](#value-merging-limitations).

--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -169,7 +169,7 @@ export const BuiltinTypes = {
 }
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
-export const isServiceId = (type: any): boolean => _.has(type, `annotations.${CORE_ANNOTATIONS.SERVICE_ID}`)
+export const isServiceId = (type: any): boolean => type.annotations?.[CORE_ANNOTATIONS.SERVICE_ID] ?? false
 
 export const BuiltinTypesByFullName: Record<string, PrimitiveType> = _.keyBy(Object.values(BuiltinTypes), builtinType =>
   builtinType.elemID.getFullName(),

--- a/packages/adapter-api/test/builtins.test.ts
+++ b/packages/adapter-api/test/builtins.test.ts
@@ -32,13 +32,22 @@ describe('builtins', () => {
   })
 
   describe('isServiceId', () => {
-    it('should return true when service ID is present', () => {
+    it('should return true when service ID is true', () => {
       const result = isServiceId({
         annotations: {
-          _service_id: 'ID',
+          _service_id: true,
         },
       })
       expect(result).toEqual(true)
+    })
+
+    it('should return false when service ID is false', () => {
+      const result = isServiceId({
+        annotations: {
+          _service_id: false,
+        },
+      })
+      expect(result).toEqual(false)
     })
 
     it('should return false when service ID is missing', () => {


### PR DESCRIPTION
The docs were a bit misleading so it wasn't clear that the `_service_id` annotation is a bool (and not `_is_service_id`), leading to the change in salto-io#5794.
Reverted the implementation and updated the test.
Also corrected the docs and fixed some lint warnings.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
