### PR TITLE
SALTO-6131 - Prioritize namespace tags on top of global tags

### DIFF
--- a/packages/logging/src/internal/pino.ts
+++ b/packages/logging/src/internal/pino.ts
@@ -288,7 +288,7 @@ export const loggerRepo = (
          We must "normalize" logTags because there are types of tags that pino doesn't support
          for example - Functions.
          */
-        const normalizedLogTags = normalizeLogTags({ ...namespaceTags, ...global.globalLogTags })
+        const normalizedLogTags = normalizeLogTags({ ...global.globalLogTags, ...namespaceTags })
         const [formattedOrError, unconsumedArgs] =
           typeof message === 'string' ? formatMessage(message, ...args) : [message, args]
 

--- a/packages/logging/test/internal/pino_logger.test.ts
+++ b/packages/logging/test/internal/pino_logger.test.ts
@@ -392,6 +392,7 @@ describe('pino based logger', () => {
             initialConfig.globalTags = logTags
             logger = createLogger()
             logger.assignGlobalTags({ newTag: 'data', superNewTag: 'tag', functionTag: () => 5 })
+            logger.assignTags({ newTag: 'overridden' })
             await logLine({ level: 'warn' })
           })
           it('should contain old tags', () => {
@@ -406,7 +407,7 @@ describe('pino based logger', () => {
             expect(line).toContain('hello { world: true }')
           })
           it('should contain new logTags also', async () => {
-            expect(line).toContain('newTag="data"')
+            expect(line).toContain('newTag="overridden"')
             expect(line).toContain('functionTag=5')
             expect(line).toContain('superNewTag="tag"')
           })


### PR DESCRIPTION
Prioritize namespace tags on top of global tags

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
