### PR TITLE
SALTO-6105: Remove allow empty from `transformElement`

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -425,7 +425,6 @@ export const transformElement = async <T extends Element>({
   strict,
   elementsSource,
   runOnFields,
-  allowEmpty,
   allowEmptyArrays,
   allowEmptyObjects,
 }: {
@@ -434,7 +433,6 @@ export const transformElement = async <T extends Element>({
   strict?: boolean
   elementsSource?: ReadOnlyElementsSource
   runOnFields?: boolean
-  allowEmpty?: boolean
   allowEmptyArrays?: boolean
   allowEmptyObjects?: boolean
 }): Promise<T> => {
@@ -444,8 +442,8 @@ export const transformElement = async <T extends Element>({
     transformFunc,
     strict,
     elementsSource,
-    allowEmptyArrays: allowEmptyArrays ?? allowEmpty,
-    allowEmptyObjects: allowEmptyObjects ?? allowEmpty,
+    allowEmptyArrays,
+    allowEmptyObjects,
   })
 
   if (isInstanceElement(element)) {
@@ -457,8 +455,8 @@ export const transformElement = async <T extends Element>({
         strict,
         elementsSource,
         pathID: element.elemID,
-        allowEmptyArrays: allowEmptyArrays ?? allowEmpty,
-        allowEmptyObjects: allowEmptyObjects ?? allowEmpty,
+        allowEmptyArrays,
+        allowEmptyObjects,
       })) || {}
 
     newElement = new InstanceElement(
@@ -482,7 +480,6 @@ export const transformElement = async <T extends Element>({
             strict,
             elementsSource,
             runOnFields,
-            allowEmpty,
             allowEmptyArrays,
             allowEmptyObjects,
           })
@@ -531,7 +528,6 @@ export const transformElement = async <T extends Element>({
         strict,
         elementsSource,
         runOnFields,
-        allowEmpty,
         allowEmptyArrays,
         allowEmptyObjects,
       }),
@@ -547,7 +543,6 @@ export const transformElement = async <T extends Element>({
         strict,
         elementsSource,
         runOnFields,
-        allowEmpty,
         allowEmptyArrays,
         allowEmptyObjects,
       }),

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1881,91 +1881,91 @@ describe('Test utils.ts', () => {
       })
     })
     describe('allowEmpty', () => {
-      const element = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
-        val1: [],
-        val2: undefined,
-        val3: {},
-      })
-
-      it('allowEmpty = true should not remove empty objects and arrays', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmpty: true,
-        })
-        expect(transformedElement.value).toEqual({ val1: [], val3: {} })
-      })
-
-      it('allowEmpty = false should remove empty objects and arrays', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmpty: false,
-        })
-        expect(transformedElement.value).toEqual({})
-      })
-    })
-    describe('allowEmptyArrays', () => {
-      const element = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
-        val1: [],
-        val2: undefined,
-        val3: {
-          emptyObj: {},
-          nestedArray: [],
+      const type = new ObjectType({
+        elemID: new ElemID('adapter', 'type'),
+        fields: {
+          arr: { refType: new ListType(BuiltinTypes.NUMBER) },
+          obj: {
+            refType: new ObjectType({
+              elemID: new ElemID('adapter', 'nestedType'),
+              fields: {
+                nestedArr: { refType: new ListType(BuiltinTypes.STRING) },
+                val: { refType: BuiltinTypes.STRING },
+              },
+            }),
+          },
+          emptyObj: { refType: new ObjectType({ elemID: new ElemID('adapter', 'emptyType') }) },
         },
       })
-
-      it('allowEmptyArrays = true should not remove empty arrays', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmptyArrays: true,
-        })
-        expect(transformedElement.value).toEqual({ val1: [], val3: { nestedArray: [] } })
-      })
-
-      it('allowEmptyArrays = false should remove empty arrays', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmptyArrays: false,
-        })
-        expect(transformedElement.value).toEqual({})
-      })
-    })
-    describe('allowEmptyObjects', () => {
-      const element = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
-        val1: [],
-        val2: undefined,
-        val3: {
-          emptyObj: {},
-          nestedArray: [],
+      const element = new InstanceElement('instance', type, {
+        arr: [],
+        obj: {
+          nestedArr: [],
+          val: 'a',
         },
-        obj: {},
+        emptyObj: {
+          nested: {},
+        },
+      })
+      describe('with allowEmptyArrays', () => {
+        it('should remove empty objects and not remove empty list', async () => {
+          const result = await transformElement({
+            element,
+            transformFunc: ({ value }) => value,
+            strict: false,
+            allowEmptyArrays: true,
+          })
+          expect(result.value).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
+              val: 'a',
+            },
+          })
+        })
       })
 
-      it('allowEmptyObjects = true should not remove empty objects', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmptyObjects: true,
+      describe('with allowEmptyObjects', () => {
+        it('should remove empty lists and not remove empty objects', async () => {
+          const result = await transformElement({
+            element,
+            transformFunc: ({ value }) => value,
+            strict: false,
+            allowEmptyObjects: true,
+          })
+
+          expect(result).toEqual({
+            obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
         })
-        expect(transformedElement.value).toEqual({ val3: { emptyObj: {} }, obj: {} })
       })
 
-      it('allowEmptyObjects = false should remove empty objects', async () => {
-        const transformedElement = await transformElement({
-          element,
-          transformFunc: ({ value }) => value,
-          strict: false,
-          allowEmptyObjects: false,
+      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+        it('should not remove empty lists and not remove empty objects', async () => {
+          const result = await transformElement({
+            element,
+            transformFunc: ({ value }) => value,
+            strict: false,
+            allowEmptyArrays: true,
+            allowEmptyObjects: true,
+          })
+
+          expect(result).toEqual({
+            arr: [],
+            obj: {
+              nestedArr: [],
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+          })
         })
-        expect(transformedElement.value).toEqual({})
       })
     })
   })

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -1934,7 +1934,7 @@ describe('Test utils.ts', () => {
             allowEmptyObjects: true,
           })
 
-          expect(result).toEqual({
+          expect(result.value).toEqual({
             obj: {
               val: 'a',
             },
@@ -1955,7 +1955,7 @@ describe('Test utils.ts', () => {
             allowEmptyObjects: true,
           })
 
-          expect(result).toEqual({
+          expect(result.value).toEqual({
             arr: [],
             obj: {
               nestedArr: [],


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

will be merged after next release

---
_Release Notes_: 

_Core_:
- `allowEmpty` param is removed from `transformElement`. Alternatively, you may use `allowEmptyArrays` and `allowEmptyObjects`.

---
_User Notifications_: 
None
