### PR TITLE
SALTO-5334, SALTO-5346 - Salesforce: move PermissionSet refs to custom references code

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -34,16 +34,19 @@ import {
 } from '../types'
 import { profilesHandler } from './profiles'
 import { managedElementsHandler } from './managed_elements'
+import { permissionSetsHandler } from './permission_sets'
 
 const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
   profiles: profilesHandler,
   managedElements: managedElementsHandler,
+  permisisonSets: permissionSetsHandler,
 }
 
 const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
   {
     profiles: false,
     managedElements: false,
+    permisisonSets: true,
   }
 
 export const customReferencesConfiguration = (

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -46,7 +46,7 @@ const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
   {
     profiles: false,
     managedElements: false,
-    permisisonSets: true,
+    permisisonSets: false,
   }
 
 export const customReferencesConfiguration = (

--- a/packages/salesforce-adapter/src/custom_references/permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/permission_sets.ts
@@ -1,0 +1,65 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ReferenceInfo, Element, InstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { PERMISSION_SET_METADATA_TYPE } from '../constants'
+import { isInstanceOfTypeSync } from '../filters/utils'
+import { WeakReferencesHandler } from '../types'
+import { mapProfileOrPermissionSetSections } from './profiles'
+
+const log = logger(module)
+const { makeArray } = collections.array
+
+const referencesFromPermissionSets = (
+  permissionSet: InstanceElement,
+): ReferenceInfo[] =>
+  mapProfileOrPermissionSetSections(
+    permissionSet,
+    (sectionName, sectionEntryKey, target, sourceField) => ({
+      source: permissionSet.elemID.createNestedID(
+        sectionName,
+        sectionEntryKey,
+        ...makeArray(sourceField),
+      ),
+      target,
+      type: 'weak',
+    }),
+  )
+
+const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
+  elements: Element[],
+): Promise<ReferenceInfo[]> => {
+  const permissionSets = elements.filter(
+    isInstanceOfTypeSync(PERMISSION_SET_METADATA_TYPE),
+  )
+  const refs = log.timeDebug(
+    () => permissionSets.flatMap(referencesFromPermissionSets),
+    `Generating references from ${permissionSets.length} permission sets.`,
+  )
+  log.debug(
+    'Generated %d references for %d elements.',
+    refs.length,
+    elements.length,
+  )
+  return refs
+}
+
+export const permissionSetsHandler: WeakReferencesHandler = {
+  findWeakReferences,
+  removeWeakReferences: () => async () => ({ fixedElements: [], errors: [] }),
+}

--- a/packages/salesforce-adapter/src/custom_references/profiles.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles.ts
@@ -257,7 +257,7 @@ const sectionsReferenceParams: Record<section, ReferenceFromSectionParams> = {
   },
 }
 
-const mapProfileSections = <T>(
+export const mapProfileOrPermissionSetSections = <T>(
   profile: InstanceElement,
   f: (
     sectionName: string,
@@ -276,7 +276,7 @@ const mapProfileSections = <T>(
   )
 
 const referencesFromProfile = (profile: InstanceElement): ReferenceInfo[] =>
-  mapProfileSections(
+  mapProfileOrPermissionSetSections(
     profile,
     (sectionName, sectionEntryKey, target, sourceField) => ({
       source: profile.elemID.createNestedID(
@@ -307,7 +307,7 @@ const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
 
 const profileEntriesTargets = (profile: InstanceElement): Dictionary<ElemID> =>
   _(
-    mapProfileSections(
+    mapProfileOrPermissionSetSections(
       profile,
       (sectionName, sectionEntryKey, target, sourceField): [string, ElemID] => [
         [sectionName, sectionEntryKey, ...makeArray(sourceField)].join('.'),

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -226,6 +226,8 @@ const filter: LocalFilterCreator = ({ config }) => ({
       otherProfileRefs: config.fetchProfile.isFeatureEnabled(
         'generateRefsInProfiles',
       ),
+      permissionsSetRefs:
+        config.fetchProfile.isCustomReferencesHandlerEnabled('permisisonSets'),
     })
     await addReferences(
       elements,

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -227,7 +227,7 @@ const filter: LocalFilterCreator = ({ config }) => ({
         'generateRefsInProfiles',
       ),
       permissionsSetRefs:
-        config.fetchProfile.isCustomReferencesHandlerEnabled('permisisonSets'),
+        !config.fetchProfile.isCustomReferencesHandlerEnabled('permisisonSets'),
     })
     await addReferences(
       elements,

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -270,7 +270,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: {
       field: 'field',
-      parentTypes: ['ReportColumn', 'PermissionSetFieldPermissions'],
+      parentTypes: ['ReportColumn'],
     },
     target: { type: CUSTOM_FIELD },
   },
@@ -430,7 +430,6 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
         'FlowRecordCreate',
         'FlowRecordDelete',
         'FlowStart',
-        'PermissionSetObjectPermissions',
       ],
     },
     target: { type: CUSTOM_OBJECT },
@@ -893,9 +892,17 @@ export const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefiniti
       src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
       target: { type: CUSTOM_FIELD },
     },
+    {
+      src: { field: 'field', parentTypes: ['PermissionSetFieldPermissions'] },
+      target: { type: CUSTOM_FIELD },
+    },
   ]
 
-export const referencesFromProfile: FieldReferenceDefinition[] = [
+const referencesFromProfileOrPermissionSet: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'object', parentTypes: ['PermissionSetObjectPermissions'] },
+    target: { type: CUSTOM_OBJECT },
+  },
   {
     src: { field: 'object', parentTypes: ['ProfileObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
@@ -948,7 +955,7 @@ export const referencesFromProfile: FieldReferenceDefinition[] = [
 const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   ...defaultFieldNameToTypeMappingDefs,
   ...fieldPermissionEnumDisabledExtraMappingDefs,
-  ...referencesFromProfile,
+  ...referencesFromProfileOrPermissionSet,
 ]
 
 export const getReferenceMappingDefs = (args: {
@@ -960,7 +967,7 @@ export const getReferenceMappingDefs = (args: {
     refDefs = refDefs.concat(fieldPermissionEnumDisabledExtraMappingDefs)
   }
   if (args.otherProfileRefs) {
-    refDefs = refDefs.concat(referencesFromProfile)
+    refDefs = refDefs.concat(referencesFromProfileOrPermissionSet)
   }
   return refDefs
 }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -270,7 +270,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: {
       field: 'field',
-      parentTypes: ['ReportColumn', 'PermissionSetFieldPermissions'],
+      parentTypes: ['ReportColumn'],
     },
     target: { type: CUSTOM_FIELD },
   },
@@ -430,7 +430,6 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
         'FlowRecordCreate',
         'FlowRecordDelete',
         'FlowStart',
-        'PermissionSetObjectPermissions',
       ],
     },
     target: { type: CUSTOM_OBJECT },
@@ -934,6 +933,17 @@ export const referencesFromProfile: FieldReferenceDefinition[] = [
   },
 ]
 
+export const referencesFromPermissionSets: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'field', parentTypes: ['PermissionSetFieldPermissions'] },
+    target: { type: CUSTOM_FIELD },
+  },
+  {
+    src: { field: 'object', parentTypes: ['PermissionSetObjectPermissions'] },
+    target: { type: CUSTOM_OBJECT },
+  },
+]
+
 /**
  * The rules for finding and resolving values into (and back from) reference expressions.
  * Overlaps between rules are allowed, and the first successful conversion wins.
@@ -949,11 +959,13 @@ const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   ...defaultFieldNameToTypeMappingDefs,
   ...fieldPermissionEnumDisabledExtraMappingDefs,
   ...referencesFromProfile,
+  ...referencesFromPermissionSets,
 ]
 
 export const getReferenceMappingDefs = (args: {
   enumFieldPermissions: boolean
   otherProfileRefs: boolean
+  permissionsSetRefs: boolean
 }): FieldReferenceDefinition[] => {
   let refDefs = defaultFieldNameToTypeMappingDefs
   if (args.enumFieldPermissions) {
@@ -961,6 +973,9 @@ export const getReferenceMappingDefs = (args: {
   }
   if (args.otherProfileRefs) {
     refDefs = refDefs.concat(referencesFromProfile)
+  }
+  if (args.permissionsSetRefs) {
+    refDefs = refDefs.concat(referencesFromPermissionSets)
   }
   return refDefs
 }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -270,7 +270,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: {
       field: 'field',
-      parentTypes: ['ReportColumn'],
+      parentTypes: ['ReportColumn', 'PermissionSetFieldPermissions'],
     },
     target: { type: CUSTOM_FIELD },
   },
@@ -430,6 +430,7 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
         'FlowRecordCreate',
         'FlowRecordDelete',
         'FlowStart',
+        'PermissionSetObjectPermissions',
       ],
     },
     target: { type: CUSTOM_OBJECT },
@@ -892,17 +893,9 @@ export const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefiniti
       src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
       target: { type: CUSTOM_FIELD },
     },
-    {
-      src: { field: 'field', parentTypes: ['PermissionSetFieldPermissions'] },
-      target: { type: CUSTOM_FIELD },
-    },
   ]
 
-const referencesFromProfileOrPermissionSet: FieldReferenceDefinition[] = [
-  {
-    src: { field: 'object', parentTypes: ['PermissionSetObjectPermissions'] },
-    target: { type: CUSTOM_OBJECT },
-  },
+export const referencesFromProfile: FieldReferenceDefinition[] = [
   {
     src: { field: 'object', parentTypes: ['ProfileObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
@@ -955,7 +948,7 @@ const referencesFromProfileOrPermissionSet: FieldReferenceDefinition[] = [
 const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   ...defaultFieldNameToTypeMappingDefs,
   ...fieldPermissionEnumDisabledExtraMappingDefs,
-  ...referencesFromProfileOrPermissionSet,
+  ...referencesFromProfile,
 ]
 
 export const getReferenceMappingDefs = (args: {
@@ -967,7 +960,7 @@ export const getReferenceMappingDefs = (args: {
     refDefs = refDefs.concat(fieldPermissionEnumDisabledExtraMappingDefs)
   }
   if (args.otherProfileRefs) {
-    refDefs = refDefs.concat(referencesFromProfileOrPermissionSet)
+    refDefs = refDefs.concat(referencesFromProfile)
   }
   return refDefs
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -209,7 +209,11 @@ export type BrokenOutgoingReferencesSettings = {
   perTargetTypeOverrides?: Record<string, OutgoingReferenceBehavior>
 }
 
-const customReferencesHandlersNames = ['profiles', 'managedElements'] as const
+const customReferencesHandlersNames = [
+  'profiles',
+  'managedElements',
+  'permisisonSets',
+] as const
 export type CustomReferencesHandlers =
   (typeof customReferencesHandlersNames)[number]
 

--- a/packages/salesforce-adapter/test/custom_references/permission_sets.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/permission_sets.test.ts
@@ -1,0 +1,770 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  InstanceElement,
+  ReferenceInfo,
+  Values,
+  ElemID,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import {
+  APEX_CLASS_METADATA_TYPE,
+  APEX_PAGE_METADATA_TYPE,
+  CUSTOM_APPLICATION_METADATA_TYPE,
+  FLOW_METADATA_TYPE,
+  INSTANCE_FULL_NAME_FIELD,
+  LAYOUT_TYPE_ID_METADATA_TYPE,
+  RECORD_TYPE_METADATA_TYPE,
+  SALESFORCE,
+} from '../../src/constants'
+import { mockTypes } from '../mock_elements'
+import { createCustomObjectType, createMetadataTypeElement } from '../utils'
+import { permissionSetsHandler } from '../../src/custom_references/permission_sets'
+
+const { findWeakReferences } = permissionSetsHandler
+
+describe('permission sets custom references', () => {
+  let refs: ReferenceInfo[]
+  let permissionSetInstance: InstanceElement
+  const createTestInstances = (fields: Values): InstanceElement =>
+    new InstanceElement('test', mockTypes.PermissionSet, fields)
+
+  describe('fields', () => {
+    describe('when the fields are inaccessible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          fieldPermissions: {
+            Account: {
+              testField__c: 'NoAccess',
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create references', async () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+    describe('when the fields are accessible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          fieldPermissions: {
+            Account: {
+              testField__c: 'ReadWrite',
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create references', async () => {
+        const expectedSource = ['fieldPermissions', 'Account', 'testField__c']
+        const expectedTarget = mockTypes.Account.elemID.createNestedID(
+          'field',
+          'testField__c',
+        )
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              ...expectedSource,
+            ),
+            target: expectedTarget,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+  })
+  describe('custom apps', () => {
+    const customApp = new InstanceElement(
+      'SomeApplication',
+      createMetadataTypeElement('CustomApplication', {}),
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeApplication' },
+    )
+
+    describe('if neither default or visible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: false,
+              visible: false,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('if default', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: true,
+              visible: false,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'applicationVisibilities',
+              'SomeApplication',
+            ),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+
+    describe('if visible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: false,
+              visible: true,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toIncludeAllPartialMembers([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'applicationVisibilities',
+              'SomeApplication',
+            ),
+            target: customApp.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('if a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          applicationVisibilities: {
+            SomeApplication: {
+              application: new ReferenceExpression(
+                new ElemID(
+                  SALESFORCE,
+                  CUSTOM_APPLICATION_METADATA_TYPE,
+                  'instance',
+                  'SomeApplication',
+                ),
+              ),
+              default: false,
+              visible: true,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create references', async () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+  describe('apex classes', () => {
+    const apexClass = new InstanceElement(
+      'SomeApexClass',
+      mockTypes.ApexClass,
+      { [INSTANCE_FULL_NAME_FIELD]: 'SomeApexClass' },
+    )
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: 'SomeApexClass',
+              enabled: false,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: 'SomeApexClass',
+              enabled: true,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'classAccesses',
+              'SomeApexClass',
+            ),
+            target: apexClass.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('if a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: new ReferenceExpression(
+                new ElemID(
+                  SALESFORCE,
+                  APEX_CLASS_METADATA_TYPE,
+                  'instance',
+                  'SomeApexClass',
+                ),
+              ),
+              enabled: true,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create references', async () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+  describe('flows', () => {
+    const flow = new InstanceElement('SomeFlow', mockTypes.Flow, {
+      [INSTANCE_FULL_NAME_FIELD]: 'SomeFlow',
+    })
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          flowAccesses: {
+            SomeFlow: {
+              enabled: false,
+              flow: 'SomeFlow',
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          flowAccesses: {
+            SomeFlow: {
+              enabled: true,
+              flow: 'SomeFlow',
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'flowAccesses',
+              'SomeFlow',
+            ),
+            target: flow.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('if a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          flowAccesses: {
+            SomeFlow: {
+              enabled: true,
+              flow: new ReferenceExpression(
+                new ElemID(
+                  SALESFORCE,
+                  FLOW_METADATA_TYPE,
+                  'instance',
+                  'SomeFlow',
+                ),
+              ),
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create references', async () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+  describe('layouts', () => {
+    const layout = new InstanceElement(
+      'Account_Account_Layout@bs',
+      mockTypes.Layout,
+      { [INSTANCE_FULL_NAME_FIELD]: 'Account-Account Layout' },
+    )
+
+    describe('when there is a reference to a layout', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          layoutAssignments: {
+            'Account_Account_Layout@bs': [
+              {
+                layout: 'Account-Account Layout',
+              },
+            ],
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'layoutAssignments',
+              'Account_Account_Layout@bs',
+            ),
+            target: layout.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when there is a reference to a recordType', () => {
+      const recordTypes = [
+        new InstanceElement('SomeRecordType', mockTypes.RecordType, {
+          [INSTANCE_FULL_NAME_FIELD]: 'SomeRecordType',
+        }),
+        new InstanceElement('SomeOtherRecordType', mockTypes.RecordType, {
+          [INSTANCE_FULL_NAME_FIELD]: 'SomeOtherRecordType',
+        }),
+      ]
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          layoutAssignments: {
+            'Account_Account_Layout@bs': [
+              {
+                layout: 'Account-Account Layout',
+                recordType: 'SomeRecordType',
+              },
+              {
+                layout: 'Account-Account Layout',
+                recordType: 'SomeOtherRecordType',
+              },
+            ],
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'layoutAssignments',
+              'Account_Account_Layout@bs',
+            ),
+            target: layout.elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'layoutAssignments',
+              'Account_Account_Layout@bs',
+            ),
+            target: recordTypes[0].elemID,
+            type: 'weak',
+          },
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'layoutAssignments',
+              'Account_Account_Layout@bs',
+            ),
+            target: recordTypes[1].elemID,
+            type: 'weak',
+          },
+        ])
+      })
+      describe('if a reference already exists to a layout', () => {
+        beforeEach(async () => {
+          permissionSetInstance = createTestInstances({
+            layoutAssignments: {
+              'Account_Account_Layout@bs': [
+                {
+                  layout: new ReferenceExpression(
+                    new ElemID(
+                      SALESFORCE,
+                      LAYOUT_TYPE_ID_METADATA_TYPE,
+                      'instance',
+                      'Account-Account Layout',
+                    ),
+                  ),
+                },
+              ],
+            },
+          })
+          refs = await findWeakReferences([permissionSetInstance], undefined)
+        })
+        it('should not create references', async () => {
+          expect(refs).toBeEmpty()
+        })
+      })
+      describe('if a reference already exists to a recordType', () => {
+        beforeEach(async () => {
+          permissionSetInstance = createTestInstances({
+            layoutAssignments: {
+              'Account_Account_Layout@bs': [
+                {
+                  layout: 'Account-Account Layout',
+                  recordType: new ReferenceExpression(
+                    new ElemID(
+                      SALESFORCE,
+                      RECORD_TYPE_METADATA_TYPE,
+                      'instance',
+                      'SomeRecordType',
+                    ),
+                  ),
+                },
+                {
+                  layout: 'Account-Account Layout',
+                  recordType: new ReferenceExpression(
+                    new ElemID(
+                      SALESFORCE,
+                      RECORD_TYPE_METADATA_TYPE,
+                      'instance',
+                      'SomeOtherRecordType',
+                    ),
+                  ),
+                },
+              ],
+            },
+          })
+          refs = await findWeakReferences([permissionSetInstance], undefined)
+        })
+        it('should only create references to layout', () => {
+          expect(refs).toEqual([
+            {
+              source: permissionSetInstance.elemID.createNestedID(
+                'layoutAssignments',
+                'Account_Account_Layout@bs',
+              ),
+              target: layout.elemID,
+              type: 'weak',
+            },
+          ])
+        })
+      })
+    })
+  })
+  describe('objects', () => {
+    const customObject = createCustomObjectType('Account', {})
+
+    describe('when all permissions are disabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          objectPermissions: {
+            Account: {
+              allowCreate: false,
+              allowDelete: false,
+              allowEdit: false,
+              allowRead: false,
+              modifyAllRecords: false,
+              object: 'Account',
+              viewAllRecords: false,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should not create references', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when some permissions are enabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          objectPermissions: {
+            Account: {
+              allowCreate: true,
+              allowDelete: true,
+              allowEdit: true,
+              allowRead: true,
+              modifyAllRecords: false,
+              object: 'Account',
+              viewAllRecords: false,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'objectPermissions',
+              'Account',
+            ),
+            target: customObject.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          objectPermissions: {
+            Account: {
+              allowCreate: true,
+              allowDelete: true,
+              allowEdit: true,
+              allowRead: true,
+              modifyAllRecords: false,
+              object: new ReferenceExpression(
+                new ElemID(SALESFORCE, 'Account'),
+              ),
+              viewAllRecords: false,
+            },
+          },
+        })
+
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+  describe('Apex pages', () => {
+    const apexPage = new InstanceElement('SomeApexPage', mockTypes.ApexPage, {
+      [INSTANCE_FULL_NAME_FIELD]: 'SomeApexPage',
+    })
+
+    describe('when disabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: 'SomeApexPage',
+              enabled: false,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+
+    describe('when enabled', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: 'SomeApexPage',
+              enabled: true,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'pageAccesses',
+              'SomeApexPage',
+            ),
+            target: apexPage.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: new ReferenceExpression(
+                new ElemID(
+                  SALESFORCE,
+                  APEX_PAGE_METADATA_TYPE,
+                  'instance',
+                  'SomeApexPage',
+                ),
+              ),
+              enabled: true,
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+  describe('record types', () => {
+    const recordType = new InstanceElement(
+      'Case_SomeCaseRecordType',
+      mockTypes.RecordType,
+      { [INSTANCE_FULL_NAME_FIELD]: 'Case.SomeCaseRecordType' },
+    )
+    describe('when neither default nor visible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: false,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: false,
+              },
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+    describe('when default', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: true,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: false,
+              },
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'recordTypeVisibilities',
+              'Case',
+              'SomeCaseRecordType',
+            ),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when visible', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: false,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: true,
+              },
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should create a reference', () => {
+        expect(refs).toEqual([
+          {
+            source: permissionSetInstance.elemID.createNestedID(
+              'recordTypeVisibilities',
+              'Case',
+              'SomeCaseRecordType',
+            ),
+            target: recordType.elemID,
+            type: 'weak',
+          },
+        ])
+      })
+    })
+    describe('when visible and a reference already exists', () => {
+      beforeEach(async () => {
+        permissionSetInstance = createTestInstances({
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: false,
+                recordType: new ReferenceExpression(
+                  new ElemID(
+                    SALESFORCE,
+                    RECORD_TYPE_METADATA_TYPE,
+                    'instance',
+                    'Case.SomeCaseRecordType',
+                  ),
+                ),
+                visible: true,
+              },
+            },
+          },
+        })
+        refs = await findWeakReferences([permissionSetInstance], undefined)
+      })
+      it('should not create a reference', () => {
+        expect(refs).toBeEmpty()
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -614,6 +614,7 @@ describe('FieldReferences filter', () => {
       const modifiedDefs = getReferenceMappingDefs({
         enumFieldPermissions: false,
         otherProfileRefs: false,
+        permissionsSetRefs: false,
       }).map((def) => _.omit(def, 'serializationStrategy'))
       await addReferences(
         elements,
@@ -948,6 +949,7 @@ describe('getReferenceMappingDefs', () => {
       defs = getReferenceMappingDefs({
         enumFieldPermissions: false,
         otherProfileRefs: false,
+        permissionsSetRefs: false,
       })
     })
     it('should not have any profile-related references', () => {
@@ -961,6 +963,7 @@ describe('getReferenceMappingDefs', () => {
       defs = getReferenceMappingDefs({
         enumFieldPermissions: false,
         otherProfileRefs: true,
+        permissionsSetRefs: true,
       })
     })
     it('should have profile-related references, but not FLS', () => {
@@ -979,6 +982,7 @@ describe('getReferenceMappingDefs', () => {
       defs = getReferenceMappingDefs({
         enumFieldPermissions: true,
         otherProfileRefs: false,
+        permissionsSetRefs: false,
       })
     })
     it('should have only FLS-related profile references', () => {
@@ -997,6 +1001,7 @@ describe('getReferenceMappingDefs', () => {
       defs = getReferenceMappingDefs({
         enumFieldPermissions: true,
         otherProfileRefs: true,
+        permissionsSetRefs: true,
       })
     })
     it('should have only all profile references', () => {


### PR DESCRIPTION
This implementation is based on old PR by @tomsellek  https://github.com/salto-io/salto/pull/5547

Move the extraction of references from the reference mapper to custom references. This will speed fetches in cases where `PermissionSet`s are included and some of them are very large.

---

_Release Notes_: 
Salesforce Adapter:
- Add PermissionSet custom references handler.

---
_User Notifications_: 
_None_