### PR TITLE
SALTO-6199: Fix `Brand` addition API calls following a service change

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -352,10 +352,6 @@ const removeAllApps = async (adapterAttr: Reals, changes: Change<InstanceElement
 }
 
 const getChangesForInitialCleanup = async (elements: Element[]): Promise<Change<InstanceElement>[]> => {
-  log.info(
-    'All elements: %s',
-    elements.filter(isInstanceElement).map(inst => inst.elemID.getFullName()),
-  )
   const removalChanges: Change<InstanceElement>[] = elements
     .filter(isInstanceElement)
     .filter(inst => inst.elemID.name.startsWith(TEST_PREFIX))

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -263,6 +263,16 @@ const createChangesForDeploy = async (types: ObjectType[], testSuffix: string): 
     parent: app,
     name: naclCase(`${app.elemID.name}__${groupInstance.elemID.name}`),
   })
+  const brand = createInstance({
+    typeName: BRAND_TYPE_NAME,
+    types,
+    valuesOverride: {
+      name: createName('brand'),
+      // Brand addition is split into two calls (`add` with name, `modify` with
+      // other fields), so we override some arbitrary value to cover both calls.
+      removePoweredByOkta: true,
+    },
+  })
   return [
     toChange({ after: groupInstance }),
     toChange({ after: anotherGroupInstance }),
@@ -274,6 +284,7 @@ const createChangesForDeploy = async (types: ObjectType[], testSuffix: string): 
     toChange({ after: profileEnrollmentRule }),
     toChange({ after: app }),
     toChange({ after: appGroupAssignment }),
+    toChange({ after: brand }),
   ]
 }
 
@@ -341,13 +352,13 @@ const removeAllApps = async (adapterAttr: Reals, changes: Change<InstanceElement
 }
 
 const getChangesForInitialCleanup = async (elements: Element[]): Promise<Change<InstanceElement>[]> => {
+  log.info(
+    'All elements: %s',
+    elements.filter(isInstanceElement).map(inst => inst.elemID.getFullName()),
+  )
   const removalChanges: Change<InstanceElement>[] = elements
     .filter(isInstanceElement)
-    .filter(
-      inst =>
-        inst.elemID.name.startsWith(TEST_PREFIX) ||
-        (inst.elemID.typeName === DOMAIN_TYPE_NAME && inst.value.id !== 'default'),
-    )
+    .filter(inst => inst.elemID.name.startsWith(TEST_PREFIX))
     .filter(inst => ![APP_USER_SCHEMA_TYPE_NAME, APP_LOGO_TYPE_NAME].includes(inst.elemID.typeName))
     .map(instance => toChange({ before: instance }))
 
@@ -380,6 +391,19 @@ const getHiddenFieldsToOmit = (
 }
 
 describe('Okta adapter E2E', () => {
+  expect.extend({
+    toHaveEqualValues(received: Values, expected: InstanceElement) {
+      const pass = isEqualValues(received, expected.value)
+      return {
+        pass,
+        message: () =>
+          `Received unexpected result when fetching instance: ${expected.elemID.getFullName()}.\n` +
+          `Expected value: ${inspectValue(expected.value, { depth: 7 })},\n` +
+          `Received value: ${inspectValue(received, { depth: 7 })}`,
+      }
+    },
+  })
+
   describe('fetch and deploy', () => {
     let credLease: CredsLease<Credentials>
     let adapterAttr: Reals
@@ -421,7 +445,7 @@ describe('Okta adapter E2E', () => {
       })
       fetchDefinitions = createFetchDefinitions(DEFAULT_CONFIG, true)
       const types = fetchBeforeCleanupResult.elements.filter(isObjectType)
-      await deployCleanup(adapterAttr, types, fetchBeforeCleanupResult.elements.filter(isInstanceElement))
+      await deployCleanup(adapterAttr, fetchBeforeCleanupResult.elements.filter(isInstanceElement))
 
       const changesToDeploy = await createChangesForDeploy(types, testSuffix)
       await deployAndFetch(changesToDeploy)
@@ -572,16 +596,7 @@ describe('Okta adapter E2E', () => {
         // Omit hidden fields that are not written to nacl after deployment
         const fieldsToOmit = getHiddenFieldsToOmit(fetchDefinitions, deployedInstance.elemID.typeName)
         const originalValue = _.omit(instance?.value, fieldsToOmit)
-        const isEqualResult = isEqualValues(originalValue, deployedInstance.value)
-        if (!isEqualResult) {
-          log.error(
-            'Received unexpected result when deploying instance: %s. Deployed value: %s , Received value after fetch: %s',
-            deployedInstance.elemID.getFullName(),
-            inspectValue(deployedInstance.value, { depth: 7 }),
-            inspectValue(originalValue, { depth: 7 }),
-          )
-        }
-        expect(isEqualResult).toBeTruthy()
+        expect(originalValue).toHaveEqualValues(deployedInstance)
       })
     })
   })

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -204,7 +204,8 @@ export const mockDefaultValues: Record<string, Values> = {
   },
   [BRAND_TYPE_NAME]: {
     removePoweredByOkta: false,
-    agreeToCustomPrivacyPolicy: true,
+    agreeToCustomPrivacyPolicy: false,
+    isDefault: false,
   },
   [BRAND_THEME_TYPE_NAME]: {
     primaryColorHex: '#1662dd',

--- a/packages/okta-adapter/src/definitions/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy.ts
@@ -74,12 +74,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => {
-        if (isAdditionChange(change)) {
-          return ['add', 'modify']
-        }
-        return [change.action]
-      },
+      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action])
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
     [USERTYPE_TYPE_NAME]: {

--- a/packages/okta-adapter/src/definitions/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy.ts
@@ -74,7 +74,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action])
+      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
     [USERTYPE_TYPE_NAME]: {

--- a/packages/okta-adapter/src/definitions/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy.ts
@@ -16,7 +16,7 @@
 
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
-import { getChangeData, isModificationChange } from '@salto-io/adapter-api'
+import { getChangeData, isAdditionChange, isModificationChange } from '@salto-io/adapter-api'
 import { AdditionalAction, ClientOptions } from './types'
 import {
   BRAND_TYPE_NAME,
@@ -37,13 +37,51 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
     ClientOptions
   >({
     [GROUP_TYPE_NAME]: { bulkPath: '/api/v1/groups' },
-    [BRAND_TYPE_NAME]: { bulkPath: '/api/v1/brands' },
     [DOMAIN_TYPE_NAME]: { bulkPath: '/api/v1/domains' },
     [SMS_TEMPLATE_TYPE_NAME]: { bulkPath: '/api/v1/templates/sms' },
     [DEVICE_ASSURANCE_TYPE_NAME]: { bulkPath: '/api/v1/device-assurances' },
   })
 
   const customDefinitions: Record<string, Partial<InstanceDeployApiDefinitions>> = {
+    [BRAND_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/brands', method: 'post' },
+                // Brand addition only requires the name field. Other fields
+                // are set by a subsequent modify action.
+                transformation: {
+                  pick: ['name'],
+                },
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/brands/{id}', method: 'put' },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/brands/{id}', method: 'delete' },
+              },
+            },
+          ],
+        },
+      },
+      toActionNames: ({ change }) => {
+        if (isAdditionChange(change)) {
+          return ['add', 'modify']
+        }
+        return [change.action]
+      },
+      actionDependencies: [{ first: 'add', second: 'modify' }],
+    },
     [USERTYPE_TYPE_NAME]: {
       requestsByAction: {
         customizations: {


### PR DESCRIPTION
See SALTO-6199 for more details. 
TL;DR: To add a new `Brand`, we are now required to call `POST` with only the `name` field and then `PUT` with the other fields (add and then modify).

---

_Additional context for reviewer_:
I also included a change for better Jest error messages in the Okta e2e test  🎉 

---
_Release Notes_: 
None

---
_User Notifications_: 
None