### PR TITLE
SALTO-6278 ensure that updateNaclFiles get detailedChanges with baseChange in them

### DIFF
--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -244,29 +244,33 @@ export const detailedCompare = (
   const getFieldsChanges = (beforeObj: ObjectType, afterObj: ObjectType): DetailedChangeWithBaseChange[] => {
     const removeChanges = Object.keys(beforeObj.fields)
       .filter(fieldName => afterObj.fields[fieldName] === undefined)
-      .map(fieldName => ({
-        action: 'remove' as const,
-        id: beforeObj.fields[fieldName].elemID,
-        data: { before: beforeObj.fields[fieldName] },
-        elemIDs: { before: beforeObj.fields[fieldName].elemID },
-        baseChange: toChange({ before: beforeObj.fields[fieldName] }),
-      }))
+      .map(
+        (fieldName): DetailedChangeWithBaseChange => ({
+          action: 'remove',
+          id: beforeObj.fields[fieldName].elemID,
+          data: { before: beforeObj.fields[fieldName] },
+          elemIDs: { before: beforeObj.fields[fieldName].elemID },
+          baseChange: toChange({ before: beforeObj.fields[fieldName] }),
+        }),
+      )
 
     const addChanges = Object.keys(afterObj.fields)
       .filter(fieldName => beforeObj.fields[fieldName] === undefined)
-      .map(fieldName => ({
-        action: 'add' as const,
-        id: afterObj.fields[fieldName].elemID,
-        data: { after: afterObj.fields[fieldName] },
-        elemIDs: { after: afterObj.fields[fieldName].elemID },
-        baseChange: toChange({ after: afterObj.fields[fieldName] }),
-      }))
+      .map(
+        (fieldName): DetailedChangeWithBaseChange => ({
+          action: 'add',
+          id: afterObj.fields[fieldName].elemID,
+          data: { after: afterObj.fields[fieldName] },
+          elemIDs: { after: afterObj.fields[fieldName].elemID },
+          baseChange: toChange({ after: afterObj.fields[fieldName] }),
+        }),
+      )
 
     const modifyChanges = Object.keys(afterObj.fields)
       .filter(fieldName => beforeObj.fields[fieldName] !== undefined)
       .flatMap(fieldName => detailedCompare(beforeObj.fields[fieldName], afterObj.fields[fieldName], compareOptions))
 
-    return [...removeChanges, ...addChanges, ...modifyChanges]
+    return removeChanges.concat(addChanges).concat(modifyChanges)
   }
 
   // A special case to handle type changes.

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -244,27 +244,13 @@ export const detailedCompare = (
   const getFieldsChanges = (beforeObj: ObjectType, afterObj: ObjectType): DetailedChangeWithBaseChange[] => {
     const removeChanges = Object.keys(beforeObj.fields)
       .filter(fieldName => afterObj.fields[fieldName] === undefined)
-      .map(
-        (fieldName): DetailedChangeWithBaseChange => ({
-          action: 'remove',
-          id: beforeObj.fields[fieldName].elemID,
-          data: { before: beforeObj.fields[fieldName] },
-          elemIDs: { before: beforeObj.fields[fieldName].elemID },
-          baseChange: toChange({ before: beforeObj.fields[fieldName] }),
-        }),
-      )
+      .map(fieldName => beforeObj.fields[fieldName])
+      .map(field => toDetailedChangeFromBaseChange(toChange({ before: field }), { before: field.elemID }))
 
     const addChanges = Object.keys(afterObj.fields)
       .filter(fieldName => beforeObj.fields[fieldName] === undefined)
-      .map(
-        (fieldName): DetailedChangeWithBaseChange => ({
-          action: 'add',
-          id: afterObj.fields[fieldName].elemID,
-          data: { after: afterObj.fields[fieldName] },
-          elemIDs: { after: afterObj.fields[fieldName].elemID },
-          baseChange: toChange({ after: afterObj.fields[fieldName] }),
-        }),
-      )
+      .map(fieldName => afterObj.fields[fieldName])
+      .map(field => toDetailedChangeFromBaseChange(toChange({ after: field }), { after: field.elemID }))
 
     const modifyChanges = Object.keys(afterObj.fields)
       .filter(fieldName => beforeObj.fields[fieldName] !== undefined)

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -609,8 +609,14 @@ describe('detailedCompare', () => {
     describe('with field changes', () => {
       const changes = detailedCompare(before, after, { createFieldChanges: true })
       it('should add the right baseChange', () => {
-        const baseChange = toChange({ before, after })
-        changes.forEach(change => expect(change.baseChange).toEqual(baseChange))
+        changes.forEach(change => {
+          const fieldName = change.id.createBaseID().parent.name
+          expect(change.baseChange).toEqual(
+            change.id.idType === 'field'
+              ? toChange({ before: before.fields[fieldName], after: after.fields[fieldName] })
+              : toChange({ before, after }),
+          )
+        })
       })
       it('should identify field changes, and create changes with the field id', () => {
         expect(hasChange(changes, 'modify', after.fields.modify.elemID.createNestedID('modify'))).toBeTruthy()

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1775,6 +1775,10 @@ Moving the specified elements to common.
               before: typeWithFix.elemID.createNestedID('attr', 'fix1'),
               after: typeWithFix.elemID.createNestedID('attr', 'fix1'),
             },
+            baseChange: {
+              action: 'modify',
+              data: { before: type, after: typeWithFix },
+            },
           },
         ],
         errors: [
@@ -1805,6 +1809,10 @@ Moving the specified elements to common.
           elemIDs: {
             before: type.elemID.createNestedID('attr', 'fix1'),
             after: type.elemID.createNestedID('attr', 'fix1'),
+          },
+          baseChange: {
+            action: 'modify',
+            data: { before: type, after: typeWithFix },
           },
         },
       ])

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -15,7 +15,7 @@ import {
   Change,
   ChangeDataType,
   ChangeError,
-  DetailedChange,
+  DetailedChangeWithBaseChange,
   Element,
   ElemID,
   getChangeData,
@@ -574,7 +574,7 @@ export const rename = async (
   workspace: Workspace,
   sourceElemId: ElemID,
   targetElemId: ElemID,
-): Promise<DetailedChange[]> => {
+): Promise<DetailedChangeWithBaseChange[]> => {
   await renameChecks(workspace, sourceElemId, targetElemId)
 
   const renameElementChanges = await renameElement(
@@ -676,7 +676,7 @@ export class SelectorsError extends Error {
 export const fixElements = async (
   workspace: Workspace,
   selectors: ElementSelector[],
-): Promise<{ errors: ChangeError[]; changes: DetailedChange[] }> => {
+): Promise<{ errors: ChangeError[]; changes: DetailedChangeWithBaseChange[] }> => {
   const accounts = workspace.accounts()
   const adapters = await getAdapters(
     accounts,

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -15,7 +15,7 @@ import {
   ChangeDataType,
   ChangeValidator,
   CORE_ANNOTATIONS,
-  DetailedChange,
+  DetailedChangeWithBaseChange,
   Element,
   ElemID,
   Field,
@@ -38,6 +38,7 @@ import {
 } from '@salto-io/adapter-api'
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
+import { setPath } from '@salto-io/adapter-utils'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import * as api from '../src/api'
 import { getAdapterConfigOptionsType, getAdditionalReferences, getLoginStatuses } from '../src/api'
@@ -1194,8 +1195,8 @@ describe('api.ts', () => {
   })
 
   describe('rename', () => {
-    let expectedChanges: DetailedChange[]
-    let changes: DetailedChange[]
+    let expectedChanges: DetailedChangeWithBaseChange[]
+    let changes: DetailedChangeWithBaseChange[]
     beforeAll(async () => {
       const workspaceElements = mockElements.getAllElements()
       const ws = mockWorkspace({ elements: workspaceElements })
@@ -1215,10 +1216,24 @@ describe('api.ts', () => {
       const beforeRef = new ReferenceExpression(sourceElemId)
       const afterRef = new ReferenceExpression(targetElement.elemID)
 
+      const elementWithReference = await ws.getValue(refElemId.createTopLevelParentID().parent)
+      const elementWithRenamedReference = elementWithReference.clone()
+      setPath(elementWithRenamedReference, refElemId, afterRef)
+
+      const baseRemoveChange = toChange({ before: sourceElement })
+      const baseAddChange = toChange({ after: targetElement })
+      const baseModifyChange = toChange({ before: elementWithReference, after: elementWithRenamedReference })
+
       expectedChanges = [
-        { id: sourceElemId, action: 'remove', data: { before: sourceElement } },
-        { id: targetElement.elemID, action: 'add', data: { after: targetElement } },
-        { id: refElemId, action: 'modify', data: { before: beforeRef, after: afterRef } },
+        { id: sourceElemId, baseChange: baseRemoveChange, ...baseRemoveChange },
+        { id: targetElement.elemID, baseChange: baseAddChange, ...baseAddChange },
+        {
+          id: refElemId,
+          action: 'modify',
+          data: { before: beforeRef, after: afterRef },
+          elemIDs: { before: refElemId, after: refElemId },
+          baseChange: baseModifyChange,
+        },
       ]
       changes = await api.rename(ws, sourceElemId, targetElement.elemID)
     })

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -12,11 +12,13 @@ import {
   ObjectType,
   ReadOnlyElementsSource,
   SaltoError,
+  toChange,
 } from '@salto-io/adapter-api'
 import {
   applyDetailedChanges,
   buildElementsSourceFromElements,
   detailedCompare,
+  getDetailedChanges,
   transformElement,
 } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -144,11 +146,9 @@ export const buildAdaptersConfigSource = async ({
     const configsArr = collections.array.makeArray(configs)
 
     await naclSource.updateNaclFiles(
-      _.uniqBy(configsArr, conf => conf.elemID.getFullName()).map(conf => ({
-        id: conf.elemID,
-        action: 'remove',
-        data: { before: conf },
-      })),
+      _.uniqBy(configsArr, conf => conf.elemID.getFullName()).flatMap(conf =>
+        getDetailedChanges(toChange({ before: conf })),
+      ),
     )
 
     const removeUndefined = async (instance: InstanceElement): Promise<InstanceElement> =>
@@ -163,12 +163,12 @@ export const buildAdaptersConfigSource = async ({
 
     const configsToUpdate = await Promise.all(configsArr.map(removeUndefined))
     await naclSource.updateNaclFiles(
-      configsToUpdate.map(conf => ({
-        id: conf.elemID,
-        action: 'add',
-        data: { after: conf },
-        path: [...CONFIG_PATH, conf.elemID.adapter, ...(conf.path ?? [conf.elemID.adapter])],
-      })),
+      configsToUpdate.flatMap(conf =>
+        getDetailedChanges(toChange({ after: conf })).map(change => ({
+          ...change,
+          path: [...CONFIG_PATH, conf.elemID.adapter, ...(conf.path ?? [conf.elemID.adapter])],
+        })),
+      ),
     )
   }
 

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -738,7 +738,7 @@ export const filterOutHiddenChanges = async (
       return { visible: change, hidden: change }
     }
 
-    const { parent } = change.id.createTopLevelParentID()
+    const { parent, path } = change.id.createTopLevelParentID()
     const baseElem = change.id.isTopLevel() ? change.data.after : await state.get(parent)
 
     if (baseElem === undefined) {
@@ -775,7 +775,6 @@ export const filterOutHiddenChanges = async (
         changeType: TypeElement | undefined
         changePath: ReadonlyArray<string>
       }> => {
-        const { path } = change.id.createTopLevelParentID()
         if (change.id.isAttrID()) {
           return {
             changeType: (await elementAnnotationTypes(baseElem, state))[path[0]],

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -52,8 +52,6 @@ import {
   isTypeReference,
   DetailedChangeWithBaseChange,
   toChange,
-  isFieldChange,
-  getChangeData,
 } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
@@ -740,9 +738,8 @@ export const filterOutHiddenChanges = async (
       return { visible: change, hidden: change }
     }
 
-    const baseElem = isFieldChange(change.baseChange)
-      ? getChangeData(change.baseChange).parent
-      : getChangeData(change.baseChange)
+    const { parent } = change.id.createTopLevelParentID()
+    const baseElem = change.id.isTopLevel() ? change.data.after : await state.get(parent)
 
     if (baseElem === undefined) {
       // If something is not in the state it cannot be hidden

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -16,6 +16,8 @@ import {
   elementAnnotationTypes,
   safeJsonStringify,
   resolvePath,
+  applyDetailedChanges,
+  getDetailedChanges,
 } from '@salto-io/adapter-utils'
 import {
   CORE_ANNOTATIONS,
@@ -47,6 +49,8 @@ import {
   getFieldType,
   isMapType,
   isTypeReference,
+  DetailedChangeWithBaseChange,
+  toChange,
 } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
@@ -253,10 +257,13 @@ const isTopLevelModificationAfterHidden = <T extends Element>(
  * When a type changes from/to hidden, we need to create a change that adds/removes
  * the whole type to the nacl instead of just changing the hidden annotation value.
  */
-const getHiddenTypeChanges = async (changes: DetailedChange[], state: State): Promise<DetailedChange[]> =>
+const getHiddenTypeChanges = async (
+  changes: DetailedChangeWithBaseChange[],
+  state: State,
+): Promise<DetailedChangeWithBaseChange[]> =>
   awu(changes)
     .filter(change => isTopLevelModificationWithHiddenChange(change) || isHiddenAttributeChange(change, false))
-    .map(async change => {
+    .flatMap(async change => {
       const elemId = change.id.createTopLevelParentID().parent
       const elem = await state.get(elemId)
       if (!isElement(elem)) {
@@ -266,17 +273,20 @@ const getHiddenTypeChanges = async (changes: DetailedChange[], state: State): Pr
           elemId.getFullName(),
           isAttributeChangeToHidden(change, false),
         )
-        return change
+        return [change]
       }
 
       const changeToHidden = isTopLevelModificationWithHiddenChange(change)
         ? isTopLevelModificationAfterHidden(change)
         : isAttributeChangeToHidden(change, false)
-      return changeToHidden ? createRemoveChange(elem, elemId) : createAddChange(elem, elemId)
+      return getDetailedChanges(toChange(changeToHidden ? { before: elem } : { after: elem }))
     })
     .toArray()
 
-const getInstanceTypeHiddenChanges = async (changes: DetailedChange[], state: State): Promise<DetailedChange[]> => {
+const getInstanceTypeHiddenChanges = async (
+  changes: DetailedChange[],
+  state: State,
+): Promise<DetailedChangeWithBaseChange[]> => {
   const hiddenValueOnElementChanges = changes.filter(c => isHiddenAttributeChange(c, true))
 
   // Exit early to avoid unneeded calculation if there are no hidden type changes
@@ -301,11 +311,11 @@ const getInstanceTypeHiddenChanges = async (changes: DetailedChange[], state: St
     .flatMap(async elem => {
       if (isInstanceElement(elem)) {
         if (toHiddenElemIds.has(elem.refType.elemID.getFullName())) {
-          return [createRemoveChange(elem, elem.elemID)]
+          return getDetailedChanges(toChange({ before: elem }))
         }
         if (fromHiddenElemIds.has(elem.refType.elemID.getFullName())) {
-          return (await splitElementByPath(elem, pathIndex)).map(fragment =>
-            createAddChange(fragment, elem.elemID, fragment.path),
+          return (await splitElementByPath(elem, pathIndex)).flatMap(fragment =>
+            getDetailedChanges(toChange({ after: fragment })).map(change => ({ ...change, path: fragment.path })),
           )
         }
       }
@@ -316,8 +326,8 @@ const getInstanceTypeHiddenChanges = async (changes: DetailedChange[], state: St
 }
 
 const isAnnotationTypeChange = (
-  change: DetailedChange,
-): change is DetailedChange & ModificationChange<ReferenceExpression> =>
+  change: DetailedChangeWithBaseChange,
+): change is DetailedChangeWithBaseChange & ModificationChange<ReferenceExpression> =>
   isModificationChange(change) &&
   change.id.isAnnotationTypeID() &&
   isTypeReference(change.data.before) &&
@@ -376,10 +386,10 @@ const getChangeParentIdsByHideAction = (changes: DetailedChange[]): { hide: Set<
  * the values of that field in all relevant instances / annotation values
  */
 const getHiddenFieldAndAnnotationValueChanges = async (
-  changes: DetailedChange[],
+  changes: DetailedChangeWithBaseChange[],
   state: State,
   visibleElementSource: ReadOnlyElementsSource,
-): Promise<DetailedChange[]> => {
+): Promise<DetailedChangeWithBaseChange[]> => {
   // TODO hide fields marked with _hidden=true
 
   // We need to find the following cases:
@@ -438,65 +448,66 @@ const getHiddenFieldAndAnnotationValueChanges = async (
       .join(', '),
   )
 
-  const hiddenValueChanges: DetailedChange[] = []
-  const createHiddenValueChangeIfNeeded: TransformFunc = ({ value, field, path }) => {
-    if (path === undefined) {
-      return value
-    }
-    if (isField(value)) {
-      // Handle annotation values that now have a different type
-      // Note we have to do this first because when transforming fields the "field" we get here
-      // is undefined
-      const annotationsToHide = annotationTypesToHide[value.refType.elemID.getFullName()]
-      const annotationsToUnHide = annotationTypesToUnHide[value.refType.elemID.getFullName()]
-      if (annotationsToHide !== undefined || annotationsToUnHide !== undefined) {
-        Object.entries(value.annotations).forEach(([name, attrValue]) => {
-          if (annotationsToHide?.has(name)) {
-            hiddenValueChanges.push(createRemoveChange(attrValue, path.createNestedID(name)))
-          } else if (annotationsToUnHide?.has(name)) {
-            hiddenValueChanges.push(createAddChange(attrValue, path.createNestedID(name)))
-          }
-        })
+  const createHiddenValueChangeIfNeeded =
+    (hiddenValueChanges: DetailedChange[]): TransformFunc =>
+    ({ value, field, path }) => {
+      if (path === undefined) {
+        return value
       }
-    }
-    if (field === undefined) {
-      return value
-    }
-    // Handle field values in instances
-    const fieldId = field.elemID.getFullName()
-    const fieldTypeId = field.refType.elemID.getFullName()
-    if (hideFieldIds.has(fieldId)) {
-      hiddenValueChanges.push(createRemoveChange(value, path))
-      return undefined
-    }
-    if (unhideFieldIds.has(fieldId)) {
-      hiddenValueChanges.push(createAddChange(value, path))
-      return undefined
-    }
-    // Handle annotation values on types
-    if (path.idType === 'attr') {
-      const isInTypes = (id: ElemID, typeGroup: Record<string, Set<string>>): boolean =>
-        typeGroup[id.createParentID().getFullName()]?.has(id.name)
-      if (isInTypes(path, annotationTypesToHide) || hideTypeIds.has(fieldTypeId)) {
+      if (isField(value)) {
+        // Handle annotation values that now have a different type
+        // Note we have to do this first because when transforming fields the "field" we get here
+        // is undefined
+        const annotationsToHide = annotationTypesToHide[value.refType.elemID.getFullName()]
+        const annotationsToUnHide = annotationTypesToUnHide[value.refType.elemID.getFullName()]
+        if (annotationsToHide !== undefined || annotationsToUnHide !== undefined) {
+          Object.entries(value.annotations).forEach(([name, attrValue]) => {
+            if (annotationsToHide?.has(name)) {
+              hiddenValueChanges.push(createRemoveChange(attrValue, path.createNestedID(name)))
+            } else if (annotationsToUnHide?.has(name)) {
+              hiddenValueChanges.push(createAddChange(attrValue, path.createNestedID(name)))
+            }
+          })
+        }
+      }
+      if (field === undefined) {
+        return value
+      }
+      // Handle field values in instances
+      const fieldId = field.elemID.getFullName()
+      const fieldTypeId = field.refType.elemID.getFullName()
+      if (hideFieldIds.has(fieldId)) {
         hiddenValueChanges.push(createRemoveChange(value, path))
         return undefined
       }
-      if (isInTypes(path, annotationTypesToUnHide) || unhideTypeIds.has(fieldTypeId)) {
+      if (unhideFieldIds.has(fieldId)) {
         hiddenValueChanges.push(createAddChange(value, path))
         return undefined
       }
-    }
-    // Handle annotation values on fields where the annotation type has the same ID, but the type
-    // itself has changed
-    if (path.idType === 'field') {
-      if (hideTypeIds.has(fieldTypeId)) {
-        hiddenValueChanges.push(createRemoveChange(value, path))
-      } else if (unhideTypeIds.has(fieldTypeId)) {
-        hiddenValueChanges.push(createAddChange(value, path))
+      // Handle annotation values on types
+      if (path.idType === 'attr') {
+        const isInTypes = (id: ElemID, typeGroup: Record<string, Set<string>>): boolean =>
+          typeGroup[id.createParentID().getFullName()]?.has(id.name)
+        if (isInTypes(path, annotationTypesToHide) || hideTypeIds.has(fieldTypeId)) {
+          hiddenValueChanges.push(createRemoveChange(value, path))
+          return undefined
+        }
+        if (isInTypes(path, annotationTypesToUnHide) || unhideTypeIds.has(fieldTypeId)) {
+          hiddenValueChanges.push(createAddChange(value, path))
+          return undefined
+        }
       }
+      // Handle annotation values on fields where the annotation type has the same ID, but the type
+      // itself has changed
+      if (path.idType === 'field') {
+        if (hideTypeIds.has(fieldTypeId)) {
+          hiddenValueChanges.push(createRemoveChange(value, path))
+        } else if (unhideTypeIds.has(fieldTypeId)) {
+          hiddenValueChanges.push(createAddChange(value, path))
+        }
+      }
+      return value
     }
-    return value
-  }
 
   // In order to support making a field/annotation visible we must traverse all state elements
   // to find all the hidden values we need to add.
@@ -505,27 +516,31 @@ const getHiddenFieldAndAnnotationValueChanges = async (
   // by only iterating the state elements and creating remove changes for values that are
   // newly hidden, some of these remove changes may be redundant (if the value we
   // are trying to hide was already removed manually from the visible element)
-  await awu(await state.getAll())
+  return awu(await state.getAll())
     .filter(element => visibleElementSource.has(element.elemID))
-    .forEach(async element => {
+    .flatMap(async element => {
+      const hiddenValueChanges: DetailedChange[] = []
       await transformElement({
         element,
-        transformFunc: createHiddenValueChangeIfNeeded,
+        transformFunc: createHiddenValueChangeIfNeeded(hiddenValueChanges),
         strict: true,
         elementsSource: state,
         runOnFields: true,
         allowEmptyArrays: true,
         allowEmptyObjects: true,
       })
+      const after = element.clone()
+      applyDetailedChanges(after, hiddenValueChanges)
+      const baseChange = toChange({ before: element, after })
+      return hiddenValueChanges.map(change => ({ ...change, baseChange }))
     })
-
-  return hiddenValueChanges
+    .toArray()
 }
 
 const removeDuplicateChanges = (
-  origChanges: DetailedChange[],
-  additionalChanges: DetailedChange[],
-): DetailedChange[] => {
+  origChanges: DetailedChangeWithBaseChange[],
+  additionalChanges: DetailedChangeWithBaseChange[],
+): DetailedChangeWithBaseChange[] => {
   // If there are no additional changes we'll save the calculation time
   if (additionalChanges.length === 0) {
     return origChanges
@@ -564,10 +579,10 @@ const removeDuplicateChanges = (
  * types that changed visibility and fields that changed visibility.
  */
 const getHiddenChangeNaclSideEffects = async (
-  changes: DetailedChange[],
+  changes: DetailedChangeWithBaseChange[],
   state: State,
   visibleElementSource: ReadOnlyElementsSource,
-): Promise<DetailedChange[]> => {
+): Promise<DetailedChangeWithBaseChange[]> => {
   const additionalChanges = [
     ...(await getHiddenTypeChanges(changes, state)),
     ...(await getHiddenFieldAndAnnotationValueChanges(changes, state, visibleElementSource)),
@@ -710,12 +725,12 @@ const diffElements = <T extends Element>(visibleElem?: T, fullElem?: T): T | und
 // Avoid using this function from out of this file. This filters out only the hidden changes but not
 // their side effects like done in handleHiddenChanges.
 export const filterOutHiddenChanges = async (
-  changes: DetailedChange[],
+  changes: DetailedChangeWithBaseChange[],
   state: State,
-): Promise<{ visible?: DetailedChange; hidden?: DetailedChange }[]> => {
+): Promise<{ visible?: DetailedChangeWithBaseChange; hidden?: DetailedChangeWithBaseChange }[]> => {
   const filterOutHidden = async (
-    change: DetailedChange,
-  ): Promise<{ visible?: DetailedChange; hidden?: DetailedChange }> => {
+    change: DetailedChangeWithBaseChange,
+  ): Promise<{ visible?: DetailedChangeWithBaseChange; hidden?: DetailedChangeWithBaseChange }> => {
     if (isRemovalChange(change)) {
       // There should be no harm in letting remove changes through here. remove should be resilient
       // to its subject not existing. We create both visible and hidden changes in order
@@ -814,7 +829,7 @@ export const filterOutHiddenChanges = async (
             data: {
               after: hidden,
             },
-          } as DetailedChange,
+          } as DetailedChangeWithBaseChange,
         }
       }
     }
@@ -826,10 +841,10 @@ export const filterOutHiddenChanges = async (
 }
 
 export const handleHiddenChanges = async (
-  changes: DetailedChange[],
+  changes: DetailedChangeWithBaseChange[],
   state: State,
   visibleElementSource: ReadOnlyElementsSource,
-): Promise<{ visible: DetailedChange[]; hidden: DetailedChange[] }> => {
+): Promise<{ visible: DetailedChangeWithBaseChange[]; hidden: DetailedChangeWithBaseChange[] }> => {
   // The side effects here are going to be applied to the nacls, so only
   // the visible part is needed. We filter it here and not with the rest
   // of the changes in order to prevent remove changes (which are always

--- a/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
+++ b/packages/workspace/src/workspace/nacl_files/addition_wrapper.ts
@@ -18,12 +18,14 @@ import {
   isField,
   FieldDefinition,
   Field,
+  Change,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 
 export type DetailedAddition = AdditionDiff<Value> & {
   id: ElemID
   path: string[]
+  baseChange: Change<Element>
 }
 
 type NestedValue = {

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -22,6 +22,7 @@ import {
   Value,
   ElemID,
   DetailedChange,
+  DetailedChangeWithBaseChange,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { ElementsSource } from '../../elements_source'
@@ -114,7 +115,10 @@ export const createRemoveChange = (
   path,
 })
 
-export const projectChange = async (change: DetailedChange, env: ElementsSource): Promise<DetailedChange[]> => {
+export const projectChange = async (
+  change: DetailedChangeWithBaseChange,
+  env: ElementsSource,
+): Promise<DetailedChangeWithBaseChange[]> => {
   const targetElement = await env.get(change.id)
   if (targetElement === undefined) {
     return change.action === 'add' ? [change] : []

--- a/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/projections.ts
@@ -20,7 +20,6 @@ import {
   isInstanceElement,
   getChangeData,
   Value,
-  ElemID,
   DetailedChange,
   DetailedChangeWithBaseChange,
 } from '@salto-io/adapter-api'
@@ -96,24 +95,6 @@ export const projectElementOrValueToEnv = (
   }
   return projectValue(value, targetElement)
 }
-
-export const createAddChange = (value: Element | Value, id: ElemID, path?: ReadonlyArray<string>): DetailedChange => ({
-  data: { after: value },
-  action: 'add',
-  id,
-  path,
-})
-
-export const createRemoveChange = (
-  value: Element | Value,
-  id: ElemID,
-  path?: ReadonlyArray<string>,
-): DetailedChange => ({
-  data: { before: value },
-  action: 'remove',
-  id,
-  path,
-})
 
 export const projectChange = async (
   change: DetailedChangeWithBaseChange,

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -440,8 +440,9 @@ export const routeIsolated = async (
 
   const updatedCommonElement = currentCommonElement.clone()
   setPath(updatedCommonElement, change.id, undefined)
-  // Note that this base change includes only the removal of change.id from common.
-  // It doesn't include any other change of the same element.
+  // This base change is wrong!!!
+  // It includes only the removal of change.id from common.
+  // It doesn't include any other changes of the same element.
   const commonBaseChange = toChange({ before: currentCommonElement, after: updatedCommonElement })
 
   const commonChangeProjection = projectElementOrValueToEnv(getChangeData(change), currentCommonValue)
@@ -496,8 +497,9 @@ const createMergeableChange = (
       before: resolvePath(baseElement, mergeableID),
       after: resolvePath(afterElement, mergeableID),
     },
-    // Note that this base change includes only changes inside the mergeableID scope.
-    // It doesn't include any other change of the same element from other mergeableIDs.
+    // This base change is wrong!!!
+    // It includes only changes inside the mergeableID scope.
+    // It doesn't include any other changes of the same element from other mergeableIDs.
     baseChange: toChange({ before: baseElement, after: afterElement }),
   }
 }

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -56,6 +56,12 @@ type PositionInParent = {
 }
 
 const getPositionInParent = <T>(change: DetailedChangeWithBaseChange & AdditionChange<T>): PositionInParent => {
+  // this can happen only if there was a casting of a DetailedChange to a DetailedChangeWithBaseChange somewhere in the way.
+  if (change.baseChange === undefined) {
+    log.warn('No base change: %s', inspectValue(change))
+    return { followingElementIDs: [] }
+  }
+
   const changeData = getChangeData(change)
   const parent = isField(changeData) ? changeData.parent : getChangeData(change.baseChange)
   const pathInParent = getPath(parent, change.id)

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -32,6 +32,7 @@ import {
   DEFAULT_SOURCE_SCOPE,
   isElement,
   isAdditionOrModificationChange,
+  DetailedChangeWithBaseChange,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import {
@@ -224,7 +225,7 @@ export type Workspace = {
   transformToWorkspaceError<T extends SaltoElementError>(saltoElemErr: T): Promise<Readonly<WorkspaceError<T>>>
   transformError: (error: SaltoError) => Promise<WorkspaceError<SaltoError>>
   updateNaclFiles: (
-    changes: DetailedChange[],
+    changes: DetailedChangeWithBaseChange[],
     mode?: RoutingMode,
     stateOnly?: boolean,
   ) => Promise<UpdateNaclFilesResult>
@@ -964,7 +965,7 @@ export const loadWorkspace = async (
     stateOnly = false,
     validate = true,
   }: {
-    changes: DetailedChange[]
+    changes: DetailedChangeWithBaseChange[]
     mode?: RoutingMode
     validate?: boolean
     stateOnly?: boolean

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ElemID, Element, Change, isObjectType, isStaticFile, ChangeDataType } from '@salto-io/adapter-api'
+import { ElemID, Element, Change, isObjectType, isStaticFile, ChangeDataType, toChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { resolvePath } from '@salto-io/adapter-utils'
 import { collections, hash } from '@salto-io/lowerdash'
@@ -133,7 +133,7 @@ export const createMockNaclFileSource = (
     load: mockFunction<NaclFilesSource['load']>().mockImplementation(
       returnChanges({
         cacheValid: true,
-        changes: currentElements.map(e => ({ data: { after: e as ChangeDataType }, action: 'add', id: e.elemID })),
+        changes: currentElements.map(element => toChange({ after: element as ChangeDataType })),
       }),
     ),
     getSearchableNames: mockFunction<NaclFilesSource['getSearchableNames']>().mockResolvedValue(

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ElemID, Element, Change, isObjectType, isStaticFile } from '@salto-io/adapter-api'
+import { ElemID, Element, Change, isObjectType, isStaticFile, ChangeDataType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { resolvePath } from '@salto-io/adapter-utils'
 import { collections, hash } from '@salto-io/lowerdash'
@@ -14,7 +14,6 @@ import { parser } from '@salto-io/parser'
 import { NaclFilesSource, ChangeSet } from '../../src/workspace/nacl_files'
 import { Errors } from '../../src/workspace/errors'
 import { createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { createAddChange } from '../../src/workspace/nacl_files/multi_env/projections'
 import { mockStaticFilesSource } from '../utils'
 
 const { awu } = collections.asynciterable
@@ -134,7 +133,7 @@ export const createMockNaclFileSource = (
     load: mockFunction<NaclFilesSource['load']>().mockImplementation(
       returnChanges({
         cacheValid: true,
-        changes: currentElements.map(e => createAddChange(e, e.elemID)),
+        changes: currentElements.map(e => ({ data: { after: e as ChangeDataType }, action: 'add', id: e.elemID })),
       }),
     ),
     getSearchableNames: mockFunction<NaclFilesSource['getSearchableNames']>().mockResolvedValue(

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -301,15 +301,7 @@ describe('handleHiddenChanges', () => {
         },
       })
       const { field } = objectType.fields
-      const change: DetailedChangeWithBaseChange = {
-        id: field.elemID,
-        action: 'add',
-        data: { after: field },
-        baseChange: {
-          action: 'add',
-          data: { after: field },
-        },
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: field }))
       const { hidden, visible } = await handleHiddenChanges(
         [change],
         mockState([objectType]),
@@ -346,15 +338,7 @@ describe('handleHiddenChanges', () => {
       let visibleInstance: InstanceElement
       let hiddenInstance: InstanceElement
       beforeEach(async () => {
-        const change: DetailedChangeWithBaseChange = {
-          id: instance.elemID,
-          action: 'add',
-          data: { after: instance },
-          baseChange: {
-            action: 'add',
-            data: { after: instance },
-          },
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ after: instance }))
 
         result = await handleHiddenChanges([change], mockState(), createInMemoryElementSource())
         expect(result.visible).toHaveLength(1)
@@ -379,7 +363,7 @@ describe('handleHiddenChanges', () => {
           id: instance.elemID.createNestedID(INSTANCE_ANNOTATIONS.SERVICE_URL),
           action: 'add',
           data: { after: instance.annotations[INSTANCE_ANNOTATIONS.SERVICE_URL] },
-          baseChange: { action: 'modify', data: { before: instance, after: instance } },
+          baseChange: toChange({ before: instance, after: instance }),
         }
 
         result = await handleHiddenChanges([change], mockState([instanceType, instance]), createInMemoryElementSource())
@@ -400,19 +384,7 @@ describe('handleHiddenChanges', () => {
       const inst = new InstanceElement('hidden', obj, {}, [], {
         [INSTANCE_ANNOTATIONS.HIDDEN]: true,
       })
-      const change: DetailedChangeWithBaseChange = {
-        id: inst.elemID,
-        action: 'remove',
-        data: {
-          before: inst,
-        },
-        baseChange: {
-          action: 'remove',
-          data: {
-            before: inst,
-          },
-        },
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: inst }))
       it('should return the entire change and both hidden and visible', async () => {
         const res = await handleHiddenChanges(
           [change],
@@ -443,7 +415,7 @@ describe('handleHiddenChanges', () => {
         id: object.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.SERVICE_URL),
         action: 'add',
         data: { after: 'someUrl' },
-        baseChange: { action: 'modify', data: { before: object.fields.field, after: object.fields.field } },
+        baseChange: toChange({ before: object.fields.field, after: object.fields.field }),
       }
       result = await handleHiddenChanges([change], mockState([object]), createInMemoryElementSource())
     })
@@ -484,7 +456,7 @@ describe('handleHiddenChanges', () => {
           data: {
             after: new ReferenceExpression(new ElemID('a', 'b')),
           },
-          baseChange: { action: 'modify', data: { before: instance, after: instance } },
+          baseChange: toChange({ before: instance, after: instance }),
         }
 
         result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource())
@@ -507,7 +479,7 @@ describe('handleHiddenChanges', () => {
             before: 'asd',
             after: new ReferenceExpression(new ElemID('a', 'b')),
           },
-          baseChange: { action: 'modify', data: { before: instance, after: instance } },
+          baseChange: toChange({ before: instance, after: instance }),
         }
 
         result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource())
@@ -534,12 +506,7 @@ describe('handleHiddenChanges', () => {
       },
     )
 
-    const change: DetailedChangeWithBaseChange = {
-      id: workspaceInstance.elemID,
-      action: 'add',
-      data: { after: workspaceInstance },
-      baseChange: { action: 'modify', data: { before: workspaceInstance, after: workspaceInstance } },
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: workspaceInstance }))
 
     it('should not hide anything if there is no hidden part, even if nested values are undefined', async () => {
       const result = await handleHiddenChanges([change], mockState([]), createInMemoryElementSource())
@@ -573,7 +540,7 @@ describe('handleHiddenChanges', () => {
       id: instance.elemID.createNestedID('val'),
       action: 'add',
       data: { after: instance.value.val },
-      baseChange: { action: 'modify', data: { before: instance, after: instance } },
+      baseChange: toChange({ before: instance, after: instance }),
     }
     const result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource([]))
     expect(result.visible).toEqual([change])
@@ -601,10 +568,7 @@ describe('handleHiddenChanges', () => {
       data: {
         after: { inner: 'abc' },
       },
-      baseChange: {
-        action: 'modify',
-        data: { before: stateInstance, after: stateInstance },
-      },
+      baseChange: toChange({ before: stateInstance, after: stateInstance }),
     }
 
     it('should not have a hidden change', async () => {
@@ -648,7 +612,7 @@ describe('handleHiddenChanges', () => {
             },
           },
         },
-        baseChange: { action: 'modify', data: { before: stateInstance, after: stateInstance } },
+        baseChange: toChange({ before: stateInstance, after: stateInstance }),
       }
 
       it('should have a hidden change', async () => {
@@ -676,7 +640,7 @@ describe('handleHiddenChanges', () => {
             visible: 'visible',
           },
         },
-        baseChange: { action: 'modify', data: { before: stateInstance, after: stateInstance } },
+        baseChange: toChange({ before: stateInstance, after: stateInstance }),
       }
 
       it('should have a hidden change', async () => {

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -29,6 +29,7 @@ import {
   isField,
   toChange,
   TypeReference,
+  DetailedChangeWithBaseChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, toDetailedChangeFromBaseChange } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -36,7 +37,6 @@ import { mockState } from '../common/state'
 import { MergeResult } from '../../src/merger'
 import { mergeWithHidden, handleHiddenChanges, getElementHiddenParts } from '../../src/workspace/hidden_values'
 import { RemoteElementSource, createInMemoryElementSource } from '../../src/workspace/elements_source'
-import { createAddChange, createRemoveChange } from '../../src/workspace/nacl_files/multi_env/projections'
 import { State } from '../../src/workspace/state'
 
 const { awu } = collections.asynciterable
@@ -301,10 +301,14 @@ describe('handleHiddenChanges', () => {
         },
       })
       const { field } = objectType.fields
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         id: field.elemID,
         action: 'add',
         data: { after: field },
+        baseChange: {
+          action: 'add',
+          data: { after: field },
+        },
       }
       const { hidden, visible } = await handleHiddenChanges(
         [change],
@@ -342,10 +346,14 @@ describe('handleHiddenChanges', () => {
       let visibleInstance: InstanceElement
       let hiddenInstance: InstanceElement
       beforeEach(async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           id: instance.elemID,
           action: 'add',
           data: { after: instance },
+          baseChange: {
+            action: 'add',
+            data: { after: instance },
+          },
         }
 
         result = await handleHiddenChanges([change], mockState(), createInMemoryElementSource())
@@ -367,10 +375,11 @@ describe('handleHiddenChanges', () => {
     describe('when adding only the hidden annotation', () => {
       let result: { visible: DetailedChange[]; hidden: DetailedChange[] }
       beforeAll(async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           id: instance.elemID.createNestedID(INSTANCE_ANNOTATIONS.SERVICE_URL),
           action: 'add',
           data: { after: instance.annotations[INSTANCE_ANNOTATIONS.SERVICE_URL] },
+          baseChange: { action: 'modify', data: { before: instance, after: instance } },
         }
 
         result = await handleHiddenChanges([change], mockState([instanceType, instance]), createInMemoryElementSource())
@@ -391,11 +400,17 @@ describe('handleHiddenChanges', () => {
       const inst = new InstanceElement('hidden', obj, {}, [], {
         [INSTANCE_ANNOTATIONS.HIDDEN]: true,
       })
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         id: inst.elemID,
         action: 'remove',
         data: {
           before: inst,
+        },
+        baseChange: {
+          action: 'remove',
+          data: {
+            before: inst,
+          },
         },
       }
       it('should return the entire change and both hidden and visible', async () => {
@@ -424,10 +439,11 @@ describe('handleHiddenChanges', () => {
           },
         },
       })
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         id: object.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.SERVICE_URL),
         action: 'add',
         data: { after: 'someUrl' },
+        baseChange: { action: 'modify', data: { before: object.fields.field, after: object.fields.field } },
       }
       result = await handleHiddenChanges([change], mockState([object]), createInMemoryElementSource())
     })
@@ -462,12 +478,13 @@ describe('handleHiddenChanges', () => {
       let result: { visible: DetailedChange[]; hidden: DetailedChange[] }
       let filteredValue: unknown
       beforeEach(async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           id: instance.elemID.createNestedID('ref'),
           action: 'add',
           data: {
             after: new ReferenceExpression(new ElemID('a', 'b')),
           },
+          baseChange: { action: 'modify', data: { before: instance, after: instance } },
         }
 
         result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource())
@@ -483,13 +500,14 @@ describe('handleHiddenChanges', () => {
       let result: { visible: DetailedChange[]; hidden: DetailedChange[] }
       let filteredValue: unknown
       beforeEach(async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           id: instance.elemID.createNestedID('val'),
           action: 'modify',
           data: {
             before: 'asd',
             after: new ReferenceExpression(new ElemID('a', 'b')),
           },
+          baseChange: { action: 'modify', data: { before: instance, after: instance } },
         }
 
         result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource())
@@ -516,10 +534,11 @@ describe('handleHiddenChanges', () => {
       },
     )
 
-    const change: DetailedChange = {
+    const change: DetailedChangeWithBaseChange = {
       id: workspaceInstance.elemID,
       action: 'add',
       data: { after: workspaceInstance },
+      baseChange: { action: 'modify', data: { before: workspaceInstance, after: workspaceInstance } },
     }
 
     it('should not hide anything if there is no hidden part, even if nested values are undefined', async () => {
@@ -550,10 +569,11 @@ describe('handleHiddenChanges', () => {
       },
     })
 
-    const change: DetailedChange = {
+    const change: DetailedChangeWithBaseChange = {
       id: instance.elemID.createNestedID('val'),
       action: 'add',
       data: { after: instance.value.val },
+      baseChange: { action: 'modify', data: { before: instance, after: instance } },
     }
     const result = await handleHiddenChanges([change], mockState([instance]), createInMemoryElementSource([]))
     expect(result.visible).toEqual([change])
@@ -575,11 +595,15 @@ describe('handleHiddenChanges', () => {
 
     const stateInstance = new InstanceElement('instance', type, {})
 
-    const change: DetailedChange = {
+    const change: DetailedChangeWithBaseChange = {
       id: stateInstance.elemID.createNestedID('val'),
       action: 'add',
       data: {
         after: { inner: 'abc' },
+      },
+      baseChange: {
+        action: 'modify',
+        data: { before: stateInstance, after: stateInstance },
       },
     }
 
@@ -613,7 +637,7 @@ describe('handleHiddenChanges', () => {
     describe('with an addition of map with hidden value', () => {
       const stateInstance = new InstanceElement('instance', type, {})
 
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         id: stateInstance.elemID.createNestedID('map'),
         action: 'add',
         data: {
@@ -624,6 +648,7 @@ describe('handleHiddenChanges', () => {
             },
           },
         },
+        baseChange: { action: 'modify', data: { before: stateInstance, after: stateInstance } },
       }
 
       it('should have a hidden change', async () => {
@@ -642,7 +667,7 @@ describe('handleHiddenChanges', () => {
         map: {},
       })
 
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         id: stateInstance.elemID.createNestedID('map', 'val'),
         action: 'add',
         data: {
@@ -651,6 +676,7 @@ describe('handleHiddenChanges', () => {
             visible: 'visible',
           },
         },
+        baseChange: { action: 'modify', data: { before: stateInstance, after: stateInstance } },
       }
 
       it('should have a hidden change', async () => {
@@ -699,7 +725,12 @@ describe('handleHiddenChanges', () => {
 
       beforeEach(async () => {
         obj.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE] = true
-        const toHiddenChange = createAddChange(true, obj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN_VALUE))
+        const toHiddenChange: DetailedChangeWithBaseChange = {
+          id: obj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
+          action: 'add',
+          data: { after: true },
+          baseChange: { action: 'modify', data: { before: obj, after: obj } },
+        }
         changes = (await handleHiddenChanges([toHiddenChange], state, visibleSource)).visible
       })
 
@@ -721,10 +752,12 @@ describe('handleHiddenChanges', () => {
           unmergedElements: [obj, hiddenObj, inst, hidden1, hidden2],
         })
 
-        const fromHiddenChange = createRemoveChange(
-          true,
-          hiddenObj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
-        )
+        const fromHiddenChange: DetailedChangeWithBaseChange = {
+          id: hiddenObj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN_VALUE),
+          action: 'remove',
+          data: { before: true },
+          baseChange: { action: 'modify', data: { before: hiddenObj, after: hiddenObj } },
+        }
         changes = (await handleHiddenChanges([fromHiddenChange], state, visibleSource)).visible
       })
       it('should create add changes with the instance value from the state', () => {
@@ -742,7 +775,7 @@ describe('handleHiddenChanges', () => {
 
   describe('field annotation change when the field is not in the state', () => {
     let result: { visible: DetailedChange[]; hidden: DetailedChange[] }
-    let change: DetailedChange
+    let change: DetailedChangeWithBaseChange
     beforeAll(async () => {
       const stateObject = new ObjectType({ elemID: new ElemID('test', 'type') })
       const fullObject = new ObjectType({
@@ -757,6 +790,7 @@ describe('handleHiddenChanges', () => {
         id: fullObject.fields.field.elemID.createNestedID(CORE_ANNOTATIONS.SERVICE_URL),
         action: 'add',
         data: { after: 'someUrl' },
+        baseChange: { action: 'modify', data: { before: fullObject.fields.field, after: fullObject.fields.field } },
       }
       result = await handleHiddenChanges([change], mockState([stateObject]), createInMemoryElementSource())
     })
@@ -788,7 +822,12 @@ describe('handleHiddenChanges', () => {
       let changes: DetailedChange[]
 
       beforeEach(async () => {
-        const toHiddenChange = createAddChange(true, obj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN))
+        const toHiddenChange: DetailedChangeWithBaseChange = {
+          id: obj.elemID.createNestedID('attr', CORE_ANNOTATIONS.HIDDEN),
+          action: 'add',
+          data: { after: true },
+          baseChange: { action: 'modify', data: { before: obj, after: obj } },
+        }
         changes = (await handleHiddenChanges([toHiddenChange], state, visibleSource)).visible
       })
 

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -733,9 +733,21 @@ describe('multi env source', () => {
           elemIDs: { before: envObject.elemID },
           path: envObject.path,
           baseChange: {
-            action: 'modify',
+            action: 'remove',
             data: {
               before: envObject,
+            },
+          },
+        },
+        {
+          action: 'add',
+          data: { after: envObjectMeta },
+          id: envObject.elemID,
+          elemIDs: { after: envObjectMeta.elemID },
+          path: envObject.path,
+          baseChange: {
+            action: 'add',
+            data: {
               after: envObjectMeta,
             },
           },
@@ -747,23 +759,8 @@ describe('multi env source', () => {
           elemIDs: { after: envObjectMeta.elemID },
           path: envObject.path,
           baseChange: {
-            action: 'modify',
+            action: 'add',
             data: {
-              before: envObject,
-              after: envObjectMeta,
-            },
-          },
-        },
-        {
-          action: 'add',
-          data: { after: envObjectMeta },
-          id: envObject.elemID,
-          elemIDs: { after: envObjectMeta.elemID },
-          path: envObject.path,
-          baseChange: {
-            action: 'modify',
-            data: {
-              before: envObject,
               after: envObjectMeta,
             },
           },
@@ -775,10 +772,9 @@ describe('multi env source', () => {
           elemIDs: { before: field.elemID },
           path: field.path,
           baseChange: {
-            action: 'modify',
+            action: 'remove',
             data: {
               before: field,
-              after: fieldNumber,
             },
           },
         },
@@ -789,9 +785,8 @@ describe('multi env source', () => {
           elemIDs: { after: fieldNumber.elemID },
           path: field.path,
           baseChange: {
-            action: 'modify',
+            action: 'add',
             data: {
-              before: field,
               after: fieldNumber,
             },
           },

--- a/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
+++ b/packages/workspace/test/workspace/multi_env/multi_env_source.test.ts
@@ -9,7 +9,7 @@ import path from 'path'
 import {
   BuiltinTypes,
   Change,
-  DetailedChange,
+  DetailedChangeWithBaseChange,
   Element,
   ElemID,
   getChangeData,
@@ -455,11 +455,17 @@ describe('multi env source', () => {
   })
   describe('update', () => {
     it('should route an update to the proper sub source', async () => {
-      const changes: DetailedChange[] = [
+      const changes: DetailedChangeWithBaseChange[] = [
         {
           action: 'remove',
           data: {
             before: commonObject.fields.field,
+          },
+          baseChange: {
+            action: 'remove',
+            data: {
+              before: commonObject.fields.field,
+            },
           },
           id: commonObject.fields.field.elemID,
         },
@@ -467,6 +473,12 @@ describe('multi env source', () => {
           action: 'remove',
           data: {
             before: envObject,
+          },
+          baseChange: {
+            action: 'remove',
+            data: {
+              before: envObject,
+            },
           },
           id: envElemID,
         },
@@ -502,7 +514,12 @@ describe('multi env source', () => {
       // NOTE: the getAll call initialize the init state
       const currentElements = await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName)).toArray()
       expect(currentElements).toHaveLength(2)
-      const detailedChange = { ...change, id: commonElemID, path: ['test'] } as DetailedChange
+      const detailedChange = {
+        ...change,
+        baseChange: change,
+        id: commonElemID,
+        path: ['test'],
+      } as DetailedChangeWithBaseChange
       const elementChanges = await multiEnvSourceWithMockSources.updateNaclFiles(primarySourceName, [detailedChange])
       expect(elementChanges[primarySourceName].changes).toEqual([change])
       const mergedSaltoObject = new ObjectType({
@@ -542,12 +559,16 @@ describe('multi env source', () => {
       const detailedChange = {
         action: 'modify',
         data: { before: mergedSaltoObject, after: envFragment },
+        baseChange: {
+          action: 'modify',
+          data: { before: mergedSaltoObject, after: envFragment },
+        },
         path: ['bla'],
         id: objectElemID,
-      } as DetailedChange
+      } as DetailedChangeWithBaseChange
       const elementChanges = await multiEnvSourceWithMockSources.updateNaclFiles(primarySourceName, [detailedChange])
       expect(Object.keys(elementChanges).length).toEqual(1)
-      expect(elementChanges[primarySourceName].changes).toEqual([_.omit(detailedChange, ['path', 'id'])])
+      expect(elementChanges[primarySourceName].changes).toEqual([_.omit(detailedChange, ['path', 'id', 'baseChange'])])
       expect(sortElemArray(await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName)).toArray())).toEqual(
         sortElemArray([envObject, envFragment]),
       )
@@ -597,26 +618,40 @@ describe('multi env source', () => {
         {
           action: 'remove',
           data: { before: envObject },
+          baseChange: {
+            action: 'remove',
+            data: { before: envObject },
+          },
           path: ['bla1'],
           id: envElemID,
         },
         {
           action: 'modify',
           data: { before: mergedSaltoObject, after: newEnvFragment },
+          baseChange: {
+            action: 'modify',
+            data: { before: mergedSaltoObject as ObjectType, after: newEnvFragment },
+          },
           path: ['bla'],
           id: objectElemID,
         },
         {
           action: 'add',
           data: { after: commonObject },
+          baseChange: {
+            action: 'add',
+            data: { after: commonObject },
+          },
           path: ['bla1'],
           id: commonElemID,
         },
-      ] as DetailedChange[]
+      ] as DetailedChangeWithBaseChange[]
       const elementChanges = await multiEnvSourceWithMockSources.updateNaclFiles(primarySourceName, detailedChanges)
       const elements = await awu(await multiEnvSourceWithMockSources.getAll(primarySourceName)).toArray()
       expect(_.sortBy(elementChanges[primarySourceName].changes, c => getChangeData(c).elemID.getFullName())).toEqual(
-        _.sortBy(detailedChanges, c => getChangeData(c).elemID.getFullName()).map(dc => _.omit(dc, ['path', 'id'])),
+        _.sortBy(detailedChanges, c => getChangeData(c).elemID.getFullName()).map(dc =>
+          _.omit(dc, ['path', 'id', 'baseChange']),
+        ),
       )
       expect(sortElemArray(elements)).toEqual(sortElemArray([commonObject, newEnvFragment]))
     })
@@ -627,12 +662,19 @@ describe('multi env source', () => {
       const fieldNumber = field.clone()
       fieldNumber.refType = new TypeReference(BuiltinTypes.NUMBER.elemID, BuiltinTypes.NUMBER)
 
-      const changes: DetailedChange[] = [
+      const changes: DetailedChangeWithBaseChange[] = [
         {
           action: 'modify',
           data: {
             before: envObject,
             after: envObjectMeta,
+          },
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: envObject,
+              after: envObjectMeta,
+            },
           },
           id: envObject.elemID,
           elemIDs: {
@@ -646,6 +688,13 @@ describe('multi env source', () => {
           data: {
             before: envObject,
             after: envObjectMeta,
+          },
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: envObject,
+              after: envObjectMeta,
+            },
           },
           id: envObject.elemID,
           elemIDs: {
@@ -659,6 +708,13 @@ describe('multi env source', () => {
           data: {
             before: field,
             after: fieldNumber,
+          },
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: field,
+              after: fieldNumber,
+            },
           },
           id: field.elemID,
           elemIDs: {
@@ -676,6 +732,13 @@ describe('multi env source', () => {
           id: envObject.elemID,
           elemIDs: { before: envObject.elemID },
           path: envObject.path,
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: envObject,
+              after: envObjectMeta,
+            },
+          },
         },
         {
           action: 'add',
@@ -683,6 +746,13 @@ describe('multi env source', () => {
           id: envObject.elemID,
           elemIDs: { after: envObjectMeta.elemID },
           path: envObject.path,
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: envObject,
+              after: envObjectMeta,
+            },
+          },
         },
         {
           action: 'add',
@@ -690,6 +760,13 @@ describe('multi env source', () => {
           id: envObject.elemID,
           elemIDs: { after: envObjectMeta.elemID },
           path: envObject.path,
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: envObject,
+              after: envObjectMeta,
+            },
+          },
         },
         {
           action: 'remove',
@@ -697,6 +774,13 @@ describe('multi env source', () => {
           id: field.elemID,
           elemIDs: { before: field.elemID },
           path: field.path,
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: field,
+              after: fieldNumber,
+            },
+          },
         },
         {
           action: 'add',
@@ -704,6 +788,13 @@ describe('multi env source', () => {
           id: fieldNumber.elemID,
           elemIDs: { after: fieldNumber.elemID },
           path: field.path,
+          baseChange: {
+            action: 'modify',
+            data: {
+              before: field,
+              after: fieldNumber,
+            },
+          },
         },
       ])
     })

--- a/packages/workspace/test/workspace/multi_env/projections.test.ts
+++ b/packages/workspace/test/workspace/multi_env/projections.test.ts
@@ -14,8 +14,8 @@ import {
   Field,
   BuiltinTypes,
   ListType,
-  DetailedChange,
   getChangeData,
+  DetailedChangeWithBaseChange,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { AdditionDiff, ModificationDiff, RemovalDiff } from '@salto-io/dag/dist'
@@ -190,9 +190,13 @@ describe('projections', () => {
     modifiedInstance.value = _.cloneDeepWith(instance.value, v => (_.isString(v) ? 'MODIFIED' : undefined))
 
     it('should project an add change for a missing instances', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: newInstance },
+        baseChange: {
+          action: 'add',
+          data: { after: newInstance },
+        },
         id: newInstance.elemID,
       }
       const projected = await projectChange(change, source)
@@ -204,9 +208,13 @@ describe('projections', () => {
     })
 
     it('should project an add change for a non existing fragment for instances', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: newPartialInstance.value.nested2 },
+        baseChange: {
+          action: 'modify',
+          data: { before: newPartialInstance, after: newPartialInstance },
+        },
         id: newPartialInstance.elemID.createNestedID('nested2'),
       }
       const projected = await projectChange(change, source)
@@ -216,17 +224,25 @@ describe('projections', () => {
       expect(changeData).toEqual(newPartialInstance.value.nested2)
     })
     it('should not project an add change for an existing fragment for instances', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: instance },
+        baseChange: {
+          action: 'add',
+          data: { after: instance },
+        },
         id: instance.elemID,
       }
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for instances', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'modify',
         data: { before: instance, after: modifiedInstance },
+        baseChange: {
+          action: 'modify',
+          data: { before: instance, after: modifiedInstance },
+        },
         id: instance.elemID,
       }
       const projected = await projectChange(change, source)
@@ -243,9 +259,13 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for instances', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'remove',
         data: { before: instance },
+        baseChange: {
+          action: 'remove',
+          data: { before: instance },
+        },
         id: instance.elemID,
       }
       const projected = await projectChange(change, source)
@@ -271,9 +291,13 @@ describe('projections', () => {
     })
 
     it('should project an add change for a missing object type', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: newObjectType },
+        baseChange: {
+          action: 'add',
+          data: { after: newObjectType },
+        },
         id: newObjectType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -285,9 +309,13 @@ describe('projections', () => {
     })
 
     it('should project an add change for a non existing fragment for object types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: objectType.annotations.nested2 },
+        baseChange: {
+          action: 'modify',
+          data: { before: objectType, after: objectType },
+        },
         id: objectType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
@@ -297,17 +325,25 @@ describe('projections', () => {
       expect(changeData).toEqual(objectType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for object types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: objectType },
+        baseChange: {
+          action: 'add',
+          data: { after: objectType },
+        },
         id: objectType.elemID,
       }
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for object types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'modify',
         data: { before: objectType, after: modifiedObject },
+        baseChange: {
+          action: 'modify',
+          data: { before: objectType, after: modifiedObject },
+        },
         id: objectType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -324,9 +360,13 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for object types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'remove',
         data: { before: objectType },
+        baseChange: {
+          action: 'remove',
+          data: { before: objectType },
+        },
         id: objectType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -352,9 +392,13 @@ describe('projections', () => {
     })
 
     it('should project an add change for a missing primitive type', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: newPrimitiveType },
+        baseChange: {
+          action: 'add',
+          data: { after: newPrimitiveType },
+        },
         id: newPrimitiveType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -366,9 +410,13 @@ describe('projections', () => {
     })
 
     it('should project an add change for a non existing fragment for primitive types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: primitiveType.annotations.nested2 },
+        baseChange: {
+          action: 'modify',
+          data: { before: primitiveType, after: primitiveType },
+        },
         id: primitiveType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
@@ -378,17 +426,25 @@ describe('projections', () => {
       expect(changeData).toEqual(primitiveType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for primitive types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: primitiveType },
+        baseChange: {
+          action: 'add',
+          data: { after: primitiveType },
+        },
         id: primitiveType.elemID,
       }
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for primitive types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'modify',
         data: { before: primitiveType, after: modifiedPrimitive },
+        baseChange: {
+          action: 'modify',
+          data: { before: primitiveType, after: modifiedPrimitive },
+        },
         id: primitiveType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -405,9 +461,13 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for primitive types', async () => {
-      const change: DetailedChange = {
+      const change: DetailedChangeWithBaseChange = {
         action: 'remove',
         data: { before: primitiveType },
+        baseChange: {
+          action: 'remove',
+          data: { before: primitiveType },
+        },
         id: primitiveType.elemID,
       }
       const projected = await projectChange(change, source)
@@ -443,9 +503,13 @@ describe('projections', () => {
       })
 
       it('should project an add change for a missing field', async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           action: 'add',
           data: { after: newField },
+          baseChange: {
+            action: 'add',
+            data: { after: newField },
+          },
           id: newField.elemID,
         }
         const projected = await projectChange(change, source)
@@ -457,9 +521,13 @@ describe('projections', () => {
       })
 
       it('should project an add change for a non existing fragment for fields', async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           action: 'add',
           data: { after: newPartialField },
+          baseChange: {
+            action: 'add',
+            data: { after: newPartialField },
+          },
           id: newPartialField.elemID,
         }
         const projected = await projectChange(change, source)
@@ -470,17 +538,25 @@ describe('projections', () => {
         expect(data.after).toEqual(newPartialField)
       })
       it('should not project an add change for an existing fragment for fields', async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           action: 'add',
           data: { after: field },
+          baseChange: {
+            action: 'add',
+            data: { after: field },
+          },
           id: field.elemID,
         }
         await expect(projectChange(change, source)).rejects.toThrow()
       })
       it('should project a modify change for an existing fragment for fields', async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           action: 'modify',
           data: { before: field, after: modifiedField },
+          baseChange: {
+            action: 'modify',
+            data: { before: field, after: modifiedField },
+          },
           id: field.elemID,
         }
         const projected = await projectChange(change, source)
@@ -497,9 +573,13 @@ describe('projections', () => {
         })
       })
       it('should project a remove change for an existing fragment for fields', async () => {
-        const change: DetailedChange = {
+        const change: DetailedChangeWithBaseChange = {
           action: 'remove',
           data: { before: field },
+          baseChange: {
+            action: 'remove',
+            data: { before: field },
+          },
           id: field.elemID,
         }
         const projected = await projectChange(change, source)

--- a/packages/workspace/test/workspace/multi_env/projections.test.ts
+++ b/packages/workspace/test/workspace/multi_env/projections.test.ts
@@ -16,7 +16,9 @@ import {
   ListType,
   getChangeData,
   DetailedChangeWithBaseChange,
+  toChange,
 } from '@salto-io/adapter-api'
+import { toDetailedChangeFromBaseChange } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { AdditionDiff, ModificationDiff, RemovalDiff } from '@salto-io/dag/dist'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
@@ -190,15 +192,7 @@ describe('projections', () => {
     modifiedInstance.value = _.cloneDeepWith(instance.value, v => (_.isString(v) ? 'MODIFIED' : undefined))
 
     it('should project an add change for a missing instances', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: newInstance },
-        baseChange: {
-          action: 'add',
-          data: { after: newInstance },
-        },
-        id: newInstance.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: newInstance }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
@@ -211,10 +205,7 @@ describe('projections', () => {
       const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: newPartialInstance.value.nested2 },
-        baseChange: {
-          action: 'modify',
-          data: { before: newPartialInstance, after: newPartialInstance },
-        },
+        baseChange: toChange({ before: newPartialInstance, after: newPartialInstance }),
         id: newPartialInstance.elemID.createNestedID('nested2'),
       }
       const projected = await projectChange(change, source)
@@ -224,27 +215,11 @@ describe('projections', () => {
       expect(changeData).toEqual(newPartialInstance.value.nested2)
     })
     it('should not project an add change for an existing fragment for instances', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: instance },
-        baseChange: {
-          action: 'add',
-          data: { after: instance },
-        },
-        id: instance.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: instance }))
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for instances', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'modify',
-        data: { before: instance, after: modifiedInstance },
-        baseChange: {
-          action: 'modify',
-          data: { before: instance, after: modifiedInstance },
-        },
-        id: instance.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: instance, after: modifiedInstance }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('modify')
@@ -259,15 +234,7 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for instances', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'remove',
-        data: { before: instance },
-        baseChange: {
-          action: 'remove',
-          data: { before: instance },
-        },
-        id: instance.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: instance }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('remove')
@@ -291,15 +258,7 @@ describe('projections', () => {
     })
 
     it('should project an add change for a missing object type', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: newObjectType },
-        baseChange: {
-          action: 'add',
-          data: { after: newObjectType },
-        },
-        id: newObjectType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: newObjectType }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
@@ -312,10 +271,7 @@ describe('projections', () => {
       const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: objectType.annotations.nested2 },
-        baseChange: {
-          action: 'modify',
-          data: { before: objectType, after: objectType },
-        },
+        baseChange: toChange({ before: objectType, after: objectType }),
         id: objectType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
@@ -325,27 +281,11 @@ describe('projections', () => {
       expect(changeData).toEqual(objectType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for object types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: objectType },
-        baseChange: {
-          action: 'add',
-          data: { after: objectType },
-        },
-        id: objectType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: objectType }))
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for object types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'modify',
-        data: { before: objectType, after: modifiedObject },
-        baseChange: {
-          action: 'modify',
-          data: { before: objectType, after: modifiedObject },
-        },
-        id: objectType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: objectType, after: modifiedObject }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('modify')
@@ -360,15 +300,7 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for object types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'remove',
-        data: { before: objectType },
-        baseChange: {
-          action: 'remove',
-          data: { before: objectType },
-        },
-        id: objectType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: objectType }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('remove')
@@ -392,15 +324,7 @@ describe('projections', () => {
     })
 
     it('should project an add change for a missing primitive type', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: newPrimitiveType },
-        baseChange: {
-          action: 'add',
-          data: { after: newPrimitiveType },
-        },
-        id: newPrimitiveType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: newPrimitiveType }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('add')
@@ -413,10 +337,7 @@ describe('projections', () => {
       const change: DetailedChangeWithBaseChange = {
         action: 'add',
         data: { after: primitiveType.annotations.nested2 },
-        baseChange: {
-          action: 'modify',
-          data: { before: primitiveType, after: primitiveType },
-        },
+        baseChange: toChange({ before: primitiveType, after: primitiveType }),
         id: primitiveType.elemID.createNestedID('attr', 'nested2'),
       }
       const projected = await projectChange(change, source)
@@ -426,27 +347,11 @@ describe('projections', () => {
       expect(changeData).toEqual(primitiveType.annotations.nested2)
     })
     it('should not project an add change for an existing fragment for primitive types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: primitiveType },
-        baseChange: {
-          action: 'add',
-          data: { after: primitiveType },
-        },
-        id: primitiveType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: primitiveType }))
       await expect(projectChange(change, source)).rejects.toThrow()
     })
     it('should project a modify change for an existing fragment for primitive types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'modify',
-        data: { before: primitiveType, after: modifiedPrimitive },
-        baseChange: {
-          action: 'modify',
-          data: { before: primitiveType, after: modifiedPrimitive },
-        },
-        id: primitiveType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: primitiveType, after: modifiedPrimitive }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('modify')
@@ -461,15 +366,7 @@ describe('projections', () => {
       })
     })
     it('should project a remove change for an existing fragment for primitive types', async () => {
-      const change: DetailedChangeWithBaseChange = {
-        action: 'remove',
-        data: { before: primitiveType },
-        baseChange: {
-          action: 'remove',
-          data: { before: primitiveType },
-        },
-        id: primitiveType.elemID,
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ before: primitiveType }))
       const projected = await projectChange(change, source)
       expect(projected).toHaveLength(1)
       expect(projected[0].action).toBe('remove')
@@ -503,15 +400,7 @@ describe('projections', () => {
       })
 
       it('should project an add change for a missing field', async () => {
-        const change: DetailedChangeWithBaseChange = {
-          action: 'add',
-          data: { after: newField },
-          baseChange: {
-            action: 'add',
-            data: { after: newField },
-          },
-          id: newField.elemID,
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
         const projected = await projectChange(change, source)
         expect(projected).toHaveLength(1)
         expect(projected[0].action).toBe('add')
@@ -521,15 +410,7 @@ describe('projections', () => {
       })
 
       it('should project an add change for a non existing fragment for fields', async () => {
-        const change: DetailedChangeWithBaseChange = {
-          action: 'add',
-          data: { after: newPartialField },
-          baseChange: {
-            action: 'add',
-            data: { after: newPartialField },
-          },
-          id: newPartialField.elemID,
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ after: newPartialField }))
         const projected = await projectChange(change, source)
         expect(projected).toHaveLength(1)
         expect(projected[0].action).toBe('add')
@@ -538,27 +419,11 @@ describe('projections', () => {
         expect(data.after).toEqual(newPartialField)
       })
       it('should not project an add change for an existing fragment for fields', async () => {
-        const change: DetailedChangeWithBaseChange = {
-          action: 'add',
-          data: { after: field },
-          baseChange: {
-            action: 'add',
-            data: { after: field },
-          },
-          id: field.elemID,
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ after: field }))
         await expect(projectChange(change, source)).rejects.toThrow()
       })
       it('should project a modify change for an existing fragment for fields', async () => {
-        const change: DetailedChangeWithBaseChange = {
-          action: 'modify',
-          data: { before: field, after: modifiedField },
-          baseChange: {
-            action: 'modify',
-            data: { before: field, after: modifiedField },
-          },
-          id: field.elemID,
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ before: field, after: modifiedField }))
         const projected = await projectChange(change, source)
         expect(projected).toHaveLength(1)
         expect(projected[0].action).toBe('modify')
@@ -573,15 +438,7 @@ describe('projections', () => {
         })
       })
       it('should project a remove change for an existing fragment for fields', async () => {
-        const change: DetailedChangeWithBaseChange = {
-          action: 'remove',
-          data: { before: field },
-          baseChange: {
-            action: 'remove',
-            data: { before: field },
-          },
-          id: field.elemID,
-        }
+        const change = toDetailedChangeFromBaseChange(toChange({ before: field }))
         const projected = await projectChange(change, source)
         expect(projected).toHaveLength(1)
         expect(projected[0].action).toBe('remove')

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -861,6 +861,8 @@ describe('isolated routing', () => {
     primarySrcObj.annotate({ boolean: true })
     const secSrcObj = envObj.clone()
     secSrcObj.annotate({ boolean: false })
+    const commonSrcUpdated = commonObj.clone()
+    commonSrcUpdated.annotate({ boolean: undefined })
     const specificChange: DetailedChangeWithBaseChange = {
       action: 'modify',
       data: { before: false, after: true },
@@ -886,7 +888,7 @@ describe('isolated routing', () => {
       action: 'remove',
       data: { before: specificChange.data.before },
       id: specificChange.id,
-      baseChange: specificChange.baseChange,
+      baseChange: toChange({ before: commonObj, after: commonSrcUpdated }),
       path: ['test', 'path'],
     })
     expect(routedChanges.envSources?.[secSrcName][0]).toEqual({
@@ -1038,11 +1040,6 @@ describe('isolated routing', () => {
     const commonChange = routedChanges.commonSource && routedChanges.commonSource[0]
     const expectedCommonAfter = new InstanceElement('commonInst', commonObj, {
       commonField: 'commonField',
-      listField: [
-        {
-          str2: 'STR_2',
-        },
-      ],
     })
     expect(commonChange).toEqual({
       action: 'remove',

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -229,12 +229,7 @@ const onlyPrimSrc = {
 
 describe('default fetch routing', () => {
   it('should route add changes to common when there is only one configured env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const routedChanges = await routeChanges(
       [change],
       primarySrcName,
@@ -249,12 +244,7 @@ describe('default fetch routing', () => {
   })
 
   it('should route add changes to primary env when there are more then one configured env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -263,12 +253,7 @@ describe('default fetch routing', () => {
   })
 
   it('should handle ridiculously large changeset without stack overflow', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const changes: DetailedChangeWithBaseChange[] = []
     for (let i = 0; i < 140000; i += 1) {
       changes.push(change)
@@ -353,12 +338,9 @@ describe('default fetch routing', () => {
 
   it('should route env modify changes to env', async () => {
     const newEnvField = new Field(envObj, envField.name, BuiltinTypes.NUMBER)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: envObj.fields[envField.name], after: newEnvField },
-      id: newEnvField.elemID,
-      baseChange: toChange({ before: envObj.fields[envField.name], after: newEnvField }),
-    }
+    const change = toDetailedChangeFromBaseChange(
+      toChange({ before: envObj.fields[envField.name], after: newEnvField }),
+    )
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -366,12 +348,7 @@ describe('default fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route common remove changes to common', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: commonObj.fields.commonField },
-      id: commonObj.fields.commonField.elemID,
-      baseChange: toChange({ before: commonObj.fields.commonField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: commonObj.fields.commonField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -379,12 +356,7 @@ describe('default fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: envObj.fields.envField },
-      id: envObj.fields.envField.elemID,
-      baseChange: toChange({ before: envObj.fields.envField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj.fields.envField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -392,12 +364,7 @@ describe('default fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes to all environments', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: sharedObject },
-      id: commonObj.elemID,
-      baseChange: toChange({ before: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -415,12 +382,7 @@ describe('default fetch routing', () => {
       'env when there are multiple envs configured',
     async () => {
       const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
-      const change: DetailedChangeWithBaseChange = {
-        action: 'add',
-        data: { after: newField },
-        id: newField.elemID,
-        baseChange: toChange({ after: newField }),
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
       const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'default')
       expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
       expect(routedChanges.commonSource).toHaveLength(0)
@@ -430,12 +392,7 @@ describe('default fetch routing', () => {
   )
   it('should route add changes of values of env specific elements to the env when there is only one env configured', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -444,12 +401,7 @@ describe('default fetch routing', () => {
   })
   it('should route add changes of values of common elements to the primary env', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.commonSource).toHaveLength(0)
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
@@ -458,12 +410,7 @@ describe('default fetch routing', () => {
   })
   it('should route add changes of values of split elements to the common when there is only one env', async () => {
     const newField = new Field(splitObjJoined, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'default')
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
@@ -474,12 +421,7 @@ describe('default fetch routing', () => {
 
 describe('align fetch routing', () => {
   it('should route add changes to primary source', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -520,12 +462,9 @@ describe('align fetch routing', () => {
   })
 
   it('should drop common modify changes', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: commonObj.fields.commonField, after: commonObj.fields.commonField },
-      id: commonObj.fields.commonField.elemID,
-      baseChange: toChange({ before: commonObj.fields.commonField, after: commonObj.fields.commonField }),
-    }
+    const change = toDetailedChangeFromBaseChange(
+      toChange({ before: commonObj.fields.commonField, after: commonObj.fields.commonField }),
+    )
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -533,12 +472,7 @@ describe('align fetch routing', () => {
   })
 
   it('should route env modify changes to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: envObj, after: envObj },
-      id: envObj.elemID,
-      baseChange: toChange({ before: envObj, after: envObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj, after: envObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -547,12 +481,7 @@ describe('align fetch routing', () => {
   })
 
   it('should split shared modify changes and drop the common part', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: sharedObject, after: sharedObject },
-      id: commonObj.elemID,
-      baseChange: toChange({ before: sharedObject, after: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject, after: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -567,24 +496,14 @@ describe('align fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should drop common remove changes', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: commonObj.fields.commonField },
-      id: commonObj.fields.commonField.elemID,
-      baseChange: toChange({ before: commonObj.fields.commonField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: commonObj.fields.commonField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(0)
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: envObj },
-      id: envObj.elemID,
-      baseChange: toChange({ before: envObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -592,12 +511,7 @@ describe('align fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes and drop common part', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: sharedObject },
-      id: commonObj.elemID,
-      baseChange: toChange({ before: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -609,12 +523,7 @@ describe('align fetch routing', () => {
   })
   it('should route add changes of values of env specific elements to the env', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -623,12 +532,7 @@ describe('align fetch routing', () => {
   })
   it('should route add changes of values of common elements to env', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'align')
     expect(routedChanges.commonSource).toHaveLength(0)
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
@@ -655,12 +559,7 @@ describe('align fetch routing', () => {
 
 describe('override fetch routing', () => {
   it('should route add changes to common', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -669,12 +568,9 @@ describe('override fetch routing', () => {
   })
 
   it('should route common modify changes to common', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: commonObj.fields.commonField, after: commonObj.fields.commonField },
-      id: commonObj.fields.commonField.elemID,
-      baseChange: toChange({ before: commonObj.fields.commonField, after: commonObj.fields.commonField }),
-    }
+    const change = toDetailedChangeFromBaseChange(
+      toChange({ before: commonObj.fields.commonField, after: commonObj.fields.commonField }),
+    )
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -682,12 +578,9 @@ describe('override fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env modify changes to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: envObj.fields.envField, after: envObj.fields.envField },
-      id: envObj.fields.envField.elemID,
-      baseChange: toChange({ before: envObj.fields.envField, after: envObj.fields.envField }),
-    }
+    const change = toDetailedChangeFromBaseChange(
+      toChange({ before: envObj.fields.envField, after: envObj.fields.envField }),
+    )
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -695,12 +588,7 @@ describe('override fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared modify changes to common and env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: sharedObject, after: sharedObject },
-      id: commonObj.elemID,
-      baseChange: toChange({ before: sharedObject, after: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject, after: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -721,12 +609,7 @@ describe('override fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route common remove changes to common', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: commonObj.fields.commonField },
-      id: commonObj.fields.commonField.elemID,
-      baseChange: toChange({ after: commonObj.fields.commonField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: commonObj.fields.commonField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -734,12 +617,7 @@ describe('override fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should route env remove changes to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: envObj.fields.envField },
-      id: envObj.fields.envField.elemID,
-      baseChange: toChange({ before: envObj.fields.envField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj.fields.envField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -747,12 +625,7 @@ describe('override fetch routing', () => {
     expect(_.isEmpty(_.omit(routedChanges.envSources, [primarySrcName]))).toBeTruthy()
   })
   it('should split shared remove changes to common and env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: sharedObject },
-      id: commonObj.elemID,
-      baseChange: toChange({ before: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'override')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)
@@ -767,12 +640,7 @@ describe('override fetch routing', () => {
   })
   it('should route add changes of values of env specific elements to the env', async () => {
     const newField = new Field(envOnlyObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -781,12 +649,7 @@ describe('override fetch routing', () => {
   })
   it('should route add changes of values of common elements to the common', async () => {
     const newField = new Field(commonObj, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
@@ -795,12 +658,7 @@ describe('override fetch routing', () => {
   })
   it('should route add changes of values of split elements to the common', async () => {
     const newField = new Field(splitObjJoined, 'dreams', BuiltinTypes.STRING)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, onlyPrimSrc, 'override')
     expect(routedChanges.commonSource).toHaveLength(1)
     expect(routedChanges.envSources?.[primarySrcName] ?? []).toHaveLength(0)
@@ -811,12 +669,7 @@ describe('override fetch routing', () => {
 
 describe('isolated routing', () => {
   it('should route an add change to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'add',
-      data: { after: newObj },
-      id: newObj.elemID,
-      baseChange: toChange({ after: newObj }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ after: newObj }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'isolated')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -827,12 +680,7 @@ describe('isolated routing', () => {
   })
   it('should route an env modification change to env', async () => {
     const newField = new Field(envObj, envField.name, BuiltinTypes.NUMBER)
-    const change: DetailedChangeWithBaseChange = {
-      action: 'modify',
-      data: { before: envObj.fields.envField, after: newField },
-      id: newField.elemID,
-      baseChange: toChange({ before: envObj.fields.envField, after: newField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj.fields.envField, after: newField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'isolated')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -842,12 +690,7 @@ describe('isolated routing', () => {
     )
   })
   it('should route an env remove diff to env', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: envObj.fields.envField },
-      id: envObj.fields.envField.elemID,
-      baseChange: toChange({ before: envObj.fields.envField }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: envObj.fields.envField }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'isolated')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(0)
@@ -969,12 +812,7 @@ describe('isolated routing', () => {
     })
   })
   it('should route a removal diff to common and env and revert the change in secondary envs', async () => {
-    const change: DetailedChangeWithBaseChange = {
-      action: 'remove',
-      data: { before: sharedObject },
-      id: sharedObject.elemID,
-      baseChange: toChange({ before: sharedObject }),
-    }
+    const change = toDetailedChangeFromBaseChange(toChange({ before: sharedObject }))
     const routedChanges = await routeChanges([change], primarySrcName, commonSource, envSources, 'isolated')
     expect(routedChanges.envSources?.[primarySrcName]).toHaveLength(1)
     expect(routedChanges.commonSource).toHaveLength(1)

--- a/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_file_update.test.ts
@@ -18,6 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { dumpElements, parse, SourceMap } from '@salto-io/parser/src/parser'
 import { SourcePos } from '@salto-io/parser/src/parser/internal/types'
+import { toDetailedChangeFromBaseChange } from '@salto-io/adapter-utils'
 import {
   getNestedStaticFiles,
   getChangeLocations,
@@ -131,11 +132,7 @@ describe('getChangeLocations', () => {
   describe('with addition of top level element', () => {
     it('should add the element at the end of the file', () => {
       const mockType = createMockType({})
-      const change: DetailedChangeWithBaseChange = {
-        ...toChange({ after: mockType }),
-        id: mockType.elemID,
-        baseChange: toChange({ after: mockType }),
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: mockType }))
       const result = getChangeLocations(change, new SourceMap())
       expect(result).toEqual([
         {
@@ -152,11 +149,7 @@ describe('getChangeLocations', () => {
     it('should use the default filename when no path is provided', () => {
       const noPath = createMockType({})
       noPath.path = undefined
-      const change: DetailedChangeWithBaseChange = {
-        ...toChange({ after: noPath }),
-        id: noPath.elemID,
-        baseChange: toChange({ after: noPath }),
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: noPath }))
       const result = getChangeLocations(change, new SourceMap())
       expect(result).toEqual([
         {
@@ -175,10 +168,8 @@ describe('getChangeLocations', () => {
     it('should add the field before a following field', async () => {
       const mockTypeBefore = createMockType({ dropFields: ['numArray'] })
       const mockType = createMockType({})
-      const change: DetailedChangeWithBaseChange = {
-        ...toChange({ after: mockType.fields.numArray }),
-        id: mockType.fields.numArray.elemID,
-        baseChange: toChange({ before: mockTypeBefore, after: mockType }),
+      const change = {
+        ...toDetailedChangeFromBaseChange(toChange({ after: mockType.fields.numArray })),
         path: ['file'],
       }
       const sourceMap = await sourceMapForElement(mockTypeBefore)
@@ -201,10 +192,8 @@ describe('getChangeLocations', () => {
     it('should add the field at the end of the parent when no following fields are found', async () => {
       const mockTypeBefore = createMockType({ dropFields: ['obj'] })
       const mockType = createMockType({})
-      const change: DetailedChangeWithBaseChange = {
-        ...toChange({ after: mockType.fields.obj }),
-        id: mockType.fields.obj.elemID,
-        baseChange: toChange({ before: mockTypeBefore, after: mockType }),
+      const change = {
+        ...toDetailedChangeFromBaseChange(toChange({ after: mockType.fields.obj })),
         path: ['file'],
       }
       const sourceMap = await sourceMapForElement(mockTypeBefore)
@@ -227,9 +216,7 @@ describe('getChangeLocations', () => {
     it("should add the field to the end of the file when the parent isn't in the source map", () => {
       const mockType = createMockType({})
       const change: DetailedChangeWithBaseChange = {
-        ...toChange({ after: mockType.fields.numArray }),
-        id: mockType.fields.numArray.elemID,
-        baseChange: toChange({ before: createMockType({ dropFields: ['numArray'] }), after: mockType }),
+        ...toDetailedChangeFromBaseChange(toChange({ after: mockType.fields.numArray })),
         path: ['file'],
       }
       const result = getChangeLocations(change, new SourceMap())

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -24,7 +24,7 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
 import { parser } from '@salto-io/parser'
-import { detailedCompare, transformElement } from '@salto-io/adapter-utils'
+import { detailedCompare, toDetailedChangeFromBaseChange, transformElement } from '@salto-io/adapter-utils'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
 import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
@@ -53,13 +53,7 @@ const createChange = (): DetailedChangeWithBaseChange => {
     },
   })
   const change: DetailedChangeWithBaseChange = {
-    id: newElemID,
-    action: 'add',
-    data: { after: newElem },
-    baseChange: {
-      action: 'add',
-      data: { after: newElem },
-    },
+    ...toDetailedChangeFromBaseChange(toChange({ after: newElem })),
     path: ['new', 'file'],
   }
   return change

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -17,6 +17,8 @@ import {
   createRefToElmWithValue,
   InstanceElement,
   isStaticFile,
+  DetailedChangeWithBaseChange,
+  toChange,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -39,7 +41,7 @@ import { DetailedChangeWithSource, getChangeLocations } from '../../../src/works
 
 const { awu } = collections.asynciterable
 
-const createChange = (): DetailedChange => {
+const createChange = (): DetailedChangeWithBaseChange => {
   const newElemID = new ElemID('salesforce', 'new_elem')
   const newElem = new ObjectType({
     elemID: newElemID,
@@ -50,12 +52,16 @@ const createChange = (): DetailedChange => {
       },
     },
   })
-  const change = {
+  const change: DetailedChangeWithBaseChange = {
     id: newElemID,
     action: 'add',
     data: { after: newElem },
+    baseChange: {
+      action: 'add',
+      data: { after: newElem },
+    },
     path: ['new', 'file'],
-  } as DetailedChange
+  }
   return change
 }
 
@@ -456,42 +462,64 @@ describe.each([false, true])(
         await src.load({})
       })
       it('should not parse file when updating single add changes in a new file', async () => {
+        const baseChange = toChange({
+          before: new ObjectType({ elemID, annotations: { file: sfile } }),
+          after: new ObjectType({ elemID }),
+        })
         const change = {
-          id: elemID,
+          id: elemID.createNestedID('attr', 'file'),
           action: 'remove',
           data: { before: sfile },
+          baseChange,
           path: ['new', 'file'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([change])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
       })
       it('should delete before file when path is changed', async () => {
+        const newFile = new StaticFile({ filepath: afterFilePath, hash: 'XI' })
+        const baseChange = toChange({
+          before: new ObjectType({ elemID, annotations: { file: sfile } }),
+          after: new ObjectType({ elemID, annotations: { file: newFile } }),
+        })
         const change = {
-          id: elemID,
+          id: elemID.createNestedID('attr', 'file'),
           action: 'modify',
-          data: { before: sfile, after: new StaticFile({ filepath: afterFilePath, hash: 'XI' }) },
+          data: { before: sfile, after: newFile },
+          baseChange,
           path: ['new', 'file'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([change])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
       })
       it('should delete before file when it is no longer a static file', async () => {
+        const baseChange = toChange({
+          before: new ObjectType({ elemID, annotations: { file: sfile } }),
+          after: new ObjectType({ elemID, annotations: { file: '' } }),
+        })
         const change = {
           id: elemID,
           action: 'modify',
           data: { before: sfile, after: '' },
+          baseChange,
           path: ['new', 'file'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([change])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
       })
       it('should not delete static file if the change is only in content and not in path', async () => {
+        const newFile = new StaticFile({ filepath, hash: 'XII' })
+        const baseChange = toChange({
+          before: new ObjectType({ elemID, annotations: { file: sfile } }),
+          after: new ObjectType({ elemID, annotations: { file: newFile } }),
+        })
         const change = {
           id: elemID,
           action: 'modify',
-          data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
+          data: { before: sfile, after: newFile },
+          baseChange,
           path: ['new', 'file'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([change])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
       })
@@ -537,12 +565,12 @@ describe.each([false, true])(
           action: 'add',
           id: newInstanceElement1.elemID,
           data: { after: newInstanceElement1 },
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         const detailedChange2 = {
           action: 'add',
           id: newInstanceElement2.elemID,
           data: { after: newInstanceElement2 },
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
 
         await src.updateNaclFiles([detailedChange1, detailedChange2])
 
@@ -550,7 +578,7 @@ describe.each([false, true])(
           id: newInstanceElement1.elemID.createNestedID('file'),
           action: 'remove',
           data: { before: sfile },
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([removal])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
       })
@@ -577,18 +605,30 @@ describe.each([false, true])(
               },
             }) as unknown as DetailedChangeWithSource[],
         )
+        const someFile = new StaticFile({ filepath, hash: 'XII' })
+        const anotherElemID = new ElemID('salesforce', 'new_elem2')
+        const additionBaseChange = toChange({
+          before: new ObjectType({ elemID: anotherElemID }),
+          after: new ObjectType({ elemID: anotherElemID, annotations: { file: someFile } }),
+        })
         const changeAdd = {
-          id: new ElemID('salesforce', 'new_elem2'),
+          id: anotherElemID.createNestedID('attr', 'file'),
           action: 'add',
-          data: { after: new StaticFile({ filepath, hash: 'XII' }) },
+          data: { after: someFile },
+          baseChange: additionBaseChange,
           path: ['new', 'file'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
+        const removalBaseChange = toChange({
+          before: new ObjectType({ elemID, annotations: { file: someFile } }),
+          after: new ObjectType({ elemID }),
+        })
         const changeDelete = {
-          id: elemID,
+          id: elemID.createNestedID('attr', 'file'),
           action: 'remove',
-          data: { before: new StaticFile({ filepath, hash: 'XII' }) },
+          data: { before: someFile },
+          baseChange: removalBaseChange,
           path: ['old', 'file2'],
-        } as DetailedChange
+        } as DetailedChangeWithBaseChange
         await src.updateNaclFiles([changeAdd, changeDelete])
         expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
       })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -43,7 +43,12 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import { ReferenceIndexEntry } from 'index'
-import { findElement, applyDetailedChanges, safeJsonStringify } from '@salto-io/adapter-utils'
+import {
+  findElement,
+  applyDetailedChanges,
+  safeJsonStringify,
+  toDetailedChangeFromBaseChange,
+} from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { MockInterface } from '@salto-io/test-utils'
 import { parser } from '@salto-io/parser'
@@ -2132,19 +2137,7 @@ salesforce.staticFile staticFileInstance {
       const secondarySourceName = 'inactive'
       let wsWithMultipleEnvs: Workspace
       const obj = new ObjectType({ elemID: new ElemID('salesforce', 'dum') })
-      const change: DetailedChangeWithBaseChange = {
-        id: obj.elemID,
-        action: 'add',
-        data: {
-          after: obj,
-        },
-        baseChange: {
-          action: 'add',
-          data: {
-            after: obj,
-          },
-        },
-      }
+      const change = toDetailedChangeFromBaseChange(toChange({ after: obj }))
 
       beforeEach(async () => {
         wsWithMultipleEnvs = await createWorkspace(


### PR DESCRIPTION
we expect the input changes in `updateNaclFiles` to have `baseChange` in them (`DetailedChangeWithBaseChange`). this is trivial in most places because the core returns `DetailedChangeWithBaseChange[]` in most of its flows, but in some places we were building new `DetailedChange[]` and there we should make sure that they have `baseChange` too.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None