### PR TITLE
Fix custom record type quick fetch

### DIFF
--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -641,6 +641,30 @@ describe('sdf client', () => {
       expect(mockExecuteAction).toHaveBeenNthCalledWith(4, importObjectsCommandMatcher)
     })
 
+    it('should return custom record type with matching custom segment in instancesIds', async () => {
+      mockExecuteAction.mockImplementation(context => {
+        if (context.commandName === COMMANDS.LIST_OBJECTS) {
+          return Promise.resolve({
+            isSuccess: () => true,
+            data: [{ type: 'customsegment', scriptId: 'cseg123' }],
+          })
+        }
+        if (context.commandName === COMMANDS.IMPORT_OBJECTS) {
+          return Promise.resolve({
+            isSuccess: () => true,
+            data: { failedImports: [] },
+          })
+        }
+        return Promise.resolve({ isSuccess: () => true })
+      })
+
+      const { instancesIds: currentInstanceIds } = await mockClient().getCustomObjects(typeNames, typeNamesQueries)
+      expect(currentInstanceIds).toEqual([
+        { type: 'customsegment', instanceId: 'cseg123' },
+        { type: 'customrecordtype', instanceId: 'customrecord_cseg123' },
+      ])
+    })
+
     it('should pass fetch configured suite apps', async () => {
       mockExecuteAction.mockImplementation(context => {
         if (context.commandName === COMMANDS.LIST_OBJECTS) {


### PR DESCRIPTION
On quick fetch, we delete objects that aren't returned in the `object:list` command from SDF, because in general it means that they're deleted from the service. There is one exception and it is custom record types with matching custom segments - the `object:list` command returns only the custom segments, and on `object:import` the custom record types are fetched. This causes us to delete all the custom record types with matching custom segments on quick fetch. The solution is to add the matching custom record types to the returned `instancesIds` list, as it will prevent us from deleting them on quick fetch, and also we'll add them to the `netsuite.script_ids` hidden nacl (see [this comment](https://github.com/salto-io/salto/pull/5893#discussion_r1626922075))

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix custom record type quick fetch

---
_User Notifications_: 
None