### PR TITLE
SALTO-6904: add automation specific page size configuration

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -76,6 +76,7 @@ type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFil
   enableMissingReferences?: boolean
   enableIssueLayouts?: boolean
   enableNewWorkflowAPI?: boolean
+  automationPageSize?: number
 }
 
 export type MaskingConfig = {
@@ -354,6 +355,7 @@ const fetchConfigType = definitions.createUserFetchConfigType({
     enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
     enableIssueLayouts: { refType: BuiltinTypes.BOOLEAN },
     enableNewWorkflowAPI: { refType: BuiltinTypes.BOOLEAN },
+    automationPageSize: { refType: BuiltinTypes.NUMBER },
   },
   fetchCriteriaType: fetchFiltersType,
   omitElemID: true,
@@ -405,6 +407,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'fetch.enableIssueLayouts',
       'fetch.removeDuplicateProjectRoles',
       'fetch.enableNewWorkflowAPI',
+      'fetch.automationPageSize',
       'deploy.taskMaxRetries',
       'deploy.taskRetryDelay',
       SCRIPT_RUNNER_API_DEFINITIONS,

--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -217,7 +217,7 @@ export const getAutomations = async (client: JiraClient, config: JiraConfig): Pr
     : postPaginated(
         `/gateway/api/automation/internal-api/jira/${await getCloudId(client)}/pro/rest/GLOBAL/rules`,
         client,
-        config.client.pageSize?.get ?? DEFAULT_PAGE_SIZE,
+        config.fetch.automationPageSize ?? config.client.pageSize?.get ?? DEFAULT_PAGE_SIZE,
       )
 
 /**


### PR DESCRIPTION
Added a configuration to set the automation page size, which might solve the 502/504 errors for automations. It will be removed afterwards

---

The purpose is to test if the automation page size change can make a difference without reducing the general performance.

---
_Release Notes_: 
Jira Adapter:
* Added a configuration for automation page size

---
_User Notifications_: 
None