### PR TITLE
SALTO-5699 Update ignoreChanges flow

### DIFF
--- a/packages/workspace/src/workspace/static_files/functions.ts
+++ b/packages/workspace/src/workspace/static_files/functions.ts
@@ -31,9 +31,7 @@ export const getStaticFilesFunctions = (staticFilesSource: StaticFilesSource): p
         return new parser.FunctionExpression('file', [val.filepath])
       }
 
-      if ((await val.getContent()) !== undefined) {
-        await staticFilesSource.persistStaticFile(val)
-      }
+      await staticFilesSource.persistStaticFile(val)
       const finalEncoding = val.isTemplate === true ? 'template' : val.encoding
       const params = finalEncoding === DEFAULT_STATIC_FILE_ENCODING ? [val.filepath] : [val.filepath, finalEncoding]
       return new parser.FunctionExpression('file', params)

--- a/packages/workspace/test/workspace/static_files/functions.test.ts
+++ b/packages/workspace/test/workspace/static_files/functions.test.ts
@@ -55,7 +55,7 @@ describe('Functions', () => {
       isTemplate: true,
     })
   })
-  it('should not persist when dumping static file with no content', async () => {
+  it('should persist when dumping static file with no content', async () => {
     const dumped = await functions.file.dump(
       new StaticFile({
         filepath: 'filepath',
@@ -64,7 +64,7 @@ describe('Functions', () => {
     )
     expect(dumped).toHaveProperty('funcName', 'file')
     expect(dumped).toHaveProperty('parameters', ['filepath'])
-    expect(mockedStaticFilesSource.persistStaticFile).toHaveBeenCalledTimes(0)
+    expect(mockedStaticFilesSource.persistStaticFile).toHaveBeenCalledTimes(1)
   })
   it('should persist when dumping static file with content', async () => {
     const dumped = await functions.file.dump(


### PR DESCRIPTION
It now will never call `staticFilesDirStore.get` when `ignoreChanges` is true.
Also allow undefined buffer for persistStaticFile.

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
