### PR TITLE
SALTO-6027 - Salesforce: parse flow condition ref as formula

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -108,6 +108,7 @@ import installedPackageGeneratedDependencies from './filters/installed_package_g
 import createMissingInstalledPackagesInstancesFilter from './filters/create_missing_installed_packages_instances'
 import metadataInstancesAliasesFilter from './filters/metadata_instances_aliases'
 import formulaDepsFilter from './filters/formula_deps'
+import formulaRefFieldsFilter from './filters/formula_ref_fields'
 import removeUnixTimeZeroFilter from './filters/remove_unix_time_zero'
 import organizationWideDefaults from './filters/organization_settings'
 import centralizeTrackingInfoFilter from './filters/centralize_tracking_info'
@@ -239,6 +240,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: xmlAttributesFilter },
   { creator: minifyDeployFilter },
   { creator: formulaDepsFilter },
+  { creator: formulaRefFieldsFilter },
   // centralizeTrackingInfoFilter depends on customObjectsToObjectTypeFilter and must run before customTypeSplit
   { creator: centralizeTrackingInfoFilter },
   // The following filters should remain last in order to make sure they fix all elements

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -13,142 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import {
-  Element,
-  ElemID,
-  ElemIDType,
-  Field,
-  InstanceElement,
-  isObjectType,
-  ReadOnlyElementsSource,
-  ReferenceExpression,
-} from '@salto-io/adapter-api'
-import { extendGeneratedDependencies, naclCase } from '@salto-io/adapter-utils'
-import {
-  FormulaIdentifierInfo,
-  IdentifierType,
-  parseFormulaIdentifier,
-  extractFormulaIdentifiers,
-} from '@salto-io/salesforce-formula-parser'
+import { Element, Field, isObjectType, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { extendGeneratedDependencies } from '@salto-io/adapter-utils'
+import { parseFormulaIdentifier, extractFormulaIdentifiers } from '@salto-io/salesforce-formula-parser'
 import { LocalFilterCreator } from '../filter'
 import { isFormulaField } from '../transformers/transformer'
-import { CUSTOM_METADATA_SUFFIX, FORMULA, SALESFORCE } from '../constants'
-import {
-  buildElementsSourceForFetch,
-  ensureSafeFilterFetch,
-  extractFlatCustomObjectFields,
-  isInstanceOfTypeSync,
-} from './utils'
+import { FORMULA } from '../constants'
+import { buildElementsSourceForFetch, ensureSafeFilterFetch, extractFlatCustomObjectFields } from './utils'
+import { logInvalidReferences, referencesFromIdentifiers, referenceValidity } from './formula_utils'
 
 const log = logger(module)
 const { awu, groupByAsync } = collections.asynciterable
 
-const referenceFieldsWithFormulaIdentifiers: Record<string, string> = {
-  FlowCondition: 'leftValueReference',
-  FlowTestCondition: 'leftValueReference',
-  FlowTestParameter: 'leftValueReference',
-}
-
-const identifierTypeToElementName = (identifierInfo: FormulaIdentifierInfo): string[] => {
-  if (identifierInfo.type === 'customLabel') {
-    return [identifierInfo.instance]
-  }
-  if (identifierInfo.type === 'customMetadataTypeRecord') {
-    const [typeName, instanceName] = identifierInfo.instance.split('.')
-    return [`${typeName.slice(0, -1 * CUSTOM_METADATA_SUFFIX.length)}.${instanceName}`]
-  }
-  return identifierInfo.instance.split('.').slice(1)
-}
-
-const identifierTypeToElementType = (identifierInfo: FormulaIdentifierInfo): string => {
-  if (identifierInfo.type === 'customLabel') {
-    return 'CustomLabel'
-  }
-
-  return identifierInfo.instance.split('.')[0]
-}
-
-const identifierTypeToElemIdType = (identifierInfo: FormulaIdentifierInfo): ElemIDType =>
-  (
-    ({
-      standardObject: 'type',
-      customMetadataType: 'type',
-      customObject: 'type',
-      customSetting: 'type',
-      standardField: 'field',
-      customField: 'field',
-      customMetadataTypeRecord: 'instance',
-      customLabel: 'instance',
-    }) as Record<IdentifierType, ElemIDType>
-  )[identifierInfo.type]
-
-const referencesFromIdentifiers = async (typeInfos: FormulaIdentifierInfo[]): Promise<ElemID[]> =>
-  typeInfos.map(
-    identifierInfo =>
-      new ElemID(
-        SALESFORCE,
-        naclCase(identifierTypeToElementType(identifierInfo)),
-        identifierTypeToElemIdType(identifierInfo),
-        ...identifierTypeToElementName(identifierInfo).map(naclCase),
-      ),
-  )
-
-const isValidReference = async (
-  elemId: ElemID,
-  allElements: ReadOnlyElementsSource,
-): Promise<boolean> => {
-  if (elemId.idType === 'type' || elemId.idType === 'instance') {
-    return (await allElements.get(elemId)) !== undefined
-  }
-
-  // field
-  const typeElemId = new ElemID(elemId.adapter, elemId.typeName)
-  const typeElement = await allElements.get(typeElemId)
-  return (
-    typeElement !== undefined && typeElement.fields[elemId.name] !== undefined
-  )
-}
-
-const referenceValidity = async (
-  refElemId: ElemID,
-  selfElemId: ElemID,
-  allElements: ReadOnlyElementsSource,
-): Promise<'valid' | 'omitted' | 'invalid'> => {
-  const isSelfReference = (elemId: ElemID): boolean =>
-    elemId.isEqual(selfElemId)
-
-  if (isSelfReference(refElemId)) {
-    return 'omitted'
-  }
-  return (await isValidReference(refElemId, allElements)) ? 'valid' : 'invalid'
-}
-
-const logInvalidReferences = (
-  refOrigin: ElemID,
-  invalidReferences: ElemID[],
-  formula: string,
-  identifiersInfo: FormulaIdentifierInfo[][],
-): void => {
-  if (invalidReferences.length > 0) {
-    log.debug(
-      'When parsing the formula %o in %o, one or more of the identifiers %o was parsed to an invalid reference: ',
-      formula,
-      refOrigin.getFullName(),
-      identifiersInfo.flat().map((info) => info.instance),
-    )
-  }
-  invalidReferences.forEach((refElemId) => {
-    log.debug(`Invalid reference: ${refElemId.getFullName()}`)
-  })
-}
-
-const addDependenciesAnnotation = async (
-  field: Field,
-  allElements: ReadOnlyElementsSource,
-): Promise<void> => {
+const addDependenciesAnnotation = async (field: Field, allElements: ReadOnlyElementsSource): Promise<void> => {
   const formula = field.annotations[FORMULA]
   if (formula === undefined) {
     log.error(`Field ${field.elemID.getFullName()} is a formula field with no formula?`)
@@ -186,16 +65,11 @@ const addDependenciesAnnotation = async (
       References: ${references.map(ref => ref.getFullName()).join(', ')}`)
     }
 
-    const referencesWithValidity = await groupByAsync(references, (refElemId) =>
+    const referencesWithValidity = await groupByAsync(references, refElemId =>
       referenceValidity(refElemId, field.parent.elemID, allElements),
     )
 
-    logInvalidReferences(
-      field.elemID,
-      referencesWithValidity.invalid ?? [],
-      formula,
-      identifiersInfo,
-    )
+    logInvalidReferences(field.elemID, referencesWithValidity.invalid ?? [], formula, identifiersInfo)
 
     const depsAsRefExpr = (referencesWithValidity.valid ?? []).map(elemId => ({
       reference: new ReferenceExpression(elemId),
@@ -216,53 +90,7 @@ const addDependenciesToFormulaFields = async (
     .flatMap(extractFlatCustomObjectFields) // Get the types + their fields
     .filter(isFormulaField)
     .toArray()
-  await Promise.all(
-    fetchedFormulaFields.map((field) =>
-      addDependenciesAnnotation(field, allElements),
-    ),
-  )
-}
-
-const transformFieldsToReferences = async (
-  fetchedElements: Element[],
-  allElements: ReadOnlyElementsSource,
-): Promise<void> => {
-  const transformInstanceFieldToReference = async (
-    instance: InstanceElement,
-  ): Promise<void> => {
-    const fieldName =
-      referenceFieldsWithFormulaIdentifiers[instance.elemID.typeName]
-    const identifierInfo = parseFormulaIdentifier(
-      instance.value[fieldName],
-      instance.elemID.getFullName(),
-    )
-    const referenceElemIds = await referencesFromIdentifiers(identifierInfo)
-
-    const referencesWithValidity = await groupByAsync(
-      referenceElemIds,
-      (refElemId) => referenceValidity(refElemId, instance.elemID, allElements),
-    )
-
-    logInvalidReferences(
-      instance.elemID,
-      referencesWithValidity.invalid ?? [],
-      instance.value[fieldName],
-      [identifierInfo],
-    )
-
-    if (!referencesWithValidity.valid) {
-      return
-    }
-
-    instance.value[fieldName] = new ReferenceExpression(
-      referencesWithValidity.valid[0],
-    )
-  }
-
-  const fetchedInstances = fetchedElements.filter(
-    isInstanceOfTypeSync(...Object.keys(referenceFieldsWithFormulaIdentifiers)),
-  )
-  fetchedInstances.forEach(transformInstanceFieldToReference)
+  await Promise.all(fetchedFormulaFields.map(field => addDependenciesAnnotation(field, allElements)))
 }
 
 const FILTER_NAME = 'formulaDeps'
@@ -279,10 +107,9 @@ const filter: LocalFilterCreator = ({ config }) => ({
     warningMessage: 'Error while parsing formulas',
     config,
     filterName: FILTER_NAME,
-    fetchFilterFunc: async (fetchedElements) => {
+    fetchFilterFunc: async fetchedElements => {
       const allElements = buildElementsSourceForFetch(fetchedElements, config)
       await addDependenciesToFormulaFields(fetchedElements, allElements)
-      await transformFieldsToReferences(fetchedElements, allElements)
     },
   }),
 })

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -250,6 +250,10 @@ const transformFieldsToReferences = async (
       [identifierInfo],
     )
 
+    if (!referencesWithValidity.valid) {
+      return
+    }
+
     instance.value[fieldName] = new ReferenceExpression(
       referencesWithValidity.valid[0],
     )

--- a/packages/salesforce-adapter/src/filters/formula_ref_fields.ts
+++ b/packages/salesforce-adapter/src/filters/formula_ref_fields.ts
@@ -1,0 +1,79 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Element, InstanceElement, ReadOnlyElementsSource, ReferenceExpression } from '@salto-io/adapter-api'
+import { parseFormulaIdentifier } from '@salto-io/salesforce-formula-parser'
+import { collections } from '@salto-io/lowerdash'
+import { buildElementsSourceForFetch, ensureSafeFilterFetch, isInstanceOfTypeSync } from './utils'
+import { LocalFilterCreator } from '../filter'
+import { logInvalidReferences, referencesFromIdentifiers, referenceValidity } from './formula_utils'
+
+const { groupByAsync } = collections.asynciterable
+
+const referenceFieldsWithFormulaIdentifiers: Record<string, string> = {
+  FlowCondition: 'leftValueReference',
+  FlowTestCondition: 'leftValueReference',
+  FlowTestParameter: 'leftValueReference',
+}
+
+const transformFieldsToReferences = async (
+  fetchedElements: Element[],
+  allElements: ReadOnlyElementsSource,
+): Promise<void> => {
+  const transformInstanceFieldToReference = async (instance: InstanceElement): Promise<void> => {
+    const fieldName = referenceFieldsWithFormulaIdentifiers[instance.elemID.typeName]
+    const identifierInfo = parseFormulaIdentifier(instance.value[fieldName], instance.elemID.getFullName())
+    const referenceElemIds = await referencesFromIdentifiers(identifierInfo)
+
+    const referencesWithValidity = await groupByAsync(referenceElemIds, refElemId =>
+      referenceValidity(refElemId, instance.elemID, allElements),
+    )
+
+    logInvalidReferences(instance.elemID, referencesWithValidity.invalid ?? [], instance.value[fieldName], [
+      identifierInfo,
+    ])
+
+    if (!referencesWithValidity.valid) {
+      return
+    }
+
+    instance.value[fieldName] = new ReferenceExpression(referencesWithValidity.valid[0])
+  }
+
+  const fetchedInstances = fetchedElements.filter(
+    isInstanceOfTypeSync(...Object.keys(referenceFieldsWithFormulaIdentifiers)),
+  )
+  fetchedInstances.forEach(transformInstanceFieldToReference)
+}
+
+const FILTER_NAME = 'formulaRefFields'
+/**
+ * Extract references from fields containing formulas
+ * These fields are strings but their contents reference other elements using the formula notation
+ */
+const filter: LocalFilterCreator = ({ config }) => ({
+  name: FILTER_NAME,
+  onFetch: ensureSafeFilterFetch({
+    warningMessage: 'Error while parsing formulas',
+    config,
+    filterName: FILTER_NAME,
+    fetchFilterFunc: async fetchedElements => {
+      const allElements = buildElementsSourceForFetch(fetchedElements, config)
+      await transformFieldsToReferences(fetchedElements, allElements)
+    },
+  }),
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/formula_utils.ts
+++ b/packages/salesforce-adapter/src/filters/formula_utils.ts
@@ -1,0 +1,109 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { ElemID, ElemIDType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { naclCase } from '@salto-io/adapter-utils'
+import { FormulaIdentifierInfo, IdentifierType } from '@salto-io/salesforce-formula-parser'
+import { logger } from '@salto-io/logging'
+import { CUSTOM_METADATA_SUFFIX, SALESFORCE } from '../constants'
+
+const log = logger(module)
+
+const identifierTypeToElementName = (identifierInfo: FormulaIdentifierInfo): string[] => {
+  if (identifierInfo.type === 'customLabel') {
+    return [identifierInfo.instance]
+  }
+  if (identifierInfo.type === 'customMetadataTypeRecord') {
+    const [typeName, instanceName] = identifierInfo.instance.split('.')
+    return [`${typeName.slice(0, -1 * CUSTOM_METADATA_SUFFIX.length)}.${instanceName}`]
+  }
+  return identifierInfo.instance.split('.').slice(1)
+}
+
+const identifierTypeToElementType = (identifierInfo: FormulaIdentifierInfo): string => {
+  if (identifierInfo.type === 'customLabel') {
+    return 'CustomLabel'
+  }
+
+  return identifierInfo.instance.split('.')[0]
+}
+
+const identifierTypeToElemIdType = (identifierInfo: FormulaIdentifierInfo): ElemIDType =>
+  (
+    ({
+      standardObject: 'type',
+      customMetadataType: 'type',
+      customObject: 'type',
+      customSetting: 'type',
+      standardField: 'field',
+      customField: 'field',
+      customMetadataTypeRecord: 'instance',
+      customLabel: 'instance',
+    }) as Record<IdentifierType, ElemIDType>
+  )[identifierInfo.type]
+
+export const referencesFromIdentifiers = async (typeInfos: FormulaIdentifierInfo[]): Promise<ElemID[]> =>
+  typeInfos.map(
+    identifierInfo =>
+      new ElemID(
+        SALESFORCE,
+        naclCase(identifierTypeToElementType(identifierInfo)),
+        identifierTypeToElemIdType(identifierInfo),
+        ...identifierTypeToElementName(identifierInfo).map(naclCase),
+      ),
+  )
+
+const isValidReference = async (elemId: ElemID, allElements: ReadOnlyElementsSource): Promise<boolean> => {
+  if (elemId.idType === 'type' || elemId.idType === 'instance') {
+    return (await allElements.get(elemId)) !== undefined
+  }
+
+  // field
+  const typeElemId = new ElemID(elemId.adapter, elemId.typeName)
+  const typeElement = await allElements.get(typeElemId)
+  return typeElement !== undefined && typeElement.fields[elemId.name] !== undefined
+}
+
+export const referenceValidity = async (
+  refElemId: ElemID,
+  selfElemId: ElemID,
+  allElements: ReadOnlyElementsSource,
+): Promise<'valid' | 'omitted' | 'invalid'> => {
+  const isSelfReference = (elemId: ElemID): boolean => elemId.isEqual(selfElemId)
+
+  if (isSelfReference(refElemId)) {
+    return 'omitted'
+  }
+  return (await isValidReference(refElemId, allElements)) ? 'valid' : 'invalid'
+}
+
+export const logInvalidReferences = (
+  refOrigin: ElemID,
+  invalidReferences: ElemID[],
+  formula: string,
+  identifiersInfo: FormulaIdentifierInfo[][],
+): void => {
+  if (invalidReferences.length > 0) {
+    log.debug(
+      'When parsing the formula %o in %o, one or more of the identifiers %o was parsed to an invalid reference: ',
+      formula,
+      refOrigin.getFullName(),
+      identifiersInfo.flat().map(info => info.instance),
+    )
+  }
+  invalidReferences.forEach(refElemId => {
+    log.debug(`Invalid reference: ${refElemId.getFullName()}`)
+  })
+}

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -113,6 +113,7 @@ export type OptionalFeatures = {
   describeSObjects?: boolean
   skipAliases?: boolean
   formulaDeps?: boolean
+  formulaRefFields?: boolean
   fetchCustomObjectUsingRetrieveApi?: boolean
   generateRefsInProfiles?: boolean
   fetchProfilesUsingReadApi?: boolean
@@ -807,6 +808,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     describeSObjects: { refType: BuiltinTypes.BOOLEAN },
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
+    formulaRefFields: { refType: BuiltinTypes.BOOLEAN },
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
     generateRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
     fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 import {
   BuiltinTypes,
   ElemID,
@@ -26,7 +25,7 @@ import { FlatDetailedDependency } from '@salto-io/adapter-utils'
 import formulaDepsFilter from '../../src/filters/formula_deps'
 import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { createInstanceElement, formulaTypeName, Types } from '../../src/transformers/transformer'
-import { FIELD_TYPE_NAMES, FORMULA, METADATA_TYPE, SALESFORCE } from '../../src/constants'
+import { FIELD_TYPE_NAMES, FORMULA, SALESFORCE } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 
@@ -51,200 +50,196 @@ const customObjectTypeWithFields = (name: string, fields: Record<string, Primiti
 describe('Formula dependencies', () => {
   let filter: FilterWith<'onFetch'>
 
+  let typeWithFormula: ObjectType
+  let referredTypes: ObjectType[]
+  let referredInstances: InstanceElement[]
+
   beforeAll(() => {
     const config = { ...defaultFilterContext }
     filter = formulaDepsFilter({ config }) as FilterWith<'onFetch'>
   })
 
-  describe('Formula fields', () => {
-    let typeWithFormula: ObjectType
-    let referredTypes: ObjectType[]
-    let referredInstances: InstanceElement[]
-
-    beforeAll(() => {
-      typeWithFormula = createCustomObjectType('Account', {
-        fields: {
-          someField__c: {
-            refType: BuiltinTypes.STRING,
-          },
-          someFormulaField__c: {
-            refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
-            annotations: {
-              [FORMULA]: 'ISBLANK(someField__c)',
-            },
-          },
-          AccountNumber: {
-            refType: BuiltinTypes.NUMBER,
-          },
-          OwnerId: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          original_lead__c: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          LastModifiedById: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          OpportunityId: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          Opportunity__c: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          ParentId: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
-          },
-          RecordTypeId: {
-            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+  beforeAll(() => {
+    typeWithFormula = createCustomObjectType('Account', {
+      fields: {
+        someField__c: {
+          refType: BuiltinTypes.STRING,
+        },
+        someFormulaField__c: {
+          refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
+          annotations: {
+            [FORMULA]: 'ISBLANK(someField__c)',
           },
         },
-      })
-      const someCustomMetadataType = customObjectTypeWithFields('Trigger_Context_Status__mdt', {
-        Enable_After_Delete__c: BuiltinTypes.BOOLEAN,
-        Enable_After_Insert__c: BuiltinTypes.BOOLEAN,
-        DeveloperName: BuiltinTypes.STRING,
-      })
-
-      referredTypes = [
-        customObjectTypeWithFields('Contact', {
-          AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-          AssistantName: BuiltinTypes.STRING,
-          CreatedById: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        someCustomMetadataType,
-        customObjectTypeWithFields('User', {
-          ContactId: BuiltinTypes.SERVICE_ID_NUMBER,
-          ManagerId: BuiltinTypes.SERVICE_ID_NUMBER,
-          CompanyName: BuiltinTypes.STRING,
-          ProfileId: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('original_lead__r', {
-          ConvertedAccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('Center__c', {
-          My_text_field__c: BuiltinTypes.STRING,
-        }),
-        customObjectTypeWithFields('Customer_Support_Setting__c', {
-          Email_Address__c: BuiltinTypes.STRING,
-        }),
-        createCustomObjectType('Details', {}),
-        customObjectTypeWithFields('Opportunity', {
-          AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('Opportunity__r', {
-          Related_Asset__c: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('Organization', {
-          UiSkin: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('Profile', {
-          Id: BuiltinTypes.SERVICE_ID_NUMBER,
-        }),
-        customObjectTypeWithFields('RecordType', { Name: BuiltinTypes.STRING }),
-        customObjectTypeWithFields('Related_Asset__r', {
-          Name: BuiltinTypes.STRING,
-        }),
-        customObjectTypeWithFields('SRM_API_Metadata_Client_Setting__mdt', {
-          CreatedDate: BuiltinTypes.STRING,
-        }),
-      ]
-      referredInstances = [
-        createInstanceElement({ fullName: 'Details' }, mockTypes.CustomLabel),
-        createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
-
-        createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
-      ]
+        AccountNumber: {
+          refType: BuiltinTypes.NUMBER,
+        },
+        OwnerId: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        original_lead__c: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        LastModifiedById: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        OpportunityId: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        Opportunity__c: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        ParentId: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+        RecordTypeId: {
+          refType: BuiltinTypes.SERVICE_ID_NUMBER,
+        },
+      },
+    })
+    const someCustomMetadataType = customObjectTypeWithFields('Trigger_Context_Status__mdt', {
+      Enable_After_Delete__c: BuiltinTypes.BOOLEAN,
+      Enable_After_Insert__c: BuiltinTypes.BOOLEAN,
+      DeveloperName: BuiltinTypes.STRING,
     })
 
-    describe('When the formula has a reference', () => {
-      it('Should return a field reference as a dependency', async () => {
-        const elements = [typeWithFormula.clone()]
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'someField__c'))
+    referredTypes = [
+      customObjectTypeWithFields('Contact', {
+        AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+        AssistantName: BuiltinTypes.STRING,
+        CreatedById: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      someCustomMetadataType,
+      customObjectTypeWithFields('User', {
+        ContactId: BuiltinTypes.SERVICE_ID_NUMBER,
+        ManagerId: BuiltinTypes.SERVICE_ID_NUMBER,
+        CompanyName: BuiltinTypes.STRING,
+        ProfileId: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('original_lead__r', {
+        ConvertedAccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('Center__c', {
+        My_text_field__c: BuiltinTypes.STRING,
+      }),
+      customObjectTypeWithFields('Customer_Support_Setting__c', {
+        Email_Address__c: BuiltinTypes.STRING,
+      }),
+      createCustomObjectType('Details', {}),
+      customObjectTypeWithFields('Opportunity', {
+        AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('Opportunity__r', {
+        Related_Asset__c: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('Organization', {
+        UiSkin: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('Profile', {
+        Id: BuiltinTypes.SERVICE_ID_NUMBER,
+      }),
+      customObjectTypeWithFields('RecordType', { Name: BuiltinTypes.STRING }),
+      customObjectTypeWithFields('Related_Asset__r', {
+        Name: BuiltinTypes.STRING,
+      }),
+      customObjectTypeWithFields('SRM_API_Metadata_Client_Setting__mdt', {
+        CreatedDate: BuiltinTypes.STRING,
+      }),
+    ]
+    referredInstances = [
+      createInstanceElement({ fullName: 'Details' }, mockTypes.CustomLabel),
+      createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
+
+      createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
+    ]
+  })
+
+  describe('When the formula has a reference', () => {
+    it('Should return a field reference as a dependency', async () => {
+      const elements = [typeWithFormula.clone()]
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'someField__c'))
+    })
+    it('Should return a Metadata Type Record field reference as a dependency', async () => {
+      const customMetadataType = customObjectTypeWithFields('SomeCustomMetadataType__mdt', {
+        SomeTextField__c: BuiltinTypes.STRING,
       })
-      it('Should return a Metadata Type Record field reference as a dependency', async () => {
-        const customMetadataType = customObjectTypeWithFields('SomeCustomMetadataType__mdt', {
-          SomeTextField__c: BuiltinTypes.STRING,
-        })
-        const typeUnderTest = typeWithFormula.clone()
-        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-          '$CustomMetadata.SomeCustomMetadataType__mdt.SomeCustomMetadataTypeRecord.SomeTextField__c'
-        const elements = [
-          typeUnderTest,
-          customMetadataType,
-          createInstanceElement(
-            { fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' },
-            customMetadataType,
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+        '$CustomMetadata.SomeCustomMetadataType__mdt.SomeCustomMetadataTypeRecord.SomeTextField__c'
+      const elements = [
+        typeUnderTest,
+        customMetadataType,
+        createInstanceElement({ fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' }, customMetadataType),
+      ]
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+
+      const expectedRefs = [
+        {
+          reference: new ReferenceExpression(new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt')),
+        },
+        {
+          reference: new ReferenceExpression(
+            new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt', 'field', 'SomeTextField__c'),
           ),
-        ]
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-
-        const expectedRefs = [
-          {
-            reference: new ReferenceExpression(new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt')),
-          },
-          {
-            reference: new ReferenceExpression(
-              new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt', 'field', 'SomeTextField__c'),
+        },
+        {
+          reference: new ReferenceExpression(
+            new ElemID(
+              SALESFORCE,
+              'SomeCustomMetadataType__mdt',
+              'instance',
+              'SomeCustomMetadataType_SomeCustomMetadataTypeRecord@v',
             ),
-          },
-          {
-            reference: new ReferenceExpression(
-              new ElemID(
-                SALESFORCE,
-                'SomeCustomMetadataType__mdt',
-                'instance',
-                'SomeCustomMetadataType_SomeCustomMetadataTypeRecord@v',
-              ),
-            ),
-          },
-        ]
-        expect(deps).toEqual(expectedRefs)
-      })
-      it("should not return a reference if it refers to something that doesn't exist", async () => {
-        const typeUnderTest = typeWithFormula.clone()
-        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-          'ISBLANK(someField__c) && ISBLANK(GarbageType.DreckField)'
-
-        await filter.onFetch([typeUnderTest])
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(deps).toHaveLength(1)
-        expect(deps[0].reference.elemID.typeName).not.toEqual('GarbageType')
-      })
+          ),
+        },
+      ]
+      expect(deps).toEqual(expectedRefs)
     })
+    it("should not return a reference if it refers to something that doesn't exist", async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+        'ISBLANK(someField__c) && ISBLANK(GarbageType.DreckField)'
 
-    describe('When referencing RecordType', () => {
-      it('should extract the correct dependencies', async () => {
-        const typeUnderTest = typeWithFormula.clone()
-        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-          `IF( RecordType.Name = 'New Sale', 'Onboarding - New',
+      await filter.onFetch([typeUnderTest])
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(deps).toHaveLength(1)
+      expect(deps[0].reference.elemID.typeName).not.toEqual('GarbageType')
+    })
+  })
+
+  describe('When referencing RecordType', () => {
+    it('should extract the correct dependencies', async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+        `IF( RecordType.Name = 'New Sale', 'Onboarding - New',
           IF( RecordType.Name = 'Upgrade', 'Onboarding - Upgrade',
             IF( RecordType.Name = 'Add-On', 'Onboarding - Add-On', "")))`
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'RecordTypeId'))
-        expect(deps[1]).toEqual(depNameToRefExpr('RecordType'))
-        expect(deps[2]).toEqual(depNameToRefExpr('RecordType', 'Name'))
-      })
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'RecordTypeId'))
+      expect(deps[1]).toEqual(depNameToRefExpr('RecordType'))
+      expect(deps[2]).toEqual(depNameToRefExpr('RecordType', 'Name'))
     })
+  })
 
-    describe('Complex formulas', () => {
-      const standardFormula = `IF(Owner.Contact.CreatedBy.Manager.Profile.Id = "03d3h000000khEQ",TRUE,false)
+  describe('Complex formulas', () => {
+    const standardFormula = `IF(Owner.Contact.CreatedBy.Manager.Profile.Id = "03d3h000000khEQ",TRUE,false)
       && IF(($CustomMetadata.Trigger_Context_Status__mdt.by_handler.Enable_After_Insert__c ||
         $CustomMetadata.Trigger_Context_Status__mdt.by_class.DeveloperName = "Default"),true,FALSE)
       && IF( ($Label.Details = "Value" || Opportunity.Account.Parent.Parent.Parent.LastModifiedBy.Contact.AssistantName = "Marie"), true ,false)
@@ -254,161 +249,161 @@ describe('Formula dependencies', () => {
       && IF ( ( TEXT($Organization.UiSkin) = "lex" ) ,true,false)    
       && IF ( ( $Setup.Customer_Support_Setting__c.Email_Address__c = "test@gmail.com" ) ,true,false)    
       && IF ( (  $User.CompanyName = "acme" ) ,true,false)`
-      const processBuilderFormula = `IF([Account].Owner.Manager.Contact.Account.AccountNumber  = "text" ,TRUE,FALSE)
+    const processBuilderFormula = `IF([Account].Owner.Manager.Contact.Account.AccountNumber  = "text" ,TRUE,FALSE)
           || IF([Account].original_lead__r.ConvertedAccountId != "",TRUE,FALSE)
           || IF($CustomMetadata.Trigger_Context_Status__mdt.by_class.Enable_After_Delete__c , TRUE,FALse)`
-      const standardFormulaExpectedRefs = [
-        'salesforce.Account.field.LastModifiedById',
-        'salesforce.Account.field.OpportunityId',
-        'salesforce.Account.field.Opportunity__c',
-        'salesforce.Account.field.OwnerId',
-        'salesforce.Account.field.ParentId',
-        'salesforce.Center__c',
-        'salesforce.Center__c.field.My_text_field__c',
-        'salesforce.Contact',
-        'salesforce.Contact.field.AssistantName',
-        'salesforce.Contact.field.CreatedById',
-        'salesforce.CustomLabel.instance.Details',
-        'salesforce.Customer_Support_Setting__c',
-        'salesforce.Customer_Support_Setting__c.field.Email_Address__c',
-        'salesforce.Opportunity',
-        'salesforce.Opportunity.field.AccountId',
-        'salesforce.Opportunity__r',
-        'salesforce.Opportunity__r.field.Related_Asset__c',
-        'salesforce.Organization',
-        'salesforce.Organization.field.UiSkin',
-        'salesforce.Profile',
-        'salesforce.Profile.field.Id',
-        'salesforce.Related_Asset__r',
-        'salesforce.Related_Asset__r.field.Name',
-        'salesforce.SRM_API_Metadata_Client_Setting__mdt',
-        'salesforce.SRM_API_Metadata_Client_Setting__mdt.field.CreatedDate',
-        'salesforce.Trigger_Context_Status__mdt',
-        'salesforce.Trigger_Context_Status__mdt.field.DeveloperName',
-        'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Insert__c',
-        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
-        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_handler@uuvu',
-        'salesforce.User',
-        'salesforce.User.field.CompanyName',
-        'salesforce.User.field.ContactId',
-        'salesforce.User.field.ManagerId',
-        'salesforce.User.field.ProfileId',
-      ]
-      const processBuilderFormulaExpectedRefs = [
-        'salesforce.Account.field.AccountNumber',
-        'salesforce.Account.field.OwnerId',
-        'salesforce.Account.field.original_lead__c',
-        'salesforce.Contact',
-        'salesforce.Contact.field.AccountId',
-        'salesforce.Trigger_Context_Status__mdt',
-        'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Delete__c',
-        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
-        'salesforce.User',
-        'salesforce.User.field.ContactId',
-        'salesforce.User.field.ManagerId',
-        'salesforce.original_lead__r',
-        'salesforce.original_lead__r.field.ConvertedAccountId',
-      ]
-      it('Should extract the correct references from a complex standard formula', async () => {
-        const typeUnderTest = typeWithFormula.clone()
-        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = standardFormula
-        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(deps.map(({ reference }: { reference: ReferenceExpression }) => reference.elemID.getFullName())).toEqual(
-          standardFormulaExpectedRefs,
-        )
-      })
-
-      it('Should extract the correct references from a Process Builder formula', async () => {
-        const typeUnderTest = typeWithFormula.clone()
-        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = processBuilderFormula
-        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(
-          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()),
-        ).toEqual(processBuilderFormulaExpectedRefs)
-      })
+    const standardFormulaExpectedRefs = [
+      'salesforce.Account.field.LastModifiedById',
+      'salesforce.Account.field.OpportunityId',
+      'salesforce.Account.field.Opportunity__c',
+      'salesforce.Account.field.OwnerId',
+      'salesforce.Account.field.ParentId',
+      'salesforce.Center__c',
+      'salesforce.Center__c.field.My_text_field__c',
+      'salesforce.Contact',
+      'salesforce.Contact.field.AssistantName',
+      'salesforce.Contact.field.CreatedById',
+      'salesforce.CustomLabel.instance.Details',
+      'salesforce.Customer_Support_Setting__c',
+      'salesforce.Customer_Support_Setting__c.field.Email_Address__c',
+      'salesforce.Opportunity',
+      'salesforce.Opportunity.field.AccountId',
+      'salesforce.Opportunity__r',
+      'salesforce.Opportunity__r.field.Related_Asset__c',
+      'salesforce.Organization',
+      'salesforce.Organization.field.UiSkin',
+      'salesforce.Profile',
+      'salesforce.Profile.field.Id',
+      'salesforce.Related_Asset__r',
+      'salesforce.Related_Asset__r.field.Name',
+      'salesforce.SRM_API_Metadata_Client_Setting__mdt',
+      'salesforce.SRM_API_Metadata_Client_Setting__mdt.field.CreatedDate',
+      'salesforce.Trigger_Context_Status__mdt',
+      'salesforce.Trigger_Context_Status__mdt.field.DeveloperName',
+      'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Insert__c',
+      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
+      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_handler@uuvu',
+      'salesforce.User',
+      'salesforce.User.field.CompanyName',
+      'salesforce.User.field.ContactId',
+      'salesforce.User.field.ManagerId',
+      'salesforce.User.field.ProfileId',
+    ]
+    const processBuilderFormulaExpectedRefs = [
+      'salesforce.Account.field.AccountNumber',
+      'salesforce.Account.field.OwnerId',
+      'salesforce.Account.field.original_lead__c',
+      'salesforce.Contact',
+      'salesforce.Contact.field.AccountId',
+      'salesforce.Trigger_Context_Status__mdt',
+      'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Delete__c',
+      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
+      'salesforce.User',
+      'salesforce.User.field.ContactId',
+      'salesforce.User.field.ManagerId',
+      'salesforce.original_lead__r',
+      'salesforce.original_lead__r.field.ConvertedAccountId',
+    ]
+    it('Should extract the correct references from a complex standard formula', async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = standardFormula
+      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(deps.map(({ reference }: { reference: ReferenceExpression }) => reference.elemID.getFullName())).toEqual(
+        standardFormulaExpectedRefs,
+      )
     })
-    describe('CPQ formulas', () => {
-      const simpleFormula = 'SBQQ__DistriBUtor__r.Name '
-      const formulaWithUnknownRelationship = 'SBQQ__random__r.Name '
-      const simpleFormulaExpectedDeps = [
-        'salesforce.SBQQ__QuoTE__c.field.SBQQ__DistriBUtor__c',
-        'salesforce.Account',
-        'salesforce.Account.field.Name',
-      ].sort()
-      const formulaWithUnknownRelationshipExpectedDeps = [
-        'salesforce.SBQQ__QuoTE__c.field.SBQQ__random__c',
-        'salesforce.SBQQ__random__r',
-        'salesforce.SBQQ__random__r.field.Name',
-      ].sort()
-      let typeWithCpqFormula: ObjectType
-      let referredObjectTypes: ObjectType[]
 
-      beforeAll(() => {
-        typeWithCpqFormula = createCustomObjectType('SBQQ__QuoTE__c', {
-          fields: {
-            SBQQ__DistriBUtor__c: {
-              refType: BuiltinTypes.STRING,
-            },
-            SBQQ__random__c: {
-              refType: BuiltinTypes.STRING,
-            },
-            someField__c: {
-              refType: BuiltinTypes.STRING,
-            },
-            someFormulaField__c: {
-              refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
-              annotations: {
-                [FORMULA]: '',
-              },
+    it('Should extract the correct references from a Process Builder formula', async () => {
+      const typeUnderTest = typeWithFormula.clone()
+      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = processBuilderFormula
+      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName())).toEqual(
+        processBuilderFormulaExpectedRefs,
+      )
+    })
+  })
+  describe('CPQ formulas', () => {
+    const simpleFormula = 'SBQQ__DistriBUtor__r.Name '
+    const formulaWithUnknownRelationship = 'SBQQ__random__r.Name '
+    const simpleFormulaExpectedDeps = [
+      'salesforce.SBQQ__QuoTE__c.field.SBQQ__DistriBUtor__c',
+      'salesforce.Account',
+      'salesforce.Account.field.Name',
+    ].sort()
+    const formulaWithUnknownRelationshipExpectedDeps = [
+      'salesforce.SBQQ__QuoTE__c.field.SBQQ__random__c',
+      'salesforce.SBQQ__random__r',
+      'salesforce.SBQQ__random__r.field.Name',
+    ].sort()
+    let typeWithCpqFormula: ObjectType
+    let referredObjectTypes: ObjectType[]
+
+    beforeAll(() => {
+      typeWithCpqFormula = createCustomObjectType('SBQQ__QuoTE__c', {
+        fields: {
+          SBQQ__DistriBUtor__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          SBQQ__random__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          someField__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          someFormulaField__c: {
+            refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
+            annotations: {
+              [FORMULA]: '',
             },
           },
-        })
-        referredObjectTypes = [
-          customObjectTypeWithFields('SBQQ__random__r', {
-            Name: BuiltinTypes.STRING,
-          }),
-          customObjectTypeWithFields('Account', { Name: BuiltinTypes.STRING }),
-        ]
+        },
       })
-
-      it('Should extract the correct references from a CPQ formula', async () => {
-        const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
-        elements[0].fields.someFormulaField__c.annotations[FORMULA] = simpleFormula
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(
-          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-        ).toEqual(simpleFormulaExpectedDeps)
-      })
-
-      it('Should extract the correct references from a CPQ formula with unknown relationship', async () => {
-        const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
-        elements[0].fields.someFormulaField__c.annotations[FORMULA] = formulaWithUnknownRelationship
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(
-          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-        ).toEqual(formulaWithUnknownRelationshipExpectedDeps)
-      })
+      referredObjectTypes = [
+        customObjectTypeWithFields('SBQQ__random__r', {
+          Name: BuiltinTypes.STRING,
+        }),
+        customObjectTypeWithFields('Account', { Name: BuiltinTypes.STRING }),
+      ]
     })
-    describe('Deeply nested formulas', () => {
-      const deeplyNestedFormula = `
+
+    it('Should extract the correct references from a CPQ formula', async () => {
+      const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
+      elements[0].fields.someFormulaField__c.annotations[FORMULA] = simpleFormula
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(
+        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+      ).toEqual(simpleFormulaExpectedDeps)
+    })
+
+    it('Should extract the correct references from a CPQ formula with unknown relationship', async () => {
+      const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
+      elements[0].fields.someFormulaField__c.annotations[FORMULA] = formulaWithUnknownRelationship
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(
+        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+      ).toEqual(formulaWithUnknownRelationshipExpectedDeps)
+    })
+  })
+  describe('Deeply nested formulas', () => {
+    const deeplyNestedFormula = `
       IF(INCLUDES( COVID19_Status__c  ,'Fraud evaluation on hold'),'Negative',
         IF(INCLUDES(COVID19_Status__c,'Volume increase'),'Positive',
           IF(INCLUDES(COVID19_Status__c,'Volume decrease'),'Negative',
@@ -420,79 +415,31 @@ describe('Formula dependencies', () => {
                       IF(INCLUDES(COVID19_Status__c,'Paused eCommerce operations'),'Negative',
                         IF(INCLUDES(COVID19_Status__c,'Started ecomm operations'),'Positive',""))))))))))
       `
-      const typeWithDeeplyNestedFormula = createCustomObjectType('Account', {
-        fields: {
-          COVID19_Status__c: {
-            refType: BuiltinTypes.STRING,
-          },
-          someFormulaField__c: {
-            refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.TEXT)],
-            annotations: {
-              [FORMULA]: '',
-            },
-          },
-        },
-      })
-
-      it('should not take too long', async () => {
-        const elements = [typeWithDeeplyNestedFormula.clone()]
-        elements[0].fields.someFormulaField__c.annotations[FORMULA] = deeplyNestedFormula
-        await filter.onFetch(elements)
-        const deps =
-          // eslint-disable-next-line no-underscore-dangle
-          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-        expect(deps).toBeDefined()
-        expect(
-          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-        ).toEqual(['salesforce.Account.field.COVID19_Status__c'])
-      })
-    })
-  })
-
-  describe('Reference fields', () => {
-    const objectType = new ObjectType({
-      elemID: new ElemID(SALESFORCE, 'FlowCondition'),
-      annotations: { [METADATA_TYPE]: 'FlowCondition' },
+    const typeWithDeeplyNestedFormula = createCustomObjectType('Account', {
       fields: {
-        leftValueReference: {
+        COVID19_Status__c: {
           refType: BuiltinTypes.STRING,
+        },
+        someFormulaField__c: {
+          refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.TEXT)],
+          annotations: {
+            [FORMULA]: '',
+          },
         },
       },
     })
-    const referringInstance = new InstanceElement('SomeFlowCondition', objectType, {
-      leftValueReference: '$Label.SomeLabel',
-    })
 
-    describe('when there is a valid reference', () => {
-      const referredInstance = new InstanceElement('SomeLabel', mockTypes.CustomLabel, { fullName: 'SomeLabel' })
-      const elements = [objectType, referringInstance, referredInstance].map(element => element.clone())
-
-      beforeEach(async () => {
-        await filter.onFetch(elements)
-      })
-
-      it('should replace the field value with a reference expression', () => {
-        const referringInstanceAfterTest = elements.find(elem =>
-          elem.elemID.isEqual(referringInstance.elemID),
-        ) as InstanceElement
-        expect(referringInstanceAfterTest.value.leftValueReference).toEqual(
-          new ReferenceExpression(referredInstance.elemID),
-        )
-      })
-    })
-    describe('when the reference is not valid', () => {
-      const elements = [objectType, referringInstance].map(element => element.clone())
-
-      beforeEach(async () => {
-        await filter.onFetch(elements)
-      })
-
-      it('should replace the field value with a reference expression', () => {
-        const referringInstanceAfterTest = elements.find(elem =>
-          elem.elemID.isEqual(referringInstance.elemID),
-        ) as InstanceElement
-        expect(referringInstanceAfterTest.value.leftValueReference).toEqual(referringInstance.value.leftValueReference)
-      })
+    it('should not take too long', async () => {
+      const elements = [typeWithDeeplyNestedFormula.clone()]
+      elements[0].fields.someFormulaField__c.annotations[FORMULA] = deeplyNestedFormula
+      await filter.onFetch(elements)
+      const deps =
+        // eslint-disable-next-line no-underscore-dangle
+        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+      expect(deps).toBeDefined()
+      expect(
+        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+      ).toEqual(['salesforce.Account.field.COVID19_Status__c'])
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/formula_deps.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_deps.test.ts
@@ -26,7 +26,7 @@ import { FlatDetailedDependency } from '@salto-io/adapter-utils'
 import formulaDepsFilter from '../../src/filters/formula_deps'
 import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { createInstanceElement, formulaTypeName, Types } from '../../src/transformers/transformer'
-import { FIELD_TYPE_NAMES, FORMULA, SALESFORCE } from '../../src/constants'
+import { FIELD_TYPE_NAMES, FORMULA, METADATA_TYPE, SALESFORCE } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 
@@ -50,392 +50,449 @@ const customObjectTypeWithFields = (name: string, fields: Record<string, Primiti
 
 describe('Formula dependencies', () => {
   let filter: FilterWith<'onFetch'>
-  let typeWithFormula: ObjectType
-  let referredTypes: ObjectType[]
-  let referredInstances: InstanceElement[]
 
   beforeAll(() => {
     const config = { ...defaultFilterContext }
     filter = formulaDepsFilter({ config }) as FilterWith<'onFetch'>
-
-    typeWithFormula = createCustomObjectType('Account', {
-      fields: {
-        someField__c: {
-          refType: BuiltinTypes.STRING,
-        },
-        someFormulaField__c: {
-          refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
-          annotations: {
-            [FORMULA]: 'ISBLANK(someField__c)',
-          },
-        },
-        AccountNumber: {
-          refType: BuiltinTypes.NUMBER,
-        },
-        OwnerId: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        original_lead__c: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        LastModifiedById: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        OpportunityId: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        Opportunity__c: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        ParentId: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-        RecordTypeId: {
-          refType: BuiltinTypes.SERVICE_ID_NUMBER,
-        },
-      },
-    })
-    const someCustomMetadataType = customObjectTypeWithFields('Trigger_Context_Status__mdt', {
-      Enable_After_Delete__c: BuiltinTypes.BOOLEAN,
-      Enable_After_Insert__c: BuiltinTypes.BOOLEAN,
-      DeveloperName: BuiltinTypes.STRING,
-    })
-    referredTypes = [
-      customObjectTypeWithFields('Contact', {
-        AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-        AssistantName: BuiltinTypes.STRING,
-        CreatedById: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      someCustomMetadataType,
-      customObjectTypeWithFields('User', {
-        ContactId: BuiltinTypes.SERVICE_ID_NUMBER,
-        ManagerId: BuiltinTypes.SERVICE_ID_NUMBER,
-        CompanyName: BuiltinTypes.STRING,
-        ProfileId: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('original_lead__r', {
-        ConvertedAccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('Center__c', {
-        My_text_field__c: BuiltinTypes.STRING,
-      }),
-      customObjectTypeWithFields('Customer_Support_Setting__c', {
-        Email_Address__c: BuiltinTypes.STRING,
-      }),
-      createCustomObjectType('Details', {}),
-      customObjectTypeWithFields('Opportunity', {
-        AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('Opportunity__r', {
-        Related_Asset__c: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('Organization', {
-        UiSkin: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('Profile', {
-        Id: BuiltinTypes.SERVICE_ID_NUMBER,
-      }),
-      customObjectTypeWithFields('RecordType', { Name: BuiltinTypes.STRING }),
-      customObjectTypeWithFields('Related_Asset__r', {
-        Name: BuiltinTypes.STRING,
-      }),
-      customObjectTypeWithFields('SRM_API_Metadata_Client_Setting__mdt', {
-        CreatedDate: BuiltinTypes.STRING,
-      }),
-    ]
-    referredInstances = [
-      createInstanceElement({ fullName: 'Details' }, mockTypes.CustomLabel),
-      createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
-      createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
-    ]
   })
 
-  describe('When the formula has a reference', () => {
-    it('Should return a field reference as a dependency', async () => {
-      const elements = [typeWithFormula.clone()]
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'someField__c'))
-    })
-    it('Should return a Metadata Type Record field reference as a dependency', async () => {
-      const customMetadataType = customObjectTypeWithFields('SomeCustomMetadataType__mdt', {
-        SomeTextField__c: BuiltinTypes.STRING,
-      })
-      const typeUnderTest = typeWithFormula.clone()
-      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-        '$CustomMetadata.SomeCustomMetadataType__mdt.SomeCustomMetadataTypeRecord.SomeTextField__c'
-      const elements = [
-        typeUnderTest,
-        customMetadataType,
-        createInstanceElement({ fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' }, customMetadataType),
-      ]
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-
-      const expectedRefs = [
-        {
-          reference: new ReferenceExpression(new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt')),
-        },
-        {
-          reference: new ReferenceExpression(
-            new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt', 'field', 'SomeTextField__c'),
-          ),
-        },
-        {
-          reference: new ReferenceExpression(
-            new ElemID(
-              SALESFORCE,
-              'SomeCustomMetadataType__mdt',
-              'instance',
-              'SomeCustomMetadataType_SomeCustomMetadataTypeRecord@v',
-            ),
-          ),
-        },
-      ]
-      expect(deps).toEqual(expectedRefs)
-    })
-    it("should not return a reference if it refers to something that doesn't exist", async () => {
-      const typeUnderTest = typeWithFormula.clone()
-      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-        'ISBLANK(someField__c) && ISBLANK(GarbageType.DreckField)'
-
-      await filter.onFetch([typeUnderTest])
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(deps).toHaveLength(1)
-      expect(deps[0].reference.elemID.typeName).not.toEqual('GarbageType')
-    })
-  })
-
-  describe('When referencing RecordType', () => {
-    it('should extract the correct dependencies', async () => {
-      const typeUnderTest = typeWithFormula.clone()
-      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
-        `IF( RecordType.Name = 'New Sale', 'Onboarding - New',
-        IF( RecordType.Name = 'Upgrade', 'Onboarding - Upgrade',
-          IF( RecordType.Name = 'Add-On', 'Onboarding - Add-On', "")))`
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'RecordTypeId'))
-      expect(deps[1]).toEqual(depNameToRefExpr('RecordType'))
-      expect(deps[2]).toEqual(depNameToRefExpr('RecordType', 'Name'))
-    })
-  })
-
-  describe('Complex formulas', () => {
-    const standardFormula = `IF(Owner.Contact.CreatedBy.Manager.Profile.Id = "03d3h000000khEQ",TRUE,false)
-    && IF(($CustomMetadata.Trigger_Context_Status__mdt.by_handler.Enable_After_Insert__c ||
-      $CustomMetadata.Trigger_Context_Status__mdt.by_class.DeveloperName = "Default"),true,FALSE)
-    && IF( ($Label.Details = "Value" || Opportunity.Account.Parent.Parent.Parent.LastModifiedBy.Contact.AssistantName = "Marie"), true ,false)
-    && IF( (Opportunity__r.Related_Asset__r.Name), true ,false)    
-    && IF ( ( $ObjectType.Center__c.Fields.My_text_field__c = "My_Text_Field__c") ,true,false)    
-    && IF ( ( $ObjectType.SRM_API_Metadata_Client_Setting__mdt.Fields.CreatedDate  = "My_Text_Field__c") ,true,false)    
-    && IF ( ( TEXT($Organization.UiSkin) = "lex" ) ,true,false)    
-    && IF ( ( $Setup.Customer_Support_Setting__c.Email_Address__c = "test@gmail.com" ) ,true,false)    
-    && IF ( (  $User.CompanyName = "acme" ) ,true,false)`
-    const processBuilderFormula = `IF([Account].Owner.Manager.Contact.Account.AccountNumber  = "text" ,TRUE,FALSE)
-        || IF([Account].original_lead__r.ConvertedAccountId != "",TRUE,FALSE)
-        || IF($CustomMetadata.Trigger_Context_Status__mdt.by_class.Enable_After_Delete__c , TRUE,FALse)`
-    const standardFormulaExpectedRefs = [
-      'salesforce.Account.field.LastModifiedById',
-      'salesforce.Account.field.OpportunityId',
-      'salesforce.Account.field.Opportunity__c',
-      'salesforce.Account.field.OwnerId',
-      'salesforce.Account.field.ParentId',
-      'salesforce.Center__c',
-      'salesforce.Center__c.field.My_text_field__c',
-      'salesforce.Contact',
-      'salesforce.Contact.field.AssistantName',
-      'salesforce.Contact.field.CreatedById',
-      'salesforce.CustomLabel.instance.Details',
-      'salesforce.Customer_Support_Setting__c',
-      'salesforce.Customer_Support_Setting__c.field.Email_Address__c',
-      'salesforce.Opportunity',
-      'salesforce.Opportunity.field.AccountId',
-      'salesforce.Opportunity__r',
-      'salesforce.Opportunity__r.field.Related_Asset__c',
-      'salesforce.Organization',
-      'salesforce.Organization.field.UiSkin',
-      'salesforce.Profile',
-      'salesforce.Profile.field.Id',
-      'salesforce.Related_Asset__r',
-      'salesforce.Related_Asset__r.field.Name',
-      'salesforce.SRM_API_Metadata_Client_Setting__mdt',
-      'salesforce.SRM_API_Metadata_Client_Setting__mdt.field.CreatedDate',
-      'salesforce.Trigger_Context_Status__mdt',
-      'salesforce.Trigger_Context_Status__mdt.field.DeveloperName',
-      'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Insert__c',
-      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
-      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_handler@uuvu',
-      'salesforce.User',
-      'salesforce.User.field.CompanyName',
-      'salesforce.User.field.ContactId',
-      'salesforce.User.field.ManagerId',
-      'salesforce.User.field.ProfileId',
-    ]
-    const processBuilderFormulaExpectedRefs = [
-      'salesforce.Account.field.AccountNumber',
-      'salesforce.Account.field.OwnerId',
-      'salesforce.Account.field.original_lead__c',
-      'salesforce.Contact',
-      'salesforce.Contact.field.AccountId',
-      'salesforce.Trigger_Context_Status__mdt',
-      'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Delete__c',
-      'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
-      'salesforce.User',
-      'salesforce.User.field.ContactId',
-      'salesforce.User.field.ManagerId',
-      'salesforce.original_lead__r',
-      'salesforce.original_lead__r.field.ConvertedAccountId',
-    ]
-    it('Should extract the correct references from a complex standard formula', async () => {
-      const typeUnderTest = typeWithFormula.clone()
-      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = standardFormula
-      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(deps.map(({ reference }: { reference: ReferenceExpression }) => reference.elemID.getFullName())).toEqual(
-        standardFormulaExpectedRefs,
-      )
-    })
-
-    it('Should extract the correct references from a Process Builder formula', async () => {
-      const typeUnderTest = typeWithFormula.clone()
-      typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = processBuilderFormula
-      const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName())).toEqual(
-        processBuilderFormulaExpectedRefs,
-      )
-    })
-  })
-  describe('CPQ formulas', () => {
-    const simpleFormula = 'SBQQ__DistriBUtor__r.Name '
-    const formulaWithUnknownRelationship = 'SBQQ__random__r.Name '
-    const simpleFormulaExpectedDeps = [
-      'salesforce.SBQQ__QuoTE__c.field.SBQQ__DistriBUtor__c',
-      'salesforce.Account',
-      'salesforce.Account.field.Name',
-    ].sort()
-    const formulaWithUnknownRelationshipExpectedDeps = [
-      'salesforce.SBQQ__QuoTE__c.field.SBQQ__random__c',
-      'salesforce.SBQQ__random__r',
-      'salesforce.SBQQ__random__r.field.Name',
-    ].sort()
-    let typeWithCpqFormula: ObjectType
-    let referredObjectTypes: ObjectType[]
+  describe('Formula fields', () => {
+    let typeWithFormula: ObjectType
+    let referredTypes: ObjectType[]
+    let referredInstances: InstanceElement[]
 
     beforeAll(() => {
-      typeWithCpqFormula = createCustomObjectType('SBQQ__QuoTE__c', {
+      typeWithFormula = createCustomObjectType('Account', {
         fields: {
-          SBQQ__DistriBUtor__c: {
-            refType: BuiltinTypes.STRING,
-          },
-          SBQQ__random__c: {
-            refType: BuiltinTypes.STRING,
-          },
           someField__c: {
             refType: BuiltinTypes.STRING,
           },
           someFormulaField__c: {
             refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
             annotations: {
+              [FORMULA]: 'ISBLANK(someField__c)',
+            },
+          },
+          AccountNumber: {
+            refType: BuiltinTypes.NUMBER,
+          },
+          OwnerId: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          original_lead__c: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          LastModifiedById: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          OpportunityId: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          Opportunity__c: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          ParentId: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+          RecordTypeId: {
+            refType: BuiltinTypes.SERVICE_ID_NUMBER,
+          },
+        },
+      })
+      const someCustomMetadataType = customObjectTypeWithFields('Trigger_Context_Status__mdt', {
+        Enable_After_Delete__c: BuiltinTypes.BOOLEAN,
+        Enable_After_Insert__c: BuiltinTypes.BOOLEAN,
+        DeveloperName: BuiltinTypes.STRING,
+      })
+
+      referredTypes = [
+        customObjectTypeWithFields('Contact', {
+          AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+          AssistantName: BuiltinTypes.STRING,
+          CreatedById: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        someCustomMetadataType,
+        customObjectTypeWithFields('User', {
+          ContactId: BuiltinTypes.SERVICE_ID_NUMBER,
+          ManagerId: BuiltinTypes.SERVICE_ID_NUMBER,
+          CompanyName: BuiltinTypes.STRING,
+          ProfileId: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('original_lead__r', {
+          ConvertedAccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('Center__c', {
+          My_text_field__c: BuiltinTypes.STRING,
+        }),
+        customObjectTypeWithFields('Customer_Support_Setting__c', {
+          Email_Address__c: BuiltinTypes.STRING,
+        }),
+        createCustomObjectType('Details', {}),
+        customObjectTypeWithFields('Opportunity', {
+          AccountId: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('Opportunity__r', {
+          Related_Asset__c: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('Organization', {
+          UiSkin: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('Profile', {
+          Id: BuiltinTypes.SERVICE_ID_NUMBER,
+        }),
+        customObjectTypeWithFields('RecordType', { Name: BuiltinTypes.STRING }),
+        customObjectTypeWithFields('Related_Asset__r', {
+          Name: BuiltinTypes.STRING,
+        }),
+        customObjectTypeWithFields('SRM_API_Metadata_Client_Setting__mdt', {
+          CreatedDate: BuiltinTypes.STRING,
+        }),
+      ]
+      referredInstances = [
+        createInstanceElement({ fullName: 'Details' }, mockTypes.CustomLabel),
+        createInstanceElement({ fullName: 'Trigger_Context_Status.by_class' }, someCustomMetadataType),
+
+        createInstanceElement({ fullName: 'Trigger_Context_Status.by_handler' }, someCustomMetadataType),
+      ]
+    })
+
+    describe('When the formula has a reference', () => {
+      it('Should return a field reference as a dependency', async () => {
+        const elements = [typeWithFormula.clone()]
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'someField__c'))
+      })
+      it('Should return a Metadata Type Record field reference as a dependency', async () => {
+        const customMetadataType = customObjectTypeWithFields('SomeCustomMetadataType__mdt', {
+          SomeTextField__c: BuiltinTypes.STRING,
+        })
+        const typeUnderTest = typeWithFormula.clone()
+        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+          '$CustomMetadata.SomeCustomMetadataType__mdt.SomeCustomMetadataTypeRecord.SomeTextField__c'
+        const elements = [
+          typeUnderTest,
+          customMetadataType,
+          createInstanceElement(
+            { fullName: 'SomeCustomMetadataType.SomeCustomMetadataTypeRecord' },
+            customMetadataType,
+          ),
+        ]
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+
+        const expectedRefs = [
+          {
+            reference: new ReferenceExpression(new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt')),
+          },
+          {
+            reference: new ReferenceExpression(
+              new ElemID(SALESFORCE, 'SomeCustomMetadataType__mdt', 'field', 'SomeTextField__c'),
+            ),
+          },
+          {
+            reference: new ReferenceExpression(
+              new ElemID(
+                SALESFORCE,
+                'SomeCustomMetadataType__mdt',
+                'instance',
+                'SomeCustomMetadataType_SomeCustomMetadataTypeRecord@v',
+              ),
+            ),
+          },
+        ]
+        expect(deps).toEqual(expectedRefs)
+      })
+      it("should not return a reference if it refers to something that doesn't exist", async () => {
+        const typeUnderTest = typeWithFormula.clone()
+        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+          'ISBLANK(someField__c) && ISBLANK(GarbageType.DreckField)'
+
+        await filter.onFetch([typeUnderTest])
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(deps).toHaveLength(1)
+        expect(deps[0].reference.elemID.typeName).not.toEqual('GarbageType')
+      })
+    })
+
+    describe('When referencing RecordType', () => {
+      it('should extract the correct dependencies', async () => {
+        const typeUnderTest = typeWithFormula.clone()
+        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] =
+          `IF( RecordType.Name = 'New Sale', 'Onboarding - New',
+          IF( RecordType.Name = 'Upgrade', 'Onboarding - Upgrade',
+            IF( RecordType.Name = 'Add-On', 'Onboarding - Add-On', "")))`
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(deps[0]).toEqual(depNameToRefExpr(typeWithFormula.elemID.typeName, 'RecordTypeId'))
+        expect(deps[1]).toEqual(depNameToRefExpr('RecordType'))
+        expect(deps[2]).toEqual(depNameToRefExpr('RecordType', 'Name'))
+      })
+    })
+
+    describe('Complex formulas', () => {
+      const standardFormula = `IF(Owner.Contact.CreatedBy.Manager.Profile.Id = "03d3h000000khEQ",TRUE,false)
+      && IF(($CustomMetadata.Trigger_Context_Status__mdt.by_handler.Enable_After_Insert__c ||
+        $CustomMetadata.Trigger_Context_Status__mdt.by_class.DeveloperName = "Default"),true,FALSE)
+      && IF( ($Label.Details = "Value" || Opportunity.Account.Parent.Parent.Parent.LastModifiedBy.Contact.AssistantName = "Marie"), true ,false)
+      && IF( (Opportunity__r.Related_Asset__r.Name), true ,false)    
+      && IF ( ( $ObjectType.Center__c.Fields.My_text_field__c = "My_Text_Field__c") ,true,false)    
+      && IF ( ( $ObjectType.SRM_API_Metadata_Client_Setting__mdt.Fields.CreatedDate  = "My_Text_Field__c") ,true,false)    
+      && IF ( ( TEXT($Organization.UiSkin) = "lex" ) ,true,false)    
+      && IF ( ( $Setup.Customer_Support_Setting__c.Email_Address__c = "test@gmail.com" ) ,true,false)    
+      && IF ( (  $User.CompanyName = "acme" ) ,true,false)`
+      const processBuilderFormula = `IF([Account].Owner.Manager.Contact.Account.AccountNumber  = "text" ,TRUE,FALSE)
+          || IF([Account].original_lead__r.ConvertedAccountId != "",TRUE,FALSE)
+          || IF($CustomMetadata.Trigger_Context_Status__mdt.by_class.Enable_After_Delete__c , TRUE,FALse)`
+      const standardFormulaExpectedRefs = [
+        'salesforce.Account.field.LastModifiedById',
+        'salesforce.Account.field.OpportunityId',
+        'salesforce.Account.field.Opportunity__c',
+        'salesforce.Account.field.OwnerId',
+        'salesforce.Account.field.ParentId',
+        'salesforce.Center__c',
+        'salesforce.Center__c.field.My_text_field__c',
+        'salesforce.Contact',
+        'salesforce.Contact.field.AssistantName',
+        'salesforce.Contact.field.CreatedById',
+        'salesforce.CustomLabel.instance.Details',
+        'salesforce.Customer_Support_Setting__c',
+        'salesforce.Customer_Support_Setting__c.field.Email_Address__c',
+        'salesforce.Opportunity',
+        'salesforce.Opportunity.field.AccountId',
+        'salesforce.Opportunity__r',
+        'salesforce.Opportunity__r.field.Related_Asset__c',
+        'salesforce.Organization',
+        'salesforce.Organization.field.UiSkin',
+        'salesforce.Profile',
+        'salesforce.Profile.field.Id',
+        'salesforce.Related_Asset__r',
+        'salesforce.Related_Asset__r.field.Name',
+        'salesforce.SRM_API_Metadata_Client_Setting__mdt',
+        'salesforce.SRM_API_Metadata_Client_Setting__mdt.field.CreatedDate',
+        'salesforce.Trigger_Context_Status__mdt',
+        'salesforce.Trigger_Context_Status__mdt.field.DeveloperName',
+        'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Insert__c',
+        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
+        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_handler@uuvu',
+        'salesforce.User',
+        'salesforce.User.field.CompanyName',
+        'salesforce.User.field.ContactId',
+        'salesforce.User.field.ManagerId',
+        'salesforce.User.field.ProfileId',
+      ]
+      const processBuilderFormulaExpectedRefs = [
+        'salesforce.Account.field.AccountNumber',
+        'salesforce.Account.field.OwnerId',
+        'salesforce.Account.field.original_lead__c',
+        'salesforce.Contact',
+        'salesforce.Contact.field.AccountId',
+        'salesforce.Trigger_Context_Status__mdt',
+        'salesforce.Trigger_Context_Status__mdt.field.Enable_After_Delete__c',
+        'salesforce.Trigger_Context_Status__mdt.instance.Trigger_Context_Status_by_class@uuvu',
+        'salesforce.User',
+        'salesforce.User.field.ContactId',
+        'salesforce.User.field.ManagerId',
+        'salesforce.original_lead__r',
+        'salesforce.original_lead__r.field.ConvertedAccountId',
+      ]
+      it('Should extract the correct references from a complex standard formula', async () => {
+        const typeUnderTest = typeWithFormula.clone()
+        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = standardFormula
+        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(deps.map(({ reference }: { reference: ReferenceExpression }) => reference.elemID.getFullName())).toEqual(
+          standardFormulaExpectedRefs,
+        )
+      })
+
+      it('Should extract the correct references from a Process Builder formula', async () => {
+        const typeUnderTest = typeWithFormula.clone()
+        typeUnderTest.fields.someFormulaField__c.annotations[FORMULA] = processBuilderFormula
+        const elements = [typeUnderTest, ...referredTypes, ...referredInstances]
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          typeUnderTest.fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(
+          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()),
+        ).toEqual(processBuilderFormulaExpectedRefs)
+      })
+    })
+    describe('CPQ formulas', () => {
+      const simpleFormula = 'SBQQ__DistriBUtor__r.Name '
+      const formulaWithUnknownRelationship = 'SBQQ__random__r.Name '
+      const simpleFormulaExpectedDeps = [
+        'salesforce.SBQQ__QuoTE__c.field.SBQQ__DistriBUtor__c',
+        'salesforce.Account',
+        'salesforce.Account.field.Name',
+      ].sort()
+      const formulaWithUnknownRelationshipExpectedDeps = [
+        'salesforce.SBQQ__QuoTE__c.field.SBQQ__random__c',
+        'salesforce.SBQQ__random__r',
+        'salesforce.SBQQ__random__r.field.Name',
+      ].sort()
+      let typeWithCpqFormula: ObjectType
+      let referredObjectTypes: ObjectType[]
+
+      beforeAll(() => {
+        typeWithCpqFormula = createCustomObjectType('SBQQ__QuoTE__c', {
+          fields: {
+            SBQQ__DistriBUtor__c: {
+              refType: BuiltinTypes.STRING,
+            },
+            SBQQ__random__c: {
+              refType: BuiltinTypes.STRING,
+            },
+            someField__c: {
+              refType: BuiltinTypes.STRING,
+            },
+            someFormulaField__c: {
+              refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.CHECKBOX)],
+              annotations: {
+                [FORMULA]: '',
+              },
+            },
+          },
+        })
+        referredObjectTypes = [
+          customObjectTypeWithFields('SBQQ__random__r', {
+            Name: BuiltinTypes.STRING,
+          }),
+          customObjectTypeWithFields('Account', { Name: BuiltinTypes.STRING }),
+        ]
+      })
+
+      it('Should extract the correct references from a CPQ formula', async () => {
+        const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
+        elements[0].fields.someFormulaField__c.annotations[FORMULA] = simpleFormula
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(
+          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+        ).toEqual(simpleFormulaExpectedDeps)
+      })
+
+      it('Should extract the correct references from a CPQ formula with unknown relationship', async () => {
+        const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
+        elements[0].fields.someFormulaField__c.annotations[FORMULA] = formulaWithUnknownRelationship
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(
+          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+        ).toEqual(formulaWithUnknownRelationshipExpectedDeps)
+      })
+    })
+    describe('Deeply nested formulas', () => {
+      const deeplyNestedFormula = `
+      IF(INCLUDES( COVID19_Status__c  ,'Fraud evaluation on hold'),'Negative',
+        IF(INCLUDES(COVID19_Status__c,'Volume increase'),'Positive',
+          IF(INCLUDES(COVID19_Status__c,'Volume decrease'),'Negative',
+            IF(INCLUDES(COVID19_Status__c,'Not affected'),'Neutral',
+              IF(INCLUDES(COVID19_Status__c,'Staff changes/challenges'),'Negative',
+                IF(INCLUDES(COVID19_Status__c,'Have manual review'),'Neutral',
+                  IF(INCLUDES(COVID19_Status__c,'Have Manual Review;Potential increase in chargebacks'),'Neutral',
+                    IF(INCLUDES(COVID19_Status__c,'Potential increase in Chargebacks'),'Positive',
+                      IF(INCLUDES(COVID19_Status__c,'Paused eCommerce operations'),'Negative',
+                        IF(INCLUDES(COVID19_Status__c,'Started ecomm operations'),'Positive',""))))))))))
+      `
+      const typeWithDeeplyNestedFormula = createCustomObjectType('Account', {
+        fields: {
+          COVID19_Status__c: {
+            refType: BuiltinTypes.STRING,
+          },
+          someFormulaField__c: {
+            refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.TEXT)],
+            annotations: {
               [FORMULA]: '',
             },
           },
         },
       })
-      referredObjectTypes = [
-        customObjectTypeWithFields('SBQQ__random__r', {
-          Name: BuiltinTypes.STRING,
-        }),
-        customObjectTypeWithFields('Account', { Name: BuiltinTypes.STRING }),
-      ]
-    })
 
-    it('Should extract the correct references from a CPQ formula', async () => {
-      const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
-      elements[0].fields.someFormulaField__c.annotations[FORMULA] = simpleFormula
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(
-        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-      ).toEqual(simpleFormulaExpectedDeps)
-    })
-
-    it('Should extract the correct references from a CPQ formula with unknown relationship', async () => {
-      const elements = [typeWithCpqFormula.clone(), ...referredObjectTypes]
-      elements[0].fields.someFormulaField__c.annotations[FORMULA] = formulaWithUnknownRelationship
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(
-        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-      ).toEqual(formulaWithUnknownRelationshipExpectedDeps)
+      it('should not take too long', async () => {
+        const elements = [typeWithDeeplyNestedFormula.clone()]
+        elements[0].fields.someFormulaField__c.annotations[FORMULA] = deeplyNestedFormula
+        await filter.onFetch(elements)
+        const deps =
+          // eslint-disable-next-line no-underscore-dangle
+          elements[0].fields.someFormulaField__c.annotations._generated_dependencies
+        expect(deps).toBeDefined()
+        expect(
+          deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
+        ).toEqual(['salesforce.Account.field.COVID19_Status__c'])
+      })
     })
   })
-  describe('Deeply nested formulas', () => {
-    const deeplyNestedFormula = `
-    IF(INCLUDES( COVID19_Status__c  ,'Fraud evaluation on hold'),'Negative',
-      IF(INCLUDES(COVID19_Status__c,'Volume increase'),'Positive',
-        IF(INCLUDES(COVID19_Status__c,'Volume decrease'),'Negative',
-          IF(INCLUDES(COVID19_Status__c,'Not affected'),'Neutral',
-            IF(INCLUDES(COVID19_Status__c,'Staff changes/challenges'),'Negative',
-              IF(INCLUDES(COVID19_Status__c,'Have manual review'),'Neutral',
-                IF(INCLUDES(COVID19_Status__c,'Have Manual Review;Potential increase in chargebacks'),'Neutral',
-                  IF(INCLUDES(COVID19_Status__c,'Potential increase in Chargebacks'),'Positive',
-                    IF(INCLUDES(COVID19_Status__c,'Paused eCommerce operations'),'Negative',
-                      IF(INCLUDES(COVID19_Status__c,'Started ecomm operations'),'Positive',""))))))))))
-    `
-    const typeWithDeeplyNestedFormula = createCustomObjectType('Account', {
+
+  describe('Reference fields', () => {
+    const objectType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'FlowCondition'),
+      annotations: { [METADATA_TYPE]: 'FlowCondition' },
       fields: {
-        COVID19_Status__c: {
+        leftValueReference: {
           refType: BuiltinTypes.STRING,
-        },
-        someFormulaField__c: {
-          refType: Types.formulaDataTypes[formulaTypeName(FIELD_TYPE_NAMES.TEXT)],
-          annotations: {
-            [FORMULA]: '',
-          },
         },
       },
     })
+    const referringInstance = new InstanceElement('SomeFlowCondition', objectType, {
+      leftValueReference: '$Label.SomeLabel',
+    })
 
-    it('should not take too long', async () => {
-      const elements = [typeWithDeeplyNestedFormula.clone()]
-      elements[0].fields.someFormulaField__c.annotations[FORMULA] = deeplyNestedFormula
-      await filter.onFetch(elements)
-      const deps =
-        // eslint-disable-next-line no-underscore-dangle
-        elements[0].fields.someFormulaField__c.annotations._generated_dependencies
-      expect(deps).toBeDefined()
-      expect(
-        deps.map((refExpr: { reference: ReferenceExpression }) => refExpr.reference.elemID.getFullName()).sort(),
-      ).toEqual(['salesforce.Account.field.COVID19_Status__c'])
+    describe('when there is a valid reference', () => {
+      const referredInstance = new InstanceElement('SomeLabel', mockTypes.CustomLabel, { fullName: 'SomeLabel' })
+      const elements = [objectType, referringInstance, referredInstance].map(element => element.clone())
+
+      beforeEach(async () => {
+        await filter.onFetch(elements)
+      })
+
+      it('should replace the field value with a reference expression', () => {
+        const referringInstanceAfterTest = elements.find(elem =>
+          elem.elemID.isEqual(referringInstance.elemID),
+        ) as InstanceElement
+        expect(referringInstanceAfterTest.value.leftValueReference).toEqual(
+          new ReferenceExpression(referredInstance.elemID),
+        )
+      })
+    })
+    describe('when the reference is not valid', () => {
+      const elements = [objectType, referringInstance].map(element => element.clone())
+
+      beforeEach(async () => {
+        await filter.onFetch(elements)
+      })
+
+      it('should replace the field value with a reference expression', () => {
+        const referringInstanceAfterTest = elements.find(elem =>
+          elem.elemID.isEqual(referringInstance.elemID),
+        ) as InstanceElement
+        expect(referringInstanceAfterTest.value.leftValueReference).toEqual(referringInstance.value.leftValueReference)
+      })
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/formula_ref_fields.test.ts
+++ b/packages/salesforce-adapter/test/filters/formula_ref_fields.test.ts
@@ -1,0 +1,75 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { BuiltinTypes, ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { METADATA_TYPE, SALESFORCE } from '../src/constants'
+import { mockTypes } from './mock_elements'
+import { FilterWith } from './filters/mocks'
+import { defaultFilterContext } from './utils'
+import filterCreator from '../src/filters/formula_ref_fields'
+
+describe('Formula reference fields', () => {
+  let filter: FilterWith<'onFetch'>
+
+  beforeAll(() => {
+    const config = { ...defaultFilterContext }
+    filter = filterCreator({ config }) as FilterWith<'onFetch'>
+  })
+
+  const objectType = new ObjectType({
+    elemID: new ElemID(SALESFORCE, 'FlowCondition'),
+    annotations: { [METADATA_TYPE]: 'FlowCondition' },
+    fields: {
+      leftValueReference: {
+        refType: BuiltinTypes.STRING,
+      },
+    },
+  })
+  const referringInstance = new InstanceElement('SomeFlowCondition', objectType, {
+    leftValueReference: '$Label.SomeLabel',
+  })
+
+  describe('when there is a valid reference', () => {
+    const referredInstance = new InstanceElement('SomeLabel', mockTypes.CustomLabel, { fullName: 'SomeLabel' })
+    const elements = [objectType, referringInstance, referredInstance].map(element => element.clone())
+
+    beforeEach(async () => {
+      await filter.onFetch(elements)
+    })
+
+    it('should replace the field value with a reference expression', () => {
+      const referringInstanceAfterTest = elements.find(elem =>
+        elem.elemID.isEqual(referringInstance.elemID),
+      ) as InstanceElement
+      expect(referringInstanceAfterTest.value.leftValueReference).toEqual(
+        new ReferenceExpression(referredInstance.elemID),
+      )
+    })
+  })
+  describe('when the reference is not valid', () => {
+    const elements = [objectType, referringInstance].map(element => element.clone())
+
+    beforeEach(async () => {
+      await filter.onFetch(elements)
+    })
+
+    it('should replace the field value with a reference expression', () => {
+      const referringInstanceAfterTest = elements.find(elem =>
+        elem.elemID.isEqual(referringInstance.elemID),
+      ) as InstanceElement
+      expect(referringInstanceAfterTest.value.leftValueReference).toEqual(referringInstance.value.leftValueReference)
+    })
+  })
+})


### PR DESCRIPTION
Treat specific fields as containing formula-like identifiers and replace them with references.

---

I could not figure out a way to do this in the reference mapper because the type of the referred element is not known a-priori.

Workspace diff: https://github.com/salto-io/tomsellek-sf-salto-6027/pull/1/files

---
_Release Notes_: 
Salesforce: Some flow fields are now references

---
_User Notifications_: 
Salesforce: Some flow fields are now references