### PR TITLE
SALTO-5472 query referenced ASV only

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -92,7 +92,6 @@ import { parsedDatasetType } from '../src/type_parsers/analytics_parsers/parsed_
 import { parsedWorkbookType } from '../src/type_parsers/analytics_parsers/parsed_workbook'
 import { bundleType as bundle } from '../src/types/bundle_type'
 import { addApplicationIdToType } from '../src/transformer'
-import { UNKNOWN_TYPE_REFERENCES_ELEM_ID } from '../src/filters/data_account_specific_values'
 
 const log = logger(module)
 const { awu } = collections.asynciterable

--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -687,6 +687,16 @@ describe('Netsuite adapter E2E with real account', () => {
           .filter(element => element.annotations[CORE_ANNOTATIONS.ALIAS] === undefined)
           // some sub-instances don't have alias
           .filter(element => getElementValueOrAnnotations(element)[IS_SUB_INSTANCE] !== true)
+          .filter(element => {
+            if (!isInstanceElement(element)) {
+              return true
+            }
+            const type = element.getTypeSync()
+            if (!isCustomRecordType(type)) {
+              return true
+            }
+            return type.annotations[CORE_ANNOTATIONS.HIDDEN] !== true
+          })
 
         expect(elementsWithoutAlias.every(elem => elem.annotations[CORE_ANNOTATIONS.HIDDEN])).toBeTruthy()
       })
@@ -983,8 +993,6 @@ describe('Netsuite adapter E2E with real account', () => {
           .concat(filesToImport)
           .concat(existingFileCabinetInstances)
           .concat(newFileCabinetInstancesElemIds)
-          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID })
-          .concat({ elemID: UNKNOWN_TYPE_REFERENCES_ELEM_ID.createNestedID('instance', ElemID.CONFIG_NAME) })
 
         const expectedElements = _.uniq(allTypes.map(type => type.elemID.getFullName())).sort()
 

--- a/packages/netsuite-adapter/src/account_specific_values_resolver.ts
+++ b/packages/netsuite-adapter/src/account_specific_values_resolver.ts
@@ -32,7 +32,6 @@ import {
 import NetsuiteClient from './client/client'
 import { WORKFLOW } from './constants'
 import { isDataObjectType } from './types'
-import { getUnknownTypeReferencesMap } from './filters/data_account_specific_values'
 import { getResolvedAccountSpecificValues as getWorkflowResolvedAccountSpecificValues } from './filters/workflow_account_specific_values'
 import { getResolvingErrors as getDataInstanceResolvingErrors } from './change_validators/data_account_specific_values'
 
@@ -74,8 +73,6 @@ export const getUpdatedSuiteQLNameToInternalIdsMap = async (
 
   const suiteQLNameToInternalIdsMap = toSuiteQLNameToInternalIdsMap(suiteQLTablesMap)
 
-  const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
-
   const missingInternalIdsFromWorkflows = workflowInstances.flatMap(
     instance => getWorkflowResolvedAccountSpecificValues(instance, suiteQLNameToInternalIdsMap).missingInternalIds,
   )
@@ -83,7 +80,6 @@ export const getUpdatedSuiteQLNameToInternalIdsMap = async (
     instance =>
       getDataInstanceResolvingErrors({
         instance,
-        unknownTypeReferencesMap,
         suiteQLNameToInternalIdsMap,
       }).missingInternalIds,
   )

--- a/packages/netsuite-adapter/src/account_specific_values_resolver.ts
+++ b/packages/netsuite-adapter/src/account_specific_values_resolver.ts
@@ -1,0 +1,104 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import {
+  Change,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  ReadOnlyElementsSource,
+} from '@salto-io/adapter-api'
+import {
+  getSuiteQLTableInternalIdsMap,
+  SUITEQL_TABLE,
+  updateSuiteQLTableInstances,
+} from './data_elements/suiteql_table_elements'
+import NetsuiteClient from './client/client'
+import { WORKFLOW } from './constants'
+import { isDataObjectType } from './types'
+import { getUnknownTypeReferencesMap } from './filters/data_account_specific_values'
+import { getResolvedAccountSpecificValues as getWorkflowResolvedAccountSpecificValues } from './filters/workflow_account_specific_values'
+import { getResolvingErrors as getDataInstanceResolvingErrors } from './change_validators/data_account_specific_values'
+
+const { awu } = collections.asynciterable
+
+const toSuiteQLNameToInternalIdsMap = (
+  suiteQLTablesMap: Record<string, InstanceElement>,
+): Record<string, Record<string, string[]>> =>
+  _(suiteQLTablesMap)
+    .mapValues(getSuiteQLTableInternalIdsMap)
+    .mapValues(internalIdsMap =>
+      _(internalIdsMap)
+        .entries()
+        .groupBy(([_key, value]) => value.name)
+        .mapValues(rows => rows.map(([key, _value]) => key))
+        .value(),
+    )
+    .value()
+
+export const getUpdatedSuiteQLNameToInternalIdsMap = async (
+  client: NetsuiteClient,
+  elementsSource: ReadOnlyElementsSource,
+  changes: ReadonlyArray<Change>,
+): Promise<Record<string, Record<string, string[]>>> => {
+  const instances = changes.filter(isAdditionOrModificationChange).map(getChangeData).filter(isInstanceElement)
+  const workflowInstances = instances.filter(instance => instance.elemID.typeName === WORKFLOW)
+  const dataInstances = instances.filter(instance => isDataObjectType(instance.getTypeSync()))
+
+  if (workflowInstances.length === 0 && dataInstances.length === 0) {
+    return {}
+  }
+
+  const suiteQLTablesMap = await awu(await elementsSource.list())
+    .filter(elemId => elemId.idType === 'instance' && elemId.typeName === SUITEQL_TABLE)
+    .map(elemId => elementsSource.get(elemId))
+    .filter(isInstanceElement)
+    .map(instance => instance.clone())
+    .keyBy(instance => instance.elemID.name)
+
+  const suiteQLNameToInternalIdsMap = toSuiteQLNameToInternalIdsMap(suiteQLTablesMap)
+
+  const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
+
+  const missingInternalIdsFromWorkflows = workflowInstances.flatMap(
+    instance => getWorkflowResolvedAccountSpecificValues(instance, suiteQLNameToInternalIdsMap).missingInternalIds,
+  )
+  const missingInternalIdsFromDataInstances = dataInstances.flatMap(
+    instance =>
+      getDataInstanceResolvingErrors({
+        instance,
+        unknownTypeReferencesMap,
+        suiteQLNameToInternalIdsMap,
+      }).missingInternalIds,
+  )
+
+  const missingInternalIds = missingInternalIdsFromDataInstances.concat(missingInternalIdsFromWorkflows)
+  if (missingInternalIds.length === 0) {
+    return suiteQLNameToInternalIdsMap
+  }
+
+  await updateSuiteQLTableInstances({
+    client,
+    queryBy: 'name',
+    itemsToQuery: missingInternalIds.map(({ tableName, name }) => ({ tableName, item: name })),
+    suiteQLTablesMap,
+  })
+
+  return toSuiteQLNameToInternalIdsMap(suiteQLTablesMap)
+}

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -330,7 +330,6 @@ export default class NetsuiteAdapter implements AdapterOperations {
               config,
               timeZoneAndFormat: params.timeZoneAndFormat,
               fetchTime: params.fetchTime,
-              suiteQLNameToInternalIdsMap: {},
             }
           case 'deploy':
             return {

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -348,9 +348,9 @@ export default class NetsuiteAdapter implements AdapterOperations {
       return filter.filtersRunner(getFilterOpts(), filtersCreators)
     }
 
-    this.fixElementsFunc = combineElementFixers({
-      ..._.mapValues(customReferenceHandlers, handler => handler.removeWeakReferences({ elementsSource })),
-    })
+    this.fixElementsFunc = combineElementFixers(
+      _.mapValues(customReferenceHandlers, handler => handler.removeWeakReferences({ elementsSource })),
+    )
   }
 
   public fetchByQuery: FetchByQueryFunc = async (

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -26,7 +26,7 @@ import { walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import { removeIdenticalValues } from '../filters/data_instances_diff'
 import { isDataObjectType } from '../types'
 import { ACCOUNT_SPECIFIC_VALUE, ID_FIELD, INTERNAL_ID } from '../constants'
-import { getSuiteQLNameToInternalIdsMap } from '../data_elements/suiteql_table_elements'
+import { MissingInternalId } from '../data_elements/suiteql_table_elements'
 import { getResolvedAccountSpecificValue, getUnknownTypeReferencesMap } from '../filters/data_account_specific_values'
 import { NetsuiteChangeValidator } from './types'
 import { cloneChange } from './utils'
@@ -48,30 +48,42 @@ const getPathsWithUnresolvedAccountSpecificValue = (instance: InstanceElement): 
   return fieldsWithUnresolvedAccountSpecificValue
 }
 
-const getResolvingErrors = ({
+export const getResolvingErrors = ({
   instance,
   unknownTypeReferencesMap,
-  suiteQLTablesMap,
+  suiteQLNameToInternalIdsMap,
 }: {
   instance: InstanceElement
   unknownTypeReferencesMap: Record<string, Record<string, string[]>>
-  suiteQLTablesMap: Record<string, Record<string, string[]>>
-}): ChangeError[] => {
+  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
+}): { changeErrors: ChangeError[]; missingInternalIds: MissingInternalId[] } => {
   const changeErrors: ChangeError[] = []
+  const missingInternalIds: MissingInternalId[] = []
   walkOnElement({
     element: instance,
     func: ({ path, value }) => {
-      const { error } = getResolvedAccountSpecificValue(path, value, unknownTypeReferencesMap, suiteQLTablesMap)
+      const { error, missingInternalId } = getResolvedAccountSpecificValue(
+        path,
+        value,
+        unknownTypeReferencesMap,
+        suiteQLNameToInternalIdsMap,
+      )
       if (error !== undefined) {
         changeErrors.push(error)
+      }
+      if (missingInternalId !== undefined) {
+        missingInternalIds.push(missingInternalId)
       }
       return WALK_NEXT_STEP.RECURSE
     },
   })
-  return changeErrors
+  return { changeErrors, missingInternalIds }
 }
 
-const changeValidator: NetsuiteChangeValidator = async (changes, { elementsSource, config }) => {
+const changeValidator: NetsuiteChangeValidator = async (
+  changes,
+  { elementsSource, config, suiteQLNameToInternalIdsMap },
+) => {
   const relevantChangedInstances = changes
     .filter(isAdditionOrModificationChange)
     .filter(isInstanceChange)
@@ -92,9 +104,8 @@ const changeValidator: NetsuiteChangeValidator = async (changes, { elementsSourc
 
   if (config.fetch.resolveAccountSpecificValues !== false) {
     const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
-    const suiteQLTablesMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
-    return relevantChangedInstances.flatMap(instance =>
-      getResolvingErrors({ instance, unknownTypeReferencesMap, suiteQLTablesMap }),
+    return relevantChangedInstances.flatMap(
+      instance => getResolvingErrors({ instance, unknownTypeReferencesMap, suiteQLNameToInternalIdsMap }).changeErrors,
     )
   }
 

--- a/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/data_account_specific_values.ts
@@ -50,11 +50,11 @@ const getPathsWithUnresolvedAccountSpecificValue = (instance: InstanceElement): 
 
 export const getResolvingErrors = ({
   instance,
-  unknownTypeReferencesMap,
+  unknownTypeReferencesMap = {},
   suiteQLNameToInternalIdsMap,
 }: {
   instance: InstanceElement
-  unknownTypeReferencesMap: Record<string, Record<string, string[]>>
+  unknownTypeReferencesMap?: Record<string, Record<string, string[]>>
   suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
 }): { changeErrors: ChangeError[]; missingInternalIds: MissingInternalId[] } => {
   const changeErrors: ChangeError[] = []

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -24,5 +24,6 @@ export type NetsuiteChangeValidator = (
     elementsSource: ReadOnlyElementsSource
     config: NetsuiteConfig
     client: NetsuiteClient
+    suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
   },
 ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/config/query.ts
+++ b/packages/netsuite-adapter/src/config/query.ts
@@ -53,7 +53,6 @@ export type FetchByQueryFailures = {
   failedFilePaths: FailedFiles
   failedTypes: FailedTypes
   failedCustomRecords: string[]
-  largeSuiteQLTables: string[]
 }
 
 export type FetchByQueryReturnType = {

--- a/packages/netsuite-adapter/src/config/suggestions.ts
+++ b/packages/netsuite-adapter/src/config/suggestions.ts
@@ -31,6 +31,11 @@ import {
 import { FetchByQueryFailures, convertToQueryParams, isCriteriaQuery } from './query'
 import { emptyQueryParams, fullFetchConfig } from './config_creator'
 
+const DEPRECATED_CONFIGS_TO_REMOVE = [
+  'fetch.skipResolvingAccountSpecificValuesToTypes',
+  'suiteAppClient.maxRecordsPerSuiteQLTable',
+]
+
 export const STOP_MANAGING_ITEMS_MSG =
   'Salto failed to fetch some items from NetSuite. Failed items must be excluded from the fetch.'
 
@@ -43,6 +48,9 @@ export const toLargeTypesExcludedMessage = (updatedLargeTypes: string[]): string
   " To include them, increase the types elements' size limitations and remove their exclusion rules."
 
 export const ALIGNED_INACTIVE_CRITERIAS = 'The exclusion criteria of inactive elements was modified.'
+
+export const toRemovedDeprecatedConfigsMessage = (paths: string[]): string =>
+  `The following configs are deprecated and will be removed from the adapter config: ${paths.join(', ')}.`
 
 const createFolderExclude = (folderPaths: NetsuiteFilePathsQueryParams): string[] =>
   folderPaths.map(folder => `^${_.escapeRegExp(folder)}.*`)
@@ -237,6 +245,12 @@ const splitConfig = (config: NetsuiteConfig): InstanceElement[] => {
   ]
 }
 
+const removeDeprecatedConfigs = (config: NetsuiteConfig): string[] => {
+  const definedDeprecatedConfigs = DEPRECATED_CONFIGS_TO_REMOVE.filter(path => _.get(config, path) !== undefined)
+  definedDeprecatedConfigs.forEach(path => _.unset(config, path))
+  return definedDeprecatedConfigs
+}
+
 export const getConfigFromConfigChanges = (
   failures: FetchByQueryFailures,
   currentConfig: NetsuiteConfig,
@@ -246,12 +260,14 @@ export const getConfigFromConfigChanges = (
   const updatedLargeFolders = updateConfigFromLargeFolders(config, failures.failedFilePaths)
   const updatedLargeTypes = updateConfigFromLargeTypes(config, failures)
   const alignedInactiveCriterias = alignInactiveExclusionCriterias(config)
+  const removedDeprecatedConfigs = removeDeprecatedConfigs(config)
 
   const messages = [
     didUpdateFromFailures ? STOP_MANAGING_ITEMS_MSG : undefined,
     updatedLargeFolders.length > 0 ? toLargeFoldersExcludedMessage(updatedLargeFolders) : undefined,
     updatedLargeTypes.length > 0 ? toLargeTypesExcludedMessage(updatedLargeTypes) : undefined,
     alignedInactiveCriterias ? ALIGNED_INACTIVE_CRITERIAS : undefined,
+    removedDeprecatedConfigs.length > 0 ? toRemovedDeprecatedConfigsMessage(removedDeprecatedConfigs) : undefined,
   ].filter(values.isDefined)
 
   return messages.length > 0

--- a/packages/netsuite-adapter/src/config/suggestions.ts
+++ b/packages/netsuite-adapter/src/config/suggestions.ts
@@ -42,11 +42,6 @@ export const toLargeTypesExcludedMessage = (updatedLargeTypes: string[]): string
   `The following types were excluded from the fetch as the elements of that type were too numerous: ${updatedLargeTypes.join(', ')}.` +
   " To include them, increase the types elements' size limitations and remove their exclusion rules."
 
-export const toLargeSuiteQLTablesExcludedMessage = (largeSuiteQLTables: string[]): string =>
-  `The following SuiteQL tables were excluded from the fetch as the records of that table were too numerous: ${largeSuiteQLTables.join(', ')}.` +
-  " Those tables are used to resolve ACCOUNT_SPECIFIC_VALUEs, and without them Salto won't be able to resolve ACCOUNT_SPECIFIC_VALUEs of those types." +
-  " To include them, increase the table records' size limitations and remove their exclusion rules."
-
 export const ALIGNED_INACTIVE_CRITERIAS = 'The exclusion criteria of inactive elements was modified.'
 
 const createFolderExclude = (folderPaths: NetsuiteFilePathsQueryParams): string[] =>
@@ -206,21 +201,6 @@ const updateConfigFromLargeTypes = (
   return []
 }
 
-const updateConfigFromLargeSuiteQLTables = (
-  config: NetsuiteConfig,
-  { largeSuiteQLTables }: FetchByQueryFailures,
-): string[] => {
-  if (largeSuiteQLTables.length > 0) {
-    config.fetch = {
-      ...config.fetch,
-      skipResolvingAccountSpecificValuesToTypes: (config.fetch.skipResolvingAccountSpecificValuesToTypes ?? []).concat(
-        largeSuiteQLTables,
-      ),
-    }
-  }
-  return largeSuiteQLTables
-}
-
 // TODO: remove at May 24.
 const alignInactiveExclusionCriterias = (config: NetsuiteConfig): boolean => {
   let isUpdated = false
@@ -265,14 +245,12 @@ export const getConfigFromConfigChanges = (
   const didUpdateFromFailures = updateConfigFromFailedFetch(config, failures)
   const updatedLargeFolders = updateConfigFromLargeFolders(config, failures.failedFilePaths)
   const updatedLargeTypes = updateConfigFromLargeTypes(config, failures)
-  const updatedLargeSuiteQLTables = updateConfigFromLargeSuiteQLTables(config, failures)
   const alignedInactiveCriterias = alignInactiveExclusionCriterias(config)
 
   const messages = [
     didUpdateFromFailures ? STOP_MANAGING_ITEMS_MSG : undefined,
     updatedLargeFolders.length > 0 ? toLargeFoldersExcludedMessage(updatedLargeFolders) : undefined,
     updatedLargeTypes.length > 0 ? toLargeTypesExcludedMessage(updatedLargeTypes) : undefined,
-    updatedLargeSuiteQLTables.length > 0 ? toLargeSuiteQLTablesExcludedMessage(updatedLargeSuiteQLTables) : undefined,
     alignedInactiveCriterias ? ALIGNED_INACTIVE_CRITERIAS : undefined,
   ].filter(values.isDefined)
 

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -116,7 +116,6 @@ export type FetchParams = {
   addImportantValues?: boolean
   addLockedCustomRecordTypes?: boolean
   resolveAccountSpecificValues?: boolean
-  skipResolvingAccountSpecificValuesToTypes?: string[]
 } & LockedElementsConfig['fetch']
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -131,7 +130,6 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   addImportantValues: 'addImportantValues',
   addLockedCustomRecordTypes: 'addLockedCustomRecordTypes',
   resolveAccountSpecificValues: 'resolveAccountSpecificValues',
-  skipResolvingAccountSpecificValuesToTypes: 'skipResolvingAccountSpecificValuesToTypes',
 }
 
 export type AdditionalSdfDeployDependencies = {
@@ -198,13 +196,11 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
   httpTimeoutLimitInMinutes?: number
-  maxRecordsPerSuiteQLTable?: MaxInstancesPerType[]
 }
 
 export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
   suiteAppConcurrencyLimit: 'suiteAppConcurrencyLimit',
   httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
-  maxRecordsPerSuiteQLTable: 'maxRecordsPerSuiteQLTable',
 }
 
 export type NetsuiteConfig = {
@@ -389,7 +385,6 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
         }),
       },
     },
-    maxRecordsPerSuiteQLTable: { refType: new ListType(maxInstancesPerConfigType) },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -578,7 +573,6 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     addImportantValues: { refType: BuiltinTypes.BOOLEAN },
     addLockedCustomRecordTypes: { refType: BuiltinTypes.BOOLEAN },
     resolveAccountSpecificValues: { refType: BuiltinTypes.BOOLEAN },
-    skipResolvingAccountSpecificValuesToTypes: { refType: new ListType(BuiltinTypes.STRING) },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -360,12 +360,7 @@ const validateAdditionalDependencies = ({
   }
 }
 
-const validateFetchConfig = ({
-  include,
-  exclude,
-  fieldsToOmit,
-  skipResolvingAccountSpecificValuesToTypes,
-}: Record<keyof FetchParams, unknown>): void => {
+const validateFetchConfig = ({ include, exclude, fieldsToOmit }: Record<keyof FetchParams, unknown>): void => {
   validateDefined(include, [CONFIG.fetch, FETCH_PARAMS.include])
   validatePlainObject(include, [CONFIG.fetch, FETCH_PARAMS.include])
   validateFetchParameters(include)
@@ -381,17 +376,6 @@ const validateFetchConfig = ({
 
   if (fieldsToOmit !== undefined) {
     validateFieldsToOmitConfig(fieldsToOmit)
-  }
-
-  if (skipResolvingAccountSpecificValuesToTypes !== undefined) {
-    validateArrayOfStrings(skipResolvingAccountSpecificValuesToTypes, [
-      CONFIG.fetch,
-      FETCH_PARAMS.skipResolvingAccountSpecificValuesToTypes,
-    ])
-    validateRegularExpressions(skipResolvingAccountSpecificValuesToTypes, [
-      CONFIG.fetch,
-      FETCH_PARAMS.skipResolvingAccountSpecificValuesToTypes,
-    ])
   }
 }
 
@@ -423,16 +407,12 @@ const validateDeployParams = ({
 const validateSuiteAppClientParams = ({
   suiteAppConcurrencyLimit,
   httpTimeoutLimitInMinutes,
-  maxRecordsPerSuiteQLTable,
 }: Record<keyof SuiteAppClientConfig, unknown>): void => {
   if (suiteAppConcurrencyLimit !== undefined) {
     validateNumber(suiteAppConcurrencyLimit, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.suiteAppConcurrencyLimit])
   }
   if (httpTimeoutLimitInMinutes !== undefined) {
     validateNumber(httpTimeoutLimitInMinutes, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.httpTimeoutLimitInMinutes])
-  }
-  if (maxRecordsPerSuiteQLTable !== undefined) {
-    validateMaxInstancesPerType(maxRecordsPerSuiteQLTable, { validateInvalidTypes: false })
   }
 }
 

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -16,7 +16,6 @@
 import _ from 'lodash'
 import Ajv from 'ajv'
 import { logger } from '@salto-io/logging'
-import { collections, regex, strings } from '@salto-io/lowerdash'
 import {
   CORE_ANNOTATIONS,
   ElemID,
@@ -29,30 +28,29 @@ import {
 } from '@salto-io/adapter-api'
 import NetsuiteClient from '../client/client'
 import { NetsuiteConfig } from '../config/types'
-import { ALLOCATION_TYPE, EMPLOYEE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../constants'
-import { getLastServerTime } from '../server_time'
-import { toSuiteQLWhereDateString } from '../changes_detector/date_formats'
+import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../constants'
 import { SuiteQLTableName } from './types'
 
 const log = logger(module)
-const { awu } = collections.asynciterable
 
 export const SUITEQL_TABLE = 'suiteql_table'
 export const INTERNAL_IDS_MAP = 'internalIdsMap'
 
-const VERSION_FIELD = 'version'
-const LATEST_VERSION = 1
-
 const ALLOCATION_TYPE_QUERY_LIMIT = 50
+const ITEMS_PER_QUERY_LIMIT = 200
 
-const MAX_ALLOWED_RECORDS = 100_000
+export type MissingInternalId = {
+  tableName: string
+  name: string
+}
 
 type InternalIdsMap = Record<string, { name: string }>
+
+type QueryBy = 'internalId' | 'name'
 
 type QueryParams = {
   internalIdField: 'id' | 'key'
   nameField: string
-  lastModifiedDateField?: 'lastmodifieddate'
 }
 
 type SavedSearchInternalIdsResult = {
@@ -131,175 +129,139 @@ export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undef
   item: {
     internalIdField: 'id',
     nameField: 'itemid',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   transaction: {
     internalIdField: 'id',
     nameField: 'trandisplayname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   account: {
     internalIdField: 'id',
     nameField: 'accountsearchdisplayname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   bom: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   customer: {
     internalIdField: 'id',
     nameField: 'companyname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   accountingPeriod: {
     internalIdField: 'id',
     nameField: 'periodname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   calendarEvent: {
     internalIdField: 'id',
     nameField: 'title',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   charge: {
     internalIdField: 'id',
     nameField: 'description',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   classification: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   contact: {
     internalIdField: 'id',
     nameField: 'entitytitle',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   currency: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   department: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   employee: {
     internalIdField: 'id',
     nameField: 'entityid',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   expenseCategory: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   generalToken: {
     internalIdField: 'id',
     nameField: 'externalid',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   inventoryNumber: {
     internalIdField: 'id',
     nameField: 'inventorynumber',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   job: {
     internalIdField: 'id',
     nameField: 'companyname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   location: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   manufacturingCostTemplate: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   partner: {
     internalIdField: 'id',
     nameField: 'companyname',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   paymentCard: {
     internalIdField: 'id',
     nameField: 'nameoncard',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   paymentCardToken: {
     internalIdField: 'id',
     nameField: 'externalid',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   paymentMethod: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   phoneCall: {
     internalIdField: 'id',
     nameField: 'title',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   priceLevel: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   pricingGroup: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   subsidiary: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   task: {
     internalIdField: 'id',
     nameField: 'title',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   term: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   timeBill: {
     internalIdField: 'id',
     nameField: 'displayfield',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   unitsType: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   usage: {
     internalIdField: 'id',
     nameField: 'externalid',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   vendor: {
     internalIdField: 'id',
     nameField: 'entitytitle',
-    lastModifiedDateField: 'lastmodifieddate',
   },
   vendorCategory: {
     internalIdField: 'id',
     nameField: 'name',
-    lastModifiedDateField: 'lastmodifieddate',
   },
-
-  // tables with no 'lastmodifieddate' field
   billingSchedule: {
     internalIdField: 'id',
     nameField: 'name',
@@ -471,217 +433,53 @@ export const getSuiteQLTableInternalIdsMap = (instance: InstanceElement): Intern
   return instance.value[INTERNAL_IDS_MAP]
 }
 
-export const getSuiteQLNameToInternalIdsMap = async (
-  elementsSource: ReadOnlyElementsSource,
-): Promise<Record<string, Record<string, string[]>>> => {
-  const suiteQLTableInstances = await awu(await elementsSource.list())
-    .filter(elemId => elemId.idType === 'instance' && elemId.typeName === SUITEQL_TABLE)
-    .map(elemId => elementsSource.get(elemId))
-    .filter(isInstanceElement)
-    .toArray()
+const getSavedSearchInternlIdsMap =
+  (searchType: string) =>
+  async (client: NetsuiteClient, queryBy: QueryBy, items: string[]): Promise<InternalIdsMap> => {
+    const result = await Promise.all(
+      _.chunk(items, ITEMS_PER_QUERY_LIMIT).map(itemsChunk =>
+        client.runSavedSearchQuery({
+          type: searchType,
+          columns: ['internalid', 'name'],
+          filters:
+            queryBy === 'internalId'
+              ? [['internalid', 'anyof', ...itemsChunk]]
+              : itemsChunk
+                  .map(name => ['name', 'is', name])
+                  .reduce(
+                    (filter, curr, i) => (i < itemsChunk.length - 1 ? [...filter, curr, 'OR'] : [...filter, curr]),
+                    [] as Array<string[] | string>,
+                  ),
+        }),
+      ),
+    ).then(results => results.flatMap(res => res ?? []))
+    const ajv = new Ajv({ allErrors: true, strict: false })
+    if (result.length === 0) {
+      log.warn('failed to search %s using saved search query', searchType)
+      return {}
+    }
+    if (!ajv.validate<SavedSearchInternalIdsResult[]>(SAVED_SEARCH_INTERNAL_IDS_RESULT_SCHEMA, result)) {
+      log.error('Got invalid results from %s saved search query: %s', searchType, ajv.errorsText())
+      return {}
+    }
+    return Object.fromEntries(result.map(res => [res.internalid[0].value, { name: res.name }]))
+  }
 
-  return _(suiteQLTableInstances)
-    .keyBy(instance => instance.elemID.name)
-    .mapValues(getSuiteQLTableInternalIdsMap)
-    .mapValues(internalIdsMap =>
-      _(internalIdsMap)
-        .entries()
-        .groupBy(([_key, value]) => value.name)
-        .mapValues(rows => rows.map(([key, _value]) => key))
-        .value(),
-    )
-    .value()
-}
-
-const getWhereParam = (
-  { lastModifiedDateField }: Pick<QueryParams, 'lastModifiedDateField'>,
-  lastFetchTime: Date | undefined,
-): string | undefined =>
-  lastModifiedDateField !== undefined && lastFetchTime !== undefined
-    ? `${lastModifiedDateField} >= ${toSuiteQLWhereDateString(lastFetchTime)}`
-    : undefined
-
-const shouldSkipQuery = async (
+const getAllocationTypeInternalIdsMap = async (
   client: NetsuiteClient,
-  tableName: string,
-  queryParams: QueryParams,
-  lastFetchTime: Date | undefined,
-  maxAllowedRecords: number,
-): Promise<{ skip: boolean; exclude?: boolean }> => {
-  const whereParam = getWhereParam(queryParams, lastFetchTime)
-  const query = {
-    select: 'count(*) as count',
-    from: tableName,
-    where: whereParam,
-  }
-  const results = await client.runSuiteQL(query)
-  if (results?.length !== 1) {
-    log.warn('query received unexpected number of results: %o', { query, numOfResults: results?.length })
-    return { skip: true }
-  }
-  const [result] = results
-  if (!_.isString(result.count) || !strings.isNumberStr(result.count)) {
-    log.warn('query received unexpected result (expected "count" to be a number string): %o', {
-      query,
-      result,
-    })
-    return { skip: true }
-  }
-  const count = Number(result.count)
-  if (count > maxAllowedRecords) {
-    log.warn(
-      `skipping query of ${tableName}${whereParam !== '' ? ` (WHERE ${whereParam})` : ''} because it has ${count} results (max allowed: ${maxAllowedRecords})`,
-    )
-    return { skip: true, exclude: true }
-  }
-  return { skip: false }
-}
-
-const getInternalIdsMap = async (
-  client: NetsuiteClient,
-  tableName: string,
-  { internalIdField, nameField, lastModifiedDateField }: QueryParams,
-  lastFetchTime: Date | undefined,
+  queryBy: QueryBy,
+  items: string[],
 ): Promise<InternalIdsMap> => {
-  const results = await client.runSuiteQL({
-    select: `${internalIdField}, ${nameField}`,
-    from: tableName,
-    where: getWhereParam({ lastModifiedDateField }, lastFetchTime),
-    orderBy: internalIdField,
-  })
-  if (results === undefined) {
-    log.warn('failed to query table %s', tableName)
-    return {}
-  }
-  const validResults = results.flatMap(res => {
-    const internalId = res[internalIdField]
-    const name = res[nameField]
-    if (typeof internalId === 'string' && internalId !== '' && typeof name === 'string' && name !== '') {
-      return { internalId, name }
-    }
-    log.warn('ignoring invalid result from table %s: %o', tableName, res)
-    return []
-  })
-  return Object.fromEntries(validResults.map(({ internalId, name }) => [internalId, { name }]))
-}
-
-const isUpdatedExistingInstance = (
-  existingInstance: InstanceElement | undefined,
-): existingInstance is InstanceElement => existingInstance?.value[VERSION_FIELD] === LATEST_VERSION
-
-const createOrGetExistingInstance = (
-  suiteQLTableType: ObjectType,
-  tableName: string,
-  existingInstance: InstanceElement | undefined,
-): InstanceElement =>
-  isUpdatedExistingInstance(existingInstance)
-    ? existingInstance
-    : new InstanceElement(tableName, suiteQLTableType, { [INTERNAL_IDS_MAP]: {} }, undefined, {
-        [CORE_ANNOTATIONS.HIDDEN]: true,
-      })
-
-const fixExistingInstance = (suiteQLTableType: ObjectType, existingInstance: InstanceElement | undefined): void => {
-  if (existingInstance !== undefined) {
-    existingInstance.refType = createRefToElmWithValue(suiteQLTableType)
-    if (existingInstance.value[INTERNAL_IDS_MAP] === undefined) {
-      existingInstance.value[INTERNAL_IDS_MAP] = {}
-    }
-  }
-}
-
-const getSuiteQLTableInstance = async (
-  client: NetsuiteClient,
-  suiteQLTableType: ObjectType,
-  tableName: string,
-  queryParams: QueryParams,
-  elementsSource: ReadOnlyElementsSource,
-  lastFetchTime: Date | undefined,
-  isPartial: boolean,
-  maxAllowedRecords: number,
-  largeSuiteQLTables: string[],
-): Promise<InstanceElement | undefined> => {
-  const instanceElemId = suiteQLTableType.elemID.createNestedID('instance', tableName)
-  const existingInstance = await elementsSource.get(instanceElemId)
-  fixExistingInstance(suiteQLTableType, existingInstance)
-
-  const lastFetchTimeForQuery = isUpdatedExistingInstance(existingInstance) ? lastFetchTime : undefined
-
-  // we always want to query employees, for _changed_by
-  if (tableName !== EMPLOYEE) {
-    if (isPartial) {
-      return existingInstance
-    }
-    const shouldSkip = await shouldSkipQuery(client, tableName, queryParams, lastFetchTimeForQuery, maxAllowedRecords)
-    if (shouldSkip.skip) {
-      if (shouldSkip.exclude) {
-        largeSuiteQLTables.push(tableName)
-      }
-      return undefined
-    }
-  }
-
-  const instance = createOrGetExistingInstance(suiteQLTableType, tableName, existingInstance)
-  Object.assign(
-    instance.value[INTERNAL_IDS_MAP],
-    await getInternalIdsMap(client, tableName, queryParams, lastFetchTimeForQuery),
-  )
-  instance.value[VERSION_FIELD] = LATEST_VERSION
-  return instance
-}
-
-const getSavedSearchQueryInstance = async (
-  client: NetsuiteClient,
-  suiteQLTableType: ObjectType,
-  searchType: string,
-  elementsSource: ReadOnlyElementsSource,
-  isPartial: boolean,
-): Promise<InstanceElement | undefined> => {
-  const instanceElemId = suiteQLTableType.elemID.createNestedID('instance', searchType)
-  const existingInstance = await elementsSource.get(instanceElemId)
-  fixExistingInstance(suiteQLTableType, existingInstance)
-  if (isPartial) {
-    return existingInstance
-  }
-  const instance = createOrGetExistingInstance(suiteQLTableType, searchType, existingInstance)
-  const result = await client.runSavedSearchQuery({
-    type: searchType,
-    columns: ['internalid', 'name'],
-    filters: [],
-  })
-  const ajv = new Ajv({ allErrors: true, strict: false })
-  if (result === undefined) {
-    log.warn('failed to search %s using saved search query', searchType)
-  } else if (!ajv.validate<SavedSearchInternalIdsResult[]>(SAVED_SEARCH_INTERNAL_IDS_RESULT_SCHEMA, result)) {
-    log.error('Got invalid results from %s saved search query: %s', searchType, ajv.errorsText())
-  } else {
-    instance.value[INTERNAL_IDS_MAP] = Object.fromEntries(
-      result.map(res => [res.internalid[0].value, { name: res.name }]),
-    )
-  }
-  instance.value[VERSION_FIELD] = LATEST_VERSION
-  return instance
-}
-
-const getAllocationTypeInstance = async (
-  client: NetsuiteClient,
-  suiteQLTableType: ObjectType,
-  elementsSource: ReadOnlyElementsSource,
-  isPartial: boolean,
-): Promise<InstanceElement | undefined> => {
-  const instanceElemId = suiteQLTableType.elemID.createNestedID('instance', ALLOCATION_TYPE)
-  const existingInstance = await elementsSource.get(instanceElemId)
-  fixExistingInstance(suiteQLTableType, existingInstance)
-  if (isPartial) {
-    return existingInstance
-  }
-  const instance = createOrGetExistingInstance(suiteQLTableType, ALLOCATION_TYPE, existingInstance)
   const ajv = new Ajv({ allErrors: true, strict: false })
   const getAllocationTypes = async (exclude: string[] = []): Promise<Record<string, { name: string }>> => {
+    const anyOfFilter = [[ALLOCATION_TYPE, 'anyof', ..._.difference(items, exclude)]]
+    const noneOfFilter = exclude.length > 0 ? [[ALLOCATION_TYPE, 'noneof', ...exclude]] : []
     const result = await client.runSavedSearchQuery(
       {
         type: 'resourceAllocation',
         columns: [ALLOCATION_TYPE],
-        filters: exclude.length > 0 ? [[ALLOCATION_TYPE, 'noneof', ...exclude]] : [],
+        // we can't filter by name, so we query all allocation types when queryBy='name'
+        filters: queryBy === 'internalId' ? anyOfFilter : noneOfFilter,
       },
       ALLOCATION_TYPE_QUERY_LIMIT,
     )
@@ -704,88 +502,126 @@ const getAllocationTypeInstance = async (
       ...(await getAllocationTypes(Object.keys(internalIdToName).concat(exclude))),
     }
   }
-  instance.value[INTERNAL_IDS_MAP] = await getAllocationTypes()
-  instance.value[VERSION_FIELD] = LATEST_VERSION
-  return instance
+  const internalIdsMap = await getAllocationTypes()
+  if (queryBy === 'name') {
+    return _.pickBy(internalIdsMap, row => items.includes(row.name))
+  }
+  return internalIdsMap
 }
 
-const getAdditionalInstances = (
+const ADDITIONAL_QUERIES: Record<string, ReturnType<typeof getSavedSearchInternlIdsMap>> = {
+  [TAX_SCHEDULE]: getSavedSearchInternlIdsMap(TAX_SCHEDULE),
+  [PROJECT_EXPENSE_TYPE]: getSavedSearchInternlIdsMap(PROJECT_EXPENSE_TYPE),
+  [ALLOCATION_TYPE]: getAllocationTypeInternalIdsMap,
+}
+
+const getInternalIdsMap = async (
   client: NetsuiteClient,
+  queryBy: QueryBy,
+  tableName: string,
+  items: string[],
+): Promise<InternalIdsMap> => {
+  if (ADDITIONAL_QUERIES[tableName] !== undefined) {
+    return ADDITIONAL_QUERIES[tableName](client, queryBy, items)
+  }
+  const queryParams = QUERIES_BY_TABLE_NAME[tableName as SuiteQLTableName]
+  if (queryParams === undefined) {
+    return {}
+  }
+  const { internalIdField, nameField } = queryParams
+  const results = await Promise.all(
+    _.chunk(items, ITEMS_PER_QUERY_LIMIT).map(itemsChunk =>
+      client.runSuiteQL({
+        select: `${internalIdField}, ${nameField}`,
+        from: tableName,
+        where: `${queryBy === 'internalId' ? internalIdField : nameField} in (${itemsChunk.map(id => `'${id}'`).join(', ')})`,
+        orderBy: internalIdField,
+      }),
+    ),
+  ).then(result => result.flatMap(res => res ?? []))
+  if (results.length === 0) {
+    log.warn('received no results from query table %s', tableName)
+    return {}
+  }
+  const validResults = results.flatMap(res => {
+    const internalId = res[internalIdField]
+    const name = res[nameField]
+    if (typeof internalId === 'string' && internalId !== '' && typeof name === 'string' && name !== '') {
+      return { internalId, name }
+    }
+    log.warn('ignoring invalid result from table %s: %o', tableName, res)
+    return []
+  })
+  return Object.fromEntries(validResults.map(({ internalId, name }) => [internalId, { name }]))
+}
+
+export const updateSuiteQLTableInstances = async ({
+  client,
+  queryBy,
+  itemsToQuery,
+  suiteQLTablesMap,
+}: {
+  client: NetsuiteClient
+  queryBy: QueryBy
+  itemsToQuery: { tableName: string; item: string }[]
+  suiteQLTablesMap: Record<string, InstanceElement>
+}): Promise<void> => {
+  const itemsToQueryByTableName = _.mapValues(
+    _.groupBy(itemsToQuery, row => row.tableName),
+    rows => _.uniq(rows.map(row => row.item)),
+  )
+
+  await Promise.all(
+    Object.entries(itemsToQueryByTableName).map(async ([tableName, items]) =>
+      Object.assign(
+        getSuiteQLTableInternalIdsMap(suiteQLTablesMap[tableName]),
+        await getInternalIdsMap(client, queryBy, tableName, items),
+      ),
+    ),
+  )
+}
+
+const getSuiteQLTableInstance = async (
   suiteQLTableType: ObjectType,
+  tableName: string,
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
-  shouldSkipSuiteQLTable: (tableName: string) => boolean,
-): Promise<InstanceElement | undefined>[] => [
-  shouldSkipSuiteQLTable(TAX_SCHEDULE)
-    ? Promise.resolve(undefined)
-    : getSavedSearchQueryInstance(client, suiteQLTableType, TAX_SCHEDULE, elementsSource, isPartial),
-  shouldSkipSuiteQLTable(PROJECT_EXPENSE_TYPE)
-    ? Promise.resolve(undefined)
-    : getSavedSearchQueryInstance(client, suiteQLTableType, PROJECT_EXPENSE_TYPE, elementsSource, isPartial),
-  shouldSkipSuiteQLTable(ALLOCATION_TYPE)
-    ? Promise.resolve(undefined)
-    : getAllocationTypeInstance(client, suiteQLTableType, elementsSource, isPartial),
-]
-
-const getMaxAllowedRecordsForTable = (config: NetsuiteConfig, tableName: string): number => {
-  const maxAllowedRecords = (config.suiteAppClient?.maxRecordsPerSuiteQLTable ?? [])
-    .filter(maxType => regex.isFullRegexMatch(tableName, maxType.name))
-    .map(maxType => maxType.limit)
-  if (maxAllowedRecords.length === 0) {
-    return MAX_ALLOWED_RECORDS
+): Promise<InstanceElement> => {
+  if (isPartial) {
+    const instanceElemId = suiteQLTableType.elemID.createNestedID('instance', tableName)
+    const existingInstance = await elementsSource.get(instanceElemId)
+    if (isInstanceElement(existingInstance)) {
+      existingInstance.refType = createRefToElmWithValue(suiteQLTableType)
+      return existingInstance
+    }
   }
-  return Math.max(...maxAllowedRecords)
+  const newInstance = new InstanceElement(tableName, suiteQLTableType)
+  newInstance.annotate({ [CORE_ANNOTATIONS.HIDDEN]: true })
+  return newInstance
 }
 
 export const getSuiteQLTableElements = async (
   config: NetsuiteConfig,
-  client: NetsuiteClient,
   elementsSource: ReadOnlyElementsSource,
   isPartial: boolean,
-): Promise<{ elements: TopLevelElement[]; largeSuiteQLTables: string[] }> => {
-  if (config.fetch.resolveAccountSpecificValues !== true || !client.isSuiteAppConfigured()) {
-    return { elements: [], largeSuiteQLTables: [] }
+): Promise<{ elements: TopLevelElement[] }> => {
+  if (config.fetch.resolveAccountSpecificValues !== true) {
+    return { elements: [] }
   }
   const suiteQLTableType = new ObjectType({
     elemID: new ElemID(NETSUITE, SUITEQL_TABLE),
     annotations: { [CORE_ANNOTATIONS.HIDDEN]: true },
   })
 
-  const shouldSkipSuiteQLTable = (tableName: string): boolean => {
-    const shouldSkip = (config.fetch.skipResolvingAccountSpecificValuesToTypes ?? []).some(name =>
-      regex.isFullRegexMatch(tableName, name),
-    )
-    if (shouldSkip) {
-      log.debug('skipping query of SuiteQL table %s', tableName)
-    }
-    return shouldSkip
-  }
-
-  const largeSuiteQLTables: string[] = []
-  const lastFetchTime = await getLastServerTime(elementsSource)
   const instances = await Promise.all(
     Object.entries(QUERIES_BY_TABLE_NAME)
-      .map(([tableName, queryParams]) => {
-        if (queryParams === undefined || shouldSkipSuiteQLTable(tableName)) {
-          return undefined
-        }
-        return getSuiteQLTableInstance(
-          client,
-          suiteQLTableType,
-          tableName,
-          queryParams,
-          elementsSource,
-          lastFetchTime,
-          isPartial,
-          getMaxAllowedRecordsForTable(config, tableName),
-          largeSuiteQLTables,
-        )
-      })
-      .concat(getAdditionalInstances(client, suiteQLTableType, elementsSource, isPartial, shouldSkipSuiteQLTable)),
-  ).then(res => res.flatMap(instance => instance ?? []))
+      .filter(([_tableName, queryParams]) => queryParams !== undefined)
+      .map(([tableName, _queryParams]) => tableName)
+      .concat(Object.keys(ADDITIONAL_QUERIES))
+      .map(tableName => getSuiteQLTableInstance(suiteQLTableType, tableName, elementsSource, isPartial)),
+  )
 
   return {
     elements: [suiteQLTableType, ...instances],
-    largeSuiteQLTables,
   }
 }

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -571,13 +571,18 @@ export const updateSuiteQLTableInstances = async ({
     rows => _.uniq(rows.map(row => row.item)),
   )
 
-  await Promise.all(
-    Object.entries(itemsToQueryByTableName).map(async ([tableName, items]) =>
-      Object.assign(
-        getSuiteQLTableInternalIdsMap(suiteQLTablesMap[tableName]),
-        await getInternalIdsMap(client, queryBy, tableName, items),
+  await log.timeDebug(
+    () =>
+      Promise.all(
+        Object.entries(itemsToQueryByTableName).map(async ([tableName, items]) =>
+          Object.assign(
+            getSuiteQLTableInternalIdsMap(suiteQLTablesMap[tableName]),
+            await getInternalIdsMap(client, queryBy, tableName, items),
+          ),
+        ),
       ),
-    ),
+    'updating %d suiteql_table elements',
+    Object.keys(itemsToQueryByTableName).length,
   )
 }
 

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -31,7 +31,7 @@ export type LocalFilterOpts = {
   timeZoneAndFormat?: TimeZoneAndFormat
   changesGroupId?: string
   fetchTime?: Date
-  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
+  suiteQLNameToInternalIdsMap?: Record<string, Record<string, string[]>>
 }
 
 export type RemoteFilterOpts = LocalFilterOpts & {

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -31,6 +31,7 @@ export type LocalFilterOpts = {
   timeZoneAndFormat?: TimeZoneAndFormat
   changesGroupId?: string
   fetchTime?: Date
+  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
 }
 
 export type RemoteFilterOpts = LocalFilterOpts & {

--- a/packages/netsuite-adapter/src/filters/author_information/system_note.ts
+++ b/packages/netsuite-adapter/src/filters/author_information/system_note.ts
@@ -192,16 +192,15 @@ const getEmployeeInternalIdsMap = async (
     .filter(name => existingEmployeeInternalIdsMap[name] === undefined)
     .map(internalId => ({ tableName: EMPLOYEE, item: internalId }))
 
-  if (employeeInternalIdsToQuery.length > 0) {
-    await updateSuiteQLTableInstances({
-      client,
-      queryBy: 'internalId',
-      itemsToQuery: employeeInternalIdsToQuery,
-      suiteQLTablesMap: {
-        [EMPLOYEE]: employeeSuiteQLTableInstance,
-      },
-    })
-  }
+  await updateSuiteQLTableInstances({
+    client,
+    queryBy: 'internalId',
+    itemsToQuery: employeeInternalIdsToQuery,
+    suiteQLTablesMap: {
+      [EMPLOYEE]: employeeSuiteQLTableInstance,
+    },
+  })
+
   return _.mapValues(getSuiteQLTableInternalIdsMap(employeeSuiteQLTableInstance), row => row.name)
 }
 

--- a/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
@@ -429,7 +429,7 @@ const filterCreator: RemoteFilterCreator = ({
   config,
   elementsSource,
   isPartial,
-  suiteQLNameToInternalIdsMap,
+  suiteQLNameToInternalIdsMap = {},
 }) => ({
   name: 'dataAccountSpecificValues',
   remote: true,

--- a/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/data_account_specific_values.ts
@@ -33,7 +33,7 @@ import {
   isAdditionOrModificationChange,
   ChangeError,
 } from '@salto-io/adapter-api'
-import { TransformFunc, naclCase, transformValuesSync } from '@salto-io/adapter-utils'
+import { TransformFunc, naclCase, setPath, transformValuesSync } from '@salto-io/adapter-utils'
 import { isDataObjectType, isFileCabinetType, isStandardType } from '../types'
 import {
   ACCOUNT_SPECIFIC_VALUE,
@@ -46,12 +46,13 @@ import {
   TYPES_PATH,
 } from '../constants'
 import { TYPE_ID } from '../client/suiteapp_client/constants'
-import { LocalFilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
 import {
   SUITEQL_TABLE,
   getSuiteQLTableInternalIdsMap,
-  getSuiteQLNameToInternalIdsMap,
+  updateSuiteQLTableInstances,
+  MissingInternalId,
 } from '../data_elements/suiteql_table_elements'
 
 const log = logger(module)
@@ -70,6 +71,20 @@ const SOAP_REFERENCE_FIELDS = new Set([NAME_FIELD, INTERNAL_ID, TYPE_ID])
 
 type ResolvedAccountSpecificValue = {
   [ID_FIELD]: string
+}
+
+type AccountSpecificValueToTransform = {
+  instance: InstanceElement
+  path: ElemID
+  internalId: string
+  fallbackName: string | undefined
+  suiteQLTableInstance: InstanceElement | undefined
+}
+
+type ResolvedAccountSpecificValueResult = {
+  value: Value
+  error?: ChangeError
+  missingInternalId?: MissingInternalId
 }
 
 const FIELD_NAME_TO_SUITEQL_TABLE: Record<string, string> = {
@@ -255,12 +270,13 @@ const getSuiteQLTableInstance = (
     .find(instance => instance !== undefined)
 }
 
-const setAccountSpecificValues = (
-  dataInstance: InstanceElement,
-  unknownTypeReferencesInstance: InstanceElement,
+const getAccountSpecificValuesToTransform = (
+  instance: InstanceElement,
   suiteQLTablesMap: Record<string, InstanceElement>,
-): void => {
-  const transformIds: TransformFunc = ({ value, field, path }) => {
+): AccountSpecificValueToTransform[] => {
+  const result: AccountSpecificValueToTransform[] = []
+
+  const getAccountSpecificValuesFunc: TransformFunc = ({ value, field, path }) => {
     if (!isNestedObject(path, value)) {
       return value
     }
@@ -272,29 +288,34 @@ const setAccountSpecificValues = (
     if (!isSoapReferenceObject(value)) {
       // some inner objects that are not references also have internalId (e.g mainAddress),
       // but it's not required for addition/modification of the instance/field, so we can just omit it.
-      return _.omit(value, INTERNAL_ID)
+      delete value[INTERNAL_ID]
+      return value
     }
 
     if (fallbackName === undefined) {
       log.warn('value in %s is missing name field: %o', path.getFullName(), value)
     }
 
-    const suiteQLTableInstance = getSuiteQLTableInstance(field, typeId, suiteQLTablesMap)
-    if (suiteQLTableInstance === undefined) {
-      const name = getNameFromUnknownTypeReference(path, unknownTypeReferencesInstance, internalId, fallbackName)
-      return toResolvedAccountSpecificValue({ type: UNKNOWN_TYPE, name })
-    }
-    const name = getNameFromSuiteQLTableInstance(suiteQLTableInstance, internalId, fallbackName)
-    return toResolvedAccountSpecificValue({ type: suiteQLTableInstance.elemID.name, name })
+    result.push({
+      instance,
+      path,
+      internalId,
+      fallbackName,
+      suiteQLTableInstance: getSuiteQLTableInstance(field, typeId, suiteQLTablesMap),
+    })
+
+    return value
   }
 
-  dataInstance.value = transformValuesSync({
-    values: dataInstance.value,
-    type: dataInstance.getTypeSync(),
-    transformFunc: transformIds,
+  transformValuesSync({
+    values: instance.value,
+    type: instance.getTypeSync(),
+    transformFunc: getAccountSpecificValuesFunc,
     strict: false,
-    pathID: dataInstance.elemID,
+    pathID: instance.elemID,
   })
+
+  return result
 }
 
 const toMissingInternalIdError = (elemId: ElemID, name: string): ChangeError => {
@@ -320,8 +341,8 @@ export const getResolvedAccountSpecificValue = (
   path: ElemID | undefined,
   value: Value,
   unknownTypeReferencesMap: Record<string, Record<string, string[]>>,
-  suiteQLTablesMap: Record<string, Record<string, string[]>>,
-): { value: Value; error?: ChangeError } => {
+  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>,
+): ResolvedAccountSpecificValueResult => {
   if (!isNestedObject(path, value)) {
     return { value }
   }
@@ -338,7 +359,9 @@ export const getResolvedAccountSpecificValue = (
 
   const { [REGEX_TYPE]: type, [REGEX_NAME]: name } = regexRes.groups
   const nameToInternalIds =
-    type === UNKNOWN_TYPE ? unknownTypeReferencesMap[getUnknownTypeReferencesPath(path)] : suiteQLTablesMap[type]
+    type === UNKNOWN_TYPE
+      ? unknownTypeReferencesMap[getUnknownTypeReferencesPath(path)]
+      : suiteQLNameToInternalIdsMap[type]
 
   if (nameToInternalIds === undefined) {
     log.warn('did not find internal ids map of %s for path %s', type, path.getFullName())
@@ -348,7 +371,11 @@ export const getResolvedAccountSpecificValue = (
   const internalIds = nameToInternalIds[name] ?? []
   if (internalIds.length === 0) {
     log.warn('did not find name %s in internal ids map of %s for path %s', name, type, path.getFullName())
-    return { value: undefined, error: toMissingInternalIdError(path, name) }
+    return {
+      value: undefined,
+      error: toMissingInternalIdError(path, name),
+      missingInternalId: type !== UNKNOWN_TYPE ? { tableName: type, name } : undefined,
+    }
   }
 
   const resolvedValue = { [INTERNAL_ID]: internalIds[0] }
@@ -369,11 +396,11 @@ export const getResolvedAccountSpecificValue = (
 const resolveAccountSpecificValues = ({
   instance,
   unknownTypeReferencesMap,
-  suiteQLTablesMap,
+  suiteQLNameToInternalIdsMap,
 }: {
   instance: InstanceElement
   unknownTypeReferencesMap: Record<string, Record<string, string[]>>
-  suiteQLTablesMap: Record<string, Record<string, string[]>>
+  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
 }): void => {
   const resolve: TransformFunc = ({ path, field, value }) => {
     if (field !== undefined) {
@@ -383,7 +410,7 @@ const resolveAccountSpecificValues = ({
       path,
       value,
       unknownTypeReferencesMap,
-      suiteQLTablesMap,
+      suiteQLNameToInternalIdsMap,
     )
     return resolvedValue
   }
@@ -397,8 +424,15 @@ const resolveAccountSpecificValues = ({
   })
 }
 
-const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }) => ({
+const filterCreator: RemoteFilterCreator = ({
+  client,
+  config,
+  elementsSource,
+  isPartial,
+  suiteQLNameToInternalIdsMap,
+}) => ({
   name: 'dataAccountSpecificValues',
+  remote: true,
   onFetch: async elements => {
     if (config.fetch.resolveAccountSpecificValues === false) {
       return
@@ -412,11 +446,38 @@ const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }
     const unknownTypeReferencesElements = await getUnknownTypeReferencesElements(elementsSource, isPartial)
     elements.push(...Object.values(unknownTypeReferencesElements))
 
-    instances
+    const accountSpecificValuesToTransform = instances
       .filter(instance => isDataObjectType(instance.getTypeSync()))
-      .forEach(instance => {
-        setAccountSpecificValues(instance, unknownTypeReferencesElements.instance, suiteQLTablesMap)
-      })
+      .flatMap(instance => getAccountSpecificValuesToTransform(instance, suiteQLTablesMap))
+
+    const internalIdsToQuery = accountSpecificValuesToTransform.flatMap(({ suiteQLTableInstance, internalId }) =>
+      suiteQLTableInstance !== undefined &&
+      getSuiteQLTableInternalIdsMap(suiteQLTableInstance)[internalId] === undefined
+        ? { tableName: suiteQLTableInstance.elemID.name, item: internalId }
+        : [],
+    )
+
+    await updateSuiteQLTableInstances({
+      client,
+      queryBy: 'internalId',
+      itemsToQuery: internalIdsToQuery,
+      suiteQLTablesMap,
+    })
+
+    accountSpecificValuesToTransform.forEach(({ instance, path, internalId, fallbackName, suiteQLTableInstance }) => {
+      if (suiteQLTableInstance === undefined) {
+        const name = getNameFromUnknownTypeReference(
+          path,
+          unknownTypeReferencesElements.instance,
+          internalId,
+          fallbackName,
+        )
+        setPath(instance, path, toResolvedAccountSpecificValue({ type: UNKNOWN_TYPE, name }))
+      } else {
+        const name = getNameFromSuiteQLTableInstance(suiteQLTableInstance, internalId, fallbackName)
+        setPath(instance, path, toResolvedAccountSpecificValue({ type: suiteQLTableInstance.elemID.name, name }))
+      }
+    })
 
     addReferenceTypes(elements)
   },
@@ -434,9 +495,8 @@ const filterCreator: LocalFilterCreator = ({ config, elementsSource, isPartial }
       return
     }
     const unknownTypeReferencesMap = await getUnknownTypeReferencesMap(elementsSource)
-    const suiteQLTablesMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
     relevantChangedInstances.forEach(instance => {
-      resolveAccountSpecificValues({ instance, unknownTypeReferencesMap, suiteQLTablesMap })
+      resolveAccountSpecificValues({ instance, unknownTypeReferencesMap, suiteQLNameToInternalIdsMap })
     })
   },
 })

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -21,7 +21,6 @@ import {
   Element,
   ElemID,
   InstanceElement,
-  ReadOnlyElementsSource,
   Value,
   Values,
   getChangeData,
@@ -32,7 +31,7 @@ import {
   ReferenceExpression,
   ChangeError,
 } from '@salto-io/adapter-api'
-import { WALK_NEXT_STEP, resolvePath, walkOnElement, walkOnValue } from '@salto-io/adapter-utils'
+import { WALK_NEXT_STEP, resolvePath, setPath, walkOnElement, walkOnValue } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../client/client'
 import { RemoteFilterCreator } from '../filter'
 import {
@@ -54,9 +53,10 @@ import {
   QueryRecordSchema,
 } from '../client/suiteapp_client/types'
 import {
+  MissingInternalId,
   SUITEQL_TABLE,
-  getSuiteQLNameToInternalIdsMap,
   getSuiteQLTableInternalIdsMap,
+  updateSuiteQLTableInstances,
 } from '../data_elements/suiteql_table_elements'
 import { INTERNAL_ID_TO_TYPES } from '../data_elements/types'
 import { captureServiceIdInfo } from '../service_id_info'
@@ -107,6 +107,23 @@ type GetFieldTypeIDFunc = (params: {
   isFieldWithAccountSpecificValue: boolean
   selectRecordTypeMap: Record<string, unknown>
 }) => string | string[] | undefined
+
+type AccountSpecificValueToTransform = {
+  field: QueryRecordField
+  value: Values
+  internalId: string
+}
+
+type ResolvedAccountSpecificValue = {
+  path: ElemID
+  value: string
+}
+
+type ResolvedAccountSpecificValuesResult = {
+  resolvedAccountSpecificValues: ResolvedAccountSpecificValue[]
+  resolveWarnings: ChangeError[]
+  missingInternalIds: MissingInternalId[]
+}
 
 const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, string> = {
   STDITEMTAXSCHEDULE: TAX_SCHEDULE,
@@ -484,7 +501,7 @@ const getWorkflowIdsToQuery = async (
   return _.uniq(result.map(row => row.internalid[0].value))
 }
 
-const query = async (
+const runRecordsQuery = async (
   client: NetsuiteClient,
   instances: InstanceElement[],
   queryRecords: QueryRecord[],
@@ -516,30 +533,22 @@ const isResolvedAccountSpecificValue = (name: string): boolean =>
 const getResolvedAccountSpecificValue = (name: string): string =>
   name.slice(RESOLVED_ACCOUNT_SPECIFIC_VALUE_PREFIX.length, name.length - RESOLVED_ACCOUNT_SPECIFIC_VALUE_SUFFIX.length)
 
-const setFieldValue = (
+const getNameByInternalId = (
   field: QueryRecordField,
-  value: Values,
   internalId: string,
   suiteQLTablesMap: Record<string, InstanceElement>,
-): void => {
-  const { name } =
-    makeArray(field.type)
-      .map(typeName => getSuiteQLTableInternalIdsMap(suiteQLTablesMap[typeName])[internalId])
-      .find(res => res !== undefined) ?? {}
-  if (name === undefined) {
-    log.warn('could not find internal id %s of type %s', internalId, field.type)
-    return
-  }
-  value[field.name] = toResolvedAccountSpecificValue(name)
-}
+): string | undefined =>
+  makeArray(field.type)
+    .map(typeName => getSuiteQLTableInternalIdsMap(suiteQLTablesMap[typeName])[internalId])
+    .find(res => res !== undefined)?.name
 
-const setParametersValues = (
+const getParametersAccountSpecificValueToTransform = (
   instance: InstanceElement,
   value: Values,
   formulaWithInternalIds: string,
   suiteQLTablesMap: Record<string, InstanceElement>,
   selectRecordTypeMap: Record<string, unknown>,
-): void => {
+): AccountSpecificValueToTransform[] => {
   const params = getConditionParameters(value[INIT_CONDITION])
     // not only params with ACCOUNT_SPECIFIC_VALUE are represented with internalid in the formula (e.g roles)
     // but only params that have selectrecordtype are represented with internalid in the formula
@@ -554,47 +563,55 @@ const setParametersValues = (
       params.length,
       formulaWithInternalIds,
     )
-    return
+    return []
   }
-  _.sortBy(params, param => value[INIT_CONDITION][FORMULA].indexOf(`"${param.name}"`)).forEach((param, index) => {
-    if (param.value === ACCOUNT_SPECIFIC_VALUE) {
-      const internalId = internalIds[index]
-      const paramType = getQueryRecordFieldType(instance, param, 'value', suiteQLTablesMap, selectRecordTypeMap)
-      if (paramType !== undefined) {
-        setFieldValue({ name: 'value', type: paramType }, param, internalId, suiteQLTablesMap)
-      }
+  const sortedParams = _.sortBy(params, param => value[INIT_CONDITION][FORMULA].indexOf(`"${param.name}"`))
+  return sortedParams.flatMap((param, index) => {
+    if (param.value !== ACCOUNT_SPECIFIC_VALUE) {
+      return []
     }
+    const internalId = internalIds[index]
+    const paramType = getQueryRecordFieldType(instance, param, 'value', suiteQLTablesMap, selectRecordTypeMap)
+    if (paramType === undefined) {
+      return []
+    }
+    return { field: { name: 'value', type: paramType }, value: param, internalId }
   })
 }
 
-const setValuesInInstance = (
+const getAccountSpecificValueToTransform = (
   instance: InstanceElement,
   record: QueryRecord,
   results: QueryRecordResponse[],
   suiteQLTablesMap: Record<string, InstanceElement>,
   selectRecordTypeMap: Record<string, unknown>,
-): void => {
+): AccountSpecificValueToTransform[] => {
   const innerValue = record.elemID.isTopLevel() ? instance.value : resolvePath(instance, record.elemID)
   const innerResult = getInnerResult(results, record.path)
   if (innerResult === undefined) {
     log.warn('missing record %s in path %s: %o', record.serviceId, record.path.join('.'), results)
-    return
+    return []
   }
-  record.fields.forEach(field => {
+  return record.fields.flatMap(field => {
     const internalId = innerResult.body[field.name]
     if (internalId === undefined || internalId === '') {
       log.warn('missing field %s in record %s: %o', field.name, record.serviceId, innerResult.body)
-      return
+      return []
     }
     if (typeof internalId !== 'string') {
       log.warn('field %s in record %s is not a string: %o', field.name, record.serviceId, internalId)
-      return
+      return []
     }
     if (field.type === FORMULA_PARAMS) {
-      setParametersValues(instance, innerValue, internalId, suiteQLTablesMap, selectRecordTypeMap)
-    } else {
-      setFieldValue(field, innerValue, internalId, suiteQLTablesMap)
+      return getParametersAccountSpecificValueToTransform(
+        instance,
+        innerValue,
+        internalId,
+        suiteQLTablesMap,
+        selectRecordTypeMap,
+      )
     }
+    return { field, value: innerValue, internalId }
   })
 }
 
@@ -612,11 +629,14 @@ const toMultipleInternalIdsWarning = (elemID: ElemID, name: string, internalId: 
   detailedMessage: `There are multiple objects with the name "${name}". Using the first one (internal id: ${internalId}). Learn more at https://help.salto.io/en/articles/8952685-identifying-account-specific-values-in-netsuite`,
 })
 
-const resolveAccountSpecificValues = (
+export const getResolvedAccountSpecificValues = (
   instance: InstanceElement,
   suiteQLTablesMap: Record<string, Record<string, string[]>>,
-): ChangeError[] => {
+): ResolvedAccountSpecificValuesResult => {
+  const resolvedAccountSpecificValues: ResolvedAccountSpecificValue[] = []
   const resolveWarnings: ChangeError[] = []
+  const missingInternalIds: MissingInternalId[] = []
+
   const resolveAccountSpecificValueForField = (
     path: ElemID,
     value: Values,
@@ -638,13 +658,14 @@ const resolveAccountSpecificValues = (
         value,
       )
       resolveWarnings.push(toMissingInternalIdWarning(path, name, field))
-      value[field] = ACCOUNT_SPECIFIC_VALUE
+      makeArray(fieldType).forEach(type => missingInternalIds.push({ tableName: type, name }))
+      resolvedAccountSpecificValues.push({ path: path.createNestedID(field), value: ACCOUNT_SPECIFIC_VALUE })
     } else {
       if (internalIds.length > 1) {
         log.warn('there are several internal ids for name %s - using the first: %d', name, internalId)
         resolveWarnings.push(toMultipleInternalIdsWarning(path, name, internalId))
       }
-      value[field] = internalId
+      resolvedAccountSpecificValues.push({ path: path.createNestedID(field), value: internalId })
     }
   }
 
@@ -661,15 +682,7 @@ const resolveAccountSpecificValues = (
     },
   })
 
-  return resolveWarnings
-}
-
-export const resolveWorkflowsAccountSpecificValues = async (
-  workflowInstances: InstanceElement[],
-  elementsSource: ReadOnlyElementsSource,
-): Promise<ChangeError[]> => {
-  const suiteQLNameToInternalIdsMap = await getSuiteQLNameToInternalIdsMap(elementsSource)
-  return workflowInstances.flatMap(instance => resolveAccountSpecificValues(instance, suiteQLNameToInternalIdsMap))
+  return { resolvedAccountSpecificValues, resolveWarnings, missingInternalIds }
 }
 
 const getSelectRecordTypeMap = async (
@@ -686,7 +699,12 @@ const getSelectRecordTypeMap = async (
   return selectRecordTypeMap
 }
 
-const filterCreator: RemoteFilterCreator = ({ client, elementsSource, elementsSourceIndex, isPartial }) => ({
+const filterCreator: RemoteFilterCreator = ({
+  client,
+  elementsSourceIndex,
+  isPartial,
+  suiteQLNameToInternalIdsMap = {},
+}) => ({
   name: 'workflowAccountSpecificValues',
   remote: true,
   onFetch: async elements => {
@@ -709,21 +727,43 @@ const filterCreator: RemoteFilterCreator = ({ client, elementsSource, elementsSo
       return
     }
 
-    await Promise.all(
-      _.chunk(queryRecords, RECORDS_PER_QUERY).map(async (chunk: InstanceWithQueryRecords[]): Promise<void> => {
-        const chunkRecords = chunk.flatMap(item => item.records)
-        const results = (await query(client, workflowInstances, chunkRecords)) ?? []
-        if (results.length === 0) {
-          log.warn('skipping setting values due to empty result of query records: %o', chunkRecords)
-          return
-        }
-        chunk.forEach(({ instance, records }) => {
-          records.forEach(record => {
-            setValuesInInstance(instance, record, results, suiteQLTablesMap, selectRecordTypeMap)
-          })
-        })
-      }),
+    const results = await Promise.all(
+      _.chunk(queryRecords, RECORDS_PER_QUERY).map(chunk =>
+        runRecordsQuery(
+          client,
+          workflowInstances,
+          chunk.flatMap(item => item.records),
+        ),
+      ),
+    ).then(result => result.flatMap(res => res ?? []))
+
+    const accountSpecificValuesToTransform = queryRecords.flatMap(({ instance, records }) =>
+      records.flatMap(record =>
+        getAccountSpecificValueToTransform(instance, record, results, suiteQLTablesMap, selectRecordTypeMap),
+      ),
     )
+
+    const internalIdsToQuery = accountSpecificValuesToTransform.flatMap(({ field, internalId }) =>
+      getNameByInternalId(field, internalId, suiteQLTablesMap) === undefined
+        ? makeArray(field.type).map(tableName => ({ tableName, item: internalId }))
+        : [],
+    )
+
+    await updateSuiteQLTableInstances({
+      client,
+      queryBy: 'internalId',
+      itemsToQuery: internalIdsToQuery,
+      suiteQLTablesMap,
+    })
+
+    accountSpecificValuesToTransform.forEach(({ field, value, internalId }) => {
+      const name = getNameByInternalId(field, internalId, suiteQLTablesMap)
+      if (name === undefined) {
+        log.warn('could not find internal id %s of type %s', internalId, field.type)
+        return
+      }
+      value[field.name] = toResolvedAccountSpecificValue(name)
+    })
   },
   preDeploy: async changes => {
     const workflowInstances = changes
@@ -734,7 +774,11 @@ const filterCreator: RemoteFilterCreator = ({ client, elementsSource, elementsSo
     if (workflowInstances.length === 0) {
       return
     }
-    await resolveWorkflowsAccountSpecificValues(workflowInstances, elementsSource)
+    workflowInstances.forEach(instance =>
+      getResolvedAccountSpecificValues(instance, suiteQLNameToInternalIdsMap).resolvedAccountSpecificValues.forEach(
+        ({ path, value }) => setPath(instance, path, value),
+      ),
+    )
   },
 })
 

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -631,7 +631,7 @@ const toMultipleInternalIdsWarning = (elemID: ElemID, name: string, internalId: 
 
 export const getResolvedAccountSpecificValues = (
   instance: InstanceElement,
-  suiteQLTablesMap: Record<string, Record<string, string[]>>,
+  suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>,
 ): ResolvedAccountSpecificValuesResult => {
   const resolvedAccountSpecificValues: ResolvedAccountSpecificValue[] = []
   const resolveWarnings: ChangeError[] = []
@@ -647,8 +647,8 @@ export const getResolvedAccountSpecificValues = (
       return
     }
     const name = getResolvedAccountSpecificValue(fieldValue)
-    const fieldType = getQueryRecordFieldType(instance, value, field, suiteQLTablesMap, {})
-    const internalIds = _.uniq(makeArray(fieldType).flatMap(type => suiteQLTablesMap[type][name] ?? []))
+    const fieldType = getQueryRecordFieldType(instance, value, field, suiteQLNameToInternalIdsMap, {})
+    const internalIds = _.uniq(makeArray(fieldType).flatMap(type => suiteQLNameToInternalIdsMap[type][name] ?? []))
     const internalId = internalIds[0]
     if (internalIds.length === 0) {
       log.warn(

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -35,6 +35,7 @@ const loadElementsFromFolder = async (
       elementsSource,
       isPartial,
       config: netsuiteConfigFromConfig(config),
+      suiteQLNameToInternalIdsMap: {},
     },
     filters,
   )

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -35,7 +35,6 @@ const loadElementsFromFolder = async (
       elementsSource,
       isPartial,
       config: netsuiteConfigFromConfig(config),
-      suiteQLNameToInternalIdsMap: {},
     },
     filters,
   )

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -454,7 +454,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: ['largeFolder'] },
           failedTypes: expect.anything(),
           failedCustomRecords: expect.anything(),
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -476,7 +475,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: ['excludedTypeTest'] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -538,7 +536,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -560,7 +557,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: ['/path/to/file'], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -585,7 +581,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: failedTypeToInstances, excludedTypes: [] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -609,7 +604,6 @@ describe('Adapter', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         config,
       )
@@ -1593,7 +1587,6 @@ describe('Adapter', () => {
               excludedTypes: ['excludedTypeDataElements'],
             },
             failedCustomRecords: ['excludedTypeCustomRecord'],
-            largeSuiteQLTables: [],
           },
           config,
         )

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -205,7 +205,7 @@ describe('change validator', () => {
         changes,
         client,
         DEFAULT_OPTIONS.additionalDependencies,
-        DEFAULT_OPTIONS.filtersRunner,
+        expect.any(Function),
       )
     })
     it('should call netsuiteClientValidation with only valid changes', async () => {
@@ -232,7 +232,7 @@ describe('change validator', () => {
         [validChange],
         client,
         DEFAULT_OPTIONS.additionalDependencies,
-        DEFAULT_OPTIONS.filtersRunner,
+        expect.any(Function),
       )
     })
   })

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -23,7 +23,6 @@ import {
   STOP_MANAGING_ITEMS_MSG,
   getConfigFromConfigChanges,
   ALIGNED_INACTIVE_CRITERIAS,
-  toLargeSuiteQLTablesExcludedMessage,
 } from '../../src/config/suggestions'
 import { NetsuiteQueryParameters, fetchDefault, configType, NetsuiteConfig } from '../../src/config/types'
 import { INACTIVE_FIELDS } from '../../src/constants'
@@ -77,7 +76,6 @@ describe('netsuite config suggestions', () => {
           failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
-          largeSuiteQLTables: [],
         },
         currentConfigWithFetch,
       ),
@@ -93,7 +91,6 @@ describe('netsuite config suggestions', () => {
         failedFilePaths: { lockedError: lockedFiles, otherError: [newFailedFilePath], largeFolderError: [] },
         failedTypes: { lockedError: lockedTypes, unexpectedError: suggestedSkipListTypes, excludedTypes: [] },
         failedCustomRecords: [],
-        largeSuiteQLTables: [],
       },
       { fetch: fullFetchConfig() },
     )?.config as InstanceElement[]
@@ -150,7 +147,6 @@ describe('netsuite config suggestions', () => {
         failedFilePaths: { lockedError: [], otherError: [newFailedFilePath], largeFolderError: [newLargeFolderPath] },
         failedTypes: { lockedError: {}, unexpectedError: suggestedSkipListTypes, excludedTypes: ['excludedTypeTest'] },
         failedCustomRecords: ['excludedCustomRecord'],
-        largeSuiteQLTables: [],
       },
       currentConfigWithFetch,
     )
@@ -200,7 +196,6 @@ describe('netsuite config suggestions', () => {
         failedFilePaths: { lockedError: [], otherError: [newFailedFilePath], largeFolderError: [newLargeFolderPath] },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
-        largeSuiteQLTables: [],
       },
       config,
     )
@@ -208,24 +203,6 @@ describe('netsuite config suggestions', () => {
     expect(configChange?.message).toBe(
       formatConfigSuggestionsReasons([STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath])]),
     )
-  })
-
-  it('should exclude large SuiteQL tables', () => {
-    const config: NetsuiteConfig = {
-      fetch: fullFetchConfig(),
-    }
-    const configChange = getConfigFromConfigChanges(
-      {
-        failedToFetchAllAtOnce: false,
-        failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
-        failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
-        failedCustomRecords: [],
-        largeSuiteQLTables: ['account'],
-      },
-      config,
-    )
-    expect(configChange?.config[0].value.fetch.skipResolvingAccountSpecificValuesToTypes).toEqual(['account'])
-    expect(configChange?.message).toMatch(toLargeSuiteQLTablesExcludedMessage(['account']))
   })
 
   it('should align inactive fields', () => {
@@ -244,7 +221,6 @@ describe('netsuite config suggestions', () => {
         failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
-        largeSuiteQLTables: [],
       },
       config,
     )

--- a/packages/netsuite-adapter/test/config/validations.test.ts
+++ b/packages/netsuite-adapter/test/config/validations.test.ts
@@ -371,26 +371,6 @@ describe('netsuite config validations', () => {
         expect(() => validateConfig(config)).toThrow('The following regular expressions are invalid')
       })
     })
-
-    describe('skip resolving account specific values to types', () => {
-      it('should not throw', () => {
-        config.fetch.skipResolvingAccountSpecificValuesToTypes = []
-        expect(() => validateConfig(config)).not.toThrow()
-
-        config.fetch.skipResolvingAccountSpecificValuesToTypes = ['.*']
-        expect(() => validateConfig(config)).not.toThrow()
-      })
-      it('should throw if value is not a list of strings', () => {
-        config.fetch.skipResolvingAccountSpecificValuesToTypes = '.*'
-        expect(() => validateConfig(config)).toThrow(
-          'fetch.skipResolvingAccountSpecificValuesToTypes should be a list of strings',
-        )
-      })
-      it('should throw if value contain invalid regex', () => {
-        config.fetch.skipResolvingAccountSpecificValuesToTypes = ['.*', '(']
-        expect(() => validateConfig(config)).toThrow('The following regular expressions are invalid: (')
-      })
-    })
   })
 
   describe('client config', () => {

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -19,6 +19,7 @@ import {
   ElemID,
   InstanceElement,
   ObjectType,
+  ReadOnlyElementsSource,
   TopLevelElement,
   isInstanceElement,
 } from '@salto-io/adapter-api'
@@ -29,10 +30,9 @@ import {
   QUERIES_BY_TABLE_NAME,
   SUITEQL_TABLE,
   getSuiteQLTableElements,
+  updateSuiteQLTableInstances,
 } from '../../src/data_elements/suiteql_table_elements'
-import { SuiteQLTableName } from '../../src/data_elements/types'
-import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../../src/constants'
-import { SERVER_TIME_TYPE_NAME } from '../../src/server_time'
+import { ALLOCATION_TYPE, NETSUITE, TAX_SCHEDULE } from '../../src/constants'
 import { NetsuiteConfig } from '../../src/config/types'
 import { fullFetchConfig } from '../../src/config/config_creator'
 
@@ -40,10 +40,6 @@ export const NUM_OF_SUITEQL_ELEMENTS =
   Object.values(QUERIES_BY_TABLE_NAME).filter(query => query !== undefined).length +
   // additional elements are the type, and instances from getAdditionalInstances
   4
-
-const TYPE_TO_SKIP = 'vendor'
-const TYPE_WITH_MAX_RESULTS = 'unitsType'
-const TYPE_WITH_ALLOWED_MAX_RESULTS = 'term'
 
 const runSuiteQLMock = jest.fn()
 const runSavedSearchQueryMock = jest.fn()
@@ -55,13 +51,10 @@ const client = {
 
 describe('SuiteQL table elements', () => {
   let config: NetsuiteConfig
-  let serverTimeType: ObjectType
-  let serverTimeInstance: InstanceElement
   let suiteQLTableType: ObjectType
   let suiteQLTableInstance: InstanceElement
-  let oldSuiteQLTableInstance: InstanceElement
-  let emptySuiteQLTableInstance: InstanceElement
-  let result: { elements: TopLevelElement[]; largeSuiteQLTables: string[] }
+  let elementsSource: ReadOnlyElementsSource
+  let result: { elements: TopLevelElement[] }
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -69,384 +62,337 @@ describe('SuiteQL table elements', () => {
       fetch: {
         ...fullFetchConfig(),
         resolveAccountSpecificValues: true,
-        skipResolvingAccountSpecificValuesToTypes: [TYPE_TO_SKIP],
-      },
-      suiteAppClient: {
-        maxRecordsPerSuiteQLTable: [{ name: TYPE_WITH_ALLOWED_MAX_RESULTS, limit: 300_000 }],
       },
     }
-    serverTimeType = new ObjectType({ elemID: new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME) })
-    serverTimeInstance = new InstanceElement(ElemID.CONFIG_NAME, serverTimeType, {
-      serverTime: '2024-01-01T00:00:00.000Z',
-    })
     suiteQLTableType = new ObjectType({ elemID: new ElemID(NETSUITE, SUITEQL_TABLE) })
-    suiteQLTableInstance = new InstanceElement('currency', suiteQLTableType, {
+    suiteQLTableInstance = new InstanceElement(
+      'currency',
+      suiteQLTableType,
+      {
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Some name' },
+          2: { name: 'Some name 2' },
+          3: { name: 'Some name 3' },
+        },
+      },
+      undefined,
+      { [CORE_ANNOTATIONS.HIDDEN]: true },
+    )
+    elementsSource = buildElementsSourceFromElements([suiteQLTableInstance])
+  })
+
+  it('should return new elements', async () => {
+    result = await getSuiteQLTableElements(config, elementsSource, false)
+    expect(result.elements).toHaveLength(NUM_OF_SUITEQL_ELEMENTS)
+    expect(result.elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
+    expect(result.elements.filter(isInstanceElement).every(instance => _.isEmpty(instance.value))).toBeTruthy()
+  })
+
+  it('should return existing elements when isPartial=true', async () => {
+    result = await getSuiteQLTableElements(config, elementsSource, true)
+    expect(result.elements).toHaveLength(NUM_OF_SUITEQL_ELEMENTS)
+    expect(result.elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
+    const existingInstances = result.elements.filter(isInstanceElement).filter(instance => !_.isEmpty(instance.value))
+    expect(existingInstances).toHaveLength(1)
+    expect(existingInstances[0].elemID.name).toEqual('currency')
+    expect(existingInstances[0].value).toEqual({
       [INTERNAL_IDS_MAP]: {
         1: { name: 'Some name' },
         2: { name: 'Some name 2' },
         3: { name: 'Some name 3' },
       },
-      version: 1,
-    })
-    oldSuiteQLTableInstance = new InstanceElement('department', suiteQLTableType, {
-      [INTERNAL_IDS_MAP]: {
-        1: { name: 'Some name' },
-        2: { name: 'Some name 2' },
-        3: { name: 'Some name 3' },
-      },
-      version: 'old',
-    })
-    emptySuiteQLTableInstance = new InstanceElement('subsidiary', suiteQLTableType, {
-      version: 1,
     })
   })
 
-  describe('when there are no existing instances', () => {
+  it('should not return elements when fetch.resolveAccountSpecificValues=false', async () => {
+    config.fetch.resolveAccountSpecificValues = false
+    result = await getSuiteQLTableElements(config, elementsSource, true)
+    expect(result.elements).toHaveLength(0)
+  })
+
+  describe('update suiteql table instances', () => {
     beforeEach(async () => {
-      runSuiteQLMock.mockImplementation(query =>
-        query.select.includes('count(*)')
-          ? [
-              {
-                count:
-                  query.from === TYPE_WITH_MAX_RESULTS || query.from === TYPE_WITH_ALLOWED_MAX_RESULTS ? '200000' : '3',
-              },
+      result = await getSuiteQLTableElements(config, elementsSource, true)
+    })
+
+    describe('query by internalId', () => {
+      beforeEach(async () => {
+        runSuiteQLMock.mockResolvedValue([
+          { id: '3', name: 'Some name 3 - updated' },
+          { id: '4', name: 'Some name 4' },
+          { id: '5', name: 'Some name 5' },
+        ])
+        runSavedSearchQueryMock.mockImplementation(({ type, filters }) => {
+          if (type !== 'resourceAllocation') {
+            return [
+              { internalid: [{ value: '1' }], name: 'Tax Schedule 1' },
+              { internalid: [{ value: '2' }], name: 'Tax Schedule 2' },
+              { internalid: [{ value: '3' }], name: 'Tax Schedule 3' },
             ]
-          : [
-              { id: '1', name: 'Some name' },
-              { id: '2', name: 'Some name 2' },
-              { id: '3', name: 'Some name 3' },
-            ],
-      )
-      runSavedSearchQueryMock.mockImplementation(({ type, filters }) => {
-        if (type !== 'resourceAllocation') {
+          }
+          if (_.isEqual(filters, [['allocationType', 'anyof', '1', '2']])) {
+            return _.range(50).map(_i => ({
+              allocationType: [
+                {
+                  value: '1',
+                  text: 'Allocation Type 1',
+                },
+              ],
+            }))
+          }
           return [
-            { internalid: [{ value: '1' }], name: 'Tax Schedule 1' },
-            { internalid: [{ value: '2' }], name: 'Tax Schedule 2' },
-            { internalid: [{ value: '3' }], name: 'Tax Schedule 3' },
+            {
+              allocationType: [
+                {
+                  value: '2',
+                  text: 'Allocation Type 2',
+                },
+              ],
+            },
           ]
-        }
-        if (filters.length === 0) {
-          return _.range(50).map(_i => ({
-            allocationType: [
-              {
-                value: '1',
-                text: 'Allocation Type 1',
-              },
-            ],
-          }))
-        }
-        return [
-          {
-            allocationType: [
-              {
-                value: '2',
-                text: 'Allocation Type 2',
-              },
-            ],
+        })
+        await updateSuiteQLTableInstances({
+          client,
+          queryBy: 'internalId',
+          itemsToQuery: [
+            { tableName: 'currency', item: '3' },
+            { tableName: 'currency', item: '4' },
+            { tableName: 'currency', item: '5' },
+            { tableName: 'taxSchedule', item: '1' },
+            { tableName: 'taxSchedule', item: '2' },
+            { tableName: 'taxSchedule', item: '3' },
+            { tableName: 'allocationType', item: '1' },
+            { tableName: 'allocationType', item: '2' },
+            { tableName: 'item', item: '1' },
+          ],
+          suiteQLTablesMap: _.keyBy(result.elements.filter(isInstanceElement), instance => instance.elemID.name),
+        })
+      })
+
+      it('should update instance values correctly', () => {
+        expect(suiteQLTableInstance.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Some name' },
+            2: { name: 'Some name 2' },
+            3: { name: 'Some name 3 - updated' },
+            4: { name: 'Some name 4' },
+            5: { name: 'Some name 5' },
           },
-        ]
+        })
       })
-      const elementsSource = buildElementsSourceFromElements([])
-      result = await getSuiteQLTableElements(config, client, elementsSource, false)
-    })
 
-    it('should return all elements', () => {
-      // minus 2 for the skipped table (TYPE_TO_SKIP) and the table with too many records (TYPE_WITH_MAX_RESULTS)
-      expect(result.elements).toHaveLength(NUM_OF_SUITEQL_ELEMENTS - 2)
-      expect(result.elements.every(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] === true)).toBeTruthy()
-    })
-
-    it('should set instance values correctly', () => {
-      const instanceWithInternalIdsRecords = result.elements
-        .filter(isInstanceElement)
-        .find(element => QUERIES_BY_TABLE_NAME[element.elemID.name as SuiteQLTableName]?.nameField === 'name')
-      expect(instanceWithInternalIdsRecords?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Some name' },
-          2: { name: 'Some name 2' },
-          3: { name: 'Some name 3' },
-        },
-        version: 1,
+      it('should set tax schedule instance values correctly', () => {
+        const taxScheduleInstance = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === TAX_SCHEDULE)
+        expect(taxScheduleInstance?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Tax Schedule 1' },
+            2: { name: 'Tax Schedule 2' },
+            3: { name: 'Tax Schedule 3' },
+          },
+        })
       })
-    })
 
-    it('should set tax schedule instance values correctly', () => {
-      const taxScheduleInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === TAX_SCHEDULE)
-      expect(taxScheduleInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Tax Schedule 1' },
-          2: { name: 'Tax Schedule 2' },
-          3: { name: 'Tax Schedule 3' },
-        },
-        version: 1,
+      it('should set allocation type instance values correctly', () => {
+        const allocationTypeInstance = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === ALLOCATION_TYPE)
+        expect(allocationTypeInstance?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Allocation Type 1' },
+            2: { name: 'Allocation Type 2' },
+          },
+        })
       })
-    })
 
-    it('should set allocation type instance values correctly', () => {
-      const allocationTypeInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === ALLOCATION_TYPE)
-      expect(allocationTypeInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Allocation Type 1' },
-          2: { name: 'Allocation Type 2' },
-        },
-        version: 1,
+      it('should call runSuiteQL with right params', () => {
+        expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          from: 'currency',
+          orderBy: 'id',
+          select: 'id, name',
+          where: "id in ('3', '4', '5')",
+        })
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          from: 'item',
+          orderBy: 'id',
+          select: 'id, itemid',
+          where: "id in ('1')",
+        })
       })
-    })
 
-    it('should call runSavedSearch with right params', () => {
-      expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(4)
-      expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
-        type: TAX_SCHEDULE,
-        columns: ['internalid', 'name'],
-        filters: [],
+      it('should call runSavedSearch with right params', () => {
+        expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(3)
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
+          type: TAX_SCHEDULE,
+          columns: ['internalid', 'name'],
+          filters: [['internalid', 'anyof', '1', '2', '3']],
+        })
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
+          {
+            type: 'resourceAllocation',
+            columns: [ALLOCATION_TYPE],
+            filters: [[ALLOCATION_TYPE, 'anyof', '1', '2']],
+          },
+          50,
+        )
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
+          {
+            type: 'resourceAllocation',
+            columns: [ALLOCATION_TYPE],
+            filters: [[ALLOCATION_TYPE, 'anyof', '2']],
+          },
+          50,
+        )
       })
-      expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
-        type: PROJECT_EXPENSE_TYPE,
-        columns: ['internalid', 'name'],
-        filters: [],
-      })
-      expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
-        {
-          type: 'resourceAllocation',
-          columns: [ALLOCATION_TYPE],
-          filters: [],
-        },
-        50,
-      )
-      expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
-        {
-          type: 'resourceAllocation',
-          columns: [ALLOCATION_TYPE],
-          filters: [[ALLOCATION_TYPE, 'noneof', '1']],
-        },
-        50,
-      )
-    })
 
-    it('should not set values when name field do not match', () => {
-      const instanceWithoutInternalIdsRecords = result.elements
-        .filter(isInstanceElement)
-        .find(element => QUERIES_BY_TABLE_NAME[element.elemID.name as SuiteQLTableName]?.nameField === 'title')
-      expect(instanceWithoutInternalIdsRecords?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {},
-        version: 1,
+      it('should not set values when name field do not match', () => {
+        const instanceWithoutInternalIdsRecords = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === 'item')
+        expect(instanceWithoutInternalIdsRecords?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {},
+        })
       })
     })
 
-    it('should skip tables from skipResolvingAccountSpecificValuesToTypes', () => {
-      expect(result.elements.find(elem => elem.elemID.name === TYPE_TO_SKIP)).toBeUndefined()
-      expect(runSuiteQLMock).not.toHaveBeenCalledWith(expect.stringContaining(`FROM ${TYPE_TO_SKIP} `))
-    })
-
-    it('should skip tables that reach the records limitation', () => {
-      const query = QUERIES_BY_TABLE_NAME[TYPE_WITH_MAX_RESULTS]
-      expect(result.largeSuiteQLTables).toEqual([TYPE_WITH_MAX_RESULTS])
-      expect(result.elements.find(elem => elem.elemID.name === TYPE_WITH_MAX_RESULTS)).toBeUndefined()
-      expect(runSuiteQLMock).not.toHaveBeenCalledWith(
-        expect.stringContaining(`SELECT ${query?.internalIdField}, ${query?.nameField} FROM ${TYPE_WITH_MAX_RESULTS} `),
-      )
-    })
-
-    it('should not skip tables with configured records limitation', () => {
-      const query = QUERIES_BY_TABLE_NAME[TYPE_WITH_ALLOWED_MAX_RESULTS]
-      expect(result.elements.find(elem => elem.elemID.name === TYPE_WITH_ALLOWED_MAX_RESULTS)).toBeDefined()
-      expect(runSuiteQLMock).toHaveBeenCalledWith(
-        expect.objectContaining({
-          select: `${query?.internalIdField}, ${query?.nameField}`,
-          from: TYPE_WITH_ALLOWED_MAX_RESULTS,
-        }),
-      )
-    })
-  })
-
-  describe('when there are existing instances', () => {
-    beforeEach(async () => {
-      runSuiteQLMock.mockImplementation(query =>
-        query.select.includes('count(*)')
-          ? [{ count: '3' }]
-          : [
-              { id: '1', name: 'Updated name' },
-              { id: '4', name: 'New name 4' },
-              { id: '5', name: 'New name 5' },
-            ],
-      )
-      const elementsSource = buildElementsSourceFromElements([
-        serverTimeType,
-        serverTimeInstance,
-        suiteQLTableType,
-        suiteQLTableInstance,
-        oldSuiteQLTableInstance,
-        emptySuiteQLTableInstance,
-      ])
-      result = await getSuiteQLTableElements(config, client, elementsSource, false)
-    })
-
-    it('should update existing instance values', () => {
-      const updatedInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'currency')
-      expect(updatedInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Updated name' },
-          2: { name: 'Some name 2' },
-          3: { name: 'Some name 3' },
-          4: { name: 'New name 4' },
-          5: { name: 'New name 5' },
-        },
-        version: 1,
+    describe('query by name', () => {
+      beforeEach(async () => {
+        runSuiteQLMock.mockResolvedValue([
+          { id: '4', name: 'Some name 4' },
+          { id: '5', name: 'Some name 5' },
+        ])
+        runSavedSearchQueryMock.mockImplementation(({ type, filters }) => {
+          if (type !== 'resourceAllocation') {
+            return [{ internalid: [{ value: '1' }], name: 'Tax Schedule 1' }]
+          }
+          if (_.isEmpty(filters)) {
+            return _.range(50).map(_i => ({
+              allocationType: [
+                {
+                  value: '1',
+                  text: 'Allocation Type 1',
+                },
+              ],
+            }))
+          }
+          return [
+            {
+              allocationType: [
+                {
+                  value: '2',
+                  text: 'Allocation Type 2',
+                },
+              ],
+            },
+          ]
+        })
+        await updateSuiteQLTableInstances({
+          client,
+          queryBy: 'name',
+          itemsToQuery: [
+            { tableName: 'currency', item: 'Some name 4' },
+            { tableName: 'currency', item: 'Some name 5' },
+            { tableName: 'taxSchedule', item: 'Tax Schedule 1' },
+            { tableName: 'taxSchedule', item: 'Tax Schedule 2' },
+            { tableName: 'taxSchedule', item: 'Tax Schedule 3' },
+            { tableName: 'allocationType', item: 'Allocation Type 2' },
+            { tableName: 'item', item: 'Some item' },
+          ],
+          suiteQLTablesMap: _.keyBy(result.elements.filter(isInstanceElement), instance => instance.elemID.name),
+        })
       })
-    })
 
-    it('should override existing values when instance version is not latest version', () => {
-      const updatedInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'department')
-      expect(updatedInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Updated name' },
-          4: { name: 'New name 4' },
-          5: { name: 'New name 5' },
-        },
-        version: 1,
+      it('should update instance values correctly', () => {
+        expect(suiteQLTableInstance.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Some name' },
+            2: { name: 'Some name 2' },
+            3: { name: 'Some name 3' },
+            4: { name: 'Some name 4' },
+            5: { name: 'Some name 5' },
+          },
+        })
       })
-    })
 
-    it('should add values to empty instance', () => {
-      const updatedInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'subsidiary')
-      expect(updatedInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Updated name' },
-          4: { name: 'New name 4' },
-          5: { name: 'New name 5' },
-        },
-        version: 1,
+      it('should set tax schedule instance values correctly', () => {
+        const taxScheduleInstance = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === TAX_SCHEDULE)
+        expect(taxScheduleInstance?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            1: { name: 'Tax Schedule 1' },
+          },
+        })
       })
-    })
 
-    it('should call runSuiteQL with right queries', () => {
-      // instance with latest version is called with lastmodifieddate
-      expect(runSuiteQLMock).toHaveBeenCalledWith({
-        select: 'id, name',
-        from: 'currency',
-        where: "lastmodifieddate >= TO_DATE('2024-1-1', 'YYYY-MM-DD')",
-        orderBy: 'id',
+      it('should set allocation type instance values correctly', () => {
+        const allocationTypeInstance = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === ALLOCATION_TYPE)
+        expect(allocationTypeInstance?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {
+            2: { name: 'Allocation Type 2' },
+          },
+        })
       })
-      // instance without latest version is called without lastmodifieddate
-      expect(runSuiteQLMock).toHaveBeenCalledWith({ select: 'id, name', from: 'department', orderBy: 'id' })
-      // empty instance with latest version is called with lastmodifieddate
-      expect(runSuiteQLMock).toHaveBeenCalledWith({
-        select: 'id, name',
-        from: 'subsidiary',
-        where: "lastmodifieddate >= TO_DATE('2024-1-1', 'YYYY-MM-DD')",
-        orderBy: 'id',
-      })
-    })
-  })
 
-  describe('when isPartial=true', () => {
-    beforeEach(async () => {
-      runSuiteQLMock.mockImplementation(query =>
-        query.select.includes('count(*)')
-          ? [{ count: '3' }]
-          : [
-              { id: '1', entityid: 'Some name' },
-              { id: '2', entityid: 'Some name 2' },
-              { id: '3', entityid: 'Some name 3' },
-            ],
-      )
-      const elementsSource = buildElementsSourceFromElements([
-        suiteQLTableType,
-        suiteQLTableInstance,
-        oldSuiteQLTableInstance,
-        emptySuiteQLTableInstance,
-      ])
-      result = await getSuiteQLTableElements(config, client, elementsSource, true)
-    })
-
-    it('should return only existing instances and employee instance', () => {
-      expect(result.elements).toHaveLength(5)
-      const existingInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'currency')
-      expect(existingInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Some name' },
-          2: { name: 'Some name 2' },
-          3: { name: 'Some name 3' },
-        },
-        version: 1,
+      it('should call runSuiteQL with right params', () => {
+        expect(runSuiteQLMock).toHaveBeenCalledTimes(2)
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          from: 'currency',
+          orderBy: 'id',
+          select: 'id, name',
+          where: "name in ('Some name 4', 'Some name 5')",
+        })
+        expect(runSuiteQLMock).toHaveBeenCalledWith({
+          from: 'item',
+          orderBy: 'id',
+          select: 'id, itemid',
+          where: "itemid in ('Some item')",
+        })
       })
-      const oldExistingInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'department')
-      expect(oldExistingInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Some name' },
-          2: { name: 'Some name 2' },
-          3: { name: 'Some name 3' },
-        },
-        version: 'old',
-      })
-      const emptyExistingInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'subsidiary')
-      expect(emptyExistingInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {},
-        version: 1,
-      })
-      const employeeInstance = result.elements
-        .filter(isInstanceElement)
-        .find(element => element.elemID.name === 'employee')
-      expect(employeeInstance?.value).toEqual({
-        [INTERNAL_IDS_MAP]: {
-          1: { name: 'Some name' },
-          2: { name: 'Some name 2' },
-          3: { name: 'Some name 3' },
-        },
-        version: 1,
-      })
-    })
 
-    it('should not call runSuiteQL', () => {
-      expect(runSuiteQLMock).toHaveBeenCalledTimes(1)
-      expect(runSuiteQLMock).toHaveBeenCalledWith(expect.objectContaining({ from: 'employee' }))
-    })
-  })
+      it('should call runSavedSearch with right params', () => {
+        expect(runSavedSearchQueryMock).toHaveBeenCalledTimes(3)
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith({
+          type: TAX_SCHEDULE,
+          columns: ['internalid', 'name'],
+          filters: [
+            ['name', 'is', 'Tax Schedule 1'],
+            'OR',
+            ['name', 'is', 'Tax Schedule 2'],
+            'OR',
+            ['name', 'is', 'Tax Schedule 3'],
+          ],
+        })
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
+          {
+            type: 'resourceAllocation',
+            columns: [ALLOCATION_TYPE],
+            filters: [],
+          },
+          50,
+        )
+        expect(runSavedSearchQueryMock).toHaveBeenCalledWith(
+          {
+            type: 'resourceAllocation',
+            columns: [ALLOCATION_TYPE],
+            filters: [[ALLOCATION_TYPE, 'noneof', '1']],
+          },
+          50,
+        )
+      })
 
-  describe('when fetch.resolveAccountSpecificValues=false', () => {
-    beforeEach(async () => {
-      config.fetch.resolveAccountSpecificValues = false
-      const elementsSource = buildElementsSourceFromElements([])
-      result = await getSuiteQLTableElements(config, client, elementsSource, false)
-    })
-    it('should not return elements', () => {
-      expect(result.elements).toHaveLength(0)
-    })
-    it('should not run queries', () => {
-      expect(runSuiteQLMock).not.toHaveBeenCalled()
-      expect(runSavedSearchQueryMock).not.toHaveBeenCalled()
-    })
-  })
-
-  describe('when fetch.skipResolvingAccountSpecificValuesToTypes=[".*"]', () => {
-    beforeEach(async () => {
-      config.fetch.skipResolvingAccountSpecificValuesToTypes = ['.*']
-      const elementsSource = buildElementsSourceFromElements([])
-      result = await getSuiteQLTableElements(config, client, elementsSource, false)
-    })
-    it('should not return elements', () => {
-      expect(result.elements).toHaveLength(1)
-      expect(result.elements[0].elemID).toEqual(suiteQLTableType.elemID)
-    })
-    it('should not run queries', () => {
-      expect(runSuiteQLMock).not.toHaveBeenCalled()
-      expect(runSavedSearchQueryMock).not.toHaveBeenCalled()
+      it('should not set values when name field do not match', () => {
+        const instanceWithoutInternalIdsRecords = result.elements
+          .filter(isInstanceElement)
+          .find(element => element.elemID.name === 'item')
+        expect(instanceWithoutInternalIdsRecords?.value).toEqual({
+          [INTERNAL_IDS_MAP]: {},
+        })
+      })
     })
   })
 })


### PR DESCRIPTION
Instead of fetching all SuiteQL tables data, we want to fetch only the referenced internalIds in workflows and data instances.


---

_Additional context for reviewer_

~~This PR is based on #6102 . Please review it first.~~

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Query referenced ASV only

---
_User Notifications_: 
None