### PR TITLE
SALTO-6133: Fix issue with client config type in Okta

### DIFF
--- a/packages/adapter-components/src/definitions/user/client_config.ts
+++ b/packages/adapter-components/src/definitions/user/client_config.ts
@@ -56,11 +56,17 @@ export type ClientBaseConfig<RateLimitConfig extends ClientRateLimitConfig> = Pa
   timeout: ClientTimeoutConfig
 }>
 
-export const createClientConfigType = <RateLimitConfig extends ClientRateLimitConfig>(
-  adapter: string,
-  bucketNames?: (keyof RateLimitConfig)[],
-  additionRateLimitFields?: Record<string, FieldDefinition>,
-): ObjectType => {
+export const createClientConfigType = <RateLimitConfig extends ClientRateLimitConfig>({
+  adapter,
+  bucketNames,
+  additionRateLimitFields,
+  additionalClientFields,
+}: {
+  adapter: string
+  bucketNames?: (keyof RateLimitConfig)[]
+  additionRateLimitFields?: Record<string, FieldDefinition>
+  additionalClientFields?: Record<string, FieldDefinition>
+}): ObjectType => {
   const createFieldDefWithMin = (min: number): FieldDefinition => ({
     refType: BuiltinTypes.NUMBER,
     // note: not enforced yet
@@ -125,6 +131,7 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
       maxRequestsPerMinute: createFieldDefWithMin(-1),
       pageSize: { refType: clientPageSizeConfigType },
       timeout: { refType: clientTimeoutConfigType },
+      ...additionalClientFields,
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -43,6 +43,7 @@ type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string = never> =
   additionalFields?: Record<string, FieldDefinition>
   additionalFetchFields?: Record<string, FieldDefinition>
   additionalDeployFields?: Record<string, FieldDefinition>
+  additionRateLimitFields?: Record<string, FieldDefinition>
   additionalClientFields?: Record<string, FieldDefinition>
   changeValidatorNames?: string[]
   omitElemID?: boolean
@@ -59,6 +60,7 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
   additionalFields,
   additionalFetchFields,
   additionalDeployFields,
+  additionRateLimitFields,
   additionalClientFields,
   omitElemID,
 }: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType =>
@@ -66,7 +68,11 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
     elemID: new ElemID(adapterName),
     fields: {
       client: {
-        refType: createClientConfigType(adapterName, undefined, additionalClientFields),
+        refType: createClientConfigType({
+          adapter: adapterName,
+          additionRateLimitFields,
+          additionalClientFields,
+        }),
       },
       fetch: {
         refType: createUserFetchConfigType({

--- a/packages/adapter-components/test/definitions/user/client_config.test.ts
+++ b/packages/adapter-components/test/definitions/user/client_config.test.ts
@@ -19,7 +19,7 @@ import { createClientConfigType, validateClientConfig } from '../../../src/defin
 describe('client_config', () => {
   describe('createClientConfigType', () => {
     it('should return default type when no custom buckets were added', async () => {
-      const type = createClientConfigType('myAdapter')
+      const type = createClientConfigType({ adapter: 'myAdapter' })
       expect(Object.keys(type.fields)).toHaveLength(5)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()
@@ -35,7 +35,7 @@ describe('client_config', () => {
         total: number
         a: number
         b: number
-      }>('myAdapter', ['a', 'b'])
+      }>({ adapter: 'myAdapter', bucketNames: ['a', 'b'] })
       expect(Object.keys(type.fields)).toHaveLength(5)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()

--- a/packages/adapter-components/test/definitions/user/client_config.test.ts
+++ b/packages/adapter-components/test/definitions/user/client_config.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ObjectType } from '@salto-io/adapter-api'
+import { BuiltinTypes, ElemID, ObjectType } from '@salto-io/adapter-api'
 import { createClientConfigType, validateClientConfig } from '../../../src/definitions/user/client_config'
 
 describe('client_config', () => {
@@ -44,6 +44,49 @@ describe('client_config', () => {
       const rateLimitType = await type.fields.rateLimit.getType()
       expect(rateLimitType).toBeInstanceOf(ObjectType)
       expect(new Set(Object.keys((rateLimitType as ObjectType).fields))).toEqual(new Set(['get', 'total', 'a', 'b']))
+    })
+    describe('with additional fields provided', () => {
+      it('should add additional client fields when provided', () => {
+        const type = createClientConfigType<{
+          total: number
+          a: number
+          b: number
+        }>({
+          adapter: 'myAdapter',
+          additionalClientFields: {
+            myField: { refType: BuiltinTypes.BOOLEAN },
+            anotherField: {
+              refType: new ObjectType({
+                elemID: new ElemID('adapter', 'test'),
+                fields: { a: { refType: BuiltinTypes.STRING } },
+              }),
+            },
+          },
+        })
+        expect(Object.keys(type.fields)).toHaveLength(7)
+        expect(type.fields.myField).toBeDefined()
+        const myFields = type.fields.myField.getTypeSync()
+        expect(myFields).toBe(BuiltinTypes.BOOLEAN)
+        expect(type.fields.anotherField).toBeDefined()
+        const anotherType = type.fields.anotherField.getTypeSync() as ObjectType
+        expect(anotherType.elemID.getFullName()).toEqual('adapter.test')
+        expect(anotherType.fields.a).toBeDefined()
+      })
+      it('should add additional rate limit fields when provided', async () => {
+        const type = createClientConfigType<{
+          total: number
+          a: number
+          b: number
+        }>({
+          adapter: 'myAdapter',
+          additionRateLimitFields: {
+            myField: { refType: BuiltinTypes.BOOLEAN },
+          },
+        })
+        expect(Object.keys(type.fields)).toHaveLength(5)
+        const rateLimitType = (await type.fields.rateLimit.getType()) as ObjectType
+        expect(rateLimitType.fields.myField).toBeDefined()
+      })
     })
   })
 

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -182,7 +182,7 @@ export const getDefaultConfig = ({ isDataCenter }: { isDataCenter: boolean }): J
 })
 
 const createClientConfigType = (): ObjectType => {
-  const configType = definitions.createClientConfigType(JIRA)
+  const configType = definitions.createClientConfigType({ adapter: JIRA })
   configType.fields.FieldConfigurationItemsDeploymentLimit = new Field(
     configType,
     'FieldConfigurationItemsDeploymentLimit',

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -117,8 +117,8 @@ export const configType = definitions.createUserConfigType({
   changeValidatorNames: [...changeValidatorNames],
   additionalFetchFields: additionalFetchConfigFields,
   additionalDeployFields: { omitMissingUsers: { refType: BuiltinTypes.BOOLEAN } },
+  additionRateLimitFields: { rateLimitBuffer: { refType: BuiltinTypes.NUMBER } },
   additionalClientFields: {
-    rateLimitBuffer: { refType: BuiltinTypes.NUMBER },
     usePrivateAPI: { refType: BuiltinTypes.BOOLEAN },
   },
   omitElemID: false,

--- a/packages/sap-adapter/src/config.ts
+++ b/packages/sap-adapter/src/config.ts
@@ -132,7 +132,7 @@ export const configType = createMatchingObjectType<Partial<SAPConfig>>({
   elemID: new ElemID(SAP),
   fields: {
     [CLIENT_CONFIG]: {
-      refType: createClientConfigType(SAP),
+      refType: createClientConfigType({ adapter: SAP }),
     },
     [FETCH_CONFIG]: {
       refType: definitions.createUserFetchConfigType({

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -141,7 +141,7 @@ export const configType = createMatchingObjectType<Partial<StripeConfig>>({
   elemID: new ElemID(STRIPE),
   fields: {
     [CLIENT_CONFIG]: {
-      refType: createClientConfigType(STRIPE),
+      refType: createClientConfigType({ adapter: STRIPE }),
     },
     [FETCH_CONFIG]: {
       refType: definitions.createUserFetchConfigType({ adapterName: STRIPE, omitElemID: true }),

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -265,7 +265,7 @@ export const configType = new ObjectType({
   elemID: new ElemID(WORKATO),
   fields: {
     [CLIENT_CONFIG]: {
-      refType: createClientConfigType(WORKATO),
+      refType: createClientConfigType({ adapter: WORKATO }),
     },
     [FETCH_CONFIG]: {
       refType: definitions.createUserFetchConfigType({

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -3076,7 +3076,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
   elemID: new ElemID(ZENDESK),
   fields: {
     [CLIENT_CONFIG]: {
-      refType: createClientConfigType(ZENDESK),
+      refType: createClientConfigType({ adapter: ZENDESK }),
     },
     [FETCH_CONFIG]: {
       refType: definitions.createUserFetchConfigType({

--- a/packages/zuora-billing-adapter/src/config.ts
+++ b/packages/zuora-billing-adapter/src/config.ts
@@ -729,7 +729,7 @@ export const configType = createMatchingObjectType<Partial<ZuoraConfig>>({
   elemID: new ElemID(ZUORA_BILLING),
   fields: {
     [CLIENT_CONFIG]: {
-      refType: createClientConfigType(ZUORA_BILLING),
+      refType: createClientConfigType({ adapter: ZUORA_BILLING }),
     },
     [FETCH_CONFIG]: {
       refType: definitions.createUserFetchConfigType({ adapterName: ZUORA_BILLING, omitElemID: true }),


### PR DESCRIPTION
We accidentally passed `usePrivateAPI` to the wrong place in the config object type 

---


_Additional context for reviewer_

will add test soon 

---
_Release Notes_: 

_Okta_adapter_:
- Fix a bug in fetch causing all fetch to include invalid config event

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
