### PR TITLE
SALTO-6241 turbocache unit tests

### DIFF
--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -43,9 +43,9 @@ commands:
       - restore_cache:
           name: Restore node modules
           keys:
-            - &node-modules-cache node-modules-v2-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - node-modules-v2-{{ arch }}-{{ .Branch }}
-            - node-modules-v2-{{ arch }}-main
+            - &node-modules-cache node-modules-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - node-modules-v2-{{ .Branch }}
+            - node-modules-v2-main
   
   store_node_modules:
     description: Cache store node_modules
@@ -63,9 +63,9 @@ commands:
       - restore_cache:
           name: Restore yarn cache
           keys:
-            - &yarn-cache yarn-cache-v2-{{ arch }}-{{ .Branch }}-{{ checksum "yarn.lock" }}
-            - yarn-cache-v2-{{ arch }}-{{ .Branch }}
-            - yarn-cache-v2-{{ arch }}-main
+            - &yarn-cache yarn-cache-v2-{{ .Branch }}-{{ checksum "yarn.lock" }}
+            - yarn-cache-v2-{{ .Branch }}
+            - yarn-cache-v2-main
 
   store_yarn_cache:
     description: Cache store yarn cache
@@ -131,6 +131,34 @@ commands:
       - restore_intermediate
       - restore_node_modules
       - setup_yarn
+
+  cached_unit_test:
+    parameters:
+      package_name:
+        type: string
+    steps:
+      - step_setup
+      - restore_turbo_cache:
+          cache_name: jest_ut-<< parameters.package_name >>
+      - run:
+          name: Check dependencies for changes
+          command: |
+            export SALTO_DEPENDENCIES_HASH="$(node ./build_utils/hash_dependencies.js -p "$(echo << parameters.package_name >> | cut -d':' -f2)")"
+      - run:
+          name: << parameters.package_name >> unit tests
+          command: |
+            yarn test --filter="$(echo "<< parameters.package_name >>" | cut -d':' -f2)" --  --forceExit --detectOpenHandles --reporters=default --reporters=jest-junit --ci --colors
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: 'reports/unittests'
+
+      - store_test_results:
+          path: reports
+      - store_turbo_cache:
+          cache_name: jest_ut-<< parameters.package_name >>
+
+      - coveralls/upload:
+          parallel: true
+          flag_name: << parameters.package_name >>  
 
   run_e2e_tests:
     parameters:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -132,36 +132,6 @@ commands:
       - restore_node_modules
       - setup_yarn
 
-  cached_unit_test:
-    parameters:
-      package_name:
-        type: string
-    steps:
-      - step_setup
-      - restore_turbo_cache:
-          cache_name: jest_ut-<< parameters.package_name >>
-      - restore_turbo_cache:
-          cache_name: build      
-      - run:
-          name: Check dependencies for changes
-          command: |
-            export SALTO_DEPENDENCIES_HASH="$(node ./build_utils/hash_dependencies.js -p "$(echo << parameters.package_name >> | cut -d':' -f2)")"
-      - run:
-          name: << parameters.package_name >> unit tests
-          command: |
-            yarn test --filter="$(echo "<< parameters.package_name >>" | cut -d':' -f2)" --  --forceExit --detectOpenHandles --reporters=default --reporters=jest-junit --ci --colors
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: 'reports/unittests'
-
-      - store_test_results:
-          path: reports
-      - store_turbo_cache:
-          cache_name: jest_ut-<< parameters.package_name >>
-
-      - coveralls/upload:
-          parallel: true
-          flag_name: << parameters.package_name >>  
-
   run_e2e_tests:
     parameters:
       should_install_java:
@@ -314,8 +284,35 @@ jobs:
     working_directory: /mnt/ramdisk/project
 
     steps:
-      - cached_unit_test:
-          package_name: << parameters.package_name >>
+      - step_setup
+      - restore_turbo_cache:
+          cache_name: jest_ut-<< parameters.package_name >>
+      - restore_turbo_cache:
+          cache_name: build      
+      - run:
+          name: Extract package name
+          command: |
+            PACKAGE_NAME="$(echo "<< parameters.package_name >>" | cut -d':' -f2)"
+            echo "export E2E_PACKAGE_NAME=$PACKAGE_NAME" >> $BASH_ENV
+      - run:
+          name: Check dependencies for changes
+          command: |
+            export SALTO_DEPENDENCIES_HASH="$(node ./build_utils/hash_dependencies.js -p $E2E_PACKAGE_NAME)"
+      - run:
+          name: << parameters.package_name >> unit tests
+          command: |
+            yarn test --filter="$E2E_PACKAGE_NAME" --  --forceExit --detectOpenHandles --reporters=default --reporters=jest-junit --ci --colors
+          environment:
+            JEST_JUNIT_OUTPUT_DIR: 'reports/unittests'
+
+      - store_test_results:
+          path: reports
+      - store_turbo_cache:
+          cache_name: jest_ut-<< parameters.package_name >>
+
+      - coveralls/upload:
+          parallel: true
+          flag_name: << parameters.package_name >>  
 
   finish_coveralls:
     docker:

--- a/.circleci/config_template.yml
+++ b/.circleci/config_template.yml
@@ -140,6 +140,8 @@ commands:
       - step_setup
       - restore_turbo_cache:
           cache_name: jest_ut-<< parameters.package_name >>
+      - restore_turbo_cache:
+          cache_name: build      
       - run:
           name: Check dependencies for changes
           command: |
@@ -312,21 +314,8 @@ jobs:
     working_directory: /mnt/ramdisk/project
 
     steps:
-      - step_setup
-      - run:
-          name: << parameters.package_name >> unit tests
-          command: |
-            PACKAGE=$(echo "<< parameters.package_name >>" | cut -d':' -f2)
-            yarn workspace $PACKAGE test -i --reporters=default --reporters=jest-junit --ci --colors --forceExit --detectOpenHandles
-          environment:
-            JEST_JUNIT_OUTPUT_DIR: 'reports/unittests'
-
-      - store_test_results:
-          path: reports
-
-      - coveralls/upload:
-          parallel: true
-          flag_name: << parameters.package_name >>  
+      - cached_unit_test:
+          package_name: << parameters.package_name >>
 
   finish_coveralls:
     docker:

--- a/build_utils/hash_dependencies.js
+++ b/build_utils/hash_dependencies.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { execSync } = require('child_process')
+const fs = require('fs')
+const tmp = require('tmp')
+const yargs = require('yargs/yargs')
+
+const main = () => {
+  const argv = yargs(process.argv)
+    .option('package_name', {
+      alias: 'p',
+      type: 'string',
+      description: 'Name of the package (omit to hash all monorepo)',
+      demandOption: false,
+    })
+    .option('dependencies', {
+      alias: 'd',
+      type: 'boolean',
+      description: 'Show the dependencies for package_name',
+      demandOption: false,
+    })
+    .option('files', {
+      alias: 'f',
+      type: 'boolean',
+      description: 'Show all the files that package_name depends on',
+      demandOption: false,
+    })
+    .help().argv
+
+  const currentPackage = argv.package_name
+  tmp.setGracefulCleanup()
+  const tempFile = tmp.fileSync()
+
+  if (currentPackage) {
+    const dependenciesGraph = JSON.parse(
+      `[${execSync('yarn workspaces list --json -v').toString().trim().split('\n').join(',')}]`,
+    )
+    const { workspaceDependencies } = dependenciesGraph.find(ws => ws.name === currentPackage)
+    if (argv.dependencies) {
+      console.log(workspaceDependencies)
+    }
+    workspaceDependencies.forEach(ws => {
+      fs.appendFileSync(tempFile.name, execSync(`find "${ws}" -type f -name "*.ts"`).toString().trim() + '\n')
+    })
+  } else {
+    if (argv.dependencies) {
+      const allPackages = execSync("yarn workspaces list --json | jq '.name'").toString().trim()
+      console.log(allPackages)
+    }
+    fs.appendFileSync(tempFile.name, execSync(`find packages -type f -name "*.ts"`).toString().trim() + '\n')
+  }
+
+  if (argv.files) {
+    // console.log(dependenciesSourceFiles.split(' ').join('\n'))
+    console.log(fs.readFileSync(tempFile.name, { encoding: 'utf8' }))
+  }
+
+  console.log(execSync(`xargs sha1sum < ${tempFile.name} | sha1sum`).toString().split(' ')[0])
+}
+
+main()

--- a/build_utils/hash_dependencies.js
+++ b/build_utils/hash_dependencies.js
@@ -66,7 +66,6 @@ const main = () => {
   }
 
   if (argv.files) {
-    // console.log(dependenciesSourceFiles.split(' ').join('\n'))
     console.log(fs.readFileSync(tempFile.name, { encoding: 'utf8' }))
   }
 

--- a/build_utils/turbo_run.sh
+++ b/build_utils/turbo_run.sh
@@ -56,6 +56,5 @@ else
 
 fi
 
-sleep 1
 yarn turbo run "${ORG_ARG[@]}" \
   --concurrency="$TURBO_CONCURRENCY"

--- a/build_utils/turbo_run.sh
+++ b/build_utils/turbo_run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 TURBO_CONCURRENCY="${TURBO_CONCURRENCY:-"100%"}"
-ORG_ARG=( "$@" )
+ORG_ARG=("$@")
+
 
 if [ -n "$CI" ]; then
 
@@ -19,8 +20,42 @@ if [ -n "$CI" ]; then
     TURBO_CONCURRENCY="$(awk -v quota="$(cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us)" -v period="$(cat /sys/fs/cgroup/cpu/cpu.cfs_period_us)" 'BEGIN { printf "%.0f\n", (quota / period) * 0.5 }')"
 
   fi
+else
+
+  #
+  # when running locally, we want to avoid turbocache missing updates in other packages
+  # and doing less work.
+  # we achieve this by setting the SALTO_DEPENDENCIES_HASH env var, which turbo.json uses in 
+  # relevant steps (e.g. test) as a hint to identify when cache invalidation is in order
+  #
+  # we piggy-back off the --filter arg, to generate the relevant hashing for the package
+  # that the user wants to run (or all of them, if we can't find it)
+  #
+
+  filter=""
+  for arg in "$@"; do
+    if [[ $arg == --filter=* ]]; then
+      filter="${arg#--filter=}"
+      break
+    elif [[ $arg == --filter ]]; then
+      shift
+      filter="$1"
+      break
+    else
+      shift
+    fi
+  done
+
+  if [ -n "$filter" ]; then
+    echo "node ./build_utils/hash_dependencies.js -p $filter"
+    export SALTO_DEPENDENCIES_HASH="$(node ./build_utils/hash_dependencies.js -p "$filter")"
+  else
+    echo "node ./build_utils/hash_dependencies.js"
+    export SALTO_DEPENDENCIES_HASH="$(node ./build_utils/hash_dependencies.js)"
+  fi
 
 fi
 
+sleep 1
 yarn turbo run "${ORG_ARG[@]}" \
   --concurrency="$TURBO_CONCURRENCY"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build-ts": "./build_utils/turbo_run.sh build-ts",
     "build-all": "yarn workspaces foreach -vpAi -j 4 run build",
     "clean": "./build_utils/turbo_run.sh clean",
-    "test": "yarn workspaces foreach -vpAi -j 4 run test --forceExit --detectOpenHandles",
+    "test": "./build_utils/turbo_run.sh test",
     "generate-notices-file": "./build_utils/generate_notices.sh",
     "lerna-version": "lerna version --no-git-tag-version --exact",
     "lerna-version-pr": "./build_utils/create_version_pr.sh",

--- a/turbo.json
+++ b/turbo.json
@@ -20,6 +20,15 @@
         ".check-format.cache"
       ]
     },
+    "test": {
+      "outputLogs": "new-only",
+      "env": [
+        "SALTO_DEPENDENCIES_HASH"
+      ],
+      "outputs": [
+        "coverage/**"
+      ]
+    },
     "clean": {
       "cache": false
     }

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,7 @@
       ]
     },
     "test": {
+      "dependsOn": [ "^build-ts"],
       "outputLogs": "new-only",
       "env": [
         "SALTO_DEPENDENCIES_HASH"


### PR DESCRIPTION
add turbocache to unit tests

---

this part was split off of SALTO-3518

---
_Release Notes_: 

with this PR, we now support turbocache for both local tests and CircleCI.
if you need to test a specific package, do (for example):
```
yarn test --filter @salto-io/zendesk-adapter
```

before the turbocache run, we will check if any source files have been modified in any of the dependencies of the package you are testing (or the entire project, if you run all tests).

---
_User Notifications_: 
