### PR TITLE
SALTO-6080 pushing entities one by one upon fetch to prevent RangeError

### DIFF
--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -79,7 +79,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
     if (valuesByType[typeName] === undefined) {
       valuesByType[typeName] = []
     }
-    valuesByType[typeName].push(...validEntries)
+    validEntries.forEach(entry => valuesByType[typeName].push(entry))
   }
 
   const handleError: ElementGenerator['handleError'] = ({ typeName, error }) => {

--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -90,7 +90,7 @@ class WalkErrors<T> extends Map<NodeId, Error> {
   }
 
   set(nodeId: NodeId, value: Error, visited: Set<string> = new Set()): this {
-    log.error('Error encountered while walking on node %s: original stack: %s', nodeId, value.stack)
+    log.error('Error encountered while walking on node %s: %s\n stack: %s', nodeId, value, value.stack)
     const idAsString = nodeId.toString()
     if (visited.has(idAsString)) {
       return this

--- a/packages/dag/src/nodemap.ts
+++ b/packages/dag/src/nodemap.ts
@@ -15,9 +15,11 @@
  */
 import wu from 'wu'
 import { collections, values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
 
 const { difference } = collections.set
 type DFS_STATUS = 'in_progress' | 'done'
+const log = logger(module)
 
 export type NodeId = collections.set.SetId
 export type Edge = [NodeId, NodeId]
@@ -88,6 +90,7 @@ class WalkErrors<T> extends Map<NodeId, Error> {
   }
 
   set(nodeId: NodeId, value: Error, visited: Set<string> = new Set()): this {
+    log.error('Error encountered while walking on node %s: original stack: %s', nodeId, value.stack)
     const idAsString = nodeId.toString()
     if (visited.has(idAsString)) {
       return this


### PR DESCRIPTION
We originally used `...` to push all validEntries, when there are a lot of entries, this will cause `Maximum call stack size exceeded` Error


---

- I also added a log of the original error stack. It was very hard to debug since we lose the original error stack while walking on a DAG.

---
_Release Notes_: 
_Confluence Adapter_:
- fix fetch for large amount of pages

---
_User Notifications_: 
_Confluence Adapter_:
- fix fetch for large amount of pages
