### PR TITLE
SALTO-5999: Fix Components handling in automation 

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -377,7 +377,9 @@ const proccessComponentPreDeploy = (component: Component, config: JiraConfig): v
   }
   if (isRequestTypeComponent(component)) {
     const requestType = component.value.requestType.value
-    component.value.serviceDesk = requestType.value.serviceDeskId
+    if (requestType?.value !== undefined) {
+      component.value.serviceDesk = requestType.value.serviceDeskId
+    }
   }
   if (component.children) {
     component.children.forEach(child => proccessComponentPreDeploy(child, config))
@@ -387,10 +389,15 @@ const proccessComponentPreDeploy = (component: Component, config: JiraConfig): v
   }
 }
 const modifyComponentsPreDeploy = (instance: InstanceElement, config: JiraConfig): void => {
-  if (!instance.value.components || !config.fetch.enableJSM) {
+  if (!config.fetch.enableJSM) {
     return
   }
-  instance.value.components.forEach((component: Component) => proccessComponentPreDeploy(component, config))
+  if (instance.value.components) {
+    instance.value.components.forEach((component: Component) => proccessComponentPreDeploy(component, config))
+  }
+  if (instance.value.trigger) {
+    proccessComponentPreDeploy(instance.value.trigger, config)
+  }
 }
 
 const proccessComponentPostDeploy = (component: Component, config: JiraConfig): void => {
@@ -411,10 +418,15 @@ const proccessComponentPostDeploy = (component: Component, config: JiraConfig): 
 }
 
 const modifyComponentsPostDeploy = (instance: InstanceElement, config: JiraConfig): void => {
-  if (!instance.value.components || !config.fetch.enableJSM) {
+  if (!config.fetch.enableJSM) {
     return
   }
-  instance.value.components.forEach((component: Component) => proccessComponentPostDeploy(component, config))
+  if (instance.value.components) {
+    instance.value.components.forEach((component: Component) => proccessComponentPostDeploy(component, config))
+  }
+  if (instance.value.trigger) {
+    proccessComponentPostDeploy(instance.value.trigger, config)
+  }
 }
 
 const updateAutomation = async (

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -392,10 +392,10 @@ const modifyComponentsPreDeploy = (instance: InstanceElement, config: JiraConfig
   if (!config.fetch.enableJSM) {
     return
   }
-  if (instance.value.components) {
+  if (instance.value.components !== undefined) {
     instance.value.components.forEach((component: Component) => proccessComponentPreDeploy(component, config))
   }
-  if (instance.value.trigger) {
+  if (instance.value.trigger !== undefined) {
     proccessComponentPreDeploy(instance.value.trigger, config)
   }
 }
@@ -421,10 +421,10 @@ const modifyComponentsPostDeploy = (instance: InstanceElement, config: JiraConfi
   if (!config.fetch.enableJSM) {
     return
   }
-  if (instance.value.components) {
+  if (instance.value.components !== undefined) {
     instance.value.components.forEach((component: Component) => proccessComponentPostDeploy(component, config))
   }
-  if (instance.value.trigger) {
+  if (instance.value.trigger !== undefined) {
     proccessComponentPostDeploy(instance.value.trigger, config)
   }
 }

--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -63,7 +63,9 @@ const ASSET_COMPONENT_SCHEME = Joi.object({
     schemaId: Joi.string().required(),
     schemaLabel: Joi.string(),
     objectTypeLabel: Joi.string(),
-  }).unknown(true),
+  })
+    .unknown(true)
+    .required(),
 }).unknown(true)
 
 export const isAssetComponent = createSchemeGuard<AssetComponent>(ASSET_COMPONENT_SCHEME)
@@ -195,10 +197,12 @@ const processComponents = (component: Component): void => {
 /* Since the children and conditions of the components can also be of the AssetComponent type,
  * we need to handle them the same way as we handle the top-level component value. */
 const modifyAssetsComponents = (instance: InstanceElement): void => {
-  if (!instance.value.components) {
-    return
+  if (instance.value.components) {
+    instance.value.components.forEach(processComponents)
   }
-  instance.value.components.forEach(processComponents)
+  if (instance.value.trigger) {
+    processComponents(instance.value.trigger)
+  }
 }
 
 export const getAutomations = async (client: JiraClient, config: JiraConfig): Promise<Values[]> =>

--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -197,10 +197,10 @@ const processComponents = (component: Component): void => {
 /* Since the children and conditions of the components can also be of the AssetComponent type,
  * we need to handle them the same way as we handle the top-level component value. */
 const modifyAssetsComponents = (instance: InstanceElement): void => {
-  if (instance.value.components) {
+  if (instance.value.components !== undefined) {
     instance.value.components.forEach(processComponents)
   }
-  if (instance.value.trigger) {
+  if (instance.value.trigger !== undefined) {
     processComponents(instance.value.trigger)
   }
 }

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -832,6 +832,16 @@ describe('automationDeploymentFilter', () => {
             name: 'someName',
             state: 'ENABLED',
             projects: [],
+            trigger: {
+              component: 'ACTION',
+              schemaVersion: 1,
+              value: {
+                objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+                schemaId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+              },
+              children: [],
+              conditions: [],
+            },
             components: [
               {
                 component: 'ACTION',
@@ -886,6 +896,19 @@ describe('automationDeploymentFilter', () => {
                 conditions: [],
               },
             ],
+            conditions: [],
+          })
+          expect(automationInstance.value.trigger).toEqual({
+            component: 'ACTION',
+            schemaVersion: 1,
+            value: {
+              objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+              schemaId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+              schemaLabel: 'schemaName',
+              objectTypeLabel: 'objectTypeName',
+              workspaceId: 'w11',
+            },
+            children: [],
             conditions: [],
           })
         })
@@ -1098,6 +1121,19 @@ describe('automationDeploymentFilter', () => {
             name: 'someName',
             state: 'ENABLED',
             projects: [],
+            trigger: {
+              component: 'ACTION',
+              schemaVersion: 1,
+              value: {
+                objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+                workspaceId: 'w11',
+                schemaId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+                schemaLabel: 'schemaName',
+                objectTypeLabel: 'objectTypeName',
+              },
+              children: [],
+              conditions: [],
+            },
             components: [
               {
                 component: 'ACTION',
@@ -1152,6 +1188,16 @@ describe('automationDeploymentFilter', () => {
                 conditions: [],
               },
             ],
+            conditions: [],
+          })
+          expect(automationInstance.value.trigger).toEqual({
+            component: 'ACTION',
+            schemaVersion: 1,
+            value: {
+              objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+              schemaId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+            },
+            children: [],
             conditions: [],
           })
         })

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -637,6 +637,27 @@ describe('automationFetchFilter', () => {
             ruleScope: {
               resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
             },
+            trigger: {
+              component: 'ACTION',
+              schemaVersion: 1,
+              type: 'cmdb.object.create',
+              value: {
+                objectTypeId: '35',
+                workspaceId: '68d020c3-b88e-47dc-9231-452f7dc63521',
+                schemaLabel: 'idoA Schema',
+                schemaId: '5',
+                objectTypeLabel: 'R&D',
+                attributes: [
+                  {
+                    name: 'Name',
+                    value: 'idoA automation',
+                    isLabel: true,
+                  },
+                ],
+              },
+              children: [],
+              conditions: [],
+            },
             components: [
               {
                 component: 'ACTION',
@@ -765,6 +786,27 @@ describe('automationFetchFilter', () => {
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
+        trigger: {
+          component: 'ACTION',
+          schemaVersion: 1,
+          type: 'cmdb.object.create',
+          value: {
+            objectTypeId: '35',
+            workspaceId: '68d020c3-b88e-47dc-9231-452f7dc63521',
+            schemaLabel: 'idoA Schema',
+            schemaId: '5',
+            objectTypeLabel: 'R&D',
+            attributes: [
+              {
+                name: 'Name',
+                value: 'idoA automation',
+                isLabel: true,
+              },
+            ],
+          },
+          children: [],
+          conditions: [],
+        },
         components: [
           {
             component: 'ACTION',
@@ -846,6 +888,24 @@ describe('automationFetchFilter', () => {
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
+        trigger: {
+          component: 'ACTION',
+          schemaVersion: 1,
+          type: 'cmdb.object.create',
+          value: {
+            objectTypeId: '35',
+            schemaId: '5',
+            attributes: [
+              {
+                name: 'Name',
+                value: 'idoA automation',
+                isLabel: true,
+              },
+            ],
+          },
+          children: [],
+          conditions: [],
+        },
         components: [
           {
             component: 'ACTION',
@@ -915,6 +975,26 @@ describe('automationFetchFilter', () => {
                   ruleScope: {
                     resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
                   },
+                  trigger: {
+                    component: 'ACTION',
+                    schemaVersion: 1,
+                    type: 'cmdb.object.create',
+                    value: {
+                      workspaceId: '68d020c3-b88e-47dc-9231-452f7dc63521',
+                      schemaLabel: 'idoA Schema',
+                      schemaId: '5',
+                      objectTypeLabel: 'R&D',
+                      attributes: [
+                        {
+                          name: 'Name',
+                          value: 'idoA automation',
+                          isLabel: true,
+                        },
+                      ],
+                    },
+                    children: [],
+                    conditions: [],
+                  },
                   components: [
                     {
                       component: 'ACTION',
@@ -975,6 +1055,23 @@ describe('automationFetchFilter', () => {
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
+        trigger: {
+          component: 'ACTION',
+          schemaVersion: 1,
+          type: 'cmdb.object.create',
+          value: {
+            schemaId: '5',
+            attributes: [
+              {
+                name: 'Name',
+                value: 'idoA automation',
+                isLabel: true,
+              },
+            ],
+          },
+          children: [],
+          conditions: [],
+        },
         components: [
           {
             component: 'ACTION',
@@ -1024,6 +1121,7 @@ describe('automationFetchFilter', () => {
                   ruleScope: {
                     resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
                   },
+                  trigger: {},
                   components: [
                     {
                       component: 'ACTION',
@@ -1084,6 +1182,7 @@ describe('automationFetchFilter', () => {
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
+        trigger: {},
         components: [
           {
             component: 'ACTION',


### PR DESCRIPTION
This PR addresses issues related to special component handling in automation: requestType default field and trigger components. 
The changes ensure that different formats of requestType are supported and that trigger components are handled the same as the component fields is handled. 

---

_Additional context for reviewer_
more context in https://salto-io.atlassian.net/browse/SALTO-5999

---
_Release Notes_: 
_Jira Adapter:
* Fix handling of requestType field and trigger components in automations to support various formats and proper processing.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
