### PR TITLE
SALTO-5782: return only cycle from getCycle

### DIFF
--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -246,7 +246,12 @@ export class AbstractNodeMap extends collections.map.DefaultMap<NodeId, Set<Node
   getCycle(): Edge[] | undefined {
     const getCycleFrom = (id: NodeId, nodeColors: Map<NodeId, DFS_STATUS>, path: Edge[] = []): Edge[] | undefined => {
       if (nodeColors.has(id)) {
-        return nodeColors.get(id) === 'in_progress' ? path : undefined
+        if (nodeColors.get(id) === 'in_progress') {
+          // Found a cycle - the cycle is "closed" on this node.
+          // In order to return just the cycle, we need to remove any edges that lead up to this node
+          return path.slice(path.findIndex(edge => edge[0] === id))
+        }
+        return undefined
       }
       nodeColors.set(id, 'in_progress')
       const children = this.get(id).keys()

--- a/packages/dag/test/nodemap.test.ts
+++ b/packages/dag/test/nodemap.test.ts
@@ -471,21 +471,39 @@ describe('NodeMap', () => {
     })
 
     describe('for a graph with cycles', () => {
-      beforeEach(() => {
-        subject.addNode(1, [6])
-        subject.addNode(2, [3])
-        subject.addNode(3, [4])
-        subject.addNode(4, [2])
-        subject.addNode(5, [6])
-        subject.addNode(6, [])
-      })
+      describe('when the cycle is disconnected from the rest of the graph', () => {
+        beforeEach(() => {
+          subject.addNode(1, [6])
+          subject.addNode(2, [3])
+          subject.addNode(3, [4])
+          subject.addNode(4, [2])
+          subject.addNode(5, [6])
+          subject.addNode(6, [])
+        })
 
-      it('should return the cycles', () => {
-        expect(subject.getCycle()).toEqual([
-          [2, 3],
-          [3, 4],
-          [4, 2],
-        ])
+        it('should return the cycles', () => {
+          expect(subject.getCycle()).toEqual([
+            [2, 3],
+            [3, 4],
+            [4, 2],
+          ])
+        })
+      })
+      describe('when there are edges that lead to a cycle', () => {
+        beforeEach(() => {
+          subject.addNode(1, [2])
+          subject.addNode(2, [3])
+          subject.addNode(3, [4])
+          subject.addNode(4, [2])
+        })
+        it('should only return the cycle without the leading edges', () => {
+          // The 1->2 edge is not part of the cycle
+          expect(subject.getCycle()).toEqual([
+            [2, 3],
+            [3, 4],
+            [4, 2],
+          ])
+        })
       })
     })
   })


### PR DESCRIPTION
Before this fix, getCycle would return edges that lead up to the cycle along with the actual cycle This causes issues in depending code which assumed the return of "getCycle" is just the cycle

---



---
_Release Notes_: 
Core:
- Fix issue where plan would go into infinite loop on specific cases of circular dependencies

---
_User Notifications_: 
_None_