### PR TITLE
SALTO-5933: fix type for section

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2172,6 +2172,7 @@ export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
       fieldTypeOverrides: [
         { fieldName: 'id', fieldType: 'number' },
         { fieldName: 'parent_section_id', fieldType: 'number' },
+        { fieldName: 'direct_parent_type', fieldType: 'string' },
         { fieldName: 'sections', fieldType: 'list<section>' },
         { fieldName: 'articles', fieldType: 'list<article>' },
         { fieldName: 'translations', fieldType: 'list<section_translation>' },


### PR DESCRIPTION
fix type for section

---

_Additional context for reviewer_
adding direct_parent_type to filedTypeOverrides so that it will appear in the type as this field is added in a filter

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
