### PR TITLE
SALTO-5914: retry automations on 502 errors

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -42,6 +42,8 @@ import { JiraConfig } from '../../config/config'
 import { getCloudId } from './cloud_id'
 import { convertRuleScopeValueToProjects } from './automation_structure'
 
+const AUTOMATION_RETRY_CODES = [504, 502]
+
 export type AssetComponent = {
   value: {
     workspaceId?: string
@@ -121,8 +123,8 @@ const requestPageRecurse = async ({
 
     return response.data
   } catch (e) {
-    // we get an occasional 504 from the Automation's APIs, Atlassian's solution is to retry
-    if (!(e instanceof clientUtils.HTTPError && e.response?.status === 504)) {
+    // we get an occasional 504/502 from the Automation's APIs, Atlassian's solution is to retry
+    if (!(e instanceof clientUtils.HTTPError && AUTOMATION_RETRY_CODES.includes(e.response?.status))) {
       throw e
     }
   }

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -581,6 +581,27 @@ describe('automationFetchFilter', () => {
 
     expect(elements[1].elemID.getFullName()).toEqual('jira.Automation.instance.automationName_projectName')
   })
+  it('should retry if response is 502', async () => {
+    const { client: cli, connection: conn } = mockClient(false)
+    client = cli
+    connection = conn
+
+    conn.post.mockImplementationOnce(mockPostResponse) // for cloud id
+    conn.post.mockImplementationOnce(async () => {
+      throw new HTTPError('failed', { data: {}, status: 502 })
+    })
+    conn.post.mockImplementationOnce(mockPostResponse)
+    const elements = [project2Instance]
+    await (
+      automationFetchFilter(
+        getFilterParams({
+          client,
+        }),
+      ) as filterUtils.FilterWith<'onFetch'>
+    ).onFetch(elements)
+
+    expect(elements[1].elemID.getFullName()).toEqual('jira.Automation.instance.automationName_projectName')
+  })
   it('should fail if retry response is 504 and passed retries count', async () => {
     const { client: cli, connection: conn } = mockClient(false)
     client = cli


### PR DESCRIPTION
Retry automations also on 502

---

None

---
_Release Notes_: 
Jira Adapter:
* Added retry on 502 errors on automations

---
_User Notifications_: 
None
