### PR TITLE
SALTO-5928: Using strong references for managed elements

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/managed_elements.ts
+++ b/packages/salesforce-adapter/src/custom_references/managed_elements.ts
@@ -41,7 +41,7 @@ const installedPackageReference = (
       'instance',
       naclCase(namespace),
     ]),
-    type: 'weak',
+    type: 'strong',
   }
 }
 

--- a/packages/salesforce-adapter/test/custom_references/managed_elements.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/managed_elements.test.ts
@@ -55,7 +55,7 @@ describe('managed elements', () => {
           {
             source: customObjectFromInstalledPackage.elemID,
             target: PACKAGE_ID,
-            type: 'weak',
+            type: 'strong',
           },
         ])
       })
@@ -91,7 +91,7 @@ describe('managed elements', () => {
             {
               source: customFieldFromInstalledPackage.elemID,
               target: PACKAGE_ID,
-              type: 'weak',
+              type: 'strong',
             },
           ])
         })
@@ -121,7 +121,7 @@ describe('managed elements', () => {
             {
               source: customMetadataFromInstalledPackage.elemID,
               target: PACKAGE_ID,
-              type: 'weak',
+              type: 'strong',
             },
           ])
         })
@@ -151,7 +151,7 @@ describe('managed elements', () => {
             {
               source: instanceFromInstalledPackage.elemID,
               target: PACKAGE_ID,
-              type: 'weak',
+              type: 'strong',
             },
           ])
         })

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -42,7 +42,7 @@ import { RemoteMap, RemoteMapEntry } from './remote_map'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-export const REFERENCE_INDEXES_VERSION = 8
+export const REFERENCE_INDEXES_VERSION = 9
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ChangeReferences = {


### PR DESCRIPTION
They should never have been weak.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce_:
* Using strong custom references for managed elements.

---
_User Notifications_: 
None.
