### PR TITLE
SALTO-5948: Allow throwing an error during the DAG walk

### DIFF
--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -645,9 +645,10 @@ describe('NodeMap', () => {
       })
 
       describe('when the handler throws a FatalError', () => {
-        const handlerMock = jest.fn()
+        let handlerMock: jest.Mock<void>
         let error: Error
         beforeEach(() => {
+          handlerMock = jest.fn()
           subject.addNode(5, [1])
           try {
             subject.walkSync((id: NodeId) => {
@@ -931,10 +932,11 @@ describe('NodeMap', () => {
       })
 
       describe('when the handler throws a FatalError', () => {
-        const handlerMock = jest.fn()
+        let handlerMock: jest.Mock<void>
         let error: Error
         let resolve: (value: void | PromiseLike<void>) => void
         beforeEach(async () => {
+          handlerMock = jest.fn()
           subject.addNode(6, [3])
           await subject
             .walkAsync(async (id: NodeId) => {


### PR DESCRIPTION
Currently, if we throw an error during the DAG walk, the error isn’t thrown immediately but is instead caught and only thrown as a combined error (containing all the errors that occurred) once the graph walk is complete. 
We want to optimize this behavior and allow certain errors to be thrown before the graph walk is complete. 

To achieve this, we have exposed a `FatalError` error class. If the handler throws such an error, then we throw and exit during the walk. It's important to note that for `walkAsync`, jobs that have already started will not be interrupted; however, the function will return with an error.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
