### PR TITLE
SALTO_6050: fail gracefully when workflowV2 version does not match the service

### DIFF
--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -577,9 +577,7 @@ const deployWorkflow = async ({
       error.response?.status === 409 &&
       error.message.includes('Workflow version and version token must match')
     ) {
-      throw new Error(
-        `The environment is not synced to the Jira Service for the workflow '${getChangeData(change).value.workflows[0].name}', please run fetch and try again`,
-      )
+      throw new Error('The workflow version does not match the version in Jira; please fetch and try again')
     }
     throw error
   }

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -1607,6 +1607,20 @@ It is strongly recommended to rename these transitions so they are unique in Jir
           })
         })
 
+        it('should fail gracefully when the version does not match the service', async () => {
+          deployChangeMock.mockRejectedValueOnce(
+            new clientUtils.HTTPError('Workflow version and version token must match', {
+              status: 409,
+              data: {},
+            }),
+          )
+          const result = await filter.deploy([toChange({ before: workflowInstanceBefore, after: workflowInstance })])
+          expect(result.deployResult.errors).toHaveLength(1)
+          expect(result.deployResult.errors[0].message).toEqual(
+            "Error: The environment is not synced to the Jira Service for the workflow 'workflow', please run fetch and try again",
+          )
+        })
+
         it('should not fail the deployment if the migration fails', async () => {
           connection.get.mockResolvedValueOnce({
             status: 200,

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -1617,7 +1617,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
           const result = await filter.deploy([toChange({ before: workflowInstanceBefore, after: workflowInstance })])
           expect(result.deployResult.errors).toHaveLength(1)
           expect(result.deployResult.errors[0].message).toEqual(
-            "Error: The environment is not synced to the Jira Service for the workflow 'workflow', please run fetch and try again",
+            'Error: The workflow version does not match the version in Jira; please fetch and try again',
           )
         })
 


### PR DESCRIPTION
_fail gracefully when workflowV2 version does not match the service_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
