### PR TITLE
SALTO-5965: Pass spread request context to extractor context

### DIFF
--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -138,7 +138,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
       createExtractor(
         {
           ...requestDef,
-          context: { ...requestDef.context, context },
+          context: { ...requestDef.context, ...context },
         },
         typeName,
       )


### PR DESCRIPTION
we need to spread context otherwise real context will be nested twice under context

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
