### PR TITLE
SALTO-6047 pagerDuty enforce subdomain

### DIFF
--- a/packages/pagerduty-adapter/src/client/connection.ts
+++ b/packages/pagerduty-adapter/src/client/connection.ts
@@ -28,10 +28,10 @@ export const validateCredentials = async ({
   credentials: Credentials
 }): Promise<AccountInfo> => {
   try {
-    const users = await connection.get('/users?include[]=subdomains')
+    const users = await connection.get('/users?limit=1&include[]=subdomains')
     const subdomain = users.data.users[0].subdomains[0]
     if (subdomain !== credentials.subdomain) {
-      throw new Error('Subdomain does not match')
+      throw new Error('The subdomain given does not match with the subdomain that associated with the token')
     }
     return { accountId: credentials.subdomain }
   } catch (e) {

--- a/packages/pagerduty-adapter/src/client/connection.ts
+++ b/packages/pagerduty-adapter/src/client/connection.ts
@@ -28,7 +28,11 @@ export const validateCredentials = async ({
   credentials: Credentials
 }): Promise<AccountInfo> => {
   try {
-    await connection.get('/services')
+    const users = await connection.get('/users?include[]=subdomains')
+    const subdomain = users.data.users[0].subdomains[0]
+    if (subdomain !== credentials.subdomain) {
+      throw new Error('Subdomain does not match')
+    }
     return { accountId: credentials.subdomain }
   } catch (e) {
     log.error('Failed to validate credentials: %s', e)

--- a/packages/pagerduty-adapter/test/adapter.test.ts
+++ b/packages/pagerduty-adapter/test/adapter.test.ts
@@ -76,7 +76,7 @@ describe('adapter', () => {
   beforeEach(async () => {
     mockAxiosAdapter = new MockAdapter(axios, { delayResponse: 1, onNoMatch: 'throwException' })
     mockAxiosAdapter
-      .onGet('https://api.pagerduty.com/users?include[]=subdomains')
+      .onGet('https://api.pagerduty.com/users?limit=1&include[]=subdomains')
       .reply(200, { users: [{ subdomains: ['salto'] }] })
     ;([...fetchMockReplies, ...deployMockReplies] as MockReply[]).forEach(({ url, method, params, response }) => {
       const mock = getMockFunction(method, mockAxiosAdapter).bind(mockAxiosAdapter)


### PR DESCRIPTION
SALTO-6047 pagerDuty enforce subdomain
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
