### PR TITLE
SALTO-5817 support deployment of settings instances

### DIFF
--- a/packages/adapter-components/src/deployment/deploy/requester.ts
+++ b/packages/adapter-components/src/deployment/deploy/requester.ts
@@ -282,7 +282,13 @@ export const getRequester = <TOptions extends APIDefinitionsOptions>({
     throwOnUnresolvedReferences(data)
 
     const callArgs = {
-      queryParams: mergedEndpointDef.queryArgs,
+      queryParams:
+        mergedEndpointDef.queryArgs !== undefined
+          ? replaceAllArgs({
+              value: mergedEndpointDef.queryArgs,
+              context: _.merge({}, value, additionalContext),
+            })
+          : undefined,
       headers: mergedEndpointDef.headers,
       data,
     }

--- a/packages/adapter-components/test/deployment/deploy/requester.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/requester.test.ts
@@ -610,7 +610,11 @@ describe('DeployRequester', () => {
       elementSource: buildElementsSourceFromElements([]),
       sharedContext: {},
     })
-    expect(client.delete).toHaveBeenCalledWith({ url: '/test/endpoint/1', data: undefined, queryParams: undefined })
+    expect(client.delete).toHaveBeenCalledWith({
+      url: '/test/endpoint/1',
+      data: undefined,
+      queryParams: { instanceId: '1' },
+    })
   })
 
   it('should include request body when deploy request config contains omitRequestBody=false', async () => {
@@ -646,7 +650,7 @@ describe('DeployRequester', () => {
     expect(client.delete).toHaveBeenCalledWith({
       url: '/test/endpoint/1',
       data: { id: '1', creatableField: 'creatableValue', ignored: 'ignored' },
-      queryParams: undefined,
+      queryParams: { instanceId: '1' },
     })
   })
 

--- a/packages/adapter-components/test/deployment/deploy/requester.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/requester.test.ts
@@ -120,6 +120,9 @@ describe('DeployRequester', () => {
                           instanceId: '{obj.id}',
                         },
                         endpoint: {
+                          queryArgs: {
+                            instanceId: '{instanceId}',
+                          },
                           path: '/test/endpoint/{instanceId}',
                           method: 'delete',
                         },
@@ -281,7 +284,7 @@ describe('DeployRequester', () => {
     ).rejects.toThrow('Could not find requests for change adapter.test.instance.instance action modify')
   })
 
-  it('should use context in URL', async () => {
+  it('should use context in URL and queryParams', async () => {
     client.delete.mockResolvedValue({
       status: 200,
       data: {},
@@ -304,6 +307,7 @@ describe('DeployRequester', () => {
     expect(client.delete).toHaveBeenCalledWith(
       expect.objectContaining({
         url: '/test/endpoint/1',
+        queryParams: { instanceId: '1' },
       }),
     )
   })

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -15,6 +15,7 @@
  */
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
+import { isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { AdditionalAction, ClientOptions } from '../types'
 import {
   addSpaceKey,
@@ -246,6 +247,12 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
       },
     },
     [SPACE_SETTINGS_TYPE_NAME]: {
+      toActionNames: ({ change }) => {
+        if (isAdditionOrModificationChange(change)) {
+          return ['modify']
+        }
+        return [change.action]
+      }, // no addition of space settings, we should modify instead
       requestsByAction: {
         default: {
           request: {

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -29,6 +29,7 @@ import {
   LABEL_TYPE_NAME,
   PAGE_TYPE_NAME,
   PERMISSION_TYPE_NAME,
+  SPACE_SETTINGS_TYPE_NAME,
   SPACE_TYPE_NAME,
   TEMPLATE_TYPE_NAME,
 } from '../../constants'
@@ -244,12 +245,33 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
-    settings: {
+    [SPACE_SETTINGS_TYPE_NAME]: {
       requestsByAction: {
+        default: {
+          request: {
+            endpoint: {
+              queryArgs: {
+                spaceKey: '{spaceKey}',
+              },
+            },
+            context: {
+              spaceKey: '{_parent.0.key}',
+            },
+          },
+        },
         customizations: {
           modify: [
             {
+              condition: {
+                transformForCheck: {
+                  pick: ['custom'],
+                },
+              },
               request: {
+                transformation: {
+                  pick: ['custom'],
+                  adjust: ({ value }) => ({ value: { ..._.get(value, 'custom') } }),
+                },
                 endpoint: {
                   path: '/wiki/rest/api/settings/lookandfeel/custom',
                   method: 'post',


### PR DESCRIPTION
- Resolve args on request.queryArgs (adapter-component)
- Initial support in deployment of space settings. There still some things todo but I think this adds some value and can be merge until we will support more complex cases.
- Convert action to modification from addition when deploying new space with its settings. 

TODO:
On this PR we support modification of custom settings. Global is not configurable.
- Allow to set which settings definition to use on a space ('custom', 'global', 'theme'). using [this](https://developer.atlassian.com/cloud/confluence/rest/v1/api-group-settings/#api-wiki-rest-api-settings-lookandfeel-put) API
- Block somehow modification on global field on settings instance, as this is not editable in the sevice
- Explore more about 'theme' option. As I understand this option is from some plugins 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Confluence Adapter_:
- support deployment of custom space settings

---
_User Notifications_: 
_Confluence Adapter_:
- support deployment of custom space settings
