### PR TITLE
SALTO-6236: Salesforce CustomMetadata Records deploy fail when attempting to delete field values

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -115,6 +115,8 @@ export type ServiceMDTRecordValue = MetadataValues & {
   values: ServiceMDTRecordFieldValue | ServiceMDTRecordFieldValue[]
 }
 
+// Salesforce expects xsi:nil="true" for null values
+// We pass "true" here since fast-xml-parser  omits these values and no value is needed here
 export const XSI_NIL_TRUE = { [`${XML_ATTRIBUTE_PREFIX}xsi:nil="true"`]: true }
 
 const isServiceMDTRecordFieldValue = (

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -115,8 +115,8 @@ export type ServiceMDTRecordValue = MetadataValues & {
   values: ServiceMDTRecordFieldValue | ServiceMDTRecordFieldValue[]
 }
 
-// Salesforce expects xsi:nil="true" for null values
-// We pass "true" here since fast-xml-parser  omits these values and no value is needed here
+// Salesforce expects xsi:nil="true" for null values explicitly.
+// We put the "true" value in the key since fast-xml-parser omits boolean values.
 export const XSI_NIL_TRUE = { [`${XML_ATTRIBUTE_PREFIX}xsi:nil="true"`]: true }
 
 const isServiceMDTRecordFieldValue = (

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -227,7 +227,6 @@ const formatRecordValuesForService = async (
         value: XSI_NIL_TRUE,
       }
     })
-    .filter(isDefined)
     .toArray()
 
   return {

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -115,6 +115,8 @@ export type ServiceMDTRecordValue = MetadataValues & {
   values: ServiceMDTRecordFieldValue | ServiceMDTRecordFieldValue[]
 }
 
+export const XSI_NIL_TRUE = { [`${XML_ATTRIBUTE_PREFIX}xsi:nil="true"`]: true }
+
 const isServiceMDTRecordFieldValue = (
   value: Values,
 ): value is ServiceMDTRecordFieldValue =>
@@ -219,11 +221,13 @@ const formatRecordValuesForService = async (
           value: { '#text': fieldValue, 'attr_xsi:type': xsdType },
         }
       }
+      // No value was provided for the field or field value was removed
       return {
         field: fieldName,
-        value: { 'attr_xsi:nil': 'true' },
+        value: XSI_NIL_TRUE,
       }
     })
+    .filter(isDefined)
     .toArray()
 
   return {

--- a/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
@@ -28,6 +28,7 @@ import { mockTypes, mockInstances } from '../mock_elements'
 import { defaultFilterContext } from '../utils'
 import makeFilter, {
   ServiceMDTRecordValue,
+  XSI_NIL_TRUE,
 } from '../../src/filters/custom_metadata'
 import {
   MetadataInstanceElement,
@@ -319,7 +320,7 @@ describe('CustomMetadata filter', () => {
             field: 'email__c',
             value: { 'attr_xsi:type': 'xsd:string', '#text': 'test@user.com' },
           },
-          { field: 'number__c', value: { 'attr_xsi:nil': 'true' } }, // null value handling
+          { field: 'number__c', value: XSI_NIL_TRUE }, // null value handling
           {
             field: 'percent__c',
             value: { 'attr_xsi:type': 'xsd:double', '#text': 23 },


### PR DESCRIPTION
Bugfix: Salesforce CustomMetadata Records deploy fail when attempting to delete field values

---

It seems like Salesforce started to enforce providing value to the xsi:nil attribute which indicates no value (null). This caused deletions in CustomMetadata Records to fail as we used to send them as <xsi:nil/> instead of <xsi:nil=”true”/>. 

---
_Release Notes_: 
Salesforce Adapter:
- Bugfix: Salesforce CustomMetadata Records deploy fail when attempting to delete field values

---
_User Notifications_: 
_None_
