### PR TITLE
SALTO-5890: Add logs for near limit visibility

### DIFF
--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -118,10 +118,16 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
 
   // eslint-disable-next-line class-methods-use-this
   protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
+    const rateLimitHeaders = 
+      _.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX))
+    if (rateLimitHeaders !== undefined && 
+      rateLimitHeaders['x-ratelimit-nearlimit']) {
+        log.trace('temp performance log, rate limit near limit reached')
+    }
     return headers !== undefined
       ? {
           ...super.extractHeaders(headers),
-          ..._.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX)),
+          ...rateLimitHeaders,
         }
       : undefined
   }

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -118,11 +118,9 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
 
   // eslint-disable-next-line class-methods-use-this
   protected extractHeaders(headers: Record<string, string> | undefined): Record<string, string> | undefined {
-    const rateLimitHeaders = 
-      _.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX))
-    if (rateLimitHeaders !== undefined && 
-      rateLimitHeaders['x-ratelimit-nearlimit']) {
-        log.trace('temp performance log, rate limit near limit reached')
+    const rateLimitHeaders = _.pickBy(headers, (_val, key) => key.toLowerCase().startsWith(RATE_LIMIT_HEADER_PREFIX))
+    if (rateLimitHeaders !== undefined && rateLimitHeaders['x-ratelimit-nearlimit']) {
+      log.trace('temp performance log, rate limit near limit reached')
     }
     return headers !== undefined
       ? {


### PR DESCRIPTION
Currently it is impossible to filter out which fetches receive the near limit header due to datadog limitation.
I added a temp log to make it more visible

---

The header is returned as "X-RateLimit-NearLimit":"false" or "X-RateLimit-NearLimit":"true"
As datadog [does not allow you to search for special chars in the message](https://docs.datadoghq.com/logs/explorer/search_syntax/#:~:text=You%20cannot%20search%20for%20special%20characters%20in%20a%20log%20message) and as "true" is a common word in API responses I added a temp log to understand where we stand with the near limit for different customers

---
_Release Notes_: 
None

---
_User Notifications_: 
None
