### PR TITLE
SALTO_5950: (Jira) fix warnings on requestType field in Automations

### DIFF
--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -183,7 +183,7 @@ export const createAutomationTypes = (): {
       schemaId: { refType: BuiltinTypes.STRING },
       objectTypeLabel: { refType: BuiltinTypes.STRING },
       objectTypeId: { refType: BuiltinTypes.STRING },
-      requestType: { refType: BuiltinTypes.STRING },
+      requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
       serviceDesk: {
         refType: BuiltinTypes.STRING,
         annotations: {


### PR DESCRIPTION
There were warnings on `requestType` field in `Automation` with an “edit request type” action after fetch.
The error happened because we defined this field as string.
Fixed this by changing the type to unknown.

* As we know this field can be either reference expression or `{ type: string; value: string }`

---

_Additional context for reviewer_
jira ticket: https://salto-io.atlassian.net/browse/SALTO-5950

---
_Release Notes_:
Jira Adapter:
* Fixed warnings on `requestType` field in `Automation`

---
_User Notifications_: 
_None_
