### PR TITLE
SALTO-2242 separate e2es into their own workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,9 @@ commands:
               command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
       - run:
           name: Run E2E tests for package << parameters.package_name >>
-          command: cd packages/<< parameters.package_name >> && yarn e2e-test --reporters=default --reporters=jest-junit --coverage=false
+          command: |
+            pushd packages/<< parameters.package_name >>
+            yarn e2e-test --reporters=default --reporters=jest-junit --coverage=false
           no_output_timeout: 20m
           environment:
             SALTO_LOG_LEVEL: 'info'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,6 +8,52 @@ orbs:
   macos: circleci/macos@2.4.1
 
 commands:
+  install_java:
+    steps:
+      - run:
+          name: Install Java
+          command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
+  run_e2e_tests:
+    parameters:
+      should_install_java:
+        type: boolean
+        default: false
+      package_name:
+        type: string
+
+    steps:
+      - run:
+          name: configure sources.list
+          command: |
+            if curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list; then
+              echo "found sources.list file"
+              sudo mv /tmp/sources.list /etc/apt/sources.list
+              sudo apt update
+            else
+              echo "did not find sources.list file, using the default one"
+            fi
+            echo "using sources.list:"
+            cat /etc/apt/sources.list
+      - when:
+          condition: << parameters.should_install_java >>
+          steps:
+            - install_java
+      - run:
+          name: Run E2E tests
+          command: cd packages/<< parameters.package_name >> && yarn e2e-test --reporters=default --reporters=jest-junit --coverage=false
+          no_output_timeout: 20m
+          environment:
+            SALTO_LOG_LEVEL: 'info'
+            # enable telemetry for end2end so we can count more events
+            # webpack configuration is irrelevant in this case and therefore
+            # we explicitly configure it in here
+            SALTO_TELEMETRY_DISABLE: '0'
+            SALTO_TELEMETRY_URL: 'https://telemetry.salto.io'
+            JEST_JUNIT_OUTPUT_DIR: 'reports/e2e/'
+
+      - store_test_results:
+          path: reports
+
   set_s3_pkg_urls:
     steps:
       - run:
@@ -172,7 +218,7 @@ jobs:
           name: Release version
           command: ./.circleci/scripts/release_version.sh << pipeline.git.base_revision >>
 
-  e2e_test:
+  cli_e2e_test:
     docker:
       - image: cimg/node:14.15
 
@@ -183,37 +229,115 @@ jobs:
       - attach_workspace:
           at: .
 
-      - run:
-          name: configure sources.list
-          command: |
-            if curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list; then
-              echo "found sources.list file"
-              sudo mv /tmp/sources.list /etc/apt/sources.list
-              sudo apt update
-            else
-              echo "did not find sources.list file, using the default one"
-            fi
-            echo "using sources.list:"
-            cat /etc/apt/sources.list
-      - run:
-          name: Install java
-          command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
-      - run:
-          name: Run E2E tests
-          command: yarn test --reporters=default --reporters=jest-junit --coverage=false
-          no_output_timeout: 20m
-          environment:
-            RUN_E2E_TESTS: '1'
-            SALTO_LOG_LEVEL: 'info'
-            # enable telemetry for end2end so we can count more events
-            # webpack configuration is irrelevant in this case and therefore
-            # we explicitly configure it in here
-            SALTO_TELEMETRY_DISABLE: '0'
-            SALTO_TELEMETRY_URL: 'https://telemetry.salto.io'
-            JEST_JUNIT_OUTPUT_DIR: 'reports/e2e/'
+      - run_e2e_tests:
+          package_name: 'cli'
+          should_install_java: false
 
-      - store_test_results:
-          path: reports
+  jira_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'jira-adapter'
+          should_install_java: true
+
+  netsuite_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'netsuite-adapter'
+          should_install_java: true
+
+  okta_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'okta-adapter'
+          should_install_java: false
+
+
+  salesforce_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'salesforce-adapter'
+          should_install_java: false
+
+  stripe_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'stripe-adapter'
+          should_install_java: false
+
+  zendesk_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'zendesk-adapter'
+          should_install_java: false
+
+  zuora_e2e_test:
+    docker:
+      - image: cimg/node:14.15
+
+    resource_class: large
+    working_directory: /mnt/ramdisk/project
+
+    steps:
+      - attach_workspace:
+          at: .
+
+      - run_e2e_tests:
+          package_name: 'zuora-billing-adapter'
+          should_install_java: false
 
   package_cli:
     docker:
@@ -371,21 +495,48 @@ jobs:
           command: .circleci/scripts/publish-canary.sh
 
 workflows:
-  version: 2
 
   commit:
     jobs:
       - build
+
+      - cli_e2e_test:
+          requires:
+            - build
+
+      - jira_e2e_test:
+          requires:
+            - build
+
+      - netsuite_e2e_test:
+          requires:
+            - build
+
+      - okta_e2e_test:
+          requires:
+            - build
+      
+      - salesforce_e2e_test:
+          requires:
+            - build
+
+      - stripe_e2e_test:
+          requires:
+            - build
+      
+      - zendesk_e2e_test:
+          requires:
+            - build
+      
+      - zuora_e2e_test:
+          requires:
+            - build
 
       - save_project_cache:
           requires:
             - build
 
       - unit_test:
-          requires:
-            - build
-
-      - e2e_test:
           requires:
             - build
 
@@ -409,13 +560,11 @@ workflows:
           requires:
             - build
             - unit_test
-            # - e2e_test
 
       - package_vscode_extension:
           requires:
             - build
             - unit_test
-            # - e2e_test
 
       - sync_s3_pkg_latest:
           requires:
@@ -431,7 +580,15 @@ workflows:
           requires:
             - build
             - unit_test
-            - e2e_test
+            - cli_e2e_test
+            - jira_e2e_test
+            - netsuite_e2e_test
+            - okta_e2e_test
+            - salesforce_e2e_test
+            - stripe_e2e_test
+            - zendesk_e2e_test
+            - zuora_e2e_test
+
 
       - publish_on_version_change:
           context: salto
@@ -442,4 +599,12 @@ workflows:
           requires:
             - build
             - unit_test
-            - e2e_test
+            - cli_e2e_test
+            - jira_e2e_test
+            - netsuite_e2e_test
+            - okta_e2e_test
+            - salesforce_e2e_test
+            - stripe_e2e_test
+            - zendesk_e2e_test
+            - zuora_e2e_test
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,11 +8,6 @@ orbs:
   macos: circleci/macos@2.4.1
 
 commands:
-  install_java:
-    steps:
-      - run:
-          name: Install Java
-          command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
   run_e2e_tests:
     parameters:
       should_install_java:
@@ -20,7 +15,6 @@ commands:
         default: false
       package_name:
         type: string
-
     steps:
       - run:
           name: configure sources.list
@@ -37,9 +31,11 @@ commands:
       - when:
           condition: << parameters.should_install_java >>
           steps:
-            - install_java
+            run:
+              name: Install Java
+              command: sudo apt update && sudo apt install -y openjdk-17-jdk --no-install-recommends
       - run:
-          name: Run E2E tests
+          name: Run E2E tests for package << parameters.package_name >>
           command: cd packages/<< parameters.package_name >> && yarn e2e-test --reporters=default --reporters=jest-junit --coverage=false
           no_output_timeout: 20m
           environment:
@@ -218,126 +214,22 @@ jobs:
           name: Release version
           command: ./.circleci/scripts/release_version.sh << pipeline.git.base_revision >>
 
-  cli_e2e_test:
+  e2e_tests:
+    parameters:
+      package_name:
+        type: string
+      should_install_java:
+        type: boolean
     docker:
       - image: cimg/node:14.15
-
     resource_class: large
     working_directory: /mnt/ramdisk/project
-
     steps:
       - attach_workspace:
           at: .
-
       - run_e2e_tests:
-          package_name: 'cli'
-          should_install_java: false
-
-  jira_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'jira-adapter'
-          should_install_java: true
-
-  netsuite_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'netsuite-adapter'
-          should_install_java: true
-
-  okta_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'okta-adapter'
-          should_install_java: false
-
-
-  salesforce_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'salesforce-adapter'
-          should_install_java: false
-
-  stripe_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'stripe-adapter'
-          should_install_java: false
-
-  zendesk_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'zendesk-adapter'
-          should_install_java: false
-
-  zuora_e2e_test:
-    docker:
-      - image: cimg/node:14.15
-
-    resource_class: large
-    working_directory: /mnt/ramdisk/project
-
-    steps:
-      - attach_workspace:
-          at: .
-
-      - run_e2e_tests:
-          package_name: 'zuora-billing-adapter'
-          should_install_java: false
+          package_name: <<parameters.package_name>>
+          should_install_java: <<parameters.should_install_java>>     
 
   package_cli:
     docker:
@@ -495,42 +387,37 @@ jobs:
           command: .circleci/scripts/publish-canary.sh
 
 workflows:
-
   commit:
     jobs:
       - build
 
-      - cli_e2e_test:
+      - e2e_tests:
           requires:
             - build
+          matrix:
+            alias: e2e_tests_without_java
+            parameters:
+              package_name: 
+                - cli
+                - okta-adapter
+                - salesforce-adapter
+                - stripe-adapter
+                - zendesk-adapter
+                - zuora-billing-adapter
+              should_install_java: 
+                - false
 
-      - jira_e2e_test:
+      - e2e_tests:
           requires:
             - build
-
-      - netsuite_e2e_test:
-          requires:
-            - build
-
-      - okta_e2e_test:
-          requires:
-            - build
-      
-      - salesforce_e2e_test:
-          requires:
-            - build
-
-      - stripe_e2e_test:
-          requires:
-            - build
-      
-      - zendesk_e2e_test:
-          requires:
-            - build
-      
-      - zuora_e2e_test:
-          requires:
-            - build
+          matrix:
+            alias: e2e_tests_with_java
+            parameters:
+              package_name: 
+                - jira-adapter
+                - netsuite-adapter
+              should_install_java: 
+                - true
 
       - save_project_cache:
           requires:
@@ -580,15 +467,8 @@ workflows:
           requires:
             - build
             - unit_test
-            - cli_e2e_test
-            - jira_e2e_test
-            - netsuite_e2e_test
-            - okta_e2e_test
-            - salesforce_e2e_test
-            - stripe_e2e_test
-            - zendesk_e2e_test
-            - zuora_e2e_test
-
+            - e2e_tests_without_java
+            - e2e_tests_with_java
 
       - publish_on_version_change:
           context: salto
@@ -599,12 +479,5 @@ workflows:
           requires:
             - build
             - unit_test
-            - cli_e2e_test
-            - jira_e2e_test
-            - netsuite_e2e_test
-            - okta_e2e_test
-            - salesforce_e2e_test
-            - stripe_e2e_test
-            - zendesk_e2e_test
-            - zuora_e2e_test
-
+            - e2e_tests_without_java
+            - e2e_tests_with_java


### PR DESCRIPTION
Separate each package's e2e test into its own job in CircleCI so that they run in parallel

---

This still runs all e2e tests regardless of which package changed, but will make it easier to see which package's e2e tests failed, and rerun only that package instead of all e2es

---
_Release Notes_: _None_

---
_User Notifications_: _None_