### PR TITLE
Revert "Revert "SALTO-5516 order apps field in workspace by ID as wel…

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -265,8 +265,9 @@ const orderAppInstallationsInWorkspace = (instances: InstanceElement[]): void =>
     .forEach(workspace => {
       const appsList = workspace.value.apps
       if (_.isArray(appsList)) {
-        // _.sortBy is stable, so the order of apps with the same position will not change
-        workspace.value.apps = _.sortBy(appsList, ['position'])
+        workspace.value.apps = _.sortBy(appsList, 'position', app =>
+          isReferenceExpression(app.id) ? app.id.elemID.getFullName() : undefined,
+        )
       } else if (appsList !== undefined) {
         log.warn(
           `orderAppInstallationsInWorkspace - app installations are not a list in ${appsList.elemID.getFullName()}`,

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -287,11 +287,13 @@ describe('Unordered lists filter', () => {
         { title: 'bravo', type: 'alpha' },
       ],
     })
+    const referenceExpressionInWorkspaceApps = new ReferenceExpression(new ElemID('zendesk', 'd'))
     const workspaceWithMultipleApps = new InstanceElement('workspaceWithNoApps', workspaceType, {
       apps: [
-        { name: 'c', position: 3 },
-        { name: 'b', position: 2 },
-        { name: 'a', position: 1 },
+        { id: 'b', position: 2 },
+        { id: 'c', position: 3 },
+        { id: referenceExpressionInWorkspaceApps, position: 1 },
+        { id: 'a', position: 1 },
       ],
     })
 
@@ -581,13 +583,15 @@ describe('Unordered lists filter', () => {
     })
 
     it('should sort apps by position', async () => {
-      expect(instance.value.apps).toHaveLength(3)
-      expect(instance.value.apps[0].name).toEqual('a')
+      expect(instance.value.apps).toHaveLength(4)
       expect(instance.value.apps[0].position).toEqual(1)
-      expect(instance.value.apps[1].name).toEqual('b')
-      expect(instance.value.apps[1].position).toEqual(2)
-      expect(instance.value.apps[2].name).toEqual('c')
-      expect(instance.value.apps[2].position).toEqual(3)
+      expect(instance.value.apps[0].id.elemID.getFullName()).toEqual('zendesk.d')
+      expect(instance.value.apps[1].id).toEqual('a')
+      expect(instance.value.apps[1].position).toEqual(1)
+      expect(instance.value.apps[2].id).toEqual('b')
+      expect(instance.value.apps[2].position).toEqual(2)
+      expect(instance.value.apps[3].id).toEqual('c')
+      expect(instance.value.apps[3].position).toEqual(3)
     })
   })
   describe('routing attribute', () => {


### PR DESCRIPTION
…l as position" (#5887)"

This reverts commit 3a9dcaa5365111d8051704e80478a69b9c47ee21.


---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
