### PR TITLE
SALTO-5910: Add exact option to ReferenceInfo (Salesforce Profiles Weak References)

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -205,6 +205,7 @@ export type ReferenceInfo = {
   source: ElemID
   target: ElemID
   type: ReferenceType
+  exact?: boolean
 }
 
 export type GetCustomReferencesFunc = (elements: Element[], adapterConfig?: InstanceElement) => Promise<ReferenceInfo[]>

--- a/packages/salesforce-adapter/src/custom_references/profiles.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles.ts
@@ -286,6 +286,7 @@ const referencesFromProfile = (profile: InstanceElement): ReferenceInfo[] =>
       ),
       target,
       type: 'weak',
+      exact: true,
     }),
   )
 

--- a/packages/salesforce-adapter/test/custom_references/profiles.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/profiles.test.ts
@@ -85,6 +85,7 @@ describe('profiles', () => {
               source: profileInstance.elemID.createNestedID(...expectedSource),
               target: expectedTarget,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -142,6 +143,7 @@ describe('profiles', () => {
               ),
               target: customApp.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -171,6 +173,7 @@ describe('profiles', () => {
               ),
               target: customApp.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -250,6 +253,7 @@ describe('profiles', () => {
               ),
               target: apexClass.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -326,6 +330,7 @@ describe('profiles', () => {
               ),
               target: flow.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -387,6 +392,7 @@ describe('profiles', () => {
               ),
               target: layout.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -429,6 +435,7 @@ describe('profiles', () => {
               ),
               target: layout.elemID,
               type: 'weak',
+              exact: true,
             },
             {
               source: profileInstance.elemID.createNestedID(
@@ -437,6 +444,7 @@ describe('profiles', () => {
               ),
               target: recordTypes[0].elemID,
               type: 'weak',
+              exact: true,
             },
             {
               source: profileInstance.elemID.createNestedID(
@@ -445,6 +453,7 @@ describe('profiles', () => {
               ),
               target: recordTypes[1].elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -523,6 +532,7 @@ describe('profiles', () => {
                 ),
                 target: layout.elemID,
                 type: 'weak',
+                exact: true,
               },
             ])
           })
@@ -585,6 +595,7 @@ describe('profiles', () => {
               ),
               target: customObject.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -662,6 +673,7 @@ describe('profiles', () => {
               ),
               target: apexPage.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -747,6 +759,7 @@ describe('profiles', () => {
               ),
               target: recordType.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })
@@ -778,6 +791,7 @@ describe('profiles', () => {
               ),
               target: recordType.elemID,
               type: 'weak',
+              exact: true,
             },
           ])
         })

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -50,7 +50,11 @@ type ChangeReferences = {
   currentAndNew: ReferenceInfo[]
 }
 
-export type ReferenceTargetIndexValue = collections.treeMap.TreeMap<{ id: ElemID; type: ReferenceType }>
+export type ReferenceTargetIndexValue = collections.treeMap.TreeMap<{
+  id: ElemID
+  type: ReferenceType
+  exact?: boolean
+}>
 
 type GetCustomReferencesFunc = (elements: Element[]) => Promise<ReferenceInfo[]>
 
@@ -131,7 +135,7 @@ const createReferenceTree = (references: ReferenceInfo[], rootFields = false): R
         rootFields && ref.source.idType === 'field'
           ? ''
           : ref.source.createBaseID().path.join(ElemID.NAMESPACE_SEPARATOR)
-      return [key, [{ id: ref.target, type: ref.type }]]
+      return [key, [{ id: ref.target, type: ref.type, exact: ref.exact }]]
     }),
     ElemID.NAMESPACE_SEPARATOR,
   )

--- a/packages/workspace/test/workspace/reference_indexes.test.ts
+++ b/packages/workspace/test/workspace/reference_indexes.test.ts
@@ -619,6 +619,7 @@ describe('updateReferenceIndexes', () => {
                   source: inst.elemID.createNestedID('val2'),
                   target: new ElemID('test', 'type', 'instance', 'someInstance2'),
                   type: 'weak',
+                  exact: true,
                 },
                 {
                   source: inst.elemID.createNestedID('val3'),
@@ -635,7 +636,7 @@ describe('updateReferenceIndexes', () => {
           key: 'test.object.instance.instance',
           value: new collections.treeMap.TreeMap([
             ['val1', [{ id: new ElemID('test', 'type', 'instance', 'someInstance1'), type: 'strong' }]],
-            ['val2', [{ id: new ElemID('test', 'type', 'instance', 'someInstance2'), type: 'weak' }]],
+            ['val2', [{ id: new ElemID('test', 'type', 'instance', 'someInstance2'), type: 'weak', exact: true }]],
             ['val3', [{ id: new ElemID('test', 'type', 'instance', 'someInstance3'), type: 'weak' }]],
           ]),
         },


### PR DESCRIPTION
Add exact option to ReferenceInfo. Use it for Salesforce Profiles

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
