### PR TITLE
Remove cycle dependents from deploy.xml

### DIFF
--- a/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
+++ b/packages/netsuite-adapter/src/client/deploy_xml_utils.ts
@@ -27,7 +27,12 @@ const log = logger(module)
 const PROJECT_ROOT_TILDE_PREFIX = `${osPath.sep}~`
 
 export const reorderDeployXml = (deployContent: string, dependencyGraph: Graph<SDFObjectNode>): string => {
-  const nodesInCycle = new Set(dependencyGraph.findCycle())
+  const nodesInCycle = new Set(
+    dependencyGraph
+      .findCycle()
+      .flatMap(node => dependencyGraph.getNodeDependencies(node))
+      .map(node => node.id),
+  )
   log.debug(
     'The following %d objects will not be written explicity in the deploy xml since they contain a cycle: %o',
     nodesInCycle.size,

--- a/packages/netsuite-adapter/src/client/graph_utils.ts
+++ b/packages/netsuite-adapter/src/client/graph_utils.ts
@@ -38,8 +38,8 @@ type DFSParameters<T> = {
   visited: Set<string>
   resultArray?: GraphNode<T>[]
   // optional parameters for cycle detection
-  path?: string[]
-  cycle?: string[]
+  path?: GraphNode<T>[]
+  cycle?: GraphNode<T>[]
 }
 
 export class Graph<T> {
@@ -61,7 +61,7 @@ export class Graph<T> {
   private dfs(dfsParams: DFSParameters<T>): void {
     const { node, visited, resultArray = [], path = [], cycle = [] } = dfsParams
     if (visited.has(node.id)) {
-      const cycleStartIndex = path.indexOf(node.id)
+      const cycleStartIndex = path.findIndex(nodeInPath => nodeInPath.id === node.id)
       if (cycleStartIndex !== -1) {
         // node is visited & in path mean its a cycle
         cycle.push(...path.slice(cycleStartIndex))
@@ -70,7 +70,7 @@ export class Graph<T> {
     }
     visited.add(node.id)
     node.edges.forEach(dependency => {
-      this.dfs({ node: dependency, visited, resultArray, path: path.concat(node.id), cycle })
+      this.dfs({ node: dependency, visited, resultArray, path: path.concat(node), cycle })
     })
     resultArray.push(node)
   }
@@ -112,9 +112,9 @@ export class Graph<T> {
     }
   }
 
-  findCycle(): string[] {
+  findCycle(): GraphNode<T>[] {
     const visited = new Set<string>()
-    const nodesInCycle: string[] = []
+    const nodesInCycle: GraphNode<T>[] = []
 
     Array.from(this.nodes.values()).forEach(node => {
       if (!visited.has(node.id)) {

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -121,8 +121,8 @@ describe('deploy xml utils tests', () => {
 
   it('should only explictly add objects that dont have circular dependencies or dependent on cycle', async () => {
     const testNode4 = new GraphNode<SDFObjectNode>('fullName4', {
-      serviceid: 'scriptid4',
       changeType: 'addition',
+      serviceid: 'scriptid4',
       customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo,
     })
     testGraph.addNodes([testNode4] as GraphNode<Node>[])

--- a/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/deploy_xml_utils.test.ts
@@ -24,18 +24,20 @@ type SDFObjectNode = Omit<Node, 'change'>
 describe('deploy xml utils tests', () => {
   let testGraph: Graph<Node>
   let testNode1: GraphNode<SDFObjectNode>
+  let testNode2: GraphNode<SDFObjectNode>
+  let testNode3: GraphNode<SDFObjectNode>
   beforeEach(() => {
     testNode1 = new GraphNode<SDFObjectNode>('fullName1', {
       serviceid: 'scriptid1',
       changeType: 'addition',
       customizationInfo: { scriptId: 'scriptid1', typeName: '', values: {} } as CustomizationInfo,
     })
-    const testNode2 = new GraphNode<SDFObjectNode>('fullName2', {
+    testNode2 = new GraphNode<SDFObjectNode>('fullName2', {
       serviceid: 'scriptid2',
       changeType: 'addition',
       customizationInfo: { scriptId: 'scriptid2', typeName: '', values: {} } as CustomizationInfo,
     })
-    const testNode3 = new GraphNode<SDFObjectNode>('fullName3', {
+    testNode3 = new GraphNode<SDFObjectNode>('fullName3', {
       serviceid: 'scriptid3',
       changeType: 'addition',
       customizationInfo: { scriptId: 'scriptid3', typeName: '', values: {} } as CustomizationInfo,
@@ -88,11 +90,15 @@ describe('deploy xml utils tests', () => {
       changeType: 'addition',
       customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo,
     })
-    testGraph.removeNode('fullName1')
+    testGraph.addNodes([testNode4] as GraphNode<Node>[])
+
     // creates cycle in graph
     testNode4.addEdge(testNode1)
     testNode1.addEdge(testNode4)
-    testGraph.addNodes([testNode4, testNode1] as GraphNode<Node>[])
+
+    // remove dependency of testNode2 on cycle
+    testNode1.edges.delete(testNode2.id)
+
     const fixedDeployXml = `<deploy>
   <configuration>
     <path>~/AccountConfiguration/*</path>
@@ -103,6 +109,37 @@ describe('deploy xml utils tests', () => {
   <objects>
     <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/scriptid2.xml</path>
+    <path>~/Objects/*</path>
+  </objects>
+  <translationimports>
+    <path>~/Translations/*</path>
+  </translationimports>
+</deploy>
+`
+    expect(reorderDeployXml(originalDeployXml, testGraph)).toEqual(fixedDeployXml)
+  })
+
+  it('should only explictly add objects that dont have circular dependencies or dependent on cycle', async () => {
+    const testNode4 = new GraphNode<SDFObjectNode>('fullName4', {
+      serviceid: 'scriptid4',
+      changeType: 'addition',
+      customizationInfo: { scriptId: 'scriptid4', typeName: '', values: {} } as CustomizationInfo,
+    })
+    testGraph.addNodes([testNode4] as GraphNode<Node>[])
+
+    // creates cycle in graph
+    testNode4.addEdge(testNode1)
+    testNode1.addEdge(testNode4)
+
+    const fixedDeployXml = `<deploy>
+  <configuration>
+    <path>~/AccountConfiguration/*</path>
+  </configuration>
+  <files>
+    <path>~/FileCabinet/*</path>
+  </files>
+  <objects>
+    <path>~/Objects/scriptid3.xml</path>
     <path>~/Objects/*</path>
   </objects>
   <translationimports>

--- a/packages/netsuite-adapter/test/client/graph_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/graph_utils.test.ts
@@ -56,7 +56,7 @@ describe('graph utils tests', () => {
   it('should find the cycle in the graph and return its nodes', async () => {
     const cycleNodes = testGraph.findCycle()
     expect(cycleNodes).toHaveLength(2)
-    expect(cycleNodes).toEqual([testNode1.value.name, testNode2.value.name])
+    expect(cycleNodes).toEqual([testNode1, testNode2])
   })
 
   it('should remove node from graph and edges from nodes', async () => {


### PR DESCRIPTION
We should remove from deploy.xml not only objects that are in a dependency cycle, but also objects that are dependent on them.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix "unresolved reference" error in SDF deploy

---
_User Notifications_: 
None