### PR TITLE
SALTO-6045: Cloned types should not share types customizations

### DIFF
--- a/packages/adapter-components/src/openapi/type_elements/type_config_override.ts
+++ b/packages/adapter-components/src/openapi/type_elements/type_config_override.ts
@@ -38,12 +38,12 @@ export const defineAdditionalTypes = (
   typeConfig?: Record<string, TypeSwaggerConfig>,
 ): void => {
   additionalTypes.forEach(({ typeName, cloneFrom }) => {
-    const origType = definedTypes[cloneFrom]
-    if (!origType) {
+    const originalType = definedTypes[cloneFrom]
+    if (!originalType) {
       throw new Error(`could not find type ${cloneFrom} needed for additional resource ${typeName}`)
     }
     const additionalType = new ObjectType({
-      ...origType,
+      ...originalType.clone(),
       elemID: new ElemID(adapterName, typeName),
     })
     definedTypes[typeName] = additionalType

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -657,6 +657,7 @@ const createCustomizations = ({
       },
       fieldCustomizations: {
         id: { hide: true },
+        name: { hide: true },
         [naclCase('$schema')]: { omit: true },
         _links: { omit: true },
         type: { omit: true },

--- a/packages/okta-adapter/src/filters/add_important_values.ts
+++ b/packages/okta-adapter/src/filters/add_important_values.ts
@@ -26,6 +26,8 @@ import {
   NETWORK_ZONE_TYPE_NAME,
   POLICY_TYPE_NAMES,
   POLICY_RULE_TYPE_NAMES,
+  AUTOMATION_TYPE_NAME,
+  AUTOMATION_RULE_TYPE_NAME,
 } from '../constants'
 
 const importantValuesMap: Record<string, ImportantValues> = {
@@ -159,13 +161,15 @@ const importantValuesMap: Record<string, ImportantValues> = {
     },
   ],
   ...Object.fromEntries(
-    POLICY_TYPE_NAMES.concat(POLICY_RULE_TYPE_NAMES).map(policyName => [
-      policyName,
-      [
-        { value: 'name', highlighted: true, indexed: false },
-        { value: 'status', highlighted: true, indexed: true },
+    POLICY_TYPE_NAMES.concat(POLICY_RULE_TYPE_NAMES, AUTOMATION_TYPE_NAME, AUTOMATION_RULE_TYPE_NAME).map(
+      policyName => [
+        policyName,
+        [
+          { value: 'name', highlighted: true, indexed: false },
+          { value: 'status', highlighted: true, indexed: true },
+        ],
       ],
-    ]),
+    ),
   ),
 }
 


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

When cloned types, we didn't create an independent new object type, which caused each cloned object type to be affected by the original types customizations.

---

_Additional context for reviewer_

I tested with both Jira and Zuora which uses `additionalTypes` in the old infra and the change doesn't effect types
The change did changed some types in Okta so I included the adjustments in this PR.

---
_Release Notes_: 
None 

---
_User Notifications_: 
None
