### PR TITLE
SLATO-6295: Simplify Salesforce Client listMetadataObjects caching

### DIFF
--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -1504,26 +1504,30 @@ describe('salesforce client', () => {
     })
 
     it('should only request non cached queries', async () => {
-      const firstReplyResult = [
+      const customObjectResult = [
         mockFileProperties({ type: 'CustomObject', fullName: 'Account' }),
         mockFileProperties({ type: 'CustomObject', fullName: 'Case' }),
+      ]
+      const customFieldResult = [
         mockFileProperties({
           type: 'CustomField',
           fullName: 'Account.Field__c',
         }),
         mockFileProperties({ type: 'CustomField', fullName: 'Case.Field__c' }),
       ]
-      const secondReplyResult = [
-        mockFileProperties({ type: 'Role', fullName: 'CEO' }),
-      ]
+      const roleResult = [mockFileProperties({ type: 'Role', fullName: 'CEO' })]
       const dodoScope = nock('http://dodo22')
         .post(/.*/, /.*<listMetadata>.*/)
         .reply(200, {
-          'a:Envelope': { 'a:Body': { a: { result: firstReplyResult } } },
+          'a:Envelope': { 'a:Body': { a: { result: customObjectResult } } },
         })
         .post(/.*/, /.*<listMetadata>.*/)
         .reply(200, {
-          'a:Envelope': { 'a:Body': { a: { result: secondReplyResult } } },
+          'a:Envelope': { 'a:Body': { a: { result: customFieldResult } } },
+        })
+        .post(/.*/, /.*<listMetadata>.*/)
+        .reply(200, {
+          'a:Envelope': { 'a:Body': { a: { result: roleResult } } },
         })
       const firstInput = [{ type: 'CustomObject' }, { type: 'CustomField' }]
       const secondInput = [...firstInput, { type: 'Role' }]
@@ -1531,8 +1535,15 @@ describe('salesforce client', () => {
         await client.listMetadataObjects(firstInput)
       const { result: secondResult } =
         await client.listMetadataObjects(secondInput)
-      expect(firstResult).toEqual(firstReplyResult)
-      expect(secondResult).toEqual(firstReplyResult.concat(secondReplyResult))
+      expect(firstResult).toIncludeSameMembers([
+        ...customObjectResult,
+        ...customFieldResult,
+      ])
+      expect(secondResult).toIncludeSameMembers([
+        ...customObjectResult,
+        ...customFieldResult,
+        ...roleResult,
+      ])
       expect(dodoScope.isDone()).toBeTrue()
     })
   })


### PR DESCRIPTION
Simplify Salesforce Client listMetadataObjects caching

---

Required step to tackle throttling issues in Change Based Fetch where we execute the same listMetadataObjects request three times on Profiles related metadata types. 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
