### PR TITLE
SALTO-5916: [Zendesk] Add a second sorting field for conditions in ticket forms

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -40,8 +40,13 @@ import {
 const log = logger(module)
 
 type ChildField = { id: ReferenceExpression }
-// eslint-disable-next-line camelcase
-type Condition = { child_fields: ChildField[]; value: ReferenceExpression | string }
+type Condition = {
+  // eslint-disable-next-line camelcase
+  parent_field_id: ReferenceExpression
+  // eslint-disable-next-line camelcase
+  child_fields: ChildField[]
+  value: ReferenceExpression | string
+}
 
 const getInstanceByFullName = (type: string, instances: InstanceElement[]): Record<string, InstanceElement> =>
   _.keyBy(
@@ -171,10 +176,13 @@ const sortConditions = (
       return
     }
     if (isValidConditions(conditions, customFieldById)) {
-      form.value[conditionType] = _.sortBy(conditions, condition =>
-        _.isString(condition.value) || _.isBoolean(condition.value)
-          ? condition.value
-          : [customFieldById[condition.value.elemID.getFullName()].value.value],
+      form.value[conditionType] = _.sortBy(
+        conditions,
+        condition =>
+          _.isString(condition.value) || _.isBoolean(condition.value)
+            ? condition.value
+            : [customFieldById[condition.value.elemID.getFullName()].value.value],
+        condition => condition.parent_field_id?.elemID?.getFullName(),
       )
     } else {
       log.warn(`could not sort conditions for ${form.elemID.getFullName()}`)

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -80,7 +80,15 @@ describe('Unordered lists filter', () => {
           ],
         },
         {
+          parent_field_id: new ReferenceExpression(customThreeInstance.elemID, customThreeInstance),
+          value: true,
+        },
+        {
           value: 'b',
+        },
+        {
+          parent_field_id: new ReferenceExpression(customOneInstance.elemID, customOneInstance),
+          value: true,
         },
       ],
       end_user_conditions: [
@@ -453,17 +461,19 @@ describe('Unordered lists filter', () => {
   describe('ticket_form', () => {
     it('sort correctly', async () => {
       const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'valid form')
-      expect(instances[0].value.agent_conditions).toHaveLength(3)
-      expect(instances[0].value.agent_conditions[0].value.elemID.name).toEqual('customA')
-      expect(instances[0].value.agent_conditions[1].value).toEqual('b')
-      expect(instances[0].value.agent_conditions[2].value.elemID.name).toEqual('customC')
+      expect(instances[0].value.agent_conditions).toHaveLength(5)
+      expect(instances[0].value.agent_conditions[0].parent_field_id.elemID.name).toEqual('customA')
+      expect(instances[0].value.agent_conditions[1].parent_field_id.elemID.name).toEqual('customC')
+      expect(instances[0].value.agent_conditions[2].value.elemID.name).toEqual('customA')
+      expect(instances[0].value.agent_conditions[3].value).toEqual('b')
+      expect(instances[0].value.agent_conditions[4].value.elemID.name).toEqual('customC')
       expect(instances[0].value.end_user_conditions).toHaveLength(3)
       expect(instances[0].value.end_user_conditions[0].value.elemID.name).toEqual('customA')
       expect(instances[0].value.end_user_conditions[1].value).toEqual('b')
       expect(instances[0].value.end_user_conditions[2].value.elemID.name).toEqual('customC')
-      expect(instances[0].value.agent_conditions[0].child_fields).toHaveLength(2)
-      expect(instances[0].value.agent_conditions[0].child_fields[0].id.elemID.name).toEqual('fieldA')
-      expect(instances[0].value.agent_conditions[0].child_fields[1].id.elemID.name).toEqual('fieldC')
+      expect(instances[0].value.agent_conditions[2].child_fields).toHaveLength(2)
+      expect(instances[0].value.agent_conditions[2].child_fields[0].id.elemID.name).toEqual('fieldA')
+      expect(instances[0].value.agent_conditions[2].child_fields[1].id.elemID.name).toEqual('fieldC')
       expect(instances[0].value.end_user_conditions[0].child_fields).toHaveLength(2)
       expect(instances[0].value.end_user_conditions[0].child_fields[0].id.elemID.name).toEqual('fieldA')
       expect(instances[0].value.end_user_conditions[0].child_fields[1].id.elemID.name).toEqual('fieldC')


### PR DESCRIPTION
Ticket field conditions are sorted by "value". if there are dup values (like `true` or `false`), the sorting is not robust enough. In this PR we add an additional field, parent_field_id, so that sorting stays consistent
---

---
_Release Notes_: 
Zendesk: 
Make sorting of conditions in Ticket Forms more consistent

---
_User Notifications_: 
Zendesk: 
Make sorting of conditions in Ticket Forms more consistent
