### PR TITLE
SALTO-5835 Allow 404 on removals in zendesk

### DIFF
--- a/packages/zendesk-adapter/src/deployment.ts
+++ b/packages/zendesk-adapter/src/deployment.ts
@@ -147,6 +147,7 @@ export const deployChange = async (
       client,
       endpointDetails: deployRequests,
       fieldsToIgnore,
+      allowedStatusCodesOnRemoval: [404],
     })
     addId({
       change,


### PR DESCRIPTION
handle 404s gracefully on removals - this fails often in e2e's

---
_Release Notes_: 
None

---
_User Notifications_: 
None