### PR TITLE
SALTO-6106: Add optional allowEmptyArrays option to top level element and enable it in Okta Application

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -187,6 +187,9 @@ export type FetchTopLevelElementDefinition<Options extends ElementFetchDefinitio
   alias?: AliasData
 
   importantValues?: ImportantValues
+
+  // when true, empty arrays in instance values will not be omitted
+  allowEmptyArrays?: boolean
 }
 
 export type ElementFetchDefinition<Options extends ElementFetchDefinitionOptions = {}> = {

--- a/packages/adapter-components/src/elements_deprecated/instance_elements.ts
+++ b/packages/adapter-components/src/elements_deprecated/instance_elements.ts
@@ -244,7 +244,7 @@ export const toBasicInstance = async ({
   return new InstanceElement(
     type.isSettings ? ElemID.CONFIG_NAME : naclName,
     type,
-    entryData !== undefined ? removeNullValues(entryData, type) : {},
+    entryData !== undefined ? removeNullValues({ values: entryData, type }) : {},
     filePath,
     parent ? { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] } : undefined,
   )

--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -81,6 +81,7 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
             toPath,
             // TODO pick better default name, include service id
             defaultName: `unnamed_${index}`,
+            allowEmptyArrays: elementDef.topLevel?.allowEmptyArrays,
           }),
         )
         .filter(isDefined)

--- a/packages/adapter-components/src/fetch/element/instance_utils.ts
+++ b/packages/adapter-components/src/fetch/element/instance_utils.ts
@@ -101,6 +101,7 @@ export const omitInstanceValues = <Options extends FetchApiDefinitionsOptions>({
     type,
     transformFunc: omitValues(defQuery),
     strict: false,
+    allowEmptyArrays: defQuery.query(type.elemID.name)?.element?.topLevel?.allowEmptyArrays,
   })
 
 /**
@@ -126,6 +127,7 @@ export type InstanceCreationParams = {
   parent?: InstanceElement
   toElemName: ElemIDCreator
   toPath: PartsCreator
+  allowEmptyArrays?: boolean
 }
 
 /**
@@ -200,10 +202,11 @@ export const createInstance = ({
   toPath,
   defaultName,
   parent,
+  allowEmptyArrays = false,
 }: InstanceCreationParams): InstanceElement | undefined => {
   const annotations = _.pick(entry, Object.keys(INSTANCE_ANNOTATIONS))
   const value = _.omit(entry, Object.keys(INSTANCE_ANNOTATIONS))
-  const refinedValue = value !== undefined ? removeNullValues(value, type) : {}
+  const refinedValue = value !== undefined ? removeNullValues({ values: value, type, allowEmptyArrays }) : {}
 
   if (_.isEmpty(refinedValue)) {
     return undefined

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -196,6 +196,8 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
         customNameMappingFunctions,
         definedTypes,
       }),
+      allowEmptyArrays: true,
+      allowEmptyObjects: true,
     })
     if (value !== undefined) {
       inst.value = value

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -329,12 +329,22 @@ export const getReachableTypes = <Options extends FetchApiDefinitionsOptions>({
 
 export const removeNullValuesTransformFunc: TransformFuncSync = ({ value }) => (value === null ? undefined : value)
 
-export const removeNullValues = (values: Values, type: ObjectType, allowEmpty = false): Values =>
+export const removeNullValues = ({
+  values,
+  type,
+  allowEmptyArrays = false,
+  allowEmptyObjects = false,
+}: {
+  values: Values
+  type: ObjectType
+  allowEmptyArrays?: boolean
+  allowEmptyObjects?: boolean
+}): Values =>
   transformValuesSync({
     values,
     type,
     transformFunc: removeNullValuesTransformFunc,
     strict: false,
-    allowEmptyArrays: allowEmpty,
-    allowEmptyObjects: allowEmpty,
+    allowEmptyArrays,
+    allowEmptyObjects,
   }) ?? {}

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -108,6 +108,9 @@ export const mockDefaultValues: Record<string, Values> = {
         honorForceAuthn: true,
         authnContextClassRef: 'urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport',
         requestCompressed: false,
+        attributeStatements: [],
+        inlineHooks: [],
+        acsEndpoints: [],
         allowMultipleAcsEndpoints: false,
         samlSignedRequestEnabled: false,
         slo: {

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -349,6 +349,7 @@ const createCustomizations = ({
         isTopLevel: true,
         serviceUrl: { path: '/admin/app/{name}/instance/{id}/#tab-general' },
         elemID: { parts: [{ fieldName: 'label' }] },
+        allowEmptyArrays: true,
       },
       fieldCustomizations: {
         name: { fieldType: 'string' },

--- a/packages/okta-adapter/src/filters/app_deployment.ts
+++ b/packages/okta-adapter/src/filters/app_deployment.ts
@@ -196,11 +196,15 @@ const filterCreator: FilterCreator = ({ elementSource, definitions, oldApiDefini
       log.error('Could not create customName field for custom apps because subdomain was missing')
       return
     }
-    // create customName field for non custom apps and delete name field as its value is not multienv
     appInstances.forEach(app => {
+      // create customName field for non custom apps and delete name field as its value is not multienv
       if (isCustomApp(app.value, subdomain)) {
         app.value.customName = app.value.name
         delete app.value.name
+      }
+      // delete `features` array if it is empty as the field is not deployable
+      if (_.isEmpty(app.value.features)) {
+        delete app.value.features
       }
     })
 

--- a/packages/okta-adapter/test/filters/app_deployment.test.ts
+++ b/packages/okta-adapter/test/filters/app_deployment.test.ts
@@ -97,6 +97,13 @@ describe('appDeploymentFilter', () => {
       expect(app?.value.name).toEqual('salesforce')
       expect(app?.value.customName).toBeUndefined()
     })
+    it('should remove "features" field if it is empty', async () => {
+      const emptyFeaturesApp = new InstanceElement('empty features app', appType, { features: [] })
+      const elements = [appType, orgSettingType, orgSettingInstance, emptyFeaturesApp]
+      await filter.onFetch(elements)
+      const app = elements.filter(isInstanceElement).find(e => e.elemID.name === 'empty features app')
+      expect(app?.value.features).toBeUndefined()
+    })
     it('should add deployment annotations for "features" field', async () => {
       const elements = [appType, orgSettingType, orgSettingInstance, customSamlAppInstance, customSwaInstance]
       await filter.onFetch(elements)


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

** **please only review last commit** **

Still TODO - 

- [x] test in Zendesk to verify no side effects
- [x] uts
- [x] noise reduction in Okta

---
_Release Notes_: 

_Okta_adapter_:
- Fix a bug in deployment of OIDC application causing applications with empty scopes to fail

---
_User Notifications_: 

_Okta_adapter_:
- Empty arrays in Okta `Application` will be visible in `Application` elements
- 
