### PR TITLE
SALTO-6293: [MS Entra] Convert http error messages to include the message from the response

### DIFF
--- a/packages/microsoft-entra-adapter/src/adapter_creator.ts
+++ b/packages/microsoft-entra-adapter/src/adapter_creator.ts
@@ -30,6 +30,7 @@ import {
   oauthRequestParameters,
 } from './client/oauth'
 import { deployAdministrativeUnitMembersFilter, deployDirectoryRoleMembersFilter } from './filters'
+import { customConvertError } from './error_utils'
 
 const { defaultCredentialsFromConfig } = credentials
 
@@ -64,6 +65,7 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
       ...filters.createCommonFilters<Options, UserConfig>(args),
     }),
   },
+  customConvertError,
   initialClients: {
     main: undefined,
   },

--- a/packages/microsoft-entra-adapter/src/error_utils.ts
+++ b/packages/microsoft-entra-adapter/src/error_utils.ts
@@ -1,0 +1,35 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import { isSaltoElementError, isSaltoError } from '@salto-io/adapter-api'
+import { deployment, client } from '@salto-io/adapter-components'
+
+const getErrorMessage = (err: Error): string => {
+  if (err instanceof client.HTTPError) {
+    const responseMessage = _.get(err.response, 'data.error.message')
+    return `${err.message}${responseMessage ? `: ${responseMessage}` : ''}`
+  }
+  return err.message
+}
+
+export const customConvertError: deployment.ConvertError = (elemID, error) => {
+  if (isSaltoError(error) && isSaltoElementError(error)) {
+    return error
+  }
+
+  return { elemID, message: getErrorMessage(error), severity: 'Error' }
+}

--- a/packages/microsoft-entra-adapter/src/filters/array_fields_deployment.ts
+++ b/packages/microsoft-entra-adapter/src/filters/array_fields_deployment.ts
@@ -34,7 +34,6 @@ import {
 import {
   deployment,
   definitions as definitionsUtils,
-  filters,
   filterUtils,
   references,
   ChangeElementResolver,
@@ -50,8 +49,8 @@ import {
   applyFunctionToChangeData,
 } from '@salto-io/adapter-utils'
 import { Options } from '../definitions/types'
-import { UserConfig } from '../config'
 import { ADAPTER_NAME } from '../constants'
+import { customConvertError } from '../error_utils'
 
 const log = logger(module)
 
@@ -262,11 +261,9 @@ const deployArrayField = async <Options extends definitionsUtils.APIDefinitionsO
  * The filter will deploy the top level change and then deploy the array field changes, which can be either additions or removals.
  */
 export const deployArrayFieldsFilterCreator =
-  ({
-    convertError = deployment.defaultConvertError,
-    ...arrayFieldDefinition
-  }: Pick<filters.FilterCreationArgs<Options, UserConfig>, 'convertError'> &
-    DeployArrayFieldFilterParams): filterUtils.AdapterFilterCreator<{}, filter.FilterResult, {}, Options> =>
+  (
+    arrayFieldDefinition: DeployArrayFieldFilterParams,
+  ): filterUtils.AdapterFilterCreator<{}, filter.FilterResult, {}, Options> =>
   ({ definitions, elementSource, sharedContext }) => ({
     name: 'deployArrayFieldsFilter',
     deploy: async (changes, changeGroup) => {
@@ -305,7 +302,7 @@ export const deployArrayFieldsFilterCreator =
         definitions: { deploy, ...otherDefs },
         changeGroup,
         elementSource,
-        convertError,
+        convertError: customConvertError,
         changeResolver: createChangeElementResolver<Change<InstanceElement>>({
           getLookUpName: references.generateLookupFunc(definitions.references?.rules ?? []),
         }),

--- a/packages/microsoft-entra-adapter/test/error_utils.test.ts
+++ b/packages/microsoft-entra-adapter/test/error_utils.test.ts
@@ -1,0 +1,66 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID } from '@salto-io/adapter-api'
+import { client } from '@salto-io/adapter-components'
+import { customConvertError } from '../src/error_utils'
+
+describe('customConvertError', () => {
+  const elemID = new ElemID('testElemID')
+
+  it('should return the error when it is SaltoElementError', () => {
+    const error = {
+      elemID: new ElemID('mock'),
+      message: 'mock',
+      name: 'mock',
+      severity: 'Error',
+      response: { data: { error: { message: 'response message' } } },
+    } as Error
+
+    const result = customConvertError(elemID, error)
+    expect(result).toEqual(error)
+  })
+
+  describe('Http error', () => {
+    it('should concat the message from the error response, when error is HTTPError', () => {
+      const error = new client.HTTPError('mock', {
+        data: { error: { message: 'response message' } },
+        status: 403,
+      })
+
+      const result = customConvertError(elemID, error)
+      expect(result).toEqual({
+        message: 'mock: response message',
+        severity: 'Error',
+        elemID,
+      })
+    })
+
+    it('should return error.message when error has no message in the response', () => {
+      const error = new client.HTTPError('mock', {
+        data: { error: { otherField: 'not a response message' } },
+        status: 403,
+      })
+
+      const result = customConvertError(elemID, error)
+      expect(result).toEqual({
+        message: 'mock',
+        severity: 'Error',
+        elemID,
+      })
+    })
+  })
+})

--- a/packages/microsoft-entra-adapter/test/filters/array_fields_deployment.test.ts
+++ b/packages/microsoft-entra-adapter/test/filters/array_fields_deployment.test.ts
@@ -342,7 +342,7 @@ describe('deploy array fields filter', () => {
     const res = await filter.deploy(changes, { changes, groupID: 'a' })
     expect(res.deployResult.appliedChanges).toHaveLength(0)
     expect(res.deployResult.errors).toHaveLength(1)
-    expect(res.deployResult.errors[0].message).toEqual('Error: Failed to modify the top level instance')
+    expect(res.deployResult.errors[0].message).toEqual('Failed to modify the top level instance')
     expect(res.deployResult.errors[0].severity).toEqual('Error')
     expect(client.post).not.toHaveBeenCalled()
     expect(client.delete).not.toHaveBeenCalled()


### PR DESCRIPTION
The error message returned in the response from Microsoft Graph when a request fails are informative (AFAICT ATM) and helpful in understanding the cause of the problem. We want the users to be able to read them as well and workaround small issues if such exist.

---
_Release Notes_: 
Microsoft Entra:
* Expand user-facing errors to include more informative messages when requests fail.

---
_User Notifications_: 
