### PR TITLE
SALTO-6276: Format salesforce deployed XMLs

### DIFF
--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -516,17 +516,18 @@ const builder = new XMLBuilder({
   indentBy: '    ',
 })
 
-const XML_VERSION_ENCODING_HEADER = '<?xml version="1.0" encoding="UTF-8"?>\n'
 const SALESFORCE_XML_NAMESPACE_URL = 'http://soap.sforce.com/2006/04/metadata'
 
 const toMetadataXml = (name: string, values: Values): string =>
-  XML_VERSION_ENCODING_HEADER.concat(
-    builder.build({
-      [name]: _.merge(_.omit(values, INSTANCE_FULL_NAME_FIELD), {
-        [`${XML_ATTRIBUTE_PREFIX}xmlns`]: SALESFORCE_XML_NAMESPACE_URL,
-      }),
+  builder.build({
+    '?xml': {
+      [`${XML_ATTRIBUTE_PREFIX}version`]: '1.0',
+      [`${XML_ATTRIBUTE_PREFIX}encoding`]: 'UTF-8',
+    },
+    [name]: _.merge(_.omit(values, INSTANCE_FULL_NAME_FIELD), {
+      [`${XML_ATTRIBUTE_PREFIX}xmlns`]: SALESFORCE_XML_NAMESPACE_URL,
     }),
-  )
+  })
 
 const cloneValuesWithAttributePrefixes = async (
   instance: InstanceElement,

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -512,10 +512,21 @@ export const fromRetrieveResult = async (
 const builder = new XMLBuilder({
   attributeNamePrefix: XML_ATTRIBUTE_PREFIX,
   ignoreAttributes: false,
+  format: true,
+  indentBy: '    ',
 })
 
+const XML_VERSION_ENCODING_HEADER = '<?xml version="1.0" encoding="UTF-8"?>\n'
+const SALESFORCE_XML_NAMESPACE_URL = 'http://soap.sforce.com/2006/04/metadata'
+
 const toMetadataXml = (name: string, values: Values): string =>
-  builder.build({ [name]: _.omit(values, INSTANCE_FULL_NAME_FIELD) })
+  XML_VERSION_ENCODING_HEADER.concat(
+    builder.build({
+      [name]: _.merge(_.omit(values, INSTANCE_FULL_NAME_FIELD), {
+        [`${XML_ATTRIBUTE_PREFIX}xmlns`]: SALESFORCE_XML_NAMESPACE_URL,
+      }),
+    }),
+  )
 
 const cloneValuesWithAttributePrefixes = async (
   instance: InstanceElement,

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -519,7 +519,7 @@ describe('SalesforceAdapter CRUD', () => {
                     deploy: {
                       quickDeployParams: {
                         requestId: '1',
-                        hash: 'cd0ece4ba3bf6418bcea8c036352b2f1',
+                        hash: 'cf4d1bc8bdab0f300fdb63389813a496',
                       },
                     },
                   },
@@ -589,7 +589,7 @@ describe('SalesforceAdapter CRUD', () => {
                     deploy: {
                       quickDeployParams: {
                         requestId: '1',
-                        hash: 'cd0ece4ba3bf6418bcea8c036352b2f1',
+                        hash: 'cf4d1bc8bdab0f300fdb63389813a496',
                       },
                     },
                   },

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -87,7 +87,11 @@ describe('XML Transformer', () => {
       it('should have empty manifest', () => {
         expect(zipFiles).toHaveProperty(
           [addManifestPath],
-          `<Package><version>${API_VERSION}</version></Package>`,
+          `<?xml version="1.0" encoding="UTF-8"?>
+<Package xmlns="http://soap.sforce.com/2006/04/metadata">
+    <version>${API_VERSION}</version>
+</Package>
+`,
         )
       })
     })
@@ -186,7 +190,7 @@ describe('XML Transformer', () => {
           const metaFilePath = `${packageName}/classes/MyClass.cls-meta.xml`
           expect(zipFiles).toHaveProperty([metaFilePath])
           const values = xmlParser.parse(zipFiles[metaFilePath])
-          expect(values).toEqual({
+          expect(values).toMatchObject({
             ApexClass: _.omit(apexClassValues, ['fullName', 'content']),
           })
         })
@@ -230,7 +234,7 @@ describe('XML Transformer', () => {
           const filePath = `${packageName}/aura/TestAuraDefinitionBundle/TestAuraDefinitionBundle.cmp-meta.xml`
           expect(zipFiles).toHaveProperty([filePath])
           const data = xmlParser.parse(zipFiles[filePath])
-          expect(data).toEqual({
+          expect(data).toMatchObject({
             AuraDefinitionBundle: _.pick(
               mockDefaultValues.AuraDefinitionBundle,
               ['apiVersion', 'description', 'type'],
@@ -289,27 +293,29 @@ describe('XML Transformer', () => {
           const filePath = `${packageName}/lwc/testLightningComponentBundle/testLightningComponentBundle.js-meta.xml`
           expect(zipFiles).toHaveProperty([filePath])
           expect(zipFiles[filePath]).toMatch(
-            `<LightningComponentBundle>
-              <apiVersion>49</apiVersion>
-              <isExposed>true</isExposed>
-              <targets>
-                <target>lightning__AppPage</target>
-                <target>lightning__RecordPage</target>
-                <target>lightning__HomePage</target>
-              </targets>
-              <targetConfigs>
-                <targetConfig targets="lightning__RecordPage">
-                  <objects>
-                    <object>Contact</object>
-                  </objects>
-                </targetConfig>
-                    <targetConfig targets="lightning__AppPage,lightning__HomePage">
-                        <supportedFormFactors>
-                            <supportedFormFactor type="Small"></supportedFormFactor>
-                        </supportedFormFactors>
-                    </targetConfig>
-              </targetConfigs>
-            </LightningComponentBundle>`.replace(/>\s+</gs, '><'),
+            `<?xml version="1.0" encoding="UTF-8"?>
+<LightningComponentBundle xmlns="http://soap.sforce.com/2006/04/metadata">
+    <apiVersion>49</apiVersion>
+    <isExposed>true</isExposed>
+    <targets>
+        <target>lightning__AppPage</target>
+        <target>lightning__RecordPage</target>
+        <target>lightning__HomePage</target>
+    </targets>
+    <targetConfigs>
+        <targetConfig targets="lightning__RecordPage">
+            <objects>
+                <object>Contact</object>
+            </objects>
+        </targetConfig>
+        <targetConfig targets="lightning__AppPage,lightning__HomePage">
+            <supportedFormFactors>
+                <supportedFormFactor type="Small"></supportedFormFactor>
+            </supportedFormFactors>
+        </targetConfig>
+    </targetConfigs>
+</LightningComponentBundle>
+`,
           )
         })
       })


### PR DESCRIPTION
This is a step towards supporting SFDX format.
Formatting the XMLs generated by the adapter to match the formatting options that SFDX uses

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_