### PR TITLE
SALTO-5441: update error message for failing to get issueLayouts

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -215,7 +215,9 @@ const deployLayoutChange = async (change: Change<InstanceElement>, client: JiraC
     const response = await getLayoutResponse({ variables, client, typeName })
     if (!isIssueLayoutResponse(response.data)) {
       log.error('received invalid response from jira', response)
-      throw Error('Failed to deploy issue layout changes due to bad response from jira service')
+      throw Error(
+        'Failed to deploy issue layout changes due to an unexpected response from Jira. Your target environment might not be synced, please fetch it and try again.',
+      )
     }
     const issueLayoutId = response.data.issueLayoutConfiguration.issueLayoutResult.id
     const url = `/rest/internal/1.0/issueLayouts/${issueLayoutId}`


### PR DESCRIPTION
updating the error message the client gets when he tries to deploy change (add, remove, or modify) regarding issue layout and he gets a failed response from jira service.
it can happen because the issue layout was in the environment and there were changes in the environment and now the issue layout no longer exists in this environment and the problem was that is environment was not sync 
I changed the error message so it will explain this possibility

---

---
_Release Notes_: 
jira adapter:
- improved the error message for some failed issue layouts deployments
---
_User Notifications_: 
N/A