### PR TITLE
SALTO-3845: cancel workflow post functions sort in DC

### DIFF
--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -145,7 +145,10 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
 
 const getValue = (value: Value): Value => (isResolvedReferenceExpression(value) ? value.elemID.getFullName() : value)
 
-const sortLists = async (instance: InstanceElement): Promise<void> => {
+const sortLists = async (instance: InstanceElement, isDataCenter: boolean): Promise<void> => {
+  if (isDataCenter) {
+    delete VALUES_TO_SORT[WORKFLOW_RULES_TYPE_NAME].postFunctions
+  }
   instance.value =
     (await transformValues({
       values: instance.value,
@@ -174,10 +177,12 @@ const sortLists = async (instance: InstanceElement): Promise<void> => {
     })) ?? {}
 }
 
-const filter: FilterCreator = () => ({
+const filter: FilterCreator = ({ client }) => ({
   name: 'sortListsFilter',
   onFetch: async elements => {
-    await awu(elements).filter(isInstanceElement).forEach(sortLists)
+    await awu(elements)
+      .filter(isInstanceElement)
+      .forEach(instance => sortLists(instance, client.isDataCenter))
   },
 })
 


### PR DESCRIPTION
Cancled the sorting of post functions
---

See Jira ticket for details. We are skipping noise reduction is it is complicated and will only influence one customer which will be communicated personally
---
_Release Notes_: 
Jira adapter:
* keep post functions order in DC

---
_User Notifications_: 
Jira adapter:
* for DC users the order of post functions in workflow will change
