### PR TITLE
SALTO-5852: Skip fetching issueType icon if response is 404

### DIFF
--- a/packages/jira-adapter/src/filters/icon_utils.ts
+++ b/packages/jira-adapter/src/filters/icon_utils.ts
@@ -55,10 +55,12 @@ const getIconContent = async (link: string, client: JiraClient): Promise<Buffer>
     const res = await client.get({ url: link, queryParams, responseType: 'arraybuffer' })
     const content = _.isString(res.data) ? Buffer.from(res.data) : res.data
     if (res.status === 404) {
-      throw new Error('Failed to fetch attachment content, attachment not found')
+      throw new Error(
+        'Failed to fetch issue type icon. It might be corrupted. To fix this, upload a new icon in your jira instance.',
+      )
     }
     if (!Buffer.isBuffer(content)) {
-      throw new Error('Failed to fetch attachment content, response is not a buffer')
+      throw new Error('Failed to fetch attachment content, response is not a buffer.')
     }
     return content
   } catch (e) {

--- a/packages/jira-adapter/src/filters/icon_utils.ts
+++ b/packages/jira-adapter/src/filters/icon_utils.ts
@@ -54,8 +54,11 @@ const getIconContent = async (link: string, client: JiraClient): Promise<Buffer>
   try {
     const res = await client.get({ url: link, queryParams, responseType: 'arraybuffer' })
     const content = _.isString(res.data) ? Buffer.from(res.data) : res.data
+    if (res.status === 404) {
+      throw new Error('Failed to fetch attachment content, attachment not found')
+    }
     if (!Buffer.isBuffer(content)) {
-      throw new Error('Failed to fetch attachment content, response is not a buffer.')
+      throw new Error('Failed to fetch attachment content, response is not a buffer')
     }
     return content
   } catch (e) {

--- a/packages/jira-adapter/src/filters/issue_type.ts
+++ b/packages/jira-adapter/src/filters/issue_type.ts
@@ -95,7 +95,7 @@ const filter: FilterCreator = ({ client, config }) => ({
           const link = `/rest/api/3/universal_avatar/view/type/issuetype/avatar/${issueType.value.avatarId}`
           await setIconContent({ client, instance: issueType, link, fieldName: 'avatar' })
         } catch (e) {
-          errors.push({ message: e.message, severity: 'Error' })
+          errors.push({ message: e.message, severity: 'Warning' })
         }
       }),
     )

--- a/packages/jira-adapter/test/filters/issue_type.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type.test.ts
@@ -205,7 +205,7 @@ describe('issueTypeFilter', () => {
           errors: [
             {
               message:
-                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, response is not a buffer',
+                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, response is not a buffer.',
               severity: 'Warning',
             },
           ],
@@ -227,7 +227,7 @@ describe('issueTypeFilter', () => {
           errors: [
             {
               message:
-                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, attachment not found',
+                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch issue type icon. It might be corrupted. To fix this, upload a new icon in your jira instance.',
               severity: 'Warning',
             },
           ],

--- a/packages/jira-adapter/test/filters/issue_type.test.ts
+++ b/packages/jira-adapter/test/filters/issue_type.test.ts
@@ -171,8 +171,8 @@ describe('issueTypeFilter', () => {
       })
       it('should not set icon content and add error if failed to fetch icon due to an http error', async () => {
         mockGet.mockImplementation(() => {
-          throw new clientUtils.HTTPError('404 Item not found', {
-            status: 404,
+          throw new clientUtils.HTTPError('500 Internal request', {
+            status: 500,
             data: {
               errorMessages: ['The content was not found.'],
             },
@@ -183,8 +183,8 @@ describe('issueTypeFilter', () => {
         expect(res).toEqual({
           errors: [
             {
-              message: 'Failed to fetch attachment content from Jira API. error: 404 Item not found',
-              severity: 'Error',
+              message: 'Failed to fetch attachment content from Jira API. error: 500 Internal request',
+              severity: 'Warning',
             },
           ],
         })
@@ -205,8 +205,30 @@ describe('issueTypeFilter', () => {
           errors: [
             {
               message:
-                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, response is not a buffer.',
-              severity: 'Error',
+                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, response is not a buffer',
+              severity: 'Warning',
+            },
+          ],
+        })
+      })
+      it('should not set icon content and add error if failed to fetch icon due to 404 response', async () => {
+        mockGet.mockImplementation(params => {
+          if (params.url === '/rest/api/3/universal_avatar/view/type/issuetype/avatar/1') {
+            return {
+              status: 404,
+              data: {},
+            }
+          }
+          throw new Error('Err')
+        })
+        const res = await filter.onFetch?.([instance])
+        expect(instance.value.avatar).toBeUndefined()
+        expect(res).toEqual({
+          errors: [
+            {
+              message:
+                'Failed to fetch attachment content from Jira API. error: Error: Failed to fetch attachment content, attachment not found',
+              severity: 'Warning',
             },
           ],
         })


### PR DESCRIPTION
In this PR:
1. Fixed fetch error due to missing icon and added proper fetch warning.
2. Decreased the severity from Error to Warning since we can deploy issueType and all related types without the issueType icon. 
---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* Fixed fetch error for missing issueTypeIcon. 

---
_User Notifications_: 
* Fixed fetch error for missing issueTypeIcon. 
