### PR TITLE
SALTO-6003: Salesforce fetch with config overrides bugfix

### DIFF
--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -332,6 +332,7 @@ export const getConfigFromConfigChanges = (
         configType,
         _.pickBy(
           {
+            ...currentConfig,
             fetch: _.pickBy(
               {
                 ...(currentConfig.fetch ?? {}),

--- a/packages/salesforce-adapter/test/config_change.test.ts
+++ b/packages/salesforce-adapter/test/config_change.test.ts
@@ -28,6 +28,7 @@ describe('Config Changes', () => {
   const includedObjectName = '.*Object.*'
   const refToObjectName = '.*refTo.*'
   const currentConfig: SalesforceConfig = {
+    deploy: {},
     fetch: {
       metadata: {
         exclude: [{ metadataType: 'Type1' }],
@@ -75,6 +76,7 @@ describe('Config Changes', () => {
 
       it('should create an instance with values same as original config besides excludeObjects', () => {
         expect(newConfig).toBeDefined()
+        expect(newConfig?.config?.[0].value.deploy).toEqual({})
         expect(newConfig?.config?.[0].value.fetch.metadata).toEqual(
           currentConfig.fetch?.metadata,
         )


### PR DESCRIPTION
Fixed an issue where config overrides from the adapter code and the user caused weird side effect with the suggested applied config

---

On my fresh Salesforce account with config suggestions on first fetch, I ran:
```
salto fetch -C 'salesforce.customReferences={}'
```
which reproduced the issue.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
