### PR TITLE
SALTO-6237: Fix leftover timers in cli tests

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -190,6 +190,11 @@ const deployPlan = async (
     cliTelemetry.actionsFailure(result.errors.length)
   }
 
+  // Since we are done deploying, clear any leftover intervals
+  Object.values(actions)
+    .filter(action => action.intervalId)
+    .forEach(action => clearInterval(action.intervalId))
+
   return result
 }
 

--- a/packages/cli/test/command_builder.test.ts
+++ b/packages/cli/test/command_builder.test.ts
@@ -270,18 +270,15 @@ describe('Command builder', () => {
           })
         })
         it('should send start and success telemetry', () => {
-          const events = cliArgs.telemetry.getEvents()
-          expect(events).toContainEqual(
-            expect.objectContaining({
-              name: buildEventName('dummy', 'start'),
-              tags: { workspaceID: 'test', installationID: '1234', app: 'test' },
-            }),
+          expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+            buildEventName('dummy', 'start'),
+            1,
+            expect.objectContaining({ workspaceID: 'test' }),
           )
-          expect(events).toContainEqual(
-            expect.objectContaining({
-              name: buildEventName('dummy', 'success'),
-              tags: { workspaceID: 'test', installationID: '1234', app: 'test' },
-            }),
+          expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+            buildEventName('dummy', 'success'),
+            1,
+            expect.objectContaining({ workspaceID: 'test' }),
           )
         })
       })
@@ -300,18 +297,15 @@ describe('Command builder', () => {
           await expect(result).rejects.toThrow(new CliError(CliExitCode.UserInputError))
         })
         it('should send start and failure telemetry', () => {
-          const events = cliArgs.telemetry.getEvents()
-          expect(events).toContainEqual(
-            expect.objectContaining({
-              name: buildEventName('dummy', 'start'),
-              tags: { workspaceID: 'test', installationID: '1234', app: 'test' },
-            }),
+          expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+            buildEventName('dummy', 'start'),
+            1,
+            expect.objectContaining({ workspaceID: 'test' }),
           )
-          expect(events).toContainEqual(
-            expect.objectContaining({
-              name: buildEventName('dummy', 'failure'),
-              tags: { workspaceID: 'test', installationID: '1234', app: 'test' },
-            }),
+          expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+            buildEventName('dummy', 'failure'),
+            1,
+            expect.objectContaining({ workspaceID: 'test' }),
           )
         })
       })
@@ -341,17 +335,22 @@ describe('Command builder', () => {
         commanderInput: [{}],
       })
 
-      const events = cliArgs.telemetry.getEvents()
-      expect(events).toContainEqual(
+      expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+        buildEventName('dummy', 'start'),
+        1,
         expect.objectContaining({
-          name: buildEventName('dummy', 'start'),
-          tags: { workspaceID: 'test', installationID: '1234', app: 'test', extraTag1: 'tag1', extraTag2: 'tag2' },
+          workspaceID: 'test',
+          extraTag1: 'tag1',
+          extraTag2: 'tag2',
         }),
       )
-      expect(events).toContainEqual(
+      expect(cliArgs.telemetry.sendCountEvent).toHaveBeenCalledWith(
+        buildEventName('dummy', 'success'),
+        1,
         expect.objectContaining({
-          name: buildEventName('dummy', 'success'),
-          tags: { workspaceID: 'test', installationID: '1234', app: 'test', extraTag1: 'tag1', extraTag2: 'tag2' },
+          workspaceID: 'test',
+          extraTag1: 'tag1',
+          extraTag2: 'tag2',
         }),
       )
     })

--- a/packages/cli/test/commands/account.test.ts
+++ b/packages/cli/test/commands/account.test.ts
@@ -208,8 +208,11 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'success']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('add', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toMatchObject({ 'adapter-newAdapter': true })
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(
+              eventName,
+              1,
+              expect.objectContaining({ 'adapter-newAdapter': true }),
+            )
           })
         })
       })
@@ -227,12 +230,7 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'failure']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('add', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toStrictEqual({
-              app: 'test',
-              installationID: '1234',
-              workspaceID: 'test',
-            })
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventName, 1, { workspaceID: 'test' })
           })
         })
       })
@@ -251,12 +249,7 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'failure']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('add', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toStrictEqual({
-              app: 'test',
-              installationID: '1234',
-              workspaceID: 'test',
-            })
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventName, 1, { workspaceID: 'test' })
           })
         })
       })
@@ -644,12 +637,9 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'success']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('login', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toMatchObject({
-              'adapter-salesforce': true,
-              installationID: '1234',
-              app: 'test',
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventName, 1, {
               workspaceID: 'test',
+              'adapter-salesforce': true,
             })
           })
         })
@@ -668,12 +658,7 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'failure']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('login', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toStrictEqual({
-              app: 'test',
-              installationID: '1234',
-              workspaceID: 'test',
-            })
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventName, 1, { workspaceID: 'test' })
           })
         })
       })
@@ -690,12 +675,7 @@ describe('account command group', () => {
           const eventTypes: (keyof TelemetryEventNames)[] = ['start', 'failure']
           eventTypes.forEach(eventType => {
             const eventName = buildEventName('login', eventType)
-            expect(telemetry.getEventsMap()[eventName]).toHaveLength(1)
-            expect(telemetry.getEventsMap()[eventName][0].tags).toStrictEqual({
-              app: 'test',
-              installationID: '1234',
-              workspaceID: 'test',
-            })
+            expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventName, 1, { workspaceID: 'test' })
           })
         })
       })

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -162,7 +162,8 @@ describe('Element command group', () => {
       })
 
       it('should not send telemetry events', () => {
-        expect(telemetry.getEvents()).toHaveLength(0)
+        expect(telemetry.sendCountEvent).not.toHaveBeenCalled()
+        expect(telemetry.sendStackEvent).not.toHaveBeenCalled()
       })
 
       it('should print clone to console', () => {

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -122,7 +122,7 @@ describe('fetch command', () => {
         expect(fetch).toHaveBeenCalled()
       })
       it('should send telemetry events', () => {
-        expect(telemetry.getEventsMap()[eventsNames.changes]).toHaveLength(1)
+        expect(telemetry.sendCountEvent).toHaveBeenCalled()
       })
     })
 
@@ -272,8 +272,7 @@ describe('fetch command', () => {
         })
         it('should not update workspace', () => {
           expect(workspace.updateNaclFiles).toHaveBeenCalledWith([], 'default')
-          expect(telemetry.getEventsMap()[eventsNames.changes]).toHaveLength(1)
-          expect(telemetry.getEventsMap()[eventsNames.changes][0].value).toEqual(0)
+          expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.changes, 0, expect.objectContaining({}))
         })
       })
       describe('with changes to write to config', () => {

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -79,10 +79,9 @@ describe('init command', () => {
         },
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
-      expect(telemetry.getEvents()).toHaveLength(2)
-      expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+      expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.success, 1, expect.objectContaining({}))
     })
     it('should print errors', async () => {
       await action({
@@ -92,10 +91,9 @@ describe('init command', () => {
         },
       })
       expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
-      expect(telemetry.getEvents()).toHaveLength(2)
-      expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+      expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.failure, 1, expect.objectContaining({}))
     })
   })
   describe('without interactive env input ', () => {
@@ -108,10 +106,9 @@ describe('init command', () => {
         },
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
-      expect(telemetry.getEvents()).toHaveLength(2)
-      expect(telemetry.getEventsMap()[eventsNames.failure]).toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.success]).not.toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+      expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.success, 1, expect.objectContaining({}))
       expect(mockInitLocalWorkspace).toHaveBeenCalledWith(expect.anything(), 'test', 'userEnvInput')
     })
     it('should print errors', async () => {
@@ -123,10 +120,9 @@ describe('init command', () => {
         },
       })
       expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
-      expect(telemetry.getEvents()).toHaveLength(2)
-      expect(telemetry.getEventsMap()[eventsNames.success]).toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.failure]).not.toBeUndefined()
-      expect(telemetry.getEventsMap()[eventsNames.start]).not.toBeUndefined()
+      expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.failure, 1, expect.objectContaining({}))
     })
   })
 

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -129,8 +129,16 @@ describe('restore command', () => {
     })
 
     it('should send telemetry events', () => {
-      expect(telemetry.getEventsMap()[eventsNames.changesToApply]).toHaveLength(1)
-      expect(telemetry.getEventsMap()[eventsNames.workspaceSize]).toHaveLength(1)
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(
+        eventsNames.changesToApply,
+        expect.anything(),
+        expect.objectContaining({}),
+      )
+      expect(telemetry.sendCountEvent).toHaveBeenCalledWith(
+        eventsNames.workspaceSize,
+        expect.anything(),
+        expect.objectContaining({}),
+      )
     })
 
     it('should print deployment to console', () => {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -41,12 +41,8 @@ import {
 import {
   Plan,
   PlanItem,
-  EVENT_TYPES,
   DeployResult,
-  telemetrySender,
   Telemetry,
-  Tags,
-  TelemetryEvent,
   CommandConfig,
   deploy as coreDeploy,
   ItemStatus,
@@ -116,32 +112,20 @@ export interface MockCliReturn {
   exitCode: number
 }
 
-export type MockTelemetry = {
-  getEvents(): TelemetryEvent[]
-  getEventsMap(): { [name: string]: TelemetryEvent[] }
-} & Telemetry
+export type MockTelemetry = jest.Mocked<Telemetry>
 
 export const getMockTelemetry = (): MockTelemetry => {
-  const commonTags = { installationID: '1234', app: 'test' }
-  const telemetry = telemetrySender({ url: '', enabled: false, token: '' }, commonTags)
-  const events: TelemetryEvent[] = []
-  telemetry.sendCountEvent = async (name: string, value: number, tags: Tags = {}): Promise<void> => {
-    events.push({
-      name,
-      value,
-      tags: { ...tags, ...commonTags },
-      type: EVENT_TYPES.COUNTER,
-      timestamp: '',
-    })
+  let stopped = false
+  return {
+    enabled: true,
+    isStopped: mockFunction<Telemetry['isStopped']>().mockReturnValue(stopped),
+    sendCountEvent: mockFunction<Telemetry['sendCountEvent']>(),
+    sendStackEvent: mockFunction<Telemetry['sendStackEvent']>(),
+    stop: mockFunction<Telemetry['stop']>().mockImplementation(async () => {
+      stopped = true
+    }),
+    flush: mockFunction<Telemetry['flush']>(),
   }
-
-  return Object.assign(telemetry, {
-    getEvents: (): TelemetryEvent[] => events,
-    getEventsMap: (): { [name: string]: TelemetryEvent[] } =>
-      _(events)
-        .groupBy(e => e.name)
-        .value(),
-  })
 }
 
 const getMockCommandConfig = (): CommandConfig => ({

--- a/packages/cli/test/telemetry.test.ts
+++ b/packages/cli/test/telemetry.test.ts
@@ -30,8 +30,12 @@ describe('telemetry event names', () => {
     cliTelemetry = getCliTelemetry(mockTelemetry, command)
     cliTelemetry.success()
 
-    expect(mockTelemetry.getEvents()).toHaveLength(1)
-    expect(mockTelemetry.getEventsMap()).toHaveProperty([buildEventName(command, 'success')])
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledTimes(1)
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledWith(
+      buildEventName(command, 'success'),
+      1,
+      expect.objectContaining({}),
+    )
   })
 
   it('should send success events with tags', () => {
@@ -41,11 +45,12 @@ describe('telemetry event names', () => {
     cliTelemetry.setTags(tags)
     cliTelemetry.success()
 
-    expect(mockTelemetry.getEvents()).toHaveLength(1)
-    expect(mockTelemetry.getEventsMap()).toHaveProperty([buildEventName(command, 'success')])
-    expect(mockTelemetry.getEventsMap()[buildEventName(command, 'success')]).toHaveLength(1)
-    expect(mockTelemetry.getEventsMap()[buildEventName(command, 'success')][0].tags).toHaveProperty('someTag')
-    expect(mockTelemetry.getEventsMap()[buildEventName(command, 'success')][0].tags.someTag).toEqual(tags.someTag)
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledTimes(1)
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledWith(
+      buildEventName(command, 'success'),
+      1,
+      expect.objectContaining(tags),
+    )
   })
 
   it('should send mergeErrors events with some value > 1', () => {
@@ -54,9 +59,12 @@ describe('telemetry event names', () => {
     cliTelemetry = getCliTelemetry(mockTelemetry, command)
     cliTelemetry.mergeErrors(42)
 
-    expect(mockTelemetry.getEvents()).toHaveLength(1)
-    expect(mockTelemetry.getEventsMap()).toHaveProperty([buildEventName(command, 'mergeErrors')])
-    expect(mockTelemetry.getEventsMap()[buildEventName(command, 'mergeErrors')][0].value).toEqual(value)
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledTimes(1)
+    expect(mockTelemetry.sendCountEvent).toHaveBeenCalledWith(
+      buildEventName(command, 'mergeErrors'),
+      value,
+      expect.objectContaining({}),
+    )
   })
 
   it('should build event name for a some command', () => {


### PR DESCRIPTION

---

_Additional context for reviewer_
Noticed as part of trying to update jest version.
There are two fixes here:
1. the "mock" telemetry sender was actually using a real telemetry sender that uses timers to send events, most tests never bothered to stop that telemetry sender. since there is really no point in using the real telemetry sender in the mock, the fix was creating a real mock that does nothing
2. in the code of the "deploy" action, there are timers that update about the status of each action, when the deploy is done, in theory, all actions should have received either a "success" or "failure" event, but if that does not happen for any reason, we should still stop all the timers at the end of the function 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_