### PR TITLE
Salto 5973 create a fix element that will remove transition rules dependent on missing jira apps

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -198,11 +198,11 @@ import changeAttributesPathFilter from './filters/assets/change_attributes_path'
 import asyncApiCallsFilter from './filters/async_api_calls'
 import addImportantValuesFilter from './filters/add_important_values'
 import ScriptRunnerClient from './client/script_runner_client'
-import { weakReferenceHandlers } from './weak_references'
 import { jiraJSMAssetsEntriesFunc, jiraJSMEntriesFunc } from './jsm_utils'
 import { hasSoftwareProject } from './utils'
 import { getWorkspaceId } from './workspace_id'
 import { JSM_ASSETS_DUCKTYPE_SUPPORTED_TYPES } from './config/api_config'
+import { createFixElementFunctions } from './fix_elements'
 
 const { getAllElements, addRemainingTypes } = elementUtils.ducktype
 const { findDataField } = elementUtils
@@ -471,9 +471,7 @@ export default class JiraAdapter implements AdapterOperations {
         objects.concatObjects,
       )
 
-    this.fixElementsFunc = combineElementFixers(
-      _.mapValues(weakReferenceHandlers, handler => handler.removeWeakReferences({ elementsSource })),
-    )
+    this.fixElementsFunc = combineElementFixers(createFixElementFunctions({ elementsSource, client, config }))
   }
 
   private async generateSwaggers(): Promise<AdapterSwaggers> {

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -55,6 +55,7 @@ type JiraDeployConfig = definitions.UserDeployConfig &
     forceDelete: boolean
     taskMaxRetries: number
     taskRetryDelay: number
+    ignoreMissingExtensions: boolean
   }
 
 type JiraFetchFilters = definitions.DefaultFetchCriteria & {
@@ -164,6 +165,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     forceDelete: false,
     taskMaxRetries: 180,
     taskRetryDelay: 1000,
+    ignoreMissingExtensions: false,
   },
   masking: {
     automationHeaders: [],
@@ -323,6 +325,7 @@ const jiraDeployConfigType = definitions.createUserDeployConfigType(JIRA, change
   taskMaxRetries: { refType: BuiltinTypes.NUMBER },
   taskRetryDelay: { refType: BuiltinTypes.NUMBER },
   forceDelete: { refType: BuiltinTypes.BOOLEAN },
+  ignoreMissingExtensions: { refType: BuiltinTypes.BOOLEAN },
 })
 
 const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
@@ -407,6 +410,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'fetch.enableNewWorkflowAPI',
       'deploy.taskMaxRetries',
       'deploy.taskRetryDelay',
+      'deploy.ignoreMissingExtensions',
       SCRIPT_RUNNER_API_DEFINITIONS,
       JSM_DUCKTYPE_API_DEFINITIONS,
     ]),

--- a/packages/jira-adapter/src/fix_elements/index.ts
+++ b/packages/jira-adapter/src/fix_elements/index.ts
@@ -1,0 +1,26 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import { FixElementsFunc } from '@salto-io/adapter-api'
+import { FixElementsArgs } from './types'
+import { weakReferenceHandlers } from '../weak_references'
+import { removeMissingExtensionsTransitionRulesHandler } from './remove_missing_extension_transition_rules'
+
+export const createFixElementFunctions = (args: FixElementsArgs): Record<string, FixElementsFunc> => ({
+  ..._.mapValues(weakReferenceHandlers, handler => handler.removeWeakReferences(args)),
+  removeMissingExtensionsTransitionRules: removeMissingExtensionsTransitionRulesHandler(args),
+})

--- a/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
+++ b/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
@@ -1,0 +1,127 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console */
+
+import _ from 'lodash'
+import { isInstanceElement, Element, ElemID } from '@salto-io/adapter-api'
+import { collections, values } from '@salto-io/lowerdash'
+import { FixElementsHandler } from './types'
+import { getInstalledExtensionsMap, ExtensionType } from '../common/extensions'
+import {
+  WorkflowV2TransitionConditionGroup,
+  WorkflowV2Transition,
+  WorkflowV2TransitionRule,
+  isWorkflowV2Instance,
+} from '../filters/workflowV2/types'
+import { HasKeyOfType, MakeOptional } from '../../../lowerdash/src/types'
+import { getExtensionIdFromWorkflowTransitionRule } from '../common/workflow/transition_rules'
+
+const { awu } = collections.asynciterable
+
+const updateAndCheckTransitionRules = <
+  K extends string,
+  T extends MakeOptional<HasKeyOfType<K, WorkflowV2TransitionRule[]>, K>,
+>(
+  obj: T,
+  key: K,
+  predicate: (value: WorkflowV2TransitionRule) => boolean,
+): boolean => {
+  const old = obj[key]
+  obj[key] = old?.filter(predicate) as T[K]
+
+  return old?.length !== obj[key]?.length
+}
+
+const updateAndCheckWorkflowConditionGroup = (
+  predicate: (transitionRule: WorkflowV2TransitionRule) => boolean,
+  conditionGroup?: WorkflowV2TransitionConditionGroup,
+): boolean => {
+  if (conditionGroup === undefined) {
+    return false
+  }
+  const fixedConditions = updateAndCheckTransitionRules(conditionGroup, 'conditions', predicate)
+
+  if (conditionGroup.conditionGroups !== undefined) {
+    const fixedConditionGroups = conditionGroup.conditionGroups.map(innerConditionGroup =>
+      updateAndCheckWorkflowConditionGroup(predicate, innerConditionGroup),
+    )
+    return fixedConditions || _.some(fixedConditionGroups)
+  }
+  return fixedConditions
+}
+
+const updateAndCheckWorkflowTransition = (
+  installedExtensionsMap: Record<string, ExtensionType>,
+  transition: WorkflowV2Transition,
+): boolean => {
+  const checkExtensionForRule = (transitionRule: WorkflowV2TransitionRule): boolean => {
+    const extensionId = getExtensionIdFromWorkflowTransitionRule(transitionRule)
+    return extensionId === undefined ? true : extensionId in installedExtensionsMap
+  }
+
+  // Fix action rules
+  const fixedActions = updateAndCheckTransitionRules(transition, 'actions', checkExtensionForRule)
+  // Fix validators rules
+  const fixedValidators = updateAndCheckTransitionRules(transition, 'validators', checkExtensionForRule)
+  // Fix condition rules
+  const fixedConditions = updateAndCheckWorkflowConditionGroup(checkExtensionForRule, transition.conditions)
+
+  return fixedActions || fixedValidators || fixedConditions
+}
+
+/**
+ * This fixer makes sure that there are no workflow transitions with rules dependent on Jira apps not installed in the target environment.
+ */
+export const removeMissingExtensionsTransitionRulesHandler: FixElementsHandler =
+  ({ client, config }) =>
+  async (elements: Element[]) => {
+    if (!config.fetch.enableNewWorkflowAPI || !config.deploy.ignoreMissingExtensions) {
+      return { fixedElements: [], errors: [] }
+    }
+    const installedExtensionsMap: Record<string, ExtensionType> = await getInstalledExtensionsMap(client)
+    const fixedTransitions: ElemID[] = []
+
+    const fixedElements = await awu(elements)
+      .filter(isInstanceElement)
+      .map(instance => instance.clone())
+      .filter(isWorkflowV2Instance)
+      .filter(workflowInstance =>
+        _.some(
+          Object.entries(workflowInstance.value.transitions).map(([transitionName, transition]) => {
+            if (updateAndCheckWorkflowTransition(installedExtensionsMap, transition)) {
+              fixedTransitions.push(workflowInstance.elemID.createNestedID('transitions', transitionName))
+              return true
+            }
+            return false
+          }),
+        ),
+      )
+      .filter(values.isDefined)
+      .toArray()
+
+    const errors = fixedTransitions.map(id => ({
+      elemID: id,
+      severity: 'Info' as const,
+      message: 'Deploying workflow transition without all of its rules.',
+      detailedMessage:
+        'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+    }))
+
+    return {
+      fixedElements,
+      errors,
+    }
+  }

--- a/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
+++ b/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
@@ -82,13 +82,13 @@ const updateAndCheckWorkflowTransition = (
   }
 
   // Fix action rules
-  const fixedActions = updateAndCheckTransitionRules(transition, 'actions', checkExtensionForRule)
+  const hasFixedActions = updateAndCheckTransitionRules(transition, 'actions', checkExtensionForRule)
   // Fix validators rules
-  const fixedValidators = updateAndCheckTransitionRules(transition, 'validators', checkExtensionForRule)
+  const hasFixedValidators = updateAndCheckTransitionRules(transition, 'validators', checkExtensionForRule)
   // Fix condition rules
-  const fixedConditions = updateAndCheckWorkflowConditionGroup(checkExtensionForRule, transition.conditions)
+  const hasFixedConditions = updateAndCheckWorkflowConditionGroup(checkExtensionForRule, transition.conditions)
 
-  return fixedActions || fixedValidators || fixedConditions
+  return hasFixedActions || hasFixedValidators || hasFixedConditions
 }
 
 /**

--- a/packages/jira-adapter/src/fix_elements/types.ts
+++ b/packages/jira-adapter/src/fix_elements/types.ts
@@ -1,0 +1,26 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { FixElementsFunc, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config/config'
+
+export type FixElementsArgs = {
+  client: JiraClient
+  config: JiraConfig
+  elementsSource: ReadOnlyElementsSource
+}
+
+export type FixElementsHandler = (args: FixElementsArgs) => FixElementsFunc

--- a/packages/jira-adapter/test/change_validators/workflowsV2/missing_extensions_transition_rules.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/missing_extensions_transition_rules.test.ts
@@ -20,6 +20,9 @@ import {
   createSkeletonWorkflowV2Instance,
   createSkeletonWorkflowV2TransitionConditionGroup,
   mockClient,
+  createConnectTransitionRule,
+  createForgeTransitionRule,
+  createSystemTransitionRule,
 } from '../../utils'
 import JiraClient from '../../../src/client/client'
 import {
@@ -28,19 +31,6 @@ import {
   EXTENSION_ID_LENGTH,
   UPM_INSTALLED_APPS_URL,
 } from '../../../src/common/extensions'
-import { WorkflowV2TransitionRule } from '../../../src/filters/workflowV2/types'
-
-const createConnectTransitionRule = (extensionId: string): WorkflowV2TransitionRule => ({
-  ruleKey: 'connect:some-rule',
-  parameters: { appKey: `${extensionId}` },
-})
-
-const createForgeTransitionRule = (extensionId: string): WorkflowV2TransitionRule => ({
-  ruleKey: 'forge:some-rule',
-  parameters: { key: `${EXTENSION_ID_ARI_PREFIX}${extensionId}/some-suffix` },
-})
-
-const createSystemTransitionRule = (): WorkflowV2TransitionRule => ({ ruleKey: 'system:some-rule' })
 
 const CONNECT_EXTENSION: ExtensionType = {
   id: 'some-random-id',

--- a/packages/jira-adapter/test/fix_elements/remove_missing_extension_transition_rules.test.ts
+++ b/packages/jira-adapter/test/fix_elements/remove_missing_extension_transition_rules.test.ts
@@ -125,7 +125,11 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.actions = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),
@@ -141,7 +145,11 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     instance.value.transitions.transition1.validators = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.validators = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),
@@ -158,7 +166,10 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     instance.value.transitions.transition1.conditions.conditions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.conditions.conditions = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),
@@ -180,7 +191,10 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     ]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.conditions.conditionGroups[0].conditions = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),
@@ -207,7 +221,7 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     instance.value.transitions.transition1.conditions.conditionGroups[0].conditions = [...validTransitionRules]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(0)
+    expect(result.fixedElements).toEqual([])
     expect(result.errors).toEqual([])
   })
   it('should fix transitions only once, irrelevant of how many invalid transition rules they have', async () => {
@@ -224,7 +238,14 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     ]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.actions = []
+    fixedInstance.value.transitions.transition1.validators = []
+    fixedInstance.value.transitions.transition1.conditions.conditions = []
+    fixedInstance.value.transitions.transition1.conditions.conditionGroups[0].conditions = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),
@@ -242,7 +263,12 @@ describe('removeMissingExtensionsTransitionRulesHandler', () => {
     instance.value.transitions.transition2.validators = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
 
     const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
-    expect(result.fixedElements).toHaveLength(1)
+
+    const fixedInstance = instance.clone()
+    fixedInstance.value.transitions.transition1.actions = []
+    fixedInstance.value.transitions.transition2.validators = []
+
+    expect(result.fixedElements).toEqual([fixedInstance])
     expect(result.errors).toEqual([
       {
         elemID: instance.elemID.createNestedID('transitions', 'transition1'),

--- a/packages/jira-adapter/test/fix_elements/remove_missing_extension_transition_rules.test.ts
+++ b/packages/jira-adapter/test/fix_elements/remove_missing_extension_transition_rules.test.ts
@@ -1,0 +1,263 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { InstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { removeMissingExtensionsTransitionRulesHandler } from '../../src/fix_elements/remove_missing_extension_transition_rules'
+import { JiraConfig, getDefaultConfig } from '../../src/config/config'
+import {
+  DEFAULT_CLOUD_ID,
+  createConnectTransitionRule,
+  createForgeTransitionRule,
+  createSkeletonWorkflowV2Instance,
+  createSkeletonWorkflowV2Transition,
+  createSkeletonWorkflowV2TransitionConditionGroup,
+  mockClient,
+} from '../utils'
+import JiraClient from '../../src/client/client'
+import {
+  EXTENSION_ID_ARI_PREFIX,
+  UPM_INSTALLED_APPS_URL,
+  ExtensionType,
+  EXTENSION_ID_LENGTH,
+} from '../../src/common/extensions'
+
+const CONNECT_EXTENSION: ExtensionType = {
+  id: 'some-random-id',
+  name: 'connect-extension',
+}
+
+const FORGE_EXTENSION: ExtensionType = {
+  id: 'a'.repeat(EXTENSION_ID_LENGTH),
+  name: 'forge-extension',
+}
+
+const NON_EXISTENT_CONNECT_EXTENSION_ID = 'non-existent-extension'
+const NON_EXISTENT_CONNECT_EXTENSION_TRANSITION_RULE = createConnectTransitionRule(NON_EXISTENT_CONNECT_EXTENSION_ID)
+const NON_EXISTENT_FORGE_EXTENSION_ID = 's'.repeat(EXTENSION_ID_LENGTH)
+const NON_EXISTENT_FORGE_EXTENSION_TRANSITION_RULE = createForgeTransitionRule(NON_EXISTENT_FORGE_EXTENSION_ID)
+const NON_EXISTENT_EXTENSIONS_TRANSITION_RULES = [
+  NON_EXISTENT_CONNECT_EXTENSION_TRANSITION_RULE,
+  NON_EXISTENT_FORGE_EXTENSION_TRANSITION_RULE,
+]
+
+describe('removeMissingExtensionsTransitionRulesHandler', () => {
+  let config: JiraConfig
+  let instance: InstanceElement
+  let elementsSource: ReadOnlyElementsSource
+  let client: JiraClient
+
+  beforeEach(() => {
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.deploy.ignoreMissingExtensions = true
+    config.fetch.enableNewWorkflowAPI = true
+    const { connection, client: tempClient } = mockClient(false, DEFAULT_CLOUD_ID)
+    client = tempClient
+    client.gqlPost = async () => ({
+      status: 200,
+      data: {
+        ecosystem: {
+          appInstallationsByContext: {
+            nodes: [
+              {
+                app: {
+                  name: FORGE_EXTENSION.name,
+                  id: EXTENSION_ID_ARI_PREFIX + FORGE_EXTENSION.id,
+                },
+              },
+            ],
+          },
+        },
+      },
+    })
+    connection.get.mockImplementation(async url => {
+      if (url === UPM_INSTALLED_APPS_URL) {
+        return {
+          status: 200,
+          data: {
+            plugins: [
+              {
+                name: CONNECT_EXTENSION.name,
+                key: CONNECT_EXTENSION.id,
+                enabled: true,
+                userInstalled: true,
+              },
+            ],
+          },
+        }
+      }
+      throw new Error(`unexpected url: ${url}`)
+    })
+    instance = createSkeletonWorkflowV2Instance('some-workflow')
+    elementsSource = buildElementsSourceFromElements([instance])
+  })
+  it('should do nothing if config.deploy.ignoreMissingExtensions is false', async () => {
+    config.deploy.ignoreMissingExtensions = false
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result).toEqual({ fixedElements: [], errors: [] })
+  })
+  it('should do nothing if config.fetch.enableNewWorkflowAPI is false', async () => {
+    config.fetch.enableNewWorkflowAPI = false
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result).toEqual({ fixedElements: [], errors: [] })
+  })
+  it('should fix transitions with action rules of missing extensions', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+  it('should fix transitions with validator rules of missing extensions', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.validators = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+  it('should fix transitions with condition rules of missing extensions', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.conditions = createSkeletonWorkflowV2TransitionConditionGroup()
+    instance.value.transitions.transition1.conditions.conditions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+  it('should fix transitions with nested condition rules of missing extensions', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.conditions = createSkeletonWorkflowV2TransitionConditionGroup()
+    instance.value.transitions.transition1.conditions.conditionGroups.push(
+      createSkeletonWorkflowV2TransitionConditionGroup(),
+    )
+    instance.value.transitions.transition1.conditions.conditionGroups[0].conditions = [
+      ...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES,
+    ]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+  it('should not fix transitions without transition rules of missing extensions', async () => {
+    const validTransitionRules = [
+      createForgeTransitionRule(FORGE_EXTENSION.id),
+      createConnectTransitionRule(CONNECT_EXTENSION.id),
+    ]
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.actions = [...validTransitionRules]
+    instance.value.transitions.transition1.validators = [...validTransitionRules]
+    instance.value.transitions.transition1.conditions = createSkeletonWorkflowV2TransitionConditionGroup()
+    instance.value.transitions.transition1.conditions.conditions = [...validTransitionRules]
+    instance.value.transitions.transition1.conditions.conditionGroups.push(
+      createSkeletonWorkflowV2TransitionConditionGroup(),
+    )
+    instance.value.transitions.transition1.conditions.conditionGroups[0].conditions = [...validTransitionRules]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(0)
+    expect(result.errors).toEqual([])
+  })
+  it('should fix transitions only once, irrelevant of how many invalid transition rules they have', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+    instance.value.transitions.transition1.validators = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+    instance.value.transitions.transition1.conditions = createSkeletonWorkflowV2TransitionConditionGroup()
+    instance.value.transitions.transition1.conditions.conditions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+    instance.value.transitions.transition1.conditions.conditionGroups.push(
+      createSkeletonWorkflowV2TransitionConditionGroup(),
+    )
+    instance.value.transitions.transition1.conditions.conditionGroups[0].conditions = [
+      ...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES,
+    ]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+  it('should fix workflows only once, irrelevant of how many invalid transition rules they have, but emit an error for each invalid transition', async () => {
+    instance.value.transitions.transition1 = createSkeletonWorkflowV2Transition('transition1')
+    instance.value.transitions.transition2 = createSkeletonWorkflowV2Transition('transition2')
+    instance.value.transitions.transition1.actions = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+    instance.value.transitions.transition2.validators = [...NON_EXISTENT_EXTENSIONS_TRANSITION_RULES]
+
+    const result = await removeMissingExtensionsTransitionRulesHandler({ config, client, elementsSource })([instance])
+    expect(result.fixedElements).toHaveLength(1)
+    expect(result.errors).toEqual([
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition1'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+      {
+        elemID: instance.elemID.createNestedID('transitions', 'transition2'),
+        severity: 'Info' as const,
+        message: 'Deploying workflow transition without all of its rules.',
+        detailedMessage:
+          'This workflow transition contains rules for Jira apps that do not exist in the target environment. It will be deployed without them.',
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/utils.ts
+++ b/packages/jira-adapter/test/utils.ts
@@ -21,12 +21,17 @@ import { adapter } from '../src/adapter_creator'
 import { Credentials } from '../src/auth'
 import { JiraConfig, configType, getDefaultConfig } from '../src/config/config'
 import JiraClient from '../src/client/client'
+import { EXTENSION_ID_ARI_PREFIX } from '../src/common/extensions'
 import { FilterCreator } from '../src/filter'
 import { paginate } from '../src/client/pagination'
 import { GetUserMapFunc, getUserMapFuncCreator } from '../src/users'
 import { JIRA, WORKFLOW_CONFIGURATION_TYPE } from '../src/constants'
 import ScriptRunnerClient from '../src/client/script_runner_client'
-import { WorkflowV2TransitionConditionGroup, WorkflowV2Transition } from '../src/filters/workflowV2/types'
+import {
+  WorkflowV2TransitionConditionGroup,
+  WorkflowV2Transition,
+  WorkflowV2TransitionRule,
+} from '../src/filters/workflowV2/types'
 
 export const createCredentialsInstance = (credentials: Credentials): InstanceElement =>
   new InstanceElement(ElemID.CONFIG_NAME, adapter.authenticationMethods.basic.credentialsType, credentials)
@@ -155,3 +160,13 @@ export const createSkeletonWorkflowV2Instance = (name: string): InstanceElement 
     },
     statuses: [],
   })
+
+export const createConnectTransitionRule = (extensionId: string): WorkflowV2TransitionRule => ({
+  ruleKey: 'connect:some-rule',
+  parameters: { appKey: `${extensionId}` },
+})
+export const createForgeTransitionRule = (extensionId: string): WorkflowV2TransitionRule => ({
+  ruleKey: 'forge:some-rule',
+  parameters: { key: `${EXTENSION_ID_ARI_PREFIX}${extensionId}/some-suffix` },
+})
+export const createSystemTransitionRule = (): WorkflowV2TransitionRule => ({ ruleKey: 'system:some-rule' })

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -35,17 +35,14 @@ export const hasMember = <T, M extends keyof T>(m: M, o: T): o is HasMember<T, M
 export const filterHasMember = <T, M extends keyof T>(m: M, objs: T[]): HasMember<T, M>[] =>
   objs.filter(f => hasMember(m, f)) as HasMember<T, M>[]
 
-// Ensures an object contains a specific key K of type T, allowing for additional properties.
-export type HasKeyOfType<K extends string, T> = { [P in K]: T } & Record<string, unknown>
+// Ensures an object contains a specific key K of type T
+export type HasKeyOfType<K extends string, T> = { [P in K]: T }
 // Extracts keys from type T whose values are assignable to type U.
 export type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T]
 // Extracts keys from type T whose values extend type U.
 export type KeysOfExtendingType<T, U> = { [K in keyof T]: U extends T[K] ? K : never }[keyof T]
 // Converts the keys of type T into an enum-like type where each key is a required property.
 export type TypeKeysEnum<T> = Required<{ [k in keyof T]: k }>
-
-// Utility type to make a specific key K optional in type T
-export type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
 
 // Extracts the union of all possible values of the properties of type `T`.
 export type ValueOf<T> = T[keyof T]

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -35,10 +35,19 @@ export const hasMember = <T, M extends keyof T>(m: M, o: T): o is HasMember<T, M
 export const filterHasMember = <T, M extends keyof T>(m: M, objs: T[]): HasMember<T, M>[] =>
   objs.filter(f => hasMember(m, f)) as HasMember<T, M>[]
 
+// Ensures an object contains a specific key K of type T, allowing for additional properties.
+export type HasKeyOfType<K extends string, T> = { [P in K]: T } & Record<string, unknown>
+// Extracts keys from type T whose values are assignable to type U.
 export type KeysOfType<T, U> = { [K in keyof T]: T[K] extends U ? K : never }[keyof T]
+// Extracts keys from type T whose values extend type U.
 export type KeysOfExtendingType<T, U> = { [K in keyof T]: U extends T[K] ? K : never }[keyof T]
+// Converts the keys of type T into an enum-like type where each key is a required property.
 export type TypeKeysEnum<T> = Required<{ [k in keyof T]: k }>
 
+// Utility type to make a specific key K optional in type T
+export type MakeOptional<T, K extends keyof T> = Omit<T, K> & Partial<Pick<T, K>>
+
+// Extracts the union of all possible values of the properties of type `T`.
 export type ValueOf<T> = T[keyof T]
 
 // makes specific fields required


### PR DESCRIPTION
Jira:

- Added a 'fix element' that will **_remove_** workflow transition rules of missing (not installed in target environment) Jira apps. This 'fix element' is under the feature flag of config.deploy.ignoreMissingExtensions in Jira NaCl.

---

_Additional context for reviewer_

Part of a series of PRs. This one depends on #5943, so review that one first.

---
_Release Notes_: 

Jira:

- Added a feature flag under config.deploy called ignoreMissingExtensions (defaults to false). When enabled, workflow transition rules of Jira apps that aren't installed in the target environment will be removed.
