### PR TITLE
SALTO-5452 cv prevent deleting associated workflow

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -70,6 +70,7 @@ import { defaultAttributeValidator } from './assets/default_attribute'
 import { automationToAssetsValidator } from './automation/automation_to_assets'
 import { addJsmProjectValidator } from './adding_jsm_project'
 import { jsmPermissionsValidator } from './jsm/jsm_permissions'
+import { referencedWorkflowDeletionChangeValidator } from './workflowsV2/referenced_workflow_deletion'
 
 const { deployTypesNotSupportedValidator, createChangeValidator } = deployment.changeValidators
 
@@ -98,7 +99,9 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     automations: automationsValidator,
     activeSchemeDeletion: activeSchemeDeletionValidator,
     sameIssueTypeNameChange: sameIssueTypeNameChangeValidator,
+    referencedWorkflowDeletion: referencedWorkflowDeletionChangeValidator,
     statusMigrationChange: statusMigrationChangeValidator,
+    
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigration: workflowSchemeMigrationValidator(client, config, paginator),
     workflowStatusMappings: workflowStatusMappingsValidator,
@@ -131,6 +134,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     addJsmProject: addJsmProjectValidator,
     deleteLabelAtttribute: deleteLabelAtttributeValidator(config),
     jsmPermissions: jsmPermissionsValidator(config, client),
+    
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -101,7 +101,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     sameIssueTypeNameChange: sameIssueTypeNameChangeValidator,
     referencedWorkflowDeletion: referencedWorkflowDeletionChangeValidator,
     statusMigrationChange: statusMigrationChangeValidator,
-    
+
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigration: workflowSchemeMigrationValidator(client, config, paginator),
     workflowStatusMappings: workflowStatusMappingsValidator,
@@ -134,7 +134,6 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     addJsmProject: addJsmProjectValidator,
     deleteLabelAtttribute: deleteLabelAtttributeValidator(config),
     jsmPermissions: jsmPermissionsValidator(config, client),
-    
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -101,7 +101,6 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     sameIssueTypeNameChange: sameIssueTypeNameChangeValidator,
     referencedWorkflowDeletion: referencedWorkflowDeletionChangeValidator,
     statusMigrationChange: statusMigrationChangeValidator,
-
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigration: workflowSchemeMigrationValidator(client, config, paginator),
     workflowStatusMappings: workflowStatusMappingsValidator,

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -99,7 +99,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     automations: automationsValidator,
     activeSchemeDeletion: activeSchemeDeletionValidator,
     sameIssueTypeNameChange: sameIssueTypeNameChangeValidator,
-    referencedWorkflowDeletion: referencedWorkflowDeletionChangeValidator,
+    referencedWorkflowDeletion: referencedWorkflowDeletionChangeValidator(config),
     statusMigrationChange: statusMigrationChangeValidator,
     // Must run after statusMigrationChangeValidator
     workflowSchemeMigration: workflowSchemeMigrationValidator(client, config, paginator),

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -67,11 +67,12 @@ export const referencedWorkflowDeletionChangeValidator: ChangeValidator = async 
     .filter(isWorkflowV2Instance)
     .filter(async workflow => (await getReferencingWorkflowSchemes(workflow, elementSource)).length > 0)
     .map(async workflow => {
-      const schemes = (await getReferencingWorkflowSchemes(workflow, elementSource))
+      const schemes = await getReferencingWorkflowSchemes(workflow, elementSource)
       return {
-      elemID: workflow.elemID,
-      severity: 'Error' as SeverityLevel,
-      message: "Can't delete a referenced workflow.",
-      detailedMessage: `Workflow is referenced by the following workflow schemes: ${schemes.map(scheme => scheme.elemID.name)}.`,
-    }})
+        elemID: workflow.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: "Can't delete a referenced workflow.",
+        detailedMessage: `Workflow is referenced by the following workflow schemes: ${schemes.map(scheme => scheme.elemID.name)}.`,
+      }
+    })
     .toArray()

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -72,6 +72,6 @@ export const referencedWorkflowDeletionChangeValidator: ChangeValidator = async 
       elemID: workflow.elemID,
       severity: 'Error' as SeverityLevel,
       message: "Can't delete a referenced workflow.",
-      detailedMessage: `Workflow is referenced by the following workflow schemes: ${schemes.map(scheme => scheme.elemID.getFullName())}.`,
+      detailedMessage: `Workflow is referenced by the following workflow schemes: ${schemes.map(scheme => scheme.elemID.name)}.`,
     }})
     .toArray()

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -55,8 +55,9 @@ const getReferencingWorkflowSchemes = async (
   if (elementSource === undefined) {
     return awu([]).toArray()
   }
-  const schemes = awu(await getInstancesFromElementSource(elementSource, [WORKFLOW_SCHEME_TYPE_NAME]))
-  return schemes.filter(scheme => isWorkflowInScheme(scheme, workflow)).toArray()
+  return awu(await getInstancesFromElementSource(elementSource, [WORKFLOW_SCHEME_TYPE_NAME]))
+    .filter(scheme => isWorkflowInScheme(scheme, workflow))
+    .toArray()
 }
 
 export const referencedWorkflowDeletionChangeValidator: ChangeValidator = async (changes, elementSource) =>

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
 import {

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -1,0 +1,76 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { getInstancesFromElementSource } from '@salto-io/adapter-utils'
+import {
+  ChangeValidator,
+  SeverityLevel,
+  getChangeData,
+  isInstanceChange,
+  isRemovalChange,
+  InstanceElement,
+  ReadOnlyElementsSource,
+  isReferenceExpression
+} from '@salto-io/adapter-api'
+import { WorkflowV2Instance, isWorkflowV2Instance } from '../../filters/workflowV2/types'
+import { WORKFLOW_SCHEME_TYPE_NAME } from '../../constants'
+
+const { awu } = collections.asynciterable
+
+const isWorkflowInScheme = (scheme: InstanceElement, workflowInst: WorkflowV2Instance): boolean => {
+  if (
+    isReferenceExpression(scheme.value.defaultWorkflow) &&
+    workflowInst.elemID.isEqual(scheme.value.defaultWorkflow.elemID)
+  ) {
+    return true
+  }
+  const items = _.get(scheme.value, 'items')
+  if (Array.isArray(items)) {
+    return items
+      .map(obj => obj?.workflow)
+      .filter(isReferenceExpression)
+      .some(workflowRef => workflowRef.elemID.isEqual(workflowInst.elemID))
+  }
+  return false
+}
+
+const hasReferencingWorkflowSchemes = async (
+  workflow: WorkflowV2Instance,
+  elementSource?: ReadOnlyElementsSource,
+): Promise<boolean> => {
+  if (elementSource === undefined) {
+    return false
+  }
+  const schemes = await getInstancesFromElementSource(elementSource, [WORKFLOW_SCHEME_TYPE_NAME])
+
+  return schemes.some(scheme => isWorkflowInScheme(scheme, workflow))
+}
+
+export const referencedWorkflowDeletionChangeValidator: ChangeValidator = async (changes, elementSource) =>
+  awu(changes)
+    .filter(isInstanceChange)
+    .filter(isRemovalChange)
+    .map(getChangeData)
+    .filter(isWorkflowV2Instance)
+    .filter(workflow => hasReferencingWorkflowSchemes(workflow, elementSource))
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: "Can't delete a referenced workflow.",
+      detailedMessage: "Workflows referenced by workflow schemes can't be deleted.",
+    }))
+    .toArray()

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -209,6 +209,7 @@ export type ChangeValidatorName =
   | 'emptyValidatorWorkflowChange'
   | 'readOnlyWorkflow'
   | 'dashboardGadgets'
+  | 'referencedWorkflowDeletion'
   | 'dashboardLayout'
   | 'permissionType'
   | 'automations'
@@ -268,6 +269,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     status: { refType: BuiltinTypes.BOOLEAN },
     privateApi: { refType: BuiltinTypes.BOOLEAN },
     emptyValidatorWorkflowChange: { refType: BuiltinTypes.BOOLEAN },
+    referencedWorkflowDeletion: {refType: BuiltinTypes.BOOLEAN},
     readOnlyWorkflow: { refType: BuiltinTypes.BOOLEAN },
     dashboardGadgets: { refType: BuiltinTypes.BOOLEAN },
     dashboardLayout: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -269,7 +269,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     status: { refType: BuiltinTypes.BOOLEAN },
     privateApi: { refType: BuiltinTypes.BOOLEAN },
     emptyValidatorWorkflowChange: { refType: BuiltinTypes.BOOLEAN },
-    referencedWorkflowDeletion: {refType: BuiltinTypes.BOOLEAN},
+    referencedWorkflowDeletion: { refType: BuiltinTypes.BOOLEAN },
     readOnlyWorkflow: { refType: BuiltinTypes.BOOLEAN },
     dashboardGadgets: { refType: BuiltinTypes.BOOLEAN },
     dashboardLayout: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -409,9 +409,7 @@ const getWorkflowPayload = (
   return workflowPayload
 }
 
-export const getWorkflowsFromWorkflowScheme = async (
-  workflowSchemeInstance: InstanceElement,
-): Promise<ReferenceExpression[]> => {
+export const getWorkflowsFromWorkflowScheme = (workflowSchemeInstance: InstanceElement): ReferenceExpression[] => {
   const { defaultWorkflow } = workflowSchemeInstance.value
   const workflows = makeArray(workflowSchemeInstance.value.items)
     .filter(isWorkflowSchemeItem)

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -409,7 +409,7 @@ const getWorkflowPayload = (
   return workflowPayload
 }
 
-const getWorkflowsFromWorkflowScheme = async (
+export const getWorkflowsFromWorkflowScheme = async (
   workflowSchemeInstance: InstanceElement,
 ): Promise<ReferenceExpression[]> => {
   const { defaultWorkflow } = workflowSchemeInstance.value

--- a/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
@@ -14,13 +14,7 @@
  * limitations under the License.
  */
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import {
-  toChange,
-  InstanceElement,
-  ReferenceExpression,
-  ReadOnlyElementsSource,
-  SeverityLevel,
-} from '@salto-io/adapter-api'
+import { toChange, InstanceElement, ReferenceExpression, ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { referencedWorkflowDeletionChangeValidator } from '../../../src/change_validators/workflowsV2/referenced_workflow_deletion'
 import { ISSUE_TYPE_NAME, WORKFLOW_SCHEME_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType, createSkeletonWorkflowV2Instance } from '../../utils'
@@ -93,9 +87,9 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
     expect(result).toEqual([
       {
         elemID: referencedWorkflowInstance.elemID,
-        severity: 'Error' as SeverityLevel,
+        severity: 'Error',
         message: "Can't delete a referenced workflow.",
-        detailedMessage: `Workflow is referenced by the following workflow schemes: ${[referencingSchemeInstance.elemID.name]}.`,
+        detailedMessage: 'Workflow is referenced by the following workflow schemes: referencingSchemeInstance.',
       },
     ])
   })
@@ -109,9 +103,10 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
     expect(result).toEqual([
       {
         elemID: defaultWorkflowInstance.elemID,
-        severity: 'Error' as SeverityLevel,
+        severity: 'Error',
         message: "Can't delete a referenced workflow.",
-        detailedMessage: `Workflow is referenced by the following workflow schemes: ${[defaultSchemeInstance.elemID.name, referencingSchemeInstance.elemID.name]}.`,
+        detailedMessage:
+          'Workflow is referenced by the following workflow schemes: defaultSchemeInstance, referencingSchemeInstance.',
       },
     ])
   })

--- a/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
@@ -1,0 +1,113 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import {
+  toChange,
+  InstanceElement,
+  ReferenceExpression,
+  ReadOnlyElementsSource,
+  SeverityLevel,
+} from '@salto-io/adapter-api'
+import { referencedWorkflowDeletionChangeValidator } from '../../../src/change_validators/workflowsV2/referenced_workflow_deletion'
+import { WORKFLOW_SCHEME_TYPE_NAME } from '../../../src/constants'
+import { createEmptyType, createSkeletonWorkflowV2Instance } from '../../utils'
+
+
+describe('referencedWorkflowDeletionChangeValidator', () => {
+  const workflowSchemeObjectType = createEmptyType(WORKFLOW_SCHEME_TYPE_NAME)
+  let defaultSchemeInstance: InstanceElement
+  let referencingSchemeInstance: InstanceElement
+  let referencedWorkflowInstance: InstanceElement
+  let unreferencedWorkflowInstance: InstanceElement
+  let defaultWorkflowInstance: InstanceElement
+  let elementSource: ReadOnlyElementsSource
+
+  beforeEach(() => {
+    defaultWorkflowInstance = createSkeletonWorkflowV2Instance('defaultWorkflowInstance')
+    referencedWorkflowInstance = createSkeletonWorkflowV2Instance('referencedWorkflowInstance')
+    unreferencedWorkflowInstance = createSkeletonWorkflowV2Instance('unreferencedWorkflowInstance')
+
+    defaultSchemeInstance = new InstanceElement('defaultSchemeInstance', workflowSchemeObjectType, {
+      name: 'defaultSchemeInstance',
+      defaultWorkflow: new ReferenceExpression(defaultWorkflowInstance.elemID),
+      items: [],
+    })
+    referencingSchemeInstance = new InstanceElement('referencingSchemeInstance', workflowSchemeObjectType, {
+      defaultWorkflow: new ReferenceExpression(defaultWorkflowInstance.elemID),
+      name: 'referencingSchemeInstance',
+      items: [{ workflow: new ReferenceExpression(referencedWorkflowInstance.elemID) }],
+    })
+  })
+
+  it('should succeed because the deleted workflow is unreferenced.', async () => {
+    elementSource = buildElementsSourceFromElements([
+      defaultWorkflowInstance,
+      referencedWorkflowInstance,
+      referencingSchemeInstance,
+    ])
+    const result = await referencedWorkflowDeletionChangeValidator(
+      [toChange({ before: unreferencedWorkflowInstance })],
+      elementSource,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should succeed because the deleted workflow is unreferenced after changing the referencing workflow scheme.', async () => {
+    const afterScheme = referencingSchemeInstance.clone()
+    afterScheme.value.items[0].workflow = new ReferenceExpression(defaultWorkflowInstance.elemID)
+    elementSource = buildElementsSourceFromElements([defaultWorkflowInstance, afterScheme])
+    const result = await referencedWorkflowDeletionChangeValidator(
+      [
+        toChange({ before: referencingSchemeInstance, after: afterScheme }),
+        toChange({ before: referencedWorkflowInstance }),
+      ],
+      elementSource,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should fail because the deleted workflow is referenced.', async () => {
+    elementSource = buildElementsSourceFromElements([defaultWorkflowInstance, referencingSchemeInstance])
+    const result = await referencedWorkflowDeletionChangeValidator(
+      [toChange({ before: referencedWorkflowInstance })],
+      elementSource,
+    )
+    expect(result).toEqual([
+      {
+        elemID: referencedWorkflowInstance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: "Can't delete a referenced workflow.",
+        detailedMessage: `Workflow is referenced by the following workflow schemes: ${[referencingSchemeInstance.elemID.name]}.`,
+      },
+    ])
+  })
+
+  it('should fail because the deleted workflow is referenced as a default workflow in a workflow scheme.', async () => {
+    elementSource = buildElementsSourceFromElements([defaultSchemeInstance, referencingSchemeInstance])
+    const result = await referencedWorkflowDeletionChangeValidator(
+      [toChange({ before: defaultWorkflowInstance })],
+      elementSource,
+    )
+    expect(result).toEqual([
+      {
+        elemID: defaultWorkflowInstance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: "Can't delete a referenced workflow.",
+        detailedMessage: `Workflow is referenced by the following workflow schemes: ${[defaultSchemeInstance.elemID.name, referencingSchemeInstance.elemID.name]}.`,
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
@@ -13,8 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from 'lodash'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { toChange, InstanceElement, ReferenceExpression, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
 import { referencedWorkflowDeletionChangeValidator } from '../../../src/change_validators/workflowsV2/referenced_workflow_deletion'
 import { ISSUE_TYPE_NAME, WORKFLOW_SCHEME_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType, createSkeletonWorkflowV2Instance } from '../../utils'
@@ -28,8 +30,11 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
   let unreferencedWorkflowInstance: InstanceElement
   let defaultWorkflowInstance: InstanceElement
   let elementSource: ReadOnlyElementsSource
+  let config: JiraConfig
 
   beforeEach(() => {
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.enableNewWorkflowAPI = true
     defaultWorkflowInstance = createSkeletonWorkflowV2Instance('defaultWorkflowInstance')
     referencedWorkflowInstance = createSkeletonWorkflowV2Instance('referencedWorkflowInstance')
     unreferencedWorkflowInstance = createSkeletonWorkflowV2Instance('unreferencedWorkflowInstance')
@@ -51,24 +56,24 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
     })
   })
 
-  it("shouldn't raise an error because the deleted workflow is unreferenced.", async () => {
+  it("shouldn't raise an error when the deleted workflow is unreferenced.", async () => {
     elementSource = buildElementsSourceFromElements([
       defaultWorkflowInstance,
       referencedWorkflowInstance,
       referencingSchemeInstance,
     ])
-    const result = await referencedWorkflowDeletionChangeValidator(
+    const result = await referencedWorkflowDeletionChangeValidator(config)(
       [toChange({ before: unreferencedWorkflowInstance })],
       elementSource,
     )
     expect(result).toEqual([])
   })
 
-  it("shouldn't raise an error because the deleted workflow is unreferenced after changing the referencing workflow scheme.", async () => {
+  it("shouldn't raise an error when the deleted workflow is unreferenced after changing the referencing workflow scheme.", async () => {
     const afterScheme = referencingSchemeInstance.clone()
     afterScheme.value.items[0].workflow = new ReferenceExpression(defaultWorkflowInstance.elemID)
     elementSource = buildElementsSourceFromElements([defaultWorkflowInstance, afterScheme])
-    const result = await referencedWorkflowDeletionChangeValidator(
+    const result = await referencedWorkflowDeletionChangeValidator(config)(
       [
         toChange({ before: referencingSchemeInstance, after: afterScheme }),
         toChange({ before: referencedWorkflowInstance }),
@@ -78,9 +83,19 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
     expect(result).toEqual([])
   })
 
-  it('should raise an error because the deleted workflow is referenced.', async () => {
+  it("shouldn't raise an error when enableNewWorkflowAPI is false, as the validator is skipped.", async () => {
+    config.fetch.enableNewWorkflowAPI = false
     elementSource = buildElementsSourceFromElements([defaultWorkflowInstance, referencingSchemeInstance])
-    const result = await referencedWorkflowDeletionChangeValidator(
+    const result = await referencedWorkflowDeletionChangeValidator(config)(
+      [toChange({ before: referencedWorkflowInstance })],
+      elementSource,
+    )
+    expect(result).toEqual([])
+  })
+
+  it('should raise an error when the deleted workflow is referenced.', async () => {
+    elementSource = buildElementsSourceFromElements([defaultWorkflowInstance, referencingSchemeInstance])
+    const result = await referencedWorkflowDeletionChangeValidator(config)(
       [toChange({ before: referencedWorkflowInstance })],
       elementSource,
     )
@@ -94,9 +109,9 @@ describe('referencedWorkflowDeletionChangeValidator', () => {
     ])
   })
 
-  it('should raise an error because the deleted workflow is referenced as a default workflow in a workflow scheme.', async () => {
+  it('should raise an error when the deleted workflow is referenced as a default workflow in a workflow scheme.', async () => {
     elementSource = buildElementsSourceFromElements([defaultSchemeInstance, referencingSchemeInstance])
-    const result = await referencedWorkflowDeletionChangeValidator(
+    const result = await referencedWorkflowDeletionChangeValidator(config)(
       [toChange({ before: defaultWorkflowInstance })],
       elementSource,
     )

--- a/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/referenced_workflow_deletion.test.ts
@@ -25,7 +25,6 @@ import { referencedWorkflowDeletionChangeValidator } from '../../../src/change_v
 import { WORKFLOW_SCHEME_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType, createSkeletonWorkflowV2Instance } from '../../utils'
 
-
 describe('referencedWorkflowDeletionChangeValidator', () => {
   const workflowSchemeObjectType = createEmptyType(WORKFLOW_SCHEME_TYPE_NAME)
   let defaultSchemeInstance: InstanceElement

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -24,7 +24,7 @@ import JiraClient from '../src/client/client'
 import { FilterCreator } from '../src/filter'
 import { paginate } from '../src/client/pagination'
 import { GetUserMapFunc, getUserMapFuncCreator } from '../src/users'
-import { JIRA } from '../src/constants'
+import { JIRA, WORKFLOW_CONFIGURATION_TYPE } from '../src/constants'
 import ScriptRunnerClient from '../src/client/script_runner_client'
 
 export const createCredentialsInstance = (credentials: Credentials): InstanceElement =>
@@ -120,4 +120,20 @@ export const getLicenseElementSource = (isFree: boolean): ReadOnlyElementsSource
 export const createEmptyType = (type: string): ObjectType =>
   new ObjectType({
     elemID: new ElemID(JIRA, type),
+  })
+
+export const createSkeletonWorkflowV2Instance = (name: string): InstanceElement =>
+  new InstanceElement(name, createEmptyType(WORKFLOW_CONFIGURATION_TYPE), {
+    name,
+    scope: {
+      project: 'project',
+      type: 'type',
+    },
+    transitions: {
+      transition: {
+        name: `${name}Transition`,
+        type: 'DIRECTED',
+      },
+    },
+    statuses: [],
   })


### PR DESCRIPTION
Jira Adapter:
- Added a Change Validator that emits an error when attempting to delete a workflow referenced by some scheme (active or inactive, it doesn't matter). This is consistent with Jira behaviour. Note, this only works when using the new Workflow API.
---

_Additional context for reviewer_

At first the ticket was about deleting an active workflow, however the current constraint (referenced by a workflow scheme) is stronger.

---
_Release Notes_: 
Jira Adapter:
- When attempting to delete a workflow referenced by workflow scheme (whether active or inactive) and error will be emitted. Note, this works only when using the new Workflow API.

