### PR TITLE
SALTO-4976: remove missing reference when transitionId is empty

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -151,10 +151,12 @@ export const walkOverTransitionIds = (transition: WorkflowTransitionV1, func: (v
   transition.rules?.postFunctions
     ?.filter(postFunction => postFunction.type === SCRIPT_RUNNER_POST_FUNCTION_TYPE)
     .forEach(postFunction => {
-      if (postFunction.configuration?.scriptRunner?.transitionId === undefined) {
-        return
+      if (
+        postFunction.configuration?.scriptRunner?.transitionId !== undefined &&
+        !_.isEmpty(postFunction.configuration.scriptRunner.transitionId)
+      ) {
+        func(postFunction.configuration.scriptRunner)
       }
-      func(postFunction.configuration.scriptRunner)
     })
 }
 
@@ -163,7 +165,7 @@ export const walkOverTransitionIdsV2 = (transition: WorkflowTransitionV2, func: 
     ?.filter(
       action =>
         action.parameters?.appKey === SCRIPT_RUNNER_POST_FUNCTION_TYPE &&
-        action.parameters.scriptRunner?.transitionId !== undefined,
+        !_.isEmpty(action.parameters.scriptRunner?.transitionId),
     )
     .forEach(action => {
       func(action.parameters.scriptRunner)

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_references.test.ts
@@ -519,6 +519,49 @@ describe('Scriptrunner references', () => {
         expect(transitionId).toBeInstanceOf(ReferenceExpression)
         expect(transitionId.elemID.getFullName()).toEndWith('.transitions.missing_21')
       })
+
+      it('should not convert to missing reference if the transitionId is empty', async () => {
+        instance.value.transitions = {
+          tran1: {
+            id: '11',
+            name: 'tran1',
+            rules: {
+              postFunctions: [
+                {
+                  type: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                  configuration: {
+                    scriptRunner: {
+                      transitionId: '',
+                    },
+                  },
+                },
+              ],
+            },
+          },
+        }
+        workflowV2Instance.value.transitions = {
+          tran1: {
+            id: '11',
+            name: 'tran1',
+            type: 'DIRECTED',
+            actions: [
+              {
+                ruleKey: 'rule1',
+                parameters: {
+                  appKey: SCRIPT_RUNNER_POST_FUNCTION_TYPE,
+                  scriptRunner: {
+                    transitionId: '',
+                  },
+                },
+              },
+            ],
+          },
+        }
+        await filterCloud.onFetch([getElement(workflowVersion)])
+        const { transitionId } = getScriptRunnerField({ workflowVersion, transitionKey: 'tran1', postFunctionIndex: 0 })
+        expect(transitionId).toEqual('')
+      })
+
       it('should not change anything if script runner is not enabled', async () => {
         await filterOff.onFetch([getElement(workflowVersion)])
         expect(


### PR DESCRIPTION
_remove missing reference when transitionId is empty_

---

_Additional context for reviewer_
* the users can use the transition name as a reference. Currently when they do that the id field is empty and they get a missingReference  that creates a fetch warning and blocks their deployment

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
