### PR TITLE
SALTO-6257: Fix object parsing in log messages in adapters infra

### DIFF
--- a/packages/adapter-components/src/fetch/request/pagination/queue.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/queue.ts
@@ -15,6 +15,7 @@
  */
 import objectHash from 'object-hash'
 import { logger } from '@salto-io/logging'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { Response, ResponseValue } from '../../../client'
 import { ClientRequestArgsNoPath, PaginationFunction } from '../../../definitions/system'
 import { HTTPEndpointIdentifier } from '../../../definitions'
@@ -95,7 +96,7 @@ export class RequestQueue<ClientOptions extends string> {
       })
       nextArgs.forEach(arg => this.enqueue(arg))
     } catch (e) {
-      log.error('Error processing args (%s): %s, stack: %s', args, e, e.stack)
+      log.error('Error processing args (%s): %s, stack: %s', safeJsonStringify(args), safeJsonStringify(e), e.stack)
       throw e
     } finally {
       this.activePromises = this.activePromises.filter(p => p.id !== promiseID)

--- a/packages/adapter-components/src/fetch/resource/type_fetcher.ts
+++ b/packages/adapter-components/src/fetch/resource/type_fetcher.ts
@@ -18,6 +18,7 @@ import objectHash from 'object-hash'
 import { ElemID, isPrimitiveValue, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections, promises, values as lowerdashValues } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { ElementQuery } from '../query'
 import { Requester } from '../request/requester'
 import { TypeResourceFetcher, ValueGeneratedItem } from '../types'
@@ -199,7 +200,13 @@ export const createTypeResourceFetcher = <ClientOptions extends string>({
         success: true,
       }
     } catch (e) {
-      log.error('[%s] Error caught while fetching %s: %s. stack: %s', adapterName, typeName, e, (e as Error).stack)
+      log.error(
+        '[%s] Error caught while fetching %s: %s. stack: %s',
+        adapterName,
+        typeName,
+        safeJsonStringify(e),
+        (e as Error).stack,
+      )
       done = true
       return {
         success: false,


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

1. fix args parsing
2. fix response parsing (in both cases we got `response: [Object]`

---
_Release Notes_: 
None

---
_User Notifications_: 
None
