### PR TITLE
SALTO-5865: Fix jsm permissions change validator 

### DIFF
--- a/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
+++ b/packages/jira-adapter/src/change_validators/jsm/jsm_permissions.ts
@@ -36,6 +36,7 @@ import {
   FORM_TYPE,
   PROJECT_TYPE,
 } from '../../constants'
+import { isJsmEnabledInService } from '../../filters/account_info'
 
 const { awu } = collections.asynciterable
 const { createPaginator, getWithCursorPagination } = clientUtils
@@ -66,6 +67,10 @@ const getAdditionChangedProjectsNames = (changes: ReadonlyArray<Change>): string
 export const jsmPermissionsValidator: (config: JiraConfig, client: JiraClient) => ChangeValidator =
   (config, client) => async changes => {
     if (!config.fetch.enableJSM) {
+      return []
+    }
+    const isJsmEnabled = await isJsmEnabledInService(client)
+    if (!isJsmEnabled) {
       return []
     }
 

--- a/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
+++ b/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
@@ -148,24 +148,7 @@ describe('jsmPermissionsValidator', () => {
           ],
         },
       })
-      mockConnection.get.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          size: 1,
-          start: 0,
-          limit: 50,
-          isLastPage: true,
-          _links: {},
-          values: [
-            {
-              id: '10',
-              projectId: '111',
-              projectKey: 'SD',
-              projectName: 'Service Desk',
-            },
-          ],
-        },
-      })
+      mockConnection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {}, status: 403 }))
       projectInstance = new InstanceElement('project1', createEmptyType(PROJECT_TYPE), {
         id: '111',
         name: 'project1',
@@ -188,7 +171,7 @@ describe('jsmPermissionsValidator', () => {
     })
     it('should not return error if JSM is disabled', async () => {
       const validator = jsmPermissionsValidator(config, client)
-      config.fetch.enableJSM = false
+      config.fetch.enableJSM = true
       const changeErrors = await validator([toChange({ before: queueInstance })])
       expect(changeErrors).toHaveLength(0)
     })

--- a/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
+++ b/packages/jira-adapter/test/change_validators/jsm/jsm_permissions.test.ts
@@ -31,80 +31,166 @@ describe('jsmPermissionsValidator', () => {
   let config: JiraConfig
   let client: JiraClient
   let mockConnection: MockInterface<clientUtils.APIConnection>
-  beforeEach(async () => {
-    const mockCli = mockClient()
-    mockConnection = mockCli.connection
-    client = mockCli.client
-    mockConnection.get.mockResolvedValueOnce({
-      status: 200,
-      data: {
-        size: 1,
-        start: 0,
-        limit: 50,
-        isLastPage: true,
-        _links: {},
-        values: [
-          {
-            id: '10',
-            projectId: '111',
-            projectKey: 'SD',
-            projectName: 'Service Desk',
-          },
-        ],
-      },
+  describe('with JSM enabled', () => {
+    beforeEach(async () => {
+      const mockCli = mockClient()
+      mockConnection = mockCli.connection
+      client = mockCli.client
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          applications: [
+            {
+              id: 'jira-software',
+              plan: 'FREE',
+            },
+            {
+              id: 'other-app',
+              plan: 'PAID',
+            },
+            {
+              id: 'jira-servicedesk',
+              plan: 'FREE',
+            },
+          ],
+        },
+      })
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          size: 1,
+          start: 0,
+          limit: 50,
+          isLastPage: true,
+          _links: {},
+          values: [
+            {
+              id: '10',
+              projectId: '111',
+              projectKey: 'SD',
+              projectName: 'Service Desk',
+            },
+          ],
+        },
+      })
+      projectInstance = new InstanceElement('project1', createEmptyType(PROJECT_TYPE), {
+        id: '111',
+        name: 'project1',
+        projectTypeKey: 'service_desk',
+      })
+      queueInstance = new InstanceElement(
+        'queue1',
+        queueType,
+        {
+          id: 22,
+          name: 'queue1',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+        },
+      )
+      config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
     })
-    projectInstance = new InstanceElement('project1', createEmptyType(PROJECT_TYPE), {
-      id: '111',
-      name: 'project1',
-      projectTypeKey: 'service_desk',
+    it('should return error if trying to deploy Jsm type without permissions', async () => {
+      const validator = jsmPermissionsValidator(config, client)
+      const projectWithoutJsmPermissions = projectInstance.clone()
+      projectWithoutJsmPermissions.value.id = '44'
+      queueInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(projectWithoutJsmPermissions.elemID, projectWithoutJsmPermissions),
+      ]
+      const changeErrors = await validator([toChange({ before: queueInstance })])
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0]).toEqual({
+        elemID: queueInstance.elemID,
+        severity: 'Error' as SeverityLevel,
+        message: 'Lacking permissions to update a JSM project',
+        detailedMessage:
+          "Cannot deploy queue1 since it is part of a project to which you do not have permissions to. Add user to project's permissions and try again.",
+      })
     })
-    queueInstance = new InstanceElement(
-      'queue1',
-      queueType,
-      {
-        id: 22,
-        name: 'queue1',
-      },
-      undefined,
-      {
-        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
-      },
-    )
-    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    config.fetch.enableJSM = true
-  })
-  it('should return error if trying to deploy Jsm type without permissions', async () => {
-    const validator = jsmPermissionsValidator(config, client)
-    const projectWithoutJsmPermissions = projectInstance.clone()
-    projectWithoutJsmPermissions.value.id = '44'
-    queueInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
-      new ReferenceExpression(projectWithoutJsmPermissions.elemID, projectWithoutJsmPermissions),
-    ]
-    const changeErrors = await validator([toChange({ before: queueInstance })])
-    expect(changeErrors).toHaveLength(1)
-    expect(changeErrors[0]).toEqual({
-      elemID: queueInstance.elemID,
-      severity: 'Error' as SeverityLevel,
-      message: 'Lacking permissions to update a JSM project',
-      detailedMessage:
-        "Cannot deploy queue1 since it is part of a project to which you do not have permissions to. Add user to project's permissions and try again.",
+    it('should not return error if trying to deploy Jsm type without valid parent', async () => {
+      const validator = jsmPermissionsValidator(config, client)
+      queueInstance.annotations[CORE_ANNOTATIONS.PARENT] = ['weirdParent']
+      const changeErrors = await validator([toChange({ before: queueInstance })])
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should not return error if trying to deploy Jsm type with permissions', async () => {
+      const validator = jsmPermissionsValidator(config, client)
+      const changeErrors = await validator([toChange({ before: queueInstance })])
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should not return error if trying to deploy Jsm type with its associated project', async () => {
+      const validator = jsmPermissionsValidator(config, client)
+      projectInstance.value.id = '44'
+      const changeErrors = await validator([toChange({ after: queueInstance }), toChange({ after: projectInstance })])
+      expect(changeErrors).toHaveLength(0)
     })
   })
-  it('should not return error if trying to deploy Jsm type without valid parent', async () => {
-    const validator = jsmPermissionsValidator(config, client)
-    queueInstance.annotations[CORE_ANNOTATIONS.PARENT] = ['weirdParent']
-    const changeErrors = await validator([toChange({ before: queueInstance })])
-    expect(changeErrors).toHaveLength(0)
-  })
-  it('should not return error if trying to deploy Jsm type with permissions', async () => {
-    const validator = jsmPermissionsValidator(config, client)
-    const changeErrors = await validator([toChange({ before: queueInstance })])
-    expect(changeErrors).toHaveLength(0)
-  })
-  it('should not return error if trying to deploy Jsm type with its associated project', async () => {
-    const validator = jsmPermissionsValidator(config, client)
-    projectInstance.value.id = '44'
-    const changeErrors = await validator([toChange({ after: queueInstance }), toChange({ after: projectInstance })])
-    expect(changeErrors).toHaveLength(0)
+  describe('with JSM disabled', () => {
+    beforeEach(async () => {
+      const mockCli = mockClient()
+      mockConnection = mockCli.connection
+      client = mockCli.client
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          applications: [
+            {
+              id: 'jira-software',
+              plan: 'FREE',
+            },
+            {
+              id: 'other-app',
+              plan: 'PAID',
+            },
+          ],
+        },
+      })
+      mockConnection.get.mockResolvedValueOnce({
+        status: 200,
+        data: {
+          size: 1,
+          start: 0,
+          limit: 50,
+          isLastPage: true,
+          _links: {},
+          values: [
+            {
+              id: '10',
+              projectId: '111',
+              projectKey: 'SD',
+              projectName: 'Service Desk',
+            },
+          ],
+        },
+      })
+      projectInstance = new InstanceElement('project1', createEmptyType(PROJECT_TYPE), {
+        id: '111',
+        name: 'project1',
+        projectTypeKey: 'service_desk',
+      })
+      queueInstance = new InstanceElement(
+        'queue1',
+        queueType,
+        {
+          id: 22,
+          name: 'queue1',
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance.elemID, projectInstance)],
+        },
+      )
+      config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.enableJSM = true
+    })
+    it('should not return error if JSM is disabled', async () => {
+      const validator = jsmPermissionsValidator(config, client)
+      config.fetch.enableJSM = false
+      const changeErrors = await validator([toChange({ before: queueInstance })])
+      expect(changeErrors).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
In this PR I fixed JSM permission change validator

---

_Additional context for reviewer_
When a user has enableJSM set to true, but no JSM enabled in the service. he is failing in jsm_permissions CV since he is trying to access an endpoint that is JSM related. We should check if JSM is enabled in the CV before we check separately for each project. 

---
_Release Notes_: 
_Jira Adapter:_
* The bug where deploy fails when a user has `enableJSM = true` but no JSM in the service is solved. 

---
_User Notifications_: 
None
