### PR TITLE
SALTO-6079: add delay to workflowV2 retries

### DIFF
--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -149,6 +149,7 @@ export const FIELD_CONFIGURATION_SCHEME_TYPE = 'FieldConfigurationScheme'
 export const FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH = 255
 export const FIELD_CONFIGURATION_ITEM_DESCRIPTION_MAX_LENGTH = 1000
 export const AUTOMATION_RETRY_PERIODS = [0, 1000 * 60, 1000 * 60 * 5] // 0, 1 minute, 5 minutes, increasing exponentially
+export const WORKFLOW_RETRY_PERIODS = [0, 1000 * 3, 1000 * 9, 1000 * 27, 1000 * 81] // 0, 3 seconds, 9 seconds, 27 seconds, 81 seconds
 // almost constant functions
 export const fetchFailedWarnings = (name: string): string =>
   `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/statuses/status_deployment.ts
+++ b/packages/jira-adapter/src/filters/statuses/status_deployment.ts
@@ -79,28 +79,30 @@ const modifyStatus = async (
   modificationChange: ModificationChange<InstanceElement>,
   client: JiraClient,
 ): Promise<void> => {
-  await acquireLockRetry(async () =>
-    client.put({
-      url: '/rest/api/3/statuses',
-      data: {
-        statuses: [createDeployableStatusValues(modificationChange)],
-      },
-    }),
-  )
+  await acquireLockRetry({
+    fn: async () =>
+      client.put({
+        url: '/rest/api/3/statuses',
+        data: {
+          statuses: [createDeployableStatusValues(modificationChange)],
+        },
+      }),
+  })
 }
 
 const addStatus = async (additionChange: AdditionChange<InstanceElement>, client: JiraClient): Promise<void> => {
-  const response = await acquireLockRetry(async () =>
-    client.post({
-      url: '/rest/api/3/statuses',
-      data: {
-        scope: {
-          type: 'GLOBAL',
+  const response = await acquireLockRetry({
+    fn: async () =>
+      client.post({
+        url: '/rest/api/3/statuses',
+        data: {
+          scope: {
+            type: 'GLOBAL',
+          },
+          statuses: [createDeployableStatusValues(additionChange)],
         },
-        statuses: [createDeployableStatusValues(additionChange)],
-      },
-    }),
-  )
+      }),
+  })
 
   if (!isStatusResponse(response.data)) {
     throw new Error(

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -80,7 +80,7 @@ import {
   TRANSITION_LIST_FIELDS,
 } from './types'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
-import { JIRA, PROJECT_TYPE, WORKFLOW_CONFIGURATION_TYPE } from '../../constants'
+import { JIRA, PROJECT_TYPE, WORKFLOW_CONFIGURATION_TYPE, WORKFLOW_RETRY_PERIODS } from '../../constants'
 import JiraClient from '../../client/client'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
 import { getLookUpName } from '../../reference_mapping'
@@ -562,15 +562,17 @@ const deployWorkflow = async ({
   }
   let response: clientUtils.ResponseValue | clientUtils.ResponseValue[] | undefined
   try {
-    response = await acquireLockRetry(() =>
-      defaultDeployChange({
-        change,
-        client,
-        apiDefinitions: config.apiDefinitions,
-        elementsSource,
-        fieldsToIgnore: fieldsToIgnoreFunc,
-      }),
-    )
+    response = await acquireLockRetry({
+      fn: () =>
+        defaultDeployChange({
+          change,
+          client,
+          apiDefinitions: config.apiDefinitions,
+          elementsSource,
+          fieldsToIgnore: fieldsToIgnoreFunc,
+        }),
+      delays: WORKFLOW_RETRY_PERIODS,
+    })
   } catch (error) {
     if (
       error instanceof clientUtils.HTTPError &&

--- a/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/statuses/status_deployment.test.ts
@@ -190,7 +190,7 @@ describe('statusDeploymentFilter', () => {
           const { deployResult } = await filter.deploy(changes)
           expect(deployResult.appliedChanges).toHaveLength(0)
           expect(deployResult.errors).toHaveLength(1)
-          expect(mockConnection.put).toHaveBeenCalledTimes(3)
+          expect(mockConnection.put).toHaveBeenCalledTimes(5)
         })
         it('addition', async () => {
           mockConnection.post.mockRejectedValue(
@@ -203,7 +203,7 @@ describe('statusDeploymentFilter', () => {
           )
           const changes = [toChange({ after: additionInstance })]
           const { deployResult } = await filter.deploy(changes)
-          expect(mockConnection.post).toHaveBeenCalledTimes(3)
+          expect(mockConnection.post).toHaveBeenCalledTimes(5)
           expect(additionInstance.value.id).not.toEqual('12345')
           expect(deployResult.appliedChanges).toHaveLength(0)
           expect(deployResult.errors).toHaveLength(1)

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -1164,6 +1164,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
       })
       config.deploy.taskMaxRetries = 3
       elementsSource = buildElementsSourceFromElements([projectInstance, workflowSchemeInstance])
+      jest.spyOn(global, 'setTimeout').mockImplementation((cb: TimerHandler) => (_.isFunction(cb) ? cb() : undefined))
       filter = workflowFilter(
         getFilterParams({
           client,
@@ -1764,7 +1765,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
               expect(result.deployResult.errors).toHaveLength(1)
               expect(result.deployResult.errors[0].message).toEqual('Error: message')
               expect(result.deployResult.errors[0].severity).toEqual('Error')
-              expect(deployChangeMock).toHaveBeenCalledTimes(3)
+              expect(deployChangeMock).toHaveBeenCalledTimes(5)
             })
           })
         })


### PR DESCRIPTION
_add delay to workflowV2 retries_

---

_Additional context for reviewer_
* add delay
* update `MAX_RETRIES` from 3 to 5

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
