### PR TITLE
SALTO-6211: add fixer for merge of options lists in ticket_field

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -732,11 +732,6 @@ export const getAdditionalReferences = async (workspace: Workspace, changes: Cha
   return referenceGroups.flat().filter(values.isDefined)
 }
 
-// const getFixedElements = (elements: Element[], fixedElements: Element[]): Element[] => {
-//   const elementFixesByElemID = _.keyBy(fixedElements, element => element.elemID.getFullName())
-//   return elements.map(element => elementFixesByElemID[element.elemID.getFullName()] ?? element)
-// }
-
 const getFixedElements = (elements: Element[], fixedElements: Element[]): Element[] => {
   const elementFixesByElemID = _.keyBy(fixedElements, element => element.elemID.getFullName())
   const origElementsByID = _.keyBy(elements, element => element.elemID.getFullName())
@@ -845,16 +840,11 @@ export const fixElements = async (
     return { errors: [], changes: [] }
   }
 
-  // const idToElement = _.keyBy(elements, e => e.elemID.getFullName())
-
   const fixes = await fixElementsContinuously(workspace, elements, adapters, MAX_FIX_RUNS)
   const changes = await awu(fixes.fixedElements)
     .flatMap(async fixedElement =>
       detailedCompare(await (await workspace.elements()).get(fixedElement.elemID), fixedElement),
     )
     .toArray()
-  // const changes = fixes.fixedElements.flatMap(element =>
-  //   detailedCompare(idToElement[element.elemID.getFullName()], element),
-  // )
   return { errors: fixes.errors, changes }
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -841,10 +841,9 @@ export const fixElements = async (
   }
 
   const fixes = await fixElementsContinuously(workspace, elements, adapters, MAX_FIX_RUNS)
+  const workspaceElements = await workspace.elements()
   const changes = await awu(fixes.fixedElements)
-    .flatMap(async fixedElement =>
-      detailedCompare(await (await workspace.elements()).get(fixedElement.elemID), fixedElement),
-    )
+    .flatMap(async fixedElement => detailedCompare(await workspaceElements.get(fixedElement.elemID), fixedElement))
     .toArray()
   return { errors: fixes.errors, changes }
 }

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -732,9 +732,16 @@ export const getAdditionalReferences = async (workspace: Workspace, changes: Cha
   return referenceGroups.flat().filter(values.isDefined)
 }
 
+// const getFixedElements = (elements: Element[], fixedElements: Element[]): Element[] => {
+//   const elementFixesByElemID = _.keyBy(fixedElements, element => element.elemID.getFullName())
+//   return elements.map(element => elementFixesByElemID[element.elemID.getFullName()] ?? element)
+// }
+
 const getFixedElements = (elements: Element[], fixedElements: Element[]): Element[] => {
   const elementFixesByElemID = _.keyBy(fixedElements, element => element.elemID.getFullName())
-  return elements.map(element => elementFixesByElemID[element.elemID.getFullName()] ?? element)
+  const origElementsByID = _.keyBy(elements, element => element.elemID.getFullName())
+  const unitedElementsIds = _.uniq(Object.keys(elementFixesByElemID).concat(Object.keys(origElementsByID)))
+  return unitedElementsIds.map(elementId => elementFixesByElemID[elementId] ?? origElementsByID[elementId])
 }
 
 const fixElementsContinuously = async (
@@ -838,11 +845,16 @@ export const fixElements = async (
     return { errors: [], changes: [] }
   }
 
-  const idToElement = _.keyBy(elements, e => e.elemID.getFullName())
+  // const idToElement = _.keyBy(elements, e => e.elemID.getFullName())
 
   const fixes = await fixElementsContinuously(workspace, elements, adapters, MAX_FIX_RUNS)
-  const changes = fixes.fixedElements.flatMap(element =>
-    detailedCompare(idToElement[element.elemID.getFullName()], element),
-  )
+  const changes = await awu(fixes.fixedElements)
+    .flatMap(async fixedElement =>
+      detailedCompare(await (await workspace.elements()).get(fixedElement.elemID), fixedElement),
+    )
+    .toArray()
+  // const changes = fixes.fixedElements.flatMap(element =>
+  //   detailedCompare(idToElement[element.elemID.getFullName()], element),
+  // )
   return { errors: fixes.errors, changes }
 }

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -1588,8 +1588,6 @@ describe('api.ts', () => {
           },
         ],
       })
-      const a = mockFixElements.mock.calls
-      console.log(a)
       expect(mockFixElements).toHaveBeenNthCalledWith(1, [
         new ObjectType({
           elemID: new ElemID('test1', 'test'),

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -556,6 +556,7 @@ export default class ZendeskAdapter implements AdapterOperations {
         config,
         elementsSource,
       }),
+      config.fixElements ? (config.fixElements as Record<string, boolean>) : undefined,
     )
   }
 

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -556,7 +556,7 @@ export default class ZendeskAdapter implements AdapterOperations {
         config,
         elementsSource,
       }),
-      config.fixElements ? (config.fixElements as Record<string, boolean>) : undefined,
+      config.fixElements,
     )
   }
 

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -48,8 +48,9 @@ import {
   validateGuideTypesConfig,
   GUIDE_SUPPORTED_TYPES,
   DEPLOY_CONFIG,
+  validateFixElementsConfig,
 } from './config'
-import { ZendeskFetchConfig } from './user_config'
+import { ZendeskFetchConfig, ZendeskFixElementsConfig } from './user_config'
 import ZendeskClient from './client/client'
 import { createConnection, instanceUrl } from './client/connection'
 import { configCreator } from './config_creator'
@@ -143,10 +144,14 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     fetch,
     deploy: configValue.deploy,
     apiDefinitions,
-    fixElements: mergeWithDefaultConfig(DEFAULT_CONFIG.fixElements ?? {}, configValue.fixElements),
+    fixElements: mergeWithDefaultConfig(
+      DEFAULT_CONFIG.fixElements ?? {},
+      configValue.fixElements,
+    ) as ZendeskFixElementsConfig,
   }
 
   validateClientConfig(CLIENT_CONFIG, adapterConfig.client)
+  validateFixElementsConfig(adapterConfig.fixElements)
   validateFetchConfig(FETCH_CONFIG, adapterConfig.fetch, apiDefinitions)
   validateDuckTypeApiDefinitionConfig(API_DEFINITIONS_CONFIG, apiDefinitions)
   validateGuideTypesConfig(apiDefinitions)

--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -143,6 +143,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
     fetch,
     deploy: configValue.deploy,
     apiDefinitions,
+    fixElements: mergeWithDefaultConfig(DEFAULT_CONFIG.fixElements ?? {}, configValue.fixElements),
   }
 
   validateClientConfig(CLIENT_CONFIG, adapterConfig.client)

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2768,6 +2768,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
   },
   [DEPLOY_CONFIG]: {
     createMissingOrganizations: false,
+    fixParentOption: false,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -3104,6 +3105,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       refType: definitions.createUserDeployConfigType(ZENDESK, changeValidatorConfigType, {
         ...defaultMissingUserFallbackField,
         createMissingOrganizations: { refType: BuiltinTypes.BOOLEAN },
+        fixParentOption: { refType: BuiltinTypes.BOOLEAN },
       }),
     },
     [API_DEFINITIONS_CONFIG]: {

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -3223,7 +3223,7 @@ export const validateOmitInactiveConfig = (
 }
 export const validateFixElementsConfig = (FixElementsConfig: ZendeskFixElementsConfig | undefined): void => {
   if (FixElementsConfig !== undefined) {
-    if (!Object.keys(FixElementsConfig).every(fixerName => (fixerName as fixerNames) !== undefined)) {
+    if (!Object.keys(FixElementsConfig).every(fixerName => (fixerNames as unknown as string[]).includes(fixerName))) {
       throw Error('Invalid Zendesk fixElements config. One of the keys is invalid')
     }
   }

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -28,6 +28,7 @@ import {
   ZENDESK,
 } from './constants'
 import {
+  fixerNames,
   Guide,
   IdLocator,
   OmitInactiveConfig,
@@ -3081,7 +3082,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
   },
 })
 
-const fixerConfigType = createMatchingObjectType<ZendeskFixElementsConfig>({
+const fixerConfigType = createMatchingObjectType<Partial<ZendeskFixElementsConfig>>({
   elemID: new ElemID(ZENDESK, 'fixElementsConfig'),
   fields: {
     mergeLists: { refType: BuiltinTypes.BOOLEAN },
@@ -3218,5 +3219,12 @@ export const validateOmitInactiveConfig = (
         },
       }),
     )
+  }
+}
+export const validateFixElementsConfig = (FixElementsConfig: ZendeskFixElementsConfig | undefined): void => {
+  if (FixElementsConfig !== undefined) {
+    if (!Object.keys(FixElementsConfig).every(fixerName => (fixerName as fixerNames) !== undefined)) {
+      throw Error('Invalid Zendesk fixElements config. One of the keys is invalid')
+    }
   }
 }

--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -36,6 +36,7 @@ import {
   ZendeskClientConfig,
   ZendeskDeployConfig,
   ZendeskFetchConfig,
+  ZendeskFixElementsConfig,
 } from './user_config'
 
 const { defaultMissingUserFallbackField } = configUtils
@@ -67,6 +68,7 @@ export const CURSOR_BASED_PAGINATION_FIELD = 'links.next'
 export const CLIENT_CONFIG = 'client'
 export const FETCH_CONFIG = 'fetch'
 export const DEPLOY_CONFIG = 'deploy'
+export const FIX_ELEMENTS_CONFIG = 'fixElements'
 
 export const API_DEFINITIONS_CONFIG = 'apiDefinitions'
 
@@ -84,6 +86,7 @@ export type ZendeskConfig = {
   [FETCH_CONFIG]: ZendeskFetchConfig
   [DEPLOY_CONFIG]?: ZendeskDeployConfig
   [API_DEFINITIONS_CONFIG]: ZendeskApiConfig
+  [FIX_ELEMENTS_CONFIG]?: ZendeskFixElementsConfig
 }
 
 export const DEFAULT_TYPES: ZendeskApiConfig['types'] = {
@@ -2768,7 +2771,12 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
   },
   [DEPLOY_CONFIG]: {
     createMissingOrganizations: false,
-    fixParentOption: false,
+  },
+  [FIX_ELEMENTS_CONFIG]: {
+    mergeLists: false,
+    fallbackUsers: true,
+    removeDupUsers: true,
+    orderElements: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -3073,6 +3081,19 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
   },
 })
 
+const fixerConfigType = createMatchingObjectType<ZendeskFixElementsConfig>({
+  elemID: new ElemID(ZENDESK, 'fixElementsConfig'),
+  fields: {
+    mergeLists: { refType: BuiltinTypes.BOOLEAN },
+    fallbackUsers: { refType: BuiltinTypes.BOOLEAN },
+    removeDupUsers: { refType: BuiltinTypes.BOOLEAN },
+    orderElements: { refType: BuiltinTypes.BOOLEAN },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
   elemID: new ElemID(ZENDESK),
   fields: {
@@ -3105,8 +3126,10 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       refType: definitions.createUserDeployConfigType(ZENDESK, changeValidatorConfigType, {
         ...defaultMissingUserFallbackField,
         createMissingOrganizations: { refType: BuiltinTypes.BOOLEAN },
-        fixParentOption: { refType: BuiltinTypes.BOOLEAN },
       }),
+    },
+    [FIX_ELEMENTS_CONFIG]: {
+      refType: fixerConfigType,
     },
     [API_DEFINITIONS_CONFIG]: {
       refType: createDucktypeAdapterApiConfigType({
@@ -3133,6 +3156,7 @@ export const configType = createMatchingObjectType<Partial<ZendeskConfig>>({
       `${FETCH_CONFIG}.omitTicketStatusTicketField`,
       `${FETCH_CONFIG}.useNewInfra`,
       DEPLOY_CONFIG,
+      FIX_ELEMENTS_CONFIG,
     ),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/zendesk-adapter/src/fix_elements/index.ts
+++ b/packages/zendesk-adapter/src/fix_elements/index.ts
@@ -20,10 +20,12 @@ import { customReferenceHandlers } from '../custom_references'
 import { fallbackUsersHandler } from './fallback_user'
 import { FixElementsArgs } from './types'
 import { removeDupUsersHandler } from './remove_dup_users'
+import { mergeListsHandler } from './merge_lists'
 
 export const createFixElementFunctions = (args: FixElementsArgs): Record<string, FixElementsFunc> => ({
   ..._.mapValues(customReferenceHandlers, handler => handler.removeWeakReferences(args)),
   fallbackUsers: fallbackUsersHandler(args),
+  mergeLists: mergeListsHandler(args),
   // removingDupes needs to be after fallbackUsers
   removeDupUsers: removeDupUsersHandler(args),
 })

--- a/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
+++ b/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
@@ -26,7 +26,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { getParent, pathNaclCase } from '@salto-io/adapter-utils'
+import { getParents, pathNaclCase } from '@salto-io/adapter-utils'
 import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
 import { FixElementsHandler } from './types'
 import { TICKET_FIELD_CUSTOM_FIELD_OPTION, TICKET_FIELD_TYPE_NAME } from '../constants'
@@ -54,13 +54,13 @@ const getAllParents = async (
   const parentNames = new Set(parentElements.map(parent => parent.elemID.getFullName()))
   const additionalRelevantParentNames = childElements
     .map(child => {
-      try {
-        return getParent(child)
-      } catch (e) {
-        log.warn(
-          `could not find parent for child ${child.elemID.getFullName()}, with error ${e}, will not fix this parent`,
-        )
+      const parent = getParents(child)[0]
+      if (isReferenceExpression(parent)) {
+        return parent
       }
+      log.warn(
+        `could not find parent for child ${child.elemID.getFullName()}, parent is not a reference expression, will not fix this parent`,
+      )
       return undefined
     })
     .filter(isDefined)

--- a/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
+++ b/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
@@ -1,0 +1,173 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-console */
+
+import {
+  ChangeError,
+  ElemID,
+  InstanceElement,
+  isInstanceElement,
+  isReferenceExpression,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { getParent, pathNaclCase } from '@salto-io/adapter-utils'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { FixElementsHandler } from './types'
+import { TICKET_FIELD_CUSTOM_FIELD_OPTION, TICKET_FIELD_TYPE_NAME } from '../constants'
+
+const { isDefined } = lowerDashValues
+const { awu } = collections.asynciterable
+const log = logger(module)
+
+const PARENT_TO_CHILD_MAP: Record<string, string> = {
+  [TICKET_FIELD_TYPE_NAME]: TICKET_FIELD_CUSTOM_FIELD_OPTION,
+}
+
+const ALL_TYPES = Object.entries(PARENT_TO_CHILD_MAP).flatMap(couple => couple)
+
+const isRelevantElement = (element: unknown): element is InstanceElement =>
+  isInstanceElement(element) && ALL_TYPES.includes(element.elemID.typeName)
+
+const getAllParents = async (
+  relevantElements: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+): Promise<InstanceElement[]> => {
+  const [parentElements, childElements] = _.partition(relevantElements, elem =>
+    Object.keys(PARENT_TO_CHILD_MAP).includes(elem.elemID.typeName),
+  )
+  const parentNames = new Set(parentElements.map(parent => parent.elemID.getFullName()))
+  const parentNamesFromChild = new Set(
+    childElements
+      .map(child => {
+        try {
+          return getParent(child)
+        } catch (e) {
+          log.warn(
+            `could not find parent for child ${child.elemID.getFullName()}, with error ${e}, will not fix this parent`,
+          )
+        }
+        return undefined
+      })
+      .filter(isDefined)
+      .map(parent => parent.elemID.getFullName())
+      // we need to get all the parent names that don't appear already in the elements
+      .filter(name => !parentNames.has(name)),
+  )
+  const parentElementsFromElementSource: InstanceElement[] = await awu(await elementsSource.list())
+    .filter(id => id.idType === 'instance' && parentNamesFromChild.has(id.getFullName()))
+    .map(id => elementsSource.get(id))
+    .toArray()
+  return parentElements.concat(parentElementsFromElementSource)
+}
+
+const getChildrenElemIdByParent = (allParents: InstanceElement[], elemIdsList: ElemID[]): Record<string, ElemID[]> =>
+  Object.fromEntries(
+    allParents.map(parent => {
+      const parentElemId = parent.elemID
+      const childrenElemIds = elemIdsList.filter(id =>
+        id
+          .getFullName()
+          .startsWith(
+            `${parentElemId.adapter}.${PARENT_TO_CHILD_MAP[parentElemId.typeName] ?? ''}.instance.${pathNaclCase(parentElemId.name)}`,
+          ),
+      )
+      return [parentElemId.getFullName(), childrenElemIds]
+    }),
+  )
+
+type FixedParentResult = { fixedParent: InstanceElement; childrenAdded: string[] }
+
+const fixParent = (
+  parent: InstanceElement,
+  childrenElemIdByParent: Record<string, ElemID[]>,
+  allChildrenByFullName: Record<string, InstanceElement>,
+): FixedParentResult | undefined => {
+  const parentOptions = parent.value.custom_field_options
+  if (!_.isArray(parentOptions)) {
+    return undefined
+  }
+  const parentOptionsElemIdSet = new Set(
+    parentOptions.map(option => (isReferenceExpression(option) ? option.elemID.getFullName() : option)),
+  )
+  const childrenIdsFromElementSource = childrenElemIdByParent[parent.elemID.getFullName()]
+  const childrenAdded: string[] = []
+  const optionsToAdd = childrenIdsFromElementSource.flatMap(childElemId => {
+    if (!parentOptionsElemIdSet.has(childElemId.getFullName())) {
+      const optionToAdd = allChildrenByFullName[childElemId.getFullName()]
+      if (!isInstanceElement(optionToAdd)) {
+        return []
+      }
+      childrenAdded.push(optionToAdd.elemID.getFullName())
+      return [new ReferenceExpression(optionToAdd.elemID, optionToAdd)]
+    }
+    return []
+  })
+  const fixedParent = parent.clone()
+  const newOptions = parentOptions.concat(optionsToAdd)
+  fixedParent.value.custom_field_options = !_.isEmpty(childrenAdded)
+    ? newOptions
+    : fixedParent.value.custom_field_options
+  // we cannot have removed children (only in parent and not in elementSource) as they will appear in the dependency
+  return !_.isEmpty(childrenAdded) ? { fixedParent, childrenAdded } : undefined
+}
+
+const getFixedParents = async (
+  allParents: InstanceElement[],
+  elementsSource: ReadOnlyElementsSource,
+): Promise<FixedParentResult[]> => {
+  const elemIdsList = await awu(await elementsSource.list()).toArray()
+  const childrenElemIdByParent = getChildrenElemIdByParent(allParents, elemIdsList)
+  const allChildrenElemIds = Object.values(childrenElemIdByParent).flatMap(list => list)
+  const allChildren: InstanceElement[] = await awu(allChildrenElemIds)
+    .map(id => elementsSource.get(id))
+    .toArray()
+  const allChildrenByFullName = _.keyBy(allChildren, child => child.elemID.getFullName())
+  return allParents.map(parent => fixParent(parent, childrenElemIdByParent, allChildrenByFullName)).filter(isDefined)
+}
+
+const getError = (fixedParentsRes: FixedParentResult): ChangeError => ({
+  elemID: fixedParentsRes.fixedParent.elemID,
+  severity: 'Warning',
+  message: 'custom_field_options were updated',
+  detailedMessage: `${fixedParentsRes.fixedParent.elemID.typeName} custom_field_options were updated.
+  The following options were added at the end of the list: ${fixedParentsRes.childrenAdded.join(', ')}.`,
+})
+
+/**
+ * In this fixer we merge custom_field_options, by updating the father list to include all options from the elementsSource.
+ * Therefor if there is a custom option that was deleted from the list however its instance was not deleted we will add it back to the list.
+ */
+export const mergeListsHandler: FixElementsHandler =
+  ({ config, elementsSource }) =>
+  async elements => {
+    if (config.deploy?.fixParentOption !== true) {
+      return {
+        fixedElements: [],
+        errors: [],
+      }
+    }
+    const relevantElements = elements.filter(isRelevantElement)
+    const allParents = await getAllParents(relevantElements, elementsSource)
+    const fixedParentsResult = await getFixedParents(allParents, elementsSource)
+
+    return {
+      fixedElements: fixedParentsResult.map(res => res.fixedParent),
+      errors: fixedParentsResult.map(getError),
+    }
+  }

--- a/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
+++ b/packages/zendesk-adapter/src/fix_elements/merge_lists.ts
@@ -155,16 +155,16 @@ const getFixedParents = async (
 
 const getError = (fixedParentsRes: FixedParentResult): ChangeError => {
   const childrenAddedMsg = !_.isEmpty(fixedParentsRes.childrenAdded)
-    ? `\nThe following options were added at the end of the list: ${fixedParentsRes.childrenAdded.join(', ')}.`
+    ? `\nThe following custom field options were added at the end of the list: ${fixedParentsRes.childrenAdded.join(', ')}.`
     : ''
   const childrenRemovedMsg = !_.isEmpty(fixedParentsRes.childrenRemoved)
-    ? `\nThe following options were removed from the list: ${fixedParentsRes.childrenRemoved.join(', ')}.`
+    ? `\nThe following custom field options were removed from the list: ${fixedParentsRes.childrenRemoved.join(', ')}.`
     : ''
   return {
     elemID: fixedParentsRes.fixedParent.elemID,
     severity: 'Warning',
-    message: 'custom_field_options were updated',
-    detailedMessage: `${fixedParentsRes.fixedParent.elemID.typeName} custom_field_options were updated.${childrenAddedMsg}${childrenRemovedMsg}`,
+    message: 'The list of custom field options was automatically updated',
+    detailedMessage: `${childrenAddedMsg}${childrenRemovedMsg}`,
   }
 }
 

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -75,6 +75,7 @@ export type ZendeskClientConfig = definitions.ClientBaseConfig<ZendeskClientRate
 export type ZendeskDeployConfig = definitions.UserDeployConfig &
   definitions.DefaultMissingUserFallbackConfig & {
     createMissingOrganizations?: boolean
+    fixParentOption?: boolean
   }
 
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -77,12 +77,16 @@ export type ZendeskDeployConfig = definitions.UserDeployConfig &
     createMissingOrganizations?: boolean
   }
 
-export type ZendeskFixElementsConfig = {
-  mergeLists?: boolean
-  fallbackUsers?: boolean
-  removeDupUsers?: boolean
-  orderElements?: boolean
-}
+export type fixerNames = 'mergeLists' | 'fallbackUsers' | 'removeDupUsers' | 'orderElements'
+
+export type ZendeskFixElementsConfig = Record<fixerNames, boolean>
+
+// export type ZendeskFixElementsConfig = {
+//   mergeLists?: boolean
+//   fallbackUsers?: boolean
+//   removeDupUsers?: boolean
+//   orderElements?: boolean
+// }
 
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig,

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -75,8 +75,14 @@ export type ZendeskClientConfig = definitions.ClientBaseConfig<ZendeskClientRate
 export type ZendeskDeployConfig = definitions.UserDeployConfig &
   definitions.DefaultMissingUserFallbackConfig & {
     createMissingOrganizations?: boolean
-    fixParentOption?: boolean
   }
+
+export type ZendeskFixElementsConfig = {
+  mergeLists?: boolean
+  fallbackUsers?: boolean
+  removeDupUsers?: boolean
+  orderElements?: boolean
+}
 
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig,

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -77,16 +77,11 @@ export type ZendeskDeployConfig = definitions.UserDeployConfig &
     createMissingOrganizations?: boolean
   }
 
-export type fixerNames = 'mergeLists' | 'fallbackUsers' | 'removeDupUsers' | 'orderElements'
+export const fixerNames = ['mergeLists', 'fallbackUsers', 'removeDupUsers', 'orderElements'] as const
 
-export type ZendeskFixElementsConfig = Record<fixerNames, boolean>
+type FixerNames = (typeof fixerNames)[number]
 
-// export type ZendeskFixElementsConfig = {
-//   mergeLists?: boolean
-//   fallbackUsers?: boolean
-//   removeDupUsers?: boolean
-//   orderElements?: boolean
-// }
+export type ZendeskFixElementsConfig = Record<FixerNames, boolean>
 
 export type ZendeskApiConfig = configUtils.AdapterApiConfig<
   configUtils.DuckTypeTransformationConfig,

--- a/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
@@ -23,7 +23,6 @@ import {
   ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { elementSource } from '@salto-io/workspace'
-import { createInMemoryElementSource } from '@salto-io/workspace/dist/src/workspace/elements_source'
 import { mergeListsHandler } from '../../src/fix_elements/merge_lists'
 import { TICKET_FIELD_CUSTOM_FIELD_OPTION, TICKET_FIELD_TYPE_NAME, ZENDESK } from '../../src/constants'
 import ZendeskClient from '../../src/client/client'
@@ -88,7 +87,7 @@ describe('mergeListsHandler', () => {
       new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
     ]
     fixedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
-    elementsSource = createInMemoryElementSource([clonedTicket, ticketFiledOption1])
+    elementsSource = elementSource.createInMemoryElementSource([clonedTicket, ticketFiledOption1])
     // should remove ticketFiledOption2
     const fixerRes = await mergeListsHandler({
       elementsSource,

--- a/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
@@ -23,10 +23,11 @@ import {
   ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { elementSource } from '@salto-io/workspace'
+import { createInMemoryElementSource } from '@salto-io/workspace/dist/src/workspace/elements_source'
 import { mergeListsHandler } from '../../src/fix_elements/merge_lists'
 import { TICKET_FIELD_CUSTOM_FIELD_OPTION, TICKET_FIELD_TYPE_NAME, ZENDESK } from '../../src/constants'
 import ZendeskClient from '../../src/client/client'
-import { DEFAULT_CONFIG, DEPLOY_CONFIG, ZendeskConfig } from '../../src/config'
+import { DEFAULT_CONFIG, FIX_ELEMENTS_CONFIG, ZendeskConfig } from '../../src/config'
 
 describe('mergeListsHandler', () => {
   let config: ZendeskConfig
@@ -37,24 +38,24 @@ describe('mergeListsHandler', () => {
   const ticketFieldType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_TYPE_NAME) })
   const customFieldOptionType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_CUSTOM_FIELD_OPTION) })
 
-  const ticketFiled1 = new InstanceElement('ticket1', ticketFieldType, {})
+  const ticketField1 = new InstanceElement('ticket1', ticketFieldType, {})
   const ticketFiledOption1 = new InstanceElement('ticket1Option1', customFieldOptionType, {}, undefined, {
-    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketFiled1.elemID, ticketFiled1)],
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketField1.elemID, ticketField1)],
   })
   const ticketFiledOption2 = new InstanceElement('ticket1Option2', customFieldOptionType, {}, undefined, {
-    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketFiled1.elemID, ticketFiled1)],
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketField1.elemID, ticketField1)],
   })
 
   beforeEach(() => {
-    clonedTicket = ticketFiled1.clone()
-    fixedTicket = ticketFiled1.clone()
+    clonedTicket = ticketField1.clone()
+    fixedTicket = ticketField1.clone()
     fixedTicket.value.custom_field_options = [
       new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
-      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+      new ReferenceExpression(ticketFiledOption2.elemID),
     ]
     config = {
       ...DEFAULT_CONFIG,
-      [DEPLOY_CONFIG]: { fixParentOption: true },
+      [FIX_ELEMENTS_CONFIG]: { mergeLists: true },
     }
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
@@ -77,8 +78,32 @@ describe('mergeListsHandler', () => {
       elemID: fixerRes.fixedElements[0].elemID,
       severity: 'Warning',
       message: 'custom_field_options were updated',
-      detailedMessage: `ticket_field custom_field_options were updated.
-  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+      detailedMessage:
+        'ticket_field custom_field_options were updated.\nThe following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.',
+    })
+  })
+  it('Should add remove options from the parent list when it does not appear in the elementsSource', async () => {
+    clonedTicket.value.custom_field_options = [
+      new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
+      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+    ]
+    fixedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
+    elementsSource = createInMemoryElementSource([clonedTicket, ticketFiledOption1])
+    // should remove ticketFiledOption2
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(1)
+    expect(fixerRes.fixedElements[0]).toEqual(fixedTicket)
+    expect(fixerRes.errors.length).toEqual(1)
+    expect(fixerRes.errors[0]).toEqual({
+      elemID: fixerRes.fixedElements[0].elemID,
+      severity: 'Warning',
+      message: 'custom_field_options were updated',
+      detailedMessage:
+        'ticket_field custom_field_options were updated.\nThe following options were removed from the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.',
     })
   })
 
@@ -97,8 +122,8 @@ describe('mergeListsHandler', () => {
       elemID: fixerRes.fixedElements[0].elemID,
       severity: 'Warning',
       message: 'custom_field_options were updated',
-      detailedMessage: `ticket_field custom_field_options were updated.
-  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+      detailedMessage:
+        'ticket_field custom_field_options were updated.\nThe following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.',
     })
   })
   it('Should do nothing if options and parent align', async () => {
@@ -128,8 +153,8 @@ describe('mergeListsHandler', () => {
       elemID: fixerRes.fixedElements[0].elemID,
       severity: 'Warning',
       message: 'custom_field_options were updated',
-      detailedMessage: `ticket_field custom_field_options were updated.
-  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+      detailedMessage:
+        'ticket_field custom_field_options were updated.\nThe following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.',
     })
   })
   it('Should do nothing if options are not defined', async () => {
@@ -155,23 +180,11 @@ describe('mergeListsHandler', () => {
     expect(fixerRes.fixedElements.length).toEqual(0)
     expect(fixerRes.errors.length).toEqual(0)
   })
-  it('Should do nothing if flag is false', async () => {
-    config = { ...DEFAULT_CONFIG, [DEPLOY_CONFIG]: { fixParentOption: false } }
-    clonedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
-    // should add ticketFiledOption2
-    const fixerRes = await mergeListsHandler({
-      elementsSource,
-      config,
-      client,
-    })([clonedTicket])
-    expect(fixerRes.fixedElements.length).toEqual(0)
-    expect(fixerRes.errors.length).toEqual(0)
-  })
   it('Should do nothing to options which are not references', async () => {
     fixedTicket.value.custom_field_options = [
       new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
       1234,
-      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+      new ReferenceExpression(ticketFiledOption2.elemID),
     ]
     clonedTicket.value.custom_field_options = [
       new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
@@ -189,8 +202,8 @@ describe('mergeListsHandler', () => {
       elemID: fixerRes.fixedElements[0].elemID,
       severity: 'Warning',
       message: 'custom_field_options were updated',
-      detailedMessage: `ticket_field custom_field_options were updated.
-  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+      detailedMessage:
+        'ticket_field custom_field_options were updated.\nThe following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.',
     })
   })
 })

--- a/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/merge_lists.test.ts
@@ -1,0 +1,196 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReadOnlyElementsSource,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { elementSource } from '@salto-io/workspace'
+import { mergeListsHandler } from '../../src/fix_elements/merge_lists'
+import { TICKET_FIELD_CUSTOM_FIELD_OPTION, TICKET_FIELD_TYPE_NAME, ZENDESK } from '../../src/constants'
+import ZendeskClient from '../../src/client/client'
+import { DEFAULT_CONFIG, DEPLOY_CONFIG, ZendeskConfig } from '../../src/config'
+
+describe('mergeListsHandler', () => {
+  let config: ZendeskConfig
+  let client: ZendeskClient
+  let elementsSource: ReadOnlyElementsSource
+  let clonedTicket: InstanceElement
+  let fixedTicket: InstanceElement
+  const ticketFieldType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_TYPE_NAME) })
+  const customFieldOptionType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FIELD_CUSTOM_FIELD_OPTION) })
+
+  const ticketFiled1 = new InstanceElement('ticket1', ticketFieldType, {})
+  const ticketFiledOption1 = new InstanceElement('ticket1Option1', customFieldOptionType, {}, undefined, {
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketFiled1.elemID, ticketFiled1)],
+  })
+  const ticketFiledOption2 = new InstanceElement('ticket1Option2', customFieldOptionType, {}, undefined, {
+    [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(ticketFiled1.elemID, ticketFiled1)],
+  })
+
+  beforeEach(() => {
+    clonedTicket = ticketFiled1.clone()
+    fixedTicket = ticketFiled1.clone()
+    fixedTicket.value.custom_field_options = [
+      new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
+      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+    ]
+    config = {
+      ...DEFAULT_CONFIG,
+      [DEPLOY_CONFIG]: { fixParentOption: true },
+    }
+    client = new ZendeskClient({
+      credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
+    })
+    elementsSource = elementSource.createInMemoryElementSource([clonedTicket, ticketFiledOption1, ticketFiledOption2])
+  })
+
+  it('Should add missing option to the parent list when the parent is in the elements', async () => {
+    clonedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
+    // should add ticketFiledOption2
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(1)
+    expect(fixerRes.fixedElements[0]).toEqual(fixedTicket)
+    expect(fixerRes.errors.length).toEqual(1)
+    expect(fixerRes.errors[0]).toEqual({
+      elemID: fixerRes.fixedElements[0].elemID,
+      severity: 'Warning',
+      message: 'custom_field_options were updated',
+      detailedMessage: `ticket_field custom_field_options were updated.
+  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+    })
+  })
+
+  it('Should add missing option to the parent list when the parent is not in the elements and another option is', async () => {
+    clonedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
+    // should add ticketFiledOption2
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([ticketFiledOption1])
+    expect(fixerRes.fixedElements.length).toEqual(1)
+    expect(fixerRes.fixedElements[0]).toEqual(fixedTicket)
+    expect(fixerRes.errors.length).toEqual(1)
+    expect(fixerRes.errors[0]).toEqual({
+      elemID: fixerRes.fixedElements[0].elemID,
+      severity: 'Warning',
+      message: 'custom_field_options were updated',
+      detailedMessage: `ticket_field custom_field_options were updated.
+  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+    })
+  })
+  it('Should do nothing if options and parent align', async () => {
+    clonedTicket.value.custom_field_options = [
+      new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
+      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+    ]
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(0)
+    expect(fixerRes.errors.length).toEqual(0)
+  })
+  it('Should add missing option to the parent list when the both parent and option are in the elements', async () => {
+    clonedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket, ticketFiledOption1])
+    expect(fixerRes.fixedElements.length).toEqual(1)
+    expect(fixerRes.fixedElements[0]).toEqual(fixedTicket)
+    expect(fixerRes.errors.length).toEqual(1)
+    expect(fixerRes.errors[0]).toEqual({
+      elemID: fixerRes.fixedElements[0].elemID,
+      severity: 'Warning',
+      message: 'custom_field_options were updated',
+      detailedMessage: `ticket_field custom_field_options were updated.
+  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+    })
+  })
+  it('Should do nothing if options are not defined', async () => {
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(0)
+    expect(fixerRes.errors.length).toEqual(0)
+  })
+  it('Should do nothing if parent is not defined', async () => {
+    const clonedTicketFiledOption1 = ticketFiledOption1.clone()
+    clonedTicketFiledOption1.annotations = {}
+    clonedTicket.value.custom_field_options = [
+      new ReferenceExpression(clonedTicketFiledOption1.elemID, clonedTicketFiledOption1),
+    ]
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicketFiledOption1])
+    expect(fixerRes.fixedElements.length).toEqual(0)
+    expect(fixerRes.errors.length).toEqual(0)
+  })
+  it('Should do nothing if flag is false', async () => {
+    config = { ...DEFAULT_CONFIG, [DEPLOY_CONFIG]: { fixParentOption: false } }
+    clonedTicket.value.custom_field_options = [new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1)]
+    // should add ticketFiledOption2
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(0)
+    expect(fixerRes.errors.length).toEqual(0)
+  })
+  it('Should do nothing to options which are not references', async () => {
+    fixedTicket.value.custom_field_options = [
+      new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
+      1234,
+      new ReferenceExpression(ticketFiledOption2.elemID, ticketFiledOption2),
+    ]
+    clonedTicket.value.custom_field_options = [
+      new ReferenceExpression(ticketFiledOption1.elemID, ticketFiledOption1),
+      1234,
+    ]
+    const fixerRes = await mergeListsHandler({
+      elementsSource,
+      config,
+      client,
+    })([clonedTicket])
+    expect(fixerRes.fixedElements.length).toEqual(1)
+    expect(fixerRes.fixedElements[0]).toEqual(fixedTicket)
+    expect(fixerRes.errors.length).toEqual(1)
+    expect(fixerRes.errors[0]).toEqual({
+      elemID: fixerRes.fixedElements[0].elemID,
+      severity: 'Warning',
+      message: 'custom_field_options were updated',
+      detailedMessage: `ticket_field custom_field_options were updated.
+  The following options were added at the end of the list: zendesk.ticket_field__custom_field_options.instance.ticket1Option2.`,
+    })
+  })
+})


### PR DESCRIPTION
 add fixer for merge of  options lists in ticket_field

---

_Additional context for reviewer_
In this fixer we merge custom_field_options, by updating the father list to include all options from the elementsSource.
Therefor if there is a custom option that was deleted from the list however its instance was not deleted we will add it back to the list

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
