### PR TITLE
SALTO-5545 stop using serviceUrl filter in confluence

### DIFF
--- a/packages/confluence-adapter/src/adapter_creator.ts
+++ b/packages/confluence-adapter/src/adapter_creator.ts
@@ -53,6 +53,8 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
       // deploySpaceAndPermissionsFilterCreator should run before default deploy filter
       deploySpaceAndPermissionsFilterCreator: deploySpaceAndPermissionsFilterCreator(args),
       ...filters.createCommonFilters<Options, UserConfig>(args),
+      // TODO https://salto-io.atlassian.net/browse/SALTO-5869
+      serviceUrl: () => ({ name: 'serviceUrl' }),
       // transform template body must run after references are created (fieldReferencesFilter)
       transformTemplateBodyToTemplateExpressionFilterCreator,
       // customPathsFilterCreator must run after fieldReferencesFilter


### PR DESCRIPTION

---

_Additional context for reviewer_

---
_Release Notes_: 
_Confluence Adapter_:
- temporary stop using serviceUrl filter
---
_User Notifications_: 
_Confluence Adapter_:
- temporary stop using serviceUrl filter
