### PR TITLE
SALTO-5917 - Salesforce: remove coordinate fields from auto-layout flows

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -109,6 +109,7 @@ import omitStandardFieldsNonDeployableValuesFilter from './filters/omit_standard
 import generatedDependenciesFilter from './filters/generated_dependencies'
 import { CUSTOM_REFS_CONFIG, FetchElements, FetchProfile, MetadataQuery, SalesforceConfig } from './types'
 import mergeProfilesWithSourceValuesFilter from './filters/merge_profiles_with_source_values'
+import flowCoordinatesFilter from './filters/flow_coordinates'
 import { getConfigFromConfigChanges } from './config_change'
 import {
   LocalFilterCreator,
@@ -261,6 +262,7 @@ export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreato
   { creator: importantValuesFilter },
   { creator: hideTypesFolder },
   { creator: generatedDependenciesFilter },
+  { creator: flowCoordinatesFilter },
   // createChangedAtSingletonInstanceFilter should run last
   { creator: changedAtSingletonFilter },
 ]

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -39,6 +39,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   latestSupportedApiVersion: false,
   metaTypes: false,
   cpqRulesAndConditionsRefs: true,
+  flowCoordinates: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/flow_coordinates.ts
+++ b/packages/salesforce-adapter/src/filters/flow_coordinates.ts
@@ -1,0 +1,148 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+} from '@salto-io/adapter-api'
+import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { LocalFilterCreator } from '../filter'
+import {
+  apiNameSync,
+  isInstanceOfTypeChangeSync,
+  isInstanceOfTypeSync,
+} from './utils'
+import { FLOW_METADATA_TYPE } from '../constants'
+
+const log = logger(module)
+
+const TYPES_WITH_COORDINATES = [
+  'FlowActionCall',
+  'FlowApexPluginCall',
+  'FlowAssignment',
+  'FlowCollectionProcessor',
+  'FlowCustomError',
+  'FlowDecision',
+  'FlowLoop',
+  'FlowOrchestratedStage',
+  'FlowRecordCreate',
+  'FlowRecordDelete',
+  'FlowRecordLookup',
+  'FlowRecordRollback',
+  'FlowRecordUpdate',
+  'FlowScreen',
+  'FlowStart',
+  'FlowStep',
+  'FlowSubflow',
+  'FlowTransform',
+  'FlowWait',
+]
+
+const isInCanvasAutoLayoutMode = (instance: InstanceElement): boolean => {
+  if (!instance.value.processMetadataValues) {
+    return false
+  }
+  const canvasMode = instance.value.processMetadataValues.find(
+    ({ name }: { name: string }) => name === 'CanvasMode',
+  )
+  return canvasMode?.value?.stringValue === 'AUTO_LAYOUT_CANVAS'
+}
+
+const removeCoordinatesFromAllSections: TransformFuncSync = ({
+  value,
+  field,
+}) => {
+  if (!field) {
+    return value
+  }
+  const typeName = apiNameSync(field.parent)
+  if (!typeName || !TYPES_WITH_COORDINATES.includes(typeName)) {
+    return value
+  }
+
+  if (['locationX', 'locationY'].includes(field.name)) {
+    log.debug('Removing field %s', field.elemID.getFullName())
+    return undefined
+  }
+
+  return value
+}
+
+const addZeroCoordinatesToAllSections: TransformFuncSync = ({
+  value,
+  field,
+}) => {
+  if (!field) {
+    return value
+  }
+  const typeName = apiNameSync(field.getTypeSync())
+  if (!typeName || !TYPES_WITH_COORDINATES.includes(typeName)) {
+    return value
+  }
+
+  log.debug('Adding field %s.{locationX,locationY}', field.elemID.getFullName())
+
+  value.locationX = value.locationX ?? 0
+  value.locationY = value.locationY ?? 0
+
+  return value
+}
+
+const filter: LocalFilterCreator = () => ({
+  name: 'flowCoordinatesFilter',
+  onFetch: async (elements) => {
+    elements
+      .filter(isInstanceOfTypeSync(FLOW_METADATA_TYPE))
+      .filter(isInCanvasAutoLayoutMode)
+      .forEach((instance) => {
+        instance.value = transformValuesSync({
+          values: instance.value,
+          type: instance.getTypeSync(),
+          transformFunc: removeCoordinatesFromAllSections,
+        })
+      })
+  },
+  preDeploy: async (changes) => {
+    changes
+      .filter(isInstanceOfTypeChangeSync(FLOW_METADATA_TYPE))
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .forEach((instance) => {
+        instance.value = transformValuesSync({
+          values: instance.value,
+          type: instance.getTypeSync(),
+          transformFunc: addZeroCoordinatesToAllSections,
+        })
+      })
+  },
+  onDeploy: async (changes) => {
+    changes
+      .filter(isInstanceOfTypeChangeSync(FLOW_METADATA_TYPE))
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInCanvasAutoLayoutMode)
+      .forEach((instance) => {
+        instance.value = transformValuesSync({
+          values: instance.value,
+          type: instance.getTypeSync(),
+          transformFunc: removeCoordinatesFromAllSections,
+        })
+      })
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/flow_coordinates.ts
+++ b/packages/salesforce-adapter/src/filters/flow_coordinates.ts
@@ -1,17 +1,9 @@
 /*
- *                      Copyright 2024 Salto Labs Ltd.
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { getChangeData, InstanceElement, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
@@ -88,7 +80,7 @@ const addZeroCoordinatesToAllSections: TransformFuncSync = ({ value, field }) =>
 
 const FILTER_NAME = 'flowCoordinates'
 
-const filter: LocalFilterCreator = ({config}) => ({
+const filter: LocalFilterCreator = ({ config }) => ({
   name: FILTER_NAME,
   onFetch: ensureSafeFilterFetch({
     warningMessage: '',
@@ -105,7 +97,7 @@ const filter: LocalFilterCreator = ({config}) => ({
             transformFunc: removeCoordinatesFromAllSections,
           })
         })
-    }
+    },
   }),
   preDeploy: async changes => {
     if (!config.fetchProfile.isFeatureEnabled(FILTER_NAME)) {

--- a/packages/salesforce-adapter/src/filters/flow_coordinates.ts
+++ b/packages/salesforce-adapter/src/filters/flow_coordinates.ts
@@ -13,19 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  getChangeData,
-  InstanceElement,
-  isAdditionOrModificationChange,
-} from '@salto-io/adapter-api'
+import { getChangeData, InstanceElement, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { LocalFilterCreator } from '../filter'
-import {
-  apiNameSync,
-  isInstanceOfTypeChangeSync,
-  isInstanceOfTypeSync,
-} from './utils'
+import { apiNameSync, isInstanceOfTypeChangeSync, isInstanceOfTypeSync } from './utils'
 import { FLOW_METADATA_TYPE } from '../constants'
 
 const log = logger(module)
@@ -56,16 +48,11 @@ const isInCanvasAutoLayoutMode = (instance: InstanceElement): boolean => {
   if (!instance.value.processMetadataValues) {
     return false
   }
-  const canvasMode = instance.value.processMetadataValues.find(
-    ({ name }: { name: string }) => name === 'CanvasMode',
-  )
+  const canvasMode = instance.value.processMetadataValues.find(({ name }: { name: string }) => name === 'CanvasMode')
   return canvasMode?.value?.stringValue === 'AUTO_LAYOUT_CANVAS'
 }
 
-const removeCoordinatesFromAllSections: TransformFuncSync = ({
-  value,
-  field,
-}) => {
+const removeCoordinatesFromAllSections: TransformFuncSync = ({ value, field }) => {
   if (!field) {
     return value
   }
@@ -82,10 +69,7 @@ const removeCoordinatesFromAllSections: TransformFuncSync = ({
   return value
 }
 
-const addZeroCoordinatesToAllSections: TransformFuncSync = ({
-  value,
-  field,
-}) => {
+const addZeroCoordinatesToAllSections: TransformFuncSync = ({ value, field }) => {
   if (!field) {
     return value
   }
@@ -104,11 +88,11 @@ const addZeroCoordinatesToAllSections: TransformFuncSync = ({
 
 const filter: LocalFilterCreator = () => ({
   name: 'flowCoordinatesFilter',
-  onFetch: async (elements) => {
+  onFetch: async elements => {
     elements
       .filter(isInstanceOfTypeSync(FLOW_METADATA_TYPE))
       .filter(isInCanvasAutoLayoutMode)
-      .forEach((instance) => {
+      .forEach(instance => {
         instance.value = transformValuesSync({
           values: instance.value,
           type: instance.getTypeSync(),
@@ -116,12 +100,12 @@ const filter: LocalFilterCreator = () => ({
         })
       })
   },
-  preDeploy: async (changes) => {
+  preDeploy: async changes => {
     changes
       .filter(isInstanceOfTypeChangeSync(FLOW_METADATA_TYPE))
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .forEach((instance) => {
+      .forEach(instance => {
         instance.value = transformValuesSync({
           values: instance.value,
           type: instance.getTypeSync(),
@@ -129,13 +113,13 @@ const filter: LocalFilterCreator = () => ({
         })
       })
   },
-  onDeploy: async (changes) => {
+  onDeploy: async changes => {
     changes
       .filter(isInstanceOfTypeChangeSync(FLOW_METADATA_TYPE))
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
       .filter(isInCanvasAutoLayoutMode)
-      .forEach((instance) => {
+      .forEach(instance => {
         instance.value = transformValuesSync({
           values: instance.value,
           type: instance.getTypeSync(),

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -813,7 +813,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     latestSupportedApiVersion: { refType: BuiltinTypes.BOOLEAN },
     metaTypes: { refType: BuiltinTypes.BOOLEAN },
     cpqRulesAndConditionsRefs: { refType: BuiltinTypes.BOOLEAN },
-    flowCoordinates: {refType: BuiltinTypes.BOOLEAN },
+    flowCoordinates: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -118,6 +118,7 @@ export type OptionalFeatures = {
   latestSupportedApiVersion?: boolean
   metaTypes?: boolean
   cpqRulesAndConditionsRefs?: boolean
+  flowCoordinates?: boolean
 }
 
 export type ChangeValidatorName =
@@ -812,6 +813,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     latestSupportedApiVersion: { refType: BuiltinTypes.BOOLEAN },
     metaTypes: { refType: BuiltinTypes.BOOLEAN },
     cpqRulesAndConditionsRefs: { refType: BuiltinTypes.BOOLEAN },
+    flowCoordinates: {refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
+++ b/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
@@ -23,7 +23,7 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/flow_coordinates'
-import { defaultFilterContext } from '../utils'
+import { buildFilterContext, defaultFilterContext } from '../utils'
 import { createMetadataObjectType } from '../../src/transformers/transformer'
 import { FLOW_METADATA_TYPE, METADATA_TYPE } from '../../src/constants'
 import { FilterWith } from './mocks'
@@ -87,7 +87,7 @@ const flowType = createMetadataObjectType({
 
 describe('flow coordinates filter', () => {
   const filter = filterCreator({
-    config: defaultFilterContext,
+    config: buildFilterContext({optionalFeatures: {flowCoordinates: true}}),
   }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
 
   describe('onFetch', () => {

--- a/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
+++ b/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
@@ -1,17 +1,9 @@
 /*
- *                      Copyright 2024 Salto Labs Ltd.
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
  *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import {
   BuiltinTypes,
@@ -23,7 +15,7 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/flow_coordinates'
-import { buildFilterContext, defaultFilterContext } from '../utils'
+import { buildFilterContext } from '../utils'
 import { createMetadataObjectType } from '../../src/transformers/transformer'
 import { FLOW_METADATA_TYPE, METADATA_TYPE } from '../../src/constants'
 import { FilterWith } from './mocks'
@@ -87,7 +79,7 @@ const flowType = createMetadataObjectType({
 
 describe('flow coordinates filter', () => {
   const filter = filterCreator({
-    config: buildFilterContext({optionalFeatures: {flowCoordinates: true}}),
+    config: buildFilterContext({ optionalFeatures: { flowCoordinates: true } }),
   }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
 
   describe('onFetch', () => {

--- a/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
+++ b/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
@@ -1,0 +1,400 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  BuiltinTypes,
+  Change,
+  Element,
+  getChangeData,
+  InstanceElement,
+  ListType,
+  toChange,
+} from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/flow_coordinates'
+import { defaultFilterContext } from '../utils'
+import { createMetadataObjectType } from '../../src/transformers/transformer'
+import { FLOW_METADATA_TYPE, METADATA_TYPE } from '../../src/constants'
+import { FilterWith } from './mocks'
+
+const flowAssignmentType = createMetadataObjectType({
+  annotations: {
+    [METADATA_TYPE]: 'FlowAssignment',
+  },
+  fields: {
+    label: { refType: BuiltinTypes.STRING },
+    locationX: { refType: BuiltinTypes.NUMBER },
+    locationY: { refType: BuiltinTypes.NUMBER },
+  },
+})
+
+const unrelatedTypeWithCoordinates = createMetadataObjectType({
+  annotations: {
+    [METADATA_TYPE]: 'UnrelatedType',
+  },
+  fields: {
+    locationX: { refType: BuiltinTypes.NUMBER },
+    locationY: { refType: BuiltinTypes.NUMBER },
+  },
+})
+
+const flowElementReferenceOrValue = createMetadataObjectType({
+  annotations: {
+    [METADATA_TYPE]: 'FlowElementReferenceOrValue',
+  },
+  fields: {
+    stringValue: { refType: BuiltinTypes.STRING },
+  },
+})
+
+const flowMetadataValueType = createMetadataObjectType({
+  annotations: {
+    [METADATA_TYPE]: 'FlowMetadataValue',
+  },
+  fields: {
+    name: { refType: BuiltinTypes.STRING },
+    value: { refType: flowElementReferenceOrValue },
+  },
+})
+
+const flowType = createMetadataObjectType({
+  annotations: {
+    [METADATA_TYPE]: FLOW_METADATA_TYPE,
+  },
+  fields: {
+    assignments: {
+      refType: new ListType(flowAssignmentType),
+    },
+    processMetadataValues: {
+      refType: new ListType(flowMetadataValueType),
+    },
+    irrelevantField: {
+      refType: unrelatedTypeWithCoordinates,
+    },
+  },
+})
+
+describe('flow coordinates filter', () => {
+  const filter = filterCreator({
+    config: defaultFilterContext,
+  }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+
+  describe('onFetch', () => {
+    let elements: Element[]
+    describe('when the type has the right fields but is not a flow', () => {
+      const objectType = createMetadataObjectType({
+        annotations: {
+          [METADATA_TYPE]: 'TestType',
+        },
+        fields: {
+          assignment: {
+            refType: flowAssignmentType,
+          },
+        },
+      })
+      const instance = new InstanceElement('SomeInstance', objectType, {
+        assignments: [
+          {
+            locationX: 1,
+            locationY: 2,
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        elements = [instance].map(e => e.clone())
+        await filter.onFetch(elements)
+      })
+
+      it('should not modify anything', () => {
+        expect((elements[0] as InstanceElement).value).toHaveProperty('assignments', instance.value.assignments)
+      })
+    })
+    describe('when a field of flow has the right fields but is not of a known type', () => {
+      const instance = new InstanceElement('SomeInstance', flowType, {
+        irrelevantField: {
+          locationX: 1,
+          locationY: 2,
+        },
+      })
+
+      beforeEach(async () => {
+        elements = [instance].map(e => e.clone())
+        await filter.onFetch(elements)
+      })
+
+      it('should not modify anything', () => {
+        expect((elements[0] as InstanceElement).value).toHaveProperty('irrelevantField', { locationX: 1, locationY: 2 })
+      })
+    })
+    describe('when a flow is not in auto-layout mode', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeLabel',
+            locationX: 1,
+            locationY: 2,
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'FREE_FORM_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        elements = [instance].map(e => e.clone())
+        await filter.onFetch(elements)
+      })
+
+      it('should not modify anything', () => {
+        expect((elements[0] as InstanceElement).value).toHaveProperty('assignments', instance.value.assignments)
+      })
+    })
+    describe('when a flow is in auto-layout mode', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeAssignment',
+            locationX: 1,
+            locationY: 2,
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'AUTO_LAYOUT_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        elements = [instance].map(e => e.clone())
+        await filter.onFetch(elements)
+      })
+
+      it('should remove the coordinate fields', () => {
+        expect((elements[0] as InstanceElement).value.assignments[0]).not.toHaveProperty('locationX')
+        expect((elements[0] as InstanceElement).value.assignments[0]).not.toHaveProperty('locationX')
+      })
+    })
+  })
+  describe('preDeploy', () => {
+    let changes: Change[]
+    describe('when the type has the right fields but is not a flow', () => {
+      const objectType = createMetadataObjectType({
+        annotations: {
+          [METADATA_TYPE]: 'TestType',
+        },
+        fields: {
+          assignment: {
+            refType: flowAssignmentType,
+          },
+        },
+      })
+      const instance = new InstanceElement('SomeInstance', objectType, {
+        assignments: [
+          {
+            label: 'SomeLabel',
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.preDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'assignments',
+          instance.value.assignments,
+        )
+      })
+    })
+    describe('when a field of flow has the right fields but is not of a known type', () => {
+      const instance = new InstanceElement('SomeInstance', flowType, {
+        irrelevantField: {
+          label: 'SomeLabel',
+        },
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.preDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'irrelevantField',
+          instance.value.irrelevantField,
+        )
+      })
+    })
+    describe('when deploying a flow with fields of a known type', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeLabel',
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'FREE_FORM_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.preDeploy(changes)
+      })
+
+      it('should add coordinate values', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty('assignments', [
+          {
+            label: 'SomeLabel',
+            locationX: 0,
+            locationY: 0,
+          },
+        ])
+      })
+    })
+  })
+  describe('onDeploy', () => {
+    let changes: Change[]
+    describe('when the type has the right fields but is not a flow', () => {
+      const objectType = createMetadataObjectType({
+        annotations: {
+          [METADATA_TYPE]: 'TestType',
+        },
+        fields: {
+          assignment: {
+            refType: flowAssignmentType,
+          },
+        },
+      })
+      const instance = new InstanceElement('SomeInstance', objectType, {
+        assignments: [
+          {
+            locationX: 1,
+            locationY: 2,
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.onDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'assignments',
+          instance.value.assignments,
+        )
+      })
+    })
+    describe('when a field of flow has the right fields but is not of a known type', () => {
+      const instance = new InstanceElement('SomeInstance', flowType, {
+        irrelevantField: {
+          locationX: 1,
+          locationY: 2,
+        },
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.onDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'irrelevantField',
+          instance.value.irrelevantField,
+        )
+      })
+    })
+    describe('when a flow is not in auto-layout mode', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeLabel',
+            locationX: 1,
+            locationY: 2,
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'FREE_FORM_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.onDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'assignments',
+          instance.value.assignments,
+        )
+      })
+    })
+    describe('when a flow is in auto-layout mode', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeAssignment',
+            locationX: 0,
+            locationY: 0,
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'AUTO_LAYOUT_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.onDeploy(changes)
+      })
+
+      it('should remove the coordinate fields', () => {
+        const instanceAfterTest = getChangeData(changes[0]) as InstanceElement
+        expect(instanceAfterTest.value.assignments[0]).not.toHaveProperty('locationX')
+        expect(instanceAfterTest.value.assignments[0]).not.toHaveProperty('locationX')
+      })
+    })
+  })
+})


### PR DESCRIPTION
When flows are in auto-layout mode, the coordinates of their components are meaningless, yet when they change they cause many diffs in deployments.
This PR removes these coordinate values and re-adds them as 0 for deployment (since they are required)

---
Testing: 
 - Fetch a flow in auto-layout mode. Observe the fields not being present in the NaCl files.
 - Deploy a flow with no coordinate fields. Observe a successful deployment. Observe no coordinate fields in the NaCl file post-deploy.

---
_Release Notes_: 
Salesforce: coordinate fields of flow components that belong to a flow with AUTO_LAYOUT_CANVAS mode are now removed.

---
_User Notifications_: 
Salesforce: coordinate fields of flow components that belong to a flow with AUTO_LAYOUT_CANVAS mode are now removed.