### PR TITLE
SALTO-6093 - Salesforce: Remove some more UniqueID fields from CPQ Billing types

### DIFF
--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -30,6 +30,14 @@ const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([
     'blng__FinancePeriod__c',
     ['blng__Family__c', 'blng__NextOpenPeriod__c', 'blng__UniqueId__c'],
   ],
+  ['blng__AccountBalanceSnapshot__c', ['blng__UniqueId__c']],
+  ['blng__ErrorLog__c', ['blng__UniqueId__c']],
+  ['blng__GLTreatment__c', ['blng__UniqueId__c']],
+  ['blng__Invoice__c', ['blng__UniqueId__c']],
+  ['blng__InvoiceLine__c', ['blng__UniqueId__c']],
+  ['blng__SubInvoiceLine__c', ['blng__UniqueId__c']],
+  ['blng__UsageSummary__c', ['blng__UniqueId__c']],
+  ['OrderItem', ['blng__UniqueId__c']],
 ])
 
 const fieldRemovalsForType = (


### PR DESCRIPTION
These fields can't be deployed, and contain no useful information. We can just discard them.

---


---
_Release Notes_: 
Salesforce: All 'Unique ID' fields of CPQ Billing objects are now discarded.

---
_User Notifications_: 
Salesforce: All 'Unique ID' fields of CPQ Billing objects will be removed from the workspace.