### PR TITLE
SALTO-5062: Calculating weak references from managed elements to installed packages

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -115,6 +115,7 @@ import centralizeTrackingInfoFilter from './filters/centralize_tracking_info'
 import changedAtSingletonFilter from './filters/changed_at_singleton'
 import importantValuesFilter from './filters/important_values_filter'
 import {
+  CUSTOM_REFS_CONFIG,
   FetchElements,
   FetchProfile,
   MetadataQuery,
@@ -588,6 +589,7 @@ export default class SalesforceAdapter implements AdapterOperations {
       : buildMetadataQuery({ fetchParams })
     const fetchProfile = buildFetchProfile({
       fetchParams,
+      customReferencesSettings: this.userConfig[CUSTOM_REFS_CONFIG],
       metadataQuery,
       maxItemsInRetrieveRequest: this.maxItemsInRetrieveRequest,
     })
@@ -695,7 +697,10 @@ export default class SalesforceAdapter implements AdapterOperations {
     checkOnly: boolean,
   ): Promise<DeployResult> {
     const fetchParams = this.userConfig.fetch ?? {}
-    const fetchProfile = buildFetchProfile({ fetchParams })
+    const fetchProfile = buildFetchProfile({
+      fetchParams,
+      customReferencesSettings: this.userConfig[CUSTOM_REFS_CONFIG],
+    })
     log.debug(
       `about to ${checkOnly ? 'validate' : 'deploy'} group ${changeGroup.groupID} with scope (first 100): ${safeJsonStringify(
         changeGroup.changes

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -24,35 +24,37 @@ import {
   combineCustomReferenceGetters,
   combineElementFixers,
 } from '@salto-io/adapter-components'
-import { profilesHandler } from './profiles'
 import {
+  CustomReferencesHandlers,
+  CustomReferencesSettings,
   CUSTOM_REFS_CONFIG,
   FIX_ELEMENTS_CONFIG,
   SalesforceConfig,
   WeakReferencesHandler,
 } from '../types'
+import { profilesHandler } from './profiles'
+import { managedElementsHandler } from './managed_elements'
 
-type Handlers = 'profiles'
-
-const handlers: Record<Handlers, WeakReferencesHandler> = {
+const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
   profiles: profilesHandler,
+  managedElements: managedElementsHandler,
 }
 
-const defaultHandlersConfiguration: Record<Handlers, boolean> = {
-  profiles: false,
-}
+const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
+  {
+    profiles: false,
+    managedElements: false,
+  }
 
-const customReferencesConfiguration = (
-  adapterConfig: InstanceElement,
+export const customReferencesConfiguration = (
+  customReferencesConfig: CustomReferencesSettings | undefined,
 ): Record<string, boolean> =>
-  _.defaults(
-    adapterConfig.value[CUSTOM_REFS_CONFIG],
-    defaultHandlersConfiguration,
-  )
+  _.defaults(customReferencesConfig, defaultHandlersConfiguration)
 
 export const getCustomReferences = combineCustomReferenceGetters(
   _.mapValues(handlers, (handler) => handler.findWeakReferences),
-  customReferencesConfiguration,
+  (adapterConfig: InstanceElement) =>
+    customReferencesConfiguration(adapterConfig.value[CUSTOM_REFS_CONFIG]),
 )
 
 const fixElementsConfiguration = (

--- a/packages/salesforce-adapter/src/custom_references/managed_elements.ts
+++ b/packages/salesforce-adapter/src/custom_references/managed_elements.ts
@@ -1,0 +1,95 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
+import { ElemID, Element, ReferenceInfo } from '@salto-io/adapter-api'
+import { WeakReferencesHandler } from '../types'
+import {
+  apiNameSync,
+  getNamespaceSync,
+  isInstanceOfTypeSync,
+  isStandardObjectSync,
+} from '../filters/utils'
+import { INSTALLED_PACKAGE_METADATA } from '../constants'
+
+const log = logger(module)
+const { isDefined } = values
+
+const installedPackageReference = (
+  element: Element,
+  installedPackageNamespaceToRef: Record<string, ElemID>,
+): ReferenceInfo | undefined => {
+  const namespace = getNamespaceSync(element)
+  if (namespace === undefined) {
+    return undefined
+  }
+  const installedPackageElemID = installedPackageNamespaceToRef[namespace]
+  if (installedPackageElemID === undefined) {
+    return undefined
+  }
+  return {
+    source: element.elemID,
+    target: installedPackageElemID,
+    type: 'weak',
+  }
+}
+
+const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
+  elements: Element[],
+): Promise<ReferenceInfo[]> => {
+  const installedPackageNamespaceToRef: Record<string, ElemID> =
+    Object.fromEntries(
+      elements
+        .filter(isInstanceOfTypeSync(INSTALLED_PACKAGE_METADATA))
+        .map((packageMetadata: Element): [string | undefined, ElemID] => [
+          apiNameSync(packageMetadata),
+          packageMetadata.elemID,
+        ])
+        .filter(
+          (keyVal: [string | undefined, ElemID]): keyVal is [string, ElemID] =>
+            keyVal[0] !== undefined,
+        ),
+    )
+  if (Object.keys(installedPackageNamespaceToRef).length === 0) {
+    return []
+  }
+
+  const topLevelReferences = elements
+    .map((element) =>
+      installedPackageReference(element, installedPackageNamespaceToRef),
+    )
+    .filter(isDefined)
+  const fieldReferences = elements
+    .filter(isStandardObjectSync)
+    .flatMap((standardObject) => Object.values(standardObject.fields))
+    .map((field) =>
+      installedPackageReference(field, installedPackageNamespaceToRef),
+    )
+    .filter(isDefined)
+  const references = topLevelReferences.concat(fieldReferences)
+
+  log.debug(
+    `Generated InstalledPackage instance custom references for ${references.length} elements.`,
+  )
+
+  return references
+}
+
+export const managedElementsHandler: WeakReferencesHandler = {
+  findWeakReferences,
+  removeWeakReferences: () => async () => ({ fixedElements: [], errors: [] }),
+}

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -21,6 +21,7 @@ import {
   METADATA_CONFIG,
   OptionalFeatures,
   MetadataQuery,
+  CustomReferencesSettings,
 } from '../types'
 import {
   buildDataManagement,
@@ -32,6 +33,7 @@ import {
   DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
 } from '../constants'
 import { mergeWithDefaultImportantValues } from './important_values'
+import { customReferencesConfiguration } from '../custom_references/handlers'
 
 type OptionalFeaturesDefaultValues = {
   [FeatureName in keyof OptionalFeatures]?: boolean
@@ -51,12 +53,14 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
 
 type BuildFetchProfileParams = {
   fetchParams: FetchParameters
+  customReferencesSettings?: CustomReferencesSettings
   metadataQuery?: MetadataQuery
   maxItemsInRetrieveRequest?: number
 }
 
 export const buildFetchProfile = ({
   fetchParams,
+  customReferencesSettings,
   metadataQuery = buildMetadataQuery({ fetchParams }),
   maxItemsInRetrieveRequest = DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
 }: BuildFetchProfileParams): FetchProfile => {
@@ -70,10 +74,15 @@ export const buildFetchProfile = ({
     warningSettings,
     additionalImportantValues,
   } = fetchParams
+  const enabledCustomReferencesHandlers = customReferencesConfiguration(
+    customReferencesSettings,
+  )
   return {
     dataManagement: data && buildDataManagement(data),
     isFeatureEnabled: (name) =>
       optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true,
+    isCustomReferencesHandlerEnabled: (name) =>
+      enabledCustomReferencesHandlers[name] ?? false,
     shouldFetchAllCustomSettings: () => fetchAllCustomSettings ?? true,
     maxInstancesPerType: maxInstancesPerType ?? DEFAULT_MAX_INSTANCES_PER_TYPE,
     preferActiveFlowVersions: preferActiveFlowVersions ?? false,

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -918,9 +918,19 @@ export const toListType = (type: TypeElement): ListType =>
 // if you want instances of all custom objects use isInstanceOfCustomObject
 export const isInstanceOfTypeSync =
   (...typeNames: string[]) =>
-  (elem: Element): elem is InstanceElement =>
-    isInstanceElement(elem) &&
-    typeNames.includes(apiNameSync(elem.getTypeSync()) ?? '')
+  (elem: Element): elem is InstanceElement => {
+    if (!isInstanceElement(elem)) {
+      return false
+    }
+
+    const typeApiName = apiNameSync(elem.getTypeSync())
+    if (typeApiName !== undefined) {
+      return typeNames.includes(typeApiName)
+    }
+
+    // If the type isn't resolved yet fall back on checking the type in the element ID
+    return typeNames.includes(elem.elemID.typeName)
+  }
 
 export const isInstanceOfTypeChangeSync =
   (...typeNames: string[]) =>

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -208,15 +208,16 @@ export type BrokenOutgoingReferencesSettings = {
   perTargetTypeOverrides?: Record<string, OutgoingReferenceBehavior>
 }
 
-const customReferencesTypeNames = ['profiles'] as const
-type customReferencesTypes = (typeof customReferencesTypeNames)[number]
+const customReferencesHandlersNames = ['profiles', 'managedElements'] as const
+export type CustomReferencesHandlers =
+  (typeof customReferencesHandlersNames)[number]
 
 export type CustomReferencesSettings = Partial<
-  Record<customReferencesTypes, boolean>
+  Record<CustomReferencesHandlers, boolean>
 >
 
 export type FixElementsSettings = Partial<
-  Record<customReferencesTypes, boolean>
+  Record<CustomReferencesHandlers, boolean>
 >
 
 const objectIdSettings = new ObjectType({
@@ -329,7 +330,7 @@ const brokenOutgoingReferencesSettingsType = new ObjectType({
 const customReferencesSettingsType = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'saltoCustomReferencesSettings'),
   fields: Object.fromEntries(
-    customReferencesTypeNames.map((name) => [
+    customReferencesHandlersNames.map((name) => [
       name,
       { refType: BuiltinTypes.BOOLEAN },
     ]),
@@ -339,7 +340,7 @@ const customReferencesSettingsType = new ObjectType({
 const fixElementsSettingsType = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'saltoFixElementsSettings'),
   fields: Object.fromEntries(
-    customReferencesTypeNames.map((name) => [
+    customReferencesHandlersNames.map((name) => [
       name,
       { refType: BuiltinTypes.BOOLEAN },
     ]),
@@ -1066,6 +1067,9 @@ export type FetchProfile = {
   readonly metadataQuery: MetadataQuery
   readonly dataManagement?: DataManagement
   readonly isFeatureEnabled: (name: keyof OptionalFeatures) => boolean
+  readonly isCustomReferencesHandlerEnabled: (
+    name: CustomReferencesHandlers,
+  ) => boolean
   readonly shouldFetchAllCustomSettings: () => boolean
   readonly maxInstancesPerType: number
   readonly preferActiveFlowVersions: boolean

--- a/packages/salesforce-adapter/test/custom_references/managed_elements.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/managed_elements.test.ts
@@ -1,0 +1,177 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  BuiltinTypes,
+  Element,
+  InstanceElement,
+  ReferenceInfo,
+  ObjectType,
+  Field,
+} from '@salto-io/adapter-api'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { mockTypes } from '../mock_elements'
+import { createCustomMetadataType, createCustomObjectType } from '../utils'
+import { API_NAME } from '../../src/constants'
+import { managedElementsHandler } from '../../src/custom_references/managed_elements'
+
+describe('managed elements', () => {
+  describe('weak references handler', () => {
+    const NAMESPACE = 'namespace1'
+    let installedPackageInstances: Element[]
+    let refs: ReferenceInfo[]
+
+    beforeEach(() => {
+      installedPackageInstances = [
+        createInstanceElement(
+          { fullName: NAMESPACE },
+          mockTypes.InstalledPackage,
+        ),
+        createInstanceElement(
+          { fullName: 'namespace1' },
+          mockTypes.InstalledPackage,
+        ),
+      ]
+    })
+
+    describe('CustomObjects', () => {
+      let customObject: ObjectType
+      let customObjectFromInstalledPackage: ObjectType
+
+      beforeEach(async () => {
+        customObject = createCustomObjectType('TestObject__c', {})
+        customObjectFromInstalledPackage = createCustomObjectType(
+          `${NAMESPACE}__TestObject__c`,
+          {},
+        )
+        refs = await managedElementsHandler.findWeakReferences(
+          installedPackageInstances.concat([
+            customObject,
+            customObjectFromInstalledPackage,
+          ]),
+        )
+      })
+
+      it('should generate weak references', () => {
+        expect(refs).toEqual([
+          {
+            source: customObjectFromInstalledPackage.elemID,
+            target: installedPackageInstances[0].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+
+    describe('Standard Object Custom Fields', () => {
+      let customField: Field
+      let customFieldFromInstalledPackage: Field
+
+      beforeEach(async () => {
+        const accountType = mockTypes.Account.clone()
+        customField = new Field(
+          mockTypes.Account,
+          'TestField__c',
+          BuiltinTypes.STRING,
+          { [API_NAME]: 'TestField__c' },
+        )
+        customFieldFromInstalledPackage = new Field(
+          mockTypes.Account,
+          `${NAMESPACE}__TestField__c`,
+          BuiltinTypes.STRING,
+          { [API_NAME]: `${NAMESPACE}__TestField__c` },
+        )
+        accountType.fields[customField.name] = customField
+        accountType.fields[customFieldFromInstalledPackage.name] =
+          customFieldFromInstalledPackage
+        refs = await managedElementsHandler.findWeakReferences(
+          installedPackageInstances.concat([accountType]),
+        )
+      })
+
+      it('should generate weak references', () => {
+        expect(refs).toEqual([
+          {
+            source: customFieldFromInstalledPackage.elemID,
+            target: installedPackageInstances[0].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+
+    describe('CustomMetadata types', () => {
+      let customMetadata: ObjectType
+      let customMetadataFromInstalledPackage: ObjectType
+
+      beforeEach(async () => {
+        customMetadata = createCustomMetadataType('TestCustomMetadata__mdt', {})
+        customMetadataFromInstalledPackage = createCustomMetadataType(
+          `${NAMESPACE}__TestCustomMetadata__mdt`,
+          {},
+        )
+        refs = await managedElementsHandler.findWeakReferences(
+          installedPackageInstances.concat([
+            customMetadata,
+            customMetadataFromInstalledPackage,
+          ]),
+        )
+      })
+
+      it('should generate weak references', () => {
+        expect(refs).toEqual([
+          {
+            source: customMetadataFromInstalledPackage.elemID,
+            target: installedPackageInstances[0].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+
+    describe('Instances', () => {
+      let instance: InstanceElement
+      let instanceFromInstalledPackage: InstanceElement
+
+      beforeEach(async () => {
+        instance = createInstanceElement(
+          { fullName: 'TestInstance' },
+          mockTypes.ApexClass,
+        )
+        instanceFromInstalledPackage = createInstanceElement(
+          { fullName: `${NAMESPACE}__TestInstance` },
+          mockTypes.ApexClass,
+        )
+        refs = await managedElementsHandler.findWeakReferences(
+          installedPackageInstances.concat([
+            instance,
+            instanceFromInstalledPackage,
+          ]),
+        )
+      })
+
+      it('should generate weak references', () => {
+        expect(refs).toEqual([
+          {
+            source: instanceFromInstalledPackage.elemID,
+            target: installedPackageInstances[0].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
@@ -39,325 +39,333 @@ describe('installedPackageElementsFilter', () => {
   let filter: FilterWith<'onFetch'>
 
   describe('onFetch', () => {
-    beforeEach(() => {
-      installedPackageInstances = [
-        createInstanceElement(
-          { fullName: NAMESPACE },
-          mockTypes.InstalledPackage,
-        ),
-        createInstanceElement(
-          { fullName: 'namespace1' },
-          mockTypes.InstalledPackage,
-        ),
-      ]
-      filter = filterCreator({
-        config: defaultFilterContext,
-      }) as FilterWith<'onFetch'>
-    })
-
-    describe('CustomObjects', () => {
-      let customObject: ObjectType
-      let customObjectFromInstalledPackage: ObjectType
-
-      beforeEach(async () => {
-        customObject = createCustomObjectType('TestObject__c', {})
-        customObjectFromInstalledPackage = createCustomObjectType(
-          `${NAMESPACE}__TestObject__c`,
-          {},
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          customObject,
-          customObjectFromInstalledPackage,
-        ])
+    describe('when managedElements custom references are disabled', () => {
+      beforeEach(() => {
+        installedPackageInstances = [
+          createInstanceElement(
+            { fullName: NAMESPACE },
+            mockTypes.InstalledPackage,
+          ),
+          createInstanceElement(
+            { fullName: 'namespace1' },
+            mockTypes.InstalledPackage,
+          ),
+        ]
+        filter = filterCreator({
+          config: defaultFilterContext,
+        }) as FilterWith<'onFetch'>
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          customObject.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customObjectFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toEqual([
-          {
-            reference: expect.objectContaining({
-              elemID: expect.objectContaining({
-                name: NAMESPACE,
+      describe('CustomObjects', () => {
+        let customObject: ObjectType
+        let customObjectFromInstalledPackage: ObjectType
+
+        beforeEach(async () => {
+          customObject = createCustomObjectType('TestObject__c', {})
+          customObjectFromInstalledPackage = createCustomObjectType(
+            `${NAMESPACE}__TestObject__c`,
+            {},
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            customObject,
+            customObjectFromInstalledPackage,
+          ])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            customObject.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customObjectFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toEqual([
+            {
+              reference: expect.objectContaining({
+                elemID: expect.objectContaining({
+                  name: NAMESPACE,
+                }),
               }),
-            }),
-          },
-        ])
-      })
-    })
-
-    describe('Standard Object Custom Fields', () => {
-      let customField: Field
-      let customFieldFromInstalledPackage: Field
-
-      beforeEach(async () => {
-        const accountType = mockTypes.Account.clone()
-        customField = new Field(
-          mockTypes.Account,
-          'TestField__c',
-          BuiltinTypes.STRING,
-          { [API_NAME]: 'TestField__c' },
-        )
-        customFieldFromInstalledPackage = new Field(
-          mockTypes.Account,
-          `${NAMESPACE}__TestField__c`,
-          BuiltinTypes.STRING,
-          { [API_NAME]: `${NAMESPACE}__TestField__c` },
-        )
-        accountType.fields[customField.name] = customField
-        accountType.fields[customFieldFromInstalledPackage.name] =
-          customFieldFromInstalledPackage
-        await filter.onFetch([...installedPackageInstances, accountType])
+            },
+          ])
+        })
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          customField.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customFieldFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toEqual([
-          {
-            reference: expect.objectContaining({
-              elemID: expect.objectContaining({
-                name: NAMESPACE,
+      describe('Standard Object Custom Fields', () => {
+        let customField: Field
+        let customFieldFromInstalledPackage: Field
+
+        beforeEach(async () => {
+          const accountType = mockTypes.Account.clone()
+          customField = new Field(
+            mockTypes.Account,
+            'TestField__c',
+            BuiltinTypes.STRING,
+            { [API_NAME]: 'TestField__c' },
+          )
+          customFieldFromInstalledPackage = new Field(
+            mockTypes.Account,
+            `${NAMESPACE}__TestField__c`,
+            BuiltinTypes.STRING,
+            { [API_NAME]: `${NAMESPACE}__TestField__c` },
+          )
+          accountType.fields[customField.name] = customField
+          accountType.fields[customFieldFromInstalledPackage.name] =
+            customFieldFromInstalledPackage
+          await filter.onFetch([...installedPackageInstances, accountType])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            customField.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customFieldFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toEqual([
+            {
+              reference: expect.objectContaining({
+                elemID: expect.objectContaining({
+                  name: NAMESPACE,
+                }),
               }),
-            }),
-          },
-        ])
-      })
-    })
-
-    describe('CustomMetadata types', () => {
-      let customMetadata: ObjectType
-      let customMetadataFromInstalledPackage: ObjectType
-
-      beforeEach(async () => {
-        customMetadata = createCustomMetadataType('TestCustomMetadata__mdt', {})
-        customMetadataFromInstalledPackage = createCustomMetadataType(
-          `${NAMESPACE}__TestCustomMetadata__mdt`,
-          {},
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          customMetadata,
-          customMetadataFromInstalledPackage,
-        ])
+            },
+          ])
+        })
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          customMetadata.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customMetadataFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toEqual([
-          {
-            reference: expect.objectContaining({
-              elemID: expect.objectContaining({
-                name: NAMESPACE,
+      describe('CustomMetadata types', () => {
+        let customMetadata: ObjectType
+        let customMetadataFromInstalledPackage: ObjectType
+
+        beforeEach(async () => {
+          customMetadata = createCustomMetadataType(
+            'TestCustomMetadata__mdt',
+            {},
+          )
+          customMetadataFromInstalledPackage = createCustomMetadataType(
+            `${NAMESPACE}__TestCustomMetadata__mdt`,
+            {},
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            customMetadata,
+            customMetadataFromInstalledPackage,
+          ])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            customMetadata.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customMetadataFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toEqual([
+            {
+              reference: expect.objectContaining({
+                elemID: expect.objectContaining({
+                  name: NAMESPACE,
+                }),
               }),
-            }),
-          },
-        ])
-      })
-    })
-
-    describe('Instances', () => {
-      let instance: InstanceElement
-      let instanceFromInstalledPackage: InstanceElement
-
-      beforeEach(async () => {
-        instance = createInstanceElement(
-          { fullName: 'TestInstance' },
-          mockTypes.ApexClass,
-        )
-        instanceFromInstalledPackage = createInstanceElement(
-          { fullName: `${NAMESPACE}__TestInstance` },
-          mockTypes.ApexClass,
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          instance,
-          instanceFromInstalledPackage,
-        ])
+            },
+          ])
+        })
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          instanceFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toEqual([
-          {
-            reference: expect.objectContaining({
-              elemID: expect.objectContaining({
-                name: NAMESPACE,
+      describe('Instances', () => {
+        let instance: InstanceElement
+        let instanceFromInstalledPackage: InstanceElement
+
+        beforeEach(async () => {
+          instance = createInstanceElement(
+            { fullName: 'TestInstance' },
+            mockTypes.ApexClass,
+          )
+          instanceFromInstalledPackage = createInstanceElement(
+            { fullName: `${NAMESPACE}__TestInstance` },
+            mockTypes.ApexClass,
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            instance,
+            instanceFromInstalledPackage,
+          ])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            instanceFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toEqual([
+            {
+              reference: expect.objectContaining({
+                elemID: expect.objectContaining({
+                  name: NAMESPACE,
+                }),
               }),
-            }),
-          },
-        ])
-      })
-    })
-  })
-
-  describe('onFetch with managed elements custom references enabled', () => {
-    beforeEach(() => {
-      installedPackageInstances = [
-        createInstanceElement(
-          { fullName: NAMESPACE },
-          mockTypes.InstalledPackage,
-        ),
-        createInstanceElement(
-          { fullName: 'namespace1' },
-          mockTypes.InstalledPackage,
-        ),
-      ]
-      filter = filterCreator({
-        config: buildFilterContext({
-          customReferencesSettings: {
-            managedElements: true,
-          },
-        }),
-      }) as FilterWith<'onFetch'>
-    })
-
-    describe('CustomObjects', () => {
-      let customObject: ObjectType
-      let customObjectFromInstalledPackage: ObjectType
-
-      beforeEach(async () => {
-        customObject = createCustomObjectType('TestObject__c', {})
-        customObjectFromInstalledPackage = createCustomObjectType(
-          `${NAMESPACE}__TestObject__c`,
-          {},
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          customObject,
-          customObjectFromInstalledPackage,
-        ])
-      })
-
-      it('should add generated dependencies', () => {
-        expect(
-          customObject.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customObjectFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toBeUndefined()
+            },
+          ])
+        })
       })
     })
 
-    describe('Standard Object Custom Fields', () => {
-      let customField: Field
-      let customFieldFromInstalledPackage: Field
-
-      beforeEach(async () => {
-        const accountType = mockTypes.Account.clone()
-        customField = new Field(
-          mockTypes.Account,
-          'TestField__c',
-          BuiltinTypes.STRING,
-          { [API_NAME]: 'TestField__c' },
-        )
-        customFieldFromInstalledPackage = new Field(
-          mockTypes.Account,
-          `${NAMESPACE}__TestField__c`,
-          BuiltinTypes.STRING,
-          { [API_NAME]: `${NAMESPACE}__TestField__c` },
-        )
-        accountType.fields[customField.name] = customField
-        accountType.fields[customFieldFromInstalledPackage.name] =
-          customFieldFromInstalledPackage
-        await filter.onFetch([...installedPackageInstances, accountType])
+    describe('when managedElements custom references are enabled', () => {
+      beforeEach(() => {
+        installedPackageInstances = [
+          createInstanceElement(
+            { fullName: NAMESPACE },
+            mockTypes.InstalledPackage,
+          ),
+          createInstanceElement(
+            { fullName: 'namespace1' },
+            mockTypes.InstalledPackage,
+          ),
+        ]
+        filter = filterCreator({
+          config: buildFilterContext({
+            customReferencesSettings: {
+              managedElements: true,
+            },
+          }),
+        }) as FilterWith<'onFetch'>
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          customField.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customFieldFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toBeUndefined()
-      })
-    })
+      describe('CustomObjects', () => {
+        let customObject: ObjectType
+        let customObjectFromInstalledPackage: ObjectType
 
-    describe('CustomMetadata types', () => {
-      let customMetadata: ObjectType
-      let customMetadataFromInstalledPackage: ObjectType
+        beforeEach(async () => {
+          customObject = createCustomObjectType('TestObject__c', {})
+          customObjectFromInstalledPackage = createCustomObjectType(
+            `${NAMESPACE}__TestObject__c`,
+            {},
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            customObject,
+            customObjectFromInstalledPackage,
+          ])
+        })
 
-      beforeEach(async () => {
-        customMetadata = createCustomMetadataType('TestCustomMetadata__mdt', {})
-        customMetadataFromInstalledPackage = createCustomMetadataType(
-          `${NAMESPACE}__TestCustomMetadata__mdt`,
-          {},
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          customMetadata,
-          customMetadataFromInstalledPackage,
-        ])
-      })
-
-      it('should add generated dependencies', () => {
-        expect(
-          customMetadata.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          customMetadataFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toBeUndefined()
-      })
-    })
-
-    describe('Instances', () => {
-      let instance: InstanceElement
-      let instanceFromInstalledPackage: InstanceElement
-
-      beforeEach(async () => {
-        instance = createInstanceElement(
-          { fullName: 'TestInstance' },
-          mockTypes.ApexClass,
-        )
-        instanceFromInstalledPackage = createInstanceElement(
-          { fullName: `${NAMESPACE}__TestInstance` },
-          mockTypes.ApexClass,
-        )
-        await filter.onFetch([
-          ...installedPackageInstances,
-          instance,
-          instanceFromInstalledPackage,
-        ])
+        it('should add generated dependencies', () => {
+          expect(
+            customObject.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customObjectFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toBeUndefined()
+        })
       })
 
-      it('should add generated dependencies', () => {
-        expect(
-          instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
-        ).toBeUndefined()
-        expect(
-          instanceFromInstalledPackage.annotations[
-            CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
-          ],
-        ).toBeUndefined()
+      describe('Standard Object Custom Fields', () => {
+        let customField: Field
+        let customFieldFromInstalledPackage: Field
+
+        beforeEach(async () => {
+          const accountType = mockTypes.Account.clone()
+          customField = new Field(
+            mockTypes.Account,
+            'TestField__c',
+            BuiltinTypes.STRING,
+            { [API_NAME]: 'TestField__c' },
+          )
+          customFieldFromInstalledPackage = new Field(
+            mockTypes.Account,
+            `${NAMESPACE}__TestField__c`,
+            BuiltinTypes.STRING,
+            { [API_NAME]: `${NAMESPACE}__TestField__c` },
+          )
+          accountType.fields[customField.name] = customField
+          accountType.fields[customFieldFromInstalledPackage.name] =
+            customFieldFromInstalledPackage
+          await filter.onFetch([...installedPackageInstances, accountType])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            customField.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customFieldFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toBeUndefined()
+        })
+      })
+
+      describe('CustomMetadata types', () => {
+        let customMetadata: ObjectType
+        let customMetadataFromInstalledPackage: ObjectType
+
+        beforeEach(async () => {
+          customMetadata = createCustomMetadataType(
+            'TestCustomMetadata__mdt',
+            {},
+          )
+          customMetadataFromInstalledPackage = createCustomMetadataType(
+            `${NAMESPACE}__TestCustomMetadata__mdt`,
+            {},
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            customMetadata,
+            customMetadataFromInstalledPackage,
+          ])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            customMetadata.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            customMetadataFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toBeUndefined()
+        })
+      })
+
+      describe('Instances', () => {
+        let instance: InstanceElement
+        let instanceFromInstalledPackage: InstanceElement
+
+        beforeEach(async () => {
+          instance = createInstanceElement(
+            { fullName: 'TestInstance' },
+            mockTypes.ApexClass,
+          )
+          instanceFromInstalledPackage = createInstanceElement(
+            { fullName: `${NAMESPACE}__TestInstance` },
+            mockTypes.ApexClass,
+          )
+          await filter.onFetch([
+            ...installedPackageInstances,
+            instance,
+            instanceFromInstalledPackage,
+          ])
+        })
+
+        it('should add generated dependencies', () => {
+          expect(
+            instance.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES],
+          ).toBeUndefined()
+          expect(
+            instanceFromInstalledPackage.annotations[
+              CORE_ANNOTATIONS.GENERATED_DEPENDENCIES
+            ],
+          ).toBeUndefined()
+        })
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -28,6 +28,7 @@ import {
   ReadOnlyElementsSource,
   ReferenceExpression,
   toChange,
+  TypeReference,
   Values,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
@@ -643,6 +644,7 @@ describe('filter utils', () => {
   })
   describe('isInstanceOfTypeSync and isInstanceOfTypeChangeSync', () => {
     let instance: InstanceElement
+    let unresolvedInstance: InstanceElement
     beforeEach(() => {
       instance = createInstanceElement(
         {
@@ -651,17 +653,36 @@ describe('filter utils', () => {
         },
         mockTypes.Profile,
       )
+      unresolvedInstance = new InstanceElement(
+        'UnresolvedTestInstance',
+        new TypeReference(mockTypes.Profile.elemID),
+      )
     })
     describe('isInstanceOfTypeSync', () => {
-      it('should return true when the instance type is one of the provided types', () => {
+      it('should return true when the resolved instance type is one of the provided types', () => {
         expect(instance).toSatisfy(isInstanceOfTypeSync('Profile'))
         expect(instance).toSatisfy(isInstanceOfTypeSync('Profile', 'Flow'))
       })
-      it('should return false when the instance type is not one of the provided types', () => {
+      it('should return false when the resolved instance type is not one of the provided types', () => {
         expect(instance).not.toSatisfy(isInstanceOfTypeSync('Flow'))
         expect(instance).not.toSatisfy(
           isInstanceOfTypeSync('Flow', 'ApexClass'),
         )
+      })
+      it('should return true when the unresolved instance type is one of the provided types', () => {
+        expect(unresolvedInstance).toSatisfy(isInstanceOfTypeSync('Profile'))
+        expect(unresolvedInstance).toSatisfy(
+          isInstanceOfTypeSync('Profile', 'Flow'),
+        )
+      })
+      it('should return false when the unresolved instance type is not one of the provided types', () => {
+        expect(unresolvedInstance).not.toSatisfy(isInstanceOfTypeSync('Flow'))
+        expect(unresolvedInstance).not.toSatisfy(
+          isInstanceOfTypeSync('Flow', 'ApexClass'),
+        )
+      })
+      it('should return false for a type element', () => {
+        expect(mockTypes.Profile).not.toSatisfy(isInstanceOfTypeSync('Profile'))
       })
     })
     describe('isInstanceOfTypeChangeSync', () => {

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -644,7 +644,7 @@ describe('filter utils', () => {
   })
   describe('isInstanceOfTypeSync and isInstanceOfTypeChangeSync', () => {
     let instance: InstanceElement
-    let unresolvedInstance: InstanceElement
+    let instanceWithUnresolvedType: InstanceElement
     beforeEach(() => {
       instance = createInstanceElement(
         {
@@ -653,7 +653,7 @@ describe('filter utils', () => {
         },
         mockTypes.Profile,
       )
-      unresolvedInstance = new InstanceElement(
+      instanceWithUnresolvedType = new InstanceElement(
         'UnresolvedTestInstance',
         new TypeReference(mockTypes.Profile.elemID),
       )
@@ -670,14 +670,18 @@ describe('filter utils', () => {
         )
       })
       it('should return true when the unresolved instance type is one of the provided types', () => {
-        expect(unresolvedInstance).toSatisfy(isInstanceOfTypeSync('Profile'))
-        expect(unresolvedInstance).toSatisfy(
+        expect(instanceWithUnresolvedType).toSatisfy(
+          isInstanceOfTypeSync('Profile'),
+        )
+        expect(instanceWithUnresolvedType).toSatisfy(
           isInstanceOfTypeSync('Profile', 'Flow'),
         )
       })
       it('should return false when the unresolved instance type is not one of the provided types', () => {
-        expect(unresolvedInstance).not.toSatisfy(isInstanceOfTypeSync('Flow'))
-        expect(unresolvedInstance).not.toSatisfy(
+        expect(instanceWithUnresolvedType).not.toSatisfy(
+          isInstanceOfTypeSync('Flow'),
+        )
+        expect(instanceWithUnresolvedType).not.toSatisfy(
           isInstanceOfTypeSync('Flow', 'ApexClass'),
         )
       })

--- a/packages/salesforce-adapter/test/utils.ts
+++ b/packages/salesforce-adapter/test/utils.ts
@@ -46,6 +46,7 @@ import {
 import { FilterContext } from '../src/filter'
 import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
 import {
+  CustomReferencesSettings,
   LastChangeDateOfTypesWithNestedInstances,
   OptionalFeatures,
 } from '../src/types'
@@ -444,11 +445,16 @@ export const createCustomSettingsObject = (
 
 export const buildFilterContext = ({
   optionalFeatures,
+  customReferencesSettings,
 }: {
   optionalFeatures?: OptionalFeatures
+  customReferencesSettings?: CustomReferencesSettings
 }): FilterContext => ({
   systemFields: SYSTEM_FIELDS,
-  fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures } }),
+  fetchProfile: buildFetchProfile({
+    fetchParams: { optionalFeatures },
+    customReferencesSettings,
+  }),
   elementsSource: buildElementsSourceFromElements([]),
   enumFieldPermissions: false,
   flsProfiles: [constants.ADMIN_PROFILE],


### PR DESCRIPTION
Implementing a new custom references handler for installed packages.
The old filter will only generate references if the handler is disabled, but there are some logs we will always want it to print.

---

Workspace diff: https://github.com/salto-io/ariel-sf/commit/fe51f1759dd5dc946b4e0c6a3d151db7536ead01
Explicit references to the `InstalledPackage` are removed from all managed elements.

---
_Release Notes_: 
_Salesforce_:
* Use custom (weak) references for installed packages. Disabled by default.

---
_User Notifications_: 
_Salesforce_
* Enabling the custom references handler `managedElements` will remove the explicit references to the `InstalledPackage` from all managed elements.
