### PR TITLE
remove duplicate filter calls

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -143,14 +143,8 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 export const allFilters: (LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition)[] = [
-  // excludeCustomRecordTypes should run before customRecordTypesType,
-  // because otherwise there will be broken references to excluded types.
-  { creator: excludeCustomRecordTypes },
   { creator: restoreDeletedListItems },
   { creator: restoreDeletedListItemsWithoutScriptId },
-  // excludeCustomRecordTypes should run before customRecordTypesType,
-  // because otherwise there will be broken references to excluded types.
-  { creator: excludeCustomRecordTypes },
   { creator: customRecordTypesType },
   { creator: omitSdfUntypedValues },
   { creator: dataInstancesIdentifiers },


### PR DESCRIPTION
Remove duplicate filters, that were there probably because of a rebase mistake

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None