### PR TITLE
SALTO-6049: Fix missing Reference bug in ObjectTypeAttribute

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1306,24 +1306,24 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
-    // additionalValue in ObjectTypeAttribute can be of types ObjectSchemaReferenceType or ObjectSchemaDefaultReferenceType
+  // additionalValue in ObjectTypeAttribute can be of types ObjectSchemaReferenceType or ObjectSchemaDefaultReferenceType
   {
     src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
-    target: { type: OBJECT_SCHMEA_REFERENCE_TYPE_TYPE}
+    target: { type: OBJECT_SCHMEA_REFERENCE_TYPE_TYPE },
   },
   {
     src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
-    target: { type: OBJECT_SCHMEA_DEFAULT_REFERENCE_TYPE_TYPE}
+    target: { type: OBJECT_SCHMEA_DEFAULT_REFERENCE_TYPE_TYPE },
   },
-    // Hack to handle missing references when the type is unknown
-    {
-      src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
-      serializationStrategy: 'id',
-      missingRefStrategy: 'typeAndValue',
-      target: { type: 'UnknownType' },
-    },
+  // Hack to handle missing references when the type is unknown
+  {
+    src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: 'UnknownType' },
+  },
   {
     src: { field: 'objectTypeId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'id',


### PR DESCRIPTION
In this PR I fixed missing Reference bug in ObjectTypeAttribute

---

_Additional context for reviewer_
In the ObjectTypeAttribute, there is a field named additionalValue.
This field can hold two types: ObjectSchemaDefaultReferenceType or ObjectSchemaReferenceType.
Initially, I assumed they could have the same IDs and attempted a hack to determine the reference type.
I have now updated the logic to match the approach used for the typeValueMulti field in ObjectTypeAttribute.

---
_Release Notes_: 
_Jira Adapter:_
* Fixed missing reference bug in ObjectTypeAttribute in the `additionalValue` field.

---
_User Notifications_: 
_Jira Adapter:_
* Users might encounter changes in the additionalValue field within the ObjectTypeAttribute instances, changing from a missing reference to an actual referenc