### PR TITLE
SALTO-6240: Disable Salesforce Profiles Elements Fixer by default

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -28,6 +28,7 @@ import {
   CustomReferencesHandlers,
   CustomReferencesSettings,
   CUSTOM_REFS_CONFIG,
+  FixElementsSettings,
   FIX_ELEMENTS_CONFIG,
   SalesforceConfig,
   WeakReferencesHandler,
@@ -42,17 +43,23 @@ const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
   permisisonSets: permissionSetsHandler,
 }
 
-const defaultHandlersConfiguration: Record<CustomReferencesHandlers, boolean> =
+const defaultCustomReferencesConfiguration: Required<CustomReferencesSettings> =
   {
     profiles: true,
     managedElements: true,
     permisisonSets: true,
   }
 
+const defaultFixElementsConfiguration: Required<FixElementsSettings> = {
+  profiles: false,
+  managedElements: true,
+  permisisonSets: true,
+}
+
 export const customReferencesConfiguration = (
   customReferencesConfig: CustomReferencesSettings | undefined,
-): Record<string, boolean> =>
-  _.defaults(customReferencesConfig, defaultHandlersConfiguration)
+): Required<CustomReferencesSettings> =>
+  _.defaults(customReferencesConfig, defaultCustomReferencesConfiguration)
 
 export const getCustomReferences = combineCustomReferenceGetters(
   _.mapValues(handlers, (handler) => handler.findWeakReferences),
@@ -62,8 +69,8 @@ export const getCustomReferences = combineCustomReferenceGetters(
 
 const fixElementsConfiguration = (
   config: SalesforceConfig,
-): Record<string, boolean> =>
-  _.defaults(config[FIX_ELEMENTS_CONFIG], defaultHandlersConfiguration)
+): Required<FixElementsSettings> =>
+  _.defaults(config[FIX_ELEMENTS_CONFIG], defaultFixElementsConfiguration)
 
 export const fixElementsFunc = ({
   elementsSource,


### PR DESCRIPTION
Due to some edge-cases we plan to solve in the future, we will disable the fixer for the time being.

---

Had to separate the defaults for the `customRefFuncs` and the `fixers`.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
