### PR TITLE
SALTO-5944: Avoid logging buffers in getResource

### DIFF
--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -265,13 +265,14 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<Credential
       const httpClient = axios.create({ url })
       const response = await httpClient.get(url, { responseType })
       const { data, status } = response
-      log.debug('Received response for resource request %s with status %d', url, status)
       log.trace(
-        'Full HTTP response for resource %s: %s',
+        'Full HTTP response for GET on %s: %s',
         url,
         safeJsonStringify({
           url,
-          response: data,
+          status,
+          responseType,
+          response: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
         }),
       )
       return {

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -214,13 +214,14 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
           }
         : undefined
       const { data, status } = await this.resourceClient.get(url, requestConfig)
-      log.debug('Received response for resource request %s with status %d', url, status)
       log.trace(
-        'Full HTTP response for resource %s: %s',
+        'Full HTTP response for GET on %s: %s',
         url,
         safeJsonStringify({
           url,
-          response: data,
+          status,
+          requestConfig,
+          response: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
         }),
       )
       return {


### PR DESCRIPTION
only log buffer length instead of response data
also removed the debug log as I think it kind of a dup I but can return it

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
