### PR TITLE
SALTO-5766: Reduce log chunk size

### DIFF
--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -206,7 +206,7 @@ SALTO_LOG_MAX_JSON_LOG_CHUNK_SIZE=3072 # 3K
 
 Configure the max chunk size for the formatted json log message.
 
-Default: 200 \* 1024 - 200K
+Default: 25 \* 1024 - 25K
 
 Supported formatting: Receives only number which signifies the allowed bytes amount
 

--- a/packages/logging/src/internal/config.ts
+++ b/packages/logging/src/internal/config.ts
@@ -44,7 +44,7 @@ export const DEFAULT_CONFIG: Readonly<Config> = Object.freeze({
   namespaceFilter: '*',
   colorize: null,
   globalTags: {},
-  maxJsonLogChunkSize: 200 * 1024, // 200K
+  maxJsonLogChunkSize: 25 * 1024, // 25K, DataDog recommended limit
   maxTagsPerLogMessage: 100,
 })
 


### PR DESCRIPTION
Datadog does not index for search log messages larger than 25K. Our log chunk size was 200K, which made big parts of long messages unsearchable. 
This change reduces the chunk size. It might increase our costs but according to the analysis done by @ori-moisis it should be OK (available in the [Jira ticket](salto-io.atlassian.net/browse/SALTO-5776))
---

None
---
_Release Notes_: 
Core:
* Reduced the default log chunk size to 25K

---
_User Notifications_: 
None
