### PR TITLE
SALTO-5940: Fix Forms fetching keep failing due to 403 error

### DIFF
--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -374,10 +374,14 @@ describe('forms filter', () => {
         },
       })
 
-      connection.get.mockRejectedValue(new clientUtils.HTTPError('failed', { data: {error: 'insufficientPermission'}, status: 403 }))
+      connection.get.mockRejectedValue(
+        new clientUtils.HTTPError('failed', { data: { error: 'insufficientPermission' }, status: 403 }),
+      )
       const res = (await filter.onFetch(elements)) as FilterResult
       expect(res.errors).toHaveLength(1)
-      expect(res.errors?.[0].message).toEqual('Failed to fetch forms for projects: project1 due to insufficient permissions')
+      expect(res.errors?.[0].message).toEqual(
+        'Failed to fetch forms for projects: project1 due to insufficient permissions',
+      )
     })
   })
   describe('deploy', () => {


### PR DESCRIPTION
In this PR I fixed the Forms fetching errors that were cause by 403 forbidden access. 

---

_Additional context for reviewer_
Previously, attempts to access forms without valid permissions would yield a 200 OK status with an empty data array. Our handling of this scenario was based on the assumption of successful access.

With recent updates to the API, which is private, unauthorized access now correctly returns a 403 Forbidden status. This change prompted the addition of a try-catch block to properly manage fetch errors.

Example from oriSaltoTest:
`Failed to fetch forms for projects: Dan_Avigdor_JSM@s, AlonITSM3, ITSM_project@s, Sagi_s_JSM@ts, testProject, testFacilities3, ITSM_sample_space@s, testFacilities4, test, testFacilities2, testFacilities due to insufficient permissions`

---
_Release Notes_: 
_Jira Adpater:_
* The issue where the fetch failed due to receiving a 403 error when attempting to access forms without proper permissions has been fixed. Now, the fetch will succeed and the user will see a clearer error message, making the process smoother and more straightforward.

---
_User Notifications_: 
None
