### PR TITLE
SALTO-5987 Google ws e2e longer sleep between deploy and fetch

### DIFF
--- a/packages/google-workspace-adapter/e2e_test/adapter.test.ts
+++ b/packages/google-workspace-adapter/e2e_test/adapter.test.ts
@@ -181,7 +181,7 @@ describe('Google Workspace adapter E2E', () => {
       deployResults = await deployChanges(adapterAttr, changes)
       // Google workspace API takes time to reflect the changes from the deploy.
       // So, we need to wait for some time before fetching in order to get the new elements.
-      await sleep(5000)
+      await sleep(10000)
       const fetchResult = await adapterAttr.adapter.fetch({
         progressReporter: { reportProgress: () => null },
       })


### PR DESCRIPTION
SALTO-5987 Google ws e2e longer sleep between deploy and fetch
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
