### PR TITLE
SALTO-5899: fix important value for group in Okta

### DIFF
--- a/packages/okta-adapter/src/filters/add_important_values.ts
+++ b/packages/okta-adapter/src/filters/add_important_values.ts
@@ -63,7 +63,7 @@ const importantValuesMap: Record<string, ImportantValues> = {
       indexed: true,
     },
     {
-      value: 'source',
+      value: 'source.id',
       highlighted: false,
       indexed: true,
     },


### PR DESCRIPTION
The important value was unintentionally to the entire `source` group instead of `source.id`

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
