### PR TITLE
SAAS-9608: Returning SF instance URL in client extra info

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -588,6 +588,22 @@ export const getConnectionDetails = async (
   }
 }
 
+const getAccountID = (
+  credentials: Credentials,
+  orgId: string,
+  instanceUrl?: string,
+): string => {
+  if (credentials.isSandbox) {
+    if (instanceUrl === undefined) {
+      throw new Error(
+        'Expected Salesforce organization URL to exist in the connection',
+      )
+    }
+    return instanceUrl
+  }
+  return orgId
+}
+
 export const validateCredentials = async (
   credentials: Credentials,
   minApiRequestsRemaining = 0,
@@ -605,24 +621,11 @@ export const validateCredentials = async (
       `Remaining limits: ${remainingDailyRequests}, needed: ${minApiRequestsRemaining}`,
     )
   }
-  if (credentials.isSandbox) {
-    if (instanceUrl === undefined) {
-      throw new Error(
-        'Expected Salesforce organization URL to exist in the connection',
-      )
-    }
-    return {
-      accountId: instanceUrl,
-      accountType,
-      isProduction,
-      extraInformation: { orgId },
-    }
-  }
   return {
-    accountId: orgId,
+    accountId: getAccountID(credentials, orgId, instanceUrl),
     accountType,
     isProduction,
-    extraInformation: { orgId },
+    extraInformation: { orgId, instanceUrl: instanceUrl ?? '' },
   }
 }
 

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -672,7 +672,7 @@ describe('salesforce client', () => {
         accountId: '',
         isProduction: undefined,
         accountType: undefined,
-        extraInformation: { orgId: '' },
+        extraInformation: { orgId: '', instanceUrl: '' },
       })
     })
     describe('isProduction and accountType', () => {
@@ -709,7 +709,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
             })
           })
         })
@@ -727,7 +727,7 @@ describe('salesforce client', () => {
               accountId: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
             })
           })
           it('should throw an error when there is no instanceUrl', async () => {
@@ -756,7 +756,7 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: true,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
             })
           })
         })
@@ -774,7 +774,7 @@ describe('salesforce client', () => {
               accountId: '',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '' },
+              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
             })
           })
         })


### PR DESCRIPTION
It's good to have even for non sandbox orgs.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.