### PR TITLE
SALTO-6141: support extendParent for pathParts

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -64,7 +64,7 @@ export type ElemIDDefinition<TCustomNameMappingOptions extends string = never> =
 
 export type PathDefinition<TCustomNameMappingOptions extends string = never> = {
   // when id parts info is missing, inherited from elemID (but the values are path-nacl-cased)
-  pathParts?: IDPartsDefinition<TCustomNameMappingOptions>[]
+  pathParts?: IDPartsDefinition<TCustomNameMappingOptions>[] & { extendsParent?: boolean }
 }
 
 type StandaloneFieldDefinition = {

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -248,6 +248,29 @@ describe('id utils', () => {
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual(['myAdapter', 'Records', 'myType', 'thisIsACuteCustomName'])
     })
+    it('should calculate correct path when extendParent is true', () => {
+      const parent = new InstanceElement('parent_name@s', new ObjectType({ elemID: typeID }))
+      expect(
+        getElemPath({
+          def: {
+            pathParts: [
+              {
+                parts: [{ fieldName: 'a', mapping: 'customTest' }],
+                extendsParent: true,
+              },
+            ],
+          },
+          typeID,
+          elemIDCreator: createElemIDFunc({
+            elemIDDef: {
+              parts: [{ fieldName: 'a' }],
+            },
+            typeID,
+            customNameMappingFunctions: {},
+          }),
+        })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed', parent }),
+      ).toEqual(['myAdapter', 'Records', 'myType', 'parent_name__A'])
+    })
     it('should set path to settings folder if singleton', () => {
       expect(
         getElemPath({

--- a/packages/adapter-components/test/filters/referenced_instance_names.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_names.test.ts
@@ -127,6 +127,13 @@ describe('referenced instances', () => {
         bookId: { refType: BuiltinTypes.NUMBER },
       },
     })
+    const pathWithExtendParentType = new ObjectType({
+      elemID: new ElemID(ADAPTER_NAME, 'pathWithExtendParent'),
+      fields: {
+        id: { refType: BuiltinTypes.NUMBER },
+        first: { refType: BuiltinTypes.STRING },
+      },
+    })
     const rootBook = new InstanceElement('rootBook', bookType, {
       id: 123,
       parent_book_id: 'ROOT',
@@ -300,6 +307,19 @@ describe('referenced instances', () => {
       },
     )
 
+    const pathWithExtendParentInstance = new InstanceElement(
+      'pathWithExtendParent',
+      pathWithExtendParentType,
+      {
+        id: 321,
+        first: 'fiRst',
+      },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(nestingParent.elemID, nestingParent),
+      },
+    )
+
     return [
       recipeType,
       bookType,
@@ -334,6 +354,8 @@ describe('referenced instances', () => {
       differentMappingFunctionInstance,
       complicatedPathType,
       complicatedPathInstance,
+      pathWithExtendParentType,
+      pathWithExtendParentInstance,
     ]
   }
   const lowercaseName: NameMappingOptions = 'lowercase'
@@ -622,6 +644,35 @@ describe('referenced instances', () => {
               },
             },
           },
+          pathWithExtendParent: {
+            element: {
+              topLevel: {
+                isTopLevel: true,
+                elemID: {
+                  parts: [{ fieldName: 'bookId', isReference: true }],
+                },
+                path: {
+                  pathParts: [
+                    {
+                      parts: [
+                        {
+                          fieldName: 'id',
+                        },
+                      ],
+                    },
+                    {
+                      parts: [
+                        {
+                          fieldName: 'first',
+                        },
+                      ],
+                      extendsParent: true,
+                    },
+                  ],
+                },
+              },
+            },
+          },
         },
       },
     },
@@ -668,6 +719,7 @@ describe('referenced instances', () => {
         'myAdapter.noIdFields.instance.no_idFieldsParent',
         'myAdapter.notNestingParent.instance.notNestingParent',
         'myAdapter.notStandaloneNestedField.instance.notNestingParent__fishyName',
+        'myAdapter.pathWithExtendParent.instance.pathWithExtendParent',
         'myAdapter.recipe.instance.recipe123_123_ROOT',
         'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
         'myAdapter.recipe.instance.recipe456_456_123_ROOT',
@@ -700,6 +752,7 @@ describe('referenced instances', () => {
         'myAdapter/Records/folder/recipe123_123_ROOT__lastRecipe_456_123_ROOT__Documents',
         'myAdapter/Records/noIdFields/no_idFieldsParent',
         'myAdapter/Records/notStandaloneNestedField/notNestingParent__fishyName',
+        'myAdapter/Records/pathWithExtendParent/321/nestingParent__fiRst',
         'myAdapter/Records/recipe/recipe123_123_ROOT',
         'myAdapter/Records/recipe/recipe123_123_ROOT__lastRecipe_456_123_ROOT',
         'myAdapter/Records/recipe/recipe456_456_123_ROOT',
@@ -719,7 +772,7 @@ describe('referenced instances', () => {
         .filter(isInstanceElement)
         .map(i => i.elemID.getFullName())
         .sort()
-      expect(result.length).toEqual(37)
+      expect(result.length).toEqual(39)
       expect(sortedResult).toEqual([
         'myAdapter.book.instance.123_ROOT',
         'myAdapter.book.instance.456_123_ROOT',
@@ -738,6 +791,7 @@ describe('referenced instances', () => {
         'myAdapter.noIdFields.instance.no_idFieldsParent',
         'myAdapter.notNestingParent.instance.notNestingParent',
         'myAdapter.notStandaloneNestedField.instance.notNestingParent__fishyName',
+        'myAdapter.pathWithExtendParent.instance.pathWithExtendParent',
         'myAdapter.recipe.instance.recipe123_123_ROOT',
         'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
         'myAdapter.recipe.instance.recipe456_456_123_ROOT',
@@ -780,7 +834,7 @@ describe('referenced instances', () => {
     })
     it('should not change name for duplicate elemIDs', async () => {
       const result = (await addReferencesToInstanceNames(elements, defQuery)).filter(isInstanceElement)
-      expect(result.length).toEqual(24)
+      expect(result.length).toEqual(25)
       expect(result.map(e => e.elemID.getFullName()).sort()).toEqual([
         'myAdapter.book.instance.123_ROOT',
         'myAdapter.book.instance.456_123_ROOT',
@@ -799,6 +853,7 @@ describe('referenced instances', () => {
         'myAdapter.noIdFields.instance.no_idFieldsParent',
         'myAdapter.notNestingParent.instance.notNestingParent',
         'myAdapter.notStandaloneNestedField.instance.notNestingParent__fishyName',
+        'myAdapter.pathWithExtendParent.instance.pathWithExtendParent',
         'myAdapter.recipe.instance.recipe123_123_ROOT',
         'myAdapter.recipe.instance.recipe123_123_ROOT__lastRecipe_456_123_ROOT',
         'myAdapter.recipe.instance.recipe456_456_123_ROOT',


### PR DESCRIPTION
support extendParent for pathParts

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
