### PR TITLE
SALTO-5982 issueTypeMappings missing crash

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -112,34 +112,45 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
       .filter(isInstanceElement)
       .filter(e => e.elemID.typeName === PROJECT_TYPE)
       .filter(project => project.value.issueTypeScreenScheme?.issueTypeScreenScheme?.id !== undefined)
-      .map(project => [
-        project.value.id,
-        [
-          ...new Set(
-            issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
-              .filter((issueTypeMapping: issueTypeMappingStruct) =>
-                IsIssueTypeInIssueTypeSchemesOrDefault(
-                  issueTypeMapping,
-                  issueTypeSchemesToIssueTypeList,
-                  project.value.issueTypeScheme?.issueTypeScheme.id,
+      .map(project => {
+        const projectIssueTypeMappings =
+          issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
+
+        if (projectIssueTypeMappings === undefined) {
+          log.error(
+            `Project (${project.value.id}) issueTypeScreenSchemes (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) has no issueTypeMappings`,
+          )
+          return [project.value.id, []]
+        }
+        return [
+          project.value.id,
+          [
+            ...new Set(
+              issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
+                ?.filter((issueTypeMapping: issueTypeMappingStruct) =>
+                  IsIssueTypeInIssueTypeSchemesOrDefault(
+                    issueTypeMapping,
+                    issueTypeSchemesToIssueTypeList,
+                    project.value.issueTypeScheme?.issueTypeScheme.id,
+                  ),
+                )
+                .filter((issueTypeMapping: issueTypeMappingStruct) =>
+                  isRelevantMapping(
+                    issueTypeMapping.issueTypeId,
+                    issueTypeScreenSchemesToiIssueTypeMappings[
+                      project.value.issueTypeScreenScheme.issueTypeScreenScheme.id
+                    ].length,
+                    issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].length,
+                  ),
+                )
+                .map(
+                  (issueTypeMapping: issueTypeMappingStruct) =>
+                    screensSchemesToDefaultOrViewScreens[issueTypeMapping.screenSchemeId],
                 ),
-              )
-              .filter((issueTypeMapping: issueTypeMappingStruct) =>
-                isRelevantMapping(
-                  issueTypeMapping.issueTypeId,
-                  issueTypeScreenSchemesToiIssueTypeMappings[
-                    project.value.issueTypeScreenScheme.issueTypeScreenScheme.id
-                  ].length,
-                  issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].length,
-                ),
-              )
-              .map(
-                (issueTypeMapping: issueTypeMappingStruct) =>
-                  screensSchemesToDefaultOrViewScreens[issueTypeMapping.screenSchemeId],
-              ),
-          ),
-        ],
-      ]),
+            ),
+          ],
+        ]
+      }),
   )
 }
 

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -118,7 +118,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
 
         if (projectIssueTypeMappings === undefined) {
           log.error(
-            `Project (${project.value.id}) issueTypeScreenSchemes (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) has no issueTypeMappings`,
+            `Project (${project.value.id}) issueTypeScreenScheme (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) has no issueTypeMapping`,
           )
           return [project.value.id, []]
         }
@@ -127,7 +127,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
           [
             ...new Set(
               issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
-                ?.filter((issueTypeMapping: issueTypeMappingStruct) =>
+                .filter((issueTypeMapping: issueTypeMappingStruct) =>
                   IsIssueTypeInIssueTypeSchemesOrDefault(
                     issueTypeMapping,
                     issueTypeSchemesToIssueTypeList,

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -117,8 +117,11 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
           issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
 
         if (projectIssueTypeMappings === undefined) {
+          if (project.value.issueTypeScreenScheme.issueTypeScreenScheme.id === undefined) {
+            return [project.value.id, []]
+          }
           log.error(
-            `Project (${project.value.id}) issueTypeScreenScheme (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) has no issueTypeMapping`,
+            `Project (${project.value.id}) issueTypeScreenScheme (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) missing the list "issueTypeMapping" or elements missing the issueTypeScreenScheme`,
           )
           return [project.value.id, []]
         }

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -117,9 +117,6 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
           issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
 
         if (projectIssueTypeMappings === undefined) {
-          if (project.value.issueTypeScreenScheme.issueTypeScreenScheme.id === undefined) {
-            return [project.value.id, []]
-          }
           log.error(
             `Project (${project.value.id}) issueTypeScreenScheme (${project.value.issueTypeScreenScheme.issueTypeScreenScheme.id}) missing the list "issueTypeMapping" or elements missing the issueTypeScreenScheme`,
           )
@@ -129,7 +126,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
           project.value.id,
           [
             ...new Set(
-              issueTypeScreenSchemesToiIssueTypeMappings[project.value.issueTypeScreenScheme.issueTypeScreenScheme.id]
+              projectIssueTypeMappings
                 .filter((issueTypeMapping: issueTypeMappingStruct) =>
                   IsIssueTypeInIssueTypeSchemesOrDefault(
                     issueTypeMapping,


### PR DESCRIPTION
fix the code so it will not crash when the fetch included a project with no issueTypeMappings or when the fetch did not include the issueTypeScreenSchemes of a project and add a log to report this type of cases
---

---
_Release Notes_: 
_Jira Adapter_:
* Fixed a bug that caused fetches to fail when an `Issue Type Screen Scheme` has no `Issue Type Mappings` or when the fetch did not include an `Issue Type Screen Scheme` of a `project`

---
_User Notifications_: 
N/A