### PR TITLE
README.md: Update docker build command instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ See [the vscode package documentation](packages/vscode/README.md#installation)
 ### Running using docker
 
 ```bash
-docker build --tag salto-cli
+docker build --tag salto-cli .
 docker run salto-cli
 ```
 


### PR DESCRIPTION
Add missing input path specifier to docker build command instruction
