### PR TITLE
SALTO-954 SALTO-5558 allow multiple pointers to static file

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -429,6 +429,7 @@ export const mockWorkspace = ({
     getStaticFilePathsByElemIds: mockFunction<Workspace['getStaticFilePathsByElemIds']>(),
     isChangedAtIndexEmpty: mockFunction<Workspace['isChangedAtIndexEmpty']>(),
     getElemIdsByStaticFilePaths: mockFunction<Workspace['getElemIdsByStaticFilePaths']>(),
+    getElemIdsByStaticFilePathsNew: mockFunction<Workspace['getElemIdsByStaticFilePathsNew']>(),
   }
 }
 

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -851,7 +851,9 @@ const buildNaclFilesSource = (
     const removeDanglingStaticFiles = async (allChanges: DetailedChange[]): Promise<void> => {
       const { staticFilesIndex } = await getState()
 
-      await Promise.all(getDanglingStaticFiles(allChanges, staticFilesIndex).map(file => staticFilesSource.delete(file)))
+      await Promise.all(
+        getDanglingStaticFiles(allChanges, staticFilesIndex).map(file => staticFilesSource.delete(file)),
+      )
     }
     const changesByFileName = await groupChangesByFilename(changes)
     log.debug(

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -846,10 +846,16 @@ const buildNaclFilesSource = (
 
     const removeDanglingStaticFiles = async (allChanges: DetailedChange[]): Promise<void> => {
       const {staticFilesIndex} = await getState()
+
       await Promise.all(
         getDanglingStaticFiles(allChanges).map(
-          file => staticFilesIndex.get(file.filepath) ?? staticFilesSource.delete(file),
-        ),
+          async file => {
+            const filePath = await staticFilesIndex.get(file.filepath)
+            if (!filePath) {
+              await staticFilesSource.delete(file)
+            }
+          }
+        )
       )
     }
     const changesByFileName = await groupChangesByFilename(changes)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -845,17 +845,15 @@ const buildNaclFilesSource = (
     }
 
     const removeDanglingStaticFiles = async (allChanges: DetailedChange[]): Promise<void> => {
-      const {staticFilesIndex} = await getState()
+      const { staticFilesIndex } = await getState()
 
       await Promise.all(
-        getDanglingStaticFiles(allChanges).map(
-          async file => {
-            const filePath = await staticFilesIndex.get(file.filepath)
-            if (!filePath) {
-              await staticFilesSource.delete(file)
-            }
+        getDanglingStaticFiles(allChanges).map(async file => {
+          const filePath = await staticFilesIndex.get(file.filepath)
+          if (!filePath) {
+            await staticFilesSource.delete(file)
           }
-        )
+        }),
       )
     }
     const changesByFileName = await groupChangesByFilename(changes)

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -844,10 +844,13 @@ const buildNaclFilesSource = (
       return naclFile ? naclFile.buffer : ''
     }
 
-    // This method was written with the assumption that each static file is pointed by no more
-    // then one value in the nacls. A ticket was open to fix that (SALTO-954)
     const removeDanglingStaticFiles = async (allChanges: DetailedChange[]): Promise<void> => {
-      await Promise.all(getDanglingStaticFiles(allChanges).map(file => staticFilesSource.delete(file)))
+      const {staticFilesIndex} = await getState()
+      await Promise.all(
+        getDanglingStaticFiles(allChanges).map(
+          file => staticFilesIndex.get(file.filepath) ?? staticFilesSource.delete(file),
+        ),
+      )
     }
     const changesByFileName = await groupChangesByFilename(changes)
     log.debug(

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -601,8 +601,8 @@ export const getDanglingStaticFiles = (
     .filter(isRemovalOrModificationChange)
     .map(change => change.data.before)
     .flatMap(getNestedStaticFiles)
-    .filter(file => !staticFileIndex?.has(file.filepath))
     .filter(file => !afterFilePaths.has(file.filepath))
+    .filter(async file => !staticFileIndex?.has(file.filepath))
 }
 
 const buildNaclFilesSource = (
@@ -851,14 +851,7 @@ const buildNaclFilesSource = (
     const removeDanglingStaticFiles = async (allChanges: DetailedChange[]): Promise<void> => {
       const { staticFilesIndex } = await getState()
 
-      await Promise.all(
-        getDanglingStaticFiles(allChanges, staticFilesIndex).map(async file => {
-          const filePath = await staticFilesIndex.get(file.filepath)
-          if (!filePath) {
-            await staticFilesSource.delete(file)
-          }
-        }),
-      )
+      await Promise.all(getDanglingStaticFiles(allChanges, staticFilesIndex).map(file => staticFilesSource.delete(file)))
     }
     const changesByFileName = await groupChangesByFilename(changes)
     log.debug(

--- a/packages/workspace/src/workspace/state/in_mem.ts
+++ b/packages/workspace/src/workspace/state/in_mem.ts
@@ -84,6 +84,7 @@ export const buildInMemState = (loadData: () => Promise<StateData>, persistent =
 
   const deleteRemovedStaticFiles = async (elemChanges: DetailedChange[]): Promise<void> => {
     const { staticFilesSource } = await stateData()
+    // SALTO-5898 We don't pass a static file index here, which could wrongly require deleting static files whose one element deleted the static file
     const files = getDanglingStaticFiles(elemChanges)
     await Promise.all(files.map(file => staticFilesSource.delete(file)))
   }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1193,11 +1193,15 @@ export const loadWorkspace = async (
       .flatMap(({ key: id, value: fileNames }) =>
         fileNames
           .filter(filename => filePaths === undefined || filePaths.has(filename))
-          .map(filename => ({ filename, id } )),
-      ).groupBy(({ filename }) => filename)
+          .map(filename => ({ filename, id })),
+      )
+      .groupBy(({ filename }) => filename)
     return _.mapValues(idsAndFileByFileName, idAndFiles => idAndFiles.map(({ id }) => id))
   }
-  const getElemIdsByStaticFilePaths = async (filePaths: Set<string>, envName?: string): Promise<Record<string, string>> => {
+  const getElemIdsByStaticFilePaths = async (
+    filePaths: Set<string>,
+    envName?: string,
+  ): Promise<Record<string, string>> => {
     const res = await getElemIdsByStaticFilePathsNew(filePaths, envName)
     return _.mapValues(res, ids => ids[0])
   }

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -483,24 +483,7 @@ describe('Nacl Files Source', () => {
       await src.updateNaclFiles([changeAdd, changeDelete])
       expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
     })
-    it('should not delete static file if the file is still being used by another element', async () => {
-      const changeRemove = {
-        id: new ElemID('salesforce', 'new_elem2'),
-        action: 'remove',
-        data: { before: sfile },
-        path: ['new', 'file'],
-      } as DetailedChange
-      const changeModify = {
-        id: elemID,
-        action: 'modify',
-        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
-        path: ['new', 'file'],
-      } as DetailedChange
-      await src.updateNaclFiles([changeRemove, changeModify])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
-    })
   })
-
   describe('init with parsed files', () => {
     it('should return elements from given parsed files', async () => {
       const filename = 'mytest.nacl'

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -483,6 +483,22 @@ describe('Nacl Files Source', () => {
       await src.updateNaclFiles([changeAdd, changeDelete])
       expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
     })
+    it('should not delete static file if the file is still being used by another element', async () => {
+      const changeRemove = {
+        id: new ElemID('salesforce', 'new_elem2'),
+        action: 'remove',
+        data: { before: sfile },
+        path: ['new', 'file'],
+      } as DetailedChange
+      const changeModify = {
+        id: elemID,
+        action: 'modify',
+        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' })},
+        path: ['new', 'file'],
+      } as DetailedChange
+      await src.updateNaclFiles([changeRemove, changeModify])
+      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
+    })
   })
 
   describe('init with parsed files', () => {

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -493,7 +493,7 @@ describe('Nacl Files Source', () => {
       const changeModify = {
         id: elemID,
         action: 'modify',
-        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' })},
+        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
         path: ['new', 'file'],
       } as DetailedChange
       await src.updateNaclFiles([changeRemove, changeModify])

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2632,8 +2632,8 @@ describe('workspace', () => {
         it('should return full map', async () => {
           const result = await workspace.getElemIdsByStaticFilePaths()
           expect(result).toEqual({
-            'static1.nacl': ['salesforce.lead.instance.someName1'],
-            'static2.nacl': ['salesforce.lead.instance.someName2', 'salesforce.lead.instance.someName3'],
+            'static1.nacl': 'salesforce.lead.instance.someName1',
+            'static2.nacl': 'salesforce.lead.instance.someName2',
           })
         })
       })
@@ -2642,7 +2642,7 @@ describe('workspace', () => {
           it('should return a mapping that only contains the given paths', async () => {
             const result = await workspace.getElemIdsByStaticFilePaths(new Set(['static1.nacl']))
             expect(result).toEqual({
-              'static1.nacl': ['salesforce.lead.instance.someName1'],
+              'static1.nacl': 'salesforce.lead.instance.someName1',
             })
           })
         })
@@ -2655,6 +2655,39 @@ describe('workspace', () => {
         describe('when given paths are empty', () => {
           it('should return an empty map', async () => {
             const result = await workspace.getElemIdsByStaticFilePaths(new Set())
+            expect(result).toEqual({})
+          })
+        })
+      })
+    })
+    describe('getElemIdsByStaticFilePathsNew', () => {
+      describe('with missing filepaths param', () => {
+        it('should return full map', async () => {
+          const result = await workspace.getElemIdsByStaticFilePathsNew()
+          expect(result).toEqual({
+            'static1.nacl': ['salesforce.lead.instance.someName1'],
+            'static2.nacl': ['salesforce.lead.instance.someName2', 'salesforce.lead.instance.someName3'],
+          })
+        })
+      })
+      describe('with supplied filepaths', () => {
+        describe('when specific paths are given', () => {
+          it('should return a mapping that only contains the given paths', async () => {
+            const result = await workspace.getElemIdsByStaticFilePathsNew(new Set(['static1.nacl']))
+            expect(result).toEqual({
+              'static1.nacl': ['salesforce.lead.instance.someName1'],
+            })
+          })
+        })
+        describe('when given paths do no exist', () => {
+          it('should return an empty map', async () => {
+            const result = await workspace.getElemIdsByStaticFilePathsNew(new Set(['not exists.nacl']))
+            expect(result).toEqual({})
+          })
+        })
+        describe('when given paths are empty', () => {
+          it('should return an empty map', async () => {
+            const result = await workspace.getElemIdsByStaticFilePathsNew(new Set())
             expect(result).toEqual({})
           })
         })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2553,12 +2553,12 @@ describe('workspace', () => {
     `
     const secondInstance = `
       salesforce.lead someName2 {
-      salesforce.text = file("static2.nacl")
+      salesforce.text = file("static2")
       }
     `
     const thirdInstance = `
       salesforce.lead someName3 {
-      salesforce.text = file("static2.nacl")
+      salesforce.text = file("static2")
       }
     `
     const naclFileStore = mockDirStore(undefined, undefined, {
@@ -2575,7 +2575,7 @@ describe('workspace', () => {
       })
       const secondStaticFile = new StaticFile({
         content: Buffer.from('I am a little static file'),
-        filepath: 'static2.nacl',
+        filepath: 'static2',
         hash: 'FFFF',
       })
       workspace = await createWorkspace(naclFileStore, undefined, undefined, undefined, undefined, undefined, {
@@ -2600,11 +2600,11 @@ describe('workspace', () => {
           {
             id: new ElemID('salesforce', 'lead', 'instance', 'someName1', 'salesforce', 'text'),
             action: 'remove',
-            data: { before: 'file("static2.nacl")' },
+            data: { before: new ReferenceExpression(new ElemID('salesforce.lead.instance.someName1__static2_false')) },
           },
         ]
         await workspace.updateNaclFiles(changes)
-        expect(workspace.getStaticFile({ filepath: 'static2.nacl', encoding: 'ascii' })).toBeDefined()
+        expect(workspace.getStaticFile({ filepath: 'static2', encoding: 'ascii' })).toBeDefined()
       })
     })
 
@@ -2620,7 +2620,7 @@ describe('workspace', () => {
           ElemID.fromFullName('salesforce.lead.instance.someName1'),
           ElemID.fromFullName('salesforce.lead.instance.someName2'),
         ])
-        expect(result).toEqual(['static1.nacl', 'static2.nacl'])
+        expect(result).toEqual(['static1.nacl', 'static2'])
       })
       it('get no paths when providing a bad element id', async () => {
         const result = await workspace.getStaticFilePathsByElemIds([ElemID.fromFullName('salesforce.lead.type')])
@@ -2633,7 +2633,7 @@ describe('workspace', () => {
           const result = await workspace.getElemIdsByStaticFilePaths()
           expect(result).toEqual({
             'static1.nacl': 'salesforce.lead.instance.someName1',
-            'static2.nacl': 'salesforce.lead.instance.someName2',
+            static2: 'salesforce.lead.instance.someName2',
           })
         })
       })
@@ -2666,7 +2666,7 @@ describe('workspace', () => {
           const result = await workspace.getElemIdsByStaticFilePathsNew()
           expect(result).toEqual({
             'static1.nacl': ['salesforce.lead.instance.someName1'],
-            'static2.nacl': ['salesforce.lead.instance.someName2', 'salesforce.lead.instance.someName3'],
+            static2: ['salesforce.lead.instance.someName2', 'salesforce.lead.instance.someName3'],
           })
         })
       })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2632,8 +2632,8 @@ describe('workspace', () => {
         it('should return full map', async () => {
           const result = await workspace.getElemIdsByStaticFilePaths()
           expect(result).toEqual({
-            'static1.nacl': 'salesforce.lead.instance.someName1',
-            'static2.nacl': 'salesforce.lead.instance.someName2',
+            'static1.nacl': ['salesforce.lead.instance.someName1'],
+            'static2.nacl': ['salesforce.lead.instance.someName2', 'salesforce.lead.instance.someName3'],
           })
         })
       })
@@ -2642,7 +2642,7 @@ describe('workspace', () => {
           it('should return a mapping that only contains the given paths', async () => {
             const result = await workspace.getElemIdsByStaticFilePaths(new Set(['static1.nacl']))
             expect(result).toEqual({
-              'static1.nacl': 'salesforce.lead.instance.someName1',
+              'static1.nacl': ['salesforce.lead.instance.someName1'],
             })
           })
         })


### PR DESCRIPTION
Do not delete static file unless all pointers to it are removed

---

Please think about how I can create a test for this, because this is very internal



To check this, I ran the following scenario in Zendesk with and without the change:

1. add an article named A with an attachment
2. fetch
3. add an article with the same attachment called B
4. fetch
5. change the name of the article from A to B
6. fetch
7. Make sure that A and B point to the same static file
8. delete the original B

Without the new code, the result is a workspace error with a missing static file.
With the code, this goes smoothly and the static file is preserved

---
_Release Notes_: 
Workspace:
* Allow multiple pointers to the same static file


---
_User Notifications_: _None_