### PR TITLE
SALTO-6250: fix missing user fallback logic when resolveUserIds is false

### DIFF
--- a/packages/zendesk-adapter/src/change_validators/users.ts
+++ b/packages/zendesk-adapter/src/change_validators/users.ts
@@ -117,7 +117,7 @@ export const usersValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchCo
       .map(data => resolveValues(data, lookupFunc))
       .toArray()
 
-    if (relevantInstances.length === 0) {
+    if (relevantInstances.length === 0 || fetchConfig.resolveUserIDs === false) {
       return []
     }
 

--- a/packages/zendesk-adapter/src/change_validators/users.ts
+++ b/packages/zendesk-adapter/src/change_validators/users.ts
@@ -106,6 +106,7 @@ const handleExistingUsers = ({
  * Change error will vary based on the following scenarios:
  *  1. If we could not use user fallback value for some reason, we will return an error.
  *  2. If the user has no permissions to its field, we will return a warning (default user included).
+ *  3. if resolveUserIDs is false, meaning we can't translate users, we will return no errors.
  */
 export const usersValidator: (client: ZendeskClient, fetchConfig: ZendeskFetchConfig) => ChangeValidator =
   (client, fetchConfig) => async (changes, elementSource) => {

--- a/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
@@ -52,7 +52,7 @@ const fallbackUserIsMissingError = (
 const missingUsersChangeWarning = (
   instance: InstanceElement,
   missingUsers: string[],
-  userFallbackValue: string,
+  userFallbackValue: string | number,
 ): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Warning',
@@ -102,7 +102,7 @@ const getMissingUsers =
   })
 
 const replaceMissingUsers =
-  (users: Set<string>, fallbackUser: string) =>
+  (users: Set<string>, fallbackUser: string | number) =>
   (instance: InstanceElement): undefined | { fixedInstance: InstanceElement; missingUsers: string[] } => {
     const missingUserPaths = getMissingUserPaths(users, instance)
 
@@ -156,7 +156,12 @@ export const fallbackUsersHandler: FixElementsHandler =
     }
 
     const userEmails = new Set(users.map(user => user.email))
-    const fallbackValue = await getUserFallbackValue(defaultMissingUserFallback, userEmails, client)
+    const fallbackValue = await getUserFallbackValue(
+      defaultMissingUserFallback,
+      userEmails,
+      client,
+      config[FETCH_CONFIG].resolveUserIDs,
+    )
     if (fallbackValue === undefined) {
       log.error('Error while trying to get defaultMissingUserFallback value')
       const errors = elements

--- a/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fallback_user.ts
@@ -156,12 +156,12 @@ export const fallbackUsersHandler: FixElementsHandler =
     }
 
     const userEmails = new Set(users.map(user => user.email))
-    const fallbackValue = await getUserFallbackValue(
+    const fallbackValue = await getUserFallbackValue({
       defaultMissingUserFallback,
-      userEmails,
+      existingUsers: userEmails,
       client,
-      config[FETCH_CONFIG].resolveUserIDs,
-    )
+      shouldResolveUserIDs: config[FETCH_CONFIG].resolveUserIDs,
+    })
     if (fallbackValue === undefined) {
       log.error('Error while trying to get defaultMissingUserFallback value')
       const errors = elements

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -273,12 +273,17 @@ export const getUsers = getUsersFunc()
  * Get user fallback value that will replace missing users values
  * based on the user's deploy config
  */
-export const getUserFallbackValue = async (
-  defaultMissingUserFallback: string,
-  existingUsers: Set<string>,
-  client: ZendeskClient,
-  shouldResolveUserIDs?: boolean,
-): Promise<string | number | undefined> => {
+export const getUserFallbackValue = async ({
+  defaultMissingUserFallback,
+  existingUsers,
+  client,
+  shouldResolveUserIDs,
+}: {
+  defaultMissingUserFallback: string
+  existingUsers: Set<string>
+  client: ZendeskClient
+  shouldResolveUserIDs?: boolean
+}): Promise<string | number | undefined> => {
   if (defaultMissingUserFallback === definitions.DEPLOYER_FALLBACK_VALUE) {
     try {
       const response = (

--- a/packages/zendesk-adapter/src/user_utils.ts
+++ b/packages/zendesk-adapter/src/user_utils.ts
@@ -277,7 +277,8 @@ export const getUserFallbackValue = async (
   defaultMissingUserFallback: string,
   existingUsers: Set<string>,
   client: ZendeskClient,
-): Promise<string | undefined> => {
+  shouldResolveUserIDs?: boolean,
+): Promise<string | number | undefined> => {
   if (defaultMissingUserFallback === definitions.DEPLOYER_FALLBACK_VALUE) {
     try {
       const response = (
@@ -286,7 +287,7 @@ export const getUserFallbackValue = async (
         })
       ).data
       if (isCurrentUserResponse(response)) {
-        return response.user.email
+        return shouldResolveUserIDs === false ? response.user.id : response.user.email
       }
       log.error("Received invalid response from endpoint '/api/v2/users/me'")
     } catch (e) {

--- a/packages/zendesk-adapter/test/change_validators/users.test.ts
+++ b/packages/zendesk-adapter/test/change_validators/users.test.ts
@@ -70,12 +70,13 @@ describe('usersValidator', () => {
   })
 
   const testsElementSource = createInMemoryElementSource([permissionsCustomRole, noPermissionsCustomRole])
-
+  beforeEach(async () => {
+    config = { resolveUserIDs: true } as ZendeskFetchConfig
+  })
   beforeAll(async () => {
     client = new ZendeskClient({
       credentials: { username: 'a', password: 'b', subdomain: 'ignore' },
     })
-    config = { resolveUserIDs: true } as ZendeskFetchConfig
     mockGet = jest.spyOn(client, 'get')
     mockGet.mockImplementation(() => ({
       status: 200,

--- a/packages/zendesk-adapter/test/fix_elements/fallback_user.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/fallback_user.test.ts
@@ -244,11 +244,11 @@ describe('fallbackUsersHandler', () => {
 
     it('should replace all users as fallback', () => {
       const fallbackMacro = macroInstance.clone()
-      fallbackMacro.value.actions[1].value = 'deployer@.com'
-      fallbackMacro.value.actions[2].value = 'deployer@.com'
-      fallbackMacro.value.restriction.id = 'deployer@.com'
+      fallbackMacro.value.actions[1].value = 1
+      fallbackMacro.value.actions[2].value = 1
+      fallbackMacro.value.restriction.id = 1
       const fallbackArticle = articleInstance.clone()
-      fallbackArticle.value.author_id = 'deployer@.com'
+      fallbackArticle.value.author_id = 1
 
       expect(fallbackResponse.fixedElements).toEqual([fallbackMacro, fallbackArticle])
     })

--- a/packages/zendesk-adapter/test/user_utils.test.ts
+++ b/packages/zendesk-adapter/test/user_utils.test.ts
@@ -739,20 +739,24 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: 'salto@io',
       }
-      const fallbackValue = await getUserFallbackValue(
-        deployConfig.defaultMissingUserFallback as string,
+      const fallbackValue = await getUserFallbackValue({
+        defaultMissingUserFallback: deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client,
-      )
+      })
       expect(fallbackValue).toEqual('salto@io')
     })
     it('should not return specific user value if it is missing from target env', async () => {
       deployConfig = {
         defaultMissingUserFallback: 'useruser@zendesk.com',
       }
-      expect(await getUserFallbackValue(deployConfig.defaultMissingUserFallback as string, existingUsers, client)).toBe(
-        undefined,
-      )
+      expect(
+        await getUserFallbackValue({
+          defaultMissingUserFallback: deployConfig.defaultMissingUserFallback as string,
+          existingUsers,
+          client,
+        }),
+      ).toBe(undefined)
     })
     it('should return deployer user email', async () => {
       mockGet.mockResolvedValueOnce({
@@ -764,11 +768,11 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      const fallbackValue = await getUserFallbackValue(
-        deployConfig.defaultMissingUserFallback as string,
+      const fallbackValue = await getUserFallbackValue({
+        defaultMissingUserFallback: deployConfig.defaultMissingUserFallback as string,
         existingUsers,
         client,
-      )
+      })
       expect(fallbackValue).toEqual('saltoo@io')
     })
     it('should fail and log an error in case of fallback to deployer and invalid user response', async () => {
@@ -779,9 +783,13 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      expect(await getUserFallbackValue(deployConfig.defaultMissingUserFallback as string, existingUsers, client)).toBe(
-        undefined,
-      )
+      expect(
+        await getUserFallbackValue({
+          defaultMissingUserFallback: deployConfig.defaultMissingUserFallback as string,
+          existingUsers,
+          client,
+        }),
+      ).toBe(undefined)
       expect(logError).toHaveBeenCalledWith(["Received invalid response from endpoint '/api/v2/users/me'"])
     })
     it('should fail and log an error in case of an error in current user request', async () => {
@@ -789,9 +797,13 @@ describe('userUtils', () => {
       deployConfig = {
         defaultMissingUserFallback: '##DEPLOYER##',
       }
-      expect(await getUserFallbackValue(deployConfig.defaultMissingUserFallback as string, existingUsers, client)).toBe(
-        undefined,
-      )
+      expect(
+        await getUserFallbackValue({
+          defaultMissingUserFallback: deployConfig.defaultMissingUserFallback as string,
+          existingUsers,
+          client,
+        }),
+      ).toBe(undefined)
       expect(logError).toHaveBeenCalledWith([
         'Attempt to get current user details has failed with error: %o',
         { data: {}, status: 400 },


### PR DESCRIPTION
fix missing user fallback logic when resolveUserIds is false

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk:
* fix missing user fallback logic when resolveUserIds is false. setting `defaultMissingUserFallback =  "##DEPLOYER##"` will work.

---
_User Notifications_: 
none
