### PR TITLE
enable ns e2e

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -110,8 +110,7 @@ const nullProgressReporter: ProgressReporter = {
   reportProgress: () => {},
 }
 
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Netsuite adapter E2E with real account', () => {
+describe('Netsuite adapter E2E with real account', () => {
   let adapter: NetsuiteAdapter
   let credentialsLease: CredsLease<Required<Credentials>>
   const { standardTypes, additionalTypes, innerAdditionalTypes } = getMetadataTypes()


### PR DESCRIPTION
It was disabled at the last NS outage.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None