### PR TITLE
SALTO-6188 Add support for API Token for Zendesk

### DIFF
--- a/packages/zendesk-adapter/src/adapter_creator.ts
+++ b/packages/zendesk-adapter/src/adapter_creator.ts
@@ -30,12 +30,7 @@ import {
 } from '@salto-io/adapter-components'
 import { inspectValue } from '@salto-io/adapter-utils'
 import ZendeskAdapter from './adapter'
-import {
-  Credentials,
-  oauthAccessTokenCredentialsType,
-  oauthRequestParametersType,
-  usernamePasswordCredentialsType,
-} from './auth'
+import { basicCredentialsType, Credentials, oauthAccessTokenCredentialsType, oauthRequestParametersType } from './auth'
 import {
   configType,
   ZendeskConfig,
@@ -95,6 +90,7 @@ const credentialsFromConfig = (config: Readonly<InstanceElement>): Credentials =
   return {
     username: config.value.username,
     password: config.value.password,
+    token: config.value.token,
     subdomain: config.value.subdomain,
     domain,
   }
@@ -190,7 +186,7 @@ export const adapter: Adapter = {
     }),
   authenticationMethods: {
     basic: {
-      credentialsType: usernamePasswordCredentialsType,
+      credentialsType: basicCredentialsType,
     },
     oauth: {
       createOAuthRequest,

--- a/packages/zendesk-adapter/src/auth.ts
+++ b/packages/zendesk-adapter/src/auth.ts
@@ -15,18 +15,28 @@
  */
 import { ElemID, BuiltinTypes } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
+import _ from 'lodash'
 import * as constants from './constants'
 
-const SUBDOMAIN_MESSAGE = 'subdomain (https://<your subdomain>.zendesk.com)'
+const PASSWORD_MESSAGE = 'Password authentication is deprecated by Zendesk, please use token instead'
+const SUBDOMAIN_MESSAGE = 'Subdomain (https://<your subdomain>.zendesk.com)'
 const DOMAIN_MESSAGE =
-  'domain (optional) - only fill in if your account is not under zendesk.com (https://<subdomain>.<your zendesk domain>)'
+  'Domain (optional) - only fill in if your account is not under zendesk.com (https://<subdomain>.<your zendesk domain>)'
 
-export type UsernamePasswordCredentials = {
+type CommonBasicCredentials = {
   username: string
-  password: string
   subdomain: string
   domain?: string
 }
+
+export type UsernamePasswordCredentials = CommonBasicCredentials & {
+  password: string
+}
+export type APITokenCredentials = CommonBasicCredentials & {
+  token: string
+}
+
+export type BasicCredentials = UsernamePasswordCredentials | APITokenCredentials
 
 export type OauthAccessTokenCredentials = {
   accessToken: string
@@ -41,7 +51,10 @@ export type OauthRequestParameters = {
   domain?: string
 }
 
-export const usernamePasswordCredentialsType = createMatchingObjectType<UsernamePasswordCredentials>({
+// The type here is to allow token or password to be optional
+export const basicCredentialsType = createMatchingObjectType<
+  CommonBasicCredentials & Partial<UsernamePasswordCredentials | APITokenCredentials>
+>({
   elemID: new ElemID(constants.ZENDESK),
   fields: {
     username: {
@@ -50,7 +63,12 @@ export const usernamePasswordCredentialsType = createMatchingObjectType<Username
     },
     password: {
       refType: BuiltinTypes.STRING,
-      annotations: { _required: true },
+      annotations: {
+        message: PASSWORD_MESSAGE,
+      },
+    },
+    token: {
+      refType: BuiltinTypes.STRING,
     },
     subdomain: {
       refType: BuiltinTypes.STRING,
@@ -127,7 +145,10 @@ export const oauthRequestParametersType = createMatchingObjectType<OauthRequestP
   },
 })
 
-export type Credentials = UsernamePasswordCredentials | OauthAccessTokenCredentials
+export type Credentials = BasicCredentials | OauthAccessTokenCredentials
 
 export const isOauthAccessTokenCredentials = (creds: Credentials): creds is OauthAccessTokenCredentials =>
-  (creds as OauthAccessTokenCredentials).accessToken !== undefined
+  'accessToken' in creds
+
+export const isAPITokenCredentials = (creds: Credentials): creds is APITokenCredentials =>
+  'token' in creds && !_.isEmpty(creds.token)

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -39,7 +39,7 @@ import { elements as elementsUtils } from '@salto-io/adapter-components'
 import defaultBrandMockReplies from './mock_replies/myBrand_mock_replies.json'
 import brandWithGuideMockReplies from './mock_replies/brandWithGuide_mock_replies.json'
 import { adapter } from '../src/adapter_creator'
-import { usernamePasswordCredentialsType } from '../src/auth'
+import { basicCredentialsType } from '../src/auth'
 import { configType, FETCH_CONFIG, API_DEFINITIONS_CONFIG, DEFAULT_CONFIG } from '../src/config'
 import {
   BRAND_TYPE_NAME,
@@ -126,7 +126,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -677,7 +677,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -1225,7 +1225,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -1281,7 +1281,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -1834,7 +1834,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -2380,7 +2380,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -2435,7 +2435,7 @@ describe('adapter', () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFuncWith403)
         const { elements, errors } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'token456',
               subdomain: 'myBrand',
@@ -2493,7 +2493,7 @@ describe('adapter', () => {
 
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
         mockAxiosAdapter.onPost().reply(callbackResponseFunc)
-        const creds = new InstanceElement('config', usernamePasswordCredentialsType, {
+        const creds = new InstanceElement('config', basicCredentialsType, {
           username: 'user123',
           password: 'token456',
           subdomain: 'myBrand',
@@ -2564,7 +2564,7 @@ describe('adapter', () => {
 
       it('should return fetch error when no brand matches brands config, and still generate types', async () => {
         mockAxiosAdapter.onGet().reply(callbackResponseFunc)
-        const creds = new InstanceElement('config', usernamePasswordCredentialsType, {
+        const creds = new InstanceElement('config', basicCredentialsType, {
           username: 'user123',
           password: 'token456',
           subdomain: 'myBrand',
@@ -2617,7 +2617,7 @@ describe('adapter', () => {
         })
         const { elements } = await adapter
           .operations({
-            credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+            credentials: new InstanceElement('config', basicCredentialsType, {
               username: 'user123',
               password: 'pwd456',
               subdomain: 'myBrand',
@@ -2678,7 +2678,7 @@ describe('adapter', () => {
       })
       const supportInstanceId = 1500002894482
       const operations = adapter.operations({
-        credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+        credentials: new InstanceElement('config', basicCredentialsType, {
           username: 'user123',
           password: 'pwd456',
           subdomain: 'myBrand',
@@ -2828,7 +2828,7 @@ describe('adapter', () => {
         return { key: 2 }
       })
       operations = adapter.operations({
-        credentials: new InstanceElement('config', usernamePasswordCredentialsType, {
+        credentials: new InstanceElement('config', basicCredentialsType, {
           username: 'user123',
           password: 'pwd456',
           subdomain: 'myBrand',

--- a/packages/zendesk-adapter/test/client/connection.test.ts
+++ b/packages/zendesk-adapter/test/client/connection.test.ts
@@ -58,6 +58,38 @@ describe('client connection', () => {
         'Unauthorized - update credentials and try again',
       )
     })
+    describe('authParamsFunc', () => {
+      let conn: ReturnType<typeof createConnection>
+      beforeEach(() => {
+        conn = createConnection({ retries: 3 })
+      })
+      it('should return the correct auth params for username password', async () => {
+        mockAxiosAdapter.onGet('/api/v2/account').reply(config => {
+          expect(config?.auth).toEqual({ username: 'user123', password: 'pwd456' })
+          return [200, { settings: {} }]
+        })
+        const apiConn = await conn.login({ username: 'user123', password: 'pwd456', subdomain: 'abc' })
+        expect(apiConn.accountInfo).toEqual({ accountId: 'https://abc.zendesk.com' })
+      })
+
+      it('should return the correct auth params for token', async () => {
+        mockAxiosAdapter.onGet('/api/v2/account').reply(config => {
+          expect(config?.auth).toEqual({ username: 'user123/token', password: 'token456' })
+          return [200, { settings: {} }]
+        })
+        const apiConn = await conn.login({ username: 'user123', token: 'token456', subdomain: 'abc' })
+        expect(apiConn.accountInfo).toEqual({ accountId: 'https://abc.zendesk.com' })
+      })
+
+      it('should return the correct auth params for oauth', async () => {
+        mockAxiosAdapter.onGet('/api/v2/account').reply(config => {
+          expect(config?.headers?.Authorization).toEqual('Bearer token 123')
+          return [200, { settings: {} }]
+        })
+        const apiConn = await conn.login({ accessToken: 'token 123', subdomain: 'abc' })
+        expect(apiConn.accountInfo).toEqual({ accountId: 'https://abc.zendesk.com' })
+      })
+    })
   })
 
   describe('instanceUrl', () => {


### PR DESCRIPTION
Zendesk is deprecating username/password and adding API token support

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter:__ 
* Users can now authenticate to Zendesk with username and API Token

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
