### PR TITLE
SALTO-6114: Upgrade SDF version to 1.9.0-salto-2 that is based on 2024.1 API version

### DIFF
--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -38,7 +38,7 @@
     "@salto-io/file": "0.3.58",
     "@salto-io/logging": "0.3.58",
     "@salto-io/lowerdash": "0.3.58",
-    "@salto-io/suitecloud-cli": "1.8.0-salto-2",
+    "@salto-io/suitecloud-cli": "1.9.0-salto-2",
     "ajv": "^7.1.1",
     "async-lock": "^1.2.4",
     "axios": "^0.26.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3114,17 +3114,17 @@
     lodash "^4.17.21"
     moo "^0.5.2"
 
-"@salto-io/suitecloud-cli@1.8.0-salto-2":
-  version "1.8.0-salto-2"
-  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.8.0-salto-2.tgz#faba9351b15b9caf13937fd39160d4c5c9b1945c"
-  integrity sha512-yXkmRJQLWlQUBXuW+GX7PtS0qE3BTGi9XaPvFAAe+yXamlK4I/AiywEpJ8ClLErta454wxRvLFlxJYmOy+YB+w==
+"@salto-io/suitecloud-cli@1.9.0-salto-2":
+  version "1.9.0-salto-2"
+  resolved "https://registry.yarnpkg.com/@salto-io/suitecloud-cli/-/suitecloud-cli-1.9.0-salto-2.tgz#f2f85f7148871647dbf1ddbbb68440f0183bf9da"
+  integrity sha512-4MVOfJLXkKOb7mDQ/fEJM6tTnwE63eb8+TPFvgqik2n0JVI5q53fCw1+i0+SYTRsKYP1oMmixgagsMyd12WPmg==
   dependencies:
     "@salto-io/logging" "<0.4.0"
     chalk "4.1.2"
     cli-spinner "0.2.10"
     commander "10.0.0"
-    inquirer "8.2.5"
-    xml2js "0.6.0"
+    inquirer "8.2.6"
+    xml2js "0.6.2"
 
 "@sideway/address@^4.1.3":
   version "4.1.3"
@@ -7986,10 +7986,10 @@ init-package-json@^3.0.2:
     validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^4.0.0"
 
-inquirer@8.2.5, inquirer@^8.2.4:
-  version "8.2.5"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
-  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+inquirer@8.2.6:
+  version "8.2.6"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.6.tgz#733b74888195d8d400a67ac332011b5fae5ea562"
+  integrity sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==
   dependencies:
     ansi-escapes "^4.2.1"
     chalk "^4.1.1"
@@ -8005,7 +8005,7 @@ inquirer@8.2.5, inquirer@^8.2.4:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
-    wrap-ansi "^7.0.0"
+    wrap-ansi "^6.0.1"
 
 inquirer@^7.3.1:
   version "7.3.3"
@@ -8025,6 +8025,27 @@ inquirer@^7.3.1:
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
+
+inquirer@^8.2.4:
+  version "8.2.5"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.5.tgz#d8654a7542c35a9b9e069d27e2df4858784d54f8"
+  integrity sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+    wrap-ansi "^7.0.0"
 
 internal-slot@^1.0.2:
   version "1.0.2"
@@ -13462,6 +13483,15 @@ wrap-ansi@^5.1.0:
     string-width "^3.0.0"
     strip-ansi "^5.0.0"
 
+wrap-ansi@^6.0.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
+  integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
 wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
@@ -13574,10 +13604,10 @@ xml-name-validator@^3.0.0:
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
 
-xml2js@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.0.tgz#07afc447a97d2bd6507a1f76eeadddb09f7a8282"
-  integrity sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==
+xml2js@0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/xml2js/-/xml2js-0.6.2.tgz#dd0b630083aa09c161e25a4d0901e2b2a929b499"
+  integrity sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~11.0.0"


### PR DESCRIPTION
After the CI failure in https://github.com/salto-io/salto/pull/6076/files due to:
```
error commander@11.1.0: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.18.0"
```
we are using a lower `commander` version in SDF (https://github.com/salto-io/netsuite-suitecloud-sdk/commit/d175d5c4fdd91ae3c23f7ff00efcdc3de53889f1)

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter: SALTO-5234: Upgrade SDF version to 1.9.0-salto-2 so it'll be based on 2024.1 API version

---
_User Notifications_: 
Netsuite Adapter: For existing Salto Workspaces, you should reinstall the NetSuite account by creating a temporary Salto Workspace and calling salto service add netsuite --no-login.
This will download the new SDF version that will be used globally for all WSs. The temporary Salto Workspace can be deleted.
In addition, for existing Salto Workspaces, you should delete the `~/.suitecloud-sdk/credentials` file.