### PR TITLE
SALTO-5872: add new useElementSourceForTypes flag for resolveValues func

### DIFF
--- a/packages/adapter-components/src/resolve_utils.ts
+++ b/packages/adapter-components/src/resolve_utils.ts
@@ -77,6 +77,54 @@ export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, e
   })
 }
 
+export const resolveValuesDifferentReference: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true, useElementSourceForTypes = false) => {
+  const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
+    const resolveReferenceExpression = async (expression: ReferenceExpression): Promise<ReferenceExpression> =>
+      expression.value === undefined && elementsSource !== undefined
+        ? new ReferenceExpression(
+          expression.elemID,
+          await expression.getResolvedValue(elementsSource),
+          expression.topLevelParent,
+        )
+        : expression
+    if (isReferenceExpression(value)) {
+      return getLookUpName({
+        // Make sure the reference here is always resolved
+        ref: await resolveReferenceExpression(value),
+        field,
+        path,
+        element,
+      })
+    }
+    if (isStaticFile(value)) {
+      if (value.isTemplate) {
+        const templateExpression = await parserUtils.staticFileToTemplateExpression(value)
+        // resolve of references in templateExpression usually happen in core however for templateStaticFile it is not
+        // possible to do it there, and therefore it happens here.
+        if (templateExpression)
+          templateExpression.parts = await Promise.all(
+            templateExpression?.parts.map(async part =>
+              isReferenceExpression(part) ? resolveReferenceExpression(part) : part,
+            ),
+          )
+        return templateExpression
+      }
+      const content = await value.getContent()
+      return value.encoding === 'binary' ? content : content?.toString(value.encoding)
+    }
+    return value
+  }
+
+  return transformElement({
+    element,
+    transformFunc: valuesReplacer,
+    strict: false,
+    elementsSource: useElementSourceForTypes ? elementsSource : undefined,
+    allowEmpty,
+  })
+}
+
+
 export const resolveChangeElement = <T extends Change<ChangeDataType> = Change<ChangeDataType>>(
   change: T,
   getLookUpName: GetLookupNameFunc,

--- a/packages/adapter-components/src/resolve_utils.ts
+++ b/packages/adapter-components/src/resolve_utils.ts
@@ -30,7 +30,7 @@ import {
 } from '@salto-io/adapter-api'
 import { parserUtils } from '@salto-io/parser'
 
-export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true) => {
+export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true, useElementSourceForTypes = true) => {
   const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
     const resolveReferenceExpression = async (expression: ReferenceExpression): Promise<ReferenceExpression> =>
       expression.value === undefined && elementsSource !== undefined
@@ -72,58 +72,10 @@ export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, e
     element,
     transformFunc: valuesReplacer,
     strict: false,
-    elementsSource,
+    elementsSource: useElementSourceForTypes ? elementsSource: undefined,
     allowEmpty,
   })
 }
-
-export const resolveValuesDifferentReference: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true, useElementSourceForTypes = false) => {
-  const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
-    const resolveReferenceExpression = async (expression: ReferenceExpression): Promise<ReferenceExpression> =>
-      expression.value === undefined && elementsSource !== undefined
-        ? new ReferenceExpression(
-          expression.elemID,
-          await expression.getResolvedValue(elementsSource),
-          expression.topLevelParent,
-        )
-        : expression
-    if (isReferenceExpression(value)) {
-      return getLookUpName({
-        // Make sure the reference here is always resolved
-        ref: await resolveReferenceExpression(value),
-        field,
-        path,
-        element,
-      })
-    }
-    if (isStaticFile(value)) {
-      if (value.isTemplate) {
-        const templateExpression = await parserUtils.staticFileToTemplateExpression(value)
-        // resolve of references in templateExpression usually happen in core however for templateStaticFile it is not
-        // possible to do it there, and therefore it happens here.
-        if (templateExpression)
-          templateExpression.parts = await Promise.all(
-            templateExpression?.parts.map(async part =>
-              isReferenceExpression(part) ? resolveReferenceExpression(part) : part,
-            ),
-          )
-        return templateExpression
-      }
-      const content = await value.getContent()
-      return value.encoding === 'binary' ? content : content?.toString(value.encoding)
-    }
-    return value
-  }
-
-  return transformElement({
-    element,
-    transformFunc: valuesReplacer,
-    strict: false,
-    elementsSource: useElementSourceForTypes ? elementsSource : undefined,
-    allowEmpty,
-  })
-}
-
 
 export const resolveChangeElement = <T extends Change<ChangeDataType> = Change<ChangeDataType>>(
   change: T,

--- a/packages/adapter-components/src/resolve_utils.ts
+++ b/packages/adapter-components/src/resolve_utils.ts
@@ -30,7 +30,13 @@ import {
 } from '@salto-io/adapter-api'
 import { parserUtils } from '@salto-io/parser'
 
-export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true, useElementSourceForTypes = true) => {
+export const resolveValues: ResolveValuesFunc = async (
+  element,
+  getLookUpName,
+  elementsSource,
+  allowEmpty = true,
+  useElementSourceForTypes = true,
+) => {
   const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
     const resolveReferenceExpression = async (expression: ReferenceExpression): Promise<ReferenceExpression> =>
       expression.value === undefined && elementsSource !== undefined
@@ -72,7 +78,7 @@ export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, e
     element,
     transformFunc: valuesReplacer,
     strict: false,
-    elementsSource: useElementSourceForTypes ? elementsSource: undefined,
+    elementsSource: useElementSourceForTypes ? elementsSource : undefined,
     allowEmpty,
   })
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -532,6 +532,7 @@ export type ResolveValuesFunc = <T extends Element>(
   getLookUpName: GetLookupNameFunc,
   elementsSource?: ReadOnlyElementsSource,
   allowEmpty?: boolean,
+  useElementSourceForTypes?: boolean,
 ) => Promise<T>
 
 export const findElements = (elements: Iterable<Element>, id: ElemID): Iterable<Element> =>

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -42,7 +42,8 @@ import {
   resolveChangeElement,
   definitions,
   fetch as fetchUtils,
-  restoreChangeElement, resolveValues,
+  restoreChangeElement,
+  resolveValues,
 } from '@salto-io/adapter-components'
 import { getElemIdFuncWrapper, inspectValue, logDuration } from '@salto-io/adapter-utils'
 import { collections, objects } from '@salto-io/lowerdash'

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -42,7 +42,7 @@ import {
   resolveChangeElement,
   definitions,
   fetch as fetchUtils,
-  restoreChangeElement, resolveValuesDifferentReference,
+  restoreChangeElement, resolveValues,
 } from '@salto-io/adapter-components'
 import { getElemIdFuncWrapper, inspectValue, logDuration } from '@salto-io/adapter-utils'
 import { collections, objects } from '@salto-io/lowerdash'
@@ -820,7 +820,7 @@ export default class ZendeskAdapter implements AdapterOperations {
               change,
               lookupFunc,
               async (element, getLookUpName, elementsSource) =>
-                resolveValuesDifferentReference(element, getLookUpName, elementsSource, true, false),
+                resolveValues(element, getLookUpName, elementsSource, true, false),
               this.elementsSource,
             ),
       )

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -40,10 +40,9 @@ import {
   config as configUtils,
   elements as elementUtils,
   resolveChangeElement,
-  resolveValues,
   definitions,
   fetch as fetchUtils,
-  restoreChangeElement,
+  restoreChangeElement, resolveValuesDifferentReference,
 } from '@salto-io/adapter-components'
 import { getElemIdFuncWrapper, inspectValue, logDuration } from '@salto-io/adapter-utils'
 import { collections, objects } from '@salto-io/lowerdash'
@@ -821,7 +820,7 @@ export default class ZendeskAdapter implements AdapterOperations {
               change,
               lookupFunc,
               async (element, getLookUpName, elementsSource) =>
-                resolveValues(element, getLookUpName, elementsSource, true),
+                resolveValuesDifferentReference(element, getLookUpName, elementsSource, true, false),
               this.elementsSource,
             ),
       )


### PR DESCRIPTION
add new useElementSourceForTypes flag for resolveValues func

---

_Additional context for reviewer_

---
_Release Notes_: 
Zendesk adapter:
* Fix issues on deploy of some values containing reference expressions

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
