### PR TITLE
SALTO-5987 Google ws - e2e-enable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -407,7 +407,7 @@ workflows:
                 - stripe-adapter
                 - zendesk-adapter
                 - zuora-billing-adapter
-                # - google-workspace-adapter
+                - google-workspace-adapter
               should_install_java: 
                 - false
 


### PR DESCRIPTION
SALTO-5987 Google ws - e2e-enable

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
