### PR TITLE
SALTO-5279: Adding a new SFDC optional feature for latest supported API version

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -50,6 +50,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   importantValues: true,
   hideTypesFolder: false,
   omitStandardFieldsNonDeployableValues: true,
+  latestSupportedApiVersion: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -129,7 +129,7 @@ const enrichTypeWithFields = async (
 const createOrganizationType = (config: FilterContext): ObjectType =>
   new ObjectType({
     elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
-    fields: config.fetchProfile.isFeatureEnabled('hideTypesFolder')
+    fields: config.fetchProfile.isFeatureEnabled('latestSupportedApiVersion')
       ? {
           [LATEST_SUPPORTED_API_VERSION_FIELD]: {
             refType: BuiltinTypes.NUMBER,
@@ -231,7 +231,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
         queryResult[0],
       )
 
-      if (config.fetchProfile.isFeatureEnabled('hideTypesFolder')) {
+      if (config.fetchProfile.isFeatureEnabled('latestSupportedApiVersion')) {
         await addLatestSupportedAPIVersion(client, organizationInstance)
       }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -132,6 +132,7 @@ export type OptionalFeatures = {
   importantValues?: boolean
   hideTypesFolder?: boolean
   omitStandardFieldsNonDeployableValues?: boolean
+  latestSupportedApiVersion?: boolean
 }
 
 export type ChangeValidatorName =
@@ -859,6 +860,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     importantValues: { refType: BuiltinTypes.BOOLEAN },
     hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },
     omitStandardFieldsNonDeployableValues: { refType: BuiltinTypes.BOOLEAN },
+    latestSupportedApiVersion: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -36,7 +36,7 @@ describe('organization-wide defaults filter', () => {
   const filter = filterCreator({
     config: buildFilterContext({
       optionalFeatures: {
-        hideTypesFolder: true,
+        latestSupportedApiVersion: true,
       },
     }),
     client,
@@ -182,12 +182,12 @@ describe('organization-wide defaults filter', () => {
         },
       ])
     })
-    it('should not add LatestSupportedApiVersion when hideTypesFolder feature is disabled', async () => {
+    it('should not add LatestSupportedApiVersion when latestSupportedApiVersion feature is disabled', async () => {
       const elements: Element[] = []
       const filterWithFeatureDisabled = filterCreator({
         config: buildFilterContext({
           optionalFeatures: {
-            hideTypesFolder: false,
+            latestSupportedApiVersion: false,
           },
         }),
         client,


### PR DESCRIPTION
It was tied to the feature hiding the types folder but we don't want to wait for it.

---

Workspace diff: https://github.com/salto-io/ariel-sf/commit/3a41d13f4fd0a003f566a4472d634f8f85971a19
The `latestSupportedApiVersion` field is added to the Organization settings.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
