### PR TITLE
SALTO-6095 - Salesforce: Handle Salesforce CPQ Billing Start Date fields

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -51,6 +51,7 @@ import taskOrEventFieldsModifications from './change_validators/task_or_event_fi
 import newFieldsAndObjectsFLS from './change_validators/new_fields_and_objects_fls'
 import metadataTypes from './change_validators/metadata_types'
 import elementApiVersionValidator from './change_validators/element_api_version'
+import cpqBillingStartDate from './change_validators/cpq_billing_start_date'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
@@ -110,6 +111,7 @@ export const changeValidators: Record<
   taskOrEventFieldsModifications: () => taskOrEventFieldsModifications,
   newFieldsAndObjectsFLS: (config) => newFieldsAndObjectsFLS(config),
   elementApiVersion: () => elementApiVersionValidator,
+  cpqBillingStartDate: () => cpqBillingStartDate,
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/cpq_billing_start_date.ts
+++ b/packages/salesforce-adapter/src/change_validators/cpq_billing_start_date.ts
@@ -1,0 +1,57 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ChangeError,
+  ChangeValidator,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  getChangeData,
+} from '@salto-io/adapter-api'
+import { apiNameSync, isInstanceOfTypeChangeSync } from '../filters/utils'
+
+const CPQ_BILLING_START_DATE_TIME = 'blng__StartDateTime__c'
+
+const TYPES_WITH_START_DATES = [
+  'blng__InvoiceScheduler__c',
+  'blng__BalanceSnapShotScheduler__c',
+  'blng__Usage__c',
+]
+
+const isStartDateInPast = (instance: InstanceElement): boolean =>
+  // Note: the field value contains a timezone (e.g. '2024-06-13T16:00:00.000+0000'), so the comparison should work
+  //       correctly even if we're running in a different timezone from the one we're deploying to.
+  instance.value[CPQ_BILLING_START_DATE_TIME] !== undefined &&
+  new Date(instance.value[CPQ_BILLING_START_DATE_TIME]) <= new Date()
+
+const createAdditionError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error',
+  message: `Unable to deploy records of type ${apiNameSync(instance.getTypeSync())} with a 'StartDateTime' in the past`,
+  detailedMessage:
+    "The value of the 'StartDateTime' field of this record is in the past. " +
+    "Salesforce does not allow deploying records with a 'StartDateTime' value in the past. " +
+    "To deploy this records, manually edit it so that the 'StartDateTime' value is later than the time you intend to deploy it.",
+})
+
+const changeValidator: ChangeValidator = async (changes) =>
+  changes
+    .filter(isInstanceOfTypeChangeSync(...TYPES_WITH_START_DATES))
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isStartDateInPast)
+    .map(createAdditionError)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -170,6 +170,7 @@ export type ChangeValidatorName =
   | 'taskOrEventFieldsModifications'
   | 'newFieldsAndObjectsFLS'
   | 'elementApiVersion'
+  | 'cpqBillingStartDate'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -907,6 +908,7 @@ const changeValidatorConfigType =
       taskOrEventFieldsModifications: { refType: BuiltinTypes.BOOLEAN },
       newFieldsAndObjectsFLS: { refType: BuiltinTypes.BOOLEAN },
       elementApiVersion: { refType: BuiltinTypes.BOOLEAN },
+      cpqBillingStartDate: { refType: BuiltinTypes.BOOLEAN },
     },
     annotations: {
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/cpq_billing_start_date.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/cpq_billing_start_date.test.ts
@@ -1,0 +1,91 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BuiltinTypes,
+  ChangeError,
+  InstanceElement,
+  toChange,
+} from '@salto-io/adapter-api'
+import { mockTypes } from '../mock_elements'
+import { createCustomObjectType } from '../utils'
+import changeValidator from '../../src/change_validators/cpq_billing_start_date'
+
+describe('CPQ billing StartDateTime', () => {
+  let result: ReadonlyArray<ChangeError>
+  const objectType = createCustomObjectType('blng__InvoiceScheduler__c', {
+    fields: {
+      blng__StartDateTime__c: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+  describe('When the change is to an instance of an irrelevant type', () => {
+    beforeEach(async () => {
+      const instance = new InstanceElement(
+        'SomeInstance',
+        mockTypes.Account,
+        {},
+      )
+      result = await changeValidator([toChange({ after: instance })])
+    })
+    it('should have no errors', () => {
+      expect(result).toBeEmpty()
+    })
+  })
+  describe('When the change is to a relevant type rather than an instance', () => {
+    beforeEach(async () => {
+      result = await changeValidator([toChange({ after: objectType.clone() })])
+    })
+    it('should have no errors', () => {
+      expect(result).toBeEmpty()
+    })
+  })
+  describe('When the date is in the future', () => {
+    beforeEach(async () => {
+      const futureDate = new Date()
+      futureDate.setDate(futureDate.getDate() + 1)
+      const instance = new InstanceElement('SomeInvoiceScheduler', objectType, {
+        blng__StartDateTime__c: futureDate.toString(),
+      })
+      result = await changeValidator([toChange({ after: instance })])
+    })
+    it('should have no errors', () => {
+      expect(result).toBeEmpty()
+    })
+  })
+  describe('When the date is in the past', () => {
+    beforeEach(async () => {
+      const instance = new InstanceElement('SomeInvoiceScheduler', objectType, {
+        blng__StartDateTime__c: '2024-06-13T16:00:00.000+0000',
+      })
+      result = await changeValidator([toChange({ after: instance })])
+    })
+    it('should have an error', () => {
+      expect(result).toHaveLength(1)
+      expect(result[0]).toSatisfy(
+        (error) =>
+          error.elemID.isEqual(
+            objectType.elemID.createNestedID(
+              'instance',
+              'SomeInvoiceScheduler',
+            ),
+          ) &&
+          error.severity === 'Error' &&
+          error.message.includes('blng__InvoiceScheduler__c'),
+      )
+    })
+  })
+})


### PR DESCRIPTION
See ticket for details

---

<img width="1507" alt="image" src="https://github.com/salto-io/salto/assets/117099820/e2e45ae9-02c4-4a91-bf78-be4b83100898">


---
_Release Notes_: 
Salesforce: Will now show an error when attempting to deploy CPQ Billing records with StartDateTime in the past

---
_User Notifications_: 
N/A
