### PR TITLE
SALTO-5555: errors in fetch JSM forms

### DIFF
--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -136,10 +136,6 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
               log.error(
                 `Failed to fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
               )
-              errors.push({
-                message: `Failed to fetch forms for project ${project.value.name}`,
-                severity: 'Error' as SeverityLevel,
-              })
             }
             return undefined
           }

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -128,44 +128,44 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
       await Promise.all(
         jsmProjects.flatMap(async project => {
           try {
-          const url = `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms`
-          const res = await client.get({ url })
-          if (!isFormsResponse(res)) {
-            if (isExpectedPermissionError(res)) {
-              projectsWithoutForms.push(project.elemID.name)
-            } else {
-              log.error(
-                `Failed to fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
-              )
+            const url = `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms`
+            const res = await client.get({ url })
+            if (!isFormsResponse(res)) {
+              if (isExpectedPermissionError(res)) {
+                projectsWithoutForms.push(project.elemID.name)
+              } else {
+                log.error(
+                  `Failed to fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
+                )
+              }
+              return undefined
             }
-            return undefined
-          }
-          return await Promise.all(
-            res.data.map(async formResponse => {
-              const detailedUrl = `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${formResponse.id}`
-              const detailedRes = await client.get({ url: detailedUrl })
-              if (!isDetailedFormsResponse(detailedRes.data)) {
-                projectsWithUntitledForms.add(project.elemID.name)
-                return undefined
-              }
-              const name = naclCase(`${project.value.key}_${formResponse.name}`)
-              const formValue = detailedRes.data
-              const parentPath = project.path ?? []
-              const jsmDuckTypeApiDefinitions = config[JSM_DUCKTYPE_API_DEFINITIONS]
-              if (jsmDuckTypeApiDefinitions === undefined) {
-                return undefined
-              }
-              return new InstanceElement(
-                name,
-                formType,
-                formValue,
-                [...parentPath.slice(0, -1), 'forms', pathNaclCase(name)],
-                {
-                  [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(project.elemID, project)],
-                },
-              )
-            }),
-          )
+            return await Promise.all(
+              res.data.map(async formResponse => {
+                const detailedUrl = `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${formResponse.id}`
+                const detailedRes = await client.get({ url: detailedUrl })
+                if (!isDetailedFormsResponse(detailedRes.data)) {
+                  projectsWithUntitledForms.add(project.elemID.name)
+                  return undefined
+                }
+                const name = naclCase(`${project.value.key}_${formResponse.name}`)
+                const formValue = detailedRes.data
+                const parentPath = project.path ?? []
+                const jsmDuckTypeApiDefinitions = config[JSM_DUCKTYPE_API_DEFINITIONS]
+                if (jsmDuckTypeApiDefinitions === undefined) {
+                  return undefined
+                }
+                return new InstanceElement(
+                  name,
+                  formType,
+                  formValue,
+                  [...parentPath.slice(0, -1), 'forms', pathNaclCase(name)],
+                  {
+                    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(project.elemID, project)],
+                  },
+                )
+              }),
+            )
           } catch (e) {
             log.error(
               `Failed to fetch forms for project ${project.value.name} with the following response: ${inspectValue(e)}`,

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -254,14 +254,8 @@ export const createFormType = (): {
   }
 }
 
-export const isFormsResponse = createSchemeGuard<FormsResponse>(
-  FORMS_RESPONSE_SCHEME,
-  'bad forms response from jira server',
-)
-export const isDetailedFormsResponse = createSchemeGuard<DetailedFormDataResponse>(
-  DETAILED_FORM_RESPONSE_SCHEME,
-  'bad detailed form response from jira server',
-)
+export const isFormsResponse = createSchemeGuard<FormsResponse>(FORMS_RESPONSE_SCHEME)
+export const isDetailedFormsResponse = createSchemeGuard<DetailedFormDataResponse>(DETAILED_FORM_RESPONSE_SCHEME)
 
 type createFormResponse = {
   id: number

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -44,6 +44,9 @@ describe('forms filter', () => {
   const projectType = createEmptyType(PROJECT_TYPE)
   let projectInstance: InstanceElement
   let elements: Element[]
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
   describe('on fetch', () => {
     beforeEach(async () => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -242,6 +245,143 @@ describe('forms filter', () => {
     })
   })
   describe('on fetch errors', () => {
+    let projectInstanceTwo: InstanceElement
+    const goodDetailedResponse = {
+      updated: '2023-09-28T08:20:31.552322Z',
+      uuid: 'uuid',
+      design: {
+        settings: {
+          templateId: 6,
+          name: 'name',
+          submit: {
+            lock: false,
+            pdf: false,
+          },
+          templateFormUuid: 'templateFormUuid',
+        },
+        layout: [
+          {
+            version: 1,
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  {
+                    type: 'text',
+                    text: 'form 6 content',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        conditions: {},
+        sections: {
+          36: {
+            t: 'sh',
+            i: {
+              co: {
+                cIds: {
+                  3: ['2'],
+                },
+              },
+            },
+            o: {
+              sIds: ['4'],
+            },
+          },
+        },
+        questions: {
+          3: {
+            type: 'cm',
+            label: 'Items to be verified',
+            description: '',
+            choices: [
+              {
+                id: '1',
+                label: 'Education',
+                other: false,
+              },
+              {
+                id: '2',
+                label: 'Licenses',
+                other: false,
+              },
+            ],
+            questionKey: '',
+          },
+        },
+      },
+    }
+    const badDetailedResponse = {
+      updated: '2023-09-28T08:20:31.552322Z',
+      uuid: 'uuid',
+      design: {
+        settings: {
+          templateId: 6,
+          name: '',
+          submit: {
+            lock: false,
+            pdf: false,
+          },
+          templateFormUuid: 'templateFormUuid',
+        },
+        layout: [
+          {
+            version: 1,
+            type: 'doc',
+            content: [
+              {
+                type: 'paragraph',
+                content: [
+                  {
+                    type: 'text',
+                    text: 'form 6 content',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+        conditions: {},
+        sections: {
+          36: {
+            t: 'sh',
+            i: {
+              co: {
+                cIds: {
+                  3: ['2'],
+                },
+              },
+            },
+            o: {
+              sIds: ['4'],
+            },
+          },
+        },
+        questions: {
+          3: {
+            type: 'cm',
+            label: 'Items to be verified',
+            description: '',
+            choices: [
+              {
+                id: '1',
+                label: 'Education',
+                other: false,
+              },
+              {
+                id: '2',
+                label: 'Licenses',
+                other: false,
+              },
+            ],
+            questionKey: '',
+          },
+        },
+      },
+    }
     beforeEach(async () => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
@@ -260,7 +400,18 @@ describe('forms filter', () => {
         },
         [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1'],
       )
-      connection.post.mockResolvedValueOnce({
+      projectInstanceTwo = new InstanceElement(
+        'project2',
+        projectType,
+        {
+          id: 22222,
+          name: 'project2',
+          projectTypeKey: 'service_desk',
+          key: 'project2Key',
+        },
+        [JIRA, adapterElements.RECORDS_PATH, PROJECT_TYPE, 'project1'],
+      )
+      connection.post.mockResolvedValue({
         status: 200,
         data: {
           unparsedData: {
@@ -270,94 +421,123 @@ describe('forms filter', () => {
           },
         },
       })
-
-      connection.get.mockResolvedValueOnce({
-        status: 200,
-        data: [
-          {
-            id: 1,
-            name: '',
-          },
-        ],
-      })
-
-      connection.get.mockResolvedValueOnce({
-        status: 200,
-        data: {
-          updated: '2023-09-28T08:20:31.552322Z',
-          uuid: 'uuid',
-          design: {
-            settings: {
-              templateId: 6,
-              name: '',
-              submit: {
-                lock: false,
-                pdf: false,
-              },
-              templateFormUuid: 'templateFormUuid',
-            },
-            layout: [
+      elements = [projectInstance, projectInstanceTwo, projectType]
+    })
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+    it("should return single saltoError when failed to fetch form becuase it doesn't have a title", async () => {
+      connection.get.mockImplementation(async url => {
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/11111/forms') {
+          return {
+            status: 200,
+            data: [
               {
-                version: 1,
-                type: 'doc',
-                content: [
-                  {
-                    type: 'paragraph',
-                    content: [
-                      {
-                        type: 'text',
-                        text: 'form 6 content',
-                      },
-                    ],
-                  },
-                ],
+                id: 1,
+                name: '',
               },
             ],
-            conditions: {},
-            sections: {
-              36: {
-                t: 'sh',
-                i: {
-                  co: {
-                    cIds: {
-                      3: ['2'],
-                    },
-                  },
-                },
-                o: {
-                  sIds: ['4'],
-                },
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/2/projects/11111/forms/1') {
+          return {
+            status: 200,
+            data: badDetailedResponse,
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/22222/forms') {
+          return {
+            status: 200,
+            data: [
+              {
+                id: 2,
+                name: '',
               },
-            },
-            questions: {
-              3: {
-                type: 'cm',
-                label: 'Items to be verified',
-                description: '',
-                choices: [
-                  {
-                    id: '1',
-                    label: 'Education',
-                    other: false,
-                  },
-                  {
-                    id: '2',
-                    label: 'Licenses',
-                    other: false,
-                  },
-                ],
-                questionKey: '',
-              },
-            },
-          },
-        },
+            ],
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/2/projects/22222/forms/2') {
+          return {
+            status: 200,
+            data: badDetailedResponse,
+          }
+        }
+        throw new Error('Unexpected url')
       })
-      elements = [projectInstance, projectType]
-    })
-    it("should return saltoError when failed to fetch form becuase it doesn't have name", async () => {
       const res = (await filter.onFetch(elements)) as FilterResult
       expect(res.errors).toHaveLength(1)
-      expect(res.errors?.[0].message).toEqual('Unable to fetch form for project project1 as it is missing a title.')
+      expect(res.errors?.[0].message).toEqual(
+        'Salto does not support fetching untitled forms, found in the following projects: project1, project2',
+      )
+    })
+    it('should return single saltoError when failed to fetch form because data is empty', async () => {
+      connection.get.mockImplementation(async url => {
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/11111/forms') {
+          return {
+            status: 200,
+            data: [],
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/22222/forms') {
+          return {
+            status: 200,
+            data: [],
+          }
+        }
+        throw new Error('Unexpected url')
+      })
+      const res = (await filter.onFetch(elements)) as FilterResult
+      expect(res.errors).toHaveLength(1)
+      expect(res.errors?.[0].message).toEqual(
+        'Unable to fetch forms for the following projects: project1, project2. This issue is likely due to insufficient permissions.',
+      )
+    })
+    it('should add form1 to the elements and add saltoError when failed to fetch form2 data for projectTwo', async () => {
+      connection.get.mockImplementation(async url => {
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/11111/forms') {
+          return {
+            status: 200,
+            data: [
+              {
+                id: 1,
+                name: 'form1',
+              },
+            ],
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/2/projects/11111/forms/1') {
+          return {
+            status: 200,
+            data: goodDetailedResponse,
+          }
+        }
+        if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/22222/forms') {
+          return {
+            status: 200,
+            data: [],
+          }
+        }
+        throw new Error('Unexpected url')
+      })
+      const res = (await filter.onFetch(elements)) as FilterResult
+      expect(res.errors).toHaveLength(1)
+      expect(res.errors?.[0].message).toEqual(
+        'Unable to fetch forms for the following projects: project2. This issue is likely due to insufficient permissions.',
+      )
+      const instances = elements.filter(isInstanceElement)
+      const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
+      expect(formInstance).toBeDefined()
+    })
+    it('should not add forms to elements and not add an error for a bad unexpected response', async () => {
+      connection.get.mockResolvedValue({
+        status: 404,
+        data: {},
+      })
+      const res = (await filter.onFetch(elements)) as FilterResult
+      expect(res.errors).toHaveLength(0)
+      const instances = elements.filter(isInstanceElement)
+      const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
+      expect(formInstance).toBeUndefined()
     })
   })
   describe('deploy', () => {

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -537,8 +537,7 @@ describe('forms filter', () => {
         },
       })
       const res = (await filter.onFetch(elements)) as FilterResult
-      expect(res.errors).toHaveLength(2)
-      expect(res.errors?.[0].message).toEqual('Failed to fetch forms for project project1')
+      expect(res.errors).toHaveLength(0)
       const instances = elements.filter(isInstanceElement)
       const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
       expect(formInstance).toBeUndefined()

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -542,6 +542,19 @@ describe('forms filter', () => {
       const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
       expect(formInstance).toBeUndefined()
     })
+    it('should add saltoError response when 403 error is thrown from jira client', async () => {
+      connection.get.mockRejectedValue({
+        response: {
+          status: 403,
+          data: 'insufficient permissions',
+        },
+      })
+      const res = (await filter.onFetch(elements)) as FilterResult
+      expect(res.errors).toHaveLength(1)
+      expect(res.errors?.[0].message).toEqual(
+        'Unable to fetch forms for the following projects: project1, project2. This issue is likely due to insufficient permissions.',
+      )
+    })
   })
   describe('deploy', () => {
     let formInstance: InstanceElement

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -525,16 +525,20 @@ describe('forms filter', () => {
         'Unable to fetch forms for the following projects: project2. This issue is likely due to insufficient permissions.',
       )
       const instances = elements.filter(isInstanceElement)
-      const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
-      expect(formInstance).toBeDefined()
+      const formInstances = instances.filter(e => e.elemID.typeName === FORM_TYPE)
+      expect(formInstances).toHaveLength(1)
+      expect(formInstances[0]?.elemID.name).toEqual('project1Key_form1')
     })
     it('should not add forms to elements and not add an error for a bad unexpected response', async () => {
       connection.get.mockResolvedValue({
         status: 404,
-        data: {},
+        data: {
+          message: 'not found',
+        },
       })
       const res = (await filter.onFetch(elements)) as FilterResult
-      expect(res.errors).toHaveLength(0)
+      expect(res.errors).toHaveLength(2)
+      expect(res.errors?.[0].message).toEqual('Failed to fetch forms for project project1')
       const instances = elements.filter(isInstanceElement)
       const formInstance = instances.find(e => e.elemID.typeName === FORM_TYPE)
       expect(formInstance).toBeUndefined()


### PR DESCRIPTION
In this PR I fixed the multiple errors in JSM Forms. 

---

_Additional context for reviewer_

Currently, we are logging many errors related to failures in fetching JSM forms.
|Was|Now|
|----|-----| 
|Previously, when we failed to fetch forms for an entire project, we logged an error for each project in the account.| Now, we log a single error for all projects.|
|When forms had missing titles, we logged an error for each form. |Now, we log one error covering all forms and projects.|
  
Example in oriSaltoTest:
![image](https://github.com/salto-io/salto/assets/63644199/becde458-b6dc-4acf-9d72-4f8a2d9b5a83)

In addition, I decreased the logs from Error to debug and added fetch warnings.  
#### Important Note:
**I will add tests after the initial review to ensure that my solution is acceptable.**

---
_Release Notes_: 
_Jira adapter_:
* Optimized error logging for JSM form fetching to reduce noise: Now logging a single error per account for project-wide fetch failures and a unified error for all forms with missing titles.

---
_User Notifications_: 
_Jira adapter_:
* Optimized error logging for JSM form fetching to reduce noise: Now logging a single error per account for project-wide fetch failures and a unified error for all forms with missing titles.
