### PR TITLE
SALTO-6275: issue layout dependency bug

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/issue_layout_dependency.ts
+++ b/packages/jira-adapter/src/dependency_changers/issue_layout_dependency.ts
@@ -58,9 +58,11 @@ export const issueLayoutDependencyChanger: DependencyChanger = async changes => 
     )
 
   const issueLayoutsKeysToProject = Object.fromEntries(
-    AdditionOrModificationChanges.filter(({ change }) => getChangeData(change).elemID.typeName === ISSUE_LAYOUT_TYPE)
-      .map(({ key, change }) => [key, getParent(getChangeData(change))])
-      .filter(([_, project]) => project !== undefined) as [string, InstanceElement][],
+    (
+      AdditionOrModificationChanges.filter(
+        ({ change }) => getChangeData(change).elemID.typeName === ISSUE_LAYOUT_TYPE,
+      ).map(({ key, change }) => [key, getParent(getChangeData(change))]) as [string, InstanceElement][]
+    ).filter(([_, project]) => project !== undefined && project.value !== undefined),
   )
 
   const issueLayoutsKeysToDependencyKeys = Object.entries(issueLayoutsKeysToProject)

--- a/packages/jira-adapter/test/dependency_changers/issue_layout_dependency.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/issue_layout_dependency.test.ts
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { InstanceElement, toChange, ReferenceExpression, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
+import { InstanceElement, toChange, ReferenceExpression, CORE_ANNOTATIONS, ElemID } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import {
   ISSUE_LAYOUT_TYPE,
@@ -613,6 +613,20 @@ describe('issueLayoutDependencyChanger', () => {
         action: 'add',
         dependency: { source: 'issueLayoutInstance1', target: 'issueTypeSchemeInstance1' },
       })
+    })
+    it('should not crash if the parent is a missing dependency', async () => {
+      issueLayoutInstance1.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(new ElemID('jira', 'Project', 'instance', 'missing_9'), {}),
+      ]
+      const inputChanges = new Map([
+        ['issueLayoutInstance1', toChange({ after: issueLayoutInstance1 })],
+        ['issueTypeScreenSchemeInstance1', toChange({ after: issueTypeScreenSchemeInstance1 })],
+        ['issueTypeSchemeInstance1', toChange({ after: issueTypeSchemeInstance1 })],
+        ['screenSchemeInstance1', toChange({ after: screenSchemeInstance1 })],
+        ['projectInstance1', toChange({ after: projectInstance1 })],
+      ])
+      const dependencyChanges = [...(await issueLayoutDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
     })
   })
 })


### PR DESCRIPTION
Can happen with a missing reference in the parent

---

None
---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that caused errors in deployment when an issue layout had a missing parent reference 

---
_User Notifications_: 
None
