### PR TITLE
SALTO-5987 Google ws  e2e disable

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -395,7 +395,6 @@ workflows:
                 - stripe-adapter
                 - zendesk-adapter
                 - zuora-billing-adapter
-                - google-workspace-adapter
                 - confluence-adapter
               should_install_java: 
                 - false


### PR DESCRIPTION
SALTO-5987 Google ws  e2e disable

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
