### PR TITLE
SALTO-5847 resolve ASV references of the taxSchedule field

### DIFF
--- a/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
@@ -26,7 +26,7 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, naclCase } from '@salto-io/adapter-utils'
-import { FILE, NETSUITE } from '../../src/constants'
+import { FILE, NETSUITE, RECORD_REF } from '../../src/constants'
 import { LocalFilterOpts } from '../../src/filter'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { fullFetchConfig } from '../../src/config/config_creator'
@@ -40,8 +40,10 @@ describe('data account specific values filter', () => {
   let dataType: ObjectType
   let accountType: ObjectType
   let fileType: ObjectType
+  let recordRefType: ObjectType
   let suiteQLTableType: ObjectType
   let suiteQLTableInstance: InstanceElement
+  let taxScheduleSuiteQLTableInstance: InstanceElement
   let unknownTypeReferencesType: ObjectType
   let existingUnknownTypeReferencesInstance: InstanceElement
   let filterOpts: LocalFilterOpts
@@ -49,11 +51,13 @@ describe('data account specific values filter', () => {
   beforeEach(async () => {
     accountType = new ObjectType({ elemID: new ElemID(NETSUITE, 'account') })
     fileType = new ObjectType({ elemID: new ElemID(NETSUITE, FILE) })
+    recordRefType = new ObjectType({ elemID: new ElemID(NETSUITE, RECORD_REF) })
     dataType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'someType'),
       fields: {
         accountField: { refType: accountType },
         fileField: { refType: fileType },
+        taxSchedule: { refType: recordRefType },
       },
       annotations: { source: 'soap' },
     })
@@ -61,6 +65,11 @@ describe('data account specific values filter', () => {
     suiteQLTableInstance = new InstanceElement('account', suiteQLTableType, {
       [INTERNAL_IDS_MAP]: {
         1: { name: 'Account 1' },
+      },
+    })
+    taxScheduleSuiteQLTableInstance = new InstanceElement('taxSchedule', suiteQLTableType, {
+      [INTERNAL_IDS_MAP]: {
+        1: { name: 'Tax Schedule 1' },
       },
     })
     unknownTypeReferencesType = new ObjectType({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID })
@@ -118,8 +127,11 @@ describe('data account specific values filter', () => {
             internalId: '456',
           },
         ],
+        taxSchedule: {
+          internalId: '1',
+        },
       })
-      elements = [dataType, dataInstance, suiteQLTableType, suiteQLTableInstance]
+      elements = [dataType, dataInstance, suiteQLTableType, suiteQLTableInstance, taxScheduleSuiteQLTableInstance]
     })
 
     it('should transform references to ACCOUNT_SPECIFIC_VALUE', async () => {
@@ -145,6 +157,9 @@ describe('data account specific values filter', () => {
             id: '[ACCOUNT_SPECIFIC_VALUE] (object) (Value 456)',
           },
         ],
+        taxSchedule: {
+          id: '[ACCOUNT_SPECIFIC_VALUE] (taxSchedule) (Tax Schedule 1)',
+        },
       })
     })
 
@@ -268,6 +283,9 @@ describe('data account specific values filter', () => {
             internalId: '456',
           },
         ],
+        taxSchedule: {
+          internalId: '1',
+        },
       })
     })
   })


### PR DESCRIPTION
Recognize that the ASV references of the `taxSchedule` field belongs to the taxSchedule SuiteQL table, that we're already fetching (when `resolveAccountSpecificValues=true`).

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Resolve ASV references of the `taxSchedule` field

---
_User Notifications_: 
Netsuite Adapter:
- ASV references of the `taxSchedule` field will change the type in them: from `object` to `taxSchedule`:
```
taxSchedule = {
  id = "[ACCOUNT_SPECIFIC_VALUE] (taxSchedule) (Tax Schedule 123)"
}
```