### PR TITLE
SALTO-6296 fix passing custom params to client

### DIFF
--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -145,9 +145,10 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
         typeName,
       )
 
+    const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params'])
     const callArgs = mergedEndpointDef.omitBody
-      ? _.pick(mergedEndpointDef, ['queryArgs', 'headers'])
-      : _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body'])
+      ? _.omit(mergedEndpointDef, 'body')
+      : allCallArgs
 
     log.trace(
       'traversing pages for adapter %s client %s endpoint %s.%s',

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -146,9 +146,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
       )
 
     const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params'])
-    const callArgs = mergedEndpointDef.omitBody
-      ? _.omit(mergedEndpointDef, 'body')
-      : allCallArgs
+    const callArgs = mergedEndpointDef.omitBody ? _.omit(mergedEndpointDef, 'body') : allCallArgs
 
     log.trace(
       'traversing pages for adapter %s client %s endpoint %s.%s',


### PR DESCRIPTION
fix to allow defining custom `params` in client calls
(still missing UTs)

---
_Release Notes_: 
None

---
_User Notifications_: 
None