### PR TITLE
SALTO-5972: Singleton type should be allowed to have no entries

### DIFF
--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -46,7 +46,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
     return elementDef?.topLevel?.custom(elementDef)(args)
   }
 
-  if (elementDef.topLevel.singleton && entries.length !== 1) {
+  if (elementDef.topLevel.singleton && entries.length > 1) {
     log.warn(`Expected one instance for singleton type: ${typeName} but received: ${entries.length}`)
     throw new InvalidSingletonType(
       `Could not fetch type ${typeName}, singleton types should not have more than one instance`,

--- a/packages/adapter-components/test/fetch/element/instance_element.test.ts
+++ b/packages/adapter-components/test/fetch/element/instance_element.test.ts
@@ -170,5 +170,33 @@ describe('instance element', () => {
       expect(Object.keys(res.types[0].fields).sort()).toEqual(['str', 'with_spaces@s'])
       expect(res.instances[0].value).toEqual({ str: 'A', 'with_spaces@s': 'a' })
     })
+    it('should return fetch warning when singleton type has more than one entry', () => {
+      expect(() =>
+        generateInstancesWithInitialTypes({
+          adapterName: 'myAdapter',
+          entries: [{ str: 'A' }, { str: 'B' }],
+          typeName: 'myType',
+          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+            customizations: { myType: { element: { topLevel: { isTopLevel: true, singleton: true } } } },
+          }),
+          customNameMappingFunctions: {},
+          definedTypes: {},
+        }),
+      ).toThrow('Could not fetch type myType, singleton types should not have more than one instance')
+    })
+    it('should not return fetch warning when there are no entries for singleton type', () => {
+      const res = generateInstancesWithInitialTypes({
+        adapterName: 'myAdapter',
+        entries: [],
+        typeName: 'myType',
+        defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+          customizations: { myType: { element: { topLevel: { isTopLevel: true, singleton: true } } } },
+        }),
+        customNameMappingFunctions: {},
+        definedTypes: {},
+      })
+      expect(res.errors).toBeUndefined()
+      expect(res.instances).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
Fixing inconsistency with the old infra 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
