### PR TITLE
SALTO-6112: Open Salesforce Profiles Custom References

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -44,7 +44,7 @@ const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
 
 const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
   {
-    profiles: false,
+    profiles: true,
     managedElements: true,
     permisisonSets: true,
   }

--- a/packages/workspace/src/workspace/reference_indexes.ts
+++ b/packages/workspace/src/workspace/reference_indexes.ts
@@ -42,7 +42,7 @@ import { RemoteMap, RemoteMapEntry } from './remote_map'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-export const REFERENCE_INDEXES_VERSION = 9
+export const REFERENCE_INDEXES_VERSION = 10
 export const REFERENCE_INDEXES_KEY = 'reference_indexes'
 
 type ChangeReferences = {


### PR DESCRIPTION
Opening Salesforce Custom References By Default.

---

_Release Notes_: 

_Salesforce Adapter_:
- Salesforce Profiles custom references will be available by default.

---
_User Notifications_: 
_None_
