### PR TITLE
SALTO-6288: Fix bug in deployment of MultifactorEnrollment Policy order instance

### DIFF
--- a/packages/okta-adapter/src/filters/policy_priority.ts
+++ b/packages/okta-adapter/src/filters/policy_priority.ts
@@ -192,9 +192,10 @@ const deployPriorityChange = async ({
   const { type } = instance.value
   const ruleTypeName = instance.elemID.typeName
   const baseData = { priority: setPriority(ruleTypeName, priority), type, name: instance.value.name }
-  // For sign on rules, we need to include the actions in the data
-  const data =
-    instance.elemID.typeName === SIGN_ON_RULE_TYPE_NAME ? { ...baseData, actions: instance.value.actions } : baseData
+  // SignOn and MultiFactorEnrollment rules must include the `actions` field in the payload
+  const data = [SIGN_ON_RULE_TYPE_NAME, MFA_RULE_TYPE_NAME].includes(instance.elemID.typeName)
+    ? { ...baseData, actions: instance.value.actions }
+    : baseData
   const typeDefinition = apiDefinitions.types[instance.elemID.typeName]
   const deployRequest = typeDefinition.deployRequests ? typeDefinition.deployRequests.modify : undefined
   const deployUrl = deployRequest?.url

--- a/packages/okta-adapter/test/filters/policy_priority.test.ts
+++ b/packages/okta-adapter/test/filters/policy_priority.test.ts
@@ -35,7 +35,7 @@ import policyPrioritiesFilter, {
   ALL_SUPPORTED_POLICY_NAMES,
   POLICY_RULE_TYPES_WITH_PRIORITY_INSTANCE,
 } from '../../src/filters/policy_priority'
-import { OKTA, SIGN_ON_RULE_TYPE_NAME } from '../../src/constants'
+import { MFA_RULE_TYPE_NAME, OKTA, SIGN_ON_RULE_TYPE_NAME } from '../../src/constants'
 import { createDefinitions, getFilterParams, mockClient } from '../utils'
 import OktaClient from '../../src/client/client'
 import { OldOktaDefinitionsConfig } from '../../src/config'
@@ -389,7 +389,7 @@ describe('policyPrioritiesFilter', () => {
         expect(res.deployResult.errors).toHaveLength(0)
         expect(res.deployResult.appliedChanges).toHaveLength(1)
         expect(connection.put).toHaveBeenCalledTimes(3)
-        if (policyRuleName === SIGN_ON_RULE_TYPE_NAME) {
+        if (policyRuleName === SIGN_ON_RULE_TYPE_NAME || policyRuleName === MFA_RULE_TYPE_NAME) {
           expect(connection.put).toHaveBeenCalledWith(
             '/api/v1/policies/4/rules/1',
             {


### PR DESCRIPTION
bug fix

---

_Additional context for reviewer_
After creating policy with its rules, we create api calls to update the rules order according to the user's request.
To update the priority field we must update the policy rule, and the bug was due to the fact we didn't send the `actions` field for this policy (which is mandatory in the request) 

---
_Release Notes_: 

_Okta_adapter_:
- Bug fix for deployment of priority of `MultifactorEnrollmentPolicyRule` 

---
_User Notifications_: 
None
