### PR TITLE
SALTO-6165_Improve_referenced_instance_name_filter_efficiency

### DIFF
--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -210,7 +210,7 @@ const createGraph = <TOptions extends APIDefinitionsOptions = {}>(
   elements: Element[],
   fetchDefinitionByType: Record<string, InstanceFetchApiDefinitions<TOptions>>,
 ): DAG<{ instance: InstanceElement; index: number }> => {
-  const duplicateElemIds = new Set(findDuplicates(elements.map(i => i.elemID.getFullName())))
+  const duplicateElemIds = new Set(findDuplicates(elements.filter(isInstanceElement).map(i => i.elemID.getFullName())))
   const duplicateIdsToLog = new Set<string>()
   const isDuplicateInstance = (instanceFullName: string): boolean => {
     if (duplicateElemIds.has(instanceFullName)) {

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -207,10 +207,10 @@ const updateAllReferences = ({
 
 /* Create a graph with instance names as nodes and instance name dependencies as edges */
 const createGraph = <TOptions extends APIDefinitionsOptions = {}>(
-  instances: Element[],
+  elements: Element[],
   fetchDefinitionByType: Record<string, InstanceFetchApiDefinitions<TOptions>>,
 ): DAG<{ instance: InstanceElement; index: number }> => {
-  const duplicateElemIds = new Set(findDuplicates(instances.map(i => i.elemID.getFullName())))
+  const duplicateElemIds = new Set(findDuplicates(elements.map(i => i.elemID.getFullName())))
   const duplicateIdsToLog = new Set<string>()
   const isDuplicateInstance = (instanceFullName: string): boolean => {
     if (duplicateElemIds.has(instanceFullName)) {
@@ -221,7 +221,7 @@ const createGraph = <TOptions extends APIDefinitionsOptions = {}>(
   }
 
   const graph = new DAG<{ instance: InstanceElement; index: number }>()
-  instances.forEach((instance, index) => {
+  elements.forEach((instance, index) => {
     if (!isInstanceElement(instance)) {
       return
     }


### PR DESCRIPTION
Improving running time for referenced instance name filter

---

findIndex is O(n) and we are doing it in the worst case n times. this make the filter running time O(n^2)
adding actual data from fetch on 42K instances (most of them are from type `page` in confluence, which has a reference in its element name)

before:
"(referencedInstanceNames):onFetch took 32647 ms"
after:
"(referencedInstanceNames):onFetch took 7697 ms"

---
_Release Notes_: 
None

---
_User Notifications_: 
None