### PR TITLE
SALTO-6043 Fetch and Deploy Custom Record instances of locked Custom Record Types

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -41,7 +41,7 @@ import { filter, logDuration } from '@salto-io/adapter-utils'
 import { combineElementFixers } from '@salto-io/adapter-components'
 import { createElements } from './transformer'
 import { DeployResult, TYPES_TO_SKIP, isCustomRecordType } from './types'
-import { BUNDLE } from './constants'
+import { BUNDLE, CUSTOM_RECORD_TYPE } from './constants'
 import convertListsToMaps from './filters/convert_lists_to_maps'
 import replaceElementReferences from './filters/element_references'
 import parseReportTypes from './filters/parse_report_types'
@@ -111,11 +111,12 @@ import dependencyChanger from './dependency_changer'
 import { cloneChange } from './change_validators/utils'
 import { getChangeGroupIdsFunc } from './group_changes'
 import { getCustomRecords } from './custom_records/custom_records'
+import { createLockedCustomRecordTypes } from './custom_records/custom_record_type'
 import { getDataElements } from './data_elements/data_elements'
 import { getSuiteQLTableElements } from './data_elements/suiteql_table_elements'
 import { getStandardTypesNames } from './autogen/types'
 import { getConfigTypes, toConfigElements } from './suiteapp_config_elements'
-import { ImportFileCabinetResult } from './client/types'
+import { FailedTypes, ImportFileCabinetResult } from './client/types'
 import {
   DEFAULT_VALIDATE,
   DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
@@ -132,6 +133,7 @@ import {
   buildNetsuiteQuery,
   convertToQueryParams,
   notQuery,
+  isIdsQuery,
 } from './config/query'
 import { getConfigFromConfigChanges } from './config/suggestions'
 import { NetsuiteConfig, AdditionalDependencies, QueryParams, NetsuiteQueryParameters, ObjectID } from './config/types'
@@ -382,10 +384,29 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return result
     }
 
+    const getLockedCustomRecordTypes = (failedTypes: FailedTypes, instancesIds: ObjectID[]): ObjectType[] => {
+      const scriptIdsSet = new Set(instancesIds.map(item => item.instanceId))
+      const lockedCustomRecordTypesScriptIds = _.uniq(
+        (failedTypes.lockedError[CUSTOM_RECORD_TYPE] ?? []).concat(
+          this.userConfig.fetch.lockedElementsToExclude?.types
+            .filter(isIdsQuery)
+            .filter(type => type.name === CUSTOM_RECORD_TYPE)
+            .flatMap(type => type.ids ?? [])
+            .filter(scriptId => scriptIdsSet.has(scriptId)) ?? [],
+        ),
+      )
+      if (!this.userConfig.fetch.addLockedCustomRecordTypes) {
+        log.debug('skip adding the following locked custom record types: %o', lockedCustomRecordTypesScriptIds)
+        return []
+      }
+      return createLockedCustomRecordTypes(lockedCustomRecordTypesScriptIds)
+    }
+
     const getStandardAndCustomElements = async (): Promise<{
       standardInstances: InstanceElement[]
       standardTypes: TypeElement[]
       customRecordTypes: ObjectType[]
+      lockedCustomRecordTypes: ObjectType[]
       customRecords: InstanceElement[]
       instancesIds: ObjectID[]
       failures: Omit<FetchByQueryFailures, 'largeSuiteQLTables'>
@@ -413,9 +434,10 @@ export default class NetsuiteAdapter implements AdapterOperations {
       const [standardInstances, types] = _.partition(elements, isInstanceElement)
       const [objectTypes, otherTypes] = _.partition(types, isObjectType)
       const [customRecordTypes, standardTypes] = _.partition(objectTypes, isCustomRecordType)
+      const lockedCustomRecordTypes = getLockedCustomRecordTypes(failedTypes, instancesIds)
       const { elements: customRecords, largeTypesError: failedCustomRecords } = await getCustomRecords(
         this.client,
-        customRecordTypes,
+        customRecordTypes.concat(lockedCustomRecordTypes),
         fetchQueryWithBundles,
         this.getElemIdFunc,
       )
@@ -423,6 +445,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         standardInstances,
         standardTypes: [...standardTypes, ...otherTypes],
         customRecordTypes,
+        lockedCustomRecordTypes,
         customRecords,
         instancesIds,
         failures: { failedCustomRecords, failedFilePaths, failedToFetchAllAtOnce, failedTypes },
@@ -430,7 +453,15 @@ export default class NetsuiteAdapter implements AdapterOperations {
     }
 
     const [
-      { standardInstances, standardTypes, customRecordTypes, customRecords, instancesIds, failures },
+      {
+        standardInstances,
+        standardTypes,
+        customRecordTypes,
+        lockedCustomRecordTypes,
+        customRecords,
+        instancesIds,
+        failures,
+      },
       { elements: dataElements, requestedTypes: requestedDataTypes, largeTypesError: dataTypeError },
       { elements: suiteQLTableElements, largeSuiteQLTables },
     ] = await Promise.all([
@@ -470,6 +501,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       .concat(standardInstances)
       .concat(standardTypes)
       .concat(customRecordTypes)
+      .concat(lockedCustomRecordTypes)
       .concat(customRecords)
       .concat(dataElements)
       .concat(suiteQLTableElements)

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -114,6 +114,7 @@ export type FetchParams = {
   addAlias?: boolean
   addBundles?: boolean
   addImportantValues?: boolean
+  addLockedCustomRecordTypes?: boolean
   resolveAccountSpecificValues?: boolean
   skipResolvingAccountSpecificValuesToTypes?: string[]
 } & LockedElementsConfig['fetch']
@@ -128,6 +129,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   addAlias: 'addAlias',
   addBundles: 'addBundles',
   addImportantValues: 'addImportantValues',
+  addLockedCustomRecordTypes: 'addLockedCustomRecordTypes',
   resolveAccountSpecificValues: 'resolveAccountSpecificValues',
   skipResolvingAccountSpecificValuesToTypes: 'skipResolvingAccountSpecificValuesToTypes',
 }
@@ -574,6 +576,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     addAlias: { refType: BuiltinTypes.BOOLEAN },
     addBundles: { refType: BuiltinTypes.BOOLEAN },
     addImportantValues: { refType: BuiltinTypes.BOOLEAN },
+    addLockedCustomRecordTypes: { refType: BuiltinTypes.BOOLEAN },
     resolveAccountSpecificValues: { refType: BuiltinTypes.BOOLEAN },
     skipResolvingAccountSpecificValuesToTypes: { refType: new ListType(BuiltinTypes.STRING) },
   },

--- a/packages/netsuite-adapter/src/filters/custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/custom_record_types.ts
@@ -15,6 +15,7 @@
  */
 import _ from 'lodash'
 import {
+  CORE_ANNOTATIONS,
   getChangeData,
   isAdditionChange,
   isObjectType,
@@ -106,7 +107,9 @@ const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, elementsSource
   onFetch: async elements => {
     const types = elements.filter(isObjectType)
     const existingTypeNames = new Set(types.map(type => type.elemID.getFullName()))
-    const customRecordTypes = types.filter(isCustomRecordType)
+    const customRecordTypes = types
+      .filter(isCustomRecordType)
+      .filter(type => !type.annotations[CORE_ANNOTATIONS.HIDDEN])
     const elementSourceTypes = await getElementsSourceTypes(elementsSource, isPartial, existingTypeNames)
     const elementSourceCustomRecordTypes = await getElementsSourceCustomRecordTypes(
       elementsSourceIndex,

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -74,6 +74,9 @@ export const getElementServiceIdRecords = async (
   element: Element,
   elementsSource?: ReadOnlyElementsSource,
 ): Promise<ServiceIdRecords> => {
+  if (element.annotations[CORE_ANNOTATIONS.HIDDEN]) {
+    return {}
+  }
   if (isInstanceElement(element)) {
     if (isStandardType(element.refType)) {
       return getServiceIdsToElemIds(element)

--- a/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
@@ -14,7 +14,14 @@
  * limitations under the License.
  */
 import { collections } from '@salto-io/lowerdash'
-import { BuiltinTypes, ElemID, isObjectType, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import {
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  ElemID,
+  isObjectType,
+  ObjectType,
+  ReadOnlyElementsSource,
+} from '@salto-io/adapter-api'
 import { LocalFilterOpts } from '../../src/filter'
 import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../src/constants'
 import filterCreator from '../../src/filters/custom_record_types'
@@ -26,6 +33,7 @@ const { awu } = collections.asynciterable
 describe('custom record types filter', () => {
   let customRecordType: ObjectType
   let customRecordFieldRefType: ObjectType
+  let lockedCustomRecordFieldRefType: ObjectType
   let dataType: ObjectType
 
   const filterOpts = {
@@ -60,6 +68,11 @@ describe('custom record types filter', () => {
               selectrecordtype: `[${SCRIPT_ID}=customrecord2]`,
             },
             {
+              scriptid: 'custrecord_ref_locked',
+              fieldtype: 'SELECT',
+              selectrecordtype: `[${SCRIPT_ID}=customrecord_locked]`,
+            },
+            {
               scriptid: 'custrecord_account',
               fieldtype: 'SELECT',
               selectrecordtype: '-112',
@@ -77,15 +90,29 @@ describe('custom record types filter', () => {
         [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
       },
     })
+    lockedCustomRecordFieldRefType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord_locked'),
+      annotations: {
+        scriptid: 'customrecord_locked',
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+        [CORE_ANNOTATIONS.HIDDEN]: true,
+      },
+    })
     dataType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'account'),
     })
   })
   it('should add fields to type', async () => {
-    await filterCreator(filterOpts).onFetch?.([customRecordType, customRecordFieldRefType, dataType])
+    await filterCreator(filterOpts).onFetch?.([
+      customRecordType,
+      customRecordFieldRefType,
+      lockedCustomRecordFieldRefType,
+      dataType,
+    ])
     expect(Object.keys(customRecordType.fields)).toEqual([
       'custom_custrecord_newfield',
       'custom_custrecord_ref',
+      'custom_custrecord_ref_locked',
       'custom_custrecord_account',
     ])
     expect(customRecordType.fields.custom_custrecord_newfield.refType.elemID.name).toEqual(
@@ -103,12 +130,21 @@ describe('custom record types filter', () => {
       selectrecordtype: `[${SCRIPT_ID}=customrecord2]`,
       index: 1,
     })
+    expect(customRecordType.fields.custom_custrecord_ref_locked.refType.elemID.name).toEqual(
+      BuiltinTypes.UNKNOWN.elemID.name,
+    )
+    expect(customRecordType.fields.custom_custrecord_ref_locked.annotations).toEqual({
+      scriptid: 'custrecord_ref_locked',
+      fieldtype: 'SELECT',
+      selectrecordtype: `[${SCRIPT_ID}=customrecord_locked]`,
+      index: 2,
+    })
     expect(customRecordType.fields.custom_custrecord_account.refType.elemID.name).toEqual('account')
     expect(customRecordType.fields.custom_custrecord_account.annotations).toEqual({
       scriptid: 'custrecord_account',
       fieldtype: 'SELECT',
       selectrecordtype: '-112',
-      index: 2,
+      index: 3,
     })
   })
   it('should add fields correctly on partial fetch', async () => {


### PR DESCRIPTION
Create hidden "dummy" instances of locked custom record types, and fetch their instances. The deploy of those custom record instances works out of the box (the locked custom record type must be in the target account).

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Fetch and Deploy Custom Record instances of locked Custom Record Types (use adapter config `fetch.addLockedCustomRecordTypes=true`)

---
_User Notifications_: 
Netsuite Adapter:
- When enabled in adapter config (`fetch.addLockedCustomRecordTypes=true`), custom records of locked custom record types will be fetched and added `/CustomRecords/<lock_custom_record_type_scriptid>`