### PR TITLE
Fix NS merge error

### DIFF
--- a/packages/netsuite-adapter/src/scriptid_list.ts
+++ b/packages/netsuite-adapter/src/scriptid_list.ts
@@ -31,9 +31,9 @@ import { ObjectID } from './config/types'
 
 const log = logger(module)
 
-const OBJECT_ID_TYPE_NAME = 'objectid'
-const OBJECT_ID_LIST_TYPE_NAME = 'objectid_list'
-const OBJECT_ID_LIST_FIELD_NAME = 'objectid_list'
+export const OBJECT_ID_TYPE_NAME = 'objectid'
+export const OBJECT_ID_LIST_TYPE_NAME = 'objectid_list'
+export const OBJECT_ID_LIST_FIELD_NAME = 'objectid_list'
 
 const OBJECT_ID_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_TYPE_NAME)
 const OBJECT_ID_LIST_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME)

--- a/packages/netsuite-adapter/src/scriptid_list.ts
+++ b/packages/netsuite-adapter/src/scriptid_list.ts
@@ -31,10 +31,11 @@ import { ObjectID } from './config/types'
 
 const log = logger(module)
 
-export const OBJECT_ID_LIST_TYPE_NAME = 'objectid_list'
-export const OBJECT_ID_LIST_FIELD_NAME = 'objectid_list'
+const OBJECT_ID_TYPE_NAME = 'objectid'
+const OBJECT_ID_LIST_TYPE_NAME = 'objectid_list'
+const OBJECT_ID_LIST_FIELD_NAME = 'objectid_list'
 
-const OBJECT_ID_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME)
+const OBJECT_ID_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_TYPE_NAME)
 const OBJECT_ID_LIST_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME)
 const OBJECT_ID_LIST_INSTANCE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME, 'instance', ElemID.CONFIG_NAME)
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -620,9 +620,9 @@ describe('Adapter', () => {
         it('should create scriptid list elements with an empty list', async () => {
           const { elements } = await netsuiteAdapter.fetch(mockFetchOpts)
           const scriptIdListElements = elements.filter(elem => elem.elemID.typeName === OBJECT_ID_LIST_TYPE_NAME)
-          expect(scriptIdListElements).toHaveLength(3)
+          expect(scriptIdListElements).toHaveLength(2)
           expect(scriptIdListElements.filter(isInstanceElement).length).toEqual(1)
-          expect(scriptIdListElements.filter(isObjectType).length).toEqual(2)
+          expect(scriptIdListElements.filter(isObjectType).length).toEqual(1)
           const instance = scriptIdListElements.find(isInstanceElement) as InstanceElement
           expect(collections.array.makeArray(instance.value.scriptid_list)).toEqual([])
         })
@@ -640,9 +640,9 @@ describe('Adapter', () => {
           })
           const { elements } = await netsuiteAdapter.fetch(mockFetchOpts)
           const scriptIdListElements = elements.filter(elem => elem.elemID.typeName === OBJECT_ID_LIST_TYPE_NAME)
-          expect(scriptIdListElements).toHaveLength(3)
+          expect(scriptIdListElements).toHaveLength(2)
           expect(scriptIdListElements.filter(isInstanceElement).length).toEqual(1)
-          expect(scriptIdListElements.filter(isObjectType).length).toEqual(2)
+          expect(scriptIdListElements.filter(isObjectType).length).toEqual(1)
           const instance = scriptIdListElements.find(isInstanceElement) as InstanceElement
           expect(collections.array.makeArray(instance.value[OBJECT_ID_LIST_FIELD_NAME])).toEqual([
             {
@@ -678,9 +678,9 @@ describe('Adapter', () => {
           })
           const { elements } = await adapter.fetch(mockFetchOpts)
           const scriptIdListElements = elements.filter(elem => elem.elemID.typeName === OBJECT_ID_LIST_TYPE_NAME)
-          expect(scriptIdListElements).toHaveLength(3)
+          expect(scriptIdListElements).toHaveLength(2)
           expect(scriptIdListElements.filter(isInstanceElement).length).toEqual(1)
-          expect(scriptIdListElements.filter(isObjectType).length).toEqual(2)
+          expect(scriptIdListElements.filter(isObjectType).length).toEqual(1)
           const instance = scriptIdListElements.find(isInstanceElement) as InstanceElement
           expect(collections.array.makeArray(instance.value[OBJECT_ID_LIST_FIELD_NAME])).toEqual([
             {
@@ -706,9 +706,9 @@ describe('Adapter', () => {
           })
           const { elements } = await netsuiteAdapter.fetch({ ...mockFetchOpts, withChangesDetection })
           const scriptIdListElements = elements.filter(elem => elem.elemID.typeName === OBJECT_ID_LIST_TYPE_NAME)
-          expect(scriptIdListElements).toHaveLength(3)
+          expect(scriptIdListElements).toHaveLength(2)
           expect(scriptIdListElements.filter(isInstanceElement).length).toEqual(1)
-          expect(scriptIdListElements.filter(isObjectType).length).toEqual(2)
+          expect(scriptIdListElements.filter(isObjectType).length).toEqual(1)
           const instance = scriptIdListElements.find(isInstanceElement) as InstanceElement
           expect(collections.array.makeArray(instance.value[OBJECT_ID_LIST_FIELD_NAME])).toEqual([
             {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -745,9 +745,9 @@ describe('Adapter', () => {
           })
           const { elements } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection })
           const scriptIdListElements = elements.filter(elem => elem.elemID.typeName === OBJECT_ID_LIST_TYPE_NAME)
-          expect(scriptIdListElements).toHaveLength(3)
+          expect(scriptIdListElements).toHaveLength(2)
           expect(scriptIdListElements.filter(isInstanceElement).length).toEqual(1)
-          expect(scriptIdListElements.filter(isObjectType).length).toEqual(2)
+          expect(scriptIdListElements.filter(isObjectType).length).toEqual(1)
           const instance = scriptIdListElements.find(isInstanceElement) as InstanceElement
           expect(collections.array.makeArray(instance.value[OBJECT_ID_LIST_FIELD_NAME])).toEqual([
             {


### PR DESCRIPTION
The inner `objectId` type and the `objectIdList` type had the same element id on fetch, causing them to be dropped because of merge error.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None