### PR TITLE
SALTO-5930: Workato deployment fails for invalid recipe schema

### DIFF
--- a/packages/workato-adapter/src/rlm.ts
+++ b/packages/workato-adapter/src/rlm.ts
@@ -162,7 +162,7 @@ const CONNECTION_SCHEMA = Joi.object({
 
 const RECIPE_CONFIG_SCHEMA = Joi.array().items(
   Joi.object({
-    account_id: CONNECTION_SCHEMA.required(),
+    account_id: CONNECTION_SCHEMA.optional(),
     keyword: Joi.string().required(),
     provider: Joi.string().required(),
     skip_validation: Joi.boolean().required(),


### PR DESCRIPTION
Currently workato deployment fails for all recipes due to checking the `account_id` field for all recipes though it's not mandatory.

---

The `account_id` field only appears when there's a connected connection, but it's a valid scenario to try and deploy a recipe without it, so we should allow it.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
