### PR TITLE
SALTO-6049: Fix missing Reference bug in ObjectTypeAttribute (#6018)

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -111,15 +111,6 @@ const toTypeName: referenceUtils.ContextValueMapperFunc = val => {
   return _.capitalize(val)
 }
 
-const toReferenceTypeTypeName: referenceUtils.ContextValueMapperFunc = val => {
-  // 1,2,3,4,5,8 are the default values for the reference type field in jira.
-  const defaultVals = new Set(['1', '2', '3', '4', '5', '8'])
-  if (defaultVals.has(val)) {
-    return OBJECT_SCHMEA_DEFAULT_REFERENCE_TYPE_TYPE
-  }
-  return OBJECT_SCHMEA_REFERENCE_TYPE_TYPE
-}
-
 export const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperFunc = val => {
   if (val === 'priority' || val === 'resolution') {
     return _.capitalize(val)
@@ -134,7 +125,6 @@ export type ReferenceContextStrategyName =
   | 'parentFieldId'
   | 'parentField'
   | 'gadgetPropertyValue'
-  | 'referenceTypeTypeName'
 
 export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   parentSelectedFieldType: neighborContextFunc({
@@ -153,10 +143,6 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
     contextValueMapper: resolutionAndPriorityToTypeName,
   }),
   gadgetPropertyValue: gadgetValuesContextFunc,
-  referenceTypeTypeName: neighborContextFunc({
-    contextFieldName: 'additionalValue',
-    contextValueMapper: toReferenceTypeTypeName,
-  }),
 }
 
 const groupNameSerialize: GetLookupNameFunc = ({ ref }) =>
@@ -1320,11 +1306,23 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
+  // additionalValue in ObjectTypeAttribute can be of types ObjectSchemaReferenceType or ObjectSchemaDefaultReferenceType
+  {
+    src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: OBJECT_SCHMEA_REFERENCE_TYPE_TYPE },
+  },
+  {
+    src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
+    serializationStrategy: 'id',
+    target: { type: OBJECT_SCHMEA_DEFAULT_REFERENCE_TYPE_TYPE },
+  },
+  // Hack to handle missing references when the type is unknown
   {
     src: { field: 'additionalValue', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',
-    target: { typeContext: 'referenceTypeTypeName' },
+    target: { type: 'UnknownType' },
   },
   {
     src: { field: 'objectTypeId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },


### PR DESCRIPTION
This is a hotfix on top of c01c4e7471f4660dfbc7e08dca6d83ee4b0e73d7.
The code is already merged to main as well.
THIS PR SHOULD NOT BE MERGED!!

* SALTO-6049-FixMissingRefBugInObjectTypeAttribute

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
