### PR TITLE
SALTO-6145 Fix FileCabinet fetchTarget and remove folders correctly before querying files

### DIFF
--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -17,7 +17,7 @@ import _ from 'lodash'
 import { regex } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement } from '@salto-io/adapter-api'
-import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, INACTIVE_FIELDS } from '../constants'
+import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT, FILE_CABINET_PATH_SEPARATOR, INACTIVE_FIELDS } from '../constants'
 import { removeCustomRecordTypePrefix } from '../types'
 import { fileCabinetTypesNames } from '../types/file_cabinet_types'
 import {
@@ -68,10 +68,10 @@ export const fullFetchConfig = (): FetchParams => ({
 })
 
 const updatedFetchTarget = (config: NetsuiteConfig): NetsuiteQueryParameters | undefined => {
-  if (config.fetchTarget?.customRecords === undefined) {
-    return config.fetchTarget
+  if (config.fetchTarget === undefined) {
+    return undefined
   }
-  const { types, filePaths, customRecords } = config.fetchTarget
+  const { types = {}, filePaths = [], customRecords = {} } = config.fetchTarget
   // in case that custom records are fetched, we want to fetch their types too-
   // using this config: { types: { customrecordtype: [<customRecordTypes>] } }.
   // without that addition, the custom record types wouldn't be fetched
@@ -80,15 +80,23 @@ const updatedFetchTarget = (config: NetsuiteConfig): NetsuiteQueryParameters | u
   // custom record types that have custom segments are fetch by them
   // so we need to fetch the matching custom segments too.
   const customSegmentNames = customRecordTypeNames.map(removeCustomRecordTypePrefix).filter(name => name.length > 0)
-  const customRecordTypesQuery = (types?.[CUSTOM_RECORD_TYPE] ?? []).concat(customRecordTypeNames)
-  const customSegmentsQuery = (types?.[CUSTOM_SEGMENT] ?? []).concat(customSegmentNames)
+  const customRecordTypesQuery = (types[CUSTOM_RECORD_TYPE] ?? []).concat(customRecordTypeNames)
+  const customSegmentsQuery = (types[CUSTOM_SEGMENT] ?? []).concat(customSegmentNames)
+
+  const filePathsFolders = filePaths
+    .map(path => path.substring(0, path.lastIndexOf(FILE_CABINET_PATH_SEPARATOR) + 1))
+    .filter(path => path !== FILE_CABINET_PATH_SEPARATOR)
+    // in case that the query was like ".*\.js" (all js files), we want to query all folders
+    .map(path => (path === '' ? `.*${FILE_CABINET_PATH_SEPARATOR}` : path))
+  const updatedFilePaths = _.uniq(filePaths.concat(filePathsFolders))
+
   return {
     types: {
       ...types,
       [CUSTOM_RECORD_TYPE]: customRecordTypesQuery,
       [CUSTOM_SEGMENT]: customSegmentsQuery,
     },
-    filePaths,
+    filePaths: updatedFilePaths,
     customRecords,
   }
 }

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -38,20 +38,6 @@ describe('netsuite config creator', () => {
   })
 
   describe('fetch target', () => {
-    it('should keep query without custom records', () => {
-      config.value.fetchTarget = {
-        types: {
-          addressForm: ['aaa.*', 'bbb.*'],
-        },
-        filePaths: ['eee.*', 'fff.*'],
-      }
-      expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
-        types: {
-          addressForm: ['aaa.*', 'bbb.*'],
-        },
-        filePaths: ['eee.*', 'fff.*'],
-      })
-    })
     it('should add custom record types to "types"', () => {
       config.value.fetchTarget = {
         types: {
@@ -68,6 +54,7 @@ describe('netsuite config creator', () => {
           customrecordtype: ['customrecord2', 'customrecord1'],
           customsegment: [],
         },
+        filePaths: [],
         customRecords: {
           customrecord1: ['.*'],
         },
@@ -84,6 +71,7 @@ describe('netsuite config creator', () => {
           customrecordtype: ['customrecord1'],
           customsegment: [],
         },
+        filePaths: [],
         customRecords: {
           customrecord1: ['.*'],
         },
@@ -100,9 +88,36 @@ describe('netsuite config creator', () => {
           customrecordtype: ['customrecord_cseg1'],
           customsegment: ['cseg1'],
         },
+        filePaths: [],
         customRecords: {
           customrecord_cseg1: ['.*'],
         },
+      })
+    })
+    it('should add parent folders to filePaths', () => {
+      config.value.fetchTarget = {
+        filePaths: ['/SuiteScripts/file.txt'],
+      }
+      expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
+        types: {
+          customrecordtype: [],
+          customsegment: [],
+        },
+        filePaths: ['/SuiteScripts/file.txt', '/SuiteScripts/'],
+        customRecords: {},
+      })
+    })
+    it('should add "all folders matcher" when fetchTarget includes a file extension', () => {
+      config.value.fetchTarget = {
+        filePaths: ['.*\\.js'],
+      }
+      expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
+        types: {
+          customrecordtype: [],
+          customsegment: [],
+        },
+        filePaths: ['.*\\.js', '.*/'],
+        customRecords: {},
       })
     })
   })


### PR DESCRIPTION
Make two things possible (that before didn't happen together):
- Fix FileCabinet fetchTarget - so user can request for a file only without its parent folder
- Remove folders correctly before querying files - and in fetchTarget we'll keep the folder of a queried file

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix FileCabinet fetchTarget and remove folders correctly before querying files

---
_User Notifications_: 
None