### PR TITLE
SALTO-5962: Handle Undefined 'queues' Property in Queue Categories Response

### DIFF
--- a/packages/jira-adapter/src/filters/queue_fetch.ts
+++ b/packages/jira-adapter/src/filters/queue_fetch.ts
@@ -56,6 +56,7 @@ const QUEUES_CATAGORIES_RESPONSE_SCHEME = Joi.object({
           .required(),
       }).unknown(true),
     )
+    .min(1) // Ensure that the array has at least one item
     .required(),
 })
   .unknown(true)

--- a/packages/jira-adapter/test/filters/queue_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/queue_fetch.test.ts
@@ -131,5 +131,26 @@ describe('queueFetch filter', () => {
       await filter.onFetch([queueInstance])
       expect(queueInstance.value.jql).toEqual('assignee = currentUser() AND resolution = Unresolved')
     })
+    it('should not add canBeHidden and favourite fields if response has empty categories', async () => {
+      mockGet.mockImplementation(async params => {
+        if (params.url === '/rest/servicedesk/1/servicedesk/PROJ1/queues/categories') {
+          return {
+            status: 200,
+            data: {
+              categories: [],
+            },
+          }
+        }
+        return {
+          status: 200,
+          data: [],
+        }
+      })
+      await filter.onFetch([queueInstance])
+      expect(queueInstance.value.fields).toBeUndefined()
+      expect(queueInstance.value.columns).toEqual(['Summary'])
+      expect(queueInstance.value.canBeHidden).toBeUndefined()
+      expect(queueInstance.value.favourite).toBeUndefined()
+    })
   })
 })


### PR DESCRIPTION
In this PR I handled undefined 'queues' Property in Queue Categories Response

---

_Additional context for reviewer_
Context:
We encountered an issue where the schema guard did not prevent responses with an empty categories array. This resulted in an 'undefined' error when attempting to access the queues property of the response.

Problem:
When the categories array is empty, accessing categories[0].queues causes an error since categories[0] is undefined. The current schema guard was not sufficient to prevent this scenario, leading to runtime errors.

Changes:
Modified the schema guard to include a check ensuring the categories array is not empty.

---
_Release Notes_: 
_Jira Adapter:_
* Resolved an issue where the application could encounter an 'undefined' error due to an empty categories array in the queue categories response

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
