### PR TITLE
SALTO-5927: fix parser to not use trim in createStringValue

### DIFF
--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -258,10 +258,11 @@ const consumeMultilineString: Consumer<string | TemplateExpression> = context =>
     tokens.push(context.lexer.next())
   }
   if (tokens.length > 0) {
+    // We get rid of the trailing newline
     tokens[tokens.length - 1].value = tokens[tokens.length - 1].value.slice(0, -1)
     tokens[tokens.length - 1].text = tokens[tokens.length - 1].text.slice(0, -1)
   }
-  // We get rid of the trailing newline
+
   // Getting the position of the end marker
   const end = positionAtEnd(context.lexer.next())
   const value = createStringValue(context, tokens, (_c, t) => unescapeMultilineString(t.text))

--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -19,7 +19,7 @@
 // want all of the functions to be defined inside consume value since its icky.
 
 import { Value, TemplateExpression, ElemID, Values } from '@salto-io/adapter-api'
-import _, { trimEnd } from 'lodash'
+import _ from 'lodash'
 import { Token } from 'moo'
 import { createTemplateExpression } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -105,25 +105,15 @@ const createTemplateExpressions = (
     }),
   })
 
-const trimToken = (token: Required<Token>): Required<Token> => ({
-  ...token,
-  text: trimEnd(token.text, '\r\n'),
-  value: trimEnd(token.value, '\r\n'),
-})
-
 const createStringValue = (
   context: ParseContext,
   tokens: Required<Token>[],
-  trim?: boolean,
   transformFunc?: (context: ParseContext, token: Required<Token>) => string,
 ): string | TemplateExpression => {
-  const trimmedTokens =
-    trim && tokens.length > 0 ? [...tokens.slice(0, -1), trimToken(tokens[tokens.length - 1])] : tokens
-
-  const simpleString = _.every(trimmedTokens, token => [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE].includes(token.type))
+  const simpleString = _.every(tokens, token => [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE].includes(token.type))
   return simpleString
-    ? createSimpleStringValue(context, trimmedTokens, transformFunc)
-    : createTemplateExpressions(context, trimmedTokens, transformFunc)
+    ? createSimpleStringValue(context, tokens, transformFunc)
+    : createTemplateExpressions(context, tokens, transformFunc)
 }
 
 const consumeStringData = (context: ParseContext): ConsumerReturnType<Required<Token>[]> => {
@@ -269,11 +259,12 @@ const consumeMultilineString: Consumer<string | TemplateExpression> = context =>
   }
   if (tokens.length > 0) {
     tokens[tokens.length - 1].value = tokens[tokens.length - 1].value.slice(0, -1)
+    tokens[tokens.length - 1].text = tokens[tokens.length - 1].text.slice(0, -1)
   }
   // We get rid of the trailing newline
   // Getting the position of the end marker
   const end = positionAtEnd(context.lexer.next())
-  const value = createStringValue(context, tokens, true, (_c, t) => unescapeMultilineString(t.text))
+  const value = createStringValue(context, tokens, (_c, t) => unescapeMultilineString(t.text))
   return {
     value,
     range: { start, end },

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -802,7 +802,11 @@ multiline
     expect(elements[0].annotations.str.length).toEqual(stringLength)
   })
 
-  it('test', async () => {
+  it('parse multiline string with a U+200D unicode before a \\n', async () => {
+    // we have this test as this unicode character joins characters together. in our case, the problem is when this
+    // joiner is the last character in the string - because we add a \n before the closing ''', parsing that unicode
+    // character “correctly” means joining the \n with whatever came before the \u+200D, which makes it not a \n anymore
+    // This test makes sure that we parse it correctly.
     const body = `
     type salesforce.escapedQuotes {
       str = '''

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -815,7 +815,7 @@ multiline
     const elements = await awu(parsed.elements)
       .filter(element => !isContainerType(element))
       .toArray()
-    expect(elements[0].annotations.str).toEqual('\n' + '        this is a unicode test ‍')
+    expect(elements[0].annotations.str).toEqual('\n        this is a unicode test ‍')
   })
 
   describe('simple error tests', () => {

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -802,6 +802,22 @@ multiline
     expect(elements[0].annotations.str.length).toEqual(stringLength)
   })
 
+  it('test', async () => {
+    const body = `
+    type salesforce.escapedQuotes {
+      str = '''
+
+        this is a unicode test ‍
+      '''
+    }
+ `
+    const parsed = await parse(Buffer.from(body), 'none', functions)
+    const elements = await awu(parsed.elements)
+      .filter(element => !isContainerType(element))
+      .toArray()
+    expect(elements[0].annotations.str).toEqual('\n' + '        this is a unicode test ‍')
+  })
+
   describe('simple error tests', () => {
     it('fails on invalid inheritance syntax', async () => {
       const body = `


### PR DESCRIPTION
fix parser to not use trim in createStringValue

---

_Additional context for reviewer_

---
_Release Notes_: 
core:
* fix issue where pending changes appear in multi-line string when the unicode U+200D is the last character

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
