### PR TITLE
SALTO-6259: Supporting meta types syntax in VSC extension

### DIFF
--- a/packages/vscode/syntaxes/salto.json
+++ b/packages/vscode/syntaxes/salto.json
@@ -87,7 +87,7 @@
           "name": "punctuation.definition.tag.salto"
         }
       },
-      "match": "(resource|data|type|extension)\\s+(\")?([\\w]+)(?:(\\.)(\\w+))?(\")?(?:\\s+(is)\\s+(string|object|boolean|number))?(?:\\s+(\")?([\\w\\-]+)(\")?)?\\s+({)",
+      "match": "(resource|data|type|extension)\\s+(\")?(\\w+)(?:(\\.)(\\w+))?(\")?(?:\\s+(is)\\s+(string|object|boolean|number|\\w+\\.\\w+))?(?:\\s+(\")?([\\w\\-]+)(\")?)?\\s+({)",
       "name": "meta.resource.salto"
     },
     {


### PR DESCRIPTION


---

_Additional context for reviewer_

---
_Release Notes_: 
_VS Code Extension_:
* Support for meta types syntax.

---
_User Notifications_: 
None.
