### PR TITLE
SALTO-6146 PagerDuty cache users between deploy change groups

### DIFF
--- a/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
@@ -132,6 +132,7 @@ export class AdapterImpl<
       }),
     }
     this.fetchQuery = createElementQuery(config.fetch)
+    const sharedContext = {}
     this.createFiltersRunner = () =>
       filterRunner<Co, FilterResult, {}, Options>(
         {
@@ -140,7 +141,7 @@ export class AdapterImpl<
           config: this.userConfig,
           getElemIdFunc: this.getElemIdFunc,
           elementSource,
-          sharedContext: {},
+          sharedContext,
         },
         filterCreators,
         objects.concatObjects,

--- a/packages/pagerduty-adapter/src/filters/users.ts
+++ b/packages/pagerduty-adapter/src/filters/users.ts
@@ -137,6 +137,7 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
   config,
   definitions,
   fetchQuery,
+  sharedContext,
 }) => {
   let userIdToLogin: Record<string, string> = {}
   const userDefinition = { ...definitions, fetch: { instances: USER_FETCH_DEFINITIONS } }
@@ -179,12 +180,16 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
       if (_.isEmpty(relevantChanges)) {
         return
       }
-      // TODO - SALTO-6074 - We will implement cache to avoid querying the same users in every change group
-      const users = await fetchUtils.getElements({
-        adapterName: ADAPTER_NAME,
-        fetchQuery,
-        definitions: userDefinition as definitionsUtils.RequiredDefinitions<Options>,
-      })
+      log.debug('uris preDeploy')
+      if (!sharedContext.users) {
+        log.debug('urii Fetching users for preDeploy')
+        sharedContext.users = fetchUtils.getElements({
+          adapterName: ADAPTER_NAME,
+          fetchQuery,
+          definitions: userDefinition as definitionsUtils.RequiredDefinitions<Options>,
+        })
+      }
+      const users = (await sharedContext.users) as fetchUtils.FetchElements<InstanceElement[]>
       if (!users || _.isEmpty(users.elements)) {
         log.warn('Could not find any users (onFetch)')
         return

--- a/packages/pagerduty-adapter/src/filters/users.ts
+++ b/packages/pagerduty-adapter/src/filters/users.ts
@@ -180,7 +180,7 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
       if (_.isEmpty(relevantChanges)) {
         return
       }
-      if (!sharedContext.users) {
+      if (sharedContext.users === undefined) {
         sharedContext.users = fetchUtils.getElements({
           adapterName: ADAPTER_NAME,
           fetchQuery,

--- a/packages/pagerduty-adapter/src/filters/users.ts
+++ b/packages/pagerduty-adapter/src/filters/users.ts
@@ -180,9 +180,7 @@ const filter: filterUtils.AdapterFilterCreator<UserConfig, filterUtils.FilterRes
       if (_.isEmpty(relevantChanges)) {
         return
       }
-      log.debug('uris preDeploy')
       if (!sharedContext.users) {
-        log.debug('urii Fetching users for preDeploy')
         sharedContext.users = fetchUtils.getElements({
           adapterName: ADAPTER_NAME,
           fetchQuery,


### PR DESCRIPTION
SALTO-6146 PagerDuty cache users between deploy change groups
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none