### PR TITLE
SALTO-5800 fix homepage deployment

### DIFF
--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -21,6 +21,7 @@ import {
   addSpaceKey,
   adjustPageOnModification,
   homepageAdditionToModification,
+  putHomepageIdInAdditionContext,
   shouldDeleteRestrictionOnPageModification,
   shouldNotModifyRestrictionOnPageAddition,
 } from '../utils'
@@ -127,6 +128,9 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 transformation: {
                   omit: ['restriction'],
                   adjust: adjustPageOnModification,
+                },
+                context: {
+                  custom: () => putHomepageIdInAdditionContext,
                 },
               },
               copyFromResponse: {

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -28,7 +28,7 @@ import {
   SPACE_TYPE_NAME,
   TEMPLATE_TYPE_NAME,
 } from '../../constants'
-import { adjustHomepageToId, spaceMergeAndTransformAdjust } from '../utils/space'
+import { spaceMergeAndTransformAdjust } from '../utils/space'
 
 const DEFAULT_FIELDS_TO_HIDE: Record<string, definitions.fetch.ElementFieldCustomization> = {
   created_at: {
@@ -108,7 +108,6 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
         transformation: {
           root: 'results',
-          adjust: adjustHomepageToId,
         },
       },
     ],

--- a/packages/confluence-adapter/src/definitions/utils/page.ts
+++ b/packages/confluence-adapter/src/definitions/utils/page.ts
@@ -71,7 +71,9 @@ const increasePageVersion: definitions.AdjustFunction<definitions.deploy.ChangeA
       value: {
         ...value,
         version: {
-          number: 2, // case where homepage is created in the service with version = 1
+          // In case of homepage addition, we don't have a version number yet but it is "1" in the service
+          // It has been set to one when we created the space and the default homepage was created
+          number: 2,
         },
       },
     }

--- a/packages/confluence-adapter/src/definitions/utils/page.ts
+++ b/packages/confluence-adapter/src/definitions/utils/page.ts
@@ -67,7 +67,14 @@ const increasePageVersion: definitions.AdjustFunction<definitions.deploy.ChangeA
   const value = validateValue(args.value)
   const version = _.get(value, 'version')
   if (!values.isPlainRecord(version) || !isNumber(version.number)) {
-    return { ...args, value }
+    return {
+      value: {
+        ...value,
+        version: {
+          number: 2, // case where homepage is created in the service with version = 1
+        },
+      },
+    }
   }
   return {
     value: {
@@ -78,6 +85,24 @@ const increasePageVersion: definitions.AdjustFunction<definitions.deploy.ChangeA
       },
     },
   }
+}
+
+/**
+ * custom context function that adds homepage id to additionContext in case it is a homepage of a new deployed space.
+ */
+export const putHomepageIdInAdditionContext = (
+  args: definitions.deploy.ChangeAndContext,
+): Record<string, unknown> => {
+  const spaceChange = args.changeGroup?.changes.find(c => getChangeData(c).elemID.typeName === SPACE_TYPE_NAME)
+  if (spaceChange === undefined) {
+    return {}
+  }
+  // If there is a space change on the same group as a page change, it means that the page is the space homepage
+  const homepageId = _.get(args.sharedContext?.[getChangeData(spaceChange).elemID.getFullName()], 'id')
+  if (homepageId !== undefined) {
+    return { id: homepageId }
+  }
+  return {}
 }
 
 /**

--- a/packages/confluence-adapter/src/definitions/utils/page.ts
+++ b/packages/confluence-adapter/src/definitions/utils/page.ts
@@ -92,9 +92,7 @@ const increasePageVersion: definitions.AdjustFunction<definitions.deploy.ChangeA
 /**
  * custom context function that adds homepage id to additionContext in case it is a homepage of a new deployed space.
  */
-export const putHomepageIdInAdditionContext = (
-  args: definitions.deploy.ChangeAndContext,
-): Record<string, unknown> => {
+export const putHomepageIdInAdditionContext = (args: definitions.deploy.ChangeAndContext): Record<string, unknown> => {
   const spaceChange = args.changeGroup?.changes.find(c => getChangeData(c).elemID.typeName === SPACE_TYPE_NAME)
   if (spaceChange === undefined) {
     return {}

--- a/packages/confluence-adapter/src/definitions/utils/space.ts
+++ b/packages/confluence-adapter/src/definitions/utils/space.ts
@@ -95,23 +95,13 @@ export const spaceMergeAndTransformAdjust: definitions.AdjustFunction<{
 }
 
 /**
- * Adjust function for transforming space instances upon fetch.
- * We convert homepage object returned from the service to its id, then we build a reference from it.
- */
-export const adjustHomepageToId: definitions.AdjustFunction = args => {
-  const value = validateValue(args.value)
-  value.homepage = _.get(value, 'homepage.id')
-  return { ...args, value }
-}
-
-/**
  * Group space with its homepage upon addition.
  * We want to first deploy the space, a default homepage will be created in the service. We want to modify it
  */
 export const spaceChangeGroupWithItsHomepage: deployment.grouping.ChangeIdFunction = async change => {
   const changeData = getChangeData(change)
   if (isInstanceElement(changeData)) {
-    const homepageRef = changeData.value.homepage
+    const homepageRef = changeData.value.homepageId
     // in case of addition, we want the space to be in the same group as its homepage
     if (isAdditionChange(change) && isReferenceExpression(homepageRef)) {
       return homepageRef.elemID.getFullName()

--- a/packages/confluence-adapter/test/definitions/utils/page.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/page.test.ts
@@ -24,7 +24,11 @@ import {
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ADAPTER_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME } from '../../../src/constants'
-import { adjustPageOnModification, homepageAdditionToModification, putHomepageIdInAdditionContext } from '../../../src/definitions/utils'
+import {
+  adjustPageOnModification,
+  homepageAdditionToModification,
+  putHomepageIdInAdditionContext,
+} from '../../../src/definitions/utils'
 
 describe('page definitions utils', () => {
   const pageObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, PAGE_TYPE_NAME) })

--- a/packages/confluence-adapter/test/definitions/utils/page.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/page.test.ts
@@ -52,7 +52,7 @@ describe('page definitions utils', () => {
         expect(adjustPageOnModification(args).value.version.number).toEqual(2)
       })
 
-      it('should return the same value if the version number is not a number (should not happen)', () => {
+      it('should return version = 2 if the version number is not a number (should not happen)', () => {
         const args = {
           typeName: 'mockType',
           context: {
@@ -66,7 +66,7 @@ describe('page definitions utils', () => {
           },
           value: { version: { number: 'not a number' } },
         }
-        expect(adjustPageOnModification(args).value).toEqual(args.value)
+        expect(adjustPageOnModification(args).value.version).toEqual({ number: 2 })
       })
     })
     describe('updateHomepageId', () => {

--- a/packages/confluence-adapter/test/definitions/utils/page.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/page.test.ts
@@ -24,7 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ADAPTER_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME } from '../../../src/constants'
-import { adjustPageOnModification, homepageAdditionToModification } from '../../../src/definitions/utils'
+import { adjustPageOnModification, homepageAdditionToModification, putHomepageIdInAdditionContext } from '../../../src/definitions/utils'
 
 describe('page definitions utils', () => {
   const pageObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, PAGE_TYPE_NAME) })
@@ -52,7 +52,7 @@ describe('page definitions utils', () => {
         expect(adjustPageOnModification(args).value.version.number).toEqual(2)
       })
 
-      it('should return version = 2 if the version number is not a number (should not happen)', () => {
+      it('should return version = 2 if the version number is not a number (homepage addition case)', () => {
         const args = {
           typeName: 'mockType',
           context: {
@@ -196,6 +196,48 @@ describe('page definitions utils', () => {
         sharedContext: {},
       }
       expect(homepageAdditionToModification(args)).toEqual(['modify'])
+    })
+  })
+  describe('putHomepageIdInAdditionContext', () => {
+    it('should return empty object if there is no space change in the change group', () => {
+      const args = {
+        change: pageChange,
+        changeGroup: {
+          changes: [pageChange],
+          groupID: 'group-id',
+        },
+        elementSource: buildElementsSourceFromElements([]),
+        sharedContext: {
+          [getChangeData(spaceChange).elemID.getFullName()]: { id: 'homepageId' },
+        },
+      }
+      expect(putHomepageIdInAdditionContext(args)).toEqual({})
+    })
+    it('should return empty object if there is no homepageId in the shared context', () => {
+      const args = {
+        change: pageChange,
+        changeGroup: {
+          changes: [spaceChange],
+          groupID: 'group-id',
+        },
+        elementSource: buildElementsSourceFromElements([]),
+        sharedContext: {},
+      }
+      expect(putHomepageIdInAdditionContext(args)).toEqual({})
+    })
+    it('should return homepageId in the shared context', () => {
+      const args = {
+        change: pageChange,
+        changeGroup: {
+          changes: [spaceChange],
+          groupID: 'group-id',
+        },
+        elementSource: buildElementsSourceFromElements([]),
+        sharedContext: {
+          [getChangeData(spaceChange).elemID.getFullName()]: { id: 'homepageId' },
+        },
+      }
+      expect(putHomepageIdInAdditionContext(args)).toEqual({ id: 'homepageId' })
     })
   })
 })

--- a/packages/confluence-adapter/test/definitions/utils/space.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/space.test.ts
@@ -16,7 +16,6 @@
 
 import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
 import {
-  adjustHomepageToId,
   createPermissionUniqueKey,
   isPermissionObject,
   restructurePermissionsAndCreateInternalIdMap,
@@ -221,17 +220,6 @@ describe('space definitions utils', () => {
           type2_id2_key2_targetType2: 'internalId2',
         },
       })
-    })
-  })
-
-  describe('adjustHomepageToId', () => {
-    it('should convert homepage object to id', () => {
-      const item = {
-        typeName: 'mockType',
-        value: { homepage: { someField: 'yay', id: 'mockId' } },
-        context: {},
-      }
-      expect(adjustHomepageToId(item).value).toEqual({ homepage: 'mockId' })
     })
   })
 

--- a/packages/confluence-adapter/test/definitions/utils/space.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/space.test.ts
@@ -233,14 +233,14 @@ describe('space definitions utils', () => {
 
     it('should return element full name when change is not addition change', async () => {
       const spaceInstance = new InstanceElement('mockSpaceName', spaceObjectType, {
-        homepage: new ReferenceExpression(homepageInstance.elemID),
+        homepageId: new ReferenceExpression(homepageInstance.elemID),
       })
       const change = toChange({ before: spaceInstance })
       expect(await spaceChangeGroupWithItsHomepage(change)).toEqual('confluence.space.instance.mockSpaceName')
     })
     it('should return homepage full name when change is addition', async () => {
       const spaceInstance = new InstanceElement('mockName', spaceObjectType, {
-        homepage: new ReferenceExpression(homepageInstance.elemID),
+        homepageId: new ReferenceExpression(homepageInstance.elemID),
       })
       const change = toChange({ after: spaceInstance })
       expect(await spaceChangeGroupWithItsHomepage(change)).toEqual('confluence.page.instance.mockPageName')


### PR DESCRIPTION
In context to resolveAllArgs, we didn't passed the data (after transformation), but only the value from the original change

---



---
_Release Notes_: 
_Confluence Adapter_:
- Fix homepage deployment

---
_User Notifications_: 
_Confluence Adapter_:
- Fix homepage deployment
