### PR TITLE
SALTO-5890: log jira rate limit headers

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -91,7 +91,9 @@ const getRetryDelayFromHeaders = (headers: Record<string, string>): number | und
       log.warn(`Received invalid x-rate-limit-reset values: ${rateLimitResetHeaderValue}, ${lowercaseHeaders.date}`)
       return undefined
     }
-    log.trace(`Received x-rate-limit-reset value: ${rateLimitResetHeaderValue} matched with date: ${lowercaseHeaders.date}`)
+    log.trace(
+      `Received x-rate-limit-reset value: ${rateLimitResetHeaderValue} matched with date: ${lowercaseHeaders.date}`,
+    )
     return resetTime - currentTime
   }
   return undefined
@@ -110,7 +112,7 @@ const shouldRetryOnTimeout = (errorCode: string | undefined, retryOnTimeout: boo
   // axios returns ECONNABORTED on timeouts, but servers can sometimes return ETIMEDOUT
   retryOnTimeout ? ['ECONNABORTED', 'ETIMEDOUT'].includes(errorCode ?? '') : false
 
-export const createRetryOptions = ( 
+export const createRetryOptions = (
   retryOptions: Required<ClientRetryConfig>,
   timeoutOptions?: ClientTimeoutConfig,
 ): RetryOptions => ({

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -116,15 +116,15 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
     }
   }
 
-    // eslint-disable-next-line class-methods-use-this
-    protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
-      return headers !== undefined
-        ? {
-            ...super.extractHeaders(headers),
-            ..._.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX)),
-          }
-        : undefined
-    }
+  // eslint-disable-next-line class-methods-use-this
+  protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    return headers !== undefined
+      ? {
+          ...super.extractHeaders(headers),
+          ..._.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX)),
+        }
+      : undefined
+  }
 
   // Sends a post request to a JIRA JSP page
   public async jspPost(

--- a/packages/jira-adapter/test/client/client.test.ts
+++ b/packages/jira-adapter/test/client/client.test.ts
@@ -56,8 +56,11 @@ describe('client', () => {
   })
 
   describe('get', () => {
+    const validHeaders = { 'X-RateLimit-Reset': '2024-05-05T18:02Z', 'X-RateLimit-NearLimit': true, 'Retry-After': '5' }
+    const filteredHeaders = { 'Do-Not-Extract': 'true' }
     beforeEach(async () => {
-      mockAxios.onGet('/myPath').reply(200, { response: 'asd' }, { 'X-RateLimit-Reset': '2024-05-05T18:02Z', 'X-RateLimit-NearLimit': true, 'Retry-After': '5', 'Do-Not-Extract': 'true' })
+      extractHeadersFunc.mockClear()
+      mockAxios.onGet('/myPath').reply(200, { response: 'asd' }, { ...validHeaders, ...filteredHeaders })
       result = await client.get({ url: '/myPath' })
     })
     it('should request the correct path with auth headers', () => {
@@ -68,17 +71,13 @@ describe('client', () => {
       expect(request?.url).toEqual('/myPath')
     })
     it('should return the response', () => {
-      expect(result).toEqual({ status: 200, data: { response: 'asd' } })
+      expect(result).toEqual({ status: 200, data: { response: 'asd' }, headers: validHeaders })
     })
     it('should call extractHeaders', () => {
       expect(extractHeadersFunc).toHaveBeenCalled()
     })
     it('should extract the correct headers', () => {
-      expect(extractHeadersFunc).toHaveNthReturnedWith(1, {
-        'X-RateLimit-Reset': '2024-05-05T18:02Z',
-        'X-RateLimit-NearLimit': true,
-        'Retry-After': '5',
-      })
+      expect(extractHeadersFunc).toHaveNthReturnedWith(1, validHeaders)
     })
   })
   it('should preserve headers', async () => {


### PR DESCRIPTION
Logs were added to Jira's rate limit headers.
I also added general logs to trace in case we retry due rate limit

---

The responses of the calls do not log in case of a retry as it is an internal axios mechanism to which we provide a call-back

---
_Release Notes_: 
Jira Adapter: added logs to better understand rate limits

---
_User Notifications_: 
None
