### PR TITLE
SALTO-6096 - Salesforce: Handle circular dependency between ProductRule and ErrorCondition

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -459,6 +459,7 @@ export const DATA_INSTANCES_CHANGED_AT_MAGIC = '__DataInstances__'
 // CPQ CustomObjects
 export const CPQ_NAMESPACE = 'SBQQ'
 export const CPQ_PRODUCT_RULE = 'SBQQ__ProductRule__c'
+export const CPQ_ERROR_CONDITION = 'SBQQ__ErrorCondition__c'
 export const CPQ_PRICE_RULE = 'SBQQ__PriceRule__c'
 export const CPQ_PRICE_CONDITION = 'SBQQ__PriceCondition__c'
 export const CPQ_LOOKUP_QUERY = 'SBQQ__LookupQuery__c'
@@ -503,6 +504,7 @@ export const CPQ_TARGET_FIELD = 'SBQQ__TargetField__c'
 export const CPQ_TARGET_OBJECT = 'SBQQ__TargetObject__c'
 export const CPQ_CONDITIONS_MET = 'SBQQ__ConditionsMet__c'
 export const CPQ_PRICE_CONDITION_RULE_FIELD = 'SBQQ__Rule__c'
+export const CPQ_ERROR_CONDITION_RULE_FIELD = 'SBQQ__Rule__c'
 
 export const CPQ_QUOTE_NO_PRE = 'Quote__c'
 export const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'
@@ -562,6 +564,12 @@ export const ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP =
   )
 export const ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP =
   groupIdForInstanceChangeGroup('add', 'Custom PriceRule and PriceCondition')
+export const ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP =
+  groupIdForInstanceChangeGroup(
+    'add',
+    'Custom ProductRule and ProductCondition',
+  )
+
 export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
 
 export const UNLIMITED_INSTANCES_VALUE = -1

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -565,10 +565,7 @@ export const ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP =
 export const ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP =
   groupIdForInstanceChangeGroup('add', 'Custom PriceRule and PriceCondition')
 export const ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP =
-  groupIdForInstanceChangeGroup(
-    'add',
-    'Custom ProductRule and ProductCondition',
-  )
+  groupIdForInstanceChangeGroup('add', 'Custom ProductRule and ErrorCondition')
 
 export const METADATA_CHANGE_GROUP = 'Salesforce Metadata'
 

--- a/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
+++ b/packages/salesforce-adapter/src/custom_object_instances_deploy.ts
@@ -85,6 +85,10 @@ import {
   CPQ_PRICE_CONDITION,
   CPQ_CONDITIONS_MET,
   CPQ_PRICE_CONDITION_RULE_FIELD,
+  CPQ_PRODUCT_RULE,
+  CPQ_ERROR_CONDITION,
+  CPQ_ERROR_CONDITION_RULE_FIELD,
+  ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
 } from './constants'
 import {
   getIdFields,
@@ -1179,6 +1183,22 @@ const deployAddCustomPriceRulesAndConditions = async (
     dataManagement,
   )
 
+const deployAddCustomProductRulesAndConditions = async (
+  changes: ReadonlyArray<Change<InstanceElement>>,
+  client: SalesforceClient,
+  dataManagement: DataManagement | undefined,
+): Promise<DeployResult> =>
+  deployRulesAndConditionsGroup(
+    CPQ_PRODUCT_RULE,
+    CPQ_CONDITIONS_MET,
+    CPQ_ERROR_CONDITION,
+    CPQ_ERROR_CONDITION_RULE_FIELD,
+    changes,
+    ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
+    client,
+    dataManagement,
+  )
+
 export const deployCustomObjectInstancesGroup = async (
   changes: ReadonlyArray<Change<InstanceElement>>,
   client: SalesforceClient,
@@ -1195,6 +1215,13 @@ export const deployCustomObjectInstancesGroup = async (
     }
     case ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP: {
       return deployAddCustomPriceRulesAndConditions(
+        changes,
+        client,
+        dataManagement,
+      )
+    }
+    case ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP: {
+      return deployAddCustomProductRulesAndConditions(
         changes,
         client,
         dataManagement,

--- a/packages/salesforce-adapter/src/group_changes.ts
+++ b/packages/salesforce-adapter/src/group_changes.ts
@@ -43,6 +43,10 @@ import {
   CPQ_PRICE_CONDITION,
   ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
   CPQ_PRICE_CONDITION_RULE_FIELD,
+  CPQ_ERROR_CONDITION_RULE_FIELD,
+  ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
+  CPQ_PRODUCT_RULE,
+  CPQ_ERROR_CONDITION,
 } from './constants'
 
 const getGroupId = (change: Change): string => {
@@ -134,18 +138,37 @@ const getAddCpqCustomPriceRuleAndConditionGroupChangeIds = (
     CPQ_PRICE_CONDITION_RULE_FIELD,
   )
 
+/**
+ * Returns the changes that should be part of the special deploy group for adding SBQQ__ProductRule
+ * instances with SBQQ__ConditionsMet = 'Custom' and their corresponding SBQQ__ProductCondition instances.
+ */
+const getAddCpqCustomProductRuleAndConditionGroupChangeIds = (
+  changes: Map<ChangeId, Change>,
+): Set<ChangeId> =>
+  getAddCustomRuleAndConditionGroupChangeIds(
+    changes,
+    CPQ_PRODUCT_RULE,
+    CPQ_CONDITIONS_MET,
+    CPQ_ERROR_CONDITION,
+    CPQ_ERROR_CONDITION_RULE_FIELD,
+  )
+
 export const getChangeGroupIds: ChangeGroupIdFunction = async (changes) => {
   const changeGroupIdMap = new Map<ChangeId, ChangeGroupId>()
   const customApprovalRuleAndConditionChangeIds =
     getAddSbaaCustomApprovalRuleAndConditionGroupChangeIds(changes)
   const customPriceRuleAndConditionChangeIds =
     getAddCpqCustomPriceRuleAndConditionGroupChangeIds(changes)
+  const customProductRuleAndConditionChangeIds =
+    getAddCpqCustomProductRuleAndConditionGroupChangeIds(changes)
   wu(changes.entries()).forEach(([changeId, change]) => {
     let groupId: string
     if (customApprovalRuleAndConditionChangeIds.has(changeId)) {
       groupId = ADD_SBAA_CUSTOM_APPROVAL_RULE_AND_CONDITION_GROUP
     } else if (customPriceRuleAndConditionChangeIds.has(changeId)) {
       groupId = ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP
+    } else if (customProductRuleAndConditionChangeIds.has(changeId)) {
+      groupId = ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP
     } else {
       groupId = getGroupId(change)
     }

--- a/packages/salesforce-adapter/test/group_changes.test.ts
+++ b/packages/salesforce-adapter/test/group_changes.test.ts
@@ -41,6 +41,10 @@ import {
   CPQ_PRICE_CONDITION,
   CPQ_PRICE_CONDITION_RULE_FIELD,
   ADD_CPQ_CUSTOM_PRICE_RULE_AND_CONDITION_GROUP,
+  CPQ_PRODUCT_RULE,
+  CPQ_ERROR_CONDITION,
+  ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
+  CPQ_ERROR_CONDITION_RULE_FIELD,
 } from '../src/constants'
 import { getChangeGroupIds } from '../src/group_changes'
 import { createInstanceElement } from '../src/transformers/transformer'
@@ -388,6 +392,70 @@ describe('Group changes function', () => {
       )
       expect(result.changeGroupIdMap.get('PriceCondition')).toEqual(
         "Addition of data instances of type 'SBQQ__PriceCondition__c'",
+      )
+    })
+  })
+  describe('when changes are additions of SBQQ__ProductRule__c and SBQQ__ProductCondition__c', () => {
+    let result: ChangeGroupIdFunctionReturn
+    beforeEach(async () => {
+      const customProductRule = new InstanceElement(
+        'CustomProductRule',
+        mockTypes[CPQ_PRODUCT_RULE],
+        {
+          [CPQ_CONDITIONS_MET]: 'Custom',
+        },
+      )
+      const productRule = new InstanceElement(
+        'ProductRule',
+        mockTypes[CPQ_PRODUCT_RULE],
+        {
+          [CPQ_CONDITIONS_MET]: 'All',
+        },
+      )
+      const customProductCondition = new InstanceElement(
+        'CustomErrorCondition',
+        mockTypes[CPQ_ERROR_CONDITION],
+        {
+          [CPQ_ERROR_CONDITION_RULE_FIELD]: new ReferenceExpression(
+            customProductRule.elemID,
+            customProductRule,
+          ),
+        },
+      )
+      const productCondition = new InstanceElement(
+        'ErrorCondition',
+        mockTypes[CPQ_ERROR_CONDITION],
+        {
+          [CPQ_ERROR_CONDITION_RULE_FIELD]: new ReferenceExpression(
+            productRule.elemID,
+            productRule,
+          ),
+        },
+      )
+      const addedInstances = [
+        customProductRule,
+        productRule,
+        customProductCondition,
+        productCondition,
+      ]
+      const changeMap = new Map<string, Change>()
+      addedInstances.forEach((instance) => {
+        changeMap.set(instance.elemID.name, toChange({ after: instance }))
+      })
+      result = await getChangeGroupIds(changeMap)
+    })
+    it('should create correct groups', () => {
+      expect(result.changeGroupIdMap.get('CustomProductRule')).toEqual(
+        ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
+      )
+      expect(result.changeGroupIdMap.get('CustomErrorCondition')).toEqual(
+        ADD_CPQ_CUSTOM_PRODUCT_RULE_AND_CONDITION_GROUP,
+      )
+      expect(result.changeGroupIdMap.get('ProductRule')).toEqual(
+        "Addition of data instances of type 'SBQQ__ProductRule__c'",
+      )
+      expect(result.changeGroupIdMap.get('ErrorCondition')).toEqual(
+        "Addition of data instances of type 'SBQQ__ErrorCondition__c'",
       )
     })
   })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -30,9 +30,12 @@ import {
   ASSIGNMENT_RULES_METADATA_TYPE,
   CHANGED_AT_SINGLETON,
   CPQ_CONDITIONS_MET,
+  CPQ_ERROR_CONDITION,
+  CPQ_ERROR_CONDITION_RULE_FIELD,
   CPQ_PRICE_CONDITION,
   CPQ_PRICE_CONDITION_RULE_FIELD,
   CPQ_PRICE_RULE,
+  CPQ_PRODUCT_RULE,
   CPQ_QUOTE,
   CUSTOM_METADATA,
   CUSTOM_OBJECT,
@@ -81,6 +84,28 @@ const SBAA_APPROVAL_RULE_TYPE = createCustomObjectType(SBAA_APPROVAL_RULE, {
 })
 
 const CPQ_PRICE_RULE_TYPE = createCustomObjectType(CPQ_PRICE_RULE, {
+  fields: {
+    [CPQ_CONDITIONS_MET]: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [FIELD_ANNOTATIONS.CREATABLE]: true,
+        [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+      },
+    },
+    [OWNER_ID]: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
+        [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [constants.API_NAME]: OWNER_ID,
+      },
+    },
+  },
+})
+
+const CPQ_PRODUCT_RULE_TYPE = createCustomObjectType(CPQ_PRODUCT_RULE, {
   fields: {
     [CPQ_CONDITIONS_MET]: {
       refType: BuiltinTypes.STRING,
@@ -668,12 +693,25 @@ export const mockTypes = {
       },
     },
   }),
+  [CPQ_PRODUCT_RULE]: CPQ_PRODUCT_RULE_TYPE,
   StandardValueSet: createMetadataObjectType({
     annotations: {
       metadataType: 'StandardValueSet',
       dirName: 'standardValueSets',
       suffix: 'svs',
       hasMetaFile: true,
+    },
+  }),
+  [CPQ_ERROR_CONDITION]: createCustomObjectType(CPQ_ERROR_CONDITION, {
+    fields: {
+      [CPQ_ERROR_CONDITION_RULE_FIELD]: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [FIELD_ANNOTATIONS.QUERYABLE]: true,
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        },
+      },
     },
   }),
 }


### PR DESCRIPTION
Similar to other types that refer to each other implicitly (rather than via explicit references), we need to create a special deploy group and handle it explicitly.

---

Test:
 - Change the NaCl files of a `ProductRule` instance and the related `ErrorCondition` instance. Observe the correct group ID.

---
_Release Notes_: 
Salesforce: Circular dependency between CPQ ProductRule instances with 'Custom' ConditionsMet value and ErrorCondition instances are handled correctly.

---
_User Notifications_: 
N/A