### PR TITLE
SALTO-6150 Fix merge error on custom record type addition in the apply-patch flow

### DIFF
--- a/packages/netsuite-adapter/src/custom_records/custom_record_type.ts
+++ b/packages/netsuite-adapter/src/custom_records/custom_record_type.ts
@@ -79,7 +79,8 @@ const createCustomRecordType = (
     },
     annotationRefsOrTypes: {
       ...annotationRefsOrTypes,
-      source: BuiltinTypes.HIDDEN_STRING,
+      [SOURCE]: BuiltinTypes.HIDDEN_STRING,
+      [INTERNAL_ID]: BuiltinTypes.HIDDEN_STRING,
     },
     annotations: {
       ...instanceValues,
@@ -101,7 +102,7 @@ export const createCustomRecordTypes = (
       label: { refType: BuiltinTypes.STRING },
     },
     annotationRefsOrTypes: {
-      source: BuiltinTypes.HIDDEN_STRING,
+      [SOURCE]: BuiltinTypes.HIDDEN_STRING,
     },
     annotations: {
       [SOURCE]: SOAP,
@@ -115,7 +116,7 @@ export const createCustomRecordTypes = (
       },
     },
     annotationRefsOrTypes: {
-      source: BuiltinTypes.HIDDEN_STRING,
+      [SOURCE]: BuiltinTypes.HIDDEN_STRING,
     },
     annotations: {
       [SOURCE]: SOAP,

--- a/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
+++ b/packages/netsuite-adapter/src/filters/internal_ids/sdf_internal_ids.ts
@@ -26,7 +26,6 @@ import {
   isInstanceChange,
   isInstanceElement,
   isObjectType,
-  TypeReference,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import Ajv from 'ajv'
@@ -117,20 +116,6 @@ const queryRecordIds = async (
     scriptid: res.scriptid,
     id: 'id' in res ? res.id : res.internalid,
   }))
-}
-
-const addInternalIdAnnotationToCustomRecordTypes = (elements: Element[]): void => {
-  elements
-    .filter(isObjectType)
-    .filter(isCustomRecordType)
-    .forEach(object => {
-      if (_.isUndefined(object.annotationRefTypes[INTERNAL_ID])) {
-        object.annotationRefTypes[INTERNAL_ID] = new TypeReference(
-          BuiltinTypes.HIDDEN_STRING.elemID,
-          BuiltinTypes.HIDDEN_STRING,
-        )
-      }
-    })
 }
 
 const isSavedSearch = (element: Element): boolean => element.elemID.typeName === SAVED_SEARCH
@@ -287,7 +272,6 @@ const filterCreator: RemoteFilterCreator = ({ client }) => ({
       return
     }
     addInternalIdFieldToSupportedType(elements)
-    addInternalIdAnnotationToCustomRecordTypes(elements)
 
     const instances = elements.filter(isInstanceElement).filter(isSupportedInstance)
     await addInternalIdToInstances(client, instances)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -810,7 +810,7 @@ describe('Adapter', () => {
               scriptid: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.REQUIRED]: true } },
               internalId: { refType: BuiltinTypes.SERVICE_ID, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
             },
-            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING },
+            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING, internalId: BuiltinTypes.HIDDEN_STRING },
             annotations: {
               scriptid: 'customrecord_locked1',
               source: 'soap',
@@ -825,7 +825,7 @@ describe('Adapter', () => {
               scriptid: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.REQUIRED]: true } },
               internalId: { refType: BuiltinTypes.SERVICE_ID, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
             },
-            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING },
+            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING, internalId: BuiltinTypes.HIDDEN_STRING },
             annotations: {
               scriptid: 'customrecord_locked2',
               source: 'soap',

--- a/packages/netsuite-adapter/test/custom_records/custom_record_type.test.ts
+++ b/packages/netsuite-adapter/test/custom_records/custom_record_type.test.ts
@@ -39,7 +39,9 @@ describe('custom record type transformer', () => {
         scriptid: 'customrecord1',
         source: 'soap',
       })
-      expect(Object.keys(customRecordType.annotationRefTypes)).toEqual(Object.keys(type.fields).concat('source'))
+      expect(Object.keys(customRecordType.annotationRefTypes)).toEqual(
+        Object.keys(type.fields).concat('source', 'internalId'),
+      )
       expect(Object.keys(customRecordType.fields)).toEqual([SCRIPT_ID, INTERNAL_ID, 'translationsList'])
       expect(customRecordType.path).toEqual([NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord1'])
     })

--- a/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
+++ b/packages/netsuite-adapter/test/filters/internal_ids/sdf_internal_ids.test.ts
@@ -211,7 +211,6 @@ describe('sdf internal ids tests', () => {
       expect(otherCustomFieldInstance.value.internalId).toBe('5')
     })
     it('should add field to object', () => {
-      expect(customRecordType.annotationRefTypes.internalId).toBeDefined()
       expect(clientScriptType.fields.internalId).toBeDefined()
     })
   })


### PR DESCRIPTION
In the apply-patch flow we’re not creating the `internalId` annotation ref on added custom record types, that is a hidden string, and the result is that after the deploy we populate the `internalId` annotation of the custom record type and it is visible and not hidden. Then in the next fetch we fetch the created custom record type, this time with the `internalId` annotation ref, and it makes a merge error because `internalId` is already visible in the nacl.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix merge error on custom record type addition in the apply-patch flow

---
_User Notifications_: 
None