### PR TITLE
SALTO-6057 Fix hanging e2e tests

### DIFF
--- a/packages/e2e-credentials-store/src/jest-environment/index.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/index.ts
@@ -44,6 +44,10 @@ export class SaltoE2EJestEnvironment extends NodeEnvironment {
   }
 
   handleTestEvent(event: Event): void {
+    if (event.name === 'teardown') {
+      this.runningTasksPrinter.clear()
+      return
+    }
     const { id, type, status } = extractStatus(event) ?? {}
 
     if (!id) return

--- a/packages/e2e-credentials-store/src/jest-environment/index.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/index.ts
@@ -45,6 +45,10 @@ export class SaltoE2EJestEnvironment extends NodeEnvironment {
 
   handleTestEvent(event: Event): void {
     if (event.name === 'teardown') {
+      this.log.warn(
+        'Teardown event received, clearing running tasks. Had %d running tasks',
+        this.runningTasksPrinter.size(),
+      )
       this.runningTasksPrinter.clear()
       return
     }

--- a/packages/e2e-credentials-store/src/jest-environment/interval_scheduler.ts
+++ b/packages/e2e-credentials-store/src/jest-environment/interval_scheduler.ts
@@ -44,4 +44,8 @@ export default class IntervalScheduler {
     ;[...this.intervals.values()].map(v => v.intervalId).forEach(clearInterval)
     this.intervals.clear()
   }
+
+  size(): number {
+    return this.intervals.size
+  }
 }


### PR DESCRIPTION
Catch final event in jest circus to make sure the printer doesn't hang.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
