### PR TITLE
SALTO-6167: add references to user segment ids in article

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -737,6 +737,11 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
     target: { type: 'user_segment' },
   },
   {
+    src: { field: 'user_segment_ids' },
+    serializationStrategy: 'id',
+    target: { type: 'user_segment' },
+  },
+  {
     src: { field: 'permission_group_id' },
     serializationStrategy: 'id',
     target: { type: 'permission_group' },


### PR DESCRIPTION
add references to user segment ids in article

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* add references to user segment ids in article

---
_User Notifications_: 
zendesk:
* add references to user segment ids in article
