### PR TITLE
SALTO-5553 update field context counting

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -32,7 +32,7 @@ const p1Option = {
       position: 1,
     },
   },
-  position: 0,
+  position: 1,
 }
 
 export const createFieldValues = (name: string): Values => ({
@@ -56,17 +56,17 @@ export const createContextValues = (name: string, allElements: Element[]): Value
           position: 0,
         },
       },
-      position: 1,
+      position: 2,
     },
     p3: {
       value: 'p3',
       disabled: true,
-      position: 2,
+      position: 3,
     },
     p4: {
       value: 'p4',
       disabled: false,
-      position: 3,
+      position: 4,
     },
   },
   issueTypeIds: [

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -159,7 +159,10 @@ const transformOptionsToMap = (instance: InstanceElement): void => {
   instance.value.contexts
     ?.filter((context: Values) => context.options !== undefined)
     .forEach((context: Values) => {
-      const optionsWithIndex = context.options.map((option: Values, position: number) => ({ ...option, position }))
+      const optionsWithIndex = context.options.map((option: Values, position: number) => ({
+        ...option,
+        position: position + 1,
+      }))
 
       context.options = _.keyBy(optionsWithIndex, option => naclCase(option.value))
     })

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -331,7 +331,7 @@ describe('fields_structure', () => {
         someValue: {
           id: '1',
           value: 'someValue',
-          position: 0,
+          position: 1,
           cascadingOptions: {
             someValue3: {
               id: '3',
@@ -343,7 +343,7 @@ describe('fields_structure', () => {
         someValue2: {
           id: '2',
           value: 'someValue2',
-          position: 1,
+          position: 2,
           cascadingOptions: {
             someValue5: {
               id: '5',

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -213,7 +213,7 @@ describe('fields_structure', () => {
         someValue: {
           id: '1',
           value: 'someValue',
-          position: 0,
+          position: 1,
           cascadingOptions: {
             someValue3: {
               id: '3',
@@ -230,7 +230,7 @@ describe('fields_structure', () => {
         someValue2: {
           id: '2',
           value: 'someValue2',
-          position: 1,
+          position: 2,
           cascadingOptions: {
             someValue5: {
               id: '5',


### PR DESCRIPTION
Change the counting of the options in field-context so that it will start from 1 instead of 0 to make it compatible with the jira UI
---

---
_Release Notes_: 

_Jira Adapter_:
- update the counting of the options in field-context 
_User Notifications_: 

N/A