### PR TITLE
SALTO-5738 support deploy for page restrictions

### DIFF
--- a/packages/confluence-adapter/jest.config.js
+++ b/packages/confluence-adapter/jest.config.js
@@ -26,7 +26,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       branches: 85,
       functions: 89,
       lines: 93,
-      statements: 94,
+      statements: 93,
     },
   },
 })

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -42,6 +42,11 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         customizations: {
           add: [
             {
+              condition: {
+                transformForCheck: {
+                  omit: ['restriction', 'version'],
+                },
+              },
               request: {
                 endpoint: {
                   path: '/wiki/api/v2/pages',
@@ -52,9 +57,26 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 },
               },
             },
+            {
+              request: {
+                endpoint: {
+                  path: '/wiki/rest/api/content/{id}/restriction',
+                  method: 'put',
+                },
+                transformation: {
+                  pick: ['restriction'],
+                  adjust: ({ value }) => ({ value: { results: _.get(value, 'restriction') } }),
+                },
+              },
+            },
           ],
           modify: [
             {
+              condition: {
+                transformForCheck: {
+                  omit: ['restriction', 'version'],
+                },
+              },
               request: {
                 endpoint: {
                   path: '/wiki/api/v2/pages/{id}',
@@ -68,6 +90,18 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
               copyFromResponse: {
                 additional: {
                   pick: ['version.number'],
+                },
+              },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/wiki/rest/api/content/{id}/restriction',
+                  method: 'put',
+                },
+                transformation: {
+                  pick: ['restriction'],
+                  adjust: ({ value }) => ({ value: { results: _.get(value, 'restriction') } }),
                 },
               },
             },

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -42,11 +42,6 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         customizations: {
           add: [
             {
-              condition: {
-                transformForCheck: {
-                  omit: ['restriction', 'version'],
-                },
-              },
               request: {
                 endpoint: {
                   path: '/wiki/api/v2/pages',

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -312,15 +312,20 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
         transformation: {
           root: 'results',
-          adjust: item => ({
-            value: {
-              operation: _.get(item.value, 'operation'),
-              restrictions: {
-                user: _.get(item.value, 'restrictions.user.results'),
-                group: _.get(item.value, 'restrictions.group.results'),
+          adjust: ({ value }) => {
+            const userRestrictions = _.get(value, 'restrictions.user.results')
+            return {
+              value: {
+                operation: _.get(value, 'operation'),
+                restrictions: {
+                  user: Array.isArray(userRestrictions)
+                    ? userRestrictions.map(user => _.omit(user, ['publicName', 'profilePicture', 'displayName']))
+                    : userRestrictions,
+                  group: _.get(value, 'restrictions.group.results'),
+                },
               },
-            },
-          }),
+            }
+          },
         },
       },
     ],

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { definitions } from '@salto-io/adapter-components'
 import { Options } from '../types'
-import { adjustLabelsToIdsFunc } from '../transformation_utils'
+import { adjustLabelsToIdsFunc, adjustRestriction } from '../transformation_utils'
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
@@ -312,20 +312,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
         transformation: {
           root: 'results',
-          adjust: ({ value }) => {
-            const userRestrictions = _.get(value, 'restrictions.user.results')
-            return {
-              value: {
-                operation: _.get(value, 'operation'),
-                restrictions: {
-                  user: Array.isArray(userRestrictions)
-                    ? userRestrictions.map(user => _.omit(user, ['publicName', 'profilePicture', 'displayName']))
-                    : userRestrictions,
-                  group: _.get(value, 'restrictions.group.results'),
-                },
-              },
-            }
-          },
+          adjust: adjustRestriction,
         },
       },
     ],

--- a/packages/confluence-adapter/src/definitions/transformation_utils/index.ts
+++ b/packages/confluence-adapter/src/definitions/transformation_utils/index.ts
@@ -17,3 +17,4 @@
 export * from './generic'
 export * from './page'
 export * from './label'
+export * from './restriction'

--- a/packages/confluence-adapter/src/definitions/transformation_utils/restriction.ts
+++ b/packages/confluence-adapter/src/definitions/transformation_utils/restriction.ts
@@ -1,0 +1,35 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { definitions } from '@salto-io/adapter-components'
+
+/**
+ * Update the restriction format and omit redundant fields
+ */
+export const adjustRestriction: definitions.AdjustFunction = ({ value }) => {
+  const userRestrictions = _.get(value, 'restrictions.user.results')
+  return {
+    value: {
+      operation: _.get(value, 'operation'),
+      restrictions: {
+        user: Array.isArray(userRestrictions)
+          ? userRestrictions.map(user => _.omit(user, ['publicName', 'profilePicture', 'displayName']))
+          : userRestrictions,
+        group: _.get(value, 'restrictions.group.results'),
+      },
+    },
+  }
+}

--- a/packages/confluence-adapter/test/deploy_mock_replies.json
+++ b/packages/confluence-adapter/test/deploy_mock_replies.json
@@ -1,1 +1,6 @@
-[{"url":"/wiki/api/v2/pages/33","method":"DELETE","status":204,"response":"","headers":{}},{"url":"/wiki/rest/api/space/spaceKey","method":"PUT","status":200,"response":{"id":11,"key":"spaceKey","name":"space1","type":"personal","permissions":[],"status":"current"},"headers":{},"data":{}},{"url":"/wiki/api/v2/pages","method":"POST","status":200,"response":{"parentType":"page","id":"12345","title":"new page","status":"current","spaceId":"11"},"headers":{},"data":{}}]
+[
+  {"url":"/wiki/api/v2/pages/33","method":"DELETE","status":204,"response":"","headers":{}},
+  {"url":"/wiki/rest/api/space/spaceKey","method":"PUT","status":200,"response":{"id":11,"key":"spaceKey","name":"space1","type":"personal","permissions":[],"status":"current"},"headers":{},"data":{}},
+  {"url":"/wiki/api/v2/pages","method":"POST","status":200,"response":{"parentType":"page","id":"12345","title":"new page","status":"current","spaceId":"11"},"headers":{},"data":{}},
+  {"url":"/wiki/rest/api/content/12345/restriction","method":"PUT","status":200,"response":{"results":[]}}
+]

--- a/packages/confluence-adapter/test/transformation_utils/restriction.test.ts
+++ b/packages/confluence-adapter/test/transformation_utils/restriction.test.ts
@@ -1,0 +1,119 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { adjustRestriction } from '../../src/definitions/transformation_utils'
+
+describe('restriction transformation utils', () => {
+  describe('adjustRestriction', () => {
+    it('should remove redundant fields in user restrictions and extract items from the results fields', () => {
+      const item = {
+        typeName: 'mockType',
+        context: {},
+        value: {
+          restrictions: {
+            user: {
+              results: [
+                {
+                  type: 'known',
+                  accountId: 'account-id',
+                  accountType: 'atlassian',
+                  email: 'some@email.com',
+                  publicName: 'something',
+                  profilePicture: {
+                    path: '/some/oath',
+                    width: 48,
+                    height: 48,
+                    isDefault: false,
+                  },
+                  displayName: 'something',
+                  isExternalCollaborator: false,
+                  _expandable: {
+                    operations: '',
+                    personalSpace: '',
+                  },
+                  _links: {
+                    self: 'http://localhost/123',
+                  },
+                },
+              ],
+              start: 0,
+              limit: 100,
+              size: 1,
+            },
+            group: {
+              results: [
+                {
+                  type: 'group',
+                  name: 'group-name',
+                  id: 'group-id',
+                  _links: {
+                    self: 'http://localhost/123',
+                  },
+                },
+              ],
+              start: 0,
+              limit: 100,
+              size: 1,
+            },
+          },
+        },
+      }
+      expect(adjustRestriction(item).value).toEqual({
+        restrictions: {
+          user: [
+            {
+              type: 'known',
+              accountId: 'account-id',
+              accountType: 'atlassian',
+              email: 'some@email.com',
+              isExternalCollaborator: false,
+              _expandable: {
+                operations: '',
+                personalSpace: '',
+              },
+              _links: {
+                self: 'http://localhost/123',
+              },
+            },
+          ],
+          group: [
+            {
+              type: 'group',
+              name: 'group-name',
+              id: 'group-id',
+              _links: {
+                self: 'http://localhost/123',
+              },
+            },
+          ],
+        },
+      })
+    })
+    it('should return empty group and user restrictions if there are no restrictions', () => {
+      const item = {
+        typeName: 'mockType',
+        context: {},
+        value: {},
+      }
+      expect(adjustRestriction(item).value).toEqual({
+        restrictions: {
+          user: undefined,
+          group: undefined,
+        },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Clean up redundant details on restrictions on fetch + support deploy.

---

Tested on addition + modification

---
_Release Notes_: 
_Confluence Adapter_:
* Add support for deploying page restrictions

---
_User Notifications_: 
None