### PR TITLE
SALTO-5879: Okta: Add support for addition and removal of `BrandTheme`

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -80,6 +80,7 @@ import userFilter from './filters/user'
 import serviceUrlFilter from './filters/service_url'
 import schemaFieldsRemovalFilter from './filters/schema_field_removal'
 import appLogoFilter from './filters/app_logo'
+import brandThemeAdditionFilter from './filters/brand_theme_addition'
 import brandThemeFilesFilter from './filters/brand_theme_files'
 import groupMembersFilter from './filters/group_members'
 import unorderedListsFilter from './filters/unordered_lists'
@@ -136,6 +137,7 @@ const DEFAULT_FILTERS = [
   defaultPolicyRuleDeployment,
   schemaFieldsRemovalFilter,
   appLogoFilter,
+  brandThemeAdditionFilter,
   brandThemeFilesFilter,
   fieldReferencesFilter,
   // should run after fieldReferencesFilter

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -81,6 +81,7 @@ import serviceUrlFilter from './filters/service_url'
 import schemaFieldsRemovalFilter from './filters/schema_field_removal'
 import appLogoFilter from './filters/app_logo'
 import brandThemeAdditionFilter from './filters/brand_theme_addition'
+import brandThemeRemovalFilter from './filters/brand_theme_removal'
 import brandThemeFilesFilter from './filters/brand_theme_files'
 import groupMembersFilter from './filters/group_members'
 import unorderedListsFilter from './filters/unordered_lists'
@@ -138,6 +139,7 @@ const DEFAULT_FILTERS = [
   schemaFieldsRemovalFilter,
   appLogoFilter,
   brandThemeAdditionFilter,
+  brandThemeRemovalFilter,
   brandThemeFilesFilter,
   fieldReferencesFilter,
   // should run after fieldReferencesFilter

--- a/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
@@ -1,0 +1,56 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+  isRemovalChange,
+} from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import { BRAND_THEME_TYPE_NAME } from '../constants'
+
+/**
+ * When removing a BrandTheme, validate that its Brand is also removed.
+ *
+ * There is always a single BrandTheme instance for each Brand, and it is removed automatically when the Brand is
+ * removed. It cannot be removed in Okta by itself.
+ *
+ * This change validator ensures that a theme can be manually removed only if its Brand is also removed as part of the
+ * same deploy action.
+ */
+export const brandThemeRemovalValidator: ChangeValidator = async changes => {
+  const removeInstanceChanges = changes.filter(isInstanceChange).filter(isRemovalChange).map(getChangeData)
+
+  const removedBrandThemeInstances = removeInstanceChanges.filter(
+    instance => instance.elemID.typeName === BRAND_THEME_TYPE_NAME,
+  )
+
+  const removedNames = new Set(removeInstanceChanges.map(instance => instance.elemID.getFullName()))
+
+  return removedBrandThemeInstances
+    .filter(brandTheme =>
+      !removedNames.has(getParent(brandTheme).elemID.getFullName()),
+    )
+    .map(brandTheme => ({
+        elemID: brandTheme.elemID,
+        severity: 'Error',
+        message: 'Cannot remove brand theme if its brand is not also being removed',
+        detailedMessage:
+          'In order to remove this brand theme, remove its brand as well',
+      }),
+    )
+}

--- a/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
@@ -15,7 +15,7 @@
  */
 
 import { ChangeValidator, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
-import { getParent } from '@salto-io/adapter-utils'
+import { getParents } from '@salto-io/adapter-utils'
 import { BRAND_THEME_TYPE_NAME } from '../constants'
 
 /**
@@ -37,7 +37,7 @@ export const brandThemeRemovalValidator: ChangeValidator = async changes => {
   const removedNames = new Set(removeInstanceChanges.map(instance => instance.elemID.getFullName()))
 
   return removedBrandThemeInstances
-    .filter(brandTheme => !removedNames.has(getParent(brandTheme).elemID.getFullName()))
+    .filter(brandTheme => !removedNames.has(getParents(brandTheme)[0]?.elemID.getFullName()))
     .map(brandTheme => ({
       elemID: brandTheme.elemID,
       severity: 'Error',

--- a/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/change_validators/brand_theme_removal.ts
@@ -14,12 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ChangeValidator,
-  getChangeData,
-  isInstanceChange,
-  isRemovalChange,
-} from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
 import { BRAND_THEME_TYPE_NAME } from '../constants'
 
@@ -42,15 +37,11 @@ export const brandThemeRemovalValidator: ChangeValidator = async changes => {
   const removedNames = new Set(removeInstanceChanges.map(instance => instance.elemID.getFullName()))
 
   return removedBrandThemeInstances
-    .filter(brandTheme =>
-      !removedNames.has(getParent(brandTheme).elemID.getFullName()),
-    )
+    .filter(brandTheme => !removedNames.has(getParent(brandTheme).elemID.getFullName()))
     .map(brandTheme => ({
-        elemID: brandTheme.elemID,
-        severity: 'Error',
-        message: 'Cannot remove brand theme if its brand is not also being removed',
-        detailedMessage:
-          'In order to remove this brand theme, remove its brand as well',
-      }),
-    )
+      elemID: brandTheme.elemID,
+      severity: 'Error',
+      message: 'Cannot remove brand theme if its brand is not also being removed',
+      detailedMessage: 'In order to remove this brand theme, remove its brand as well',
+    }))
 }

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -46,6 +46,7 @@ import {
   PRIVATE_API_DEFINITIONS_CONFIG,
 } from '../config'
 import { dynamicOSVersionFeatureValidator } from './dynamic_os_version_feature'
+import { brandThemeRemovalValidator } from './brand_theme_removal'
 
 const { createCheckDeploymentBasedOnConfigValidator, getDefaultChangeValidators, createChangeValidator } =
   deployment.changeValidators
@@ -78,6 +79,7 @@ export default ({ client, config }: { client: OktaClient; config: OktaConfig }):
     profileMappingRemoval: profileMappingRemovalValidator,
     brandRemoval: brandRemovalValidator,
     dynamicOSVersion: dynamicOSVersionFeatureValidator,
+    brandThemeRemoval: brandThemeRemovalValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1900,9 +1900,9 @@ const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [
 ]
 
 export const getSupportedTypes = ({
-                                    isClassicOrg,
-                                    supportedTypes,
-                                  }: {
+  isClassicOrg,
+  supportedTypes,
+}: {
   isClassicOrg: boolean
   supportedTypes: Record<string, string[]>
 }): Record<string, string[]> =>
@@ -2033,11 +2033,11 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
 })
 
 export const validateOktaFetchConfig = ({
-                                          fetchConfig,
-                                          clientConfig,
-                                          apiDefinitions,
-                                          privateApiDefinitions,
-                                        }: {
+  fetchConfig,
+  clientConfig,
+  apiDefinitions,
+  privateApiDefinitions,
+}: {
   fetchConfig: OktaFetchConfig
   clientConfig: OktaClientConfig
   apiDefinitions: OktaSwaggerApiConfig

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -971,6 +971,14 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
         },
         fieldsToIgnore: ['id', 'logo', 'favicon', '_links'],
       },
+      remove: {
+        // BrandThemes are removed automatically by Okta when the Brand is removed.
+        // We use an empty URL here to mark this action as supported in case a user removed the theme
+        // alongside its Brand.
+        // A separate Change Validator ensures that mappings aren't removed by themselves.
+        url: '',
+        method: 'delete', // This is just for typing, we intercept it in a filter and use `get`.
+      },
     },
   },
   BrandLogo: {
@@ -1924,6 +1932,7 @@ export type ChangeValidatorName =
   | 'profileMappingRemoval'
   | 'brandRemoval'
   | 'dynamicOSVersion'
+  | 'brandThemeRemoval'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -1953,6 +1962,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     profileMappingRemoval: { refType: BuiltinTypes.BOOLEAN },
     brandRemoval: { refType: BuiltinTypes.BOOLEAN },
     dynamicOSVersion: { refType: BuiltinTypes.BOOLEAN },
+    brandThemeRemoval: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -953,6 +953,15 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       fieldTypeOverrides: [{ fieldName: '_links', fieldType: 'map<unknown>' }],
     },
     deployRequests: {
+      add: {
+        url: '/api/v1/brands/{brandId}/themes/{themeId}',
+        method: 'put',
+        urlParamsToFields: {
+          brandId: '_parent.0.id',
+          themeId: 'id',
+        },
+        fieldsToIgnore: ['id', 'logo', 'favicon', '_links'],
+      },
       modify: {
         url: '/api/v1/brands/{brandId}/themes/{themeId}',
         method: 'put',
@@ -1883,9 +1892,9 @@ const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [
 ]
 
 export const getSupportedTypes = ({
-  isClassicOrg,
-  supportedTypes,
-}: {
+                                    isClassicOrg,
+                                    supportedTypes,
+                                  }: {
   isClassicOrg: boolean
   supportedTypes: Record<string, string[]>
 }): Record<string, string[]> =>
@@ -2014,11 +2023,11 @@ export const configType = createMatchingObjectType<Partial<OktaConfig>>({
 })
 
 export const validateOktaFetchConfig = ({
-  fetchConfig,
-  clientConfig,
-  apiDefinitions,
-  privateApiDefinitions,
-}: {
+                                          fetchConfig,
+                                          clientConfig,
+                                          apiDefinitions,
+                                          privateApiDefinitions,
+                                        }: {
   fetchConfig: OktaFetchConfig
   clientConfig: OktaClientConfig
   apiDefinitions: OktaSwaggerApiConfig

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -960,7 +960,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
           brandId: '_parent.0.id',
           themeId: 'id',
         },
-        fieldsToIgnore: ['id', 'logo', 'favicon', '_links'],
+        fieldsToIgnore: ['id'],
       },
       modify: {
         url: '/api/v1/brands/{brandId}/themes/{themeId}',

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -44,7 +44,6 @@ const deployBrandThemeAddition = async (
   apiDefinitions: OktaSwaggerApiConfig,
 ): Promise<void> => {
   const instance = getChangeData(change)
-  // eslint-disable-next-line no-underscore-dangle
   const brandId = getParents(instance)[0]?.id
   if (!_.isString(brandId)) {
     // Parent reference is already resolved

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -1,0 +1,90 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { Change, InstanceElement, isInstanceChange, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
+import { inspectValue } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { BRAND_THEME_TYPE_NAME } from '../constants'
+import OktaClient from '../client/client'
+import { API_DEFINITIONS_CONFIG, OktaSwaggerApiConfig } from '../config'
+import { FilterCreator } from '../filter'
+import { deployChanges, defaultDeployChange } from '../deployment'
+
+const log = logger(module)
+
+const getThemeIdByBrand = async (
+  brandId: string,
+  client: OktaClient,
+): Promise<string> => {
+  const mappingEntries = (
+    await client.get({
+      url: `/api/v1/brands/${brandId}/themes`,
+    })
+  ).data
+  if (_.isArray(mappingEntries) && mappingEntries.length === 1 && _.isString(mappingEntries[0].id)) {
+    return mappingEntries[0].id
+  }
+  log.error(`Received unexpected result for brand theme: ${inspectValue(mappingEntries)}`)
+  throw new Error('Could not find BrandTheme with the provided brandId')
+}
+
+const deployBrandThemeAddition = async (
+  change: Change<InstanceElement>,
+  client: OktaClient,
+  apiDefinitions: OktaSwaggerApiConfig,
+): Promise<void> => {
+  const instance = getChangeData(change)
+  log.info(`Deploying BrandTheme with id: ${instance.value.id}`)
+  log.info(`Parent: ${inspectValue(instance.annotations)}`)
+  // eslint-disable-next-line no-underscore-dangle
+  const brandId = instance.annotations?._parent?.[0]?.id
+  if (!_.isString(brandId)) {
+    // Parent reference is already resolved
+    log.error(`Failed to deploy BrandTheme with brandId: ${brandId}`)
+    throw new Error('BrandTheme must have valid brandId')
+  }
+  const themeId = await getThemeIdByBrand(brandId, client)
+  // Assign the existing id to the added brand theme
+  instance.value.id = themeId
+  await defaultDeployChange(change, client, apiDefinitions)
+}
+
+/**
+ * Deploy addition changes of BrandTheme instances, by finding the ID of the existing theme and updating it.
+ */
+const filterCreator: FilterCreator = ({ client, config }) => ({
+  name: 'brandThemeAdditionFilter',
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        isInstanceChange(change) &&
+        isAdditionChange(change) &&
+        getChangeData(change).elemID.typeName === BRAND_THEME_TYPE_NAME,
+    )
+
+    const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change =>
+      deployBrandThemeAddition(change, client, config[API_DEFINITIONS_CONFIG]),
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -15,7 +15,7 @@
  */
 import _ from 'lodash'
 import { Change, InstanceElement, isInstanceChange, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
-import { inspectValue } from '@salto-io/adapter-utils'
+import { getParents, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { BRAND_THEME_TYPE_NAME } from '../constants'
 import OktaClient from '../client/client'
@@ -34,8 +34,8 @@ const getThemeIdByBrand = async (brandId: string, client: OktaClient): Promise<s
   if (_.isArray(themeEntries) && themeEntries.length === 1 && _.isString(themeEntries[0].id)) {
     return themeEntries[0].id
   }
-  log.error(`Received unexpected result for brand theme: ${inspectValue(themeEntries)}`)
-  throw new Error(`Could not find BrandTheme with the provided brandId ${brandId}`)
+  log.error(`Received unexpected result for brand theme for brandId ${brandId}: ${inspectValue(themeEntries)}`)
+  throw new Error('Could not find BrandTheme with the provided brandId')
 }
 
 const deployBrandThemeAddition = async (
@@ -45,7 +45,7 @@ const deployBrandThemeAddition = async (
 ): Promise<void> => {
   const instance = getChangeData(change)
   // eslint-disable-next-line no-underscore-dangle
-  const brandId = instance.annotations?._parent?.[0]?.id
+  const brandId = getParents(instance)[0]?.id
   if (!_.isString(brandId)) {
     // Parent reference is already resolved
     log.error(`Failed to deploy BrandTheme with brandId: ${brandId}`)

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -25,10 +25,7 @@ import { deployChanges, defaultDeployChange } from '../deployment'
 
 const log = logger(module)
 
-const getThemeIdByBrand = async (
-  brandId: string,
-  client: OktaClient,
-): Promise<string> => {
+const getThemeIdByBrand = async (brandId: string, client: OktaClient): Promise<string> => {
   const themeEntries = (
     await client.get({
       url: `/api/v1/brands/${brandId}/themes`,

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -29,16 +29,16 @@ const getThemeIdByBrand = async (
   brandId: string,
   client: OktaClient,
 ): Promise<string> => {
-  const mappingEntries = (
+  const themeEntries = (
     await client.get({
       url: `/api/v1/brands/${brandId}/themes`,
     })
   ).data
-  if (_.isArray(mappingEntries) && mappingEntries.length === 1 && _.isString(mappingEntries[0].id)) {
-    return mappingEntries[0].id
+  if (_.isArray(themeEntries) && themeEntries.length === 1 && _.isString(themeEntries[0].id)) {
+    return themeEntries[0].id
   }
-  log.error(`Received unexpected result for brand theme: ${inspectValue(mappingEntries)}`)
-  throw new Error('Could not find BrandTheme with the provided brandId')
+  log.error(`Received unexpected result for brand theme: ${inspectValue(themeEntries)}`)
+  throw new Error(`Could not find BrandTheme with the provided brandId ${brandId}`)
 }
 
 const deployBrandThemeAddition = async (

--- a/packages/okta-adapter/src/filters/brand_theme_addition.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_addition.ts
@@ -47,8 +47,6 @@ const deployBrandThemeAddition = async (
   apiDefinitions: OktaSwaggerApiConfig,
 ): Promise<void> => {
   const instance = getChangeData(change)
-  log.info(`Deploying BrandTheme with id: ${instance.value.id}`)
-  log.info(`Parent: ${inspectValue(instance.annotations)}`)
   // eslint-disable-next-line no-underscore-dangle
   const brandId = instance.annotations?._parent?.[0]?.id
   if (!_.isString(brandId)) {

--- a/packages/okta-adapter/src/filters/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_removal.ts
@@ -22,7 +22,11 @@ import { BRAND_THEME_TYPE_NAME } from '../constants'
 import { deployChanges } from '../deployment'
 import OktaClient from '../client/client'
 
-const verifyBrandThemeIsDeleted = async (brandId: string, brandThemeId: string, client: OktaClient): Promise<boolean> => {
+const verifyBrandThemeIsDeleted = async (
+  brandId: string,
+  brandThemeId: string,
+  client: OktaClient,
+): Promise<boolean> => {
   try {
     return (
       (

--- a/packages/okta-adapter/src/filters/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_removal.ts
@@ -1,0 +1,76 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { getParents } from '@salto-io/adapter-utils'
+import { isInstanceChange, getChangeData, isRemovalChange } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { FilterCreator } from '../filter'
+import { BRAND_THEME_TYPE_NAME } from '../constants'
+import { deployChanges } from '../deployment'
+import OktaClient from '../client/client'
+
+const verifyBrandThemeIsDeleted = async (brandId: string, brandThemeId: string, client: OktaClient): Promise<boolean> => {
+  try {
+    return (
+      (
+        await client.get({
+          url: `/api/v1/brands/${brandId}/themes/${brandThemeId}`,
+        })
+      ).status === 404
+    )
+  } catch (error) {
+    if (error instanceof clientUtils.HTTPError && error.response?.status === 404) {
+      return true
+    }
+    throw error
+  }
+}
+
+/**
+ * Override the default BrandTheme removal with a verification of removal.
+ *
+ * BrandThemes are removed automatically by Okta when the Brand is removed, so only verify that they are removed.
+ * TODO: see if this is correct
+ * Separate change validator and dependency changer ensure that this is only executed if one of the mapping side was
+ * removed in the same deploy action.
+ */
+const filterCreator: FilterCreator = ({ client }) => ({
+  name: 'brandThemeRemovalFilter',
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        isInstanceChange(change) &&
+        isRemovalChange(change) &&
+        getChangeData(change).elemID.typeName === BRAND_THEME_TYPE_NAME,
+    )
+
+    const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change => {
+      const brandId = getParents(getChangeData(change))[0]?.id
+      const brandThemeId = getChangeData(change).value.id
+      if (!(await verifyBrandThemeIsDeleted(brandId, brandThemeId, client))) {
+        throw new Error('Expected BrandTheme to be deleted')
+      }
+    })
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/src/filters/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_removal.ts
@@ -16,11 +16,14 @@
 import _ from 'lodash'
 import { getParents } from '@salto-io/adapter-utils'
 import { isInstanceChange, getChangeData, isRemovalChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { BRAND_THEME_TYPE_NAME } from '../constants'
 import { deployChanges } from '../deployment'
 import OktaClient from '../client/client'
+
+const log = logger(module)
 
 const verifyBrandThemeIsDeleted = async (
   brandId: string,
@@ -39,6 +42,7 @@ const verifyBrandThemeIsDeleted = async (
     if (error instanceof clientUtils.HTTPError && error.response?.status === 404) {
       return true
     }
+    log.error(`Failed to verify that BrandTheme ${brandThemeId} is deleted: ${error.message}`)
     throw error
   }
 }

--- a/packages/okta-adapter/src/filters/brand_theme_removal.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_removal.ts
@@ -47,9 +47,8 @@ const verifyBrandThemeIsDeleted = async (
  * Override the default BrandTheme removal with a verification of removal.
  *
  * BrandThemes are removed automatically by Okta when the Brand is removed, so only verify that they are removed.
- * TODO: see if this is correct
- * Separate change validator and dependency changer ensure that this is only executed if one of the mapping side was
- * removed in the same deploy action.
+ *
+ * A separate change validator ensures that this is only executed if the Brand was removed in the same deploy action.
  */
 const filterCreator: FilterCreator = ({ client }) => ({
   name: 'brandThemeRemovalFilter',

--- a/packages/okta-adapter/src/logo.ts
+++ b/packages/okta-adapter/src/logo.ts
@@ -87,7 +87,15 @@ const sendLogoRequest = async ({
       ? await logoInstance.value.content.getContent()
       : undefined
   if (isRemoval) {
-    await client.delete({ url })
+    try {
+      await client.delete({ url })
+    } catch (e) {
+      if (e.response?.status === 404) {
+        // Okta returns 404 if the logo was already removed
+        return undefined
+      }
+      throw e
+    }
     return undefined
   }
   const form = new FormData()

--- a/packages/okta-adapter/test/change_validators/brand_theme_removal.test.ts
+++ b/packages/okta-adapter/test/change_validators/brand_theme_removal.test.ts
@@ -24,7 +24,7 @@ import {
 import { brandThemeRemovalValidator } from '../../src/change_validators/brand_theme_removal'
 import { OKTA, BRAND_THEME_TYPE_NAME, BRAND_TYPE_NAME } from '../../src/constants'
 
-describe('profileMappingRemovalValidator', () => {
+describe('brandThemeRemovalValidator', () => {
   const brandType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_TYPE_NAME) })
   const brandThemeType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
 

--- a/packages/okta-adapter/test/change_validators/brand_theme_removal.test.ts
+++ b/packages/okta-adapter/test/change_validators/brand_theme_removal.test.ts
@@ -1,0 +1,55 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  toChange,
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { brandThemeRemovalValidator } from '../../src/change_validators/brand_theme_removal'
+import { OKTA, BRAND_THEME_TYPE_NAME, BRAND_TYPE_NAME } from '../../src/constants'
+
+describe('profileMappingRemovalValidator', () => {
+  const brandType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_TYPE_NAME) })
+  const brandThemeType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
+
+  const brand = new InstanceElement('brand', brandType, { id: 'brandId123' })
+  const brandTheme = new InstanceElement('user type', brandThemeType, {}, undefined, {
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(brand.elemID, brand)],
+  })
+
+  it('should return an error when BrandTheme is deleted without its Brand', async () => {
+    const changeErrors = await brandThemeRemovalValidator([toChange({ before: brandTheme })])
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: brandTheme.elemID,
+        severity: 'Error',
+        message: 'Cannot remove brand theme if its brand is not also being removed',
+        detailedMessage: 'In order to remove this brand theme, remove its brand as well',
+      },
+    ])
+  })
+  it('should not return an error when BrandTheme is deleted with its brand', async () => {
+    const changeErrors = await brandThemeRemovalValidator([
+      toChange({ before: brand }),
+      toChange({ before: brandTheme }),
+    ])
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
+++ b/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
@@ -28,9 +28,15 @@ describe('brandThemeAdditionFilter', () => {
   type FilterType = filterUtils.FilterWith<'deploy'>
   let filter: FilterType
   const themeType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
-  const themeInstance = new InstanceElement('theme', themeType, {
-    secondaryColorHex: '#abcdef',
-  }, undefined, { _parent: [{ id: 'brandId123' }] })
+  const themeInstance = new InstanceElement(
+    'theme',
+    themeType,
+    {
+      secondaryColorHex: '#abcdef',
+    },
+    undefined,
+    { _parent: [{ id: 'brandId123' }] },
+  )
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -54,11 +60,13 @@ describe('brandThemeAdditionFilter', () => {
       const result = await filter.deploy([toChange({ after: themeInstance })])
       expect(result.deployResult.appliedChanges).toHaveLength(1)
       expect(mockConnection.get).toHaveBeenCalledWith('/api/v1/brands/brandId123/themes', undefined)
-      expect(mockConnection.put).toHaveBeenCalledWith('/api/v1/brands/brandId123/themes/themeId456', {
+      expect(mockConnection.put).toHaveBeenCalledWith(
+        '/api/v1/brands/brandId123/themes/themeId456',
+        {
           secondaryColorHex: '#abcdef',
-        }, undefined,
+        },
+        undefined,
       )
     })
   })
 })
-

--- a/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
+++ b/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
@@ -77,10 +77,8 @@ describe('brandThemeAdditionFilter', () => {
     })
     it('should throw an error when failing to get the theme id - no themes returned', async () => {
       mockConnection.get.mockResolvedValue({
-        status: 200, data: [
-          { id: 'themeId456' },
-          { id: 'themeId789' },
-        ],
+        status: 200,
+        data: [{ id: 'themeId456' }, { id: 'themeId789' }],
       })
       const result = await filter.deploy([toChange({ after: themeInstance })])
       expect(result.deployResult.errors).toEqual([
@@ -105,7 +103,10 @@ describe('brandThemeAdditionFilter', () => {
     it('should throw an error when the parent brand is already resolved', async () => {
       const brandType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
       const brandInstance = new InstanceElement('brand', brandType, { id: 'brandId123' })
-      themeInstance.annotations[CORE_ANNOTATIONS.PARENT][0] = new ReferenceExpression(brandInstance.elemID, brandInstance)
+      themeInstance.annotations[CORE_ANNOTATIONS.PARENT][0] = new ReferenceExpression(
+        brandInstance.elemID,
+        brandInstance,
+      )
       const result = await filter.deploy([toChange({ after: themeInstance })])
       expect(result.deployResult.errors).toEqual([
         {

--- a/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
+++ b/packages/okta-adapter/test/filters/brand_theme_addition.test.ts
@@ -1,0 +1,64 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { MockInterface } from '@salto-io/test-utils'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
+import { getFilterParams, mockClient } from '../utils'
+import OktaClient from '../../src/client/client'
+import brandThemeAdditionFilter from '../../src/filters/brand_theme_addition'
+import { OKTA, BRAND_THEME_TYPE_NAME } from '../../src/constants'
+
+describe('brandThemeAdditionFilter', () => {
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: OktaClient
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const themeType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
+  const themeInstance = new InstanceElement('theme', themeType, {
+    secondaryColorHex: '#abcdef',
+  }, undefined, { _parent: [{ id: 'brandId123' }] })
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client: cli, connection } = mockClient()
+    mockConnection = connection
+    client = cli
+    filter = brandThemeAdditionFilter(getFilterParams({ client })) as typeof filter
+  })
+
+  describe('deploy', () => {
+    it('should successfully deploy addition changes of brand theme', async () => {
+      mockConnection.get.mockResolvedValue({
+        status: 200,
+        data: [
+          {
+            id: 'themeId456',
+          },
+        ],
+      })
+      mockConnection.put.mockResolvedValue({ status: 200, data: {} })
+      const result = await filter.deploy([toChange({ after: themeInstance })])
+      expect(result.deployResult.appliedChanges).toHaveLength(1)
+      expect(mockConnection.get).toHaveBeenCalledWith('/api/v1/brands/brandId123/themes', undefined)
+      expect(mockConnection.put).toHaveBeenCalledWith('/api/v1/brands/brandId123/themes/themeId456', {
+          secondaryColorHex: '#abcdef',
+        }, undefined,
+      )
+    })
+  })
+})
+

--- a/packages/okta-adapter/test/filters/brand_theme_removal.test.ts
+++ b/packages/okta-adapter/test/filters/brand_theme_removal.test.ts
@@ -1,0 +1,76 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID, InstanceElement, ObjectType, toChange, getChangeData } from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../utils'
+import brandThemeRemovalFilter from '../../src/filters/brand_theme_removal'
+import { OKTA, BRAND_THEME_TYPE_NAME } from '../../src/constants'
+import OktaClient from '../../src/client/client'
+
+describe('brandThemeRemovalFilter', () => {
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: OktaClient
+  type FilterType = filterUtils.FilterWith<'deploy'>
+  let filter: FilterType
+  const brandThemeType = new ObjectType({ elemID: new ElemID(OKTA, BRAND_THEME_TYPE_NAME) })
+  const brandThemeInstance = new InstanceElement('theme', brandThemeType, {})
+  const notFoundError = new clientUtils.HTTPError('message', {
+    status: 404,
+    data: {},
+  })
+  const successResponse = { status: 200, data: '' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client: cli, connection } = mockClient()
+    mockConnection = connection
+    client = cli
+    filter = brandThemeRemovalFilter(getFilterParams({ client })) as typeof filter
+  })
+
+  describe('deploy', () => {
+    it('should successfully deploy removal of brand theme as a verification', async () => {
+      mockConnection.get.mockRejectedValue(notFoundError)
+      const changes = [toChange({ before: brandThemeInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(0)
+      expect(appliedChanges).toHaveLength(1)
+      expect(appliedChanges.map(change => getChangeData(change))[0]).toEqual(brandThemeInstance)
+    })
+
+    it('should fail when the brand theme exists', async () => {
+      mockConnection.get.mockResolvedValue(successResponse)
+      const changes = [toChange({ before: brandThemeInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(1)
+      expect(appliedChanges).toHaveLength(0)
+    })
+
+    it('should handle multiple changes', async () => {
+      mockConnection.get.mockRejectedValueOnce(notFoundError)
+      mockConnection.get.mockResolvedValueOnce(successResponse)
+      const changes = [toChange({ before: brandThemeInstance }), toChange({ before: brandThemeInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(1)
+      expect(appliedChanges).toHaveLength(1)
+    })
+  })
+})

--- a/packages/okta-adapter/test/logo.test.ts
+++ b/packages/okta-adapter/test/logo.test.ts
@@ -196,5 +196,25 @@ describe('logo filter', () => {
         new Error('some okta error. More info: cause1,cause2 (status code: 400)'),
       )
     })
+    it('should call send Logo Request with removal', async () => {
+      const mockDelete = mockConnection.delete
+      const appLogoChange = toChange({ before: appLogoInstance })
+      await deployLogo(appLogoChange, client)
+      expect(mockDelete).toHaveBeenCalledTimes(1)
+      expect(mockDelete).toHaveBeenCalledWith('/api/v1/apps/11/logo', undefined)
+    })
+    it('should allow 404 status when removing a logo', async () => {
+      const mockDelete = mockConnection.delete
+      mockDelete.mockRejectedValue(
+        new clientUtils.HTTPError('message', {
+          status: 404,
+          data: {},
+        }),
+      )
+      const appLogoChange = toChange({ before: appLogoInstance })
+      await deployLogo(appLogoChange, client)
+      expect(mockDelete).toHaveBeenCalledTimes(1)
+      expect(mockDelete).toHaveBeenCalledWith('/api/v1/apps/11/logo', undefined)
+    })
   })
 })


### PR DESCRIPTION
Add support for addition and removal of `BrandTheme`.

Addition: `BrandTheme`s are created automatically with default values. This PR allows to "add" a custom theme (alongside its Brand) by modifying the automatically created theme instead.

Removal: `BrandTheme`s are automatically removed when their `Brand`s are removed. This PR implements removal by just verifying that they are removed (and disallowing removal if the `Brand` wasn't removed as well).



---

_Additional context for reviewer_
Removal handling is similar to #5594

---
_Release Notes_: 
_Okta adapter_:
- Added support for addition and removal of `BrandTheme`.

---
_User Notifications_: 
None