### PR TITLE
SALTO-5945: add references between workflowV2 action to Resolution and Priority

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -131,6 +131,7 @@ export type ReferenceContextStrategyName =
   | 'parentFieldType'
   | 'workflowStatusPropertiesContext'
   | 'parentFieldId'
+  | 'parentField'
   | 'gadgetPropertyValue'
   | 'referenceTypeTypeName'
 
@@ -144,6 +145,10 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
   workflowStatusPropertiesContext: neighborContextFunc({ contextFieldName: 'key', contextValueMapper: getRefType }),
   parentFieldId: neighborContextFunc({
     contextFieldName: 'fieldId',
+    contextValueMapper: resolutionAndPriorityToTypeName,
+  }),
+  parentField: neighborContextFunc({
+    contextFieldName: 'field',
     contextValueMapper: resolutionAndPriorityToTypeName,
   }),
   gadgetPropertyValue: gadgetValuesContextFunc,
@@ -426,6 +431,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'groupId',
     missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_TYPE_NAME },
+  },
+  {
+    src: { field: 'value', parentTypes: ['WorkflowRuleConfiguration_parameters'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { typeContext: 'parentField' },
   },
   {
     src: { field: 'customIssueEventId', parentTypes: ['WorkflowTransitions'] },


### PR DESCRIPTION
_add references between workflowV2 action to Resolution and Priority_

---

_Additional context for reviewer_
before:
<img width="743" alt="Screen Shot 2024-05-19 at 11 16 17" src="https://github.com/salto-io/salto/assets/77064001/584fd519-875e-4ee7-88a8-9d66a27eb30b">

after:
<img width="713" alt="Screen Shot 2024-05-19 at 11 12 16" src="https://github.com/salto-io/salto/assets/77064001/17228eb3-ced1-45f7-ad9e-94e438157820">


---
_Release Notes_: 
Jira Adapter:
* add a reference from WorkflowConfiguration (new Workflow API) action to Resolution and Priority

---
_User Notifications_: 
_None_
