### PR TITLE
SALTO-6121: Fix default config nacl upon creation

### DIFF
--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -47,6 +47,7 @@ type ConfigTypeCreatorParams<TCustomNameMappingOptions extends string = never> =
   additionalClientFields?: Record<string, FieldDefinition>
   changeValidatorNames?: string[]
   omitElemID?: boolean
+  pathsToOmitFromDefaultConfig?: string[]
 }
 
 export type ConfigTypeCreator<TCustomNameMappingOptions extends string = never> = (
@@ -63,7 +64,8 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
   additionRateLimitFields,
   additionalClientFields,
   omitElemID,
-}: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType =>
+  pathsToOmitFromDefaultConfig = [],
+}: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType => (
   createMatchingObjectType<Partial<UserConfig<TCustomNameMappingOptions>>>({
     elemID: new ElemID(adapterName),
     fields: {
@@ -91,10 +93,16 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
       ...additionalFields,
     },
     annotations: {
-      [CORE_ANNOTATIONS.DEFAULT]: defaultConfig,
+      [CORE_ANNOTATIONS.DEFAULT]: _.omit(
+        defaultConfig,
+        'fetch.hideTypes',
+        'client',
+        ...pathsToOmitFromDefaultConfig
+      ),
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
-  })
+  }
+))
 
 export const mergeWithDefaultConfig = (defaultConfig: Values, config?: Values): Values =>
   _.mergeWith(_.cloneDeep(defaultConfig), config ?? {}, (_firstVal, secondValue) =>

--- a/packages/adapter-components/src/definitions/user/user_config.ts
+++ b/packages/adapter-components/src/definitions/user/user_config.ts
@@ -65,7 +65,7 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
   additionalClientFields,
   omitElemID,
   pathsToOmitFromDefaultConfig = [],
-}: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType => (
+}: ConfigTypeCreatorParams<TCustomNameMappingOptions>): ObjectType =>
   createMatchingObjectType<Partial<UserConfig<TCustomNameMappingOptions>>>({
     elemID: new ElemID(adapterName),
     fields: {
@@ -93,16 +93,10 @@ export const createUserConfigType = <TCustomNameMappingOptions extends string = 
       ...additionalFields,
     },
     annotations: {
-      [CORE_ANNOTATIONS.DEFAULT]: _.omit(
-        defaultConfig,
-        'fetch.hideTypes',
-        'client',
-        ...pathsToOmitFromDefaultConfig
-      ),
+      [CORE_ANNOTATIONS.DEFAULT]: _.omit(defaultConfig, 'fetch.hideTypes', 'client', ...pathsToOmitFromDefaultConfig),
       [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
     },
-  }
-))
+  })
 
 export const mergeWithDefaultConfig = (defaultConfig: Values, config?: Values): Values =>
   _.mergeWith(_.cloneDeep(defaultConfig), config ?? {}, (_firstVal, secondValue) =>

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -122,4 +122,5 @@ export const configType = definitions.createUserConfigType({
     usePrivateAPI: { refType: BuiltinTypes.BOOLEAN },
   },
   omitElemID: false,
+  pathsToOmitFromDefaultConfig: ['fetch.enableMissingReferences', 'fetch.getUsersStrategy'],
 })


### PR DESCRIPTION
Fix the current behavior that adapter config nacl contains all default config properties and align with old infra

---

_Additional context for reviewer_
we used to exclude by default the `client` config and the `hideTypes` property
This will omit those in all adapters created using the new infra

---
_Release Notes_: 
None

---
_User Notifications_: 
None
