### PR TITLE
SALTO-6235: Supporting all non-standard types in standard object CV

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/new_fields_and_objects_fls.ts
+++ b/packages/salesforce-adapter/src/change_validators/new_fields_and_objects_fls.ts
@@ -42,7 +42,7 @@ const createObjectFLSInfo = (
   flsProfiles: string[],
 ): ChangeError => ({
   message: `Read/write access to this Custom Object will be granted to ${profileNameOrNumberOfProfiles(flsProfiles)}`,
-  detailedMessage: `Deploying this new Custom Object will make it and it's Custom Fields accessible by the following Profiles: [${flsProfiles.join(', ')}].`,
+  detailedMessage: `Deploying this new Custom Object will make it and its Custom Fields accessible by the following Profiles: [${flsProfiles.join(', ')}].`,
   severity: 'Info',
   elemID: field.elemID,
 })

--- a/packages/salesforce-adapter/src/change_validators/standard_field_or_object_additions_or_deletions.ts
+++ b/packages/salesforce-adapter/src/change_validators/standard_field_or_object_additions_or_deletions.ts
@@ -32,7 +32,7 @@ import {
   isCustomObject,
   isFieldOfCustomObject,
 } from '../transformers/transformer'
-import { safeApiName } from '../filters/utils'
+import { isStandardObjectSync, safeApiName } from '../filters/utils'
 
 const { awu } = collections.asynciterable
 
@@ -107,11 +107,9 @@ const changeValidator: ChangeValidator = async (changes) => {
       Object.values(customObject.fields).includes(field),
     )
 
-  const standardObjectChanges = await awu(additionOrRemovalCustomObjectChanges)
-    .filter(
-      async (obj) => !isCustom((await safeApiName(getChangeData(obj))) ?? ''),
-    )
-    .toArray()
+  const standardObjectChanges = additionOrRemovalCustomObjectChanges.filter(
+    (change) => isStandardObjectSync(getChangeData(change)),
+  )
 
   const standardFieldAdditionErrors = await awu(standardFieldChanges)
     .filter(isAdditionChange)

--- a/packages/salesforce-adapter/test/change_validators/standard_field_or_object_additions_or_deletions.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/standard_field_or_object_additions_or_deletions.test.ts
@@ -54,7 +54,7 @@ describe('standardCustomFieldOrObject Change Validator', () => {
     })
   })
   describe('Addition or removal of custom object', () => {
-    it('should not have error for standard object addition', async () => {
+    it('should not have error for custom object addition', async () => {
       // A real scenario of CustomObject addition will also include addition of each of its fields
       const changeErrors = await changeValidator([
         toChange({ after: mockTypes.TestCustomObject__c }),
@@ -65,13 +65,28 @@ describe('standardCustomFieldOrObject Change Validator', () => {
       expect(changeErrors).toBeEmpty()
     })
 
-    it('should not have error for standard object removals', async () => {
+    it('should not have error for custom object removals', async () => {
       // A real scenario of CustomObject removal will also include removal of each of its fields
       const changeErrors = await changeValidator([
         toChange({ before: mockTypes.TestCustomObject__c }),
         ...Object.values(mockTypes.TestCustomObject__c.fields).map((field) =>
           toChange({ before: field }),
         ),
+      ])
+      expect(changeErrors).toBeEmpty()
+    })
+  })
+  describe('Addition or removal of custom event', () => {
+    it('should not have error for custom event addition', async () => {
+      const changeErrors = await changeValidator([
+        toChange({ after: mockTypes.TestCustomEvent__e }),
+      ])
+      expect(changeErrors).toBeEmpty()
+    })
+
+    it('should not have error for custom event removals', async () => {
+      const changeErrors = await changeValidator([
+        toChange({ before: mockTypes.TestCustomEvent__e }),
       ])
       expect(changeErrors).toBeEmpty()
     })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -697,6 +697,7 @@ export const mockTypes = {
     },
   }),
   TestCustomObject__c: createCustomObjectType('TestCustomObject__c', {}),
+  TestCustomEvent__e: createCustomObjectType('TestCustomEvent__e', {}),
   BusinessProcess: createMetadataObjectType({
     annotations: {
       metadataType: 'BusinessProcess',


### PR DESCRIPTION
Also improved a warning message that came up during testing.

---

_Additional context for reviewer_
Tested on my env with a custom event.

---
_Release Notes_: 
_Salesforce_:
* Fixed a bug where Custom Events were misidentified as Standard Objects and could not be deployed.

---
_User Notifications_: 
None.
