### PR TITLE
SALTO-5913: remove content from being index important value in dynamic content item variant

### DIFF
--- a/packages/zendesk-adapter/src/filters/add_important_values.ts
+++ b/packages/zendesk-adapter/src/filters/add_important_values.ts
@@ -155,7 +155,7 @@ const importantValuesMap: Record<string, ImportantValues> = {
     {
       value: 'content',
       highlighted: true,
-      indexed: true,
+      indexed: false,
     },
     {
       value: 'locale_id',


### PR DESCRIPTION
remove content from being index important value in dynamic content item variant

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* content in dynamic content item variant is no longer an indexed important value

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
