### PR TITLE
SALTO-5545 remove serviceUrl def from page type in Confluence

### DIFF
--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -253,9 +253,6 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     element: {
       topLevel: {
         isTopLevel: true,
-        serviceUrl: {
-          path: '/wiki/spaces/{spaceId.key}/pages/{id}',
-        },
         elemID: {
           // Confluence does not allow pages with the same title in the same space
           parts: [{ fieldName: 'spaceId', isReference: true }, { fieldName: 'title' }],


### PR DESCRIPTION
As title
---



---
_Release Notes_: 
None
---
_User Notifications_: 
None