### PR TITLE
SALTO-5520: Fix issue layout crashes

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -101,7 +101,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
       .filter(e => e.elemID.typeName === ISSUE_TYPE_SCHEMA_NAME)
       .map(issueTypeScheme => [
         issueTypeScheme.value.id,
-        issueTypeScheme.value.issueTypeIds.map(
+        issueTypeScheme.value.issueTypeIds?.map(
           (issueTypeIdRecord: Record<string, string>) => issueTypeIdRecord.issueTypeId,
         ),
       ]),

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -323,6 +323,16 @@ describe('issue layout filter', () => {
       const res = await getLayoutRequestsAsync(client, config, fetchQuery, [projectInstance1])
       expect(res).toBeEmpty()
     })
+    it('should not fail if the project does not have an issueTypeScheme', async () => {
+      projectInstance1.value.issueTypeScheme = undefined
+      const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
+      expect(res).toEqual({11111: {}})
+    })
+    it('should not fail if issueTypeScheme does not have issueTypeIds', async () => {
+      issueTypeSchemeInstance1.value.issueTypeIds = undefined
+      const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
+      expect(res).toEqual({11111: {}})
+    })
     it('should not fetch issue layouts if it disabled', async () => {
       const configWithEnableFalse = getDefaultConfig({ isDataCenter: false })
       configWithEnableFalse.fetch.enableIssueLayouts = false
@@ -503,6 +513,14 @@ describe('issue layout filter', () => {
       adapterContext.layoutsPromise = {
         11111: {
           11: {},
+        },
+      }
+      await layoutFilter.onFetch(elements)
+      expect(elements.filter(isInstanceElement).find(e => e.elemID.typeName === ISSUE_LAYOUT_TYPE)).toBeUndefined()
+    })
+    it('should not fail if a project does not have any screens', async () => {
+      adapterContext.layoutsPromise = {
+        11111: {
         },
       }
       await layoutFilter.onFetch(elements)

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -326,12 +326,12 @@ describe('issue layout filter', () => {
     it('should not fail if the project does not have an issueTypeScheme', async () => {
       projectInstance1.value.issueTypeScheme = undefined
       const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
-      expect(res).toEqual({11111: {}})
+      expect(res).toEqual({ 11111: {} })
     })
     it('should not fail if issueTypeScheme does not have issueTypeIds', async () => {
       issueTypeSchemeInstance1.value.issueTypeIds = undefined
       const res = await getLayoutRequestsAsync(client, config, fetchQuery, elements)
-      expect(res).toEqual({11111: {}})
+      expect(res).toEqual({ 11111: {} })
     })
     it('should not fetch issue layouts if it disabled', async () => {
       const configWithEnableFalse = getDefaultConfig({ isDataCenter: false })
@@ -520,8 +520,7 @@ describe('issue layout filter', () => {
     })
     it('should not fail if a project does not have any screens', async () => {
       adapterContext.layoutsPromise = {
-        11111: {
-        },
+        11111: {},
       }
       await layoutFilter.onFetch(elements)
       expect(elements.filter(isInstanceElement).find(e => e.elemID.typeName === ISSUE_LAYOUT_TYPE)).toBeUndefined()


### PR DESCRIPTION
Fixed a bug that causes users with empty issueTypeSchemes fetches to fail

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that caused failed fetches for some customers due to changes in issue layouts filter

---
_User Notifications_: 
None
