### PR TITLE
SALTO-5979: FixErrorDeployingDefaultAccessPolicyRule

### DIFF
--- a/packages/okta-adapter/src/filters/default_rule_deployment.ts
+++ b/packages/okta-adapter/src/filters/default_rule_deployment.ts
@@ -39,6 +39,8 @@ type PolicyRule = {
   system: boolean
 }
 
+const SUPPORTED_TYPES = [ACCESS_POLICY_RULE_TYPE_NAME, PROFILE_ENROLLMENT_RULE_TYPE_NAME]
+
 const EXPECTED_POLICY_RULE_SCHEMA = Joi.object({
   id: Joi.string().required(),
   system: Joi.boolean().required(),
@@ -128,7 +130,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       .filter(isAdditionChange)
       .filter(
         change =>
-          [PROFILE_ENROLLMENT_RULE_TYPE_NAME].includes(getChangeData(change).elemID.typeName) &&
+          SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName) &&
           getChangeData(change).value.system === true,
       )
       .map(change => getChangeData(change))
@@ -142,9 +144,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       change =>
         isInstanceChange(change) &&
         isAdditionChange(change) &&
-        [ACCESS_POLICY_RULE_TYPE_NAME, PROFILE_ENROLLMENT_RULE_TYPE_NAME].includes(
-          getChangeData(change).elemID.typeName,
-        ) &&
+        SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName) &&
         getChangeData(change).value.system === true,
     )
 
@@ -163,7 +163,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
       .filter(isAdditionChange)
       .filter(
         change =>
-          [PROFILE_ENROLLMENT_RULE_TYPE_NAME].includes(getChangeData(change).elemID.typeName) &&
+          SUPPORTED_TYPES.includes(getChangeData(change).elemID.typeName) &&
           getChangeData(change).value.system === true,
       )
       .map(change => getChangeData(change))

--- a/packages/okta-adapter/test/filters/default_rule_deployment.test.ts
+++ b/packages/okta-adapter/test/filters/default_rule_deployment.test.ts
@@ -15,7 +15,15 @@
  */
 
 import { MockInterface } from '@salto-io/test-utils'
-import { ElemID, InstanceElement, ObjectType, toChange, getChangeData, CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
+import {
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  toChange,
+  getChangeData,
+  CORE_ANNOTATIONS,
+  isInstanceElement,
+} from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { getFilterParams, mockClient } from '../utils'
 import OktaClient from '../../src/client/client'
@@ -29,58 +37,59 @@ describe('defaultPolicyRuleDeployment', () => {
   let filter: FilterType
   const accessRuleType = new ObjectType({ elemID: new ElemID(OKTA, ACCESS_POLICY_RULE_TYPE_NAME) })
   const enrollmentRuleType = new ObjectType({ elemID: new ElemID(OKTA, PROFILE_ENROLLMENT_RULE_TYPE_NAME) })
-  const accessRuleInstance = new InstanceElement(
-    'accessPolicyRule',
-    accessRuleType,
-    {
-      name: 'access',
-      system: true,
-      actions: {
-        appSignOn: {
-          access: 'ALLOW',
-          verificationMethod: { factorMode: '1FA', type: 'ASSURANCE', reauthenticateIn: 'PT12H' },
-        },
-      },
-      type: 'ACCESS_POLICY',
-    },
-    undefined,
-    {
-      [CORE_ANNOTATIONS.PARENT]: [
-        {
-          id: '111',
-        },
-      ],
-    },
-  )
-  const enrollmentRuleInstance = new InstanceElement(
-    'profileEnrollmentRule',
-    enrollmentRuleType,
-    {
-      name: 'profile enrollment',
-      system: true,
-      actions: {
-        profileEnrollment: {
-          access: 'ALLOW',
-          targetGroupIds: ['123'],
-        },
-      },
-    },
-    undefined,
-    {
-      [CORE_ANNOTATIONS.PARENT]: [
-        {
-          id: '222',
-        },
-      ],
-    },
-  )
-
+  let accessRuleInstance: InstanceElement
+  let enrollmentRuleInstance: InstanceElement
   beforeEach(() => {
     jest.clearAllMocks()
     const { client: cli, connection } = mockClient()
     mockConnection = connection
     client = cli
     filter = defaultPolicyRuleDeployment(getFilterParams({ client })) as typeof filter
+    accessRuleInstance = new InstanceElement(
+      'accessPolicyRule',
+      accessRuleType,
+      {
+        name: 'access',
+        system: true,
+        actions: {
+          appSignOn: {
+            access: 'ALLOW',
+            verificationMethod: { factorMode: '1FA', type: 'ASSURANCE', reauthenticateIn: 'PT12H' },
+          },
+        },
+        type: 'ACCESS_POLICY',
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [
+          {
+            id: '111',
+          },
+        ],
+      },
+    )
+    enrollmentRuleInstance = new InstanceElement(
+      'profileEnrollmentRule',
+      enrollmentRuleType,
+      {
+        name: 'profile enrollment',
+        system: true,
+        actions: {
+          profileEnrollment: {
+            access: 'ALLOW',
+            targetGroupIds: ['123'],
+          },
+        },
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [
+          {
+            id: '222',
+          },
+        ],
+      },
+    )
   })
 
   describe('deploy', () => {
@@ -176,10 +185,7 @@ describe('defaultPolicyRuleDeployment', () => {
   })
   describe('preDeploy', () => {
     it('should assign priority field to addition changes of type ProfileEnrollmentPolicyRule or AccessPolicyRule', async () => {
-      const changes = [
-        toChange({ after: accessRuleInstance }),
-        toChange({ after: enrollmentRuleInstance }),
-      ]
+      const changes = [toChange({ after: accessRuleInstance }), toChange({ after: enrollmentRuleInstance })]
       await filter.preDeploy(changes)
       const instances = changes.map(getChangeData).filter(isInstanceElement)
       expect(instances[0].value.priority).toEqual(99)


### PR DESCRIPTION
This PR fixes a bug where the deployment of a default access policy rule would fail.

---

_Additional context for reviewer_
When deploying a system rule of type AccessPolicyRule, you need to set its priority to 99, similar to how we handle PROFILE_ENROLLMENT_RULE_TYPE_NAME.

---
_Release Notes_: 
_Okta Adapter:_
* Fixed the deployment issue for default access policy rules by ensuring the priority is set correctly to 99.

---
_User Notifications_: 
None
