### PR TITLE
SALTO-6024: Enforce forward slash on endpoint path

### DIFF
--- a/packages/adapter-components/src/definitions/system/requests/index.ts
+++ b/packages/adapter-components/src/definitions/system/requests/index.ts
@@ -17,6 +17,7 @@ export { ApiClientDefinition, RESTApiClientDefinition } from './client'
 export { EndpointByPathAndMethod } from './endpoint'
 export { PaginationDefinitions, PaginationFunction, ClientRequestArgsNoPath } from './pagination'
 export {
+  EndpointPath,
   HTTPEndpointIdentifier,
   RequestArgs,
   HTTPMethod,

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -18,10 +18,12 @@ import { Response, ResponseValue } from '../../../client'
 
 export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 'options'
 
+export type EndpointPath = `/${string}`
+
 export type HTTPEndpointIdentifier<ClientOptions extends string> = {
   // specify the client to use to call the endpoint - defaults to the default client as specified in client.default
   client?: ClientOptions
-  path: `/${string}`
+  path: EndpointPath
   // when not specified, the method is assumed to be 'get'
   method?: HTTPMethod
 }

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -21,7 +21,7 @@ export type HTTPMethod = 'get' | 'post' | 'put' | 'patch' | 'delete' | 'head' | 
 export type HTTPEndpointIdentifier<ClientOptions extends string> = {
   // specify the client to use to call the endpoint - defaults to the default client as specified in client.default
   client?: ClientOptions
-  path: string
+  path: `/${string}`
   // when not specified, the method is assumed to be 'get'
   method?: HTTPMethod
 }

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -100,7 +100,7 @@ const DEFAULT_TRANSFORMATION = { root: 'value' }
 
 const createCustomizationsWithBasePath = (
   customizations: FetchCustomizations,
-  basePath: definitions.HTTPEndpointIdentifier<Options['clientOptions']>['path'],
+  basePath: definitions.EndpointPath,
 ): FetchCustomizations =>
   _.mapValues(customizations, customization => ({
     ...customization,
@@ -108,7 +108,7 @@ const createCustomizationsWithBasePath = (
       ...req,
       endpoint: {
         ...req.endpoint,
-        path: `${basePath}${req.endpoint.path}` as definitions.HTTPEndpointIdentifier<Options['clientOptions']>['path'],
+        path: `${basePath}${req.endpoint.path}` as definitions.EndpointPath,
       },
     })),
   }))

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -98,14 +98,17 @@ const DEFAULT_FIELD_CUSTOMIZATIONS: Record<string, definitions.fetch.ElementFiel
 
 const DEFAULT_TRANSFORMATION = { root: 'value' }
 
-const createCustomizationsWithBasePath = (customizations: FetchCustomizations, basePath: string): FetchCustomizations =>
+const createCustomizationsWithBasePath = (
+  customizations: FetchCustomizations,
+  basePath: definitions.HTTPEndpointIdentifier<Options['clientOptions']>['path'],
+): FetchCustomizations =>
   _.mapValues(customizations, customization => ({
     ...customization,
     requests: customization.requests?.map(req => ({
       ...req,
       endpoint: {
         ...req.endpoint,
-        path: `${basePath}${req.endpoint.path}`,
+        path: `${basePath}${req.endpoint.path}` as definitions.HTTPEndpointIdentifier<Options['clientOptions']>['path'],
       },
     })),
   }))

--- a/packages/okta-adapter/src/definitions/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch.ts
@@ -53,7 +53,7 @@ const getPrivateAPICustomizations = ({
   endpoint,
   serviceUrl,
 }: {
-  endpoint: string
+  endpoint: definitions.HTTPEndpointIdentifier<OktaFetchOptions['clientOptions']>['path']
   serviceUrl: string
 }): definitions.fetch.InstanceFetchApiDefinitions<OktaFetchOptions> => ({
   requests: [{ endpoint: { path: endpoint, client: 'private' } }],

--- a/packages/okta-adapter/src/definitions/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch.ts
@@ -53,7 +53,7 @@ const getPrivateAPICustomizations = ({
   endpoint,
   serviceUrl,
 }: {
-  endpoint: definitions.HTTPEndpointIdentifier<OktaFetchOptions['clientOptions']>['path']
+  endpoint: definitions.EndpointPath
   serviceUrl: string
 }): definitions.fetch.InstanceFetchApiDefinitions<OktaFetchOptions> => ({
   requests: [{ endpoint: { path: endpoint, client: 'private' } }],


### PR DESCRIPTION
Enforce forward slash on endpoints in request definitions for both fetch and deploy

---

_Additional context for reviewer_
see https://github.com/salto-io/salto/pull/5984

---
_Release Notes_: 
None

---
_User Notifications_: 
None