### PR TITLE
SALTO-5603: Do not fetch Partial requestType

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -41,6 +41,8 @@ import {
   createLayoutType,
   IssueLayoutConfiguration,
   IssueLayoutConfig,
+  ERROR_RESPONSE_SCHEME,
+  errorResponse,
 } from './layout_types'
 import { ISSUE_LAYOUT_TYPE, ISSUE_VIEW_TYPE, JIRA, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../constants'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
@@ -86,6 +88,7 @@ export const LAYOUT_TYPE_NAME_TO_DETAILS: Record<LayoutTypeName, LayoutTypeDetai
 
 export const isIssueLayoutResponse = createSchemeGuard<IssueLayoutResponse>(ISSUE_LAYOUT_RESPONSE_SCHEME)
 const isLayoutConfigItem = createSchemeGuard<LayoutConfigItem>(ISSUE_LAYOUT_CONFIG_ITEM_SCHEME)
+const isErrorResponse = createSchemeGuard<errorResponse>(ERROR_RESPONSE_SCHEME)
 
 export const getLayoutResponse = async ({
   variables,
@@ -234,7 +237,7 @@ export const fetchRequestTypeDetails = async ({
 
   const { layoutType: issueLayoutType } = createLayoutType(typeName)
   elements.push(issueLayoutType)
-
+  const requestsTypeToRemove: string[] = []
   const layouts = (
     await Promise.all(
       Object.entries(requestTypeIdToRequestType).flatMap(async ([requestTypeId, requestTypeInstance]) => {
@@ -249,6 +252,17 @@ export const fetchRequestTypeDetails = async ({
           client,
           typeName,
         })
+        if (
+          Array.isArray(response.errors) &&
+          isErrorResponse(response.errors[0]) &&
+          response.errors[0].extensions.statusCode === 404
+        ) {
+          log.info(
+            `Failed to fetch ${requestTypeInstance.annotations[CORE_ANNOTATIONS.ALIAS]} since it does not exist or user does not have required permissions`,
+          )
+          requestsTypeToRemove.push(requestTypeInstance.elemID.getFullName())
+          return undefined
+        }
         return getLayout({
           extraDefinerId: variables.extraDefinerId,
           response,
@@ -267,4 +281,6 @@ export const fetchRequestTypeDetails = async ({
   await addAnnotationRecursively(issueLayoutType, CORE_ANNOTATIONS.CREATABLE)
   await addAnnotationRecursively(issueLayoutType, CORE_ANNOTATIONS.UPDATABLE)
   await addAnnotationRecursively(issueLayoutType, CORE_ANNOTATIONS.DELETABLE)
+  // Remove request types that doesn't exist or user does not have required permissions to their layouts
+  _.remove(elements, e => requestsTypeToRemove.includes(e.elemID.getFullName()) && isInstanceElement(e))
 }

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -255,7 +255,9 @@ export const fetchRequestTypeDetails = async ({
         if (
           Array.isArray(response.errors) &&
           isErrorResponse(response.errors[0]) &&
-          response.errors[0].extensions.statusCode === 404
+          response.errors[0].extensions.statusCode === 404 &&
+          response.errors[0].message ===
+            'Entity associated with issue layout does not exist or user does not have required permissions'
         ) {
           log.info(
             `Failed to fetch ${requestTypeInstance.annotations[CORE_ANNOTATIONS.ALIAS]} since it does not exist or user does not have required permissions`,

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -192,12 +192,14 @@ export type RequestTypeWithIssueLayoutConfigInstance = InstanceElement & {
 }
 
 export type errorResponse = {
+  message: string
   extensions: {
     statusCode: number
   }
 }
 
 export const ERROR_RESPONSE_SCHEME = Joi.object({
+  message: Joi.string().required(),
   extensions: Joi.object({
     statusCode: Joi.number().required(),
   })

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -190,3 +190,19 @@ type RequestType = {
 export type RequestTypeWithIssueLayoutConfigInstance = InstanceElement & {
   value: InstanceElement['value'] & RequestType
 }
+
+export type errorResponse = {
+  extensions: {
+    statusCode: number
+  }
+}
+
+export const ERROR_RESPONSE_SCHEME = Joi.object({
+  extensions: Joi.object({
+    statusCode: Joi.number().required(),
+  })
+    .required()
+    .unknown(true),
+})
+  .unknown(true)
+  .required()

--- a/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
@@ -57,7 +57,7 @@ const filter: FilterCreator = ({ config }) => ({
     const requestFormType = objectTypes.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
     const issueViewType = objectTypes.find(e => e.elemID.typeName === ISSUE_VIEW_TYPE)
     if (requestTypeType === undefined || requestFormType === undefined || issueViewType === undefined) {
-      log.warn('Feild to find requestTypeType or requestFormType or issueViewType')
+      log.warn('Faild to find requestTypeType or requestFormType or issueViewType')
       return
     }
     requestTypeType.fields.requestForm = new Field(requestTypeType, 'requestForm', requestFormType)

--- a/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_types_layouts_to_values.ts
@@ -57,7 +57,7 @@ const filter: FilterCreator = ({ config }) => ({
     const requestFormType = objectTypes.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
     const issueViewType = objectTypes.find(e => e.elemID.typeName === ISSUE_VIEW_TYPE)
     if (requestTypeType === undefined || requestFormType === undefined || issueViewType === undefined) {
-      log.warn('Faild to find requestTypeType or requestFormType or issueViewType')
+      log.warn('Failed to find requestTypeType or requestFormType or issueViewType')
       return
     }
     requestTypeType.fields.requestForm = new Field(requestTypeType, 'requestForm', requestFormType)

--- a/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
@@ -363,5 +363,29 @@ describe('requestTypeLayoutsFilter', () => {
       const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
       expect(issueLayoutInstance).toBeDefined()
     })
+    it("should remove requestType from elements if couldn't fetch requestType layouts since it does not exist or user does not have required permissions ", async () => {
+      mockGet.mockImplementation(params => {
+        if (params.url === '/rest/gira/1') {
+          return {
+            errors: [
+              {
+                extensions: {
+                  statusCode: 404,
+                },
+              },
+            ],
+          }
+        }
+        throw new Error('Err')
+      })
+      const configWithMissingRefs = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      configWithMissingRefs.fetch.enableMissingReferences = false
+      configWithMissingRefs.fetch.enableJSM = true
+      filter = requestTypeLayoutsFilter(getFilterParams({ config: configWithMissingRefs, client })) as FilterType
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const requestTypeInstanceFound = instances.find(e => e.elemID.typeName === REQUEST_TYPE_NAME)
+      expect(requestTypeInstanceFound).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
In this PR I excluded requestTypes that being partial fetched. 

---

_Additional context for reviewer_
There is a known issue where lacking the "Browse Projects" and "Service Project Agent" permissions for a specific project prevents access to the RequestType. In the UI, this discrepancy is evident, whereas the API returns a partial RequestType, contradicting the user's experience and causing issues during deployment attempts. The error message received in such cases is: "Entity associated with issue layout does not exist or user does not have required permissions." Consequently, when this message appears, we should avoid fetching the RequestType altogether.

---
_Release Notes_: 
_Jira Adapter:_
* Stop fetching requestsType that has no requestForm or issueView.

---
_User Notifications_: 
_Jira Adapter:_
* Stop fetching requestsType that has no requestForm or issueView.
