### PR TITLE
SALTO-6000: Add typeName to error handler

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/index.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/index.ts
@@ -18,7 +18,7 @@
 export { ContextCombinationDefinition } from './dependencies'
 export { FetchApiDefinitions, InstanceFetchApiDefinitions, FetchApiDefinitionsOptions } from './fetch'
 export { FetchRequestDefinition } from './request'
-export { ResourceTransformFunc } from './resource'
+export { ResourceTransformFunc, OnErrorHandlerAction } from './resource'
 export {
   ElementFieldCustomization,
   FieldIDPart,

--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -39,7 +39,7 @@ type ConfigSuggestion = {
 
 export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion
 
-type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error, typeName: string }>
+type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error; typeName: string }>
 
 export type FetchResourceDefinition = {
   // set to true if the resource should be fetched on its own. set to false for types only fetched via recurseInto

--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -37,9 +37,9 @@ type ConfigSuggestion = {
   value: ConfigChangeSuggestion
 }
 
-type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion
+export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion
 
-type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, Error>
+type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error, typeName: string }>
 
 export type FetchResourceDefinition = {
   // set to true if the resource should be fetched on its own. set to false for types only fetched via recurseInto

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -92,7 +92,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
     const { resource: resourceDef } = defQuery.query(typeName) ?? {}
     const onError = resourceDef?.onError
 
-    const onErrorResult = onError?.custom?.(onError)(error) ?? onError
+    const onErrorResult = onError?.custom?.(onError)({ error, typeName }) ?? onError
     switch (onErrorResult?.action) {
       case 'customSaltoError':
         log.warn('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -315,7 +315,7 @@ describe('element', () => {
           }),
         })
         expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
-        expect(customErrorHandler).toHaveBeenCalledWith(fetchError)
+        expect(customErrorHandler).toHaveBeenCalledWith({ error: fetchError, typeName: 'myType' })
       })
     })
   })


### PR DESCRIPTION
To include the typeName in the fetch warning message / suggestion, we should be able to access it from handler 

---

_Additional context for reviewer_

---
_Release Notes_: 
None 

---
_User Notifications_: 
None