### PR TITLE
SALTO-5918: Performance improvements in field references filter

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -266,9 +266,6 @@ export const addReferences = async <
   >(defs, fieldReferenceResolverCreator)
   const instances = elements.filter(isInstanceElement)
 
-  // copied from Salesforce - both should be handled similarly:
-  // TODO - when transformValues becomes async the first index can be to elemID and not the whole
-  // element and we can use the element source directly instead of creating the second index
   const indexer = multiIndex.buildMultiIndex<Element>().addIndex({
     name: 'elemByElemID',
     key: elem => [elem.elemID.getFullName()],

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -30,8 +30,8 @@ import {
   generateReferenceResolverFinder,
   ReferenceContextStrategyName,
   FieldReferenceDefinition,
+  fieldNameToTypeMappingDefs,
   getLookUpName,
-  getReferenceMappingDefs,
 } from '../transformers/reference_mapping'
 import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE,
@@ -46,6 +46,7 @@ import {
   ROLE_METADATA_TYPE,
   FLOW_METADATA_TYPE,
   PROFILE_METADATA_TYPE,
+  PERMISSION_SET_METADATA_TYPE,
 } from '../constants'
 import {
   buildElementsSourceForFetch,
@@ -225,21 +226,20 @@ export const addReferences = async (
 const filter: LocalFilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async (elements) => {
-    const refDef = getReferenceMappingDefs({
-      enumFieldPermissions: config.enumFieldPermissions ?? false,
-      otherProfileRefs: config.fetchProfile.isFeatureEnabled(
-        'generateRefsInProfiles',
-      ),
-      permissionsSetRefs:
-        !config.fetchProfile.isCustomReferencesHandlerEnabled('permisisonSets'),
-    })
+    const typesToIgnore: string[] = []
+    if (!config.fetchProfile.isFeatureEnabled('generateRefsInProfiles')) {
+      typesToIgnore.push(PROFILE_METADATA_TYPE)
+    }
+    if (
+      config.fetchProfile.isCustomReferencesHandlerEnabled('permisisonSets')
+    ) {
+      typesToIgnore.push(PERMISSION_SET_METADATA_TYPE)
+    }
     await addReferences(
       elements,
       buildElementsSourceForFetch(elements, config),
-      refDef,
-      config.fetchProfile.isFeatureEnabled('generateRefsInProfiles')
-        ? []
-        : [PROFILE_METADATA_TYPE],
+      fieldNameToTypeMappingDefs,
+      typesToIgnore,
     )
   },
 })

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -224,7 +224,18 @@ export type FieldReferenceDefinition = {
   target?: referenceUtils.ReferenceTargetDefinition<ReferenceContextStrategyName>
 }
 
-export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
+/**
+ * The rules for finding and resolving values into (and back from) reference expressions.
+ * Overlaps between rules are allowed, and the first successful conversion wins.
+ * Current order (defined by generateReferenceResolverFinder):
+ *  1. Exact field names take precedence over regexp
+ *  2. Order within each group is currently *not* guaranteed (groupBy is not stable)
+ *
+ * A value will be converted into a reference expression if:
+ * 1. An element matching the rule is found.
+ * 2. Resolving the resulting reference expression back returns the original value.
+ */
+export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: {
       field: 'field',
@@ -883,18 +894,10 @@ export const defaultFieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'sobjectType', parentTypes: ['AnimationRule'] },
     target: { type: CUSTOM_OBJECT },
   },
-]
-
-// Optional reference that should not be used if enumFieldPermissions config is on
-export const fieldPermissionEnumDisabledExtraMappingDefs: FieldReferenceDefinition[] =
-  [
-    {
-      src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
-      target: { type: CUSTOM_FIELD },
-    },
-  ]
-
-export const referencesFromProfile: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'field', parentTypes: ['ProfileFieldLevelSecurity'] },
+    target: { type: CUSTOM_FIELD },
+  },
   {
     src: { field: 'object', parentTypes: ['ProfileObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
@@ -931,9 +934,6 @@ export const referencesFromProfile: FieldReferenceDefinition[] = [
     serializationStrategy: 'relativeApiName',
     target: { type: CUSTOM_FIELD, parentContext: 'instanceParent' },
   },
-]
-
-export const referencesFromPermissionSets: FieldReferenceDefinition[] = [
   {
     src: { field: 'field', parentTypes: ['PermissionSetFieldPermissions'] },
     target: { type: CUSTOM_FIELD },
@@ -943,42 +943,6 @@ export const referencesFromPermissionSets: FieldReferenceDefinition[] = [
     target: { type: CUSTOM_OBJECT },
   },
 ]
-
-/**
- * The rules for finding and resolving values into (and back from) reference expressions.
- * Overlaps between rules are allowed, and the first successful conversion wins.
- * Current order (defined by generateReferenceResolverFinder):
- *  1. Exact field names take precedence over regexp
- *  2. Order within each group is currently *not* guaranteed (groupBy is not stable)
- *
- * A value will be converted into a reference expression if:
- * 1. An element matching the rule is found.
- * 2. Resolving the resulting reference expression back returns the original value.
- */
-const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
-  ...defaultFieldNameToTypeMappingDefs,
-  ...fieldPermissionEnumDisabledExtraMappingDefs,
-  ...referencesFromProfile,
-  ...referencesFromPermissionSets,
-]
-
-export const getReferenceMappingDefs = (args: {
-  enumFieldPermissions: boolean
-  otherProfileRefs: boolean
-  permissionsSetRefs: boolean
-}): FieldReferenceDefinition[] => {
-  let refDefs = defaultFieldNameToTypeMappingDefs
-  if (args.enumFieldPermissions) {
-    refDefs = refDefs.concat(fieldPermissionEnumDisabledExtraMappingDefs)
-  }
-  if (args.otherProfileRefs) {
-    refDefs = refDefs.concat(referencesFromProfile)
-  }
-  if (args.permissionsSetRefs) {
-    refDefs = refDefs.concat(referencesFromPermissionSets)
-  }
-  return refDefs
-}
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>
   _.isString(matcher) ? matcher === name : matcher.test(name)

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -620,6 +620,7 @@ describe('FieldReferences filter', () => {
         elements,
         buildElementsSourceFromElements(elements),
         modifiedDefs,
+        [],
       )
     })
     afterAll(() => {


### PR DESCRIPTION
1. Made the instance filter sync.
2. Dropping profiles when not needed.

Also removed the comment to move to using the element source, we decided against that in #5907.

---

_Additional context for reviewer_
This filter is very slow.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
