### PR TITLE
SALTO-3621: Fixing extra newline when modifying whole elements

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -297,6 +297,10 @@ export const updateNaclFileData = async (
         }
       } else if (isElement(elem)) {
         newData = await parser.dumpElements([elem], functions, indentationLevel)
+        if (change.action === 'modify') {
+          // When replacing entire elements we already have a newline after the block so we don't need another one
+          newData = newData.trimEnd()
+        }
       } else if (isListElement) {
         newData = await parser.dumpValues(elem, functions, indentationLevel)
       } else {
@@ -417,6 +421,7 @@ const parentElementExistsInPath = (dc: DetailedChange, sourceMap: parser.SourceM
   const { parent } = dc.id.createTopLevelParentID()
   return _.some(sourceMap.get(parent.getFullName())?.map(range => range.filename === createFileNameFromPath(dc.path)))
 }
+
 export const getChangesToUpdate = (changes: DetailedChange[], sourceMap: parser.SourceMap): DetailedChange[] => {
   const isNestedAddition = (dc: DetailedChange): boolean =>
     (dc.path || false) &&

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -37,10 +37,12 @@ const createMockType = ({
   dropFields = [],
   withAnnotations = false,
   dropAnnotations = [],
+  metaType,
 }: {
   dropFields?: ('file' | 'numArray' | 'strArray' | 'obj')[]
   withAnnotations?: boolean
   dropAnnotations?: ('anno1' | 'anno2' | 'anno3')[]
+  metaType?: ObjectType
 }): ObjectType => {
   const fields = {
     file: { refType: BuiltinTypes.STRING },
@@ -70,6 +72,7 @@ const createMockType = ({
     elemID: new ElemID('salto', 'mock'),
     fields,
     annotations: withAnnotations ? annotations : undefined,
+    metaType,
     path: ['this', 'is', 'happening'],
   })
 }
@@ -376,6 +379,18 @@ describe('updateNaclFileData', () => {
 }
 `
 
+  const mockTypeMetaNacl = `type salto.mock is salto.meta {
+  string file {
+  }
+  "List<number>" numArray {
+  }
+  "List<string>" strArray {
+  }
+  "List<salto.obj>" obj {
+  }
+}
+`
+
   describe('when the data is empty and there is an element addition', () => {
     beforeEach(() => {
       const mockType = createMockType({})
@@ -407,16 +422,16 @@ describe('updateNaclFileData', () => {
           id: mockType.elemID,
           location: {
             filename: 'file',
-            start: { col: 0, line: 0, byte: 0 },
-            end: { col: 1, line: 10, byte: mockTypeNacl.length },
+            start: { col: 1, line: 0, byte: 0 },
+            end: { col: 2, line: 9, byte: mockTypeNacl.length - 1 },
           },
         },
       ]
     })
 
-    it('should return an empty result', async () => {
+    it('should return a newline', async () => {
       const result = await updateNaclFileData(mockTypeNacl, changes, {})
-      expect(result).toEqual('')
+      expect(result).toEqual('\n')
     })
   })
 
@@ -539,6 +554,30 @@ describe('updateNaclFileData', () => {
     it('should remove the field and preceding whitespaces from the element', async () => {
       const result = await updateNaclFileData(mockTypeNacl, changes, {})
       expect(result).toEqual(mockTypeMissingMiddleNacl)
+    })
+  })
+
+  describe('when data contains an element which is completely replaced', () => {
+    beforeAll(() => {
+      const mockType = createMockType({
+        metaType: new ObjectType({ elemID: new ElemID('salto', 'meta') }),
+      })
+      changes = [
+        {
+          ...toChange({ before: createMockType({}), after: mockType }),
+          id: mockType.elemID,
+          location: {
+            filename: 'file',
+            start: { col: 1, line: 0, byte: 0 },
+            end: { col: 1, line: 9, byte: mockTypeNacl.length - 1 },
+          },
+        },
+      ]
+    })
+
+    it('should add the element to the data', async () => {
+      const result = await updateNaclFileData(mockTypeNacl, changes, {})
+      expect(result).toEqual(mockTypeMetaNacl)
     })
   })
 })


### PR DESCRIPTION
Caught this when adding meta types to existing elements. It's pretty rare to see this in other cases.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
