### PR TITLE
SALTO-5980: Update Google Workspace README with reauthentication policy instructions

### DIFF
--- a/packages/google-workspace-adapter/README.md
+++ b/packages/google-workspace-adapter/README.md
@@ -26,6 +26,18 @@ The adapter also supports OAuth authentication. To authenticate using OAuth, use
    1. `Admin SDK API`
    2. `Groups Settings API`
    3. `Cloud Identity API`
-4. Run the `salto account add ...` command and follow the instructions to authenticate using OAuth. You will need to provide the `clientId` and `clientSecret`, which you can obtain from the same page you create the Oauth and set the `redirectUri`, you can go to your google [console](https://console.cloud.google.com/) => `APIs & Services` => `Credentials` .
+4. Adjust your reauthentication policy [here](https://admin.google.com/ac/security/reauth/admin-tools) to not require reauthentication.
+You can do it in 2 ways:
+   1. Check the 'Never require authentication' checkbox.
+   2. Never require authentication for a specific app:
+      1. Under 'Require reauthentication' section, check the 'Exempt Trusted apps' checkbox and click OVERRIDE.
+      2. Go to the [Apps Access Control](https://admin.google.com/ac/owl/list?tab=configuredApps) page.
+      3. Click 'Add app' -> 'OAuth App Name Or Client ID'.
+      4. Paste the client ID of the OAuth app you created in the first step and click 'search'.
+      5. Select the app and check the relevant OAuth Client ID checkbox.
+      6. Continue with the default scope.
+      7. Under 'Access to Google Data' check the 'Trusted' checkbox and continue.
+      8. View your configuration and click 'Finish'.
+5. Run the `salto account add ...` command and follow the instructions to authenticate using OAuth. You will need to provide the `clientId` and `clientSecret`, which you can obtain from the same page you create the Oauth and set the `redirectUri`, you can go to your google [console](https://console.cloud.google.com/) => `APIs & Services` => `Credentials` .
 
 Please notice - in order to log in with oauth to google workspace, we are using the refresh token. The refresh token only returns in the first request, so if you are already connected to your google workspace in your browser, you can open a guest tab and repeat the login.

--- a/packages/google-workspace-adapter/README.md
+++ b/packages/google-workspace-adapter/README.md
@@ -27,7 +27,7 @@ The adapter also supports OAuth authentication. To authenticate using OAuth, use
    2. `Groups Settings API`
    3. `Cloud Identity API`
 4. Adjust your reauthentication policy [here](https://admin.google.com/ac/security/reauth/admin-tools) to not require reauthentication.
-You can do it in 2 ways:
+   You can do it in 2 ways:
    1. Check the 'Never require authentication' checkbox.
    2. Never require authentication for a specific app:
       1. Under 'Require reauthentication' section, check the 'Exempt Trusted apps' checkbox and click OVERRIDE.


### PR DESCRIPTION
We recently found out that the default reauthentication policy defined on GW accounts requires requthentication after 16 hours, which causes us to receive an error when trying to get an access token using only our stored refresh token.
This can be configured in the admin console in 2 ways. We added guidance for both in the GW README.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
