### PR TITLE
SALTO-5520: Fixed a bug in issue layouts

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -136,7 +136,8 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
               .map(
                 (issueTypeMapping: issueTypeMappingStruct) =>
                   screensSchemesToDefaultOrViewScreens[issueTypeMapping.screenSchemeId],
-              ),
+              )
+              .filter(isDefined),
           ),
         ],
       ]),

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -366,9 +366,7 @@ describe('issue layout filter', () => {
         projectInstance1.value.issueTypeScheme = { issueTypeScheme: { id: 10 } }
         const res = getLayoutRequestsAsync(client, config, fetchQuery, elements)
         expect(Object.entries(res)).toHaveLength(1)
-        expect(res['11111']).toEqual({
-          undefined: Promise.resolve({ data: {} }),
-        })
+        expect(res['11111']).toEqual({})
       })
       it('should return the view screen and not the default screen if there is', async () => {
         issueTypeScreenSchemeInstance1.value.issueTypeMappings = [{ issueTypeId: 100, screenSchemeId: 333 }]


### PR DESCRIPTION
There was a bug in the code and in the tests that blocked Node 18 upgrade

---

For some legacy reasons, the test did not properly check a promise. The result was a transient test that failed depending on whether the promise was fulfilled or not.
The bug in the code caused us to send a wrong call in case there are no screens in a relevant screen scheme

---
_Release Notes_: 
Jira Adapter:
* A small fix in the issue layouts for Node 18

---
_User Notifications_: 
None
