### PR TITLE
SALTO-5816 support label deploy in templates

### DIFF
--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
 import { AdditionalAction, ClientOptions } from '../types'
-import { increasePagesVersion } from '../transformation_utils'
+import { increasePagesVersion, addSpaceKey } from '../transformation_utils'
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
@@ -186,6 +186,13 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
     // If updating the template deploy definitions, check if need to update global template as well
     [TEMPLATE_TYPE_NAME]: {
       requestsByAction: {
+        default: {
+          request: {
+            context: {
+              space_key: '{_parent.0.key}',
+            },
+          },
+        },
         customizations: {
           add: [
             {
@@ -193,6 +200,9 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 endpoint: {
                   path: '/wiki/rest/api/template',
                   method: 'post',
+                },
+                transformation: {
+                  adjust: addSpaceKey,
                 },
               },
             },
@@ -204,10 +214,8 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   path: '/wiki/rest/api/template',
                   method: 'put',
                 },
-                context: {
-                  queryArgs: {
-                    spaceKey: '{space.key}',
-                  },
+                transformation: {
+                  adjust: addSpaceKey,
                 },
               },
             },

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -20,6 +20,7 @@ import { increasePagesVersion, addSpaceKey } from '../transformation_utils'
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
+  LABEL_TYPE_NAME,
   PAGE_TYPE_NAME,
   PERMISSION_TYPE_NAME,
   SPACE_TYPE_NAME,
@@ -37,6 +38,34 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
   })
 
   const customDefinitions: Record<string, Partial<InstanceDeployApiDefinitions>> = {
+    [LABEL_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          // TODO add change validator to explain labels are not deployed directly SALTO-5816
+          add: [
+            {
+              request: {
+                earlySuccess: true,
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                earlySuccess: true,
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                earlySuccess: true,
+              },
+            },
+          ],
+        },
+      },
+    },
     [PAGE_TYPE_NAME]: {
       requestsByAction: {
         customizations: {

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -87,6 +87,11 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
           parts: [{ fieldName: 'prefix' }, { fieldName: 'name' }],
         },
       },
+      fieldCustomizations: {
+        id: {
+          hide: true,
+        },
+      },
     },
   },
   [SPACE_TYPE_NAME]: {

--- a/packages/confluence-adapter/src/definitions/transformation_utils/template.ts
+++ b/packages/confluence-adapter/src/definitions/transformation_utils/template.ts
@@ -13,9 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+import _ from 'lodash'
+import { definitions } from '@salto-io/adapter-components'
+import { assertValue } from './generic'
 
-export * from './generic'
-export * from './page'
-export * from './label'
-export * from './restriction'
-export * from './template'
+/**
+ * Add space.key to a template request
+ */
+export const addSpaceKey: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = ({ value, context }) => ({
+  value: {
+    ...assertValue(value),
+    space: {
+      key: _.get(context.additionalContext, 'space_key'),
+    },
+  },
+})

--- a/packages/confluence-adapter/test/transformation_utils/template.test.ts
+++ b/packages/confluence-adapter/test/transformation_utils/template.test.ts
@@ -1,0 +1,56 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { definitions } from '@salto-io/adapter-components'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { addSpaceKey } from '../../src/definitions/transformation_utils'
+
+describe('template transformation utils', () => {
+  let item: definitions.GeneratedItem<definitions.ContextParams & definitions.deploy.ChangeAndContext, unknown>
+  describe('addSpaceKey', () => {
+    beforeEach(() => {
+      const change = toChange({
+        after: new InstanceElement('aaa', new ObjectType({ elemID: new ElemID('salto', 'type') }), {
+          something: 'else',
+        }),
+      })
+      item = {
+        typeName: 'mockType',
+        context: {
+          additionalContext: {
+            space_key: 'KEY',
+          },
+          change,
+          changeGroup: {
+            groupID: 'a',
+            changes: [change],
+          },
+          elementSource: buildElementsSourceFromElements([]),
+          sharedContext: {},
+        },
+        value: { something: 'else' },
+      }
+    })
+    it('should add space key from additionalContext', () => {
+      expect(addSpaceKey(item).value).toEqual({ something: 'else', space: { key: 'KEY' } })
+    })
+    it('should add an empty object if space key does not exist', () => {
+      item.context.additionalContext = {}
+      expect(addSpaceKey(item).value).toEqual({ something: 'else', space: { key: undefined } })
+    })
+  })
+})


### PR DESCRIPTION
* First label fetch + fake deploy support, to unblock template deployments. labels do not need to be created directly, if they are created without an id they are available implicitly
* Fix non-global template addition + modification to correctly pass in the space key

---
_Release Notes_: 
_Confluence Adapter_:
* Support linking templates to existing labels
* Fix deployment of templates inside spaces

---
_User Notifications_: 
None