### PR TITLE
SALTO-6090 Fix SuiteQL query of over 100K items

### DIFF
--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_record_type.ts
@@ -24,12 +24,12 @@ const changesDetector: TypeChangesDetector = {
   getChanges: async (client, dateRange) => {
     const [startDate, endDate] = dateRange.toSuiteQLRange()
 
-    const results = await client.runSuiteQL(`
-        SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
-        FROM customrecordtype
-        WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
-        ORDER BY scriptid ASC
-      `)
+    const results = await client.runSuiteQL({
+      select: `internalid, scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time`,
+      from: 'customrecordtype',
+      where: `lastmodifieddate BETWEEN ${startDate} AND ${endDate}`,
+      orderBy: 'internalid',
+    })
 
     if (results === undefined) {
       log.warn('customrecordtype changes query failed')

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/custom_type.ts
@@ -24,12 +24,12 @@ const log = logger(module)
 const getChanges = async (type: string, client: NetsuiteClient, dateRange: DateRange): Promise<ChangedObject[]> => {
   const [startDate, endDate] = dateRange.toSuiteQLRange()
 
-  const results = await client.runSuiteQL(`
-      SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
-      FROM ${type}
-      WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
-      ORDER BY scriptid ASC
-    `)
+  const results = await client.runSuiteQL({
+    select: `internalid, scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time`,
+    from: type,
+    where: `lastmodifieddate BETWEEN ${startDate} AND ${endDate}`,
+    orderBy: 'internalid',
+  })
 
   if (results === undefined) {
     log.warn(`${type} changes query failed`)

--- a/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
+++ b/packages/netsuite-adapter/src/changes_detector/changes_detectors/file_cabinet.ts
@@ -23,13 +23,13 @@ const log = logger(module)
 export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRange) => {
   const [startDate, endDate] = dateRange.toSuiteQLRange()
 
-  const results = await client.runSuiteQL(`
-    SELECT mediaitemfolder.appfolder, file.name, ${toSuiteQLSelectDateString('file.lastmodifieddate')} as time
-    FROM file
-    JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN ${startDate} AND ${endDate}
-    ORDER BY file.id ASC
-  `)
+  const results = await client.runSuiteQL({
+    select: `file.id as fileid, mediaitemfolder.appfolder, file.name, ${toSuiteQLSelectDateString('file.lastmodifieddate')} as time`,
+    from: 'file',
+    join: 'mediaitemfolder ON mediaitemfolder.id = file.folder',
+    where: `file.lastmodifieddate BETWEEN ${startDate} AND ${endDate}`,
+    orderBy: 'fileid',
+  })
 
   if (results === undefined) {
     log.warn('file changes query failed')
@@ -53,12 +53,12 @@ export const getChangedFiles: FileCabinetChangesDetector = async (client, dateRa
 export const getChangedFolders: FileCabinetChangesDetector = async (client, dateRange) => {
   const [startDate, endDate] = dateRange.toSuiteQLRange()
 
-  const results = await client.runSuiteQL(`
-    SELECT appfolder, ${toSuiteQLSelectDateString('lastmodifieddate')} as time
-    FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN ${startDate} AND ${endDate}
-    ORDER BY id ASC
-  `)
+  const results = await client.runSuiteQL({
+    select: `id, appfolder, ${toSuiteQLSelectDateString('lastmodifieddate')} as time`,
+    from: 'mediaitemfolder',
+    where: `lastmodifieddate BETWEEN ${startDate} AND ${endDate}`,
+    orderBy: 'id',
+  })
 
   if (results === undefined) {
     log.warn('folders changes query failed')

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -49,6 +49,7 @@ import {
   SavedSearchQuery,
   SystemInformation,
   SuiteAppType,
+  SuiteQLQueryArgs,
 } from './suiteapp_client/types'
 import { CustomRecordResponse, RecordResponse } from './suiteapp_client/soap_client/types'
 import {
@@ -590,8 +591,8 @@ export default class NetsuiteClient {
     throw new Error(`Cannot deploy group ID: ${groupID}`)
   }
 
-  public async runSuiteQL(query: string): Promise<Record<string, unknown>[] | undefined> {
-    return this.suiteAppClient?.runSuiteQL(query)
+  public async runSuiteQL(args: SuiteQLQueryArgs): Promise<Record<string, unknown>[] | undefined> {
+    return this.suiteAppClient?.runSuiteQL(args)
   }
 
   public async runSavedSearchQuery(

--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -44,6 +44,15 @@ export const SUITE_QL_RESULTS_SCHEMA = {
   additionalProperties: true,
 }
 
+export type SuiteQLQueryArgs = {
+  select: string
+  from: string
+  join?: string
+  where?: string
+  groupBy?: string
+  orderBy?: string
+}
+
 export type SuiteQLResults = {
   hasMore: boolean
   items: Values[]

--- a/packages/netsuite-adapter/src/custom_records/custom_records.ts
+++ b/packages/netsuite-adapter/src/custom_records/custom_records.ts
@@ -50,7 +50,7 @@ const queryCustomRecordsTable = async (
   type: string,
 ): Promise<Record<string, SuiteQLRecord>> => {
   log.debug("querying custom record type '%s' SuiteQL table", type)
-  const result = await client.runSuiteQL(`SELECT id, scriptid FROM ${type} ORDER BY id ASC`)
+  const result = await client.runSuiteQL({ select: 'id, scriptid', from: type, orderBy: 'id' })
   const ajv = new Ajv({ allErrors: true, strict: false })
   if (!ajv.validate<SuiteQLRecord[]>(SUITE_QL_RESULTS_SCHEMA, result)) {
     log.error(`Got invalid results from listing ${type} table: ${ajv.errorsText()}`)

--- a/packages/netsuite-adapter/src/filters/author_information/constants.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/constants.ts
@@ -13,7 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export const EMPLOYEE_NAME_QUERY = 'SELECT id, entityid FROM employee ORDER BY id ASC'
+
+import { SuiteQLQueryArgs } from '../../client/suiteapp_client/types'
+
+export const EMPLOYEE_NAME_QUERY: SuiteQLQueryArgs = {
+  select: 'id, entityid',
+  from: 'employee',
+  orderBy: 'id',
+}
+
 export const EMPLOYEE_SCHEMA = {
   items: {
     properties: {

--- a/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_reference_names.ts
@@ -44,7 +44,12 @@ const querySuiteQLTable = async (
   tableName: string,
   internalIds: string[],
 ): Promise<Record<string, string>> => {
-  const results = await client.runSuiteQL(`SELECT id, name FROM ${tableName} WHERE id IN (${internalIds.join(', ')})`)
+  const results = await client.runSuiteQL({
+    select: 'id, name',
+    from: tableName,
+    where: `id IN (${internalIds.join(', ')})`,
+    orderBy: 'id',
+  })
   if (results === undefined) {
     log.warn('failed quering internal id to name mapping in table %s', tableName)
     return {}

--- a/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
@@ -95,8 +95,16 @@ const getTableName = (element: Element): string => {
   return element.elemID.typeName
 }
 
-const queryRecordIds = async (client: NetsuiteClient, query: string, recordType: string): Promise<RecordIdResult[]> => {
-  const recordIdResults = await client.runSuiteQL(query)
+const queryRecordIds = async (
+  client: NetsuiteClient,
+  idParamName: 'id' | 'internalid',
+  recordType: string,
+): Promise<RecordIdResult[]> => {
+  const recordIdResults = await client.runSuiteQL({
+    select: `scriptid, ${idParamName}`,
+    from: recordType,
+    orderBy: idParamName,
+  })
   if (recordIdResults === undefined) {
     return []
   }
@@ -145,8 +153,7 @@ const fetchRecordType = async (
   client: NetsuiteClient,
   recordType: string,
 ): Promise<Record<string, string>> => {
-  const query = `SELECT scriptid, ${idParamName} FROM ${recordType} ORDER BY ${idParamName} ASC`
-  const recordTypeIds = await queryRecordIds(client, query, recordType)
+  const recordTypeIds = await queryRecordIds(client, idParamName, recordType)
   if (_.isUndefined(recordTypeIds) || _.isEmpty(recordTypeIds)) {
     return {}
   }

--- a/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/changes_detector.test.ts
@@ -137,8 +137,8 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isCustomRecordTypeMatch('customrecord2')).toBeFalsy()
 
     expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
-    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.stringContaining('FROM customrecordtype'))
-    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.stringContaining('FROM customrecord1'))
+    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'customrecordtype' }))
+    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'customrecord1' }))
   })
 
   it('should match custom records of custom segments', async () => {
@@ -161,8 +161,8 @@ describe('changes_detector', () => {
     expect(changedObjectsQuery.isCustomRecordMatch({ type: 'customrecord_cseg1', instanceId: 'val_123' })).toBeTruthy()
 
     expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
-    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.stringContaining('FROM customrecordtype'))
-    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.stringContaining('FROM customrecord_cseg1'))
+    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'customrecordtype' }))
+    expect(runSuiteQLMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'customrecord_cseg1' }))
   })
 
   it('should return all the results of system note query failed', async () => {

--- a/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_field.test.ts
@@ -49,12 +49,12 @@ describe('custom_field', () => {
     })
 
     it('should make the right query', () => {
-      expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
-      FROM customfield
-      WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-      ORDER BY scriptid ASC
-    `)
+      expect(runSuiteQLMock).toHaveBeenCalledWith({
+        select: `internalid, scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time`,
+        from: 'customfield',
+        where: "lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+        orderBy: 'internalid',
+      })
     })
   })
 

--- a/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_list.test.ts
@@ -50,12 +50,12 @@ describe('custom_list', () => {
     })
 
     it('should make the right query', () => {
-      expect(runSuiteQLMock).toHaveBeenCalledWith(`
-      SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
-      FROM customlist
-      WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-      ORDER BY scriptid ASC
-    `)
+      expect(runSuiteQLMock).toHaveBeenCalledWith({
+        select: `internalid, scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time`,
+        from: 'customlist',
+        where: "lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+        orderBy: 'internalid',
+      })
     })
   })
 

--- a/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_record_type.test.ts
@@ -52,12 +52,12 @@ describe('custom_record_type', () => {
     })
 
     it('should make the right query', () => {
-      expect(runSuiteQLMock).toHaveBeenCalledWith(`
-        SELECT scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time
-        FROM customrecordtype
-        WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-        ORDER BY scriptid ASC
-      `)
+      expect(runSuiteQLMock).toHaveBeenCalledWith({
+        select: `internalid, scriptid, ${toSuiteQLSelectDateString('lastmodifieddate')} AS time`,
+        from: 'customrecordtype',
+        where: "lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+        orderBy: 'internalid',
+      })
     })
   })
 

--- a/packages/netsuite-adapter/test/changes_detector/custom_records.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/custom_records.test.ts
@@ -51,11 +51,17 @@ describe('custom records', () => {
     })
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, 'SELECT scriptid FROM customrecordtype  ORDER BY scriptid ASC')
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        2,
-        "SELECT scriptid FROM customrecord1 WHERE lastmodified BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') ORDER BY scriptid ASC",
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, {
+        select: 'internalid, scriptid',
+        from: 'customrecordtype',
+        orderBy: 'internalid',
+      })
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, {
+        select: 'id, scriptid',
+        from: 'customrecord1',
+        where: "lastmodified BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+        orderBy: 'id',
+      })
     })
   })
   it('return nothing when custom record types query fails', async () => {

--- a/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/file_cabinet.test.ts
@@ -50,13 +50,14 @@ describe('file_cabinet', () => {
       })
 
       it('should make the right query', () => {
-        expect(runSuiteQLMock).toHaveBeenCalledWith(`
-    SELECT mediaitemfolder.appfolder, file.name, ${toSuiteQLSelectDateString('file.lastmodifieddate')} as time
-    FROM file
-    JOIN mediaitemfolder ON mediaitemfolder.id = file.folder
-    WHERE file.lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-    ORDER BY file.id ASC
-  `)
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          select: `file.id as fileid, mediaitemfolder.appfolder, file.name, ${toSuiteQLSelectDateString('file.lastmodifieddate')} as time`,
+          from: 'file',
+          join: 'mediaitemfolder ON mediaitemfolder.id = file.folder',
+          where:
+            "file.lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+          orderBy: 'fileid',
+        })
       })
     })
 
@@ -109,12 +110,12 @@ describe('file_cabinet', () => {
       })
 
       it('should make the right query', () => {
-        expect(runSuiteQLMock).toHaveBeenCalledWith(`
-    SELECT appfolder, ${toSuiteQLSelectDateString('lastmodifieddate')} as time
-    FROM mediaitemfolder
-    WHERE lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-    ORDER BY id ASC
-  `)
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          select: `id, appfolder, ${toSuiteQLSelectDateString('lastmodifieddate')} as time`,
+          from: 'mediaitemfolder',
+          where: "lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+          orderBy: 'id',
+        })
       })
     })
 

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -33,8 +33,8 @@ describe('role', () => {
 
   it('should not return permission changes on permission query error', async () => {
     runSuiteQLMock.mockResolvedValueOnce([
-      { scriptid: 'a', time: '2021-01-11 20:55:17' },
-      { scriptid: 'b', time: '2021-01-11 21:55:17' },
+      { rolescriptid: 'a', time: '2021-01-11 20:55:17' },
+      { rolescriptid: 'b', time: '2021-01-11 21:55:17' },
       { invalid: 0 },
     ])
     runSuiteQLMock.mockResolvedValueOnce([
@@ -61,8 +61,8 @@ describe('role', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValueOnce([
-        { scriptid: 'a', time: '2021-01-11 20:55:17' },
-        { scriptid: 'b', time: '2021-01-11 21:55:17' },
+        { rolescriptid: 'a', time: '2021-01-11 20:55:17' },
+        { rolescriptid: 'b', time: '2021-01-11 21:55:17' },
         { invalid: 0 },
       ])
       runSuiteQLMock.mockResolvedValueOnce([

--- a/packages/netsuite-adapter/test/changes_detector/role.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/role.test.ts
@@ -92,26 +92,21 @@ describe('role', () => {
     })
 
     it('should make the right query', () => {
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        1,
-        `
-      SELECT role.scriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time
-      FROM role
-      JOIN systemnote ON systemnote.recordid = role.id
-      WHERE systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -118
-      GROUP BY role.scriptid
-      ORDER BY role.scriptid ASC
-    `,
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, {
+        select: `role.scriptid as rolescriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time`,
+        from: 'role',
+        join: 'systemnote ON systemnote.recordid = role.id',
+        where:
+          "systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -118",
+        groupBy: 'role.scriptid',
+        orderBy: 'rolescriptid',
+      })
 
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        2,
-        `
-      SELECT scriptid, id
-      FROM role
-      ORDER BY id ASC
-    `,
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, {
+        select: 'scriptid, id',
+        from: 'role',
+        orderBy: 'id',
+      })
 
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
         {

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -34,8 +34,16 @@ describe('script', () => {
     let results: Change[]
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
-      runSuiteQLMock.mockResolvedValueOnce([{ scriptid: 'a', id: '1' }, { scriptid: 'b', id: '2' }, { invalid: 0 }])
-      runSuiteQLMock.mockResolvedValueOnce([{ scriptid: 'c', id: '3' }, { scriptid: 'd', id: '4' }, { invalid: 0 }])
+      runSuiteQLMock.mockResolvedValueOnce([
+        { scriptscriptid: 'a', id: '1' },
+        { scriptscriptid: 'b', id: '2' },
+        { invalid: 0 },
+      ])
+      runSuiteQLMock.mockResolvedValueOnce([
+        { scriptscriptid: 'c', id: '3' },
+        { scriptscriptid: 'd', id: '4' },
+        { invalid: 0 },
+      ])
       runSuiteQLMock.mockResolvedValueOnce([
         {
           lastmodifieddate: '03/15/2021',
@@ -62,13 +70,13 @@ describe('script', () => {
     beforeEach(async () => {
       runSuiteQLMock.mockReset()
       runSuiteQLMock.mockResolvedValueOnce([
-        { scriptid: 'a', time: '2021-01-14 18:55:15' },
-        { scriptid: 'b', time: '2021-01-14 18:55:15' },
+        { scriptscriptid: 'a', time: '2021-01-14 18:55:15' },
+        { scriptscriptid: 'b', time: '2021-01-14 18:55:15' },
         { invalid: 0 },
       ])
       runSuiteQLMock.mockResolvedValueOnce([
-        { scriptid: 'c', time: '2021-01-14 18:55:15' },
-        { scriptid: 'd', time: '2021-01-14 18:55:15' },
+        { scriptscriptid: 'c', time: '2021-01-14 18:55:15' },
+        { scriptscriptid: 'd', time: '2021-01-14 18:55:15' },
         { invalid: 0 },
       ])
       runSuiteQLMock.mockResolvedValueOnce([])

--- a/packages/netsuite-adapter/test/changes_detector/script.test.ts
+++ b/packages/netsuite-adapter/test/changes_detector/script.test.ts
@@ -90,38 +90,35 @@ describe('script', () => {
     it('should make the right query', () => {
       expect(runSuiteQLMock).toHaveBeenNthCalledWith(
         1,
-        `
-      SELECT script.scriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time
-      FROM script
-      JOIN systemnote ON systemnote.recordid = script.id
-      WHERE systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -417
-      GROUP BY script.scriptid
-      ORDER BY script.scriptid ASC
-    `,
+
+        {
+          select: `script.scriptid as scriptscriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time`,
+          from: 'script',
+          join: 'systemnote ON systemnote.recordid = script.id',
+          where:
+            "systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -417",
+          groupBy: 'script.scriptid',
+          orderBy: 'scriptscriptid',
+        },
       )
 
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        2,
-        `
-      SELECT script.scriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time
-      FROM scriptdeployment 
-      JOIN systemnote ON systemnote.recordid = scriptdeployment.primarykey
-      JOIN script ON scriptdeployment.script = script.id
-      WHERE systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -418
-      GROUP BY script.scriptid
-      ORDER BY script.scriptid ASC
-    `,
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, {
+        select: `script.scriptid as scriptscriptid, ${toSuiteQLSelectDateString('MAX(systemnote.date)')} as time`,
+        from: 'scriptdeployment',
+        join: 'systemnote ON systemnote.recordid = scriptdeployment.primarykey JOIN script ON scriptdeployment.script = script.id',
+        where:
+          "systemnote.date BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD') AND systemnote.recordtypeid = -418",
+        groupBy: 'script.scriptid',
+        orderBy: 'scriptscriptid',
+      })
 
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        3,
-        `
-      SELECT internalid
-      FROM customfield
-      WHERE fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')
-      ORDER BY internalid ASC
-    `,
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, {
+        select: 'internalid',
+        from: 'customfield',
+        where:
+          "fieldtype = 'SCRIPT' AND lastmodifieddate BETWEEN TO_DATE('2021-1-11', 'YYYY-MM-DD') AND TO_DATE('2021-2-23', 'YYYY-MM-DD')",
+        orderBy: 'internalid',
+      })
     })
   })
 

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -76,7 +76,7 @@ describe('SuiteAppClient', () => {
           ],
         })
 
-        const results = await client.runSuiteQL('query')
+        const results = await client.runSuiteQL({ select: 'field', from: 'table' })
 
         expect(results).toEqual([{ a: 1 }, { a: 2 }])
         expect(mockAxiosAdapter.history.post.length).toBe(1)
@@ -84,7 +84,7 @@ describe('SuiteAppClient', () => {
         expect(req.url).toEqual(
           'https://account-id.suitetalk.api.netsuite.com/services/rest/query/v1/suiteql?limit=1000&offset=0',
         )
-        expect(JSON.parse(req.data)).toEqual({ q: 'query' })
+        expect(JSON.parse(req.data)).toEqual({ q: 'SELECT field FROM table' })
         expect(req.headers).toEqual({
           Authorization: expect.any(String),
           'Content-Type': 'application/json',
@@ -106,7 +106,7 @@ describe('SuiteAppClient', () => {
           })
         })
 
-        const results = await client.runSuiteQL('query')
+        const results = await client.runSuiteQL({ select: 'field', from: 'table' })
 
         expect(results).toEqual(items)
         expect(mockAxiosAdapter.history.post.length).toBe(2)
@@ -147,7 +147,7 @@ describe('SuiteAppClient', () => {
           })
         })
 
-        const results = await client.runSuiteQL('query')
+        const results = await client.runSuiteQL({ select: 'field', from: 'table' })
 
         expect(results).toEqual(items)
         expect(mockAxiosAdapter.history.post.length).toBe(2)
@@ -163,13 +163,15 @@ describe('SuiteAppClient', () => {
 
       it('should throw InvalidSuiteAppCredentialsError', async () => {
         mockAxiosAdapter.onPost().reply(401, 'Invalid SuiteApp credentials')
-        await expect(client.runSuiteQL('query')).rejects.toThrow(InvalidSuiteAppCredentialsError)
+        await expect(client.runSuiteQL({ select: 'field', from: 'table' })).rejects.toThrow(
+          InvalidSuiteAppCredentialsError,
+        )
       })
 
       describe('query failure', () => {
         it('exception thrown', async () => {
           mockAxiosAdapter.onPost().reply(() => [])
-          expect(await client.runSuiteQL('')).toBeUndefined()
+          expect(await client.runSuiteQL({ select: '', from: '' })).toBeUndefined()
         })
         it('should throw customize error', async () => {
           mockAxiosAdapter.onPost().reply(400, {
@@ -180,8 +182,12 @@ describe('SuiteAppClient', () => {
               },
             ],
           })
-          await expect(client.runSuiteQL('query', { 'some err': 'custom error1' })).rejects.toThrow('custom error1')
-          await expect(client.runSuiteQL('query', { 'other error': 'custom error2' })).resolves.not.toThrow()
+          await expect(
+            client.runSuiteQL({ select: 'field', from: 'table' }, { 'some err': 'custom error1' }),
+          ).rejects.toThrow('custom error1')
+          await expect(
+            client.runSuiteQL({ select: 'field', from: 'table' }, { 'other error': 'custom error2' }),
+          ).resolves.not.toThrow()
         })
         it('with concurrency error retry', async () => {
           jest
@@ -203,7 +209,7 @@ describe('SuiteAppClient', () => {
               ],
             })
 
-          expect(await client.runSuiteQL('query')).toEqual([{ a: 1 }, { a: 2 }])
+          expect(await client.runSuiteQL({ select: 'field', from: 'table' })).toEqual([{ a: 1 }, { a: 2 }])
           expect(mockAxiosAdapter.history.post.length).toBe(3)
         })
         it('with server error retry', async () => {
@@ -226,12 +232,12 @@ describe('SuiteAppClient', () => {
               ],
             })
 
-          expect(await client.runSuiteQL('query')).toEqual([{ a: 1 }, { a: 2 }])
+          expect(await client.runSuiteQL({ select: 'field', from: 'table' })).toEqual([{ a: 1 }, { a: 2 }])
           expect(mockAxiosAdapter.history.post.length).toBe(4)
         })
         it('invalid results', async () => {
           mockAxiosAdapter.onPost().reply(200, {})
-          expect(await client.runSuiteQL('')).toBeUndefined()
+          expect(await client.runSuiteQL({ select: 'field', from: 'table' })).toBeUndefined()
           expect(mockAxiosAdapter.history.post.length).toBe(6)
         })
       })

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -110,8 +110,21 @@ describe('netsuite system note author information', () => {
 
   it('should query information from api', async () => {
     await filterCreator(filterOpts).onFetch?.(elements)
-    const recordTypeSystemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
-    const fieldSystemNotesQuery = `SELECT name, field, recordid, ${toSuiteQLSelectDateString('MAX(date)')} AS date FROM systemnote WHERE date >= TO_DATE('2022-1-1', 'YYYY-MM-DD') AND (field LIKE 'MEDIAITEM.%' OR field LIKE 'MEDIAITEMFOLDER.%') GROUP BY name, field, recordid ORDER BY name, field, recordid ASC`
+    const recordTypeSystemNotesQuery = {
+      select: 'name, recordid, recordtypeid, date',
+      from: `(SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid)`,
+      orderBy: 'name, recordid, recordtypeid',
+    }
+
+    const fieldSystemNotesQuery = {
+      select: `name, field, recordid, ${toSuiteQLSelectDateString('MAX(date)')} AS date`,
+      from: 'systemnote',
+      where:
+        "date >= TO_DATE('2022-1-1', 'YYYY-MM-DD') AND (field LIKE 'MEDIAITEM.%' OR field LIKE 'MEDIAITEMFOLDER.%')",
+      groupBy: 'name, field, recordid',
+      orderBy: 'name, field, recordid',
+    }
+
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, fieldSystemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, recordTypeSystemNotesQuery)
@@ -126,7 +139,11 @@ describe('netsuite system note author information', () => {
       customRecordTypeWithNoInstances,
       missingInstance,
     ])
-    const systemNotesQuery = `SELECT name, recordid, recordtypeid, date FROM (SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid) ORDER BY name, recordid, recordtypeid ASC`
+    const systemNotesQuery = {
+      select: 'name, recordid, recordtypeid, date',
+      from: `(SELECT name, recordid, recordtypeid, ${toSuiteQLSelectDateString('MAX(date)')} as date FROM systemnote WHERE date >= ${toSuiteQLWhereDateString(new Date('2022-01-01'))} AND recordtypeid IN (-112, 1, -123) GROUP BY name, recordid, recordtypeid)`,
+      orderBy: 'name, recordid, recordtypeid',
+    }
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, EMPLOYEE_NAME_QUERY)
     expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, systemNotesQuery)
     expect(runSuiteQLMock).toHaveBeenCalledTimes(2)

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -181,15 +181,21 @@ describe('sdf internal ids tests', () => {
       await filterCreator(filterOpts).onFetch?.(elements.concat(clientScriptType))
     })
     it('should query information from api', () => {
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, 'SELECT scriptid, id FROM clientscript ORDER BY id ASC')
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        2,
-        'SELECT scriptid, internalid FROM customfield ORDER BY internalid ASC',
-      )
-      expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-        3,
-        'SELECT scriptid, internalid FROM customrecordtype ORDER BY internalid ASC',
-      )
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, {
+        select: 'scriptid, id',
+        from: 'clientscript',
+        orderBy: 'id',
+      })
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, {
+        select: 'scriptid, internalid',
+        from: 'customfield',
+        orderBy: 'internalid',
+      })
+      expect(runSuiteQLMock).toHaveBeenNthCalledWith(3, {
+        select: 'scriptid, internalid',
+        from: 'customrecordtype',
+        orderBy: 'internalid',
+      })
       expect(runSuiteQLMock).toHaveBeenCalledTimes(3)
       expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
         { type: 'savedsearch', filters: [], columns: ['id', 'internalid'] },
@@ -243,11 +249,16 @@ describe('sdf internal ids tests', () => {
         )
       })
       it('should query information from api', () => {
-        expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, 'SELECT scriptid, id FROM clientscript ORDER BY id ASC')
-        expect(runSuiteQLMock).toHaveBeenNthCalledWith(
-          2,
-          'SELECT scriptid, internalid FROM customrecordtype ORDER BY internalid ASC',
-        )
+        expect(runSuiteQLMock).toHaveBeenNthCalledWith(1, {
+          select: 'scriptid, id',
+          from: 'clientscript',
+          orderBy: 'id',
+        })
+        expect(runSuiteQLMock).toHaveBeenNthCalledWith(2, {
+          select: 'scriptid, internalid',
+          from: 'customrecordtype',
+          orderBy: 'internalid',
+        })
         expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
         expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
           { type: 'savedsearch', filters: [], columns: ['id', 'internalid'] },


### PR DESCRIPTION
SuiteQL returns only the first 100K items. In this PR we fix it and retrieve whole items when there are more than 100K items, by making more queries with filtering by the last queried item id - `WHERE ... AND id > {lastQueriedItemId}`

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix SuiteQL query of over 100K items

---
_User Notifications_: 
Netsuite Adapter:
- Missing files/folders will be fetched & added to the FileCabinet folder