### PR TITLE
SALTO-6042 remove source.list override patch from ci pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,18 +17,6 @@ commands:
       package_name:
         type: string
     steps:
-      - run:
-          name: configure sources.list
-          command: |
-            if curl -sL https://salto-cli-releases.s3.eu-central-1.amazonaws.com/build_artifacts/apt/sources.list -o /tmp/sources.list; then
-              echo "found sources.list file"
-              sudo mv /tmp/sources.list /etc/apt/sources.list
-              sudo apt update
-            else
-              echo "did not find sources.list file, using the default one"
-            fi
-            echo "using sources.list:"
-            cat /etc/apt/sources.list
       - when:
           condition: << parameters.should_install_java >>
           steps:


### PR DESCRIPTION
removing a patch that replaced the Ubuntu sources with an alternative mirror, due to some network issue in the past, and is no longer required.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
