### PR TITLE
SALTO-6145 ignore invalid regexes

### DIFF
--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -88,6 +88,7 @@ const updatedFetchTarget = (config: NetsuiteConfig): NetsuiteQueryParameters | u
     .filter(path => path !== FILE_CABINET_PATH_SEPARATOR)
     // in case that the query was like ".*\.js" (all js files), we want to query all folders
     .map(path => (path === '' ? `.*${FILE_CABINET_PATH_SEPARATOR}` : path))
+    .filter(regex.isValidRegex)
   const updatedFilePaths = _.uniq(filePaths.concat(filePathsFolders))
 
   return {

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -120,6 +120,20 @@ describe('netsuite config creator', () => {
         customRecords: {},
       })
     })
+    it('should ignore invalid parent folder regex', () => {
+      config.value.fetchTarget = {
+        // extracting "/Templates/[^/" creates an invalid regex
+        filePaths: ['/SuiteScripts/file.txt', '/Templates/[^/]*\\.html'],
+      }
+      expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
+        types: {
+          customrecordtype: [],
+          customsegment: [],
+        },
+        filePaths: ['/SuiteScripts/file.txt', '/Templates/[^/]*\\.html', '/SuiteScripts/'],
+        customRecords: {},
+      })
+    })
   })
 
   describe('include custom records', () => {


### PR DESCRIPTION
We should ignore invalid regexes when we add the parent folder to `fetchTarget.filePaths`.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
