### PR TITLE
SALTO-5960: add mutex to handle async issues in contexts projects filter

### DIFF
--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -39,6 +39,7 @@
     "@salto-io/dag": "0.3.58",
     "@salto-io/logging": "0.3.58",
     "@salto-io/lowerdash": "0.3.58",
+    "async-mutex": "^0.5.0",
     "form-data": "^4.0.0",
     "joi": "^17.4.0",
     "lodash": "^4.17.21",


### PR DESCRIPTION
_add mutex to handle async issues in contexts projects filter_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
