### PR TITLE
SALTO-6048 - Salesforce: Remove Salesforce CPQ Billing unique ID field

### DIFF
--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -26,7 +26,10 @@ import { apiNameSync } from './utils'
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
   ['blng__RevenueRecognitionTreatment__c', ['blng__UniqueId__c']],
-  ['blng__FinancePeriod__c', ['blng__Family__c', 'blng__NextOpenPeriod__c']],
+  [
+    'blng__FinancePeriod__c',
+    ['blng__Family__c', 'blng__NextOpenPeriod__c', 'blng__UniqueId__c'],
+  ],
 ])
 
 const fieldRemovalsForType = (

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -25,7 +25,10 @@ import { apiNameSync, isCustomObjectSync, metadataTypeSync } from './utils'
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
-  ['blng__RevenueRecognitionTreatment__c', ['blng__UniqueId__c']],
+  [
+    'blng__RevenueRecognitionTreatment__c',
+    ['blng__UniqueId__c', 'blng__Family__c', 'blng__NextOpenPeriod__c'],
+  ],
 ])
 
 const fieldRemovalsForType = (

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -25,10 +25,8 @@ import { apiNameSync } from './utils'
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
-  [
-    'blng__RevenueRecognitionTreatment__c',
-    ['blng__UniqueId__c', 'blng__Family__c', 'blng__NextOpenPeriod__c'],
-  ],
+  ['blng__RevenueRecognitionTreatment__c', ['blng__UniqueId__c']],
+  ['blng__FinancePeriod__c', ['blng__Family__c', 'blng__NextOpenPeriod__c']],
 ])
 
 const fieldRemovalsForType = (

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -13,66 +13,78 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { isObjectType, Element, isInstanceElement } from '@salto-io/adapter-api'
-import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import {
+  isObjectType,
+  Element,
+  isInstanceElement,
+  ObjectType,
+} from '@salto-io/adapter-api'
+import { TransformFunc, transformValuesSync } from '@salto-io/adapter-utils'
 import { LocalFilterCreator } from '../filter'
-import { metadataType } from '../transformers/transformer'
-
-const { awu } = collections.asynciterable
+import { apiNameSync, isCustomObjectSync, metadataTypeSync } from './utils'
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
   ['blng__RevenueRecognitionTreatment__c', ['blng__UniqueId__c']],
 ])
 
-const removeFieldsFromTypes = async (
-  elements: Element[],
+const fieldRemovalsForType = (
+  type: ObjectType,
   typeNameToFieldRemovals: Map<string, string[]>,
-): Promise<void> => {
-  await awu(elements)
-    .filter(isObjectType)
-    .forEach(async (type) => {
-      const fieldsToRemove =
-        typeNameToFieldRemovals.get(await metadataType(type)) ?? []
-      fieldsToRemove.forEach((fieldName) => {
-        delete type.fields[fieldName]
-      })
-    })
+): string[] => {
+  const typeName = isCustomObjectSync(type)
+    ? apiNameSync(type) ?? ''
+    : metadataTypeSync(type)
+  return typeNameToFieldRemovals.get(typeName) ?? []
 }
 
-const removeValuesFromInstances = async (
+const removeFieldsFromTypes = (
   elements: Element[],
   typeNameToFieldRemovals: Map<string, string[]>,
-): Promise<void> => {
-  const removeValuesFunc: TransformFunc = async ({ value, field }) => {
+): void => {
+  elements.filter(isObjectType).forEach((type) => {
+    const fieldsToRemove = fieldRemovalsForType(type, typeNameToFieldRemovals)
+    fieldsToRemove.forEach((fieldName) => {
+      delete type.fields[fieldName]
+    })
+  })
+}
+
+const removeValuesFromInstances = (
+  elements: Element[],
+  typeNameToFieldRemovals: Map<string, string[]>,
+): void => {
+  const removeValuesFunc: TransformFunc = ({ value, field }) => {
     if (!field) return value
-    const fieldParent = field.parent
-    const fieldsToRemove =
-      typeNameToFieldRemovals.get(await metadataType(fieldParent)) ?? []
+    const fieldsToRemove = fieldRemovalsForType(
+      field.parent,
+      typeNameToFieldRemovals,
+    )
     if (fieldsToRemove.includes(field.name)) {
       return undefined
     }
     return value
   }
 
-  await awu(elements)
+  elements
     .filter(isInstanceElement)
     // The below filter is temporary optimization to save calling transformValues for all instances
     // since TYPE_NAME_TO_FIELD_REMOVALS contains currently only top level types
-    .filter(async (inst) =>
-      typeNameToFieldRemovals.has(await metadataType(inst)),
+    .filter(
+      (inst) =>
+        fieldRemovalsForType(inst.getTypeSync(), typeNameToFieldRemovals)
+          .length > 0,
     )
-    .forEach(async (inst) => {
+    .forEach((inst) => {
       inst.value =
-        (await transformValues({
+        transformValuesSync({
           values: inst.value,
-          type: await inst.getType(),
+          type: inst.getTypeSync(),
           transformFunc: removeValuesFunc,
           strict: true,
           allowEmpty: true,
           pathID: inst.elemID,
-        })) || inst.value
+        }) || inst.value
     })
 }
 
@@ -85,8 +97,8 @@ export const makeFilter =
   () => ({
     name: 'removeFieldsAndValuesFilter',
     onFetch: async (elements: Element[]) => {
-      await removeValuesFromInstances(elements, typeNameToFieldRemovals)
-      await removeFieldsFromTypes(elements, typeNameToFieldRemovals)
+      removeValuesFromInstances(elements, typeNameToFieldRemovals)
+      removeFieldsFromTypes(elements, typeNameToFieldRemovals)
     },
   })
 

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -23,6 +23,7 @@ const { awu } = collections.asynciterable
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
+  ['blng__RevenueRecognitionTreatment__c', ['blng__UniqueId__c']],
 ])
 
 const removeFieldsFromTypes = async (

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -21,7 +21,7 @@ import {
 } from '@salto-io/adapter-api'
 import { TransformFunc, transformValuesSync } from '@salto-io/adapter-utils'
 import { LocalFilterCreator } from '../filter'
-import { apiNameSync, isCustomObjectSync, metadataTypeSync } from './utils'
+import { apiNameSync } from './utils'
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
   ['Profile', ['tabVisibilities']],
@@ -35,9 +35,7 @@ const fieldRemovalsForType = (
   type: ObjectType,
   typeNameToFieldRemovals: Map<string, string[]>,
 ): string[] => {
-  const typeName = isCustomObjectSync(type)
-    ? apiNameSync(type) ?? ''
-    : metadataTypeSync(type)
+  const typeName = apiNameSync(type) ?? ''
   return typeNameToFieldRemovals.get(typeName) ?? []
 }
 

--- a/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
@@ -163,8 +163,8 @@ describe('remove fields filter', () => {
       )
     })
   })
-  describe('Billing UniqueId', () => {
-    const billingType = createCustomObjectType(
+  describe('CPQ billing types', () => {
+    const revenueRecognitionTreatmentType = createCustomObjectType(
       'blng__RevenueRecognitionTreatment__c',
       {
         annotations: {
@@ -186,19 +186,49 @@ describe('remove fields filter', () => {
         },
       },
     )
-    const billingInstance = new InstanceElement('SomeInstance', billingType, {
-      blng__Active__c: true,
-      blng__UniqueId__c: 'some_unique_id',
-      blng__Family__c: 'some_family',
-      blng__NextOpenPeriod__c: 'some_period',
+    const financePeriodType = createCustomObjectType('blng__FinancePeriod__c', {
+      annotations: {
+        apiName: 'blng__FinancePeriod__c',
+      },
+      fields: {
+        blng__Family__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        blng__NextOpenPeriod__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        blng__PeriodStatus__c: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
     })
+    const revenueRecognitionTreatmentInstance = new InstanceElement(
+      'SomeInstance',
+      revenueRecognitionTreatmentType,
+      {
+        blng__Active__c: true,
+        blng__UniqueId__c: 'some_unique_id',
+      },
+    )
+    const financePeriodInstance = new InstanceElement(
+      'SomeInstance',
+      financePeriodType,
+      {
+        blng__Family__c: 'some_family',
+        blng__NextOpenPeriod__c: 'some_period',
+        blng__PeriodStatus__c: 'some_status',
+      },
+    )
 
     let elements: Element[]
 
     beforeEach(async () => {
-      elements = [billingType, billingInstance].map((element) =>
-        element.clone(),
-      )
+      elements = [
+        revenueRecognitionTreatmentType,
+        revenueRecognitionTreatmentInstance,
+        financePeriodType,
+        financePeriodInstance,
+      ].map((element) => element.clone())
       const filterUnderTest = removeFieldAndValuesFilter({
         config: defaultFilterContext,
       }) as FilterWith<'onFetch'>
@@ -206,16 +236,23 @@ describe('remove fields filter', () => {
     })
 
     it('should remove only the appropriate field', () => {
-      const objectType = elements[0] as ObjectType
-      const instance = elements[1] as InstanceElement
-      expect(objectType.fields).not.toContainKey('blng__UniqueId__c')
-      expect(objectType.fields).not.toContainKey('blng__Family__c')
-      expect(objectType.fields).not.toContainKey('blng__NextOpenPeriod__c')
-      expect(objectType.fields).toContainKey('blng__Active__c')
-      expect(instance.value).not.toContainKey('blng__UniqueId__c')
-      expect(instance.value).not.toContainKey('blng__Family__c')
-      expect(instance.value).not.toContainKey('blng__NextOpenPeriod__c')
-      expect(instance.value).toContainKey('blng__Active__c')
+      const revenueObjectType = elements[0] as ObjectType
+      const revenueInstance = elements[1] as InstanceElement
+      const financeObjectType = elements[2] as ObjectType
+      const financeInstance = elements[3] as InstanceElement
+      expect(revenueObjectType.fields).not.toContainKey('blng__UniqueId__c')
+      expect(revenueObjectType.fields).toContainKey('blng__Active__c')
+      expect(revenueInstance.value).not.toContainKey('blng__UniqueId__c')
+      expect(revenueInstance.value).toContainKey('blng__Active__c')
+
+      expect(financeObjectType.fields).not.toContainKey('blng__Family__c')
+      expect(financeObjectType.fields).not.toContainKey(
+        'blng__NextOpenPeriod__c',
+      )
+      expect(financeObjectType.fields).toContainKey('blng__PeriodStatus__c')
+      expect(financeInstance.value).not.toContainKey('blng__Family__c')
+      expect(financeInstance.value).not.toContainKey('blng__NextOpenPeriod__c')
+      expect(financeInstance.value).toContainKey('blng__PeriodStatus__c')
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
@@ -171,18 +171,26 @@ describe('remove fields filter', () => {
           apiName: 'blng__RevenueRecognitionTreatment__c',
         },
         fields: {
-          blng_Active__c: {
+          blng__Active__c: {
             refType: BuiltinTypes.BOOLEAN,
           },
           blng__UniqueId__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          blng__Family__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          blng__NextOpenPeriod__c: {
             refType: BuiltinTypes.STRING,
           },
         },
       },
     )
     const billingInstance = new InstanceElement('SomeInstance', billingType, {
-      blng_Active__c: true,
+      blng__Active__c: true,
       blng__UniqueId__c: 'some_unique_id',
+      blng__Family__c: 'some_family',
+      blng__NextOpenPeriod__c: 'some_period',
     })
 
     let elements: Element[]
@@ -198,12 +206,16 @@ describe('remove fields filter', () => {
     })
 
     it('should remove only the appropriate field', () => {
-      expect((elements[0] as ObjectType).fields).not.toContainKey(
-        'blng__UniqueId__c',
-      )
-      expect((elements[1] as InstanceElement).value).not.toContainKey(
-        'blng__UniqueId__c',
-      )
+      const objectType = elements[0] as ObjectType
+      const instance = elements[1] as InstanceElement
+      expect(objectType.fields).not.toContainKey('blng__UniqueId__c')
+      expect(objectType.fields).not.toContainKey('blng__Family__c')
+      expect(objectType.fields).not.toContainKey('blng__NextOpenPeriod__c')
+      expect(objectType.fields).toContainKey('blng__Active__c')
+      expect(instance.value).not.toContainKey('blng__UniqueId__c')
+      expect(instance.value).not.toContainKey('blng__Family__c')
+      expect(instance.value).not.toContainKey('blng__NextOpenPeriod__c')
+      expect(instance.value).toContainKey('blng__Active__c')
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
+++ b/packages/salesforce-adapter/test/filters/remove_fields_and_values.test.ts
@@ -167,6 +167,9 @@ describe('remove fields filter', () => {
     const billingType = createCustomObjectType(
       'blng__RevenueRecognitionTreatment__c',
       {
+        annotations: {
+          apiName: 'blng__RevenueRecognitionTreatment__c',
+        },
         fields: {
           blng_Active__c: {
             refType: BuiltinTypes.BOOLEAN,


### PR DESCRIPTION
This field can't be deployed, so no reason to have it around.
While we're at it, change a bunch of async stuff to sync.
---
The path of least resistance seems to be to delete the field. Is there a reason to hide it instead?

Tests:
 - fetch an env with the CPQ Billing package installed with/without this PR. Observe the field `blng__UniqueId__c` removed from `blng__RevenueRecognitionTreatment__c`, and that the fields `blng__Family__c`, `blng__NextOpenPeriod__c` and `blng__UniqueId__c` are removed from `blng__FinancePeriod__c`.

---
_Release Notes_: 

Salesforce: CPQ Billing - automatically-generated fields in the 'RevenueRecognitionTreatment' and 'FinancePeriod' will no longer be fetched.

---
_User Notifications_: 
Salesforce: CPQ Billing - The `blng__UniqueId__c` field is removed from the `blng__RevenueRecognitionTreatment__c` type and all its instances. The `blng__Family__c`, `blng__NextOpenPeriod__c` and `blng__UniqueId__c` fields are removed from the `blng__FinancePeriod__c` type abd all its instances.