### PR TITLE
SAAS-10839 Return nested important value keys

### DIFF
--- a/packages/adapter-utils/src/important_values.ts
+++ b/packages/adapter-utils/src/important_values.ts
@@ -109,9 +109,7 @@ const extractImportantValuesFromElement = ({
       we do not support non primitive values as indexed important values`)
         return undefined
       }
-      const valueSplit = value.split('.')
-      const finalValue = indexedOnly === true ? valueSplit.pop() ?? value : value
-      return { key: finalValue, value: valueData }
+      return { key: value, value: valueData }
     })
     .filter(isDefined)
 

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -270,7 +270,7 @@ describe('getImportantValues', () => {
     })
     expect(res).toEqual([{ key: 'name', value: 'test inst' }])
   })
-  it('should return only  primitive values if indexed is true', async () => {
+  it('should return only primitive values if indexed is true', async () => {
     // check undefined, number, array of primitive, string --> need to return
     // reference, other obj --> should not return
     const obj2 = new ObjectType({
@@ -366,7 +366,7 @@ describe('getImportantValues', () => {
       { key: 'stringArray', value: ['1', '2'] },
       { key: 'undefinedVal', value: undefined },
       { key: 'reference', value: new ReferenceExpression(inst.elemID) },
-      { key: 'id', value: 12345 },
+      { key: 'obj.id', value: 12345 },
     ])
   })
 })


### PR DESCRIPTION
For better understanding of the context of an important value, e.g. we now return `accountId.author` instead of just `author`.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
