### PR TITLE
SALTO-5668: Google Workspace OAuth - enforce consent + login screen

### DIFF
--- a/packages/google-workspace-adapter/README.md
+++ b/packages/google-workspace-adapter/README.md
@@ -39,5 +39,3 @@ The adapter also supports OAuth authentication. To authenticate using OAuth, use
       7. Under 'Access to Google Data' check the 'Trusted' checkbox and continue.
       8. View your configuration and click 'Finish'.
 5. Run the `salto account add ...` command and follow the instructions to authenticate using OAuth. You will need to provide the `clientId` and `clientSecret`, which you can obtain from the same page you create the Oauth and set the `redirectUri`, you can go to your google [console](https://console.cloud.google.com/) => `APIs & Services` => `Credentials` .
-
-Please notice - in order to log in with oauth to google workspace, we are using the refresh token. The refresh token only returns in the first request, so if you are already connected to your google workspace in your browser, you can open a guest tab and repeat the login.

--- a/packages/google-workspace-adapter/src/client/oauth.ts
+++ b/packages/google-workspace-adapter/src/client/oauth.ts
@@ -55,6 +55,11 @@ export const createOAuthRequest = (userInput: InstanceElement): OAuthRequestPara
   const url = oAuth2Client.generateAuthUrl({
     access_type: 'offline',
     scope: REQUIRED_OAUTH_SCOPES,
+    // A refresh token is only returned the first time the user consents to providing access.
+    // Setting the prompt to 'consent' will force this consent every time, forcing a refresh_token to be returned.
+    // We should also set the prompt to 'select_account' to ensure that the user is prompted to select an account,
+    // and is not blocked to using the current account that is logged in.
+    prompt: 'consent select_account',
   })
 
   return {


### PR DESCRIPTION
We want to be able to choose the desired google workspace account even if we're already logged in to this account/another one.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
