### PR TITLE
SALTO-5850 add missing data instances reference names

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -56,6 +56,7 @@ import removeUnsupportedTypes from './filters/remove_unsupported_types'
 import dataInstancesInternalId from './filters/data_instances_internal_id'
 import dataAccountSpecificValues from './filters/data_account_specific_values'
 import dataInstancesReferences from './filters/data_instances_references'
+import dataInstancesReferenceNames from './filters/data_instances_reference_names'
 import dataTypesCustomFields from './filters/data_types_custom_fields'
 import dataInstancesCustomFields from './filters/data_instances_custom_fields'
 import dataInstancesAttributes from './filters/data_instances_attributes'
@@ -185,6 +186,8 @@ export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefi
   { creator: dataInstancesNullFields },
   { creator: removeUnsupportedTypes },
   { creator: dataInstancesReferences },
+  // dataInstancesReferenceNames must run after dataInstancesReferences and before dataAccountSpecificValues
+  { creator: dataInstancesReferenceNames, addsNewInformation: true },
   { creator: dataInstancesInternalId },
   { creator: dataAccountSpecificValues },
   { creator: suiteAppInternalIds },

--- a/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
@@ -1,0 +1,102 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import NetsuiteClient from '../client/client'
+import { RemoteFilterCreator } from '../filter'
+import { INTERNAL_ID, NAME_FIELD } from '../constants'
+
+const log = logger(module)
+
+const { awu } = collections.asynciterable
+const { makeArray } = collections.array
+
+type ReferenceNameParams = {
+  typeName: string
+  fieldName: string
+  suiteQLTableName: string
+}
+
+const REFERENCE_NAMES_PARAMS: ReferenceNameParams[] = [
+  {
+    typeName: 'account',
+    fieldName: 'restrictToAccountingBookList',
+    suiteQLTableName: 'accountingbook',
+  },
+]
+
+const querySuiteQLTable = async (
+  client: NetsuiteClient,
+  tableName: string,
+  internalIds: string[],
+): Promise<Record<string, string>> => {
+  const results = await client.runSuiteQL(`SELECT id, name FROM ${tableName} WHERE id IN (${internalIds.join(', ')})`)
+  if (results === undefined) {
+    log.warn('failed quering internal id to name mapping in table %s', tableName)
+    return {}
+  }
+  const validResults = results.flatMap(res => {
+    const { id, name } = res
+    if (typeof id === 'string' && id !== '' && typeof name === 'string' && name !== '') {
+      return { id, name }
+    }
+    log.warn('ignoring invalid result from table %s: %o', tableName, res)
+    return []
+  })
+  return Object.fromEntries(validResults.map(({ id, name }) => [id, name]))
+}
+
+const addMissingReferenceNames = async (
+  instances: InstanceElement[],
+  params: ReferenceNameParams,
+  client: NetsuiteClient,
+): Promise<void> => {
+  const referencesWithoutName = instances
+    .filter(instance => instance.elemID.typeName === params.typeName)
+    .flatMap(instance => makeArray(instance.value[params.fieldName]))
+    .filter(ref => _.isPlainObject(ref) && ref[INTERNAL_ID] !== undefined && ref[NAME_FIELD] === undefined)
+
+  if (referencesWithoutName.length === 0) {
+    return
+  }
+  const internalIdsToQuery: string[] = _.uniq(referencesWithoutName.map(ref => ref[INTERNAL_ID]))
+  const internalIdToName = await querySuiteQLTable(client, params.suiteQLTableName, internalIdsToQuery)
+  referencesWithoutName.forEach(ref => {
+    const name = internalIdToName[ref[INTERNAL_ID]]
+    if (name !== undefined) {
+      ref[NAME_FIELD] = name
+    } else {
+      log.warn(
+        'could not find name of reference with internal id %s in table %s',
+        ref[INTERNAL_ID],
+        params.suiteQLTableName,
+      )
+    }
+  })
+}
+
+const filterCreator: RemoteFilterCreator = ({ client }) => ({
+  name: 'dataInstancesReferenceNames',
+  remote: true,
+  onFetch: async elements => {
+    const instances = elements.filter(isInstanceElement)
+    await awu(REFERENCE_NAMES_PARAMS).forEach(params => addMissingReferenceNames(instances, params, client))
+  },
+})
+
+export default filterCreator

--- a/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
@@ -23,7 +23,6 @@ import { INTERNAL_ID, NAME_FIELD } from '../constants'
 
 const log = logger(module)
 
-const { awu } = collections.asynciterable
 const { makeArray } = collections.array
 
 type ReferenceNameParams = {
@@ -95,7 +94,7 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
   remote: true,
   onFetch: async elements => {
     const instances = elements.filter(isInstanceElement)
-    await awu(REFERENCE_NAMES_PARAMS).forEach(params => addMissingReferenceNames(instances, params, client))
+    await Promise.all(REFERENCE_NAMES_PARAMS.map(params => addMissingReferenceNames(instances, params, client)))
   },
 })
 

--- a/packages/netsuite-adapter/src/filters/replace_record_ref.ts
+++ b/packages/netsuite-adapter/src/filters/replace_record_ref.ts
@@ -25,11 +25,8 @@ import {
   TypeElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { collections } from '@salto-io/lowerdash'
 import { EMPLOYEE, NETSUITE, PARENT, RECORD_REF } from '../constants'
 import { LocalFilterCreator } from '../filter'
-
-const { awu } = collections.asynciterable
 
 const fieldNameToTypeName: Record<string, string | undefined> = {
   taxEngine: undefined,
@@ -431,6 +428,7 @@ const filterCreator: LocalFilterCreator = () => ({
   name: 'replaceRecordRef',
   onFetch: async elements => {
     const recordRefElemId = new ElemID(NETSUITE, RECORD_REF)
+    const recordRefListElemId = new ElemID(NETSUITE, 'recordRefList')
 
     const recordRefType = elements.filter(isObjectType).find(e => e.elemID.isEqual(recordRefElemId))
     if (recordRefType === undefined) {
@@ -444,26 +442,22 @@ const filterCreator: LocalFilterCreator = () => ({
     const containers = elements.filter(isContainerType)
     const typeMap = _.keyBy([...types, ...primitives, ...containers], e => e.elemID.name)
 
-    await awu(types).forEach(async element => {
-      element.fields = Object.fromEntries(
-        await awu(Object.entries(element.fields))
-          .map(async ([name, field]) => {
-            let newField = field
-            const fieldRealType = getFieldType(element, field, typeMap)
-            if (fieldRealType !== undefined) {
-              if ((await field.getType()).elemID.isEqual(recordRefElemId)) {
-                newField = new Field(element, name, fieldRealType, { ...field.annotations, isReference: true })
-              }
-              if ((await field.getType()).elemID.isEqual(new ElemID(NETSUITE, 'recordRefList'))) {
-                newField = new Field(element, name, new ListType(fieldRealType), {
-                  ...field.annotations,
-                  isReference: true,
-                })
-              }
+    types.forEach(type => {
+      type.fields = Object.fromEntries(
+        Object.values(type.fields)
+          .map(field => {
+            const fieldType = field.getTypeSync()
+            const fieldRealType = getFieldType(type, field, typeMap)
+            const refFieldAnnotations = { ...field.annotations, isReference: true }
+            if (fieldRealType !== undefined && fieldType.elemID.isEqual(recordRefElemId)) {
+              return new Field(type, field.name, fieldRealType, refFieldAnnotations)
             }
-            return [name, newField]
+            if (fieldType.elemID.isEqual(recordRefListElemId)) {
+              return new Field(type, field.name, new ListType(fieldRealType ?? recordRefType), refFieldAnnotations)
+            }
+            return field
           })
-          .toArray(),
+          .map(field => [field.name, field]),
       )
     })
   },

--- a/packages/netsuite-adapter/test/filters/data_instances_reference_names.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_reference_names.test.ts
@@ -1,0 +1,76 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/data_instances_reference_names'
+import { NETSUITE } from '../../src/constants'
+import { RemoteFilterOpts } from '../../src/filter'
+
+const runSuiteQLMock = jest.fn()
+
+describe('data isntances reference names filter', () => {
+  let accountInstance: InstanceElement
+
+  const filterOpts = {
+    client: {
+      runSuiteQL: runSuiteQLMock,
+    },
+  } as unknown as RemoteFilterOpts
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    accountInstance = new InstanceElement('account123', new ObjectType({ elemID: new ElemID(NETSUITE, 'account') }), {
+      restrictToAccountingBookList: [
+        {
+          internalId: '1',
+        },
+      ],
+    })
+  })
+
+  it('should set reference name', async () => {
+    runSuiteQLMock.mockResolvedValue([
+      { id: '1', name: 'accountingBook1' },
+      // filtered corrupted result
+      { id: '2' },
+    ])
+    await filterCreator(filterOpts).onFetch?.([accountInstance])
+    expect(accountInstance.value.restrictToAccountingBookList).toEqual([
+      {
+        internalId: '1',
+        name: 'accountingBook1',
+      },
+    ])
+  })
+  it('should not query if there are no missing reference names', async () => {
+    accountInstance.value.restrictToAccountingBookList = [
+      {
+        internalId: '1',
+        name: 'accountingBook1',
+      },
+    ]
+    await filterCreator(filterOpts).onFetch?.([accountInstance])
+    expect(runSuiteQLMock).not.toHaveBeenCalled()
+  })
+  it('should not set reference name if query result is undefined', async () => {
+    runSuiteQLMock.mockResolvedValue(undefined)
+    await filterCreator(filterOpts).onFetch?.([accountInstance])
+    expect(accountInstance.value.restrictToAccountingBookList).toEqual([
+      {
+        internalId: '1',
+      },
+    ])
+  })
+})

--- a/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
+++ b/packages/netsuite-adapter/test/filters/replace_record_ref.test.ts
@@ -20,6 +20,7 @@ import { LocalFilterOpts } from '../../src/filter'
 
 describe('replaceRecordRef', () => {
   let recordRefType: ObjectType
+  let recordRefListType: ObjectType
   let typeWithRecordRef: ObjectType
   let elements: TypeElement[]
   const departmentType = new ObjectType({ elemID: new ElemID(NETSUITE, 'department') })
@@ -27,16 +28,18 @@ describe('replaceRecordRef', () => {
 
   beforeEach(() => {
     recordRefType = new ObjectType({ elemID: new ElemID(NETSUITE, 'recordRef') })
+    recordRefListType = new ObjectType({ elemID: new ElemID(NETSUITE, 'recordRefList') })
     typeWithRecordRef = new ObjectType({
       elemID: new ElemID(NETSUITE, 'typeWithRecordRef'),
       fields: {
         department: { refType: recordRefType },
         parent: { refType: recordRefType },
-        subsidiaryList: { refType: new ObjectType({ elemID: new ElemID(NETSUITE, 'recordRefList') }) },
+        subsidiaryList: { refType: recordRefListType },
         recordRef: { refType: recordRefType },
+        recordRefList: { refType: recordRefListType },
       },
     })
-    elements = [typeWithRecordRef, recordRefType, departmentType, subsidiaryType]
+    elements = [typeWithRecordRef, recordRefType, recordRefListType, departmentType, subsidiaryType]
   })
 
   it('should add field to record ref type', async () => {
@@ -52,5 +55,6 @@ describe('replaceRecordRef', () => {
     ).toBe('subsidiary')
     expect((await typeWithRecordRef.fields.parent.getType()).elemID.name).toBe('typeWithRecordRef')
     expect((await typeWithRecordRef.fields.recordRef.getType()).elemID.name).toBe('recordRef')
+    expect((await typeWithRecordRef.fields.recordRefList.getType()).elemID.name).toBe('List<netsuite.recordRef>')
   })
 })


### PR DESCRIPTION
Some references in data instances return with only `internalId` field, and without the `name` field. In those cases we currently set the value to "[ACCOUNT_SPEICIFIC_VALUE] (object) (unknown object)", but this way those instances aren't deployable (we don't know what is the internalId behind "unknown object").

This behavior happens only in specific fields. At this point there is only one field like that we saw with "unknown object" - `restrictToAccountingBookList` field in `account` instances, and we identify that this field is a list of "accounting book" records. Using SuiteQL we query the referenced "accounting book" records (only the referenced records) and we set the `name` field with the matching name of the "accounting book" (by its `internalId`). The filter is extendable to other fields & SuiteQL tables in the future.

Another change in this PR is that all fields that had the type `recordRefList` now have the type `List<netsuite.recordRef>` - and this clears the value of those fields in data instances.

**NOTE - this PR should be merged with communication to customers

---
_Release Notes_: 
Netsuite Adapter:
- add missing data instances reference names
- replace `recordRefList` field type with `List<netsuite.recordRef>` field type

---
_User Notifications_: 
Netsuite Adapter:
- the value of `restrictToAccountingBookList` in `account` instances will have the correct reference names, instead of "unknown object"
- `recordRefList` field type will be replaced with `List<netsuite.recordRef>` field type, in types and instances

_Example_
before:
```
type netsuite.account {
  ...
  netsuite.recordRefList restrictToAccountingBookList {
  }
}

netsuite.account account123 {
  ...
  restrictToAccountingBookList = {
    recordRef = [
      {
        id = "[ACCOUNT_SPECIFIC_VALUE] (object) (unknown object)"
      },
    ]
  }
}
```

after:
```
type netsuite.account {
  ...
  "List<netsuite.recordRef>" restrictToAccountingBookList {
    isReference = true
  }
}

netsuite.account account123 {
  ...
  restrictToAccountingBookList = [
    {
      id = "[ACCOUNT_SPECIFIC_VALUE] (object) (accounting book 123)"
    },
  ]
}
```