### PR TITLE
SALTO-5674 - Salesforce:Quick Fetch omits data instances due to missing refs

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -404,11 +404,11 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     if (dataManagement === undefined) {
       return {}
     }
-    const fetchedCustomObjectInstances = elements.filter(isInstanceElement)
+    const fetchedInstances = elements.filter(isInstanceElement)
     // In the partial fetch case, a fetched element may reference an element that was not fetched but exists in the workspace
     const elementsSource = buildElementsSourceForFetch(elements, config)
     const allElements = await awu(await elementsSource.getAll()).toArray()
-    const referenceSources = fetchedCustomObjectInstances.filter(
+    const fetchedCustomObjectInstances = fetchedInstances.filter(
       isInstanceOfCustomObjectSync,
     )
     const allInstances = allElements.filter(isInstanceElement)
@@ -420,15 +420,15 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
       await buildCustomObjectPrefixKeyMap(allElements)
     const { reverseReferencesMap, missingRefs } =
       await replaceLookupsWithRefsAndCreateRefMap(
-        referenceSources,
+        fetchedCustomObjectInstances,
         internalToInstance,
         (internalId: string): string =>
           internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
         dataManagement,
       )
     const instancesWithCollidingElemID =
-      getInstancesWithCollidingElemID(allInstances)
-    const instancesWithEmptyId = allInstances.filter(
+      getInstancesWithCollidingElemID(fetchedInstances)
+    const instancesWithEmptyId = fetchedCustomObjectInstances.filter(
       (instance) => instance.elemID.name === ElemID.CONFIG_NAME,
     )
     const missingRefOriginInternalIDs = new Set(


### PR DESCRIPTION
When we fetch instances in fetch-with-changes-detection, we may fetch referring instances without the instances they refer to. In order to resolve these references we need to look for the reference targets in the workspace.

---

Tests:
* Run the test case described in the ticket. Confirm it fails before this change and passes after it.

---
_Release Notes_: 
Salesforce: References from custom object instances will now be resolved correctly in quickfetch.

---
_User Notifications_: 
N/A