### PR TITLE
PROD-279: Salesforce Workspace Changes

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -125,12 +125,6 @@ const { makeArray } = collections.array
 const { PROFILE_METADATA_TYPE } = constants
 const { isDefined } = lowerDashValues
 
-const extractReferenceTo = (annotations: Values): (string | undefined)[] =>
-  makeArray(annotations[constants.FIELD_ANNOTATIONS.REFERENCE_TO]).map(
-    (ref: ReferenceExpression | string): string | undefined =>
-      isReferenceExpression(ref) ? ref.elemID.typeName : ref,
-  )
-
 describe('Salesforce adapter E2E with real account', () => {
   let client: SalesforceClient
   let adapter: SalesforceAdapter
@@ -237,30 +231,6 @@ describe('Salesforce adapter E2E with real account', () => {
             ),
           ),
         )
-
-        // Test picklist values
-        expect(
-          lead.fields.CleanStatus.annotations[
-            constants.FIELD_ANNOTATIONS.VALUE_SET
-          ]
-            .map((val: Values) => val[constants.CUSTOM_VALUE.FULL_NAME])
-            .sort(),
-        ).toEqual([
-          'Acknowledged',
-          'Different',
-          'Inactive',
-          'Matched',
-          'NotFound',
-          'Pending',
-          'SelectMatch',
-          'Skipped',
-        ])
-
-        // Test lookup reference_to annotation
-        expect(extractReferenceTo(lead.fields.OwnerId.annotations)).toEqual([
-          'Group',
-          'User',
-        ])
 
         // Test default value for checkbox
         expect(
@@ -1539,7 +1509,6 @@ describe('Salesforce adapter E2E with real account', () => {
 
       const testLookup = (annotations: Values): void => {
         expect(annotations[constants.LABEL]).toBe('Lookup label')
-        expect(extractReferenceTo(annotations)).toEqual(['Opportunity'])
         expect(annotations[CORE_ANNOTATIONS.REQUIRED]).toBeFalsy()
         const lookupFilter =
           annotations[constants.FIELD_ANNOTATIONS.LOOKUP_FILTER]
@@ -1576,7 +1545,6 @@ describe('Salesforce adapter E2E with real account', () => {
 
       const testMasterDetail = (annotations: Values): void => {
         expect(annotations[constants.LABEL]).toBe('MasterDetail label')
-        expect(extractReferenceTo(annotations)).toEqual(['Case'])
         expect(
           annotations[constants.FIELD_ANNOTATIONS.REPARENTABLE_MASTER_DETAIL],
         ).toBe(true)

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -45,8 +45,8 @@ const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
 const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
   {
     profiles: false,
-    managedElements: false,
-    permisisonSets: false,
+    managedElements: true,
+    permisisonSets: true,
   }
 
 export const customReferencesConfiguration = (

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -48,8 +48,8 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   extraDependenciesV2: true,
   extendedCustomFieldInformation: false,
   importantValues: true,
-  hideTypesFolder: false,
-  omitStandardFieldsNonDeployableValues: false,
+  hideTypesFolder: true,
+  omitStandardFieldsNonDeployableValues: true,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
+++ b/packages/salesforce-adapter/test/filters/installed_package_generated_dependencies.test.ts
@@ -26,7 +26,6 @@ import {
   buildFilterContext,
   createCustomMetadataType,
   createCustomObjectType,
-  defaultFilterContext,
 } from '../utils'
 import filterCreator from '../../src/filters/installed_package_generated_dependencies'
 import { API_NAME } from '../../src/constants'
@@ -52,7 +51,11 @@ describe('installedPackageElementsFilter', () => {
           ),
         ]
         filter = filterCreator({
-          config: defaultFilterContext,
+          config: buildFilterContext({
+            customReferencesSettings: {
+              managedElements: false,
+            },
+          }),
         }) as FilterWith<'onFetch'>
       })
 

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -42,7 +42,7 @@ import { RemoteMap, RemoteMapEntry } from './remote_map'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-export const REFERENCE_INDEXES_VERSION = 7
+export const REFERENCE_INDEXES_VERSION = 8
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ChangeReferences = {


### PR DESCRIPTION
Salesforce Workspace Changes

---

Rollout for [PROD-279](https://salto-io.atlassian.net/browse/PROD-279)

---
_Release Notes_: 
Salesforce Adapter:
- Converted PermissionSet references to custom references.
- Converted managed Elements references to custom references.
- The `Types` folder will be hidden by default.
- Standard Picklist Fields non deployable values will be omitted by default.

---
_User Notifications_: 
Salesforce:
- Types folder will be removed.
- `_generated_dependencies` from managed elements will be removed.
- Strong references from PermissionSet instances will be removed.
- The annotations `valueSet` and `referenceTo` will be removed from Standard Picklist Fields.


[PROD-279]: https://salto-io.atlassian.net/browse/PROD-279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ