### PR TITLE
SALTO-5878 when resolving values, give precedence for the already-resolved value if available

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -105,7 +105,7 @@ const getResolvedValue = async (
         'without elementsSource because value does not exist',
     )
   }
-  const value = (await elementsSource?.get(elemID)) ?? resolvedValue
+  const value = resolvedValue ?? (await elementsSource?.get(elemID))
   // When there's no value in the ElementSource & in the Ref
   // Fallback to a placeholder Type. This resembles the behavior
   // before the RefType change.

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -364,7 +364,7 @@ describe('Values', () => {
       )
     })
 
-    it('should resolve with element source if possible', async () => {
+    it('should resolve from value if possible', async () => {
       const ref = new TypeReference(elemID, BuiltinTypes.STRING)
       expect(
         await ref.getResolvedValue({
@@ -373,19 +373,19 @@ describe('Values', () => {
           has: jest.fn(),
           getAll: jest.fn(),
         }),
-      ).toEqual(BuiltinTypes.NUMBER)
+      ).toEqual(BuiltinTypes.STRING)
     })
 
-    it('should resolve without element source if it returns undefined', async () => {
-      const ref = new TypeReference(elemID, BuiltinTypes.STRING)
+    it('should resolve from element source if value is undefined', async () => {
+      const ref = new TypeReference(elemID)
       expect(
         await ref.getResolvedValue({
           list: jest.fn(),
-          get: async () => undefined,
+          get: async () => BuiltinTypes.NUMBER,
           has: jest.fn(),
           getAll: jest.fn(),
         }),
-      ).toEqual(BuiltinTypes.STRING)
+      ).toEqual(BuiltinTypes.NUMBER)
     })
 
     it("should return empty obj with ID if element returns undefined and type doesn't exist", async () => {

--- a/packages/adapter-utils/test/important_values.test.ts
+++ b/packages/adapter-utils/test/important_values.test.ts
@@ -23,6 +23,7 @@ import {
   ObjectType,
   ReadOnlyElementsSource,
   ReferenceExpression,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '../src/element_source'
 import { getImportantValues, toImportantValues } from '../src/important_values'
@@ -201,12 +202,21 @@ describe('getImportantValues', () => {
         other: 'bla',
       },
     })
+    const instNoImportant = inst.clone()
+    instNoImportant.refType = new TypeReference(objNoImportant.elemID, objNoImportant)
     const elementSourceNoImportant = buildElementsSourceFromElements([objNoImportant, userType])
-    const res = await getImportantValues({
-      element: inst,
-      elementSource: elementSourceNoImportant,
-    })
-    expect(res).toEqual([])
+    expect(
+      await getImportantValues({
+        element: instNoImportant,
+      }),
+    ).toEqual([])
+    instNoImportant.refType = new TypeReference(objNoImportant.elemID)
+    expect(
+      await getImportantValues({
+        element: instNoImportant,
+        elementSource: elementSourceNoImportant,
+      }),
+    ).toEqual([])
   })
   it('should return only indexed values', async () => {
     const res = await getImportantValues({

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -473,38 +473,37 @@ const runPostFetch = async ({
 }
 
 // SALTO-5878 safety due to changed order of precedence when resolving referenced values / types - can remove if we don't see this log
-const updateInconsistentTypes = (validAccountElements: Element[]): void => {
-  const objectTypesByElemID = _.keyBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
-  const isInconsistentType = (e: InstanceElement | Field): boolean =>
-    e.refType.type !== undefined &&
-    objectTypesByElemID[e.refType.elemID.getFullName()] !== undefined &&
-    !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()])
-  const fields = Object.values(objectTypesByElemID)
-    .flatMap(obj => Object.values(obj.fields))
-    .filter(f => isObjectType(f.refType.type))
-  const elementsWithInconsistentTypes: (InstanceElement | Field)[] = validAccountElements
-    .filter(isInstanceElement)
-    .filter(isInconsistentType)
-  fields.forEach(f => {
-    if (isInconsistentType(f)) {
-      elementsWithInconsistentTypes.push(f)
-    }
-  })
-
-  if (elementsWithInconsistentTypes.length > 0) {
-    log.error(
-      'found inconsistent types in the following %d types (%d elements), the types will be resolved from the element source. %s',
-      _.uniq(elementsWithInconsistentTypes.map(e => e.refType.elemID.getFullName())).length,
-      elementsWithInconsistentTypes.length,
-      elementsWithInconsistentTypes.map(e => e.elemID.getFullName()).join(','),
-    )
-    elementsWithInconsistentTypes.forEach(e => {
-      e.refType = new TypeReference(e.refType.elemID)
+const updateInconsistentTypes = (validAccountElements: Element[]): void =>
+  log.timeDebug(() => {
+    const objectTypesByElemID = _.keyBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
+    const isInconsistentType = (e: InstanceElement | Field): boolean =>
+      e.refType.type !== undefined &&
+      objectTypesByElemID[e.refType.elemID.getFullName()] !== undefined &&
+      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()])
+    const fields = Object.values(objectTypesByElemID)
+      .flatMap(obj => Object.values(obj.fields))
+      .filter(f => isObjectType(f.refType.type))
+    const elementsWithInconsistentTypes: (InstanceElement | Field)[] = validAccountElements
+      .filter(isInstanceElement)
+      .filter(isInconsistentType)
+    fields.forEach(f => {
+      if (isInconsistentType(f)) {
+        elementsWithInconsistentTypes.push(f)
+      }
     })
-  } else {
-    log.debug('no inconsistent types found')
-  }
-}
+
+    if (elementsWithInconsistentTypes.length > 0) {
+      log.warn(
+        'found inconsistent types in the following %d types (%d elements), the types will be resolved from the element source. %s',
+        _.uniq(elementsWithInconsistentTypes.map(e => e.refType.elemID.getFullName())).length,
+        elementsWithInconsistentTypes.length,
+        elementsWithInconsistentTypes.map(e => e.elemID.getFullName()).join(','),
+      )
+      elementsWithInconsistentTypes.forEach(e => {
+        e.refType = new TypeReference(e.refType.elemID)
+      })
+    }
+  }, 'looking for inconsistent types (SALTO-5878)')
 
 const fetchAndProcessMergeErrors = async (
   accountsToAdapters: Record<string, AdapterOperations>,

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1381,7 +1381,7 @@ describe('fetch', () => {
         const expectedHiddenInstanceAlternateId = instanceWithHiddenAlternateId.clone()
         expectedHiddenInstanceAlternateId.refType = _.clone(expectedHiddenInstanceAlternateId.refType)
         expectedHiddenInstanceAlternateId.refType.type = expect.anything()
-        expect(getChangeData(changes[1].change)).toEqual(expectedHiddenInstanceAlternateId)
+        expect(expectedHiddenInstanceAlternateId.isEqual(getChangeData(changes[1].change))).toBeTrue()
       })
     })
 
@@ -1408,7 +1408,8 @@ describe('fetch', () => {
         const expectedHiddenInstanceAlternateId = instanceWithHiddenAlternateId.clone()
         expectedHiddenInstanceAlternateId.refType = _.clone(expectedHiddenInstanceAlternateId.refType)
         expectedHiddenInstanceAlternateId.refType.type = expect.anything()
-        expect(passed).toEqual([expectedHiddenInstanceAlternateId])
+        expect(passed.length).toBe(1)
+        expect(passed[0].isEqual(expectedHiddenInstanceAlternateId)).toBeTrue()
       })
     })
   })

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -243,7 +243,7 @@ const filter: FilterCreator = ({ config, getElemIdFunc }) => ({
       new ListType(BuiltinTypes.STRING),
     )
     fieldContextType.fields.defaultValue = new Field(fieldContextType, 'defaultValue', fieldContextDefaultValueType)
-    fieldContextType.fields.options = new Field(fieldType, 'options', new MapType(fieldContextOptionType))
+    fieldContextType.fields.options = new Field(fieldContextType, 'options', new MapType(fieldContextOptionType))
 
     fieldContextOptionType.fields.position = new Field(fieldContextOptionType, 'position', BuiltinTypes.NUMBER)
     fieldContextOptionType.fields.cascadingOptions = new Field(

--- a/packages/zendesk-adapter/src/filters/custom_field_options/custom_object_field_options.ts
+++ b/packages/zendesk-adapter/src/filters/custom_field_options/custom_object_field_options.ts
@@ -16,12 +16,10 @@
 import {
   isInstanceElement,
   Element,
-  ObjectType,
   InstanceElement,
-  ElemID,
   CORE_ANNOTATIONS,
   ReferenceExpression,
-  BuiltinTypes,
+  isObjectType,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
@@ -39,22 +37,6 @@ const { RECORDS_PATH } = elementsUtils
 const log = logger(module)
 
 const FILTER_NAME = 'customObjectFieldOptionsFilter'
-
-export const customObjectFieldOptionType = new ObjectType({
-  elemID: new ElemID(ZENDESK, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME),
-  fields: {
-    id: {
-      refType: BuiltinTypes.SERVICE_ID_NUMBER,
-      annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
-    },
-    // name is not added because it's not needed
-    raw_name: { refType: BuiltinTypes.STRING },
-    value: { refType: BuiltinTypes.STRING },
-  },
-  annotations: {
-    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
-  },
-})
 
 type CustomObjectFieldOption = {
   id: number
@@ -89,6 +71,13 @@ const onFetch = async (elements: Element[]): Promise<void> => {
       log.error(
         `custom_field_options of ${customObjectField.elemID.getFullName()} is not in the expected format - ${inspectValue(options)}`,
       )
+      return
+    }
+    const customObjectFieldOptionType = elements
+      .filter(isObjectType)
+      .find(e => e.elemID.typeName === CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME)
+    if (customObjectFieldOptionType === undefined) {
+      log.error(`${CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME} object type not found`)
       return
     }
     const optionInstances = options.map(option => {

--- a/packages/zendesk-adapter/test/filters/custom_objects/custom_object_field_options.test.ts
+++ b/packages/zendesk-adapter/test/filters/custom_objects/custom_object_field_options.test.ts
@@ -15,6 +15,7 @@
  */
 import { elements as elementsUtils, filterUtils } from '@salto-io/adapter-components'
 import {
+  BuiltinTypes,
   CORE_ANNOTATIONS,
   ElemID,
   InstanceElement,
@@ -24,9 +25,7 @@ import {
   Value,
 } from '@salto-io/adapter-api'
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
-import filterCreator, {
-  customObjectFieldOptionType,
-} from '../../../src/filters/custom_field_options/custom_object_field_options'
+import filterCreator from '../../../src/filters/custom_field_options/custom_object_field_options'
 import { createFilterCreatorParams } from '../../utils'
 import {
   CUSTOM_FIELD_OPTIONS_FIELD_NAME,
@@ -43,6 +42,22 @@ const createOptionsValue = (id: number, value?: string): Value => ({
   name: id.toString(),
   raw_name: id.toString().repeat(2),
   value: value ?? id.toString().repeat(3),
+})
+
+const customObjectFieldOptionType = new ObjectType({
+  elemID: new ElemID(ZENDESK, CUSTOM_OBJECT_FIELD_OPTIONS_TYPE_NAME),
+  fields: {
+    id: {
+      refType: BuiltinTypes.SERVICE_ID_NUMBER,
+      annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+    },
+    // name is not added because it's not needed
+    raw_name: { refType: BuiltinTypes.STRING },
+    value: { refType: BuiltinTypes.STRING },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
 })
 
 const createOptionInstance = ({ id, value }: { id: number; value: string }): InstanceElement => {
@@ -68,15 +83,15 @@ describe('customObjectFieldOptionsFilter', () => {
     const invalidCustomObjectField = customObjectField.clone()
     invalidCustomObjectField.value[CUSTOM_FIELD_OPTIONS_FIELD_NAME][2].id = 'invalid'
 
-    const elements = [customObjectField, invalidCustomObjectField]
+    const elements = [customObjectField, invalidCustomObjectField, customObjectFieldOptionType]
     await customObjectFieldOptionsFilter.onFetch(elements)
-    expect(elements).toHaveLength(5)
+    expect(elements).toHaveLength(6)
     expect(elements[0]).toMatchObject(customObjectField)
     expect(elements[1]).toMatchObject(invalidCustomObjectField)
-    expect(elements[2]).toMatchObject(createOptionInstance(createOptionsValue(1, '!!')))
-    expect(elements[3]).toMatchObject(createOptionInstance(createOptionsValue(2)))
-    expect(elements[4]).toMatchObject(createOptionInstance(createOptionsValue(3)))
-    expect(elements[2].annotations[CORE_ANNOTATIONS.PARENT][0]).toMatchObject(
+    expect(elements[3]).toMatchObject(createOptionInstance(createOptionsValue(1, '!!')))
+    expect(elements[4]).toMatchObject(createOptionInstance(createOptionsValue(2)))
+    expect(elements[5]).toMatchObject(createOptionInstance(createOptionsValue(3)))
+    expect(elements[3].annotations[CORE_ANNOTATIONS.PARENT][0]).toMatchObject(
       new ReferenceExpression(customObjectField.elemID, customObjectField),
     )
   })


### PR DESCRIPTION
this can fix a regression introduced in zendesk by https://github.com/salto-io/salto/pull/5733/files#diff-89893d1af4da92a0633bf2148169be4c5bfbc87b840ef9a7eb4e82ebdc75682cR825 , that caused the ducktype call to [replaceInstanceTypeForDeploy](https://github.com/salto-io/salto/blob/main/packages/zendesk-adapter/src/adapter.ts#L808) to have no effect during the [resolveChangeElement](https://github.com/salto-io/salto/blob/main/packages/zendesk-adapter/src/adapter.ts#L820) call.

~I'm not 100% about the reasons for giving the old precedence, so this is still WIP. we can also solve this by adding a variant of `resolveValues` that will use the element source for the values but not for the types, but we prefer not to use it if we can avoid it since it should be ok to pass an element source in these cases as well.~
cc @edenhassid 


---
_Release Notes_: 
None

---
_User Notifications_: 
None