### PR TITLE
SAAS-6162 Improve performance on template body filter

### DIFF
--- a/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
+++ b/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
@@ -141,20 +141,21 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
         spaceByKey: {},
         pageBySpaceFullNameAndTitle: {},
       }
-      instances.forEach(
-        inst => {
-          if (inst.elemID.typeName === SPACE_TYPE_NAME) {
-            indices.spaceByKey[inst.value.key] = inst
-          } else if (inst.elemID.typeName === PAGE_TYPE_NAME) {
-            const spaceRef = inst.value.spaceId
-            if (!isReferenceExpression(spaceRef)) {
-              return
-            }
-            const spaceFullName = spaceRef.elemID.getFullName()
-            indices.pageBySpaceFullNameAndTitle[spaceFullName] = _.merge(indices.pageBySpaceFullNameAndTitle[spaceFullName], { [inst.value.title]: inst, })
+      instances.forEach(inst => {
+        if (inst.elemID.typeName === SPACE_TYPE_NAME) {
+          indices.spaceByKey[inst.value.key] = inst
+        } else if (inst.elemID.typeName === PAGE_TYPE_NAME) {
+          const spaceRef = inst.value.spaceId
+          if (!isReferenceExpression(spaceRef)) {
+            return
           }
-        },
-      )
+          const spaceFullName = spaceRef.elemID.getFullName()
+          indices.pageBySpaceFullNameAndTitle[spaceFullName] = _.merge(
+            indices.pageBySpaceFullNameAndTitle[spaceFullName],
+            { [inst.value.title]: inst },
+          )
+        }
+      })
 
       const templateInstances = instances.filter(inst => TEMPLATE_TYPE_NAMES.includes(inst.elemID.typeName))
       templateInstances.forEach(templateInst => {

--- a/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
+++ b/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
@@ -137,25 +137,22 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
     name: 'templateBodyToTemplateExpressionFilter',
     onFetch: async elements => {
       const instances = elements.filter(isInstanceElement)
-      const indices: PossibleRefsInTemplateIndices = instances.reduce<PossibleRefsInTemplateIndices>(
-        (acc, inst) => {
+      const indices: PossibleRefsInTemplateIndices = {
+        spaceByKey: {},
+        pageBySpaceFullNameAndTitle: {},
+      }
+      instances.forEach(
+        inst => {
           if (inst.elemID.typeName === SPACE_TYPE_NAME) {
-            acc.spaceByKey[inst.value.key] = inst
+            indices.spaceByKey[inst.value.key] = inst
           } else if (inst.elemID.typeName === PAGE_TYPE_NAME) {
             const spaceRef = inst.value.spaceId
             if (!isReferenceExpression(spaceRef)) {
-              return acc
+              return
             }
-            acc.pageBySpaceFullNameAndTitle[inst.value.spaceId.elemID.getFullName()] = {
-              ...acc.pageBySpaceFullNameAndTitle[inst.value.spaceId.elemID.getFullName()],
-              [inst.value.title]: inst,
-            }
+            const spaceFullName = spaceRef.elemID.getFullName()
+            indices.pageBySpaceFullNameAndTitle[spaceFullName] = _.merge(indices.pageBySpaceFullNameAndTitle[spaceFullName], { [inst.value.title]: inst, })
           }
-          return acc
-        },
-        {
-          spaceByKey: {},
-          pageBySpaceFullNameAndTitle: {},
         },
       )
 

--- a/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
+++ b/packages/confluence-adapter/src/filters/transform_template_body_to_template_expression.ts
@@ -144,7 +144,8 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
       instances.forEach(inst => {
         if (inst.elemID.typeName === SPACE_TYPE_NAME) {
           indices.spaceByKey[inst.value.key] = inst
-        } else if (inst.elemID.typeName === PAGE_TYPE_NAME) {
+        }
+        if (inst.elemID.typeName === PAGE_TYPE_NAME) {
           const spaceRef = inst.value.spaceId
           if (!isReferenceExpression(spaceRef)) {
             return


### PR DESCRIPTION
Create indices using `reduce` and `...` spreading was not efficient

---

Adding data from running the filter on 42k instances (99% of them are from type `page`)
before:
"(templateBodyToTemplateExpressionFilter):onFetch took 404669 ms"}
after:
"(templateBodyToTemplateExpressionFilter):onFetch took 177 ms" 🤯 

---

_Release Notes_: 
None

---

_User Notifications_: 
None