### PR TITLE
salto-6161 JSM omit restrictionStatus field in RequestType

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1902,6 +1902,7 @@ const JSM_DUCKTYPE_TYPES: JiraDuckTypeConfig['types'] = {
         { fieldName: 'portalId' },
         { fieldName: 'groupIds' },
         { fieldName: 'canCreateRequest' },
+        { fieldName: 'restrictionStatus' },
       ],
       fieldsToHide: [{ fieldName: 'id' }, { fieldName: 'icon' }, { fieldName: 'serviceDeskId' }],
       serviceIdField: 'id',


### PR DESCRIPTION
salto-6161 JSM omit restrictionStatus field in RequestType

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
