### PR TITLE
SALTO-4242 (Okta): Adding removal for app user schema

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -95,6 +95,7 @@ import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import groupPushPathFilter from './filters/group_push_path'
 import renameDefaultAccessPolicy from './filters/rename_default_access_policy'
+import appUserSchemaRemovalFilter from './filters/app_user_schema_removal'
 import {
   APP_LOGO_TYPE_NAME,
   BRAND_LOGO_TYPE_NAME,
@@ -128,6 +129,7 @@ const DEFAULT_FILTERS = [
   authorizationRuleFilter,
   // should run before fieldReferencesFilter
   urlReferencesFilter,
+  appUserSchemaRemovalFilter,
   userFilter,
   groupMembersFilter,
   groupPushFilter,

--- a/packages/okta-adapter/src/change_validators/app_user_schema_and_application.ts
+++ b/packages/okta-adapter/src/change_validators/app_user_schema_and_application.ts
@@ -42,7 +42,9 @@ export const appUserSchemaAndApplicationValidator: ChangeValidator = async chang
         return !removedApplicationNames.has(getParent(appUserSchema).elemID.getFullName())
       } catch (e) {
         log.error(
-          `Could not run appUserSchemaAndApplicationValidator validator for instance ${appUserSchema.elemID.getFullName}: ${e}`,
+          'Could not run appUserSchemaAndApplicationValidator validator for instance %s: %s',
+          appUserSchema.elemID.getFullName(),
+          e,
         )
         return false
       }

--- a/packages/okta-adapter/src/change_validators/app_user_schema_and_application.ts
+++ b/packages/okta-adapter/src/change_validators/app_user_schema_and_application.ts
@@ -1,0 +1,56 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeValidator, getChangeData, isInstanceChange, isRemovalChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { getParent } from '@salto-io/adapter-utils'
+import { APPLICATION_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+
+/**
+ * When removing AppUserSchema, validate the parent Application gets removed as well
+ */
+export const appUserSchemaAndApplicationValidator: ChangeValidator = async changes => {
+  const removalInstanceChanges = changes.filter(isInstanceChange).filter(isRemovalChange).map(getChangeData)
+
+  const removedAppUserSchemaInstances = removalInstanceChanges.filter(
+    instance => instance.elemID.typeName === APP_USER_SCHEMA_TYPE_NAME,
+  )
+
+  const removedApplicationNames = new Set(
+    removalInstanceChanges
+      .filter(instance => instance.elemID.typeName === APPLICATION_TYPE_NAME)
+      .map(instance => instance.elemID.getFullName()),
+  )
+
+  return removedAppUserSchemaInstances
+    .filter(appUserSchema => {
+      try {
+        return !removedApplicationNames.has(getParent(appUserSchema).elemID.getFullName())
+      } catch (e) {
+        log.error(
+          `Could not run appUserSchemaAndApplicationValidator validator for instance ${appUserSchema.elemID.getFullName}: ${e}`,
+        )
+        return false
+      }
+    })
+    .map(appUserSchema => ({
+      elemID: appUserSchema.elemID,
+      severity: 'Error',
+      message: 'Cannot remove app user schema without its parent application',
+      detailedMessage: `In order to remove ${appUserSchema.elemID.name} of type ${APP_USER_SCHEMA_TYPE_NAME}, the instance ${getParent(appUserSchema).elemID.name} of type ${APPLICATION_TYPE_NAME} must be removed as well.`,
+    }))
+}

--- a/packages/okta-adapter/src/change_validators/app_user_schema_removal.ts
+++ b/packages/okta-adapter/src/change_validators/app_user_schema_removal.ts
@@ -23,7 +23,7 @@ const log = logger(module)
 /**
  * When removing AppUserSchema, validate the parent Application gets removed as well
  */
-export const appUserSchemaAndApplicationValidator: ChangeValidator = async changes => {
+export const appUserSchemaRemovalValidator: ChangeValidator = async changes => {
   const removalInstanceChanges = changes.filter(isInstanceChange).filter(isRemovalChange).map(getChangeData)
 
   const removedAppUserSchemaInstances = removalInstanceChanges.filter(

--- a/packages/okta-adapter/src/change_validators/app_user_schema_removal.ts
+++ b/packages/okta-adapter/src/change_validators/app_user_schema_removal.ts
@@ -21,7 +21,9 @@ import { APPLICATION_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME } from '../constants'
 const log = logger(module)
 
 /**
- * When removing AppUserSchema, validate the parent Application gets removed as well
+ * When removing AppUserSchema, validate the parent Application gets removed as well.
+ * AppUserSchema cannot be removed via the API, but the client removes it automatically when the parent Application is removed.
+ * Therefore, we allow the removal of AppUserSchema only if the parent Application is removed as well.
  */
 export const appUserSchemaRemovalValidator: ChangeValidator = async changes => {
   const removalInstanceChanges = changes.filter(isInstanceChange).filter(isRemovalChange).map(getChangeData)
@@ -44,7 +46,7 @@ export const appUserSchemaRemovalValidator: ChangeValidator = async changes => {
         log.error(
           'Could not run appUserSchemaAndApplicationValidator validator for instance %s: %s',
           appUserSchema.elemID.getFullName(),
-          e,
+          e.message,
         )
         return false
       }
@@ -53,6 +55,6 @@ export const appUserSchemaRemovalValidator: ChangeValidator = async changes => {
       elemID: appUserSchema.elemID,
       severity: 'Error',
       message: 'Cannot remove app user schema without its parent application',
-      detailedMessage: `In order to remove ${appUserSchema.elemID.name} of type ${APP_USER_SCHEMA_TYPE_NAME}, the instance ${getParent(appUserSchema).elemID.name} of type ${APPLICATION_TYPE_NAME} must be removed as well.`,
+      detailedMessage: `In order to remove this Application User Schema, the Application ${getParent(appUserSchema).elemID.name} must be removed as well.`,
     }))
 }

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -37,7 +37,7 @@ import { appGroupAssignmentValidator } from './app_group_assignments'
 import { appUrlsValidator } from './app_urls'
 import { profileMappingRemovalValidator } from './profile_mapping_removal'
 import { brandRemovalValidator } from './brand_removal'
-import { appUserSchemaAndApplicationValidator } from './app_user_schema_and_application'
+import { appUserSchemaRemovalValidator } from './app_user_schema_removal'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -81,7 +81,7 @@ export default ({ client, config }: { client: OktaClient; config: OktaConfig }):
     brandRemoval: brandRemovalValidator,
     dynamicOSVersion: dynamicOSVersionFeatureValidator,
     brandThemeRemoval: brandThemeRemovalValidator,
-    appUserSchemaAndApplication: appUserSchemaAndApplicationValidator,
+    appUserSchemaRemoval: appUserSchemaRemovalValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -37,6 +37,7 @@ import { appGroupAssignmentValidator } from './app_group_assignments'
 import { appUrlsValidator } from './app_urls'
 import { profileMappingRemovalValidator } from './profile_mapping_removal'
 import { brandRemovalValidator } from './brand_removal'
+import { appUserSchemaAndApplicationValidator } from './app_user_schema_and_application'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -80,6 +81,7 @@ export default ({ client, config }: { client: OktaClient; config: OktaConfig }):
     brandRemoval: brandRemovalValidator,
     dynamicOSVersion: dynamicOSVersionFeatureValidator,
     brandThemeRemoval: brandThemeRemovalValidator,
+    appUserSchemaAndApplication: appUserSchemaAndApplicationValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -1937,7 +1937,7 @@ export type ChangeValidatorName =
   | 'brandRemoval'
   | 'dynamicOSVersion'
   | 'brandThemeRemoval'
-  | 'appUserSchemaAndApplication'
+  | 'appUserSchemaRemoval'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -1968,7 +1968,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     brandRemoval: { refType: BuiltinTypes.BOOLEAN },
     dynamicOSVersion: { refType: BuiltinTypes.BOOLEAN },
     brandThemeRemoval: { refType: BuiltinTypes.BOOLEAN },
-    appUserSchemaAndApplication: { refType: BuiltinTypes.BOOLEAN },
+    appUserSchemaRemoval: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -505,6 +505,10 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       serviceUrl: '/admin/universaldirectory#app/{_parent.0.id}',
     },
     deployRequests: {
+      remove: {
+        url: '',
+        method: 'delete',
+      },
       modify: {
         url: '/api/v1/meta/schemas/apps/{applicationId}/default',
         method: 'post',
@@ -1933,6 +1937,7 @@ export type ChangeValidatorName =
   | 'brandRemoval'
   | 'dynamicOSVersion'
   | 'brandThemeRemoval'
+  | 'appUserSchemaAndApplication'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -1963,6 +1968,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     brandRemoval: { refType: BuiltinTypes.BOOLEAN },
     dynamicOSVersion: { refType: BuiltinTypes.BOOLEAN },
     brandThemeRemoval: { refType: BuiltinTypes.BOOLEAN },
+    appUserSchemaAndApplication: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -505,6 +505,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       serviceUrl: '/admin/universaldirectory#app/{_parent.0.id}',
     },
     deployRequests: {
+      // Hack to pass through createCheckDeploymentBasedOnConfigValidator validator for removals
       remove: {
         url: '',
         method: 'delete',

--- a/packages/okta-adapter/src/filters/app_user_schema_removal.ts
+++ b/packages/okta-adapter/src/filters/app_user_schema_removal.ts
@@ -27,7 +27,7 @@ const verifyApplicationIsDeleted = async (applicationId: string, client: OktaCli
     return (
       (
         await client.get({
-          url: `/api/v1/meta/schemas/apps/${applicationId}`,
+          url: `/api/v1/apps/${applicationId}`,
         })
       ).status === 404
     )
@@ -60,9 +60,9 @@ const filterCreator: FilterCreator = ({ client }) => ({
 
     const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change => {
       const appUserSchemaInstance = getChangeData(change)
-      const parentApplicationId = getParents(appUserSchemaInstance)[0].id
+      const parentApplicationId = getParents(appUserSchemaInstance)[0]?.id
       if (!_.isString(parentApplicationId) || !(await verifyApplicationIsDeleted(parentApplicationId, client))) {
-        throw new Error('Expected AppUserSchema to be deleted')
+        throw new Error('Expected the parent Application to be deleted')
       }
     })
 

--- a/packages/okta-adapter/src/filters/app_user_schema_removal.ts
+++ b/packages/okta-adapter/src/filters/app_user_schema_removal.ts
@@ -16,7 +16,7 @@
 import _ from 'lodash'
 import { isInstanceChange, getChangeData, isRemovalChange } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
-import { getParents } from '@salto-io/adapter-utils'
+import { getParent } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { APP_USER_SCHEMA_TYPE_NAME } from '../constants'
 import { deployChanges } from '../deployment'
@@ -61,7 +61,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
 
     const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change => {
       const appUserSchemaInstance = getChangeData(change)
-      const parentApplicationId = getParents(appUserSchemaInstance)[0]?.id
+      const parentApplicationId = getParent(appUserSchemaInstance).value.id
       if (!_.isString(parentApplicationId) || !(await verifyApplicationIsDeleted(parentApplicationId, client))) {
         throw new Error('Expected AppUserSchema to be deleted')
       }

--- a/packages/okta-adapter/src/filters/app_user_schema_removal.ts
+++ b/packages/okta-adapter/src/filters/app_user_schema_removal.ts
@@ -1,0 +1,77 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { isInstanceChange, getChangeData, isRemovalChange } from '@salto-io/adapter-api'
+import { client as clientUtils } from '@salto-io/adapter-components'
+import { getParents } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import { APP_USER_SCHEMA_TYPE_NAME } from '../constants'
+import { deployChanges } from '../deployment'
+import OktaClient from '../client/client'
+
+const verifyApplicationIsDeleted = async (applicationId: string, client: OktaClient): Promise<boolean> => {
+  try {
+    return (
+      (
+        await client.get({
+          url: `/api/v1/meta/schemas/apps/${applicationId}/default`,
+        })
+      ).status === 404
+    )
+  } catch (error) {
+    if (error instanceof clientUtils.HTTPError && error.response?.status === 404) {
+      return true
+    }
+    throw error
+  }
+}
+
+/**
+ * Override the default AppUserSchema removal with a verification of removal.
+ *
+ * AppUserSchema are removed automatically by Okta when it's parent Application is removed, so instead only
+ * verify that they are removed.
+ * Separate change validator and dependency changer ensure that this is only executed if the application was
+ * removed in the same deploy action.
+ */
+// TODO: what is the dependency changer?
+const filterCreator: FilterCreator = ({ client }) => ({
+  name: 'appUserSchemaRemovalFilter',
+  deploy: async changes => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        isInstanceChange(change) &&
+        isRemovalChange(change) &&
+        getChangeData(change).elemID.typeName === APP_USER_SCHEMA_TYPE_NAME,
+    )
+
+    const deployResult = await deployChanges(relevantChanges.filter(isInstanceChange), async change => {
+      const appUserSchemaInstance = getChangeData(change)
+      const parentApplicationId = getParents(appUserSchemaInstance)[0]?.id
+      if (!_.isString(parentApplicationId) || !(await verifyApplicationIsDeleted(parentApplicationId, client))) {
+        throw new Error('Expected AppUserSchema to be deleted')
+      }
+    })
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/test/change_validators/app_user_schema_removal.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_user_schema_removal.test.ts
@@ -1,0 +1,90 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  toChange,
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { appUserSchemaAndApplicationValidator } from '../../src/change_validators/app_user_schema_and_application'
+import { OKTA, APPLICATION_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME } from '../../src/constants'
+
+describe('appUserSchemaRemovalValidator', () => {
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const appUserSchemaType = new ObjectType({ elemID: new ElemID(OKTA, APP_USER_SCHEMA_TYPE_NAME) })
+
+  const app = new InstanceElement('app', appType, { name: 'A', default: false })
+  const appUserSchema1 = new InstanceElement(
+    'appUserSchema',
+    appUserSchemaType,
+    {
+      name: 'B',
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(app.elemID, app, app)],
+    },
+  )
+  const appUserSchema2 = new InstanceElement(
+    'appUserSchema',
+    appUserSchemaType,
+    {
+      name: 'B',
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [
+        new ReferenceExpression(app.elemID, app, app),
+        new ReferenceExpression(app.elemID, app, app),
+      ],
+    },
+  )
+  it('should return an error when AppUserSchema is deleted without its parent Application', async () => {
+    const changeErrors = await appUserSchemaAndApplicationValidator([toChange({ before: appUserSchema1 })])
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors).toEqual([
+      {
+        elemID: appUserSchema1.elemID,
+        severity: 'Error',
+        message: 'Cannot remove app user schema without its parent application',
+        detailedMessage: `In order to remove ${appUserSchema1.elemID.name} of type ${APP_USER_SCHEMA_TYPE_NAME}, the instance ${app.elemID.name} of type ${APPLICATION_TYPE_NAME} must be removed as well.`,
+      },
+    ])
+  })
+  it('should log an error when AppUserSchema with 2 parents is deleted', async () => {
+    const logging = logger('okta-adapter/src/change_validators/app_user_schema_and_application')
+    const e = new Error(
+      `Expected ${appUserSchema2.elemID.getFullName()} to have exactly one parent, found ${appUserSchema2.annotations[CORE_ANNOTATIONS.PARENT].length}`,
+    )
+    const logErrorSpy = jest.spyOn(logging, 'error')
+    await appUserSchemaAndApplicationValidator([toChange({ before: appUserSchema2 })])
+    expect(logErrorSpy).toHaveBeenCalledWith(
+      'Could not run appUserSchemaAndApplicationValidator validator for instance %s: %s',
+      appUserSchema2.elemID.getFullName(),
+      e,
+    )
+  })
+  it('should not return an error when AppUserSchema is deleted with its parent Application', async () => {
+    const changeErrors = await appUserSchemaAndApplicationValidator([
+      toChange({ before: appUserSchema1 }),
+      toChange({ before: app }),
+    ])
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/change_validators/app_user_schema_removal.test.ts
+++ b/packages/okta-adapter/test/change_validators/app_user_schema_removal.test.ts
@@ -22,7 +22,7 @@ import {
   CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { appUserSchemaAndApplicationValidator } from '../../src/change_validators/app_user_schema_and_application'
+import { appUserSchemaRemovalValidator } from '../../src/change_validators/app_user_schema_removal'
 import { OKTA, APPLICATION_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME } from '../../src/constants'
 
 describe('appUserSchemaRemovalValidator', () => {
@@ -56,7 +56,7 @@ describe('appUserSchemaRemovalValidator', () => {
     },
   )
   it('should return an error when AppUserSchema is deleted without its parent Application', async () => {
-    const changeErrors = await appUserSchemaAndApplicationValidator([toChange({ before: appUserSchema1 })])
+    const changeErrors = await appUserSchemaRemovalValidator([toChange({ before: appUserSchema1 })])
     expect(changeErrors).toHaveLength(1)
     expect(changeErrors).toEqual([
       {
@@ -68,12 +68,12 @@ describe('appUserSchemaRemovalValidator', () => {
     ])
   })
   it('should log an error when AppUserSchema with 2 parents is deleted', async () => {
-    const logging = logger('okta-adapter/src/change_validators/app_user_schema_and_application')
+    const logging = logger('okta-adapter/src/change_validators/app_user_schema_removal')
     const e = new Error(
       `Expected ${appUserSchema2.elemID.getFullName()} to have exactly one parent, found ${appUserSchema2.annotations[CORE_ANNOTATIONS.PARENT].length}`,
     )
     const logErrorSpy = jest.spyOn(logging, 'error')
-    await appUserSchemaAndApplicationValidator([toChange({ before: appUserSchema2 })])
+    await appUserSchemaRemovalValidator([toChange({ before: appUserSchema2 })])
     expect(logErrorSpy).toHaveBeenCalledWith(
       'Could not run appUserSchemaAndApplicationValidator validator for instance %s: %s',
       appUserSchema2.elemID.getFullName(),
@@ -81,7 +81,7 @@ describe('appUserSchemaRemovalValidator', () => {
     )
   })
   it('should not return an error when AppUserSchema is deleted with its parent Application', async () => {
-    const changeErrors = await appUserSchemaAndApplicationValidator([
+    const changeErrors = await appUserSchemaRemovalValidator([
       toChange({ before: appUserSchema1 }),
       toChange({ before: app }),
     ])

--- a/packages/okta-adapter/test/filters/app_user_schema_removal.test.ts
+++ b/packages/okta-adapter/test/filters/app_user_schema_removal.test.ts
@@ -14,15 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  ElemID,
-  InstanceElement,
-  ObjectType,
-  toChange,
-  getChangeData,
-  CORE_ANNOTATIONS,
-  ReferenceExpression,
-} from '@salto-io/adapter-api'
+import { ElemID, InstanceElement, ObjectType, toChange, getChangeData, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
 import { MockInterface } from '@salto-io/test-utils'
 import { getFilterParams, mockClient } from '../utils'
@@ -48,7 +40,7 @@ describe('appUserSchemaRemovalFilter', () => {
     },
     undefined,
     {
-      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(app.elemID, app, app)],
+      [CORE_ANNOTATIONS.PARENT]: [app.value],
     },
   )
   const notFoundError = new clientUtils.HTTPError('message', {
@@ -75,7 +67,6 @@ describe('appUserSchemaRemovalFilter', () => {
       expect(appliedChanges).toHaveLength(1)
       expect(appliedChanges.map(change => getChangeData(change))[0]).toEqual(appUserSchemaInstance)
     })
-
     it('should fail when the parent application exists', async () => {
       mockConnection.get.mockResolvedValue(successResponse)
       const changes = [toChange({ before: appUserSchemaInstance })]
@@ -84,7 +75,6 @@ describe('appUserSchemaRemovalFilter', () => {
       expect(errors).toHaveLength(1)
       expect(appliedChanges).toHaveLength(0)
     })
-
     it('should handle multiple changes', async () => {
       mockConnection.get.mockRejectedValueOnce(notFoundError)
       mockConnection.get.mockResolvedValueOnce(successResponse)

--- a/packages/okta-adapter/test/filters/app_user_schema_removal.test.ts
+++ b/packages/okta-adapter/test/filters/app_user_schema_removal.test.ts
@@ -1,0 +1,98 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  toChange,
+  getChangeData,
+  CORE_ANNOTATIONS,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { client as clientUtils, filterUtils } from '@salto-io/adapter-components'
+import { MockInterface } from '@salto-io/test-utils'
+import { getFilterParams, mockClient } from '../utils'
+import appUserSchemaRemovalFilter from '../../src/filters/app_user_schema_removal'
+import { APPLICATION_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME, OKTA } from '../../src/constants'
+import OktaClient from '../../src/client/client'
+
+type FilterType = filterUtils.FilterWith<'deploy'>
+
+describe('appUserSchemaRemovalFilter', () => {
+  let mockConnection: MockInterface<clientUtils.APIConnection>
+  let client: OktaClient
+  let filter: FilterType
+  const appType = new ObjectType({ elemID: new ElemID(OKTA, APPLICATION_TYPE_NAME) })
+  const appUserSchemaType = new ObjectType({ elemID: new ElemID(OKTA, APP_USER_SCHEMA_TYPE_NAME) })
+
+  const app = new InstanceElement('app', appType, { name: 'A', default: false, id: '1' })
+  const appUserSchemaInstance = new InstanceElement(
+    'appUserSchema',
+    appUserSchemaType,
+    {
+      name: 'B',
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(app.elemID, app, app)],
+    },
+  )
+  const notFoundError = new clientUtils.HTTPError('message', {
+    status: 404,
+    data: {},
+  })
+  const successResponse = { status: 200, data: '' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    const { client: cli, connection } = mockClient()
+    mockConnection = connection
+    client = cli
+    filter = appUserSchemaRemovalFilter(getFilterParams({ client })) as typeof filter
+  })
+
+  describe('deploy', () => {
+    it('should successfully deploy removal of app user schema as a verification', async () => {
+      mockConnection.get.mockRejectedValue(notFoundError)
+      const changes = [toChange({ before: appUserSchemaInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(0)
+      expect(appliedChanges).toHaveLength(1)
+      expect(appliedChanges.map(change => getChangeData(change))[0]).toEqual(appUserSchemaInstance)
+    })
+
+    it('should fail when the parent application exists', async () => {
+      mockConnection.get.mockResolvedValue(successResponse)
+      const changes = [toChange({ before: appUserSchemaInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(1)
+      expect(appliedChanges).toHaveLength(0)
+    })
+
+    it('should handle multiple changes', async () => {
+      mockConnection.get.mockRejectedValueOnce(notFoundError)
+      mockConnection.get.mockResolvedValueOnce(successResponse)
+      const changes = [toChange({ before: appUserSchemaInstance }), toChange({ before: appUserSchemaInstance })]
+      const result = await filter.deploy(changes)
+      const { appliedChanges, errors } = result.deployResult
+      expect(errors).toHaveLength(1)
+      expect(appliedChanges).toHaveLength(1)
+    })
+  })
+})


### PR DESCRIPTION
_When removing an application, the client also automatically removes the related `appUserSchema`. This PR introduces an option to remove the appUserSchema concurrently with the application. In the background, we ensure that the application is removed successfully, and no additional actions are needed regarding the `appUserSchema`._

---

_Additional context for reviewer_
Jira ticket: https://salto-io.atlassian.net/browse/SALTO-4242

---
_Release Notes_: 
_Users can now remove `appUserSchema` along with removing it's parent application._

---
_User Notifications_: 
_None_
