### PR TITLE
SALTO-5860-allowEmpty-for-recurseInto

### DIFF
--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -90,6 +90,7 @@ export const omitInstanceValues = <Options extends FetchApiDefinitionsOptions>({
     type,
     transformFunc: omitValues(defQuery),
     strict: false,
+    allowEmpty: true,
   })
 
 export type InstanceCreationParams = {

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -183,6 +183,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
       type: inst.getTypeSync(),
       strict: false,
       pathID: inst.elemID,
+      allowEmpty: true,
       transformFunc: extractStandaloneInstancesFromField({
         adapterName,
         defQuery,


### PR DESCRIPTION
SALTO-5860-allowEmpty-for-recurseInto
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
