### PR TITLE
SALTO-6017: fix dependsOn context

### DIFF
--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -189,7 +189,9 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
         (requestDefQuery.query(callerIdentifier.typeName) ?? []).map(requestDef => {
           const mergedDef = getMergedRequestDefinition(requestDef).merged
           const allArgs = findAllUnresolvedArgs(mergedDef)
-          const relevantArgRoots = _.uniq(allArgs.map(arg => arg.split('.')[0]).filter(arg => arg.length > 0))
+          const relevantArgRoots = _.uniq(allArgs.map(arg => arg.split('.')[0]).filter(arg => arg.length > 0)).concat(
+            _.keys(contextPossibleArgs),
+          )
           const contextFunc =
             mergedDef.context?.custom !== undefined
               ? mergedDef.context.custom(mergedDef.context)

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -78,6 +78,15 @@ describe('fetch', () => {
             statusText: 'OK',
           }
         }
+        if (url === '/api/v1/fields/group1/depending_options') {
+          return {
+            data: {
+              depending_options: [{ name: 'deps1' }],
+            },
+            status: 200,
+            statusText: 'OK',
+          }
+        }
         if (url === '/api/v1/fields/789/default_option') {
           throw new Error('error fetching default option')
         }
@@ -126,6 +135,36 @@ describe('fetch', () => {
                 },
               },
               customizations: {
+                depending_option: {
+                  requests: [
+                    {
+                      endpoint: {
+                        path: '/api/v1/fields/{parent_id}/depending_options',
+                      },
+                      transformation: {
+                        root: 'depending_options',
+                      },
+                    },
+                  ],
+                  resource: {
+                    directFetch: true,
+                    context: {
+                      dependsOn: {
+                        parent_id: {
+                          parentTypeName: 'group',
+                          transformation: {
+                            root: 'name',
+                          },
+                        },
+                      },
+                    },
+                  },
+                  element: {
+                    topLevel: {
+                      isTopLevel: true,
+                    },
+                  },
+                },
                 group: {
                   requests: [
                     {
@@ -262,6 +301,8 @@ describe('fetch', () => {
         reason: 'error fetching options',
       })
       expect(res.elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+        'myAdapter.depending_option',
+        'myAdapter.depending_option.instance.deps1Custom',
         'myAdapter.field',
         'myAdapter.field.instance.field1Custom',
         'myAdapter.field.instance.field2Custom',


### PR DESCRIPTION
see [SALTO-6017](https://salto-io.atlassian.net/browse/SALTO-6017) for details
---

I'll only merge this code as part of the PR for the guide elements in Zendesk - i just want to make sure that this doesn't break anything and on main i don't have a convenient way to check the code :)
reiterating: I PR'd this so that it's easier to talk about, THIS PR IS NOT GOINT TO BE MERGED


[SALTO-6017]: https://salto-io.atlassian.net/browse/SALTO-6017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ