### PR TITLE
SALTO-5867 Google ws add e2e logs

### DIFF
--- a/packages/google-workspace-adapter/e2e_test/adapter.test.ts
+++ b/packages/google-workspace-adapter/e2e_test/adapter.test.ts
@@ -39,7 +39,7 @@ import {
   safeJsonStringify,
 } from '@salto-io/adapter-utils'
 import { fetch as fetchUtils, definitions as definitionsUtils } from '@salto-io/adapter-components'
-import { collections } from '@salto-io/lowerdash'
+import { collections, promises } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { CredsLease } from '@salto-io/e2e-credentials-store'
 import {
@@ -57,6 +57,8 @@ import { mockDefaultValues } from './mock_elements'
 import { createFetchDefinitions } from '../src/definitions'
 
 const { awu } = collections.asynciterable
+const { sleep } = promises.timeout
+
 const log = logger(module)
 
 jest.setTimeout(1000 * 60 * 10)
@@ -177,10 +179,18 @@ describe('Google Workspace adapter E2E', () => {
 
     const deployAndFetch = async (changes: Change[]): Promise<void> => {
       deployResults = await deployChanges(adapterAttr, changes)
+      await sleep(5000)
       const fetchResult = await adapterAttr.adapter.fetch({
         progressReporter: { reportProgress: () => null },
       })
       elements = fetchResult.elements
+      log.info(
+        'Fetched these Test elements: %o',
+        elements
+          .filter(isInstanceElement)
+          .filter(checkNameField)
+          .map(e => e.elemID.getFullName()),
+      )
       adapterAttr = realAdapter({
         credentials: credLease.value,
         elementsSource: buildElementsSourceFromElements(elements),


### PR DESCRIPTION
SALTO-5867 Google ws add e2e logs
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
