### PR TITLE
SALTO-5958: Moving generated dependencies filter to not be last

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -279,9 +279,9 @@ export const allFilters: Array<
   { creator: metadataInstancesAliasesFilter },
   { creator: importantValuesFilter },
   { creator: hideTypesFolder },
+  { creator: generatedDependenciesFilter },
   // createChangedAtSingletonInstanceFilter should run last
   { creator: changedAtSingletonFilter },
-  { creator: generatedDependenciesFilter },
 ]
 
 // By default we run all filters and provide a client


### PR DESCRIPTION
The comment says changed at singelton should be last.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
