### PR TITLE
SALTO-6284: Salesforce LWC deploy XML parsing bug-fix

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -115,8 +115,8 @@ export type ServiceMDTRecordValue = MetadataValues & {
   values: ServiceMDTRecordFieldValue | ServiceMDTRecordFieldValue[]
 }
 
-// Salesforce expects xsi:nil="true" for null values explicitly.
-// We put the "true" value in the key since fast-xml-parser omits boolean values.
+// Special handling since the XML parser implementation will omit the value "true" for attributes
+// As a workaround, we pass it as part of the key
 export const XSI_NIL_TRUE = { [`${XML_ATTRIBUTE_PREFIX}xsi:nil="true"`]: true }
 
 const isServiceMDTRecordFieldValue = (

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -115,7 +115,7 @@ export type ServiceMDTRecordValue = MetadataValues & {
   values: ServiceMDTRecordFieldValue | ServiceMDTRecordFieldValue[]
 }
 
-// Special handling since the XML parser implementation will omit the value "true" for attributes
+// Special handling since the fast-xml-parser implementation will omit the value "true" for attributes
 // As a workaround, we pass it as part of the key
 export const XSI_NIL_TRUE = { [`${XML_ATTRIBUTE_PREFIX}xsi:nil="true"`]: true }
 

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -559,7 +559,8 @@ const cloneValuesWithAttributePrefixes = async (
     if (pathID && allAttributesPaths.has(pathID.getFullName())) {
       return XML_ATTRIBUTE_PREFIX + key
     }
-    // Special handling since the XML parser implementation will omit "true" or true values
+    // Special handling since the XML parser implementation will omit the value "true" for attributes
+    // As a workaround, we pass it as part of the key
     if (pathID && trueValueAttributePaths.has(pathID.getFullName())) {
       return `${XML_ATTRIBUTE_PREFIX}${key}="true"`
     }

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -533,7 +533,6 @@ const cloneValuesWithAttributePrefixes = async (
   instance: InstanceElement,
 ): Promise<Values> => {
   const allAttributesPaths = new Set<string>()
-  // Special handling since the XML transformer will omit these values
   const trueValueAttributePaths: Set<string> = new Set<string>()
   const createPathsSetCallback: TransformFunc = ({ value, field, path }) => {
     if (path && field && field.annotations[IS_ATTRIBUTE]) {
@@ -560,6 +559,7 @@ const cloneValuesWithAttributePrefixes = async (
     if (pathID && allAttributesPaths.has(pathID.getFullName())) {
       return XML_ATTRIBUTE_PREFIX + key
     }
+    // Special handling since the XML parser implementation will omit "true" or true values
     if (pathID && trueValueAttributePaths.has(pathID.getFullName())) {
       return `${XML_ATTRIBUTE_PREFIX}${key}="true"`
     }

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -533,9 +533,15 @@ const cloneValuesWithAttributePrefixes = async (
   instance: InstanceElement,
 ): Promise<Values> => {
   const allAttributesPaths = new Set<string>()
+  // Special handling since the XML transformer will omit these values
+  const trueValueAttributePaths: Set<string> = new Set<string>()
   const createPathsSetCallback: TransformFunc = ({ value, field, path }) => {
     if (path && field && field.annotations[IS_ATTRIBUTE]) {
-      allAttributesPaths.add(path.getFullName())
+      if (value === true || value === 'true') {
+        trueValueAttributePaths.add(path.getFullName())
+      } else {
+        allAttributesPaths.add(path.getFullName())
+      }
     }
     return value
   }
@@ -554,9 +560,11 @@ const cloneValuesWithAttributePrefixes = async (
     if (pathID && allAttributesPaths.has(pathID.getFullName())) {
       return XML_ATTRIBUTE_PREFIX + key
     }
+    if (pathID && trueValueAttributePaths.has(pathID.getFullName())) {
+      return `${XML_ATTRIBUTE_PREFIX}${key}="true"`
+    }
     return key
   }
-
   return mapKeysRecursive(
     instance.value,
     addAttributePrefixFunc,

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -559,7 +559,7 @@ const cloneValuesWithAttributePrefixes = async (
     if (pathID && allAttributesPaths.has(pathID.getFullName())) {
       return XML_ATTRIBUTE_PREFIX + key
     }
-    // Special handling since the XML parser implementation will omit the value "true" for attributes
+    // Special handling since the fast-xml-parser implementation will omit the value "true" for attributes
     // As a workaround, we pass it as part of the key
     if (pathID && trueValueAttributePaths.has(pathID.getFullName())) {
       return `${XML_ATTRIBUTE_PREFIX}${key}="true"`

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -815,6 +815,16 @@ export const mockDefaultValues = {
               object: 'Contact',
             },
           ],
+          property: [
+            {
+              name: 'testTrueProp',
+              default: 'true',
+            },
+            {
+              name: 'testFalseProp',
+              default: 'false',
+            },
+          ],
           targets: 'lightning__RecordPage',
         },
         {

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -815,16 +815,6 @@ export const mockDefaultValues = {
               object: 'Contact',
             },
           ],
-          property: [
-            {
-              name: 'testTrueProp',
-              default: 'true',
-            },
-            {
-              name: 'testFalseProp',
-              default: 'false',
-            },
-          ],
           targets: 'lightning__RecordPage',
         },
         {

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -307,6 +307,8 @@ describe('XML Transformer', () => {
             <objects>
                 <object>Contact</object>
             </objects>
+            <property name="testTrueProp" default="true"></property>
+            <property name="testFalseProp" default="false"></property>
         </targetConfig>
         <targetConfig targets="lightning__AppPage,lightning__HomePage">
             <supportedFormFactors>

--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -281,9 +281,26 @@ describe('XML Transformer', () => {
       })
       describe('LightningComponentBundle', () => {
         beforeEach(async () => {
+          const mockLightningComponentBundleValues = _.clone(
+            mockDefaultValues.LightningComponentBundle,
+          )
+          _.set(
+            mockLightningComponentBundleValues.targetConfigs.targetConfig[0],
+            'property',
+            [
+              {
+                name: 'testTrueProp',
+                default: 'true',
+              },
+              {
+                name: 'testFalseProp',
+                default: 'false',
+              },
+            ],
+          )
           await pkg.add(
             createInstanceElement(
-              mockDefaultValues.LightningComponentBundle,
+              mockLightningComponentBundleValues,
               mockTypes.LightningComponentBundle,
             ),
           )


### PR DESCRIPTION
Salesforce LWC deploy XML parsing bug-fix

---

There's a bug when a property has the attribute `default` with the value true. This is demonstrated in the UTs and pretty straightforward.

---
_Release Notes_: 
Salesfore Adapter:
- Fixed a bug where deploy of LightningWebComponent failed on `Attribute name "default" associated with an element type "property" must be followed by the ' = ' character.`

---
_User Notifications_: 
_None_
