### PR TITLE
SALTO-5935: Return empty results for fix elements when provided element list is empty

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -792,6 +792,7 @@ export const fixElements = async (
   workspace: Workspace,
   selectors: ElementSelector[],
 ): Promise<{ errors: ChangeError[]; changes: DetailedChange[] }> => {
+  log.trace('Fixing elements by the following selectors: %o', selectors.map(selector => selector.origin))
   const accounts = workspace.accounts()
   const adapters = await getAdapters(
     accounts,
@@ -820,6 +821,10 @@ export const fixElements = async (
     .map(id => workspace.getValue(id))
     .filter(values.isDefined)
     .toArray()
+
+  if (_.isEmpty(elements)) {
+    return { errors: [], changes: [] }
+  }
 
   const idToElement = _.keyBy(elements, e => e.elemID.getFullName())
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -792,7 +792,6 @@ export const fixElements = async (
   workspace: Workspace,
   selectors: ElementSelector[],
 ): Promise<{ errors: ChangeError[]; changes: DetailedChange[] }> => {
-  log.trace('Fixing elements by the following selectors: %o', selectors.map(selector => selector.origin))
   const accounts = workspace.accounts()
   const adapters = await getAdapters(
     accounts,
@@ -822,7 +821,14 @@ export const fixElements = async (
     .filter(values.isDefined)
     .toArray()
 
+  log.debug(
+    'about to fixElements: %o, found by selectors: %o',
+    elements.map(element => element.elemID.getFullName()),
+    selectors.map(selector => selector.origin),
+  )
+
   if (_.isEmpty(elements)) {
+    log.debug('fixElements found no elements to fix')
     return { errors: [], changes: [] }
   }
 

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1640,5 +1640,14 @@ describe('api.ts', () => {
         api.fixElements(ws, [workspace.createElementSelector(type.elemID.createNestedID('attr', 'a').getFullName())]),
       ).rejects.toThrow()
     })
+    it('should return empty results when there are no elements to fix', async () => {
+      const res = await api.fixElements(
+        ws,
+        [workspace.createElementSelector('test1.test2')] // this selector doesn't match any element in workspace
+      )
+
+      expect(res).toEqual({ changes: [], errors: [] })
+      expect(mockFixElements).toHaveBeenCalledTimes(0)
+    })
   })
 })

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1643,7 +1643,7 @@ describe('api.ts', () => {
     it('should return empty results when there are no elements to fix', async () => {
       const res = await api.fixElements(
         ws,
-        [workspace.createElementSelector('test1.test2')] // this selector doesn't match any element in workspace
+        [workspace.createElementSelector('test1.test2')], // this selector doesn't match any element in workspace
       )
 
       expect(res).toEqual({ changes: [], errors: [] })


### PR DESCRIPTION
Fixed a bug which caused `fixElements` to throw when element list was empty

---

---
_Release Notes_: 
None

---
_User Notifications_: 
None