### PR TITLE
SALTO-5994 Add updatedConfig option to dummy adapter

### DIFF
--- a/packages/dummy-adapter/src/adapter.ts
+++ b/packages/dummy-adapter/src/adapter.ts
@@ -23,13 +23,17 @@ import {
   getChangeData,
   isInstanceElement,
   FixElementsFunc,
+  InstanceElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { generateElements, GeneratorParams } from './generator'
 import { changeValidator } from './change_validator'
 
 export default class DummyAdapter implements AdapterOperations {
-  public constructor(private genParams: GeneratorParams) {}
+  public constructor(
+    private genParams: GeneratorParams,
+    private updatedConfig: InstanceElement | undefined,
+  ) {}
 
   /**
    * Fetch configuration elements: objects, types and instances for the given HubSpot account.
@@ -38,6 +42,7 @@ export default class DummyAdapter implements AdapterOperations {
   public async fetch({ progressReporter }: FetchOptions): Promise<FetchResult> {
     return {
       elements: await generateElements(this.genParams, progressReporter),
+      updatedConfig: this.updatedConfig ? { config: [this.updatedConfig], message: 'Fetched config' } : undefined,
     }
   }
 

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -21,6 +21,7 @@ import {
   ObjectType,
   ListType,
   GetCustomReferencesFunc,
+  InstanceElement,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
@@ -44,6 +45,7 @@ export const configType = new ObjectType({
     importantValuesFreq: { refType: new ListType(BuiltinTypes.NUMBER) },
     templateExpressionFreq: { refType: new ListType(BuiltinTypes.NUMBER) },
     templateStaticFileFreq: { refType: new ListType(BuiltinTypes.NUMBER) },
+    updatedConfig: { refType: BuiltinTypes.JSON },
   },
 })
 
@@ -59,7 +61,13 @@ const getCustomReferences: GetCustomReferencesFunc = async elements =>
     : []
 
 export const adapter: Adapter = {
-  operations: context => new DummyAdapter(context.config?.value as GeneratorParams),
+  operations: context => {
+    const genParams = context.config?.value as GeneratorParams
+    const updatedConfig = genParams.updatedConfig
+      ? new InstanceElement(ElemID.CONFIG_NAME, configType, genParams.updatedConfig)
+      : undefined
+    return new DummyAdapter(genParams, updatedConfig)
+  },
   validateCredentials: async () => ({ accountId: '' }),
   authenticationMethods: {
     basic: {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -194,9 +194,10 @@ export type GeneratorParams = {
   fieldsToOmitOnDeploy?: string[]
   elementsToExclude?: string[]
   importantValuesFreq?: number
+  updatedConfig?: Record<string, unknown>
 }
 
-export const defaultParams: Omit<GeneratorParams, 'extraNaclPaths'> = {
+export const defaultParams: Omit<GeneratorParams, 'extraNaclPaths' | 'updatedConfig'> = {
   seed: 123456,
   numOfRecords: 522,
   numOfPrimitiveTypes: 44,

--- a/packages/dummy-adapter/test/adapter.test.ts
+++ b/packages/dummy-adapter/test/adapter.test.ts
@@ -52,7 +52,7 @@ const nullProgressReporter: ProgressReporter = {
 }
 
 describe('dummy adapter', () => {
-  const adapter = new DummyAdapter(testParams)
+  const adapter = new DummyAdapter(testParams, undefined)
   describe('deploy', () => {
     it('should be defined', () => {
       expect(adapter.deploy).toBeDefined()
@@ -100,7 +100,7 @@ describe('dummy adapter', () => {
     const progressReportMock = {
       reportProgress: jest.fn(),
     }
-    it('should return the result of the generateElement command withuot modifications', async () => {
+    it('should return the result of the generateElement command without modifications', async () => {
       const mockReporter = { reportProgress: jest.fn() }
       const fetchResult = await adapter.fetch({ progressReporter: mockReporter })
       expect(fetchResult).toEqual({ elements: await generator.generateElements(testParams, mockReporter) })
@@ -130,10 +130,23 @@ describe('dummy adapter', () => {
         }
       })
     })
+    it('should replace the config with the updatedConfig', async () => {
+      const updatedConfig = new InstanceElement(
+        'updatedConfig',
+        new ObjectType({ elemID: new ElemID('updatedConfig') }),
+        {
+          some: 'value',
+        },
+      )
+      const mockReporter = { reportProgress: jest.fn() }
+      const adapterWithUpdatedConfig = new DummyAdapter(testParams, updatedConfig)
+      const fetchResult = await adapterWithUpdatedConfig.fetch({ progressReporter: mockReporter })
+      expect(fetchResult.updatedConfig).toEqual({ config: [updatedConfig], message: 'Fetched config' })
+    })
   })
 
   describe('deployModifier', () => {
-    const adapterWithDeployModifiers = new DummyAdapter({ ...testParams, changeErrors: [mockChangeError] })
+    const adapterWithDeployModifiers = new DummyAdapter({ ...testParams, changeErrors: [mockChangeError] }, undefined)
     it('should be defined', () => {
       expect(adapterWithDeployModifiers.deployModifiers).toBeDefined()
     })

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -29,6 +29,7 @@ describe('adapter creator', () => {
       'generateEnvName',
       'fieldsToOmitOnDeploy',
       'elementsToExclude',
+      'updatedConfig',
     ])
   })
   it('should return an empty creds type', () => {


### PR DESCRIPTION
Adding the field `updatedConfig` to the dummy adapter configuration will have the adapter return the given value.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
