### PR TITLE
SALTO-5643: Adding members in the order they are defined

### DIFF
--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -258,14 +258,6 @@ export class ElemID {
     return new ElemID(this.adapter, this.typeName)
   }
 
-  createSiblingID(name: string): ElemID {
-    if (this.isTopLevel()) {
-      throw new Error(`Cannot create sibling for top level element ID ${this.getFullName()}.`)
-    }
-
-    return new ElemID(this.adapter, this.typeName, this.idType, ...this.nameParts.slice(0, -1), name)
-  }
-
   createAllElemIdParents(): ElemID[] {
     return this.isTopLevel() ? [this] : [this, ...this.createParentID().createAllElemIdParents()]
   }
@@ -296,6 +288,14 @@ export class ElemID {
       }
     }
     return { parent, path }
+  }
+
+  createSiblingID(name: string): ElemID {
+    if (this.isTopLevel()) {
+      throw new Error(`Cannot create sibling for top level element ID ${this.getFullName()}.`)
+    }
+
+    return new ElemID(this.adapter, this.typeName, this.idType, ...this.nameParts.slice(0, -1), name)
   }
 
   getRelativePath(other: ElemID): ReadonlyArray<string> {

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -258,6 +258,14 @@ export class ElemID {
     return new ElemID(this.adapter, this.typeName)
   }
 
+  createSiblingID(name: string): ElemID {
+    if (this.isTopLevel()) {
+      throw new Error(`Cannot create sibling for top level element ID ${this.getFullName()}.`)
+    }
+
+    return new ElemID(this.adapter, this.typeName, this.idType, ...this.nameParts.slice(0, -1), name)
+  }
+
   createAllElemIdParents(): ElemID[] {
     return this.isTopLevel() ? [this] : [this, ...this.createParentID().createAllElemIdParents()]
   }

--- a/packages/adapter-api/test/elements.test.ts
+++ b/packages/adapter-api/test/elements.test.ts
@@ -829,6 +829,68 @@ describe('Test elements.ts', () => {
         })
       })
     })
+    describe('createSiblingID', () => {
+      describe('from type ID', () => {
+        it('should fail', () => {
+          expect(() => typeId.createSiblingID('sibling')).toThrow()
+        })
+      })
+      describe('from field ID', () => {
+        let sibling: ElemID
+        beforeEach(() => {
+          sibling = fieldId.createSiblingID('sibling')
+        })
+        it('should keep the original id type', () => {
+          expect(sibling.idType).toEqual(fieldId.idType)
+        })
+        it('should have the new name', () => {
+          expect(sibling.name).toEqual('sibling')
+        })
+        it('should have the same non-terminal name parts', () => {
+          expect(sibling.getFullNameParts().slice(0, -1)).toEqual(fieldId.getFullNameParts().slice(0, -1))
+        })
+      })
+      describe('from annotation ID', () => {
+        let sibling: ElemID
+        beforeEach(() => {
+          sibling = annotationTypeId.createSiblingID('sibling')
+        })
+        it('should keep the original id type', () => {
+          expect(sibling.idType).toEqual(annotationTypeId.idType)
+        })
+        it('should have the new name', () => {
+          expect(sibling.name).toEqual('sibling')
+        })
+        it('should have the same non-terminal name parts', () => {
+          expect(sibling.getFullNameParts().slice(0, -1)).toEqual(annotationTypeId.getFullNameParts().slice(0, -1))
+        })
+      })
+      describe('from instance ID', () => {
+        it('should fail', () => {
+          expect(() => typeInstId.createSiblingID('sibling')).toThrow()
+        })
+      })
+      describe('from value ID', () => {
+        let sibling: ElemID
+        beforeEach(() => {
+          sibling = valueId.createSiblingID('sibling')
+        })
+        it('should keep the original id type', () => {
+          expect(sibling.idType).toEqual(valueId.idType)
+        })
+        it('should have the new name', () => {
+          expect(sibling.name).toEqual('sibling')
+        })
+        it('should have the same non-terminal name parts', () => {
+          expect(sibling.getFullNameParts().slice(0, -1)).toEqual(valueId.getFullNameParts().slice(0, -1))
+        })
+      })
+      describe('from variable ID', () => {
+        it('should fail', () => {
+          expect(() => variableId.createSiblingID('sibling')).toThrow()
+        })
+      })
+    })
     describe('isAttrID', () => {
       it('should identify non-instance element annotation IDs', () => {
         const objectAnno = new ElemID('salto', 'obj', 'attr', 'something')

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -341,7 +341,10 @@ export const updateNaclFileData = async (
 
           if (change.action === 'remove') {
             // For removals, dropping newline and indent at the end of the block to avoid empty lines
-            data = data.trimEnd()
+            const lastNewlineIndex = data.search(/\s+$/)
+            if (lastNewlineIndex !== -1) {
+              data = data.slice(0, lastNewlineIndex)
+            }
           }
 
           parts.push({

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -87,7 +87,6 @@ const getPositionInParent = (change: DetailedChange): PositionInParent => {
     return { followingElementIDs: [] }
   }
 
-  const idNameParts = change.id.getFullNameParts().slice(0, -1)
   const elementName = change.id.name
   const index = Object.keys(container).indexOf(elementName)
   if (index === -1) {
@@ -98,7 +97,7 @@ const getPositionInParent = (change: DetailedChange): PositionInParent => {
   return {
     followingElementIDs: Object.keys(container)
       .slice(index + 1)
-      .map(k => ElemID.fromFullNameParts([...idNameParts, k])),
+      .map(k => change.id.createSiblingID(k)),
     indexInParent: index,
   }
 }
@@ -200,7 +199,7 @@ const fixEdgeIndentation = (data: string, action: ActionName, initialIndentation
     lines.push(lastLine)
   }
   if (action === 'add') {
-    /* When adding the placement we are given is right before the closing bracket.
+    /* When adding the placement we are given is right before following member or the closing bracket of the parent.
      * The string that dump gave us has an empty last line, meaning we have to recreate the
      * indentation that was there previously. We also have to slice from the beginning of the first
      * line the initial indentation that was there in the beginning.

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -497,8 +497,8 @@ describe('updateNaclFileData', () => {
             filename: 'file',
             start: { col: 3, line: 3, byte: 40 },
             end: { col: 3, line: 3, byte: 40 },
+            indexInParent: 3,
           },
-          indexInParent: 3,
         },
         {
           ...toChange({ after: mockType.fields.numArray }),
@@ -507,8 +507,8 @@ describe('updateNaclFileData', () => {
             filename: 'file',
             start: { col: 3, line: 3, byte: 40 },
             end: { col: 3, line: 3, byte: 40 },
+            indexInParent: 2,
           },
-          indexInParent: 2,
         },
       ]
     })

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -164,8 +164,8 @@ describe('getChangeLocations', () => {
             filename: 'file.nacl',
             start: { line: 2, col: 5, byte: 12 },
             end: { line: 2, col: 5, byte: 12 },
+            indexInParent: 1,
           },
-          indexInParent: 1,
         },
       ])
     })
@@ -304,8 +304,8 @@ describe('getChangeLocations', () => {
             filename: 'file.nacl',
             start: { line: 2, col: 5, byte: 12 },
             end: { line: 2, col: 5, byte: 12 },
+            indexInParent: 1,
           },
-          indexInParent: 1,
         },
       ])
     })
@@ -339,8 +339,8 @@ describe('getChangeLocations', () => {
             filename: 'file.nacl',
             start: { line: 2, col: 5, byte: 12 },
             end: { line: 2, col: 5, byte: 12 },
+            indexInParent: 1,
           },
-          indexInParent: 1,
         },
       ])
     })

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -345,6 +345,41 @@ describe('getChangeLocations', () => {
       ])
     })
   })
+
+  describe('with addition of value to array', () => {
+    it('should add the value before the following value', () => {
+      const change = {
+        ...toChange({ after: mockInstance.value.strArray[1] }),
+        id: mockInstance.elemID.createNestedID('strArray', '1'),
+        baseChange: toChange({ after: mockInstance }),
+        path: ['file'],
+      }
+      const sourceMap = new Map([
+        [
+          mockInstance.elemID.createNestedID('strArray', '2').getFullName(),
+          [
+            {
+              filename: 'file.nacl',
+              start: { line: 2, col: 5, byte: 12 },
+              end: { line: 5, col: 5, byte: 26 },
+            },
+          ],
+        ],
+      ])
+      result = getChangeLocations(change, sourceMap)
+      expect(result).toEqual([
+        {
+          ...change,
+          location: {
+            filename: 'file.nacl',
+            start: { line: 2, col: 5, byte: 12 },
+            end: { line: 2, col: 5, byte: 12 },
+            indexInParent: 1,
+          },
+        },
+      ])
+    })
+  })
 })
 
 describe('updateNaclFileData', () => {


### PR DESCRIPTION
Instead of adding new fields, annotations or values at the end of their parent in NaCl files, add them in the order they are defined in their parent object. This will ensure that members always show up in the same place in the NaCl if they are removed and added again.

---

_Additional context for reviewer_
Still need to add higher level tests, IMO it's cleaner to split into a separate PR.

---
_Release Notes_: 
_Core_
* Element members (field, annotations or values) are added in the same location consistently instead of being appended.

---
_User Notifications_: 
None.
