### PR TITLE
SALTO-6251: remove import between salesforce test and e2e

### DIFF
--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -60,8 +60,9 @@ import {
   createValueSetEntry,
   createCustomObjectType,
   nullProgressReporter,
+  createElement,
+  removeElement,
 } from './utils'
-import { createElement, removeElement } from '../e2e_test/utils'
 import { mockTypes, mockDefaultValues } from './mock_elements'
 import {
   mockDeployResult,


### PR DESCRIPTION
Since the tests and e2e tests are not part of the same typescript project, there can't be imports from one to the other

---

_Additional context for reviewer_
This was the minimal code duplication I could make, trying to have this really shared (by letting one project reference the other or creating a third project) turned out to be more difficult...


---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_