### PR TITLE
SALTO-5346 - Salesforce: Implement fixElements for permission sets

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/permission_sets.ts
@@ -20,7 +20,10 @@ import { collections } from '@salto-io/lowerdash'
 import { PERMISSION_SET_METADATA_TYPE } from '../constants'
 import { isInstanceOfTypeSync } from '../filters/utils'
 import { WeakReferencesHandler } from '../types'
-import { mapProfileOrPermissionSetSections } from './profiles'
+import {
+  mapProfileOrPermissionSetSections,
+  removeWeakReferencesFromProfilesOrPermissionSets,
+} from './profile_permission_set_utils'
 
 const log = logger(module)
 const { makeArray } = collections.array
@@ -59,7 +62,20 @@ const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
   return refs
 }
 
+const removeWeakReferences: WeakReferencesHandler['removeWeakReferences'] =
+  ({ elementsSource }) =>
+  async (elements) => {
+    const permissionSets = elements.filter(
+      isInstanceOfTypeSync(PERMISSION_SET_METADATA_TYPE),
+    )
+
+    return removeWeakReferencesFromProfilesOrPermissionSets(
+      permissionSets,
+      elementsSource,
+    )
+  }
+
 export const permissionSetsHandler: WeakReferencesHandler = {
   findWeakReferences,
-  removeWeakReferences: () => async () => ({ fixedElements: [], errors: [] }),
+  removeWeakReferences,
 }

--- a/packages/salesforce-adapter/src/custom_references/profile_permission_set_utils.ts
+++ b/packages/salesforce-adapter/src/custom_references/profile_permission_set_utils.ts
@@ -1,0 +1,350 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { collections, promises } from '@salto-io/lowerdash'
+import {
+  ChangeError,
+  ElemID,
+  FixElementsFunc,
+  InstanceElement,
+  ReadOnlyElementsSource,
+  Values,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { Types } from '../transformers/transformer'
+import {
+  APEX_CLASS_METADATA_TYPE,
+  APEX_PAGE_METADATA_TYPE,
+  API_NAME_SEPARATOR,
+  CUSTOM_APPLICATION_METADATA_TYPE,
+  FLOW_METADATA_TYPE,
+  LAYOUT_TYPE_ID_METADATA_TYPE,
+  RECORD_TYPE_METADATA_TYPE,
+  SALESFORCE,
+} from '../constants'
+
+const { makeArray } = collections.array
+const { awu } = collections.asynciterable
+const { pickAsync } = promises.object
+
+const log = logger(module)
+
+enum section {
+  APEX_CLASS = 'classAccesses',
+  APEX_PAGE = 'pageAccesses',
+  APP_VISIBILITY = 'applicationVisibilities',
+  FIELD_PERMISSIONS = 'fieldPermissions',
+  FLOW = 'flowAccesses',
+  LAYOUTS = 'layoutAssignments',
+  OBJECT = 'objectPermissions',
+  RECORD_TYPE = 'recordTypeVisibilities',
+}
+
+const FIELD_NO_ACCESS = 'NoAccess'
+
+const getMetadataElementName = (fullName: string): string =>
+  Types.getElemId(fullName.replace(API_NAME_SEPARATOR, '_'), true).name
+
+type ReferenceInSection = {
+  sourceField?: string
+  target: ElemID
+}
+
+type RefTargetsGetter = (
+  sectionEntry: Values,
+  sectionEntryKey: string,
+) => ReferenceInSection[]
+
+type ReferenceFromSectionParams = {
+  filter?: (sectionEntry: Values) => boolean
+  targetsGetter: RefTargetsGetter
+}
+
+const mapSectionEntries = <T>(
+  profile: InstanceElement,
+  sectionName: section,
+  { filter = () => true, targetsGetter }: ReferenceFromSectionParams,
+  f: (sectionEntryKey: string, target: ElemID, sourceField?: string) => T,
+): T[] => {
+  const sectionValue = profile.value[sectionName]
+  if (!_.isPlainObject(sectionValue)) {
+    if (sectionValue !== undefined) {
+      log.warn(
+        'Section %s of %s is not an object, skipping.',
+        sectionName,
+        profile.elemID,
+      )
+    }
+    return []
+  }
+  return Object.entries(sectionValue as Values)
+    .filter(([, sectionEntry]) => filter(sectionEntry))
+    .flatMap(([sectionEntryKey, sectionEntry]) => {
+      const targets = targetsGetter(sectionEntry, sectionEntryKey)
+      return targets.map(({ target, sourceField }) =>
+        f(sectionEntryKey, target, sourceField),
+      )
+    })
+}
+
+const isEnabled = (sectionEntry: Values): boolean =>
+  sectionEntry.enabled === true
+
+const isAnyAccessEnabledForObject = (
+  objectAccessSectionEntry: Values,
+): boolean =>
+  [
+    objectAccessSectionEntry.allowCreate,
+    objectAccessSectionEntry.allowDelete,
+    objectAccessSectionEntry.allowEdit,
+    objectAccessSectionEntry.allowRead,
+    objectAccessSectionEntry.modifyAllRecords,
+    objectAccessSectionEntry.viewAllRecords,
+  ].some((permission) => permission === true)
+
+const isAnyAccessEnabledForField = (
+  fieldPermissionsSectionEntry: Values,
+): boolean =>
+  Object.values(fieldPermissionsSectionEntry).some(
+    (val) => val !== FIELD_NO_ACCESS,
+  )
+
+const referenceToInstance =
+  (fieldName: string, targetType: string): RefTargetsGetter =>
+  (sectionEntry) => {
+    if (!_.isString(sectionEntry[fieldName])) {
+      return []
+    }
+    const elemIdName = getMetadataElementName(sectionEntry[fieldName])
+    return [
+      {
+        target: Types.getElemId(targetType, false).createNestedID(
+          'instance',
+          elemIdName,
+        ),
+      },
+    ]
+  }
+
+const referenceToType =
+  (fieldName: string): RefTargetsGetter =>
+  (sectionEntry) => {
+    if (!_.isString(sectionEntry[fieldName])) {
+      return []
+    }
+    return [
+      {
+        target: Types.getElemId(sectionEntry[fieldName], true),
+      },
+    ]
+  }
+
+const referencesToFields: RefTargetsGetter = (
+  sectionEntry,
+  sectionEntryKey,
+) => {
+  const typeElemId = Types.getElemId(sectionEntryKey, true)
+  return Object.entries(sectionEntry)
+    .filter(([, fieldAccess]) => fieldAccess !== FIELD_NO_ACCESS)
+    .map(([fieldName]) => ({
+      target: typeElemId.createNestedID(
+        'field',
+        getMetadataElementName(fieldName),
+      ),
+      sourceField: fieldName,
+    }))
+}
+
+const layoutReferences: RefTargetsGetter = (sectionEntry) => {
+  if (!_.isString(sectionEntry[0]?.layout)) {
+    return []
+  }
+  const layoutElemIdName = getMetadataElementName(sectionEntry[0].layout)
+  const layoutRef = {
+    target: new ElemID(
+      SALESFORCE,
+      LAYOUT_TYPE_ID_METADATA_TYPE,
+      'instance',
+      layoutElemIdName,
+    ),
+  }
+
+  const recordTypeRefs = sectionEntry
+    .filter((layoutAssignment: Values) =>
+      _.isString(layoutAssignment.recordType),
+    )
+    .map((layoutAssignment: Values) => ({
+      target: new ElemID(
+        SALESFORCE,
+        RECORD_TYPE_METADATA_TYPE,
+        'instance',
+        getMetadataElementName(layoutAssignment.recordType),
+      ),
+    }))
+
+  return [layoutRef].concat(recordTypeRefs)
+}
+
+const recordTypeReferences: RefTargetsGetter = (sectionEntry) =>
+  Object.entries(sectionEntry)
+    .filter(
+      ([, recordTypeVisibility]) =>
+        recordTypeVisibility.default === true ||
+        recordTypeVisibility.visible === true,
+    )
+    .filter(([, recordTypeVisibility]) =>
+      _.isString(recordTypeVisibility.recordType),
+    )
+    .map(([recordTypeVisibilityKey, recordTypeVisibility]) => ({
+      target: new ElemID(
+        SALESFORCE,
+        RECORD_TYPE_METADATA_TYPE,
+        'instance',
+        getMetadataElementName(recordTypeVisibility.recordType),
+      ),
+      sourceField: recordTypeVisibilityKey,
+    }))
+
+const sectionsReferenceParams: Record<section, ReferenceFromSectionParams> = {
+  [section.APP_VISIBILITY]: {
+    filter: (appVisibilityEntry) =>
+      appVisibilityEntry.default || appVisibilityEntry.visible,
+    targetsGetter: referenceToInstance(
+      'application',
+      CUSTOM_APPLICATION_METADATA_TYPE,
+    ),
+  },
+  [section.APEX_CLASS]: {
+    filter: isEnabled,
+    targetsGetter: referenceToInstance('apexClass', APEX_CLASS_METADATA_TYPE),
+  },
+  [section.FLOW]: {
+    filter: isEnabled,
+    targetsGetter: referenceToInstance('flow', FLOW_METADATA_TYPE),
+  },
+  [section.APEX_PAGE]: {
+    filter: isEnabled,
+    targetsGetter: referenceToInstance('apexPage', APEX_PAGE_METADATA_TYPE),
+  },
+  [section.OBJECT]: {
+    filter: isAnyAccessEnabledForObject,
+    targetsGetter: referenceToType('object'),
+  },
+  [section.FIELD_PERMISSIONS]: {
+    filter: isAnyAccessEnabledForField,
+    targetsGetter: referencesToFields,
+  },
+  [section.LAYOUTS]: {
+    targetsGetter: layoutReferences,
+  },
+  [section.RECORD_TYPE]: {
+    targetsGetter: recordTypeReferences,
+  },
+}
+
+export const mapProfileOrPermissionSetSections = <T>(
+  profile: InstanceElement,
+  f: (
+    sectionName: string,
+    sectionEntryKey: string,
+    target: ElemID,
+    sourceField?: string,
+  ) => T,
+): T[] =>
+  Object.entries(sectionsReferenceParams).flatMap(([sectionName, params]) =>
+    mapSectionEntries(
+      profile,
+      sectionName as section,
+      params,
+      _.curry(f)(sectionName),
+    ),
+  )
+
+const profileEntriesTargets = (
+  profile: InstanceElement,
+): _.Dictionary<ElemID> =>
+  _(
+    mapProfileOrPermissionSetSections(
+      profile,
+      (sectionName, sectionEntryKey, target, sourceField): [string, ElemID] => [
+        [sectionName, sectionEntryKey, ...makeArray(sourceField)].join('.'),
+        target,
+      ],
+    ),
+  )
+    .fromPairs()
+    .value()
+
+export const removeWeakReferencesFromProfilesOrPermissionSets = async (
+  profilesOrPermissionSets: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+): ReturnType<FixElementsFunc> => {
+  const removeBrokenReferencesFromProfileOrPermissionSet = (
+    profile: InstanceElement,
+    brokenReferenceFields: string[],
+    elemIdGetter: (fieldName: string) => ElemID,
+  ): ChangeError => {
+    const profileBrokenReferenceFields = brokenReferenceFields
+      .filter((field) => _(profile.value).has(field))
+      .map((field) => elemIdGetter(field).getFullName())
+      .sort()
+
+    log.trace(
+      `Removing ${profileBrokenReferenceFields.length} broken references from ${profile.elemID.getFullName()}: ${profileBrokenReferenceFields.join(
+        ', ',
+      )}`,
+    )
+
+    return {
+      elemID: profile.elemID,
+      severity: 'Info' as const,
+      message: 'Dropping profile fields which reference missing types',
+      detailedMessage: `The profile has ${profileBrokenReferenceFields.length} fields which reference types which are not available in the workspace.`,
+    }
+  }
+  const entriesTargets: _.Dictionary<ElemID> = _.merge(
+    {},
+    ...profilesOrPermissionSets.map(profileEntriesTargets),
+  )
+  const elementNames = new Set(
+    await awu(await elementsSource.list())
+      .map((elemID) => elemID.getFullName())
+      .toArray(),
+  )
+  const brokenReferenceFields = Object.keys(
+    await pickAsync(
+      entriesTargets,
+      async (target) => !elementNames.has(target.getFullName()),
+    ),
+  )
+  const profilesWithBrokenReferences = profilesOrPermissionSets.filter(
+    (profile) =>
+      brokenReferenceFields.some((field) => _(profile.value).has(field)),
+  )
+  const fixedElements = profilesWithBrokenReferences.map((profile) => {
+    const fixed = profile.clone()
+    fixed.value = _.omit(fixed.value, brokenReferenceFields)
+    return fixed
+  })
+  const errors = profilesWithBrokenReferences.map((profile) =>
+    removeBrokenReferencesFromProfileOrPermissionSet(
+      profile,
+      brokenReferenceFields,
+      (fieldName) => entriesTargets[fieldName],
+    ),
+  )
+  return { fixedElements, errors }
+}

--- a/packages/salesforce-adapter/src/custom_references/profile_permission_set_utils.ts
+++ b/packages/salesforce-adapter/src/custom_references/profile_permission_set_utils.ts
@@ -74,18 +74,18 @@ type ReferenceFromSectionParams = {
 }
 
 const mapSectionEntries = <T>(
-  profile: InstanceElement,
+  profileOrPermissionSet: InstanceElement,
   sectionName: section,
   { filter = () => true, targetsGetter }: ReferenceFromSectionParams,
   f: (sectionEntryKey: string, target: ElemID, sourceField?: string) => T,
 ): T[] => {
-  const sectionValue = profile.value[sectionName]
+  const sectionValue = profileOrPermissionSet.value[sectionName]
   if (!_.isPlainObject(sectionValue)) {
     if (sectionValue !== undefined) {
       log.warn(
         'Section %s of %s is not an object, skipping.',
         sectionName,
-        profile.elemID,
+        profileOrPermissionSet.elemID,
       )
     }
     return []

--- a/packages/salesforce-adapter/src/custom_references/profiles.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles.ts
@@ -14,266 +14,19 @@
  * limitations under the License.
  */
 
-import _, { Dictionary } from 'lodash'
-import { collections, promises } from '@salto-io/lowerdash'
+import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import {
-  Element,
-  ElemID,
-  InstanceElement,
-  ReferenceInfo,
-  Values,
-} from '@salto-io/adapter-api'
+import { Element, InstanceElement, ReferenceInfo } from '@salto-io/adapter-api'
 import { WeakReferencesHandler } from '../types'
-import {
-  APEX_CLASS_METADATA_TYPE,
-  APEX_PAGE_METADATA_TYPE,
-  API_NAME_SEPARATOR,
-  CUSTOM_APPLICATION_METADATA_TYPE,
-  SALESFORCE,
-  FLOW_METADATA_TYPE,
-  LAYOUT_TYPE_ID_METADATA_TYPE,
-  PROFILE_METADATA_TYPE,
-  RECORD_TYPE_METADATA_TYPE,
-} from '../constants'
-import { Types } from '../transformers/transformer'
+import { PROFILE_METADATA_TYPE } from '../constants'
 import { isInstanceOfTypeSync } from '../filters/utils'
+import {
+  mapProfileOrPermissionSetSections,
+  removeWeakReferencesFromProfilesOrPermissionSets,
+} from './profile_permission_set_utils'
 
 const { makeArray } = collections.array
-const { awu } = collections.asynciterable
-const { pickAsync } = promises.object
 const log = logger(module)
-
-enum section {
-  APEX_CLASS = 'classAccesses',
-  APEX_PAGE = 'pageAccesses',
-  APP_VISIBILITY = 'applicationVisibilities',
-  FIELD_PERMISSIONS = 'fieldPermissions',
-  FLOW = 'flowAccesses',
-  LAYOUTS = 'layoutAssignments',
-  OBJECT = 'objectPermissions',
-  RECORD_TYPE = 'recordTypeVisibilities',
-}
-
-const FIELD_NO_ACCESS = 'NoAccess'
-
-const getMetadataElementName = (fullName: string): string =>
-  Types.getElemId(fullName.replace(API_NAME_SEPARATOR, '_'), true).name
-
-type ReferenceInSection = {
-  sourceField?: string
-  target: ElemID
-}
-
-type RefTargetsGetter = (
-  sectionEntry: Values,
-  sectionEntryKey: string,
-) => ReferenceInSection[]
-
-type ReferenceFromSectionParams = {
-  filter?: (sectionEntry: Values) => boolean
-  targetsGetter: RefTargetsGetter
-}
-
-const mapSectionEntries = <T>(
-  profile: InstanceElement,
-  sectionName: section,
-  { filter = () => true, targetsGetter }: ReferenceFromSectionParams,
-  f: (sectionEntryKey: string, target: ElemID, sourceField?: string) => T,
-): T[] => {
-  const sectionValue = profile.value[sectionName]
-  if (!_.isPlainObject(sectionValue)) {
-    if (sectionValue !== undefined) {
-      log.warn(
-        'Section %s of %s is not an object, skipping.',
-        sectionName,
-        profile.elemID,
-      )
-    }
-    return []
-  }
-  return Object.entries(sectionValue as Values)
-    .filter(([, sectionEntry]) => filter(sectionEntry))
-    .flatMap(([sectionEntryKey, sectionEntry]) => {
-      const targets = targetsGetter(sectionEntry, sectionEntryKey)
-      return targets.map(({ target, sourceField }) =>
-        f(sectionEntryKey, target, sourceField),
-      )
-    })
-}
-
-const isEnabled = (sectionEntry: Values): boolean =>
-  sectionEntry.enabled === true
-
-const isAnyAccessEnabledForObject = (
-  objectAccessSectionEntry: Values,
-): boolean =>
-  [
-    objectAccessSectionEntry.allowCreate,
-    objectAccessSectionEntry.allowDelete,
-    objectAccessSectionEntry.allowEdit,
-    objectAccessSectionEntry.allowRead,
-    objectAccessSectionEntry.modifyAllRecords,
-    objectAccessSectionEntry.viewAllRecords,
-  ].some((permission) => permission === true)
-
-const isAnyAccessEnabledForField = (
-  fieldPermissionsSectionEntry: Values,
-): boolean =>
-  Object.values(fieldPermissionsSectionEntry).some(
-    (val) => val !== FIELD_NO_ACCESS,
-  )
-
-const referenceToInstance =
-  (fieldName: string, targetType: string): RefTargetsGetter =>
-  (sectionEntry) => {
-    if (!_.isString(sectionEntry[fieldName])) {
-      return []
-    }
-    const elemIdName = getMetadataElementName(sectionEntry[fieldName])
-    return [
-      {
-        target: Types.getElemId(targetType, false).createNestedID(
-          'instance',
-          elemIdName,
-        ),
-      },
-    ]
-  }
-
-const referenceToType =
-  (fieldName: string): RefTargetsGetter =>
-  (sectionEntry) => {
-    if (!_.isString(sectionEntry[fieldName])) {
-      return []
-    }
-    return [
-      {
-        target: Types.getElemId(sectionEntry[fieldName], true),
-      },
-    ]
-  }
-
-const referencesToFields: RefTargetsGetter = (
-  sectionEntry,
-  sectionEntryKey,
-) => {
-  const typeElemId = Types.getElemId(sectionEntryKey, true)
-  return Object.entries(sectionEntry)
-    .filter(([, fieldAccess]) => fieldAccess !== FIELD_NO_ACCESS)
-    .map(([fieldName]) => ({
-      target: typeElemId.createNestedID(
-        'field',
-        getMetadataElementName(fieldName),
-      ),
-      sourceField: fieldName,
-    }))
-}
-
-const layoutReferences: RefTargetsGetter = (sectionEntry) => {
-  if (!_.isString(sectionEntry[0]?.layout)) {
-    return []
-  }
-  const layoutElemIdName = getMetadataElementName(sectionEntry[0].layout)
-  const layoutRef = {
-    target: new ElemID(
-      SALESFORCE,
-      LAYOUT_TYPE_ID_METADATA_TYPE,
-      'instance',
-      layoutElemIdName,
-    ),
-  }
-
-  const recordTypeRefs = sectionEntry
-    .filter((layoutAssignment: Values) =>
-      _.isString(layoutAssignment.recordType),
-    )
-    .map((layoutAssignment: Values) => ({
-      target: new ElemID(
-        SALESFORCE,
-        RECORD_TYPE_METADATA_TYPE,
-        'instance',
-        getMetadataElementName(layoutAssignment.recordType),
-      ),
-    }))
-
-  return [layoutRef].concat(recordTypeRefs)
-}
-
-const recordTypeReferences: RefTargetsGetter = (sectionEntry) =>
-  Object.entries(sectionEntry)
-    .filter(
-      ([, recordTypeVisibility]) =>
-        recordTypeVisibility.default === true ||
-        recordTypeVisibility.visible === true,
-    )
-    .filter(([, recordTypeVisibility]) =>
-      _.isString(recordTypeVisibility.recordType),
-    )
-    .map(([recordTypeVisibilityKey, recordTypeVisibility]) => ({
-      target: new ElemID(
-        SALESFORCE,
-        RECORD_TYPE_METADATA_TYPE,
-        'instance',
-        getMetadataElementName(recordTypeVisibility.recordType),
-      ),
-      sourceField: recordTypeVisibilityKey,
-    }))
-
-const sectionsReferenceParams: Record<section, ReferenceFromSectionParams> = {
-  [section.APP_VISIBILITY]: {
-    filter: (appVisibilityEntry) =>
-      appVisibilityEntry.default || appVisibilityEntry.visible,
-    targetsGetter: referenceToInstance(
-      'application',
-      CUSTOM_APPLICATION_METADATA_TYPE,
-    ),
-  },
-  [section.APEX_CLASS]: {
-    filter: isEnabled,
-    targetsGetter: referenceToInstance('apexClass', APEX_CLASS_METADATA_TYPE),
-  },
-  [section.FLOW]: {
-    filter: isEnabled,
-    targetsGetter: referenceToInstance('flow', FLOW_METADATA_TYPE),
-  },
-  [section.APEX_PAGE]: {
-    filter: isEnabled,
-    targetsGetter: referenceToInstance('apexPage', APEX_PAGE_METADATA_TYPE),
-  },
-  [section.OBJECT]: {
-    filter: isAnyAccessEnabledForObject,
-    targetsGetter: referenceToType('object'),
-  },
-  [section.FIELD_PERMISSIONS]: {
-    filter: isAnyAccessEnabledForField,
-    targetsGetter: referencesToFields,
-  },
-  [section.LAYOUTS]: {
-    targetsGetter: layoutReferences,
-  },
-  [section.RECORD_TYPE]: {
-    targetsGetter: recordTypeReferences,
-  },
-}
-
-export const mapProfileOrPermissionSetSections = <T>(
-  profile: InstanceElement,
-  f: (
-    sectionName: string,
-    sectionEntryKey: string,
-    target: ElemID,
-    sourceField?: string,
-  ) => T,
-): T[] =>
-  Object.entries(sectionsReferenceParams).flatMap(([sectionName, params]) =>
-    mapSectionEntries(
-      profile,
-      sectionName as section,
-      params,
-      _.curry(f)(sectionName),
-    ),
-  )
 
 const referencesFromProfile = (profile: InstanceElement): ReferenceInfo[] =>
   mapProfileOrPermissionSetSections(
@@ -305,69 +58,17 @@ const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
   return refs
 }
 
-const profileEntriesTargets = (profile: InstanceElement): Dictionary<ElemID> =>
-  _(
-    mapProfileOrPermissionSetSections(
-      profile,
-      (sectionName, sectionEntryKey, target, sourceField): [string, ElemID] => [
-        [sectionName, sectionEntryKey, ...makeArray(sourceField)].join('.'),
-        target,
-      ],
-    ),
-  )
-    .fromPairs()
-    .value()
-
 const removeWeakReferences: WeakReferencesHandler['removeWeakReferences'] =
   ({ elementsSource }) =>
   async (elements) => {
     const profiles = elements.filter(
       isInstanceOfTypeSync(PROFILE_METADATA_TYPE),
     )
-    const entriesTargets: Dictionary<ElemID> = _.merge(
-      {},
-      ...profiles.map(profileEntriesTargets),
-    )
-    const elementNames = new Set(
-      await awu(await elementsSource.list())
-        .map((elemID) => elemID.getFullName())
-        .toArray(),
-    )
-    const brokenReferenceFields = Object.keys(
-      await pickAsync(
-        entriesTargets,
-        async (target) => !elementNames.has(target.getFullName()),
-      ),
-    )
-    const profilesWithBrokenReferences = profiles.filter((profile) =>
-      brokenReferenceFields.some((field) => _(profile.value).has(field)),
-    )
-    const fixedElements = profilesWithBrokenReferences.map((profile) => {
-      const fixed = profile.clone()
-      fixed.value = _.omit(fixed.value, brokenReferenceFields)
-      return fixed
-    })
-    const errors = profilesWithBrokenReferences.map((profile) => {
-      const profileBrokenReferenceFields = brokenReferenceFields
-        .filter((field) => _(profile.value).has(field))
-        .map((field) => entriesTargets[field].getFullName())
-        .sort()
 
-      log.trace(
-        `Removing ${profileBrokenReferenceFields.length} broken references from ${profile.elemID.getFullName()}: ${profileBrokenReferenceFields.join(
-          ', ',
-        )}`,
-      )
-
-      return {
-        elemID: profile.elemID,
-        severity: 'Info' as const,
-        message: 'Dropping profile fields which reference missing types',
-        detailedMessage: `The profile has ${profileBrokenReferenceFields.length} fields which reference types which are not available in the workspace.`,
-      }
-    })
-
-    return { fixedElements, errors }
+    return removeWeakReferencesFromProfilesOrPermissionSets(
+      profiles,
+      elementsSource,
+    )
   }
 
 export const profilesHandler: WeakReferencesHandler = {

--- a/packages/salesforce-adapter/test/custom_references/profiles.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/profiles.test.ts
@@ -38,11 +38,12 @@ import { createCustomObjectType, createMetadataTypeElement } from '../utils'
 import { profilesHandler } from '../../src/custom_references/profiles'
 
 describe('profiles', () => {
+  let profileInstance: InstanceElement
+  const createTestInstance = (fields: Values): InstanceElement =>
+    new InstanceElement('test', mockTypes.Profile, fields)
+
   describe('weak references handler', () => {
     let refs: ReferenceInfo[]
-    let profileInstance: InstanceElement
-    const createTestInstance = (fields: Values): InstanceElement =>
-      new InstanceElement('test', mockTypes.Profile, fields)
 
     describe('fields', () => {
       describe('when the fields are inaccessible', () => {
@@ -814,69 +815,70 @@ describe('profiles', () => {
   })
 
   describe('fix elements', () => {
-    const profileInstance = new InstanceElement('test', mockTypes.Profile, {
-      fieldPermissions: {
-        Account: {
-          testField__c: 'ReadWrite',
-        },
-      },
-      applicationVisibilities: {
-        SomeApplication: {
-          application: 'SomeApplication',
-          default: true,
-          visible: true,
-        },
-      },
-      classAccesses: {
-        SomeApexClass: {
-          apexClass: 'SomeApexClass',
-          enabled: true,
-        },
-      },
-      flowAccesses: {
-        SomeFlow: {
-          enabled: true,
-          flow: 'SomeFlow',
-        },
-      },
-      layoutAssignments: {
-        'Account_Account_Layout@bs': [
-          {
-            layout: 'Account-Account Layout',
-          },
-        ],
-      },
-      objectPermissions: {
-        Account: {
-          allowCreate: true,
-          allowDelete: true,
-          allowEdit: true,
-          allowRead: true,
-          modifyAllRecords: false,
-          object: 'Account',
-          viewAllRecords: false,
-        },
-      },
-      pageAccesses: {
-        SomeApexPage: {
-          apexPage: 'SomeApexPage',
-          enabled: true,
-        },
-      },
-      recordTypeVisibilities: {
-        Case: {
-          SomeCaseRecordType: {
-            default: true,
-            recordType: 'Case.SomeCaseRecordType',
-            visible: false,
-          },
-        },
-      },
-    })
     let fixElementsFunc: FixElementsFunc
 
     describe('when references are missing', () => {
       beforeEach(() => {
+        profileInstance = createTestInstance({
+          fieldPermissions: {
+            Account: {
+              testField__c: 'ReadWrite',
+            },
+          },
+          applicationVisibilities: {
+            SomeApplication: {
+              application: 'SomeApplication',
+              default: true,
+              visible: true,
+            },
+          },
+          classAccesses: {
+            SomeApexClass: {
+              apexClass: 'SomeApexClass',
+              enabled: true,
+            },
+          },
+          flowAccesses: {
+            SomeFlow: {
+              enabled: true,
+              flow: 'SomeFlow',
+            },
+          },
+          layoutAssignments: {
+            'Account_Account_Layout@bs': [
+              {
+                layout: 'Account-Account Layout',
+              },
+            ],
+          },
+          objectPermissions: {
+            Account: {
+              allowCreate: true,
+              allowDelete: true,
+              allowEdit: true,
+              allowRead: true,
+              modifyAllRecords: false,
+              object: 'Account',
+              viewAllRecords: false,
+            },
+          },
+          pageAccesses: {
+            SomeApexPage: {
+              apexPage: 'SomeApexPage',
+              enabled: true,
+            },
+          },
+          recordTypeVisibilities: {
+            Case: {
+              SomeCaseRecordType: {
+                default: true,
+                recordType: 'Case.SomeCaseRecordType',
+                visible: false,
+              },
+            },
+          },
+        })
+
         const elementsSource = buildElementsSourceFromElements([])
         fixElementsFunc = profilesHandler.removeWeakReferences({
           elementsSource,
@@ -983,7 +985,7 @@ describe('profiles', () => {
           profileInstance,
         ])
         expect(fixedElements).toEqual([
-          new InstanceElement('test', mockTypes.Profile, {
+          createTestInstance({
             fieldPermissions: {
               Account: {},
             },


### PR DESCRIPTION
Implement `fixElements` for permission sets by reusing the code from profiles. Move common code to a shared utils file. Add unit tests and refactor the profiles tests a bit.

---


---
_Release Notes_: 
N/A

---
_User Notifications_: 
N/A