### PR TITLE
SALTO-6172 - Salesforce: Missing reference from LightningPage to QuickAction

### DIFF
--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -84,7 +84,10 @@ export type ReferenceSourceTransformation = {
   validate: (referringFieldValue: string | number, serializedRefExpr: string) => boolean
 }
 
-export type ReferenceSourceTransformationName = 'exact' | 'asString' | 'asCaseInsensitiveString'
+const removeGlobalPrefix = (fieldValue: string): string =>
+  fieldValue.startsWith('Global.') ? fieldValue.substr(7) : fieldValue
+
+export type ReferenceSourceTransformationName = 'exact' | 'asString' | 'asCaseInsensitiveString' | 'globalPrefix'
 export const ReferenceSourceTransformationLookup: Record<
   ReferenceSourceTransformationName,
   ReferenceSourceTransformation
@@ -102,6 +105,11 @@ export const ReferenceSourceTransformationLookup: Record<
     transform: fieldValue => _.toString(fieldValue).toLocaleLowerCase(),
     validate: (referringFieldValue, serializedRefExpr) =>
       _.toString(referringFieldValue).toLocaleLowerCase() === _.toString(serializedRefExpr).toLocaleLowerCase(),
+  },
+  globalPrefix: {
+    transform: fieldValue => removeGlobalPrefix(_.toString(fieldValue)),
+    validate: (referringFieldValue, serializedRefExpr) =>
+      removeGlobalPrefix(_.toString(referringFieldValue)) === serializedRefExpr,
   },
 }
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -911,6 +911,11 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'object', parentTypes: ['PermissionSetObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
   },
+  {
+    src: { field: 'value', parentTypes: ['ComponentInstancePropertyListItem'] },
+    sourceTransformation: 'globalPrefix',
+    target: { type: 'QuickAction' },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>


### PR DESCRIPTION
`LightningPage.flexiPageRegions.itemInstances.componentInstances.componentInstanceProperties` may contain references to `QuickAction` when the name value is `"actionNames"`. 
e.g.

```
salesforce.LightningPage SomePage {
  flexiPageRegions = [
    {
      itemInstances = [
        {
          componentInstance = {
            componentInstanceProperties = [
              {
                name = "actionNames"
                valueList = {
                  valueListItems = [
                    {
                      value = "Global.NewTask"
                    },
                    {
                      value = "Opportunity.SomeQuickAction"
                    },
                ]
            }
    ...
```

---

Note the potential `Global.` prefix that needs to be handled if the `QuickAction` is not nested under any object type

Tests: 
 - Created a Lightning page with a global `QuickAction` and verified it becomes a reference after a fetch.

Workspace diff: https://github.com/salto-io/tomsellek-sf-6172/pull/1/files

---
_Release Notes_: 
Salesforce: Will now generate references from `LightningPage` to `QuickAction`.

---
_User Notifications_: 
Salesforce: Will now generate references from `LightningPage` to `QuickAction`.