### PR TITLE
SALTO-5323 reverse change elemIDs

### DIFF
--- a/packages/adapter-utils/src/change.ts
+++ b/packages/adapter-utils/src/change.ts
@@ -13,13 +13,28 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { Change, isAdditionOrModificationChange, isRemovalOrModificationChange, toChange } from '@salto-io/adapter-api'
+import {
+  Change,
+  DetailedChange,
+  isAdditionOrModificationChange,
+  isRemovalOrModificationChange,
+  toChange,
+} from '@salto-io/adapter-api'
 
-export const reverseChange = <T extends Change>(change: T): T => {
+const hasElemIDs = <T extends Change | DetailedChange>(change: T): change is T & Pick<DetailedChange, 'elemIDs'> =>
+  'elemIDs' in change
+
+export const reverseChange = <T extends Change | DetailedChange>(change: T): T => {
   const before = isAdditionOrModificationChange(change) ? change.data.after : undefined
   const after = isRemovalOrModificationChange(change) ? change.data.before : undefined
+  const reversedElemIDs =
+    hasElemIDs(change) && change.elemIDs !== undefined
+      ? { elemIDs: { before: change.elemIDs.after, after: change.elemIDs.before } }
+      : {}
+
   return {
     ...change,
     ...toChange({ before, after }),
+    ...reversedElemIDs,
   }
 }

--- a/packages/adapter-utils/test/change.test.ts
+++ b/packages/adapter-utils/test/change.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ObjectType, ElemID, toChange } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, toChange, DetailedChange } from '@salto-io/adapter-api'
 import { reverseChange } from '../src/change'
 
 describe('reverseChange', () => {
@@ -39,5 +39,56 @@ describe('reverseChange', () => {
     type2.annotations.test = 'test'
     const change = toChange({ before: type, after: type2 })
     expect(reverseChange(change)).toEqual(toChange({ before: type2, after: type }))
+  })
+
+  describe('reverse detailed change elemIDs', () => {
+    it('should reverse addition change', () => {
+      const changeElemId = type.elemID.createNestedID('attr', 'list', '0')
+      const change: DetailedChange = {
+        id: changeElemId,
+        elemIDs: { after: changeElemId },
+        action: 'add',
+        data: { after: 'a' },
+      }
+      expect(reverseChange(change)).toEqual({
+        id: changeElemId,
+        elemIDs: { before: changeElemId },
+        action: 'remove',
+        data: { before: 'a' },
+      })
+    })
+
+    it('should reverse removal change', () => {
+      const changeElemId = type.elemID.createNestedID('attr', 'list', '0')
+      const change: DetailedChange = {
+        id: changeElemId,
+        elemIDs: { before: changeElemId },
+        action: 'remove',
+        data: { before: 'a' },
+      }
+      expect(reverseChange(change)).toEqual({
+        id: changeElemId,
+        elemIDs: { after: changeElemId },
+        action: 'add',
+        data: { after: 'a' },
+      })
+    })
+
+    it('should reverse modification change', () => {
+      const changeElemId = type.elemID.createNestedID('attr', 'list', '0')
+      const changeBeforeElemId = type.elemID.createNestedID('attr', 'list', '1')
+      const change: DetailedChange = {
+        id: changeElemId,
+        elemIDs: { before: changeBeforeElemId, after: changeElemId },
+        action: 'modify',
+        data: { before: 'a', after: 'a' },
+      }
+      expect(reverseChange(change)).toEqual({
+        id: changeElemId,
+        elemIDs: { before: changeElemId, after: changeBeforeElemId },
+        action: 'modify',
+        data: { before: 'a', after: 'a' },
+      })
+    })
   })
 })


### PR DESCRIPTION
in `reverseChange`, reverse the `change.elemIDs` too (in case of `detailedChange` input).

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None