### PR TITLE
SALTO-5967: JSM pagination

### DIFF
--- a/packages/adapter-components/src/client/pagination/pagination.ts
+++ b/packages/adapter-components/src/client/pagination/pagination.ts
@@ -178,17 +178,16 @@ export const getWithPageOffsetAndLastPagination = (firstPage: number): Paginatio
   return nextPageFullPages
 }
 
-export const getWithOffsetAndLimit = (): PaginationFunc => {
-  // Hard coded "isLast" and "values" in order to fit the configuration scheme which only allows
+export const getWithOffsetAndLimit = (isLastPageField: string): PaginationFunc => {
+  // Hard coded "values" in order to fit the configuration scheme which only allows
   // "paginationField" to be configured
   type PageResponse = {
-    isLast: boolean
     values: unknown[]
     [k: string]: unknown
   }
   const isPageResponse = (responseData: unknown, paginationField: string): responseData is PageResponse =>
     _.isObject(responseData) &&
-    _.isBoolean(_.get(responseData, 'isLast')) &&
+    _.isBoolean(_.get(responseData, isLastPageField)) &&
     Array.isArray(_.get(responseData, 'values')) &&
     _.isNumber(_.get(responseData, paginationField))
 
@@ -202,7 +201,7 @@ export const getWithOffsetAndLimit = (): PaginationFunc => {
         `Response from ${getParams.url} expected page with pagination field ${paginationField}, got ${safeJsonStringify(responseData)}`,
       )
     }
-    if (responseData.isLast) {
+    if (_.get(responseData, isLastPageField)) {
       return []
     }
     const currentPageStart = _.get(responseData, paginationField) as number

--- a/packages/adapter-components/test/client/pagination.test.ts
+++ b/packages/adapter-components/test/client/pagination.test.ts
@@ -1223,7 +1223,7 @@ describe('client_pagination', () => {
   describe('getWithOffsetAndLimit', () => {
     let paginate: PaginationFunc
     beforeEach(async () => {
-      paginate = getWithOffsetAndLimit()
+      paginate = getWithOffsetAndLimit('isLast')
     })
     describe('with paginationField', () => {
       describe('when response is a valid page', () => {
@@ -1258,6 +1258,27 @@ describe('client_pagination', () => {
             }),
           ).toEqual([])
         })
+        it('should work with different last page values', () => {
+          paginate = getWithOffsetAndLimit('isLastPage')
+          expect(
+            paginate({
+              pageSize: 2,
+              getParams: { url: '/ep', paginationField: 'startAt' },
+              currentParams: {},
+              responseData: { isLastPage: false, startAt: 0, values: [1, 2] },
+              page: [{ isLastPage: false, startAt: 0, values: [1, 2] }],
+            }),
+          ).toEqual([{ startAt: '2' }])
+          expect(
+            paginate({
+              pageSize: 2,
+              getParams: { url: '/ep', paginationField: 'startAt' },
+              currentParams: { startAt: '2' },
+              responseData: { isLastPage: true, startAt: 2, values: [3] },
+              page: [{ isLastPage: true, startAt: 2, values: [3] }],
+            }),
+          ).toEqual([])
+        })
       })
       describe('when response is not a valid page', () => {
         it('should throw error', async () => {
@@ -1270,6 +1291,19 @@ describe('client_pagination', () => {
               page: [{ isLast: false, startAt: 0, values: [1, 2] }],
             }),
           ).toThrow('Response from /ep expected page with pagination field wrong')
+        })
+        it('should throw error when isLastPage is not valid', async () => {
+          expect(() =>
+            paginate({
+              pageSize: 2,
+              getParams: { url: '/ep', paginationField: 'startAt' },
+              currentParams: {},
+              responseData: { isLastPage: false, startAt: 0, values: [1, 2] },
+              page: [{ isLastPage: false, startAt: 0, values: [1, 2] }],
+            }),
+          ).toThrow(
+            'Response from /ep expected page with pagination field startAt, got {"isLastPage":false,"startAt":0,"values":[1,2]}',
+          )
         })
       })
     })

--- a/packages/jira-adapter/src/client/pagination.ts
+++ b/packages/jira-adapter/src/client/pagination.ts
@@ -19,6 +19,8 @@ import { client as clientUtils } from '@salto-io/adapter-components'
 
 const { makeArray } = collections.array
 
+const JSM_IS_LAST_PAGE = 'isLastPage'
+const JSM_PAGINATION_URL_PATTERN = /^\/rest\/servicedeskapi\/servicedesk/
 const ITEM_INDEX_PAGINATION_URLS = [
   '/rest/api/3/users/search',
   '/rest/api/2/user/search',
@@ -75,6 +77,10 @@ export const paginate: clientUtils.PaginationFuncCreator = args => {
       firstIndex: 0,
       pageSizeArgName: args.getParams.pageSizeArgName,
     })
+  }
+  if (JSM_PAGINATION_URL_PATTERN.test(args.getParams?.url)) {
+    // special handling for endpoints that use JSM pagination
+    return clientUtils.getWithOffsetAndLimit(JSM_IS_LAST_PAGE)
   }
   return clientUtils.getAllPagesWithOffsetAndTotal()
 }

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1883,6 +1883,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   RequestType: {
     request: {
       url: '/rest/servicedeskapi/servicedesk/projectId:{projectId}/requesttype',
+      paginationField: 'start',
       recurseInto: [
         {
           type: 'RequestType__workflowStatuses',
@@ -1944,6 +1945,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   Queue: {
     request: {
       url: '/rest/servicedeskapi/servicedesk/projectId:{projectId}/queue',
+      paginationField: 'start',
     },
     transformation: {
       idFields: ['name', 'projectKey'],
@@ -2165,6 +2167,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
   ObjectSchemas: {
     request: {
       url: '/gateway/api/jsm/assets/workspace/{workspaceId}/v1/objectschema/list',
+      paginationField: 'startAt',
       recurseInto: [
         {
           type: 'ObjectSchemaStatuses',


### PR DESCRIPTION
Added pagination to JSM

---

There are two different pagination types. Object Schema uses the regular [Jira API pagination](https://developer.atlassian.com/cloud/jira/platform/rest/v3/intro/#pagination) and the [JSM API pagination](https://developer.atlassian.com/cloud/jira/service-desk/rest/intro/#pagination)

I went over all of the JSM APIs, both in api_config and all the get calls in the filters.

I did not add noise reduction, as the noise would be too big

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug where Object Schemas, Queues, and Request Types would bring partial results for big environments

---
_User Notifications_: 
None
