### PR TITLE
Improve FileCabinet files query by excluding excluded file extensions

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -123,6 +123,7 @@ import {
   ALL_TYPES_REGEX,
   DEFAULT_WARN_STALE_DATA,
   DEFAULT_DEPLOY_REFERENCED_ELEMENTS,
+  EXTENSION_REGEX,
 } from './config/constants'
 import {
   FetchByQueryFunc,
@@ -379,6 +380,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       const result = await this.client.importFileCabinetContent(
         updatedFetchQuery,
         this.userConfig.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
+        this.userConfig.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
       )
       progressReporter.reportProgress({ message: 'Fetching instances' })
       return result

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -237,9 +237,10 @@ export default class NetsuiteClient {
   async importFileCabinetContent(
     query: NetsuiteQuery,
     maxFileCabinetSizeInGB: number,
+    extensionsToExclude: string[],
   ): Promise<ImportFileCabinetResult> {
     if (this.suiteAppFileCabinet !== undefined) {
-      return this.suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB)
+      return this.suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB, extensionsToExclude)
     }
 
     return this.sdfClient.importFileCabinetContent(query, maxFileCabinetSizeInGB)

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -43,7 +43,6 @@ import SuiteAppClient from './suiteapp_client'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from './types'
 import { ImportFileCabinetResult } from '../types'
 import { FILE_CABINET_PATH_SEPARATOR, INTERNAL_ID, PARENT, PATH } from '../../constants'
-import { DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB } from '../../config/constants'
 import { NetsuiteQuery } from '../../config/query'
 import { isFileCabinetType, isFileInstance } from '../../types'
 import { filterFilePathsInFolders, filterFolderPathsInFolders, largeFoldersToExclude } from '../file_cabinet_utils'
@@ -165,7 +164,11 @@ export const THROW_ON_MISSING_FEATURE_ERROR: Record<string, string> = {
 }
 
 export type SuiteAppFileCabinetOperations = {
-  importFileCabinet: (query: NetsuiteQuery, maxFileCabinetSizeInGB: number) => Promise<ImportFileCabinetResult>
+  importFileCabinet: (
+    query: NetsuiteQuery,
+    maxFileCabinetSizeInGB: number,
+    extensionsToExclude: string[],
+  ) => Promise<ImportFileCabinetResult>
   deploy: (changes: ReadonlyArray<Change<InstanceElement>>, type: DeployType) => Promise<FileCabinetDeployResult>
 }
 
@@ -281,11 +284,17 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
     return (await queryFolders(whereQuery, isSuiteBundlesEnabled)).folderResults
   }
 
-  const queryFiles = (folderIdsToQuery: string[], isSuiteBundlesEnabled: boolean): Promise<FileResult[]> =>
+  const queryFiles = (
+    folderIdsToQuery: string[],
+    isSuiteBundlesEnabled: boolean,
+    extensionsToExclude: string[],
+  ): Promise<FileResult[]> =>
     retryOnRetryableError(async () => {
+      const whereNotHideInBundle = isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''
+      const whereNotExtension = extensionsToExclude.map(reg => `NOT REGEXP_LIKE(name, '${reg}') AND `).join('')
       const whereQueries = _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(
         foldersToQueryChunk =>
-          `${isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''}folder IN (${foldersToQueryChunk.join(', ')})`,
+          `${whereNotExtension}${whereNotHideInBundle}folder IN (${foldersToQueryChunk.join(', ')})`,
       )
       const results = await Promise.all(
         whereQueries.map(async whereQuery => {
@@ -359,7 +368,7 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
   const fullPath = (fileParts: string[]): string =>
     `${FILE_CABINET_PATH_SEPARATOR}${fileParts.join(FILE_CABINET_PATH_SEPARATOR)}`
 
-  const queryFileCabinet = async (query: NetsuiteQuery): Promise<FileCabinetResults> => {
+  const queryFileCabinet = async (query: NetsuiteQuery, extensionsToExclude: string[]): Promise<FileCabinetResults> => {
     if (fileCabinetResults === undefined) {
       const { folderResults, isSuiteBundlesEnabled } = await queryTopLevelFolders()
       const topLevelFoldersResults = folderResults.filter(folder => query.isParentFolderMatch(`/${folder.name}`))
@@ -394,6 +403,7 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
           ? await queryFiles(
               filteredFolderResults.map(folder => folder.id),
               isSuiteBundlesEnabled,
+              extensionsToExclude,
             )
           : []
       const filteredFilesResults = removeFilesWithoutParentFolder(filesResults, filteredFolderResults)
@@ -406,13 +416,14 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
 
   const importFileCabinet = async (
     query: NetsuiteQuery,
-    maxFileCabinetSizeInGB: number = DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
+    maxFileCabinetSizeInGB: number,
+    extensionsToExclude: string[],
   ): Promise<ImportFileCabinetResult> => {
     if (!query.areSomeFilesMatch()) {
       return { elements: [], failedPaths: { lockedError: [], otherError: [], largeFolderError: [] } }
     }
 
-    const { foldersResults, filesResults } = await queryFileCabinet(query)
+    const { foldersResults, filesResults } = await queryFileCabinet(query, extensionsToExclude)
     const unfilteredFoldersCustomizationInfo = foldersResults.map(folder => ({
       path: folder.path,
       typeName: 'folder',

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -36,6 +36,7 @@ import {
   DATA_FILE_TYPES,
   DEFAULT_MAX_INSTANCES_PER_TYPE,
   DEFAULT_MAX_INSTANCES_VALUE,
+  EXTENSION_REGEX,
   FILE_CABINET,
   GROUPS_TO_DATA_FILE_TYPES,
   INCLUDE_ALL,
@@ -143,7 +144,7 @@ const excludeDataFileTypes = (config: NetsuiteConfig): string[] => {
   if (dataFileTypesToExclude.length === 0) {
     return []
   }
-  const dataFileTypesToExcludeRegex = `.*\\.(${dataFileTypesToExclude.join('|')})`
+  const dataFileTypesToExcludeRegex = `${EXTENSION_REGEX}(${dataFileTypesToExclude.join('|')})`
   return [dataFileTypesToExcludeRegex.toLowerCase(), dataFileTypesToExcludeRegex.toUpperCase()]
 }
 

--- a/packages/netsuite-adapter/src/config/constants.ts
+++ b/packages/netsuite-adapter/src/config/constants.ts
@@ -37,7 +37,8 @@ export const INCLUDE_ALL = 'All'
 export const FILE_CABINET = 'FileCabinet'
 export const ALL_TYPES_REGEX = '.*'
 
-export const FILE_TYPES_TO_EXCLUDE_REGEX = '.*\\.(csv|pdf|eml|png|gif|jpeg|xls|xlsx|doc|docx|ppt|pptx)'
+export const EXTENSION_REGEX = '.*\\.'
+export const FILE_TYPES_TO_EXCLUDE_REGEX = `${EXTENSION_REGEX}(csv|pdf|eml|png|gif|jpeg|xls|xlsx|doc|docx|ppt|pptx)`
 
 // Taken from https://github.com/salto-io/netsuite-suitecloud-sdk/blob/e009e0eefcd918635353d093be6a6c2222d223b8/packages/node-cli/src/validation/InteractiveAnswersValidator.js#L27
 export const SUITEAPP_ID_FORMAT_REGEX = /^[a-z0-9]+(\.[a-z0-9]+){2}$/

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -74,6 +74,7 @@ import {
 } from '../src/client/types'
 import * as changesDetector from '../src/changes_detector/changes_detector'
 import * as deletionCalculator from '../src/deletion_calculator'
+import SdfClient from '../src/client/sdf_client'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
 import * as suiteAppFileCabinet from '../src/client/suiteapp_client/suiteapp_file_cabinet'
@@ -157,7 +158,7 @@ describe('Adapter', () => {
           { name: SAVED_SEARCH },
           { name: TRANSACTION_FORM },
         ],
-        fileCabinet: ['^Some/File/Regex$'],
+        fileCabinet: ['^Some/File/Regex$', '.*\\.(csv|pdf|png)'],
         customRecords: [],
       },
     },
@@ -201,13 +202,13 @@ describe('Adapter', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
-    client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+    client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
       elements: [],
       instancesIds: [],
       failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
       failedToFetchAllAtOnce: false,
     })
-    client.importFileCabinetContent = mockFunction<NetsuiteClient['importFileCabinetContent']>().mockResolvedValue({
+    client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
       elements: [],
       failedPaths: { lockedError: [], otherError: [], largeFolderError: [] },
     })
@@ -247,11 +248,11 @@ describe('Adapter', () => {
         scriptId: 'custentity_my_script_id',
       }
 
-      client.importFileCabinetContent = mockFunction<NetsuiteClient['importFileCabinetContent']>().mockResolvedValue({
+      client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [folderCustomizationInfo, fileCustomizationInfo],
         failedPaths: { lockedError: [], otherError: [], largeFolderError: [] },
       })
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [customTypeInfo, featuresCustomTypeInfo],
         instancesIds: [],
         failedToFetchAllAtOnce: false,
@@ -441,7 +442,7 @@ describe('Adapter', () => {
     })
 
     it('should filter large file cabinet folders', async () => {
-      client.importFileCabinetContent = mockFunction<NetsuiteClient['importFileCabinetContent']>().mockResolvedValue({
+      client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [],
         failedPaths: { lockedError: [], otherError: [], largeFolderError: ['largeFolder'] },
       })
@@ -460,7 +461,7 @@ describe('Adapter', () => {
     })
 
     it('should filter types with too many instances from SDF', async () => {
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [],
         instancesIds: [],
         failedToFetchAllAtOnce: false,
@@ -503,7 +504,7 @@ describe('Adapter', () => {
         },
         scriptId: 'unknown',
       }
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [customTypeInfo],
         instancesIds: [],
         failedToFetchAllAtOnce: false,
@@ -545,7 +546,7 @@ describe('Adapter', () => {
     })
 
     it('should call getConfigFromConfigChanges with failed file paths', async () => {
-      client.importFileCabinetContent = mockFunction<NetsuiteClient['importFileCabinetContent']>().mockResolvedValue({
+      client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [],
         failedPaths: { lockedError: [], otherError: ['/path/to/file'], largeFolderError: [] },
       })
@@ -568,7 +569,7 @@ describe('Adapter', () => {
 
     it('should call getConfigFromConfigChanges with failedTypeToInstances', async () => {
       const failedTypeToInstances = { testType: ['scriptid1', 'scriptid1'] }
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [],
         instancesIds: [],
         failedToFetchAllAtOnce: false,
@@ -592,7 +593,7 @@ describe('Adapter', () => {
     })
 
     it('should call getConfigFromConfigChanges with false for fetchAllAtOnce', async () => {
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [],
         instancesIds: [],
         failedToFetchAllAtOnce: true,
@@ -627,7 +628,7 @@ describe('Adapter', () => {
           expect(collections.array.makeArray(instance.value.scriptid_list)).toEqual([])
         })
         it('should create scriptid list elements with a non-empty list', async () => {
-          client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+          client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
             elements: [],
             instancesIds: [
               {
@@ -665,7 +666,7 @@ describe('Adapter', () => {
             config,
             getElemIdFunc: mockGetElemIdFunc,
           })
-          client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+          client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
             elements: [],
             instancesIds: [
               {
@@ -693,7 +694,7 @@ describe('Adapter', () => {
       describe('partial fetch', () => {
         it('should create new scriptid list elements if they do not exist in the elementsSource', async () => {
           const withChangesDetection = true
-          client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+          client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
             elements: [],
             instancesIds: [
               {
@@ -732,7 +733,7 @@ describe('Adapter', () => {
             config,
             getElemIdFunc: mockGetElemIdFunc,
           })
-          client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+          client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
             elements: [],
             instancesIds: [
               {
@@ -782,7 +783,7 @@ describe('Adapter', () => {
         },
         getElemIdFunc: mockGetElemIdFunc,
       })
-      client.getCustomObjects = mockFunction<NetsuiteClient['getCustomObjects']>().mockResolvedValue({
+      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [],
         instancesIds: [
           { type: 'customrecordtype', instanceId: 'customrecord_locked1' },
@@ -1407,9 +1408,9 @@ describe('Adapter', () => {
       })
     })
 
-    it('should use suiteapp_file_cabinet importFileCabinet', async () => {
+    it('should use suiteAppFileCabinet importFileCabinet and pass it the right params', async () => {
       await adapter.fetch(mockFetchOpts)
-      expect(suiteAppImportFileCabinetMock).toHaveBeenCalled()
+      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(expect.anything(), 3, ['.*\\.(csv|pdf|png)'])
     })
 
     it('should not create serverTime elements when getSystemInformation returns undefined', async () => {

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -286,7 +286,7 @@ describe('suiteapp_file_cabinet', () => {
 
   describe('importFileCabinet', () => {
     const maxFileCabinetSizeInGB = 1
-    const extensionsToExclude = ['.*\\csv']
+    const extensionsToExclude = ['.*\\.csv']
     it('should return all the files', async () => {
       const suiteAppFileCabinet = createSuiteAppFileCabinetOperations(suiteAppClient)
       const { elements } = await suiteAppFileCabinet.importFileCabinet(
@@ -558,7 +558,7 @@ describe('suiteapp_file_cabinet', () => {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -613,7 +613,7 @@ describe('suiteapp_file_cabinet', () => {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -634,7 +634,7 @@ describe('suiteapp_file_cabinet', () => {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3, 4)",
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (5, 3, 4)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -702,7 +702,7 @@ describe('suiteapp_file_cabinet', () => {
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(4, {
         select: 'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url',
         from: 'file',
-        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND folder IN (5, 3, 4)",
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND folder IN (5, 3, 4)",
         orderBy: 'id',
       })
     })

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -286,9 +286,14 @@ describe('suiteapp_file_cabinet', () => {
 
   describe('importFileCabinet', () => {
     const maxFileCabinetSizeInGB = 1
+    const extensionsToExclude = ['.*\\csv']
     it('should return all the files', async () => {
       const suiteAppFileCabinet = createSuiteAppFileCabinetOperations(suiteAppClient)
-      const { elements } = await suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB)
+      const { elements } = await suiteAppFileCabinet.importFileCabinet(
+        query,
+        maxFileCabinetSizeInGB,
+        extensionsToExclude,
+      )
       expect(elements).toEqual(expectedResults)
     })
 
@@ -303,6 +308,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual(expectedResults)
       expect(mockSuiteAppClient.readLargeFile).toHaveBeenCalledWith(2)
@@ -341,6 +347,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual([
         ...expectedResults.filter(res => !('link' in res.values)),
@@ -375,6 +382,7 @@ describe('suiteapp_file_cabinet', () => {
       const { failedPaths } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(failedPaths).toEqual({
         lockedError: ['/folder5/folder4/file2'],
@@ -388,6 +396,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual([
         expectedResults[0],
@@ -399,7 +408,11 @@ describe('suiteapp_file_cabinet', () => {
     })
 
     it('should call suiteql with missing feature error param', async () => {
-      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
+      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+        query,
+        maxFileCabinetSizeInGB,
+        extensionsToExclude,
+      )
       expect(mockSuiteAppClient.runSuiteQL).toHaveBeenCalledWith(
         expect.objectContaining({ select: expect.stringContaining('id, name, bundleable') }),
         THROW_ON_MISSING_FEATURE_ERROR,
@@ -420,7 +433,7 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       const suiteAppFileCabinet = createSuiteAppFileCabinetOperations(suiteAppClient)
-      expect(await suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB)).toEqual({
+      expect(await suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB, extensionsToExclude)).toEqual({
         elements: [],
         failedPaths: { lockedError: [], largeFolderError: [], otherError: [] },
       })
@@ -432,6 +445,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual([])
       expect(suiteAppClient.runSuiteQL).not.toHaveBeenCalled()
@@ -450,7 +464,11 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       await expect(
-        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB),
+        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+          query,
+          maxFileCabinetSizeInGB,
+          extensionsToExclude,
+        ),
       ).rejects.toThrow()
     })
 
@@ -467,14 +485,22 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       await expect(
-        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB),
+        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+          query,
+          maxFileCabinetSizeInGB,
+          extensionsToExclude,
+        ),
       ).rejects.toThrow()
     })
 
     it('throw an error when readFiles failed', async () => {
       mockSuiteAppClient.readFiles.mockResolvedValue(undefined)
       await expect(
-        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB),
+        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+          query,
+          maxFileCabinetSizeInGB,
+          extensionsToExclude,
+        ),
       ).rejects.toThrow()
     })
 
@@ -491,7 +517,11 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       await expect(
-        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB),
+        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+          query,
+          maxFileCabinetSizeInGB,
+          extensionsToExclude,
+        ),
       ).rejects.toThrow()
     })
 
@@ -508,7 +538,11 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       await expect(
-        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB),
+        createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+          query,
+          maxFileCabinetSizeInGB,
+          extensionsToExclude,
+        ),
       ).rejects.toThrow()
     })
 
@@ -518,12 +552,13 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       const suiteQlQuery = {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "hideinbundle = 'F' AND folder IN (5, 3)",
+        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -536,6 +571,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements, failedPaths } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(mockLargeFoldersToExclude).toHaveBeenCalledWith(
         [
@@ -560,6 +596,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual([expectedResults[1], expectedResults[3]])
     })
@@ -570,12 +607,13 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       const suiteQlQuery = {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "hideinbundle = 'F' AND folder IN (5, 3)",
+        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -590,12 +628,13 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       const suiteQlQuery = {
         select:
           'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
         from: 'file',
-        where: "hideinbundle = 'F' AND folder IN (5, 3, 4)",
+        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND hideinbundle = 'F' AND folder IN (5, 3, 4)",
         orderBy: 'id',
       }
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, suiteQlQuery)
@@ -605,7 +644,11 @@ describe('suiteapp_file_cabinet', () => {
     it('should not query folder if no file in that folder is matched by the query', async () => {
       query.isParentFolderMatch.mockImplementationOnce(() => true).mockImplementation(() => false)
       query.isFileMatch.mockImplementation(path => path === '/folder6/file21')
-      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(query, maxFileCabinetSizeInGB)
+      await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
+        query,
+        maxFileCabinetSizeInGB,
+        extensionsToExclude,
+      )
       // no folder should match, queryFiles shouldn't be called
       expect(suiteAppClient.runSuiteQL).toHaveBeenCalledTimes(2)
     })
@@ -623,6 +666,7 @@ describe('suiteapp_file_cabinet', () => {
       const { elements } = await createSuiteAppFileCabinetOperations(suiteAppClient).importFileCabinet(
         query,
         maxFileCabinetSizeInGB,
+        extensionsToExclude,
       )
       expect(elements).toEqual(expectedResults)
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(
@@ -658,7 +702,7 @@ describe('suiteapp_file_cabinet', () => {
       expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(4, {
         select: 'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url',
         from: 'file',
-        where: 'folder IN (5, 3, 4)',
+        where: "NOT REGEXP_LIKE(name, '.*\\csv') AND folder IN (5, 3, 4)",
         orderBy: 'id',
       })
     })


### PR DESCRIPTION
It happens quite often that we're fetching a large amount of files, then we're excluding most of them because of their extensions. The query can be improved by adding it a regex of the excluded file extensions from the user's adapter config.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve FileCabinet files query by excluding excluded file extensions

---
_User Notifications_: 
None