### PR TITLE
SALTO-6219 hide accessToken in CLI

### DIFF
--- a/packages/cli/src/callbacks.ts
+++ b/packages/cli/src/callbacks.ts
@@ -162,6 +162,7 @@ const isPasswordInputType = (fieldName: string): boolean =>
     'suiteAppTokenSecret',
     'suiteAppActivationKey',
     'clientSecret',
+    'accessToken',
   ].includes(fieldName)
 
 export const getFieldInputType = (fieldType: TypeElement, fieldName: string): string => {


### PR DESCRIPTION
Hide `accessToken` values on account add/login in CLI


---
_Release Notes_: 
None

---
_User Notifications_: 
None