### PR TITLE
SALTO-6116 Ignore conflicts caused by different line separators

### DIFF
--- a/packages/core/src/core/merge_content.ts
+++ b/packages/core/src/core/merge_content.ts
@@ -41,8 +41,9 @@ const splitToLinesWithTerminators = (multilineString: string): LineWithTerminato
       linesWithTerminators.push(Object.assign(currentLine, { terminator: '\r\n' }))
       currentLine = ''
       i += 1 // Skip the \n part
-    } else if (char === '\r' || char === '\n' || char === '\u2028' || char === '\u2029') {
-      // Other terminators: \r, \n, \u2028, \u2029
+    } else if (char === '\r' || char === '\n') {
+      // Other terminators: \r, \n. In general, \u2028 & \u2029 are considered line terminators too,
+      // but Monaco Editor doesn't treat them as so (shows an unknown char), so we can ignore them too.
       linesWithTerminators.push(Object.assign(currentLine, { terminator: char }))
       currentLine = ''
     } else {

--- a/packages/core/src/core/merge_content.ts
+++ b/packages/core/src/core/merge_content.ts
@@ -58,7 +58,10 @@ const splitToLinesWithTerminators = (multilineString: string): LineWithTerminato
 }
 
 const joinLinesWithTerminators = (lines: LineWithTerminator[]): string =>
-  lines.reduce((res, line) => res.concat(line, line.terminator ?? '\n'), '')
+  lines.reduce(
+    (res, line, i) => res.concat(line, line.terminator === '' && i < lines.length - 1 ? '\n' : line.terminator ?? '\n'),
+    '',
+  )
 
 const isConflictChunk = (chunk: diff3.ICommResult<LineWithTerminator>): boolean =>
   !('common' in chunk) && chunk.buffer1.length > 0 && chunk.buffer2.length > 0

--- a/packages/core/test/core/merge_content.test.ts
+++ b/packages/core/test/core/merge_content.test.ts
@@ -28,11 +28,16 @@ describe('merge contents', () => {
   const base = 'hello world!\nmy name is:\nNaCls'
   const current = 'Hello World!\nmy name is:\nNaCls'
   const incomingMergeable = 'hello world!\nmy name is:\nNaCls the great!'
+  const incomingMergeableWithDifferentLineTerminator =
+    'hello world!\r\nmy name is:\r\nNaCls the great!\r\nthe great!\r\n'
   const incomingUnmergeable = 'HELLO WORLD!\nmy name is:\nNaCls the great!'
   const incomingAdded = 'my name is:\nNaCls\nthe great!'
+  const incomingAddedWithDifferentLineTerminator = 'my name is:\r\nNaCls\r\nthe great!\r\nthe great!'
 
   const modifiedMerged = 'Hello World!\nmy name is:\nNaCls the great!'
+  const modifiedMergedWithMixedLineTerminators = 'Hello World!\nmy name is:\nNaCls the great!\r\nthe great!\r\n'
   const addedMerged = 'Hello World!\nmy name is:\nNaCls\nthe great!'
+  const addedMergedWithMixedLineTerminators = 'Hello World!\nmy name is:\nNaCls\nthe great!\r\nthe great!'
 
   describe('merge strings', () => {
     it('should merge modified value', () => {
@@ -40,6 +45,16 @@ describe('merge contents', () => {
     })
     it('should merge added value', () => {
       expect(mergeStrings(changeId, { current, base: undefined, incoming: incomingAdded })).toEqual(addedMerged)
+    })
+    it('should merge modified value with different line terminator', () => {
+      expect(mergeStrings(changeId, { current, base, incoming: incomingMergeableWithDifferentLineTerminator })).toEqual(
+        modifiedMergedWithMixedLineTerminators,
+      )
+    })
+    it('should merge added value with different line terminator', () => {
+      expect(
+        mergeStrings(changeId, { current, base: undefined, incoming: incomingAddedWithDifferentLineTerminator }),
+      ).toEqual(addedMergedWithMixedLineTerminators)
     })
     it('should not merge unmergeable modified value', () => {
       expect(mergeStrings(changeId, { current, base, incoming: incomingUnmergeable })).toBeUndefined()


### PR DESCRIPTION
We should be able to auto merge strings when there are different line separators between the base/current/incoming versions. The easiest solution would be to take the line separator of the `current` version (if there are mixed line separators in current - take the most common one*) and use it in the merged version**.

*we’ll lose the other used separators in current, but I guess that it’s fine.

**only in conflicts auto-merge - other fetched files will be kept as fetched even they have mixed line separators.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Core:
- Ignore conflicts caused by different line separators

---
_User Notifications_: 
None