### PR TITLE
SAAS-9608: Move account URL in to AccountInfo type

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -175,6 +175,7 @@ export const isAdapterSuccessInstallResult = (result: AdapterInstallResult): res
 
 export type AccountInfo = {
   accountId: string
+  accountUrl?: string
   accountType?: string
   isProduction?: boolean
   extraInformation?: Record<string, string>

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -623,9 +623,10 @@ export const validateCredentials = async (
   }
   return {
     accountId: getAccountID(credentials, orgId, instanceUrl),
+    accountUrl: instanceUrl,
     accountType,
     isProduction,
-    extraInformation: { orgId, instanceUrl: instanceUrl ?? '' },
+    extraInformation: { orgId },
   }
 }
 

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -672,7 +672,7 @@ describe('salesforce client', () => {
         accountId: '',
         isProduction: undefined,
         accountType: undefined,
-        extraInformation: { orgId: '', instanceUrl: '' },
+        extraInformation: { orgId: '' },
       })
     })
     describe('isProduction and accountType', () => {
@@ -707,9 +707,10 @@ describe('salesforce client', () => {
               await validateCredentials(sandboxCredentials, 3, connection),
             ).toEqual({
               accountId: 'https://url.com/',
+              accountUrl: 'https://url.com/',
               isProduction: false,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
+              extraInformation: { orgId: '' },
             })
           })
         })
@@ -725,9 +726,10 @@ describe('salesforce client', () => {
               await validateCredentials(sandboxCredentials, 3, connection),
             ).toEqual({
               accountId: 'https://url.com/',
+              accountUrl: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
+              extraInformation: { orgId: '' },
             })
           })
           it('should throw an error when there is no instanceUrl', async () => {
@@ -754,9 +756,10 @@ describe('salesforce client', () => {
               await validateCredentials(credentials, 3, connection),
             ).toEqual({
               accountId: '',
+              accountUrl: 'https://url.com/',
               isProduction: true,
               accountType: PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
+              extraInformation: { orgId: '' },
             })
           })
         })
@@ -772,9 +775,10 @@ describe('salesforce client', () => {
               await validateCredentials(credentials, 3, connection),
             ).toEqual({
               accountId: '',
+              accountUrl: 'https://url.com/',
               isProduction: false,
               accountType: NON_PRODUCTION_ORGANIZATION_TYPE,
-              extraInformation: { orgId: '', instanceUrl: 'https://url.com/' },
+              extraInformation: { orgId: '' },
             })
           })
         })


### PR DESCRIPTION
This field can be relevant for all adapters and has semantic meaning (it should be a URL leading to the account in the service).

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
