### PR TITLE
Revert "SALTO-5872: add new useElementSourceForTypes flag for resolveValues func (#5850)"

### DIFF
--- a/packages/adapter-components/src/resolve_utils.ts
+++ b/packages/adapter-components/src/resolve_utils.ts
@@ -30,13 +30,7 @@ import {
 } from '@salto-io/adapter-api'
 import { parserUtils } from '@salto-io/parser'
 
-export const resolveValues: ResolveValuesFunc = async (
-  element,
-  getLookUpName,
-  elementsSource,
-  allowEmpty = true,
-  useElementSourceForTypes = true,
-) => {
+export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, elementsSource, allowEmpty = true) => {
   const valuesReplacer: TransformFunc = async ({ value, field, path }) => {
     const resolveReferenceExpression = async (expression: ReferenceExpression): Promise<ReferenceExpression> =>
       expression.value === undefined && elementsSource !== undefined
@@ -78,7 +72,7 @@ export const resolveValues: ResolveValuesFunc = async (
     element,
     transformFunc: valuesReplacer,
     strict: false,
-    elementsSource: useElementSourceForTypes ? elementsSource : undefined,
+    elementsSource,
     allowEmpty,
   })
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -532,7 +532,6 @@ export type ResolveValuesFunc = <T extends Element>(
   getLookUpName: GetLookupNameFunc,
   elementsSource?: ReadOnlyElementsSource,
   allowEmpty?: boolean,
-  useElementSourceForTypes?: boolean,
 ) => Promise<T>
 
 export const findElements = (elements: Iterable<Element>, id: ElemID): Iterable<Element> =>

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -40,10 +40,10 @@ import {
   config as configUtils,
   elements as elementUtils,
   resolveChangeElement,
+  resolveValues,
   definitions,
   fetch as fetchUtils,
   restoreChangeElement,
-  resolveValues,
 } from '@salto-io/adapter-components'
 import { getElemIdFuncWrapper, inspectValue, logDuration } from '@salto-io/adapter-utils'
 import { collections, objects } from '@salto-io/lowerdash'
@@ -821,7 +821,7 @@ export default class ZendeskAdapter implements AdapterOperations {
               change,
               lookupFunc,
               async (element, getLookUpName, elementsSource) =>
-                resolveValues(element, getLookUpName, elementsSource, true, false),
+                resolveValues(element, getLookUpName, elementsSource, true),
               this.elementsSource,
             ),
       )


### PR DESCRIPTION
This reverts commit 680f619358385c31cbce2a778a1f90d698eaae39.

after we merge https://github.com/salto-io/salto/pull/5849, we can revert the workaround from https://github.com/salto-io/salto/pull/5850

---
_Release Notes_: 
None

---
_User Notifications_: 
None
