### PR TITLE
SALTO-6022 allow isTopLevel to be false

### DIFF
--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -117,7 +117,8 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
   const generate: ElementGenerator['generate'] = () => {
     const allResults = Object.entries(valuesByType).flatMap(([typeName, values]) => {
       try {
-        return generateInstancesWithInitialTypes({
+        return defQuery.query(typeName)?.element?.topLevel === undefined ? { instances: [], types: [] } :
+        generateInstancesWithInitialTypes({
           adapterName,
           defQuery,
           entries: values,

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -117,16 +117,17 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
   const generate: ElementGenerator['generate'] = () => {
     const allResults = Object.entries(valuesByType).flatMap(([typeName, values]) => {
       try {
-        return defQuery.query(typeName)?.element?.topLevel === undefined ? { instances: [], types: [] } :
-        generateInstancesWithInitialTypes({
-          adapterName,
-          defQuery,
-          entries: values,
-          typeName,
-          definedTypes: predefinedTypes,
-          getElemIdFunc,
-          customNameMappingFunctions,
-        })
+        return defQuery.query(typeName)?.element?.topLevel === undefined
+          ? { instances: [], types: [] }
+          : generateInstancesWithInitialTypes({
+              adapterName,
+              defQuery,
+              entries: values,
+              typeName,
+              definedTypes: predefinedTypes,
+              getElemIdFunc,
+              customNameMappingFunctions,
+            })
       } catch (e) {
         // TODO decide how to handle error based on args (SALTO-5842)
         if (e instanceof InvalidSingletonType) {

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -134,7 +134,7 @@ export const getInstanceCreationFunctions = <Options extends FetchApiDefinitions
   const { element: elementDef, resource: resourceDef } = defQuery.query(typeName) ?? {}
 
   if (!elementDef?.topLevel?.isTopLevel) {
-    // should have already been tested in caller
+    // should have already been tested in caller, we should not get here if topLevel is undefined
     const error = `type ${adapterName}:${typeName} is not defined as top-level, cannot create instances`
     throw new Error(error)
   }

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -52,7 +52,7 @@ describe('element', () => {
       const generator = getElementGenerator({
         adapterName: 'myAdapter',
         defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-          customizations: { myType: { element: { topLevel: { isTopLevel: true } } } },
+          customizations: { myType: { element: {} } },
         }),
         customNameMappingFunctions: {},
       })
@@ -62,8 +62,7 @@ describe('element', () => {
       })
       const res = generator.generate()
       expect(res.errors).toEqual([])
-      expect(res.elements.length).toBe(1)
-      expect(res.elements.map(e => e.elemID.getFullName())).toEqual(['myAdapter.myType'])
+      expect(res.elements).toEqual([])
     })
     it('should create instances and matching type when entries are provided and no defs', () => {
       const entries = [


### PR DESCRIPTION
- In case directFetch is true we want to allow topLevelDef to be undefined without throwing an error. In this case Instances will not be created but the fetched data can be used for recurseInto or dependsOn types

---


---
_Release Notes_: 
None

---
_User Notifications_: 
None
