### PR TITLE
SALTO-5918: Using element source in field references filter

### DIFF
--- a/packages/adapter-components/src/references/context.ts
+++ b/packages/adapter-components/src/references/context.ts
@@ -31,12 +31,12 @@ const log = logger(module)
 export type ContextValueMapperFunc = (val: string) => string | undefined
 export type ContextFunc = ({
   instance,
-  elementsSource,
+  elementSource,
   field,
   fieldPath,
 }: {
   instance: InstanceElement
-  elementsSource: ReadOnlyElementsSource
+  elementSource: ReadOnlyElementsSource
   field: Field
   fieldPath?: ElemID
   levelsUp?: number
@@ -78,7 +78,7 @@ export const neighborContextGetter =
     contextValueMapper?: ContextValueMapperFunc
     getLookUpName: GetLookupNameFunc
   }): ContextFunc =>
-  async ({ instance, elementsSource, fieldPath }) => {
+  async ({ instance, elementSource, fieldPath }) => {
     if (fieldPath === undefined || contextFieldName === undefined) {
       return undefined
     }
@@ -87,7 +87,7 @@ export const neighborContextGetter =
       const contextField = await getField(await instance.getType(), fieldPath.createTopLevelParentID().path)
       const refWithValue = new ReferenceExpression(
         context.elemID,
-        context.value ?? (await elementsSource.get(context.elemID)),
+        context.value ?? (await elementSource.get(context.elemID)),
       )
       return getLookUpName({ ref: refWithValue, field: contextField, path, element: instance })
     }

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -273,9 +273,6 @@ export const addReferences = async <
   >(defs, fieldReferenceResolverCreator)
   const instances = elements.filter(isInstanceElement)
 
-  // copied from Salesforce - both should be handled similarly:
-  // TODO - when transformValues becomes async the first index can be to elemID and not the whole
-  // element and we can use the element source directly instead of creating the second index
   const indexer = multiIndex.buildMultiIndex<Element>()
 
   fieldsToGroupBy.forEach(fieldName =>

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -76,18 +76,17 @@ export const buildElementsSourceFromElements = (
   }
 
   const get = async (id: ElemID): Promise<Value> => {
-    let element: Readonly<Element> | undefined = elementsMap[id.getFullName()]
-    if (element !== undefined) {
-      return element
+    if (id.getFullName() in elementsMap) {
+      return elementsMap[id.getFullName()]
     }
 
     if (!id.isTopLevel()) {
       const { parent } = id.createTopLevelParentID()
       const topLevel = elementsMap[parent.getFullName()]
       if (topLevel !== undefined) {
-        element = resolvePath(topLevel, id)
-        if (element !== undefined) {
-          return element
+        const value = resolvePath(topLevel, id)
+        if (value !== undefined) {
+          return value
         }
       }
     }

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -76,11 +76,12 @@ export const buildElementsSourceFromElements = (
   }
 
   const get = async (id: ElemID): Promise<Value> => {
-    if (id.getFullName() in elementsMap) {
-      return elementsMap[id.getFullName()]
-    }
-
-    if (!id.isTopLevel()) {
+    if (id.isTopLevel()) {
+      const element = elementsMap[id.getFullName()]
+      if (element !== undefined) {
+        return element
+      }
+    } else {
       const { parent } = id.createTopLevelParentID()
       const topLevel = elementsMap[parent.getFullName()]
       if (topLevel !== undefined) {

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -550,7 +550,7 @@ export const findInstances = (elements: Iterable<Element>, typeID: ElemID): Iter
   return instances.filter(e => e.refType.elemID.isEqual(typeID))
 }
 
-export const getPath = (rootElement: Element, fullElemID: ElemID): string[] | undefined => {
+export const getPath = (rootElement: Readonly<Element>, fullElemID: ElemID): string[] | undefined => {
   // If rootElement is an objectType or an instance (i.e., a top level element),
   // we want to compare the top level id of fullElemID.
   // If it is a field we want to compare the base id.
@@ -602,7 +602,7 @@ export const setPath = (rootElement: Element, fullElemID: ElemID, value: Value):
   }
 }
 
-export const resolvePath = (rootElement: Element, fullElemID: ElemID): Value => {
+export const resolvePath = (rootElement: Readonly<Element>, fullElemID: ElemID): Value => {
   const path = getPath(rootElement, fullElemID)
   if (path === undefined) return undefined
   if (_.isEmpty(path)) return rootElement

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -42,11 +42,11 @@ describe('elementSource', () => {
           },
         }),
       ]
-      const elementsSource = buildElementsSourceFromElements(elements)
+      const elementSource = buildElementsSourceFromElements(elements)
 
       describe('getAll', () => {
         it('should return all the elements', async () => {
-          const receivedElements = await toArrayAsync(await elementsSource.getAll())
+          const receivedElements = await toArrayAsync(await elementSource.getAll())
           expect(receivedElements).toEqual(elements)
         })
 
@@ -66,38 +66,38 @@ describe('elementSource', () => {
 
       describe('get', () => {
         it('should return element if it exists', async () => {
-          expect(await elementsSource.get(new ElemID('adapter', 'type1'))).toBe(elements[0])
+          expect(await elementSource.get(new ElemID('adapter', 'type1'))).toBe(elements[0])
         })
 
-        it('should return undefined if it does not exists', async () => {
-          expect(await elementsSource.get(new ElemID('adapter', 'type3'))).toBeUndefined()
+        it('should return undefined if it does not exist', async () => {
+          expect(await elementSource.get(new ElemID('adapter', 'type3'))).toBeUndefined()
         })
 
         it('should return a nested field if it exists', async () => {
-          expect(await elementsSource.get(new ElemID('adapter', 'nestedType', 'field', 'strField'))).toBe(
+          expect(await elementSource.get(new ElemID('adapter', 'nestedType', 'field', 'strField'))).toBe(
             elements[2].fields.strField,
           )
         })
 
-        it('should return a nested field if it does not exist', async () => {
-          expect(await elementsSource.get(new ElemID('adapter', 'nestedType', 'field', 'numField'))).toBeUndefined()
+        it('should return undefined if a nested field does not exist', async () => {
+          expect(await elementSource.get(new ElemID('adapter', 'nestedType', 'field', 'numField'))).toBeUndefined()
         })
       })
 
       describe('list', () => {
         it('should return all the elements ids', async () => {
-          const receivedElementsIds = await collections.asynciterable.toArrayAsync(await elementsSource.list())
+          const receivedElementsIds = await collections.asynciterable.toArrayAsync(await elementSource.list())
           expect(receivedElementsIds).toEqual(elements.map(e => e.elemID))
         })
       })
 
       describe('has', () => {
         it('should return true if element id exists', async () => {
-          expect(await elementsSource.has(new ElemID('adapter', 'type1'))).toBeTruthy()
+          expect(await elementSource.has(new ElemID('adapter', 'type1'))).toBeTruthy()
         })
 
         it('should return false if element id does not exist', async () => {
-          expect(await elementsSource.has(new ElemID('adapter', 'type3'))).toBeFalsy()
+          expect(await elementSource.has(new ElemID('adapter', 'type3'))).toBeFalsy()
         })
       })
     })
@@ -198,7 +198,7 @@ describe('elementSource', () => {
     let resolveTypeShallowSpy: jest.SpyInstance
     let unresolvedType: ObjectType
     let objectType: ObjectType
-    let elementsSource: ReadOnlyElementsSource
+    let elementSource: ReadOnlyElementsSource
     beforeEach(() => {
       unresolvedType = new ObjectType({
         elemID: new ElemID('adapter', 'unresolvedType'),
@@ -212,15 +212,15 @@ describe('elementSource', () => {
           },
         },
       })
-      const originalElementsSource = buildElementsSourceFromElements([objectType, unresolvedType])
-      elementsSource = buildLazyShallowTypeResolverElementsSource(originalElementsSource)
+      const originalElementSource = buildElementsSourceFromElements([objectType, unresolvedType])
+      elementSource = buildLazyShallowTypeResolverElementsSource(originalElementSource)
     })
     it('should resolve the type shallowly once', async () => {
-      const resolvedElement = await elementsSource.get(objectType.elemID)
+      const resolvedElement = await elementSource.get(objectType.elemID)
       expect(resolvedElement.fields[UNRESOLVED_FIELD_NAME]?.refType).toEqual(
         new TypeReference(unresolvedType.elemID, unresolvedType),
       )
-      expect(resolvedElement).toEqual(await elementsSource.get(objectType.elemID))
+      expect(resolvedElement).toEqual(await elementSource.get(objectType.elemID))
       const callsOnTheObjectType = resolveTypeShallowSpy.mock.calls.filter(args => args[0] === objectType)
       expect(callsOnTheObjectType).toHaveLength(1)
     })

--- a/packages/adapter-utils/test/element_source.test.ts
+++ b/packages/adapter-utils/test/element_source.test.ts
@@ -15,6 +15,7 @@
  */
 import _ from 'lodash'
 import {
+  BuiltinTypes,
   ElemID,
   InstanceElement,
   ObjectType,
@@ -34,6 +35,12 @@ describe('elementSource', () => {
       const elements = [
         new ObjectType({ elemID: new ElemID('adapter', 'type1') }),
         new ObjectType({ elemID: new ElemID('adapter', 'type2') }),
+        new ObjectType({
+          elemID: new ElemID('adapter', 'nestedType'),
+          fields: {
+            strField: { refType: BuiltinTypes.STRING },
+          },
+        }),
       ]
       const elementsSource = buildElementsSourceFromElements(elements)
 
@@ -58,12 +65,22 @@ describe('elementSource', () => {
       })
 
       describe('get', () => {
-        it('should return element if exists', async () => {
+        it('should return element if it exists', async () => {
           expect(await elementsSource.get(new ElemID('adapter', 'type1'))).toBe(elements[0])
         })
 
-        it('should return undefined if not exists', async () => {
+        it('should return undefined if it does not exists', async () => {
           expect(await elementsSource.get(new ElemID('adapter', 'type3'))).toBeUndefined()
+        })
+
+        it('should return a nested field if it exists', async () => {
+          expect(await elementsSource.get(new ElemID('adapter', 'nestedType', 'field', 'strField'))).toBe(
+            elements[2].fields.strField,
+          )
+        })
+
+        it('should return a nested field if it does not exist', async () => {
+          expect(await elementsSource.get(new ElemID('adapter', 'nestedType', 'field', 'numField'))).toBeUndefined()
         })
       })
 

--- a/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
+++ b/packages/jira-adapter/test/references/dashboard_gadget_properties.test.ts
@@ -82,30 +82,40 @@ describe('DashboardGadgetReferences', () => {
 
   describe('gadgetValuesContextFunc', () => {
     let field: Field
-    let elementsSource: ReadOnlyElementsSource
+    let elementSource: ReadOnlyElementsSource
 
     beforeEach(async () => {
       // field are elemByElemID are only needed because it is mandatory in ContextFunc, but are not going to be used
       field = new Field(filterType, 'mock', filterType)
-      elementsSource = buildElementsSourceFromElements([])
+      elementSource = buildElementsSourceFromElements([])
     })
 
     it('should return undefined if fieldPath is undefined', async () => {
-      const result = await gadgetValuesContextFunc({ instance, elementsSource, field })
+      const result = await gadgetValuesContextFunc({ instance, elementSource, field })
       expect(result).toBeUndefined()
     })
 
     it('should return FIELD_TYPE_NAME for valid keys: ystattype, xstattype, statistictype, statType', async () => {
       const fieldPath = instance.elemID.createNestedID('properties', 'values', '4', 'value')
-      const result1 = await gadgetValuesContextFunc({ instance, elementsSource, field, fieldPath })
+      const result1 = await gadgetValuesContextFunc({ instance, elementSource, field, fieldPath })
       expect(result1).toEqual('Field')
     })
     it('should determine type based on value prefix for the key: projectOrFilterId', async () => {
       const projectPath = instance.elemID.createNestedID('properties', 'values', '2', 'value')
       const filterPath = instance.elemID.createNestedID('properties', 'values', '3', 'value')
-      const result1 = await gadgetValuesContextFunc({ instance, elementsSource, field, fieldPath: projectPath })
+      const result1 = await gadgetValuesContextFunc({
+        instance,
+        elementSource,
+        field,
+        fieldPath: projectPath,
+      })
       expect(result1).toEqual('Project')
-      const result2 = await gadgetValuesContextFunc({ instance, elementsSource, field, fieldPath: filterPath })
+      const result2 = await gadgetValuesContextFunc({
+        instance,
+        elementSource,
+        field,
+        fieldPath: filterPath,
+      })
       expect(result2).toEqual('Filter')
     })
   })

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -179,15 +179,12 @@ export const addReferences = async (
     await referenceElements.getAll(),
     extractFlatCustomObjectFields,
   )
-  const { elemIDLookup } = await multiIndex
-    .buildMultiIndex<Element>()
-    .addIndex({
-      name: 'elemIDLookup',
-      filter: hasApiName,
-      key: async (elem) => [await metadataType(elem), await apiName(elem)],
-      map: (elem) => elem.elemID,
-    })
-    .process(elementsAndFields)
+  const elemIDLookup = await multiIndex.keyByAsync({
+    iter: elementsAndFields,
+    filter: hasApiName,
+    key: async (elem) => [await metadataType(elem), await apiName(elem)],
+    map: (elem) => elem.elemID,
+  })
 
   const fieldsWithResolvedReferences = new Set<string>()
   const instances = elements.filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -22,7 +22,7 @@ import {
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { collections, multiIndex } from '@salto-io/lowerdash'
+import { collections, multiIndex, promises } from '@salto-io/lowerdash'
 import { apiName, metadataType } from '../transformers/transformer'
 import { LocalFilterCreator } from '../filter'
 import {
@@ -51,10 +51,12 @@ import {
   hasApiName,
 } from './utils'
 
-const { awu } = collections.asynciterable
 const log = logger(module)
 const { flatMapAsync } = collections.asynciterable
+const { withLimitedConcurrency } = promises.array
 const { neighborContextGetter, replaceReferenceValues } = referenceUtils
+
+const maxConcurrency = 20
 
 const workflowActionMapper: referenceUtils.ContextValueMapperFunc = (
   val: string,
@@ -187,17 +189,19 @@ export const addReferences = async (
   })
 
   const fieldsWithResolvedReferences = new Set<string>()
-  const instances = elements.filter(isInstanceElement)
-  await awu(instances).forEach(async (instance) => {
-    instance.value = await replaceReferenceValues({
-      instance,
-      resolverFinder,
-      elemIDLookupMaps: { elemIDLookup },
-      fieldsWithResolvedReferences,
-      elementsSource: referenceElements,
-      contextStrategyLookup,
-    })
-  })
+  await withLimitedConcurrency(
+    elements.filter(isInstanceElement).map((instance) => async () => {
+      instance.value = await replaceReferenceValues({
+        instance,
+        resolverFinder,
+        elemIDLookupMaps: { elemIDLookup },
+        fieldsWithResolvedReferences,
+        elementsSource: referenceElements,
+        contextStrategyLookup,
+      })
+    }),
+    maxConcurrency,
+  )
   log.debug('added references in the following fields: %s', [
     ...fieldsWithResolvedReferences,
   ])

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -100,7 +100,7 @@ const contextStrategyLookup: Record<
   ReferenceContextStrategyName,
   referenceUtils.ContextFunc
 > = {
-  instanceParent: async ({ instance, elementsSource }) => {
+  instanceParent: async ({ instance, elementSource: elementsSource }) => {
     const parentRef = getParents(instance)[0]
     const parent = isReferenceExpression(parentRef)
       ? await elementsSource.get(parentRef.elemID)
@@ -193,7 +193,7 @@ export const addReferences = async (
       resolverFinder,
       elemIDLookupMaps: { elemIDLookup },
       fieldsWithResolvedReferences,
-      elementsSource: referenceElements,
+      elementSource: referenceElements,
       contextStrategyLookup,
     })
   })

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -1041,9 +1041,7 @@ export type ReferenceResolverFinder = (
 export const generateReferenceResolverFinder = (
   defs: FieldReferenceDefinition[],
 ): ReferenceResolverFinder => {
-  const referenceDefinitions = defs.map((def) =>
-    FieldReferenceResolver.create(def),
-  )
+  const referenceDefinitions = defs.map(FieldReferenceResolver.create)
 
   const matchersByFieldName = _(referenceDefinitions)
     .filter((def) => _.isString(def.src.field))

--- a/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/fields_with_context_references.test.ts
@@ -221,6 +221,7 @@ describe('fields with context references filter', () => {
           productRuleValues.SBQQ__LookupProductField__c,
         )
       })
+
       it('Should replace value of field that exists in lookup object with reference', () => {
         const value = productRule.value.SBQQ__LookupMessageField__c
         expect(value).toBeInstanceOf(ReferenceExpression)
@@ -244,6 +245,7 @@ describe('fields with context references filter', () => {
           productRuleValues.SBQQ__LookupProductField__c,
         )
       })
+
       it('Should replace value of field that exists in lookup object with reference', () => {
         const value = productRule.value.SBQQ__LookupMessageField__c
         expect(value).toBeInstanceOf(ReferenceExpression)


### PR DESCRIPTION
Resolving a very old TODO to use the element source directly in the field references filter.
This doesn't make a huge difference in runtime, but leads to a cleaner implementation. We will chase performance improvements in later PRs.

---

_Additional context for reviewer_
This filter is super slow in some SFDC cases. We might also filter out profiles in that specific case in the future, but this PR is already big enough.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
