### PR TITLE
SALTO-5925: Fix Forms bug

### DIFF
--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -38,7 +38,7 @@ import {
 } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { resolveValues, client as clientUtils } from '@salto-io/adapter-components'
+import { resolveValues } from '@salto-io/adapter-components'
 import { FilterCreator } from '../../filter'
 import { FORM_TYPE, JSM_DUCKTYPE_API_DEFINITIONS, PROJECT_TYPE, SERVICE_DESK } from '../../constants'
 import { getCloudId } from '../automation/cloud_id'
@@ -50,10 +50,6 @@ import { getLookUpName } from '../../reference_mapping'
 
 const { isDefined } = lowerDashValues
 const log = logger(module)
-
-const isExpectedPermissionError = (
-  response: clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>,
-): boolean => response.status === 200 && response.data.length === 0
 
 const deployForms = async (change: Change<InstanceElement>, client: JiraClient): Promise<void> => {
   const form = getChangeData(change)
@@ -131,13 +127,9 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
             const url = `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms`
             const res = await client.get({ url })
             if (!isFormsResponse(res)) {
-              if (isExpectedPermissionError(res)) {
-                projectsWithoutForms.push(project.elemID.name)
-              } else {
-                log.error(
-                  `Failed to fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
-                )
-              }
+              log.debug(
+                `Didn't fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
+              )
               return undefined
             }
             return await Promise.all(

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -473,16 +473,16 @@ describe('forms filter', () => {
     it('should return single saltoError when failed to fetch form because data is empty', async () => {
       connection.get.mockImplementation(async url => {
         if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/11111/forms') {
-          return {
-            status: 200,
-            data: [],
-          }
+          throw new clientUtils.HTTPError('insufficient permissions', {
+            status: 403,
+            data: {},
+          })
         }
         if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/22222/forms') {
-          return {
-            status: 200,
-            data: [],
-          }
+          throw new clientUtils.HTTPError('insufficient permissions', {
+            status: 403,
+            data: {},
+          })
         }
         throw new Error('Unexpected url')
       })
@@ -512,10 +512,10 @@ describe('forms filter', () => {
           }
         }
         if (url === '/gateway/api/proforma/cloudid/cloudId/api/1/projects/22222/forms') {
-          return {
-            status: 200,
-            data: [],
-          }
+          throw new clientUtils.HTTPError('insufficient permissions', {
+            status: 403,
+            data: {},
+          })
         }
         throw new Error('Unexpected url')
       })


### PR DESCRIPTION
Currently, users who have no forms are receiving a Salto fetch warning indicating that they lack permissions. Jira has changed their API so that when attempting to access forms without the necessary permissions, a 403 error is returned instead of an empty list.


---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* Fixed JSM Forms bug where users without forms received a permission error.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
