### PR TITLE
SALTO-6105: split allow empty in transformValues and transformValuesSync

### DIFF
--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -333,5 +333,6 @@ export const removeNullValues = (values: Values, type: ObjectType, allowEmpty = 
     type,
     transformFunc: removeNullValuesTransformFunc,
     strict: false,
-    allowEmpty,
+    allowEmptyArrays: allowEmpty,
+    allowEmptyObjects: allowEmpty,
   }) ?? {}

--- a/packages/adapter-components/src/filters/sort_lists.ts
+++ b/packages/adapter-components/src/filters/sort_lists.ts
@@ -46,7 +46,8 @@ const sortLists = (instance: InstanceElement, defQuery: DefQuery<ElementFetchDef
       values: instance.value,
       type: instance.getTypeSync(),
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
       transformFunc: ({ value, field }: TransformFuncArgs) => {
         if (field === undefined || !Array.isArray(value)) {
           return value

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -227,7 +227,8 @@ export const replaceReferenceValues = async <TContext extends string, CustomInde
       transformFunc: transformPrimitive,
       strict: false,
       pathID: instance.elemID,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? instance.value
   )
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -240,7 +240,7 @@ const recurseIntoValue = ({
       // because we cannot get here with an object
       const isEmptyString = _.isString(newVal) && _.isEmpty(newVal)
       if (isEmptyString) {
-        log.warn('found empty string %s in field %s, string will be omitted: %s', newVal, field?.name, allowEmptyArrays)
+        log.warn('found empty string found in path %s, string will be omitted: %s', keyPathID, !allowEmptyArrays)
       }
       const valueIsEmpty = (Array.isArray(newVal) && _.isEmpty(newVal)) || isEmptyString
       return valueIsEmpty && !allowEmptyArrays ? undefined : newVal

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -85,7 +85,8 @@ type TransformValuesBaseArgs = {
   strict?: boolean
   pathID?: ElemID
   isTopLevel?: boolean
-  allowEmpty?: boolean
+  allowEmptyArrays?: boolean
+  allowEmptyObjects?: boolean
 }
 
 type TransformValuesSyncArgs = TransformValuesBaseArgs & { transformFunc: TransformFuncSync }
@@ -149,14 +150,22 @@ const fieldMapperGenerator = (type: ObjectType | TypeMap | MapType | ListType, v
       : undefined
 }
 
-const removeEmptyParts = (value: Value, allowEmpty: boolean): Value => {
+const removeEmptyParts = ({
+  value,
+  allowEmptyArrays,
+  allowEmptyObjects,
+}: {
+  value: Value
+  allowEmptyArrays: boolean
+  allowEmptyObjects: boolean
+}): Value => {
   if (Array.isArray(value)) {
     const filtered = value.filter(isDefined)
-    return filtered.length === 0 && (value.length > 0 || !allowEmpty) ? undefined : filtered
+    return filtered.length === 0 && (value.length > 0 || !allowEmptyArrays) ? undefined : filtered
   }
   if (_.isPlainObject(value)) {
     const filtered = _.omitBy(value, _.isUndefined)
-    return _.isEmpty(filtered) && (!_.isEmpty(value) || !allowEmpty) ? undefined : filtered
+    return _.isEmpty(filtered) && (!_.isEmpty(value) || !allowEmptyObjects) ? undefined : filtered
   }
   return value
 }
@@ -165,7 +174,7 @@ type recurseIntoValueArgs = {
   newVal: Value
   transformFunc: (value: Value, keyPathID?: ElemID, field?: Field) => Value
   strict: boolean
-  allowEmpty: boolean
+  allowEmptyArrays: boolean
   isAsync: boolean
   keyPathID?: ElemID
   field?: Field
@@ -176,7 +185,7 @@ const recurseIntoValue = ({
   newVal,
   transformFunc,
   strict,
-  allowEmpty,
+  allowEmptyArrays,
   isAsync,
   keyPathID,
   field,
@@ -230,7 +239,7 @@ const recurseIntoValue = ({
       // objects, arrays and strings. we don't need to check for objects here
       // because we cannot get here with an object
       const valueIsEmpty = (Array.isArray(newVal) || _.isString(newVal)) && _.isEmpty(newVal)
-      return valueIsEmpty && !allowEmpty ? undefined : newVal
+      return valueIsEmpty && !allowEmptyArrays ? undefined : newVal
     }
     const fieldMapper = fieldMapperGenerator(fieldType, newVal)
     return objMapFunc(newVal, (value: Value, key: string) =>
@@ -251,7 +260,8 @@ export const transformValues = async ({
   pathID = undefined,
   elementsSource,
   isTopLevel = true,
-  allowEmpty = false,
+  allowEmptyArrays = false,
+  allowEmptyObjects = false,
 }: TransformValuesArgs): Promise<Values | undefined> => {
   const transformValue = async (value: Value, keyPathID?: ElemID, field?: Field): Promise<Value> => {
     if (field === undefined && strict) {
@@ -267,13 +277,13 @@ export const transformValues = async ({
       newVal,
       transformFunc: transformValue,
       strict,
-      allowEmpty,
+      allowEmptyArrays,
       isAsync: true,
       keyPathID,
       field,
       fieldType: await field?.getType(elementsSource),
     })
-    return removeEmptyParts(recursed, allowEmpty)
+    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowEmptyObjects })
   }
 
   const fieldMapper = fieldMapperGenerator(type, values)
@@ -286,14 +296,14 @@ export const transformValues = async ({
       ),
       _.isUndefined,
     )
-    return _.isEmpty(result) && !allowEmpty ? undefined : result
+    return _.isEmpty(result) && !allowEmptyObjects ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)
       .map((value, index) => transformValue(value, pathID?.createNestedID(String(index)), fieldMapper(String(index))))
       .filter(value => !_.isUndefined(value))
       .toArray()
-    return result.length === 0 && !allowEmpty ? undefined : result
+    return result.length === 0 && !allowEmptyArrays ? undefined : result
   }
   return newVal
 }
@@ -305,7 +315,8 @@ export const transformValuesSync = ({
   strict = true,
   pathID = undefined,
   isTopLevel = true,
-  allowEmpty = false,
+  allowEmptyArrays = false,
+  allowEmptyObjects = false,
 }: TransformValuesSyncArgs): lowerDashTypes.NonPromise<Value> | undefined => {
   const transformValue = (value: Value, keyPathID?: ElemID, field?: Field): lowerDashTypes.NonPromise<Value> => {
     if (field === undefined && strict) {
@@ -321,13 +332,13 @@ export const transformValuesSync = ({
       newVal,
       transformFunc: transformValue,
       strict,
-      allowEmpty,
+      allowEmptyArrays,
       isAsync: false,
       keyPathID,
       field,
       fieldType: field?.getTypeSync(),
     })
-    return removeEmptyParts(recursed, allowEmpty)
+    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowEmptyObjects })
   }
 
   const fieldMapper = fieldMapperGenerator(type, values)
@@ -338,13 +349,13 @@ export const transformValuesSync = ({
       _.mapValues(newVal ?? {}, (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))),
       _.isUndefined,
     )
-    return _.isEmpty(result) && !allowEmpty ? undefined : result
+    return _.isEmpty(result) && !allowEmptyObjects ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = newVal
       .map((value, index) => transformValue(value, pathID?.createNestedID(String(index)), fieldMapper(String(index))))
       .filter(value => !_.isUndefined(value))
-    return result.length === 0 && !allowEmpty ? undefined : result
+    return result.length === 0 && !allowEmptyArrays ? undefined : result
   }
   return newVal
 }
@@ -385,7 +396,8 @@ export const transformElementAnnotations = async <T extends Element>({
     strict,
     pathID: isType(element) ? element.elemID.createNestedID('attr') : element.elemID,
     elementsSource,
-    allowEmpty,
+    allowEmptyArrays: allowEmpty,
+    allowEmptyObjects: allowEmpty,
     isTopLevel: false,
   })) || {}
 
@@ -422,7 +434,8 @@ export const transformElement = async <T extends Element>({
         strict,
         elementsSource,
         pathID: element.elemID,
-        allowEmpty,
+        allowEmptyArrays: allowEmpty,
+        allowEmptyObjects: allowEmpty,
       })) || {}
 
     newElement = new InstanceElement(

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -882,7 +882,7 @@ describe('Test utils.ts', () => {
         },
       })
       describe('with allowEmptyArrays', () => {
-        it('should not remove empty list and remove empty objects', async () => {
+        it('should remove empty objects and not remove empty list', async () => {
           const result = await transformValues({
             values: {
               arr: [],
@@ -910,7 +910,7 @@ describe('Test utils.ts', () => {
       })
 
       describe('with allowEmptyObjects', () => {
-        it('should not remove empty objects and remove empty list', async () => {
+        it('should remove empty lists and not remove empty objects', async () => {
           const result = await transformValues({
             values: {
               arr: [],
@@ -929,6 +929,38 @@ describe('Test utils.ts', () => {
 
           expect(result).toEqual({
             obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
+        })
+      })
+
+      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+        it('should not remove empty lists and not remove empty objects', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyObjects: true,
+            allowEmptyArrays: true,
+          })
+
+          expect(result).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
               val: 'a',
             },
             emptyObj: {
@@ -1489,7 +1521,7 @@ describe('Test utils.ts', () => {
         },
       })
       describe('with allowEmptyArrays', () => {
-        it('should not remove empty list and remove empty objects', async () => {
+        it('should remove empty objects and not remove empty lists', async () => {
           const result = await transformValues({
             values: {
               arr: [],
@@ -1536,6 +1568,38 @@ describe('Test utils.ts', () => {
 
           expect(result).toEqual({
             obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
+        })
+      })
+
+      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+        it('should not remove empty lists and not remove empty objects', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyObjects: true,
+            allowEmptyArrays: true,
+          })
+
+          expect(result).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
               val: 'a',
             },
             emptyObj: {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -864,51 +864,78 @@ describe('Test utils.ts', () => {
       })
     })
 
-    describe('with allowEmptyArrays', () => {
-      it('should not remove empty list', async () => {
-        const result = await transformValues({
-          values: [],
-          type: new ListType(BuiltinTypes.NUMBER),
-          transformFunc: ({ value }) => value,
-          allowEmptyArrays: true,
-        })
+    describe('allowEmpty', () => {
+      const type = new ObjectType({
+        elemID: new ElemID('adapter', 'type'),
+        fields: {
+          arr: { refType: new ListType(BuiltinTypes.NUMBER) },
+          obj: {
+            refType: new ObjectType({
+              elemID: new ElemID('adapter', 'nestedType'),
+              fields: {
+                nestedArr: { refType: new ListType(BuiltinTypes.STRING) },
+                val: { refType: BuiltinTypes.STRING },
+              },
+            }),
+          },
+          emptyObj: { refType: new ObjectType({ elemID: new ElemID('adapter', 'emptyType') }) },
+        },
+      })
+      describe('with allowEmptyArrays', () => {
+        it('should not remove empty list and remove empty objects', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyArrays: true,
+          })
 
-        expect(result).toEqual([])
+          expect(result).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
+              val: 'a',
+            },
+          })
+        })
       })
 
-      it('should remove empty object', async () => {
-        const result = await transformValues({
-          values: {},
-          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
-          transformFunc: ({ value }) => value,
-          allowEmptyArrays: true,
+      describe('with allowEmptyObjects', () => {
+        it('should not remove empty objects and remove empty list', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyObjects: true,
+          })
+
+          expect(result).toEqual({
+            obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
         })
-
-        expect(result).toEqual(undefined)
-      })
-    })
-
-    describe('with allowEmptyObjects', () => {
-      it('should remove empty list', async () => {
-        const result = await transformValues({
-          values: [],
-          type: new ListType(BuiltinTypes.NUMBER),
-          transformFunc: ({ value }) => value,
-          allowEmptyObjects: true,
-        })
-
-        expect(result).toEqual(undefined)
-      })
-
-      it('should not remove empty object', async () => {
-        const result = await transformValues({
-          values: {},
-          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
-          transformFunc: ({ value }) => value,
-          allowEmptyObjects: true,
-        })
-
-        expect(result).toEqual({})
       })
     })
   })
@@ -1444,50 +1471,78 @@ describe('Test utils.ts', () => {
       })
     })
 
-    describe('with allowEmptyArrays', () => {
-      it('should not remove empty list', async () => {
-        const result = transformValuesSync({
-          values: [],
-          type: new ListType(BuiltinTypes.NUMBER),
-          transformFunc: ({ value }) => value,
-          allowEmptyArrays: true,
-        })
+    describe('allowEmpty', () => {
+      const type = new ObjectType({
+        elemID: new ElemID('adapter', 'type'),
+        fields: {
+          arr: { refType: new ListType(BuiltinTypes.NUMBER) },
+          obj: {
+            refType: new ObjectType({
+              elemID: new ElemID('adapter', 'nestedType'),
+              fields: {
+                nestedArr: { refType: new ListType(BuiltinTypes.STRING) },
+                val: { refType: BuiltinTypes.STRING },
+              },
+            }),
+          },
+          emptyObj: { refType: new ObjectType({ elemID: new ElemID('adapter', 'emptyType') }) },
+        },
+      })
+      describe('with allowEmptyArrays', () => {
+        it('should not remove empty list and remove empty objects', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyArrays: true,
+          })
 
-        expect(result).toEqual([])
+          expect(result).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
+              val: 'a',
+            },
+          })
+        })
       })
 
-      it('should remove empty object', async () => {
-        const result = transformValuesSync({
-          values: {},
-          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
-          transformFunc: ({ value }) => value,
-          allowEmptyArrays: true,
+      describe('with allowEmptyObjects', () => {
+        it('should not remove empty objects and remove empty list', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowEmptyObjects: true,
+          })
+
+          expect(result).toEqual({
+            obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
         })
-
-        expect(result).toEqual(undefined)
-      })
-    })
-    describe('with allowEmptyObjects', () => {
-      it('should remove empty list', async () => {
-        const result = transformValuesSync({
-          values: [],
-          type: new ListType(BuiltinTypes.NUMBER),
-          transformFunc: ({ value }) => value,
-          allowEmptyObjects: true,
-        })
-
-        expect(result).toEqual(undefined)
-      })
-
-      it('should not remove empty object', async () => {
-        const result = transformValuesSync({
-          values: {},
-          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
-          transformFunc: ({ value }) => value,
-          allowEmptyObjects: true,
-        })
-
-        expect(result).toEqual({})
       })
     })
   })
@@ -1780,6 +1835,67 @@ describe('Test utils.ts', () => {
           transformFunc: ({ value }) => value,
           strict: false,
           allowEmpty: false,
+        })
+        expect(transformedElement.value).toEqual({})
+      })
+    })
+    describe('allowEmptyArrays', () => {
+      const element = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        val1: [],
+        val2: undefined,
+        val3: {
+          emptyObj: {},
+          nestedArray: [],
+        },
+      })
+
+      it('allowEmptyArrays = true should not remove empty arrays', async () => {
+        const transformedElement = await transformElement({
+          element,
+          transformFunc: ({ value }) => value,
+          strict: false,
+          allowEmptyArrays: true,
+        })
+        expect(transformedElement.value).toEqual({ val1: [], val3: { nestedArray: [] } })
+      })
+
+      it('allowEmptyArrays = false should remove empty arrays', async () => {
+        const transformedElement = await transformElement({
+          element,
+          transformFunc: ({ value }) => value,
+          strict: false,
+          allowEmptyArrays: false,
+        })
+        expect(transformedElement.value).toEqual({})
+      })
+    })
+    describe('allowEmptyObjects', () => {
+      const element = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        val1: [],
+        val2: undefined,
+        val3: {
+          emptyObj: {},
+          nestedArray: [],
+        },
+        obj: {},
+      })
+
+      it('allowEmptyObjects = true should not remove empty objects', async () => {
+        const transformedElement = await transformElement({
+          element,
+          transformFunc: ({ value }) => value,
+          strict: false,
+          allowEmptyObjects: true,
+        })
+        expect(transformedElement.value).toEqual({ val3: { emptyObj: {} }, obj: {} })
+      })
+
+      it('allowEmptyObjects = false should remove empty objects', async () => {
+        const transformedElement = await transformElement({
+          element,
+          transformFunc: ({ value }) => value,
+          strict: false,
+          allowEmptyObjects: false,
         })
         expect(transformedElement.value).toEqual({})
       })

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -864,16 +864,40 @@ describe('Test utils.ts', () => {
       })
     })
 
-    describe('with allowEmpty', () => {
+    describe('with allowEmptyArrays', () => {
       it('should not remove empty list', async () => {
         const result = await transformValues({
           values: [],
           type: new ListType(BuiltinTypes.NUMBER),
           transformFunc: ({ value }) => value,
-          allowEmpty: true,
+          allowEmptyArrays: true,
         })
 
         expect(result).toEqual([])
+      })
+
+      it('should remove empty object', async () => {
+        const result = await transformValues({
+          values: {},
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmptyArrays: true,
+        })
+
+        expect(result).toEqual(undefined)
+      })
+    })
+
+    describe('with allowEmptyObjects', () => {
+      it('should remove empty list', async () => {
+        const result = await transformValues({
+          values: [],
+          type: new ListType(BuiltinTypes.NUMBER),
+          transformFunc: ({ value }) => value,
+          allowEmptyObjects: true,
+        })
+
+        expect(result).toEqual(undefined)
       })
 
       it('should not remove empty object', async () => {
@@ -881,7 +905,7 @@ describe('Test utils.ts', () => {
           values: {},
           type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
           transformFunc: ({ value }) => value,
-          allowEmpty: true,
+          allowEmptyObjects: true,
         })
 
         expect(result).toEqual({})
@@ -1420,16 +1444,39 @@ describe('Test utils.ts', () => {
       })
     })
 
-    describe('with allowEmpty', () => {
+    describe('with allowEmptyArrays', () => {
       it('should not remove empty list', async () => {
         const result = transformValuesSync({
           values: [],
           type: new ListType(BuiltinTypes.NUMBER),
           transformFunc: ({ value }) => value,
-          allowEmpty: true,
+          allowEmptyArrays: true,
         })
 
         expect(result).toEqual([])
+      })
+
+      it('should remove empty object', async () => {
+        const result = transformValuesSync({
+          values: {},
+          type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
+          transformFunc: ({ value }) => value,
+          allowEmptyArrays: true,
+        })
+
+        expect(result).toEqual(undefined)
+      })
+    })
+    describe('with allowEmptyObjects', () => {
+      it('should remove empty list', async () => {
+        const result = transformValuesSync({
+          values: [],
+          type: new ListType(BuiltinTypes.NUMBER),
+          transformFunc: ({ value }) => value,
+          allowEmptyObjects: true,
+        })
+
+        expect(result).toEqual(undefined)
       })
 
       it('should not remove empty object', async () => {
@@ -1437,7 +1484,7 @@ describe('Test utils.ts', () => {
           values: {},
           type: new ObjectType({ elemID: new ElemID('adapter', 'type') }),
           transformFunc: ({ value }) => value,
-          allowEmpty: true,
+          allowEmptyObjects: true,
         })
 
         expect(result).toEqual({})

--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -36,7 +36,8 @@ const filter: FilterCreator = () => ({
             values: instance.value,
             type: await instance.getType(),
             pathID: instance.elemID,
-            allowEmpty: true,
+            allowEmptyArrays: true,
+            allowEmptyObjects: true,
             strict: false,
             transformFunc: ({ value, field, path }) => {
               const isInArray = path?.getFullNameParts().some(isStringNumber)

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -59,7 +59,8 @@ const maskValues = async (instance: InstanceElement, masking: MaskingConfig): Pr
       type: await instance.getType(),
       pathID: instance.elemID,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
       transformFunc: ({ value, path }) => {
         if (path?.name === 'headers' && isHeaders(value)) {
           maskHeaders(value, masking.automationHeaders, instance.elemID)

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -97,7 +97,8 @@ const filter: FilterCreator = () => ({
           pathID: inst.elemID,
           transformFunc: transformSelfLinkToReference(elementsBySelfLink),
           strict: false,
-          allowEmpty: true,
+          allowEmptyArrays: true,
+          allowEmptyObjects: true,
         })) ?? inst.value
     })
   },

--- a/packages/jira-adapter/src/filters/remove_empty_values.ts
+++ b/packages/jira-adapter/src/filters/remove_empty_values.ts
@@ -41,7 +41,6 @@ const filter: FilterCreator = () => ({
             type: await instance.getType(),
             transformFunc: ({ value }) => value,
             strict: false,
-            allowEmpty: false,
           })) ?? {}
       })
   },

--- a/packages/jira-adapter/src/filters/remove_self.ts
+++ b/packages/jira-adapter/src/filters/remove_self.ts
@@ -35,7 +35,8 @@ const filter: FilterCreator = () => ({
             type: await instance.getType(),
             pathID: instance.elemID,
             strict: false,
-            allowEmpty: true,
+            allowEmptyArrays: true,
+            allowEmptyObjects: true,
             transformFunc: ({ value, path }) => {
               if (path?.name === 'self') {
                 return undefined

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -151,7 +151,8 @@ const sortLists = async (instance: InstanceElement): Promise<void> => {
       values: instance.value,
       type: await instance.getType(),
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
       transformFunc: async ({ value, field }) => {
         if (field === undefined || !Array.isArray(value)) {
           return value

--- a/packages/salesforce-adapter/src/change_validators/map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/map_keys.ts
@@ -118,7 +118,8 @@ const getMapKeyErrors = async (
         type: fieldType,
         transformFunc: findInvalidPaths,
         strict: false,
-        allowEmpty: true,
+        allowEmptyArrays: true,
+        allowEmptyObjects: true,
         pathID: after.elemID.createNestedID(fieldName),
       })
     })

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -42,7 +42,8 @@ const filterCreator: LocalFilterCreator = () => ({
             type: instance.getTypeSync(),
             transformFunc: transformPrimitive,
             strict: false,
-            allowEmpty: true,
+            allowEmptyArrays: true,
+            allowEmptyObjects: true,
           }) || {}
       })
   },

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -326,7 +326,8 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
         type: await instance.getType(),
         transformFunc,
         strict: false,
-        allowEmpty: true,
+        allowEmptyArrays: true,
+        allowEmptyObjects: true,
       })) ?? instance.value
     )
   }

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -397,7 +397,8 @@ export const transformFieldAnnotations = async (
       type: annotationsType,
       transformFunc: transformPrimitive,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) || {}
   )
 }
@@ -413,7 +414,8 @@ const transformObjectAnnotationValues = (
     values: instance.value,
     type: annotationsObject,
     transformFunc: transformPrimitive,
-    allowEmpty: true,
+    allowEmptyArrays: true,
+    allowEmptyObjects: true,
   })
 }
 

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -67,7 +67,8 @@ const resolveReferences = async (
       type: await instance.getType(),
       transformFunc: transformPrimitive,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? instance.value
 }
 

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -84,7 +84,8 @@ const removeValuesFromInstances = (
           type: inst.getTypeSync(),
           transformFunc: removeValuesFunc,
           strict: true,
-          allowEmpty: true,
+          allowEmptyArrays: true,
+          allowEmptyObjects: true,
           pathID: inst.elemID,
         }) || inst.value
     })

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -128,7 +128,8 @@ const replaceInstanceValues = async (
       type: await instance.getType(),
       transformFunc,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? values
 }
 

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -90,7 +90,8 @@ const extractToStaticFile = async (
       type: await instance.getType(),
       transformFunc,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? values
 }
 

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -57,7 +57,8 @@ const removeAttributePrefix = async (
       values: instance.value,
       type,
       strict: false,
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
       transformFunc: async ({ value, field }) => {
         const fieldType = await field?.getType()
         return isObjectType(fieldType)

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -531,7 +531,8 @@ const cloneValuesWithAttributePrefixes = async (
     transformFunc: createPathsSetCallback,
     pathID: instance.elemID,
     strict: false,
-    allowEmpty: true,
+    allowEmptyArrays: true,
+    allowEmptyObjects: true,
   })
 
   const addAttributePrefixFunc: MapKeyFunc = ({ key, pathID }) => {

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -230,7 +230,8 @@ const removeHiddenFromValues = (
     pathID,
     elementsSource,
     strict: false,
-    allowEmpty: true,
+    allowEmptyArrays: true,
+    allowEmptyObjects: true,
   })
 
 const isChangeToHidden = (change: DetailedChange, hiddenValue: boolean): boolean =>

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -82,7 +82,8 @@ const transformDynamicContentDependencies = async (
         }
         return value
       },
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? instance.value
 }
 
@@ -121,7 +122,8 @@ const returnDynamicContentsToApiValue = async (
         }
         return value
       },
-      allowEmpty: true,
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })) ?? instance.value
 }
 
@@ -166,7 +168,8 @@ const filterCreator: FilterCreator = ({ config }) => {
               }
               return value
             },
-            allowEmpty: true,
+            allowEmptyArrays: true,
+            allowEmptyObjects: true,
             strict: false,
           })) ?? instance.value
       }),


### PR DESCRIPTION
Split `allowEmpty` param `transformValues` and `transformValuesSync` to distinguish between arrays and objects

---

_Additional context for reviewer_
though `transformValues` and `transformValuesSync` are exported but currently not in use, I removed it entirely.
added `allowEmptyArrays` and `allowEmptyObjects` to `transformElement, left `allowEmpty` in `transformElement` for backward compatibility and will remove it in a separate PR

---
_Release Notes_: 

_Core_:
- Change `transformValues` and `transformValuesSync` params by splitting `allowEmpty` param to `allowEmptyArray` and `allowEmptyObjects`
- Add `allowEmptyArrays` and `allowEmptyObjects` to `transformElement`, `allowEmpty` is deprecated and will be deleted soon

---
_User Notifications_: 
None
