### PR TITLE
SALTO-5769 - Salesforce: Log when unable to map deploy messages to ElemIDs

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -279,6 +279,11 @@ const processDeployResponse = (
   }: DeployMessage): ElemID | undefined => {
     const rawElemId = typeAndNameToElemId[componentType]?.[fullName]
     if (rawElemId === undefined) {
+      log.debug(
+        'Unable to match deploy message for %s[%s] with an ElemID.',
+        fullName,
+        componentType,
+      )
       return undefined
     }
     if (rawElemId.typeName === CUSTOM_OBJECT) {
@@ -319,6 +324,13 @@ const processDeployResponse = (
       message: failure.problem,
       severity: 'Error' as SeverityLevel,
     }))
+
+  if (failedComponentErrors.some((error) => error.elemID === undefined)) {
+    log.debug(
+      'Some deploy messages could not be mapped to an ElemID. typeAndNameToElemId=%s',
+      typeAndNameToElemId,
+    )
+  }
 
   const successfulComponentProblems = allSuccessMessages
     .filter((message) => message.problem)


### PR DESCRIPTION
When we receive a deploy error we can't map to an ElemID, let's log some context to help us repro and debug.

---

---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A