### PR TITLE
SALTO-6184: Only adding errors to successful elements if the deploy failed

### DIFF
--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -350,10 +350,6 @@ const processDeployResponse = (
     )
   }
 
-  const componentErrors = failedComponentErrors.concat(
-    successfulComponentProblems,
-  )
-
   const testFailures = makeArray(result.details).flatMap((detail) =>
     makeArray((detail.runTestResult as RunTestsResult)?.failures),
   )
@@ -375,7 +371,8 @@ const processDeployResponse = (
 
   const errors = [
     ...testErrors,
-    ...componentErrors,
+    ...failedComponentErrors,
+    ...successfulComponentProblems,
     ...codeCoverageWarningErrors,
   ]
 
@@ -388,7 +385,7 @@ const processDeployResponse = (
 
   const anyErrors =
     isDefined(result.errorMessage) ||
-    componentErrors.length > 0 ||
+    failedComponentErrors.length > 0 ||
     testErrors.length > 0
   if (!isCheckOnly && result.rollbackOnError !== false && anyErrors) {
     // If we deployed with 'rollbackOnError' (the default) and any component in the group fails to deploy, then every

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -1197,12 +1197,66 @@ describe('SalesforceAdapter CRUD', () => {
           })
         })
         it('Should return the problem from successful components', () => {
-          expect(result.errors).toSatisfyAny(
-            (error) =>
-              error.elemID.isEqual(successElement.elemID) &&
-              error.severity === 'Info' &&
-              error.message === 'Something happened',
+          expect(result.errors).toIncludeAllMembers([
+            {
+              elemID: successElement.elemID,
+              severity: 'Info',
+              message: 'Something happened',
+            },
+          ])
+        })
+      })
+    })
+
+    describe('when all components succeed', () => {
+      let element: InstanceElement
+      let deployChangeGroup: ChangeGroup
+      beforeEach(() => {
+        element = createInstanceElement(
+          {
+            [INSTANCE_FULL_NAME_FIELD]: 'SuccessElement',
+          },
+          mockTypes.ApexClass,
+        )
+
+        deployChangeGroup = {
+          groupID: 'ChangeGroup',
+          changes: [toChange({ after: element })],
+        }
+      })
+      describe('when the element has a warning', () => {
+        let result: DeployResult
+        beforeEach(async () => {
+          const deployResultParams = {
+            success: false,
+            componentSuccess: [
+              {
+                fullName: apiNameSync(element),
+                componentType: metadataTypeSync(element),
+                problem: 'Something happened',
+                problemType: 'Warning',
+              },
+            ],
+          }
+          connection.metadata.deploy.mockReturnValue(
+            mockDeployResult({
+              ...deployResultParams,
+              rollbackOnError: true,
+            }),
           )
+          result = await adapter.deploy({
+            changeGroup: deployChangeGroup,
+            progressReporter: nullProgressReporter,
+          })
+        })
+        it('Should return the problem from successful component', () => {
+          expect(result.errors).toEqual([
+            {
+              elemID: element.elemID,
+              severity: 'Warning',
+              message: 'Something happened',
+            },
+          ])
         })
       })
     })


### PR DESCRIPTION
We currently have a bug where we add errors to successful elements even if they only have info or warning messages and the deployment succeeded.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce_:
* Fixed a bug where elements in a successful deployment got an error with the message: `Element was not deployed because other elements had errors and the 'rollbackOnError' option is enabled (or not set).`

---
_User Notifications_: 
None.
