### PR TITLE
SALTO-5825: unit test example

### DIFF
--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -883,6 +883,22 @@ describe('Test utils.ts', () => {
 
         expect(result).toEqual({})
       })
+      it('should not remove empty undefined object', async () => {
+        const values = {
+          type: 'ID',
+          multiValue: false,
+          value: {
+            id: undefined
+          },
+        }
+        const result = await transformValues({
+          values,
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmpty: true,
+        })
+        expect(result).toEqual(values)
+      })
     })
   })
 


### PR DESCRIPTION
A unit test example of the problem in TransformValues where we remove empty items even when set to false

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
