### PR TITLE
SALTO-6224 Omit selfServiceIcon on policy instance upon fetch

### DIFF
--- a/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
@@ -23,6 +23,16 @@ import {
 } from './utils'
 
 /*
+ * Remove self_service_icon from self_service object
+ */
+const removeSelfServiceIcon = (value: Record<string, unknown>): void => {
+  const { self_service: selfService } = value
+  if (values.isPlainRecord(selfService)) {
+    delete selfService.self_service_icon
+  }
+}
+
+/*
  * Adjust policy instance
  */
 export const adjust: definitions.AdjustFunction = async ({ value }) => {
@@ -34,6 +44,7 @@ export const adjust: definitions.AdjustFunction = async ({ value }) => {
     adjustSiteObjectToSiteId,
     adjustScriptsObjectArrayToScriptsIds,
     adjustServiceIdToTopLevel,
+    removeSelfServiceIcon,
   ].forEach(fn => fn(value))
   return { value }
 }

--- a/packages/jamf-adapter/test/adapter.test.ts
+++ b/packages/jamf-adapter/test/adapter.test.ts
@@ -203,7 +203,6 @@ describe('adapter', () => {
           'jamf.policy__scope__limit_to_users',
           'jamf.policy__scope__limitations',
           'jamf.policy__self_service',
-          'jamf.policy__self_service__self_service_icon',
           'jamf.policy__user_interaction',
           'jamf.script',
           'jamf.script.instance.Decrypt_Drive@s',

--- a/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
@@ -86,4 +86,20 @@ describe('adjust policy', () => {
       })
     })
   })
+  describe('removeSelfServiceIcon', () => {
+    it('should delete self service icon object under self_service field', async () => {
+      const value = {
+        general: {},
+        self_service_icon: "don't delete me",
+        self_service: { self_service_icon: { someField: 'this whole object will be deleted' } },
+      }
+      await expect(adjustPolicy({ value, context: {}, typeName: 'policy' })).resolves.toEqual({
+        value: {
+          general: {},
+          self_service_icon: "don't delete me",
+          self_service: {},
+        },
+      })
+    })
+  })
 })


### PR DESCRIPTION


---

We'd like to add a support on icon but not as part of the MVP (SALTO-6225)


---

_Release Notes_: 
_Jamf Adapter_:
- Omit selfServiceIcon on policy instance upon fetch

---

_User Notifications_: 
_Jamf Adapter_:
- Omit selfServiceIcon on policy instance upon fetch