### PR TITLE
SALTO-6245 change pagination function for users

### DIFF
--- a/packages/confluence-adapter/src/definitions/requests/pagination.ts
+++ b/packages/confluence-adapter/src/definitions/requests/pagination.ts
@@ -16,7 +16,7 @@
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import { ClientOptions, PaginationOptions } from '../types'
 
-const { cursorPagination, pageOffsetPagination } = fetchUtils.request.pagination
+const { cursorPagination, itemOffsetPagination } = fetchUtils.request.pagination
 
 export const USERS_PAGE_SIZE = '1000'
 
@@ -30,10 +30,12 @@ export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinit
   },
   usersPagination: {
     funcCreator: () =>
-      pageOffsetPagination({
-        firstPage: 0,
+      itemOffsetPagination({
         pageSize: Number(USERS_PAGE_SIZE),
+        dataField: '.*',
+        firstIndex: 0,
         paginationField: 'startAt',
+        pageSizeArgName: 'maxResults',
       }),
   },
 }


### PR DESCRIPTION
Using different pagination function to bring users for confluence. The old function wasn't effective and was fetching the same user more than once

---


---
_Release Notes_: 
None

---
_User Notifications_: 
None
