### PR TITLE
SALTO-6027 - Salesforce: Missing Reference From Flow Conditions to CustomLabels

### DIFF
--- a/packages/adapter-components/src/references/reference_mapping.ts
+++ b/packages/adapter-components/src/references/reference_mapping.ts
@@ -84,7 +84,10 @@ export type ReferenceSourceTransformation = {
   validate: (referringFieldValue: string | number, serializedRefExpr: string) => boolean
 }
 
-export type ReferenceSourceTransformationName = 'exact' | 'asString' | 'asCaseInsensitiveString'
+const removeGlobalPrefix = (fieldValue: string): string =>
+  fieldValue.startsWith('Global.') ? fieldValue.substr(7) : fieldValue
+
+export type ReferenceSourceTransformationName = 'exact' | 'asString' | 'asCaseInsensitiveString' | 'globalPrefix'
 export const ReferenceSourceTransformationLookup: Record<
   ReferenceSourceTransformationName,
   ReferenceSourceTransformation
@@ -102,6 +105,11 @@ export const ReferenceSourceTransformationLookup: Record<
     transform: fieldValue => _.toString(fieldValue).toLocaleLowerCase(),
     validate: (referringFieldValue, serializedRefExpr) =>
       _.toString(referringFieldValue).toLocaleLowerCase() === _.toString(serializedRefExpr).toLocaleLowerCase(),
+  },
+  globalPrefix: {
+    transform: fieldValue => removeGlobalPrefix(_.toString(fieldValue)),
+    validate: (referringFieldValue, serializedRefExpr) =>
+      removeGlobalPrefix(_.toString(referringFieldValue)) === serializedRefExpr,
   },
 }
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -947,6 +947,14 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     sourceTransformation: 'globalPrefix',
     target: { type: 'QuickAction' },
   },
+  {
+    src: {
+      field: 'leftValueReference',
+      parentTypes: ['FlowCondition', 'FlowTestCondition', 'FlowTestParameter'],
+    },
+    serializationStrategy: 'customLabel',
+    target: { type: CUSTOM_LABEL_METADATA_TYPE },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -942,6 +942,11 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'object', parentTypes: ['PermissionSetObjectPermissions'] },
     target: { type: CUSTOM_OBJECT },
   },
+  {
+    src: { field: 'value', parentTypes: ['ComponentInstancePropertyListItem'] },
+    sourceTransformation: 'globalPrefix',
+    target: { type: 'QuickAction' },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>


### PR DESCRIPTION
Add some more refs. Note that in the general case there may be refs to things other than `CustomLabel`s but this is the only case we've actually seen in the wild.

---

N/A

---
_Release Notes_: 
Salesforce: Added references from `FlowCondition` to Custom Labels

---
_User Notifications_: 
Salesforce: Added references from `FlowCondition` to Custom Labels