### PR TITLE
SALTO-5758 page and space CVs for Confluence

### DIFF
--- a/packages/confluence-adapter/src/adapter_creator.ts
+++ b/packages/confluence-adapter/src/adapter_creator.ts
@@ -26,6 +26,7 @@ import { customConvertError } from './error_utils'
 import transformTemplateBodyToTemplateExpressionFilterCreator from './filters/transform_template_body_to_template_expression'
 import customPathsFilterCreator from './filters/custom_paths'
 import deploySpaceAndPermissionsFilterCreator from './filters/deploy_space_and_permissions'
+import createChangeValidator from './change_validator'
 
 const { DEFAULT_RETRY_OPTS, RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = client
 const { defaultCredentialsFromConfig } = credentials
@@ -57,6 +58,7 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
       // customPathsFilterCreator must run after fieldReferencesFilter
       customPathsFilterCreator,
     }),
+    additionalChangeValidators: createChangeValidator(),
   },
 
   initialClients: {

--- a/packages/confluence-adapter/src/change_validator.ts
+++ b/packages/confluence-adapter/src/change_validator.ts
@@ -1,0 +1,22 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ChangeValidator } from '@salto-io/adapter-api'
+import { uniquePageTitleUnderSpaceValidator, uniqueSpaceKeyValidator } from './change_validators'
+
+export default (): Record<string, ChangeValidator> => ({
+  uniquePageTitleUnderSpace: uniquePageTitleUnderSpaceValidator,
+  uniqueSpaceKey: uniqueSpaceKeyValidator,
+})

--- a/packages/confluence-adapter/src/change_validators/index.ts
+++ b/packages/confluence-adapter/src/change_validators/index.ts
@@ -1,0 +1,18 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export { uniquePageTitleUnderSpaceValidator } from './unique_page_title_under_space'
+export { uniqueSpaceKeyValidator } from './space_key_uniqueness'

--- a/packages/confluence-adapter/src/change_validators/space_key_uniqueness.ts
+++ b/packages/confluence-adapter/src/change_validators/space_key_uniqueness.ts
@@ -1,0 +1,69 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeValidator,
+  ElemID,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { SPACE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+export const uniqueSpaceKeyValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.warn('elementSource is undefined, skipping uniqueSpaceKeyValidator')
+    return []
+  }
+  const spaceChangesInstances = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === SPACE_TYPE_NAME)
+
+  const spaceKeyToElemId = await awu(await elementSource.getAll())
+    .filter(isInstanceElement)
+    .filter(inst => inst.elemID.typeName === SPACE_TYPE_NAME)
+    .reduce<Record<string, ElemID[]>>((record, inst) => {
+      const { key } = inst.value
+      if (record[key]) {
+        record[key].push(inst.elemID)
+      } else {
+        record[key] = [inst.elemID]
+      }
+      return record
+    }, {})
+  return spaceChangesInstances.flatMap(spaceFromChange => {
+    const spaceWithTheSameKey = spaceKeyToElemId[spaceFromChange.value.key]?.find(
+      elemId => !elemId.isEqual(spaceFromChange.elemID),
+    )
+    if (spaceWithTheSameKey === undefined) {
+      return []
+    }
+    return [
+      {
+        elemID: spaceFromChange.elemID,
+        severity: 'Error',
+        message: 'Space key must be unique',
+        detailedMessage: `key: ${spaceFromChange.value.key} is already in use in space: ${spaceWithTheSameKey.getFullName()}`,
+      },
+    ]
+  })
+}

--- a/packages/confluence-adapter/src/change_validators/space_key_uniqueness.ts
+++ b/packages/confluence-adapter/src/change_validators/space_key_uniqueness.ts
@@ -32,7 +32,7 @@ export const uniqueSpaceKeyValidator: ChangeValidator = async (changes, elementS
     log.warn('elementSource is undefined, skipping uniqueSpaceKeyValidator')
     return []
   }
-  const spaceChangesInstances = changes
+  const spaceChangeInstances = changes
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(isInstanceElement)
@@ -50,7 +50,7 @@ export const uniqueSpaceKeyValidator: ChangeValidator = async (changes, elementS
       }
       return record
     }, {})
-  return spaceChangesInstances.flatMap(spaceFromChange => {
+  return spaceChangeInstances.flatMap(spaceFromChange => {
     const spaceWithTheSameKey = spaceKeyToElemId[spaceFromChange.value.key]?.find(
       elemId => !elemId.isEqual(spaceFromChange.elemID),
     )

--- a/packages/confluence-adapter/src/change_validators/unique_page_title_under_space.ts
+++ b/packages/confluence-adapter/src/change_validators/unique_page_title_under_space.ts
@@ -1,0 +1,84 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeValidator,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
+import { PAGE_TYPE_NAME } from '../constants'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+export const uniquePageTitleUnderSpaceValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.warn('elementSource is undefined, skipping uniquePageTitleUnderSpaceValidator')
+    return []
+  }
+  const pageChanges = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === PAGE_TYPE_NAME)
+
+  const spaceNameIdToPagesInstances = await awu(await elementSource.getAll()).reduce<Record<string, InstanceElement[]>>(
+    (record, elem) => {
+      if (isInstanceElement(elem) && elem.elemID.typeName === PAGE_TYPE_NAME) {
+        const spaceElemId = elem.value.spaceId.elemID.getFullName()
+        if (record[spaceElemId]) {
+          record[spaceElemId].push(elem)
+        } else {
+          record[spaceElemId] = [elem]
+        }
+      }
+      return record
+    },
+    {},
+  )
+  const spaceNameToTitlePagesIndex = _.mapValues(spaceNameIdToPagesInstances, pages =>
+    pages.reduce<Record<string, InstanceElement[]>>((record, page) => {
+      const { title } = page.value
+      if (record[title]) {
+        record[title].push(page)
+      } else {
+        record[title] = [page]
+      }
+      return record
+    }, {}),
+  )
+  return pageChanges.flatMap(pageInstFromChange => {
+    const titleToPageIndex = spaceNameToTitlePagesIndex[pageInstFromChange.value.spaceId.elemID.getFullName()] ?? {}
+    const pageWithTheSameTitle = titleToPageIndex[pageInstFromChange.value.title]?.find(
+      page => !page.elemID.isEqual(pageInstFromChange.elemID),
+    )
+    if (pageWithTheSameTitle === undefined) {
+      return []
+    }
+    return [
+      {
+        elemID: pageInstFromChange.elemID,
+        severity: 'Error',
+        message: 'Page title must be unique under space',
+        detailedMessage: `Page title: ${pageInstFromChange.value.title} is already in use by page: ${pageWithTheSameTitle.elemID.getFullName()}`,
+      },
+    ]
+  })
+}

--- a/packages/confluence-adapter/src/change_validators/unique_page_title_under_space.ts
+++ b/packages/confluence-adapter/src/change_validators/unique_page_title_under_space.ts
@@ -42,10 +42,9 @@ export const uniquePageTitleUnderSpaceValidator: ChangeValidator = async (change
   const spaceNameIdToPageInstances = await awu(await elementSource.getAll()).reduce<Record<string, InstanceElement[]>>(
     (record, elem) => {
       if (isInstanceElement(elem) && elem.elemID.typeName === PAGE_TYPE_NAME) {
-        const spaceElemId = elem.value.spaceId.elemID
-          .getFullName()
+        const spaceElemId = elem.value.spaceId.elemID.getFullName()
         record[spaceElemId] ??= []
-        record[spaceElemId].push(elem) 
+        record[spaceElemId].push(elem)
       }
       return record
     },
@@ -62,7 +61,8 @@ export const uniquePageTitleUnderSpaceValidator: ChangeValidator = async (change
       }, {}),
   )
   return pageChanges.flatMap(pageInstFromChange => {
-    const titleToPageIndex = spaceNameToTitleToPageInstancesIndex[pageInstFromChange.value.spaceId.elemID.getFullName()] ?? {}
+    const titleToPageIndex =
+      spaceNameToTitleToPageInstancesIndex[pageInstFromChange.value.spaceId.elemID.getFullName()] ?? {}
     const pageWithTheSameTitle = titleToPageIndex[pageInstFromChange.value.title]?.find(
       page => !page.elemID.isEqual(pageInstFromChange.elemID),
     )

--- a/packages/confluence-adapter/test/change_validator.test.ts
+++ b/packages/confluence-adapter/test/change_validator.test.ts
@@ -1,0 +1,27 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import changeValidatorCreator from '../src/change_validator'
+
+describe('change validators creator', () => {
+  it('should create the correct change validators', () => {
+    const changeValidators = changeValidatorCreator()
+    expect(changeValidators).toEqual({
+      uniquePageTitleUnderSpace: expect.any(Function),
+      uniqueSpaceKey: expect.any(Function),
+    })
+  })
+})

--- a/packages/confluence-adapter/test/change_validators/space_key_uniqueness.test.ts
+++ b/packages/confluence-adapter/test/change_validators/space_key_uniqueness.test.ts
@@ -1,0 +1,89 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ADAPTER_NAME, SPACE_TYPE_NAME } from '../../src/constants'
+import { uniqueSpaceKeyValidator } from '../../src/change_validators'
+
+describe('uniqueSpaceKeyValidator', () => {
+  const spaceObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, SPACE_TYPE_NAME) })
+  const space1 = new InstanceElement('space1', spaceObjectType, { key: 'space1' })
+  const space2 = new InstanceElement('space2', spaceObjectType, { key: 'space2' })
+  const elementSource = buildElementsSourceFromElements([spaceObjectType, space1, space2])
+  it('should return change error for duplicate space key on addition', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new space', spaceObjectType, {
+          key: 'space1',
+        }),
+      }),
+    ]
+    const res = await uniqueSpaceKeyValidator(changes, elementSource)
+
+    expect(res).toHaveLength(1)
+    expect(res[0].detailedMessage).toEqual('key: space1 is already in use in space: confluence.space.instance.space1')
+  })
+  it('should return change error for duplicate space key on modification', async () => {
+    const after = space1.clone()
+    after.value.key = 'space2'
+    const changes = [
+      toChange({
+        before: space1.clone(),
+        after,
+      }),
+    ]
+    const res = await uniqueSpaceKeyValidator(changes, elementSource)
+
+    expect(res).toHaveLength(1)
+    expect(res[0].detailedMessage).toEqual('key: space2 is already in use in space: confluence.space.instance.space2')
+  })
+  it('should not return change error when modifying a space', async () => {
+    const after = space1.clone()
+    after.value.someNewFiled = 'hep hep'
+    const changes = [
+      toChange({
+        before: space1.clone(),
+        after,
+      }),
+    ]
+    const res = await uniqueSpaceKeyValidator(changes, elementSource)
+    expect(res).toHaveLength(0)
+  })
+  it('should not return change error when adding a space with unique key', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new space', spaceObjectType, {
+          key: 'new key',
+        }),
+      }),
+    ]
+    const res = await uniqueSpaceKeyValidator(changes, elementSource)
+    expect(res).toHaveLength(0)
+  })
+  it('should return no change error when there is no elementSource', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new space', spaceObjectType, {
+          key: 'space1',
+        }),
+      }),
+    ]
+    const res = await uniqueSpaceKeyValidator(changes)
+
+    expect(res).toHaveLength(0)
+  })
+})

--- a/packages/confluence-adapter/test/change_validators/unique_page_title_under_space.test.ts
+++ b/packages/confluence-adapter/test/change_validators/unique_page_title_under_space.test.ts
@@ -1,0 +1,117 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ADAPTER_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME } from '../../src/constants'
+import { uniquePageTitleUnderSpaceValidator } from '../../src/change_validators/unique_page_title_under_space'
+
+describe('uniquePageTitleUnderSpaceValidator', () => {
+  const pageObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, PAGE_TYPE_NAME) })
+  const spaceObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, SPACE_TYPE_NAME) })
+  const space1 = new InstanceElement('space1', spaceObjectType, { key: 'space1' })
+  const space2 = new InstanceElement('space2', spaceObjectType, { key: 'space2' })
+  const pageInSpace1 = new InstanceElement('page1', pageObjectType, {
+    title: 'title in space1',
+    spaceId: new ReferenceExpression(space1.elemID),
+  })
+  const anotherPageInSpace1 = new InstanceElement('another page1', pageObjectType, {
+    title: 'another title in space1',
+    spaceId: new ReferenceExpression(space1.elemID),
+  })
+  const pageInSpace2 = new InstanceElement('page2', pageObjectType, {
+    title: 'title in space2',
+    spaceId: new ReferenceExpression(space2.elemID),
+  })
+  const elementSource = buildElementsSourceFromElements([
+    pageObjectType,
+    spaceObjectType,
+    space1,
+    space2,
+    pageInSpace1,
+    anotherPageInSpace1,
+    pageInSpace2,
+  ])
+  it('should return change error for duplicate page titles on addition', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new page', pageObjectType, {
+          title: 'title in space1',
+          spaceId: new ReferenceExpression(space1.elemID),
+        }),
+      }),
+    ]
+    const res = await uniquePageTitleUnderSpaceValidator(changes, elementSource)
+
+    expect(res).toHaveLength(1)
+    expect(res[0].detailedMessage).toEqual(
+      'Page title: title in space1 is already in use by page: confluence.page.instance.page1',
+    )
+  })
+  it('should return change error for duplicate page titles on modification', async () => {
+    const after = anotherPageInSpace1.clone()
+    after.value.title = 'title in space1'
+    const changes = [
+      toChange({
+        before: anotherPageInSpace1.clone(),
+        after,
+      }),
+    ]
+    const res = await uniquePageTitleUnderSpaceValidator(changes, elementSource)
+
+    expect(res).toHaveLength(1)
+    expect(res[0].detailedMessage).toEqual(
+      'Page title: title in space1 is already in use by page: confluence.page.instance.page1',
+    )
+  })
+  it('should not return change error when modifying a page', async () => {
+    const after = anotherPageInSpace1.clone()
+    after.value.someNewFiled = 'hep hep'
+    const changes = [
+      toChange({
+        before: anotherPageInSpace1.clone(),
+        after,
+      }),
+    ]
+    const res = await uniquePageTitleUnderSpaceValidator(changes, elementSource)
+    expect(res).toHaveLength(0)
+  })
+  it('should not return change error when adding a page with title exists in a different space', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new page', pageObjectType, {
+          title: 'title in space1',
+          spaceId: new ReferenceExpression(space2.elemID),
+        }),
+      }),
+    ]
+    const res = await uniquePageTitleUnderSpaceValidator(changes, elementSource)
+    expect(res).toHaveLength(0)
+  })
+  it('should return no change error when there is no elementSource', async () => {
+    const changes = [
+      toChange({
+        after: new InstanceElement('new page', pageObjectType, {
+          title: 'title in space1',
+          spaceId: new ReferenceExpression(space1.elemID),
+        }),
+      }),
+    ]
+    const res = await uniquePageTitleUnderSpaceValidator(changes)
+
+    expect(res).toHaveLength(0)
+  })
+})

--- a/packages/confluence-adapter/test/change_validators/unique_page_title_under_space.test.ts
+++ b/packages/confluence-adapter/test/change_validators/unique_page_title_under_space.test.ts
@@ -58,7 +58,7 @@ describe('uniquePageTitleUnderSpaceValidator', () => {
 
     expect(res).toHaveLength(1)
     expect(res[0].detailedMessage).toEqual(
-      'Page title: title in space1 is already in use by page: confluence.page.instance.page1',
+      '"Page" title: title in space1 is already in use by page: confluence.page.instance.page1',
     )
   })
   it('should return change error for duplicate page titles on modification', async () => {
@@ -74,7 +74,7 @@ describe('uniquePageTitleUnderSpaceValidator', () => {
 
     expect(res).toHaveLength(1)
     expect(res[0].detailedMessage).toEqual(
-      'Page title: title in space1 is already in use by page: confluence.page.instance.page1',
+      '"Page" title: title in space1 is already in use by page: confluence.page.instance.page1',
     )
   })
   it('should not return change error when modifying a page', async () => {


### PR DESCRIPTION
Added two change validator to Confluence:
1. Uniqueness of page title under space
2. Uniqueness of space key


---


---
_Release Notes_: 
_Confluence Adapter_:
- CV for uniqueness of page title under space
- CV for uniqueness of space key

---
_User Notifications_: 
_Confluence Adapter_:
- CV for uniqueness of page title under space
- CV for uniqueness of space key
