### PR TITLE
SALTO-4820: Always Retrieve Settings Instances in Fetch With Changes Detection (Salesforce)

### DIFF
--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -82,10 +82,6 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
    * @param elements
    */
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
-    // SALTO-4820. This filter shouldn't run in quick fetch as it takes a relatively long time
-    if (config.fetchProfile.metadataQuery.isFetchWithChangesDetection()) {
-      return {}
-    }
     // Fetch list of all settings types
     const { elements: settingsList, configChanges: listObjectsConfigChanges } =
       await listMetadataObjects(client, SETTINGS_METADATA_TYPE, () => true)


### PR DESCRIPTION
Always Retrieve Settings Instances in Fetch With Changes Detection

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_