### PR TITLE
SALTO-5432 override definitions removeNull fix

### DIFF
--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -64,6 +64,17 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
   log.debug('Definitions overrides:', overrides)
   const cloneDefinitions = _.cloneDeep(definitions)
   const merged = _.mergeWith(cloneDefinitions, overrides, customMerge)
-  log.debug('Merged definitions with overrides:', merged)
-  return merged
+  const removeNullObjects = (obj: Value): Value => {
+    if (_.isArray(obj)) {
+      return obj.map(removeNullObjects)
+    }
+    if (_.isPlainObject(obj)) {
+      const cleanedObj = _.omitBy(obj, _.isNull)
+      return _.mapValues(cleanedObj, removeNullObjects)
+    }
+    return obj
+  }
+  const afterRemoveNullObjects = removeNullObjects(merged)
+  log.debug('Merged definitions with overrides:', afterRemoveNullObjects)
+  return afterRemoveNullObjects
 }

--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -56,6 +56,7 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
     }
     return undefined
   }
+  log.debug('starting to merge definitions with overrides')
   const overrides = getParsedDefinitionsOverrides()
   if (_.isEmpty(overrides)) {
     return definitions
@@ -63,17 +64,6 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
   log.debug('Definitions overrides:', overrides)
   const cloneDefinitions = _.cloneDeep(definitions)
   const merged = _.mergeWith(cloneDefinitions, overrides, customMerge)
-  const removeNullObjects = (obj: Value): Value => {
-    if (_.isArray(obj)) {
-      return obj.map(removeNullObjects)
-    }
-    if (_.isObject(obj)) {
-      const cleanedObj = _.omitBy(obj, _.isNull)
-      return _.mapValues(cleanedObj, removeNullObjects)
-    }
-    return obj
-  }
-  const afterRemoveNullObjects = removeNullObjects(merged)
-  log.debug('Merged definitions with overrides:', afterRemoveNullObjects)
-  return afterRemoveNullObjects
+  log.debug('Merged definitions with overrides:', merged)
+  return merged
 }

--- a/packages/adapter-components/test/definitions/system/overrides.test.ts
+++ b/packages/adapter-components/test/definitions/system/overrides.test.ts
@@ -243,7 +243,7 @@ describe('overrides', () => {
       setupEnvVar(overridesEnvVar, jsonString)
       it('should remove a type from the fetch config', () => {
         const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
-        expect(merged.fetch.instances.customizations?.team).toBeUndefined()
+        expect(merged.fetch.instances.customizations?.team).toBeNull()
       })
     })
   })

--- a/packages/adapter-components/test/definitions/system/overrides.test.ts
+++ b/packages/adapter-components/test/definitions/system/overrides.test.ts
@@ -243,7 +243,7 @@ describe('overrides', () => {
       setupEnvVar(overridesEnvVar, jsonString)
       it('should remove a type from the fetch config', () => {
         const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
-        expect(merged.fetch.instances.customizations?.team).toBeNull()
+        expect(merged.fetch.instances.customizations?.team).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
SALTO-5432 override definitions removeNull fix

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
