### PR TITLE
SALTO-6145 add config value to force FileCabinet exclusion

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -686,6 +686,7 @@ describe('Netsuite adapter E2E with real account', () => {
           .filter(element => element.annotations[CORE_ANNOTATIONS.ALIAS] === undefined)
           // some sub-instances don't have alias
           .filter(element => getElementValueOrAnnotations(element)[IS_SUB_INSTANCE] !== true)
+          .filter(element => element.annotations[CORE_ANNOTATIONS.HIDDEN] !== true)
           .filter(element => {
             if (!isInstanceElement(element)) {
               return true
@@ -697,7 +698,7 @@ describe('Netsuite adapter E2E with real account', () => {
             return type.annotations[CORE_ANNOTATIONS.HIDDEN] !== true
           })
 
-        expect(elementsWithoutAlias.every(elem => elem.annotations[CORE_ANNOTATIONS.HIDDEN])).toBeTruthy()
+        expect(elementsWithoutAlias.map(element => element.elemID.getFullName())).toEqual([])
       })
 
       it('should fetch the created entityCustomField and its special chars', async () => {

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -385,6 +385,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         updatedFetchQuery,
         this.userConfig.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
         this.userConfig.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
+        this.userConfig.fetch.forceFileCabinetExclude ?? false,
       )
       progressReporter.reportProgress({ message: 'Fetching instances' })
       return result

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -238,9 +238,15 @@ export default class NetsuiteClient {
     query: NetsuiteQuery,
     maxFileCabinetSizeInGB: number,
     extensionsToExclude: string[],
+    forceFileCabinetExclude: boolean,
   ): Promise<ImportFileCabinetResult> {
     if (this.suiteAppFileCabinet !== undefined) {
-      return this.suiteAppFileCabinet.importFileCabinet(query, maxFileCabinetSizeInGB, extensionsToExclude)
+      return this.suiteAppFileCabinet.importFileCabinet(
+        query,
+        maxFileCabinetSizeInGB,
+        extensionsToExclude,
+        forceFileCabinetExclude,
+      )
     }
 
     return this.sdfClient.importFileCabinetContent(query, maxFileCabinetSizeInGB)

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -116,6 +116,8 @@ export type FetchParams = {
   addImportantValues?: boolean
   addLockedCustomRecordTypes?: boolean
   resolveAccountSpecificValues?: boolean
+  // SALTO-6145: should be removed
+  forceFileCabinetExclude?: boolean
 } & LockedElementsConfig['fetch']
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -130,6 +132,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   addImportantValues: 'addImportantValues',
   addLockedCustomRecordTypes: 'addLockedCustomRecordTypes',
   resolveAccountSpecificValues: 'resolveAccountSpecificValues',
+  forceFileCabinetExclude: 'forceFileCabinetExclude',
 }
 
 export type AdditionalSdfDeployDependencies = {
@@ -573,6 +576,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     addImportantValues: { refType: BuiltinTypes.BOOLEAN },
     addLockedCustomRecordTypes: { refType: BuiltinTypes.BOOLEAN },
     resolveAccountSpecificValues: { refType: BuiltinTypes.BOOLEAN },
+    forceFileCabinetExclude: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1404,7 +1404,7 @@ describe('Adapter', () => {
 
     it('should use suiteAppFileCabinet importFileCabinet and pass it the right params', async () => {
       await adapter.fetch(mockFetchOpts)
-      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(expect.anything(), 3, ['.*\\.(csv|pdf|png)'])
+      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(expect.anything(), 3, ['.*\\.(csv|pdf|png)'], false)
     })
 
     it('should not create serverTime elements when getSystemInformation returns undefined', async () => {


### PR DESCRIPTION
instead of just writing log, force excluding file cabinet folders before the files query.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None