### PR TITLE
SALTO-6036: Modify selectElementsBySelectorsWithoutReferences to also support returning emptyList 

### DIFF
--- a/packages/workspace/src/workspace/element_selector.ts
+++ b/packages/workspace/src/workspace/element_selector.ts
@@ -127,13 +127,15 @@ export const selectElementsBySelectorsWithoutReferences = ({
   elementIds,
   selectors,
   includeNested = false,
+  returnEmptyOnEmptySelectors = false,
 }: {
   elementIds: ElemID[]
   selectors: ElementSelector[]
   includeNested?: boolean
+  returnEmptyOnEmptySelectors?: boolean
 }): ElemID[] => {
   if (selectors.length === 0) {
-    return elementIds
+    return returnEmptyOnEmptySelectors ? [] : elementIds
   }
   return elementIds.filter(elementId => selectors.some(selector => match(elementId, selector, includeNested)))
 }

--- a/packages/workspace/test/element_selector.test.ts
+++ b/packages/workspace/test/element_selector.test.ts
@@ -132,15 +132,18 @@ const selectElementsWitoutRef = ({
   elements,
   selectors,
   includeNested = false,
+  returnEmptyOnEmptySelectors = false,
 }: {
   elements: ElemID[]
   selectors: string[]
   includeNested?: boolean
+  returnEmptyOnEmptySelectors?: boolean
 }): ElemID[] =>
   selectElementsBySelectorsWithoutReferences({
     elementIds: elements,
     selectors: createElementSelectors(selectors).validSelectors,
     includeNested,
+    returnEmptyOnEmptySelectors,
   })
 
 describe('element selector', () => {
@@ -789,6 +792,10 @@ describe('element selector without ref by', () => {
   it('returns all elements with no selectors', () => {
     const elements = [new ElemID('salesforce', 'value'), new ElemID('netsuite', 'value'), new ElemID('jira', 'value')]
     expect(selectElementsWitoutRef({ elements, selectors: [] })).toEqual(elements)
+  })
+  it('should return no elements when returnEmptyOnEmptySelectors is true and no selectors are given', async () => {
+    const elements = [new ElemID('salesforce', 'value'), new ElemID('netsuite', 'value'), new ElemID('jira', 'value')]
+    expect(selectElementsWitoutRef({ elements, selectors: [], returnEmptyOnEmptySelectors: true })).toEqual([])
   })
   it('should use a wildcard and a specific element id and not throw error if the wildcard covers the element id', () => {
     const elements = [new ElemID('salesforce', 'value')]


### PR DESCRIPTION
In this PR I added functionality to  selectElementsBySelectorsWithoutReferences so we will return empty list when no selectors given.

---

_Additional context for reviewer_
The desired behavior for monitoring is that if we set a monitor on our elements without specifying a selector, the monitor should apply to all elements. 

Conversely, for the "Exclude from Compare" feature, if no selector is defined, nothing should be selected. These two behaviors are opposite, and I want to support both.


---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
