### PR TITLE
SALTO-5642 fix extracted types from swagger

### DIFF
--- a/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter/adapter.ts
@@ -34,7 +34,7 @@ import {
   TypeMap,
   FixElementsFunc,
 } from '@salto-io/adapter-api'
-import { logDuration, safeJsonStringify } from '@salto-io/adapter-utils'
+import { logDuration } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, objects } from '@salto-io/lowerdash'
 import { Client } from '../../client/client_creator'
@@ -189,8 +189,7 @@ export class AdapterImpl<
    */
   @logDuration('fetching account configuration')
   async getElements(): Promise<FetchElements> {
-    const { allTypes, parsedConfigs } = await this.getAllSwaggerTypes()
-    log.debug('Full parsed configuration from swaggers: %s', safeJsonStringify(parsedConfigs))
+    const allTypes = await this.getAllSwaggerTypes()
 
     const res = await getElements({
       adapterName: this.adapterName,


### PR DESCRIPTION
small leftover from the previous fix - in the new infra we only generate types and no config, so the types are different 
(was fixed in okta at the time but not in the adapter wrapper)

---
_Release Notes_: 
None

---
_User Notifications_: 
None