### PR TITLE
SALTO-5861: [Zendesk] Fix fetching of article attachments

### DIFF
--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -164,7 +164,7 @@ const getAttachmentContent = async ({
   try {
     const path = attachment.value.relative_path
     res = await client.get({
-      url: `${path.substring(0, path.lastIndexOf('/') + 1)}`,
+      url: `${path.substring(0, path.lastIndexOf('/'))}`,
       responseType: 'arraybuffer',
     })
   } catch (e) {

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -162,8 +162,9 @@ const getAttachmentContent = async ({
   const client = brandIdToClient[attachment.value.brand]
   let res
   try {
+    const path = attachment.value.relative_path
     res = await client.get({
-      url: `${attachment.value.relative_path}`,
+      url: `${path.substring(0, path.lastIndexOf('/') + 1)}`,
       responseType: 'arraybuffer',
     })
   } catch (e) {

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -344,16 +344,13 @@ describe('article filter', () => {
         ) {
           return { status: 200, data: { article_attachments: [] } }
         }
-        if (params.url === '/hc/article_attachments/20222022/attachmentFileName.png') {
+        if (params.url === '/hc/article_attachments/20222022/') {
           return {
             status: 200,
             data: content,
           }
         }
-        if (
-          params.url === '/hc/article_attachments/123/attachmentFileName.png' ||
-          params.url === '/hc/article_attachments/133/attachmentFileName.png'
-        ) {
+        if (params.url === '/hc/article_attachments/123/' || params.url === '/hc/article_attachments/133/') {
           return {
             status: 200,
             data: content,

--- a/packages/zendesk-adapter/test/filters/article/article.test.ts
+++ b/packages/zendesk-adapter/test/filters/article/article.test.ts
@@ -344,13 +344,13 @@ describe('article filter', () => {
         ) {
           return { status: 200, data: { article_attachments: [] } }
         }
-        if (params.url === '/hc/article_attachments/20222022/') {
+        if (params.url === '/hc/article_attachments/20222022') {
           return {
             status: 200,
             data: content,
           }
         }
-        if (params.url === '/hc/article_attachments/123/' || params.url === '/hc/article_attachments/133/') {
+        if (params.url === '/hc/article_attachments/123' || params.url === '/hc/article_attachments/133') {
           return {
             status: 200,
             data: content,


### PR DESCRIPTION
When fetching article attachment, we use a url that has the filename in it - which breaks when the file name is weird. In this PR i switched it so that we use the same url but remove the filename (which was suggested by zendesk support)
---

---
_Release Notes_: 
Zendesk:
Fix fetching of article attachments with weird names

---
_User Notifications_: 
None