### PR TITLE
SALTO-6132 explicitly define serviceIds and elemId parts to empty array when not needed

### DIFF
--- a/packages/confluence-adapter/e2e_test/adapter.test.ts
+++ b/packages/confluence-adapter/e2e_test/adapter.test.ts
@@ -130,9 +130,9 @@ describe('Confluence adapter E2E', () => {
         .filter(isInstanceChange)
 
       const removalChanges = appliedChanges.map(change => toChange({ before: getChangeData(change) }))
-      // Making sure space removal is the last one, 
+      // Making sure space removal is the last one,
       // O.W page and template will be deleted in the service when we delete their father space
-      const sortedRemovalChanges = [ 
+      const sortedRemovalChanges = [
         ...removalChanges.filter(change => getChangeData(change).elemID.typeName !== SPACE_TYPE_NAME),
         ...removalChanges.filter(change => getChangeData(change).elemID.typeName === SPACE_TYPE_NAME),
       ]

--- a/packages/confluence-adapter/e2e_test/adapter.test.ts
+++ b/packages/confluence-adapter/e2e_test/adapter.test.ts
@@ -130,8 +130,13 @@ describe('Confluence adapter E2E', () => {
         .filter(isInstanceChange)
 
       const removalChanges = appliedChanges.map(change => toChange({ before: getChangeData(change) }))
-
-      await e2eUtils.deployChangesForE2e(adapterAttr, removalChanges)
+      // Making sure space removal is the last one, 
+      // O.W page and template will be deleted in the service when we delete their father space
+      const sortedRemovalChanges = [ 
+        ...removalChanges.filter(change => getChangeData(change).elemID.typeName !== SPACE_TYPE_NAME),
+        ...removalChanges.filter(change => getChangeData(change).elemID.typeName === SPACE_TYPE_NAME),
+      ]
+      await e2eUtils.deployChangesForE2e(adapterAttr, sortedRemovalChanges)
       if (credLease.return) {
         await credLease.return()
       }

--- a/packages/confluence-adapter/e2e_test/mock_elements.ts
+++ b/packages/confluence-adapter/e2e_test/mock_elements.ts
@@ -16,6 +16,7 @@
 import { Values } from '@salto-io/adapter-api'
 import { e2eUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { DEFAULT_RESTRICTION } from '../src/definitions/utils'
 import { SPACE_TYPE_NAME, PAGE_TYPE_NAME, TEMPLATE_TYPE_NAME } from '../src/constants'
 
 export const uniqueFieldsPerType: Record<string, string[]> = {
@@ -38,11 +39,7 @@ const mockDefaultValues: Record<string, Values> = {
   [PAGE_TYPE_NAME]: {
     status: 'current',
     parentType: 'page',
-    restriction: [
-      {
-        operation: 'update',
-      },
-    ],
+    restriction: DEFAULT_RESTRICTION,
   },
   [TEMPLATE_TYPE_NAME]: {
     description: 'some description',

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -216,11 +216,16 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         isTopLevel: true,
         elemID: {
           extendsParent: true,
+          parts: [],
         },
         alias: {
           aliasComponents: [{ fieldName: '_parent.0', referenceFieldName: '_alias' }],
         },
       },
+    },
+    resource: {
+      directFetch: false,
+      serviceIDFields: [],
     },
   },
   [PAGE_TYPE_NAME]: {
@@ -285,6 +290,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     ],
     resource: {
       directFetch: true,
+      serviceIDFields: [],
     },
     element: {
       topLevel: {
@@ -339,6 +345,10 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
       },
     ],
+    resource: {
+      directFetch: false,
+      serviceIDFields: [],
+    },
   },
   [TEMPLATE_TYPE_NAME]: {
     requests: [

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -342,7 +342,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
           path: '/wiki/rest/api/content/{id}/restriction',
           queryArgs: {
             expand: 'restrictions.user,restrictions.group',
-          }
+          },
         },
         transformation: {
           root: 'results',

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -340,6 +340,9 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       {
         endpoint: {
           path: '/wiki/rest/api/content/{id}/restriction',
+          queryArgs: {
+            expand: 'restrictions.user,restrictions.group',
+          }
         },
         transformation: {
           root: 'results',

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -334,6 +334,8 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     },
   },
   [RESTRICTION_TYPE_NAME]: {
+    // make topLevel undefined after merging with default definitions
+    element: {},
     requests: [
       {
         endpoint: {

--- a/packages/confluence-adapter/src/definitions/utils/restriction.ts
+++ b/packages/confluence-adapter/src/definitions/utils/restriction.ts
@@ -19,6 +19,9 @@ import { getChangeData, isEqualValues, isModificationChange } from '@salto-io/ad
 
 export const DEFAULT_RESTRICTION = [
   {
+    operation: 'read',
+  },
+  {
     operation: 'update',
   },
 ]


### PR DESCRIPTION
None

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None