### PR TITLE
SALTO-5897: order workspace macro_ids and selected_macros

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -267,6 +267,44 @@ const orderArticleLabelNames = (instances: InstanceElement[]): void => {
     })
 }
 
+const orderMacroIds = (workspace: InstanceElement): void => {
+  const macroIds = workspace.value.macro_ids
+  if (_.isArray(macroIds)) {
+    workspace.value.macro_ids = _.sortBy(macroIds, id => {
+      if (isReferenceExpression(id)) {
+        return id.elemID.getFullName()
+      }
+      return id
+    })
+  } else {
+    log.trace(`macro_ids in workspace ${workspace.elemID.getFullName()} is not an array`)
+  }
+}
+const orderSelectedMacros = (workspace: InstanceElement): void => {
+  const selectedMacros = workspace.value.selected_macros
+  if (_.isArray(selectedMacros) && selectedMacros.every(macro => macro.id !== undefined)) {
+    workspace.value.selected_macros = _.sortBy(selectedMacros, macro => {
+      if (isReferenceExpression(macro.id)) {
+        return macro.id.elemID.getFullName()
+      }
+      return macro.id
+    })
+  } else {
+    log.trace(
+      `selected macros in workspace ${workspace.elemID.getFullName()} is not an array or one of the macros does not have an id`,
+    )
+  }
+}
+
+const orderMacrosInWorkspace = (instances: InstanceElement[]): void => {
+  instances
+    .filter(e => e.elemID.typeName === WORKSPACE_TYPE_NAME)
+    .forEach(workspace => {
+      orderMacroIds(workspace)
+      orderSelectedMacros(workspace)
+    })
+}
+
 const orderAppInstallationsInWorkspace = (instances: InstanceElement[]): void => {
   instances
     .filter(e => e.elemID.typeName === WORKSPACE_TYPE_NAME)
@@ -299,6 +337,7 @@ const filterCreator: FilterCreator = () => ({
     orderArticleLabelNames(instances)
     orderAppInstallationsInWorkspace(instances)
     orderRoutingAttributes(instances)
+    orderMacrosInWorkspace(instances)
   },
 })
 


### PR DESCRIPTION
order workspace macro_ids and selected_macros

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* order workspace macro_ids and selected_macros

---
_User Notifications_: 
zendesk:
* order workspace macro_ids and selected_macros, to eliminate order diffs between envs
