### PR TITLE
SALTO-5738 handle default restriction on page deployment

### DIFF
--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -16,7 +16,12 @@
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
 import { AdditionalAction, ClientOptions } from '../types'
-import { increasePagesVersion, addSpaceKey } from '../transformation_utils'
+import {
+  increasePagesVersion,
+  addSpaceKey,
+  shouldDeleteRestrictionOnPageModification,
+  shouldNotModifyRestrictionOnPageAddition,
+} from '../transformation_utils'
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
@@ -82,6 +87,14 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
               },
             },
             {
+              condition: {
+                custom: () => shouldNotModifyRestrictionOnPageAddition,
+              },
+              request: {
+                earlySuccess: true,
+              },
+            },
+            {
               request: {
                 endpoint: {
                   path: '/wiki/rest/api/content/{id}/restriction',
@@ -118,6 +131,31 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
               },
             },
             {
+              condition: {
+                custom: () => shouldDeleteRestrictionOnPageModification,
+              },
+              request: {
+                endpoint: {
+                  path: '/wiki/rest/api/content/{id}/restriction',
+                  method: 'delete',
+                },
+              },
+            },
+            {
+              condition: {
+                custom: () => shouldDeleteRestrictionOnPageModification,
+              },
+              request: {
+                // delete page restrictions are setting them to default, so no need to make another request
+                earlySuccess: true,
+              },
+            },
+            {
+              condition: {
+                transformForCheck: {
+                  pick: ['restriction'],
+                },
+              },
               request: {
                 endpoint: {
                   path: '/wiki/rest/api/content/{id}/restriction',

--- a/packages/confluence-adapter/src/definitions/transformation_utils/restriction.ts
+++ b/packages/confluence-adapter/src/definitions/transformation_utils/restriction.ts
@@ -15,7 +15,7 @@
  */
 import _ from 'lodash'
 import { definitions } from '@salto-io/adapter-components'
-import { getChangeData, isModificationChange } from '@salto-io/adapter-api'
+import { getChangeData, isEqualValues, isModificationChange } from '@salto-io/adapter-api'
 
 export const DEFAULT_RESTRICTION = [
   {
@@ -42,10 +42,10 @@ export const shouldDeleteRestrictionOnPageModification = (args: definitions.depl
     return false
   }
   const afterRestriction = _.get(args.change.data.after.value, 'restriction')
-  if (_.isEqual(args.change.data.before.value.restriction, afterRestriction)) {
+  if (isEqualValues(args.change.data.before.value.restriction, afterRestriction)) {
     return false
   }
-  return _.isEqual(afterRestriction, DEFAULT_RESTRICTION)
+  return isEqualValues(afterRestriction, DEFAULT_RESTRICTION)
 }
 
 /**

--- a/packages/confluence-adapter/test/transformation_utils/restriction.test.ts
+++ b/packages/confluence-adapter/test/transformation_utils/restriction.test.ts
@@ -70,7 +70,7 @@ describe('restriction transformation utils', () => {
     it('should return false when there is no restriction diff', () => {
       const change = toChange({
         after: new InstanceElement('mockType', objectType, { title: 'a', restriction: [] }),
-        before: new InstanceElement('mockType', objectType, { title: 'b',restriction: [] }),
+        before: new InstanceElement('mockType', objectType, { title: 'b', restriction: [] }),
       })
       expect(shouldDeleteRestrictionOnPageModification(createMockChangeAndContext(change))).toBe(false)
     })


### PR DESCRIPTION
- When deploying a page addition with default restriction we should not modify restriction after addition as default restrictions are created anyway
- When deploying a page modification with default restriction we should not modify restriction but delete the existing restriction. Deletion, resets the restriction to the default


---



---

_Release Notes_: 
_Confluence Adapter_:
- Fully support restrictions on page deployment

---

_User Notifications_: 
_Confluence Adapter_:
- Fully support restrictions on page deployment
