### PR TITLE
SALTO-5978: Adding separate Organization API Version settings in SFDC

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -441,6 +441,7 @@ export const ArtificialTypes = {
 
 // Standard Object Types
 export const ORGANIZATION_SETTINGS = 'Organization'
+export const ORGANIZATION_API_VERSION = 'OrganizationApiVersion'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX =

--- a/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
@@ -22,82 +22,90 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ORGANIZATION_SETTINGS, SALESFORCE } from '../../src/constants'
+import {
+  ORGANIZATION_API_VERSION,
+  ORGANIZATION_SETTINGS,
+  SALESFORCE,
+} from '../../src/constants'
 import { LATEST_SUPPORTED_API_VERSION_FIELD } from '../../src/filters/organization_settings'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
 import elementApiVersionValidator from '../../src/change_validators/element_api_version'
 
 describe('Element API version Change Validator', () => {
-  let elementSource: ReadOnlyElementsSource
+  let elementsSource: ReadOnlyElementsSource
 
   const flowWithApiVersion = (apiVersion: number): InstanceElement =>
     createInstanceElement({ fullName: 'flow1', apiVersion }, mockTypes.Flow)
 
-  beforeEach(() => {
-    elementSource = buildElementsSourceFromElements([
-      new InstanceElement(
-        ElemID.CONFIG_NAME,
-        new ObjectType({
-          elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
+  describe('with latest supported API version in Organization Settings', () => {
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([
+        new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({
+            elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
+          }),
+          {
+            [LATEST_SUPPORTED_API_VERSION_FIELD]: 50,
+          },
+        ),
+      ])
+    })
+
+    it('should return no errors for valid elements', async () => {
+      const change = toChange({
+        before: flowWithApiVersion(40),
+        after: flowWithApiVersion(50),
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toBeEmpty()
+    })
+
+    it('should return an error with unsupported API version', async () => {
+      const flow = flowWithApiVersion(51)
+      const change = toChange({
+        after: flow,
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toEqual([
+        expect.objectContaining({
+          elemID: flow.elemID,
+          severity: 'Error',
+          detailedMessage:
+            expect.stringContaining('50') && expect.stringContaining('51'),
         }),
-        {
-          [LATEST_SUPPORTED_API_VERSION_FIELD]: 50,
-        },
-      ),
-    ])
+      ])
+    })
   })
 
-  it('should return no errors for valid elements', async () => {
-    const change = toChange({
-      before: flowWithApiVersion(40),
-      after: flowWithApiVersion(50),
+  describe('with missing elements source', () => {
+    it('should return no errors', async () => {
+      const change = toChange({
+        after: flowWithApiVersion(51),
+      })
+      const errors = await elementApiVersionValidator([change])
+      expect(errors).toBeEmpty()
     })
-    const errors = await elementApiVersionValidator([change], elementSource)
-    expect(errors).toBeEmpty()
   })
 
-  it('should return an error with unsupported API version', async () => {
-    const flow = flowWithApiVersion(51)
-    const change = toChange({
-      after: flow,
+  describe('with empty elements source', () => {
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([])
     })
-    const errors = await elementApiVersionValidator([change], elementSource)
-    expect(errors).toEqual([
-      expect.objectContaining({
-        elemID: flow.elemID,
-        severity: 'Error',
-        detailedMessage:
-          expect.stringContaining('50') && expect.stringContaining('51'),
-      }),
-    ])
+
+    it('should return no errors', async () => {
+      const change = toChange({
+        after: flowWithApiVersion(51),
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toBeEmpty()
+    })
   })
 
-  it('should return no errors for missing elements source', async () => {
-    const change = toChange({
-      after: flowWithApiVersion(51),
-    })
-    const errors = await elementApiVersionValidator([change])
-    expect(errors).toBeEmpty()
-  })
-
-  it('should return no errors when organization settings are missing', async () => {
-    const change = toChange({
-      after: flowWithApiVersion(51),
-    })
-    const errors = await elementApiVersionValidator(
-      [change],
-      buildElementsSourceFromElements([]),
-    )
-    expect(errors).toBeEmpty()
-  })
-  it('should return no errors when latest API version is missing from the Organization Settings instance', async () => {
-    const change = toChange({
-      after: flowWithApiVersion(51),
-    })
-    const errors = await elementApiVersionValidator(
-      [change],
-      buildElementsSourceFromElements([
+  describe('with Organization Settings with no API version', () => {
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([
         new InstanceElement(
           ElemID.CONFIG_NAME,
           new ObjectType({
@@ -105,8 +113,80 @@ describe('Element API version Change Validator', () => {
           }),
           {},
         ),
-      ]),
-    )
-    expect(errors).toBeEmpty()
+      ])
+    })
+
+    it('should return no errors', async () => {
+      const change = toChange({
+        after: flowWithApiVersion(51),
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('with Organization Settings with invalid API version', () => {
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([
+        new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({
+            elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
+          }),
+          {
+            [LATEST_SUPPORTED_API_VERSION_FIELD]: 'fifty',
+          },
+        ),
+      ])
+    })
+
+    it('should return no errors', async () => {
+      const change = toChange({
+        after: flowWithApiVersion(51),
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('with Organization API version with latest supported API version', () => {
+    beforeEach(() => {
+      elementsSource = buildElementsSourceFromElements([
+        new InstanceElement(
+          ElemID.CONFIG_NAME,
+          new ObjectType({
+            elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
+          }),
+          {
+            [LATEST_SUPPORTED_API_VERSION_FIELD]: 50,
+          },
+        ),
+      ])
+    })
+
+    it('should return no errors for valid elements', async () => {
+      const change = toChange({
+        before: flowWithApiVersion(40),
+        after: flowWithApiVersion(50),
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toBeEmpty()
+    })
+
+    it('should return an error with unsupported API version', async () => {
+      const flow = flowWithApiVersion(51)
+      const change = toChange({
+        after: flow,
+      })
+      const errors = await elementApiVersionValidator([change], elementsSource)
+      expect(errors).toEqual([
+        expect.objectContaining({
+          elemID: flow.elemID,
+          severity: 'Error',
+          detailedMessage:
+            expect.stringContaining('50') && expect.stringContaining('51'),
+        }),
+      ])
+    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -20,6 +20,7 @@ import * as filterUtilsModule from '../../src/filters/utils'
 import {
   API_NAME,
   CUSTOM_OBJECT_ID_FIELD,
+  ORGANIZATION_API_VERSION,
   ORGANIZATION_SETTINGS,
   SALESFORCE,
 } from '../../src/constants'
@@ -161,6 +162,7 @@ describe('organization-wide defaults filter', () => {
             [CORE_ANNOTATIONS.UPDATABLE]: false,
             [API_NAME]: ORGANIZATION_SETTINGS,
           },
+          isSettings: true,
         },
         {
           elemID: new ElemID(
@@ -177,6 +179,28 @@ describe('organization-wide defaults filter', () => {
             DefaultContactAccess: 'ControlledByParent',
             DefaultLeadAccess: 'ReadEditTransfer',
             DefaultOpportunityAccess: 'None',
+            LatestSupportedApiVersion: 60,
+          },
+        },
+        {
+          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
+          annotations: {
+            [CORE_ANNOTATIONS.HIDDEN]: true,
+            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+            [CORE_ANNOTATIONS.UPDATABLE]: false,
+            [CORE_ANNOTATIONS.CREATABLE]: false,
+            [CORE_ANNOTATIONS.DELETABLE]: false,
+          },
+          isSettings: true,
+        },
+        {
+          elemID: new ElemID(
+            SALESFORCE,
+            ORGANIZATION_API_VERSION,
+            'instance',
+            '_config',
+          ),
+          value: {
             LatestSupportedApiVersion: 60,
           },
         },
@@ -202,6 +226,7 @@ describe('organization-wide defaults filter', () => {
             [CORE_ANNOTATIONS.UPDATABLE]: false,
             [API_NAME]: ORGANIZATION_SETTINGS,
           },
+          isSettings: true,
         },
         {
           elemID: new ElemID(
@@ -218,6 +243,28 @@ describe('organization-wide defaults filter', () => {
             DefaultContactAccess: 'ControlledByParent',
             DefaultLeadAccess: 'ReadEditTransfer',
             DefaultOpportunityAccess: 'None',
+          },
+        },
+        {
+          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
+          annotations: {
+            [CORE_ANNOTATIONS.HIDDEN]: true,
+            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+            [CORE_ANNOTATIONS.UPDATABLE]: false,
+            [CORE_ANNOTATIONS.CREATABLE]: false,
+            [CORE_ANNOTATIONS.DELETABLE]: false,
+          },
+          isSettings: true,
+        },
+        {
+          elemID: new ElemID(
+            SALESFORCE,
+            ORGANIZATION_API_VERSION,
+            'instance',
+            '_config',
+          ),
+          value: {
+            LatestSupportedApiVersion: 60,
           },
         },
       ])


### PR DESCRIPTION
We will have the duplication for a bit until we enbale the optional feature.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce_:
* Adding a hidden Organization API Version settings type and instance which stores the latest supported API version. This is only temporary and will be removed soon.

---
_User Notifications_: 
None.