### PR TITLE
SALTO-3621: Specifying type references using generics

### DIFF
--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -32,18 +32,12 @@ const log = logger(module)
 
 export const BuiltinTypesRefByFullName: Record<string, TypeReference<PrimitiveType>> = {}
 
-export const createRefToElmWithValue = <T extends TypeElement>(element: T): TypeReference<T> => {
-  // For BuiltinTypes we use a hardcoded list of refs with values to avoid duplicate instances
-  if (isPrimitiveType(element) && element.elemID.getFullName() in BuiltinTypesRefByFullName) {
-    // Technically, all TS knows here is that the type of `element` is `T & PrimitiveType`,
-    // but that doesn't necessarily mean that `T === PrimitiveType`.
-    // We know this is the case though because there aren't (and probably never will be)
-    // any types which extend `PrimitiveType`.
-    return BuiltinTypesRefByFullName[element.elemID.getFullName()] as TypeReference<T>
-  }
-
-  return new TypeReference(element.elemID, element)
-}
+export const createRefToElmWithValue = <T extends TypeElement>(element: T): TypeReference<T> =>
+  // For BuiltinTypes we use hardcoded refs with values to avoid duplicate instances.
+  // If the element ID is in the present we know the element is of type PrimitiveType but TS does not,
+  // so we need to tell it.
+  (BuiltinTypesRefByFullName[element.elemID.getFullName()] as TypeReference<T>) ??
+  new TypeReference(element.elemID, element)
 
 // This is used to allow constructors Elements with Placeholder types
 // to receive TypeElement and save the appropriate Reference

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -34,7 +34,7 @@ export const BuiltinTypesRefByFullName: Record<string, TypeReference<PrimitiveTy
 
 export const createRefToElmWithValue = <T extends TypeElement>(element: T): TypeReference<T> => {
   // For BuiltinTypes we use a hardcoded list of refs with values to avoid duplicate instances
-  if (isPrimitiveType(element)) {
+  if (isPrimitiveType(element) && element.elemID.getFullName() in BuiltinTypesRefByFullName) {
     // Technically, all TS knows here is that the type of `element` is `T & PrimitiveType`,
     // but that doesn't necessarily mean that `T === PrimitiveType`.
     // We know this is the case though because there are (and probably never will be)

--- a/packages/adapter-api/src/elements.ts
+++ b/packages/adapter-api/src/elements.ts
@@ -37,7 +37,7 @@ export const createRefToElmWithValue = <T extends TypeElement>(element: T): Type
   if (isPrimitiveType(element) && element.elemID.getFullName() in BuiltinTypesRefByFullName) {
     // Technically, all TS knows here is that the type of `element` is `T & PrimitiveType`,
     // but that doesn't necessarily mean that `T === PrimitiveType`.
-    // We know this is the case though because there are (and probably never will be)
+    // We know this is the case though because there aren't (and probably never will be)
     // any types which extend `PrimitiveType`.
     return BuiltinTypesRefByFullName[element.elemID.getFullName()] as TypeReference<T>
   }

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -178,25 +178,25 @@ export class VariableExpression extends ReferenceExpression {
   }
 }
 
-export class TypeReference {
+export class TypeReference<T extends TypeElement = TypeElement> {
   constructor(
     public readonly elemID: ElemID,
-    public type: TypeElement | undefined = undefined,
+    public type: T | undefined = undefined,
   ) {
     if (!elemID.isTopLevel()) {
       throw new Error(`Invalid id for type reference: ${elemID.getFullName()}. Type reference must be top level.`)
     }
   }
 
-  clone(): TypeReference {
+  clone(): TypeReference<T> {
     return new TypeReference(this.elemID, this.type)
   }
 
-  async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<TypeElement> {
+  async getResolvedValue(elementsSource?: ReadOnlyElementsSource): Promise<T> {
     return getResolvedValue(this.elemID, elementsSource, this.type)
   }
 
-  getResolvedValueSync(): TypeElement | undefined {
+  getResolvedValueSync(): T | undefined {
     return this.type
   }
 

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -29,6 +29,7 @@ import {
   isInstanceElement,
   isType,
   TypeElement,
+  isObjectType,
 } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType, getSubtypes, resolvePath, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -214,6 +215,12 @@ export const createResolvedTypesElementsSource = (elementsSource: ReadOnlyElemen
           'Expected type of Instance %s to be resolved. Type elemID: %s. Returning Instance with non fully resolved type.',
           instance.elemID.getFullName(),
           instance.refType.elemID.getFullName(),
+        )
+        return instance
+      }
+      if (!isObjectType(resolvedType)) {
+        log.warn(
+          'Expected type of Instance %s to be an Object type. Type elemID: %s. Returning Instance with non fully resolved type.',
         )
         return instance
       }

--- a/packages/workspace/src/merger/internal/instances.ts
+++ b/packages/workspace/src/merger/internal/instances.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstanceElement, ElemID, TypeReference } from '@salto-io/adapter-api'
+import { InstanceElement, ElemID, TypeReference, ObjectType } from '@salto-io/adapter-api'
 import { inspectValue } from '@salto-io/adapter-utils'
 import { MergeResult, MergeError, mergeNoDuplicates, DuplicateAnnotationError } from './common'
 
@@ -44,7 +44,7 @@ export class DuplicateInstanceKeyError extends MergeError {
 }
 
 const mergeInstanceDefinitions = (
-  { elemID, refType }: { elemID: ElemID; refType: TypeReference },
+  { elemID, refType }: { elemID: ElemID; refType: TypeReference<ObjectType> },
   instanceDefs: InstanceElement[],
 ): MergeResult<InstanceElement> => {
   const valueMergeResult =

--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -325,7 +325,7 @@ const generalDeserializeParsed = async <T>(parsed: unknown, staticFileReviver?: 
       InstanceElement: v =>
         new InstanceElement(
           v.elemID.nameParts[0],
-          reviveRefTypeOfElement(v),
+          reviveRefTypeOfElement(v) as TypeReference<ObjectType>,
           restoreClasses(v.value),
           v.path,
           restoreClasses(v.annotations),


### PR DESCRIPTION
This allows us to enforce that instance types are object types using the type system and will allow us to do the same for meta types in the next PR.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
