### PR TITLE
SALTO-5843 Google ws - remove domain annotation from groups

### DIFF
--- a/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
@@ -114,7 +114,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         groups: {
           standalone: {
             typeName: 'group',
-            addParentAnnotation: true,
+            addParentAnnotation: false,
             referenceFromParent: false,
             nestPathUnderParent: false,
           },


### PR DESCRIPTION
SALTO-5843 Google ws - remove domain annotation from groups
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none
