### PR TITLE
SALTO-6076: (Jira) upgrade Automation fetch filter

### DIFF
--- a/packages/adapter-components/src/elements_deprecated/instance_elements.ts
+++ b/packages/adapter-components/src/elements_deprecated/instance_elements.ts
@@ -53,6 +53,7 @@ export type InstanceCreationParams = {
   parent?: InstanceElement
   normalized?: boolean
   getElemIdFunc?: ElemIdGetter
+  takeDefaultName?: boolean
 }
 
 export const joinInstanceNameParts = (nameParts: unknown[]): string | undefined =>
@@ -193,7 +194,14 @@ export const toBasicInstance = async ({
   parent,
   defaultName,
   getElemIdFunc,
+  takeDefaultName = false,
 }: InstanceCreationParams): Promise<InstanceElement> => {
+  const getName = (idFields: string[]): string => {
+    if (takeDefaultName) {
+      return defaultName
+    }
+    return getInstanceName(entry, idFields, type.elemID.name) ?? defaultName
+  }
   const omitFields: TransformFunc = ({ value, field }) => {
     if (field !== undefined) {
       const parentType = field.parent.elemID.name
@@ -221,7 +229,7 @@ export const toBasicInstance = async ({
     transformationDefaultConfig,
   )
 
-  const name = getInstanceName(entry, idFields, type.elemID.typeName) ?? defaultName
+  const name = getName(idFields)
   const parentName = parent && nestName ? parent.elemID.name : undefined
   const adapterName = type.elemID.adapter
   const naclName = getInstanceNaclName({

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1624,6 +1624,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
   Automation: {
     transformation: {
+      fieldsToOmit: [{ fieldName: 'ruleHome' }],
       serviceUrl: '/jira/settings/automation#/rule/{id}',
       idFields: ['name', PROJECTS_FIELD], // idFields is handled separately in automation filter.
     },

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -65,6 +65,7 @@ describe('automationFetchFilter', () => {
               'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3',
             ],
           },
+          ruleHome: 'some value', // should always omit this field
         },
       ],
     },
@@ -803,7 +804,6 @@ describe('automationFetchFilter', () => {
       expect(automation.value).toEqual({
         id: '1',
         name: 'automationName',
-        projects: [],
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
@@ -825,8 +825,6 @@ describe('automationFetchFilter', () => {
               },
             ],
           },
-          children: [],
-          conditions: [],
         },
         components: [
           {
@@ -866,11 +864,8 @@ describe('automationFetchFilter', () => {
                     },
                   ],
                 },
-                children: [],
-                conditions: [],
               },
             ],
-            conditions: [],
           },
         ],
       })
@@ -905,7 +900,6 @@ describe('automationFetchFilter', () => {
       expect(automation.value).toEqual({
         id: '1',
         name: 'automationName',
-        projects: [],
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
@@ -924,8 +918,6 @@ describe('automationFetchFilter', () => {
               },
             ],
           },
-          children: [],
-          conditions: [],
         },
         components: [
           {
@@ -959,11 +951,8 @@ describe('automationFetchFilter', () => {
                     },
                   ],
                 },
-                children: [],
-                conditions: [],
               },
             ],
-            conditions: [],
           },
         ],
       })
@@ -992,7 +981,6 @@ describe('automationFetchFilter', () => {
                 {
                   id: '1',
                   name: 'automationName',
-                  projects: [],
                   ruleScope: {
                     resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
                   },
@@ -1013,8 +1001,6 @@ describe('automationFetchFilter', () => {
                         },
                       ],
                     },
-                    children: [],
-                    conditions: [],
                   },
                   components: [
                     {
@@ -1033,8 +1019,6 @@ describe('automationFetchFilter', () => {
                           },
                         ],
                       },
-                      children: [],
-                      conditions: [],
                     },
                   ],
                 },
@@ -1072,7 +1056,6 @@ describe('automationFetchFilter', () => {
       expect(automation.value).toEqual({
         id: '1',
         name: 'automationName',
-        projects: [],
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
@@ -1090,8 +1073,6 @@ describe('automationFetchFilter', () => {
               },
             ],
           },
-          children: [],
-          conditions: [],
         },
         components: [
           {
@@ -1108,8 +1089,6 @@ describe('automationFetchFilter', () => {
                 },
               ],
             },
-            children: [],
-            conditions: [],
           },
         ],
       })
@@ -1138,7 +1117,6 @@ describe('automationFetchFilter', () => {
                 {
                   id: '1',
                   name: 'automationName',
-                  projects: [],
                   ruleScope: {
                     resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
                   },
@@ -1160,8 +1138,6 @@ describe('automationFetchFilter', () => {
                           },
                         ],
                       },
-                      children: [],
-                      conditions: [],
                     },
                   ],
                 },
@@ -1199,11 +1175,9 @@ describe('automationFetchFilter', () => {
       expect(automation.value).toEqual({
         id: '1',
         name: 'automationName',
-        projects: [],
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },
-        trigger: {},
         components: [
           {
             component: 'ACTION',
@@ -1221,8 +1195,6 @@ describe('automationFetchFilter', () => {
                 },
               ],
             },
-            children: [],
-            conditions: [],
           },
         ],
       })
@@ -1251,7 +1223,6 @@ describe('automationFetchFilter', () => {
                 {
                   id: '1',
                   name: 'automationName',
-                  projects: [],
                   ruleScope: {
                     resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
                   },
@@ -1290,7 +1261,6 @@ describe('automationFetchFilter', () => {
       expect(automation.value).toEqual({
         id: '1',
         name: 'automationName',
-        projects: [],
         ruleScope: {
           resources: ['ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8'],
         },


### PR DESCRIPTION
Automation filter doesn’t go through base flow, causing some issues.

While upgrading to new infra, we should use the new infra generic flow.

I already did it with `toBasicInstance` method, but we haven't used it to prevent issues in the meantime.

---

_Additional context for reviewer_
https://salto-io.atlassian.net/browse/SALTO-6076
https://github.com/salto-io/salto/pull/6039


---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
