### PR TITLE
SALTO-6255: Adding versioning for changed at singleton

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -138,6 +138,7 @@ import {
   addDefaults,
   apiNameSync,
   buildDataRecordsSoqlQueries,
+  changedAtOutdated,
   getFLSProfiles,
   getFullName,
   instanceInternalId,
@@ -574,7 +575,7 @@ export default class SalesforceAdapter implements AdapterOperations {
   @logDuration('fetching account configuration')
   async fetch({
     progressReporter,
-    withChangesDetection = false,
+    withChangesDetection: changesDetectionRequested = false,
   }: FetchOptions): Promise<FetchResult> {
     const fetchParams = this.userConfig.fetch ?? {}
     const baseQuery = buildMetadataQuery({ fetchParams })
@@ -583,6 +584,9 @@ export default class SalesforceAdapter implements AdapterOperations {
         client: this.client,
         metadataQuery: buildFilePropsMetadataQuery(baseQuery),
       })
+    const withChangesDetection = (await changedAtOutdated(this.elementsSource))
+      ? false
+      : changesDetectionRequested
     const metadataQuery = withChangesDetection
       ? await buildMetadataQueryForFetchWithChangesDetection({
           fetchParams,

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -51,6 +51,7 @@ import taskOrEventFieldsModifications from './change_validators/task_or_event_fi
 import newFieldsAndObjectsFLS from './change_validators/new_fields_and_objects_fls'
 import metadataTypes from './change_validators/metadata_types'
 import elementApiVersionValidator from './change_validators/element_api_version'
+import changedAtVersion from './change_validators/changed_at_version'
 import cpqBillingStartDate from './change_validators/cpq_billing_start_date'
 import cpqBillingTriggers from './change_validators/cpq_billing_triggers'
 import SalesforceClient from './client/client'
@@ -112,6 +113,7 @@ export const changeValidators: Record<
   taskOrEventFieldsModifications: () => taskOrEventFieldsModifications,
   newFieldsAndObjectsFLS: (config) => newFieldsAndObjectsFLS(config),
   elementApiVersion: () => elementApiVersionValidator,
+  changedAtVersion: () => changedAtVersion,
   cpqBillingStartDate: () => cpqBillingStartDate,
   cpqBillingTriggers: () => cpqBillingTriggers,
   ..._.mapValues(getDefaultChangeValidators(), (validator) => () => validator),

--- a/packages/salesforce-adapter/src/change_validators/changed_at_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/changed_at_version.ts
@@ -1,0 +1,46 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { logger } from '@salto-io/logging'
+import { ChangeValidator, ElemID } from '@salto-io/adapter-api'
+import { changedAtOutdated } from '../filters/utils'
+import { SALESFORCE } from '../constants'
+
+const log = logger(module)
+
+const changeValidator: ChangeValidator = async (_changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    log.error('Change validator did not receive an element source.')
+    return []
+  }
+
+  if (await changedAtOutdated(elementsSource)) {
+    return [
+      {
+        elemID: new ElemID(SALESFORCE),
+        severity: 'Error',
+        message:
+          'There have been major changes to the adapter, please fetch before deploying',
+        detailedMessage:
+          'There have been major changes to the Salesforce adapter since the last time data was fetched for the environment. This may create problems with the deployment. Please fetch the environment and refresh the deployment before deploying.',
+      },
+    ]
+  }
+
+  return []
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/changed_at_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/changed_at_version.ts
@@ -16,7 +16,7 @@
 
 import { logger } from '@salto-io/logging'
 import { ChangeValidator, ElemID } from '@salto-io/adapter-api'
-import { changedAtOutdated } from '../filters/utils'
+import { isChangedAtSingletonOutdated } from '../filters/utils'
 import { SALESFORCE } from '../constants'
 
 const log = logger(module)
@@ -27,7 +27,7 @@ const changeValidator: ChangeValidator = async (_changes, elementsSource) => {
     return []
   }
 
-  if (await changedAtOutdated(elementsSource)) {
+  if (await isChangedAtSingletonOutdated(elementsSource)) {
     return [
       {
         elemID: new ElemID(SALESFORCE),

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -18,6 +18,7 @@ import { types } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import {
   ActionName,
+  BuiltinTypes,
   CORE_ANNOTATIONS,
   ElemID,
   ObjectType,
@@ -428,6 +429,8 @@ export const EXTERNAL_DATA_SOURCE_METADATA_TYPE = 'ExternalDataSource'
 export const CURRENCY_CODE_TYPE_NAME = 'CurrencyIsoCodes'
 export const CHANGED_AT_SINGLETON = 'ChangedAtSingleton'
 
+export const CHANGED_AT_SINGLETON_VERSION_FIELD = 'version'
+export const CHANGED_AT_VERSION = 0
 export const ArtificialTypes = {
   [CHANGED_AT_SINGLETON]: new ObjectType({
     elemID: new ElemID(SALESFORCE, CHANGED_AT_SINGLETON),
@@ -435,6 +438,9 @@ export const ArtificialTypes = {
     annotations: {
       [CORE_ANNOTATIONS.HIDDEN]: true,
       [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+    },
+    fields: {
+      [CHANGED_AT_SINGLETON_VERSION_FIELD]: { refType: BuiltinTypes.NUMBER },
     },
   }),
 } as const

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -22,7 +22,12 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { LocalFilterCreator } from '../filter'
-import { ArtificialTypes, DATA_INSTANCES_CHANGED_AT_MAGIC } from '../constants'
+import {
+  ArtificialTypes,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
+  DATA_INSTANCES_CHANGED_AT_MAGIC,
+} from '../constants'
 import {
   apiNameSync,
   getChangedAtSingletonInstance,
@@ -39,7 +44,9 @@ const createCurrentChangedAtSingletonValues = (
     | {},
   metadataInstancesByType: Record<string, MetadataInstanceElement[]>,
 ): Values => {
-  const instanceValues: Values = {}
+  const instanceValues: Values = {
+    [CHANGED_AT_SINGLETON_VERSION_FIELD]: CHANGED_AT_VERSION,
+  }
   Object.entries(metadataInstancesByType).forEach(
     ([metadataType, elements]) => {
       instanceValues[metadataType] = {}
@@ -57,7 +64,13 @@ const createCurrentChangedAtSingletonValues = (
 
 const createEmptyChangedAtSingletonInstance =
   async (): Promise<InstanceElement> =>
-    new InstanceElement(ElemID.CONFIG_NAME, ArtificialTypes.ChangedAtSingleton)
+    new InstanceElement(
+      ElemID.CONFIG_NAME,
+      ArtificialTypes.ChangedAtSingleton,
+      {
+        [CHANGED_AT_SINGLETON_VERSION_FIELD]: CHANGED_AT_VERSION,
+      },
+    )
 
 const dateStringOfMostRecentlyChangedInstance = (
   instances: InstanceElement[],

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -878,7 +878,7 @@ export const getChangedAtSingletonInstance = async (
   return isInstanceElement(element) ? element : undefined
 }
 
-export const changedAtOutdated = async (
+export const isChangedAtSingletonOutdated = async (
   elementsSource: ReadOnlyElementsSource,
 ): Promise<boolean> => {
   const changedAtSingleton = await getChangedAtSingletonInstance(elementsSource)

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -104,6 +104,8 @@ import {
   DEFAULT_VALUE_FORMULA,
   FORMULA,
   FIELD_DEPENDENCY_FIELDS,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
 } from '../constants'
 import {
   CustomField,
@@ -874,6 +876,16 @@ export const getChangedAtSingletonInstance = async (
     ),
   )
   return isInstanceElement(element) ? element : undefined
+}
+
+export const changedAtOutdated = async (
+  elementsSource: ReadOnlyElementsSource,
+): Promise<boolean> => {
+  const changedAtSingleton = await getChangedAtSingletonInstance(elementsSource)
+  return (
+    (changedAtSingleton?.value[CHANGED_AT_SINGLETON_VERSION_FIELD] ?? 0) !==
+    CHANGED_AT_VERSION
+  )
 }
 
 export const isCustomType = (element: Element): element is ObjectType =>

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -170,6 +170,7 @@ export type ChangeValidatorName =
   | 'taskOrEventFieldsModifications'
   | 'newFieldsAndObjectsFLS'
   | 'elementApiVersion'
+  | 'changedAtVersion'
   | 'cpqBillingStartDate'
   | 'cpqBillingTriggers'
 
@@ -914,6 +915,7 @@ const changeValidatorConfigType =
       taskOrEventFieldsModifications: { refType: BuiltinTypes.BOOLEAN },
       newFieldsAndObjectsFLS: { refType: BuiltinTypes.BOOLEAN },
       elementApiVersion: { refType: BuiltinTypes.BOOLEAN },
+      changedAtVersion: { refType: BuiltinTypes.BOOLEAN },
       cpqBillingStartDate: { refType: BuiltinTypes.BOOLEAN },
       cpqBillingTriggers: { refType: BuiltinTypes.BOOLEAN },
     },

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -501,6 +501,8 @@ describe('SalesforceAdapter fetch', () => {
             [APEX_CLASS_FULL_NAME]: DATE,
             [ANOTHER_APEX_CLASS_FULL_NAME]: DATE,
           },
+          [constants.CHANGED_AT_SINGLETON_VERSION_FIELD]:
+            constants.CHANGED_AT_VERSION,
         }
         const elementsSource = buildElementsSourceFromElements([
           mockTypes.ApexClass,
@@ -606,8 +608,11 @@ describe('SalesforceAdapter fetch', () => {
       let testConnection: MockInterface<Connection>
       describe('Targeted fetch', () => {
         beforeEach(() => {
+          changedAtSingleton.value[
+            constants.CHANGED_AT_SINGLETON_VERSION_FIELD
+          ] = constants.CHANGED_AT_VERSION
           const existingElements = [
-            mockInstances().ChangedAtSingleton,
+            changedAtSingleton,
             mockTypes.Layout,
             mockTypes.ApexClass,
             mockTypes.CustomObject,
@@ -718,12 +723,15 @@ describe('SalesforceAdapter fetch', () => {
           },
         }
         describe('When a record was deleted', () => {
-          const existingInstanceThatDoesntExistInSalesforce =
+          const existingInstanceThatDoesNotExistInSalesforce =
             new InstanceElement('DeletedInstance', testType, {
               [constants.CUSTOM_OBJECT_ID_FIELD]: 'deletedId',
             })
           beforeEach(async () => {
             changedAtSingleton = mockInstances()[CHANGED_AT_SINGLETON]
+            changedAtSingleton.value[
+              constants.CHANGED_AT_SINGLETON_VERSION_FIELD
+            ] = constants.CHANGED_AT_VERSION
             _.set(
               changedAtSingleton.value,
               [DATA_INSTANCES_CHANGED_AT_MAGIC, testTypeName],
@@ -731,7 +739,7 @@ describe('SalesforceAdapter fetch', () => {
             )
             const elements = [
               testType,
-              existingInstanceThatDoesntExistInSalesforce,
+              existingInstanceThatDoesNotExistInSalesforce,
               changedAtSingleton,
             ]
             const elementsSource = buildElementsSourceFromElements(elements)
@@ -754,7 +762,9 @@ describe('SalesforceAdapter fetch', () => {
           it('Should return the elemID of the deleted record', () => {
             expect(
               fetchResult.partialFetchData?.deletedElements,
-            ).toContainEqual(existingInstanceThatDoesntExistInSalesforce.elemID)
+            ).toContainEqual(
+              existingInstanceThatDoesNotExistInSalesforce.elemID,
+            )
           })
         })
         describe('When a record was modified', () => {
@@ -762,6 +772,9 @@ describe('SalesforceAdapter fetch', () => {
             [constants.CUSTOM_OBJECT_ID_FIELD]: 'SomeId',
           })
           beforeEach(async () => {
+            changedAtSingleton.value[
+              constants.CHANGED_AT_SINGLETON_VERSION_FIELD
+            ] = constants.CHANGED_AT_VERSION
             const elements = [testType, testInstance, changedAtSingleton]
             const elementsSource = buildElementsSourceFromElements(elements)
             ;({ connection: testConnection, adapter: testAdapter } =

--- a/packages/salesforce-adapter/test/change_validators/changed_at_version.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/changed_at_version.test.ts
@@ -16,27 +16,22 @@
 
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { ElemID, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { createInstanceElement } from '../../src/transformers/transformer'
 import changeValidator from '../../src/change_validators/changed_at_version'
 import {
-  ArtificialTypes,
   CHANGED_AT_SINGLETON,
   CHANGED_AT_SINGLETON_VERSION_FIELD,
   CHANGED_AT_VERSION,
   SALESFORCE,
 } from '../../src/constants'
+import { mockInstances } from '../mock_elements'
 
 describe('Changed at version validator', () => {
   const mockElementsSource = (
     changedAtVersion: number,
   ): ReadOnlyElementsSource => {
-    const changedAtSingleton = createInstanceElement(
-      {
-        fullName: 'whatever',
-        [CHANGED_AT_SINGLETON_VERSION_FIELD]: changedAtVersion,
-      },
-      ArtificialTypes[CHANGED_AT_SINGLETON],
-    )
+    const changedAtSingleton = mockInstances()[CHANGED_AT_SINGLETON]
+    changedAtSingleton.value[CHANGED_AT_SINGLETON_VERSION_FIELD] =
+      changedAtVersion
     return buildElementsSourceFromElements([changedAtSingleton])
   }
 

--- a/packages/salesforce-adapter/test/change_validators/changed_at_version.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/changed_at_version.test.ts
@@ -1,0 +1,80 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ElemID, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import changeValidator from '../../src/change_validators/changed_at_version'
+import {
+  ArtificialTypes,
+  CHANGED_AT_SINGLETON,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
+  SALESFORCE,
+} from '../../src/constants'
+
+describe('Changed at version validator', () => {
+  const mockElementsSource = (
+    changedAtVersion: number,
+  ): ReadOnlyElementsSource => {
+    const changedAtSingleton = createInstanceElement(
+      {
+        fullName: 'whatever',
+        [CHANGED_AT_SINGLETON_VERSION_FIELD]: changedAtVersion,
+      },
+      ArtificialTypes[CHANGED_AT_SINGLETON],
+    )
+    return buildElementsSourceFromElements([changedAtSingleton])
+  }
+
+  describe('when the changed at version is up to date', () => {
+    const elementsSource = mockElementsSource(CHANGED_AT_VERSION)
+
+    it('should pass validation', async () => {
+      const errors = await changeValidator([], elementsSource)
+      expect(errors).toBeEmpty()
+    })
+  })
+
+  describe('when the changed at version is outdated', () => {
+    const elementsSource = mockElementsSource(CHANGED_AT_VERSION - 1)
+
+    it('should fail validation', async () => {
+      const errors = await changeValidator([], elementsSource)
+      expect(errors).toEqual([
+        {
+          elemID: new ElemID(SALESFORCE),
+          severity: 'Error',
+          message:
+            'There have been major changes to the adapter, please fetch before deploying',
+          detailedMessage:
+            'There have been major changes to the Salesforce adapter since the last time data was fetched for the environment. This may create problems with the deployment. Please fetch the environment and refresh the deployment before deploying.',
+        },
+      ])
+    })
+  })
+
+  describe('when the changed at singleton is missing', () => {
+    const elementsSource = buildElementsSourceFromElements([])
+
+    it('should pass validation', async () => {
+      const errors = await changeValidator([], elementsSource)
+      // This is only the case so long as CHANGED_AT_VERSION is 0.
+      // Once we bump we should expect this to fail.
+      expect(errors).toBeEmpty()
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/fetch_with_changes_detection.test.ts
+++ b/packages/salesforce-adapter/test/fetch_with_changes_detection.test.ts
@@ -26,6 +26,8 @@ import { CUSTOM_OBJECT_FIELDS } from '../src/fetch_profile/metadata_types'
 import {
   API_NAME,
   CHANGED_AT_SINGLETON,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
   CUSTOM_FIELD,
   CUSTOM_OBJECT,
   FIELD_ANNOTATIONS,
@@ -233,6 +235,8 @@ describe('Salesforce Fetch With Changes Detection', () => {
         [NON_UPDATED_OBJECT_NAME]: '2023-11-02T00:00:00.000Z',
         [OBJECT_WITH_DELETED_FIELD_NAME]: '2023-11-02T00:00:00.000Z',
       }
+      changedAtSingleton.value[CHANGED_AT_SINGLETON_VERSION_FIELD] =
+        CHANGED_AT_VERSION
     })
     it('should fetch only the updated CustomObject instances', async () => {
       await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })

--- a/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
+++ b/packages/salesforce-adapter/test/filters/changed_at_singleton.test.ts
@@ -30,6 +30,8 @@ import {
   CUSTOM_OBJECT,
   FLOW_METADATA_TYPE,
   DATA_INSTANCES_CHANGED_AT_MAGIC,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
 } from '../../src/constants'
 import { apiName } from '../../src/transformers/transformer'
 import {
@@ -87,7 +89,9 @@ describe('createChangedAtSingletonInstanceFilter', () => {
             elementsSource: buildElementsSourceFromElements([
               changedAtSingleton,
             ]),
-            lastChangeDateOfTypesWithNestedInstances,
+            lastChangeDateOfTypesWithNestedInstances: _.clone(
+              lastChangeDateOfTypesWithNestedInstances,
+            ),
           },
         }) as FilterWith<'onFetch'>
         fetchedElements = [updatedInstance]
@@ -109,6 +113,7 @@ describe('createChangedAtSingletonInstanceFilter', () => {
           [updatedInstanceTypeName, updatedInstanceName],
           CHANGED_AT,
         )
+        expectedValues[CHANGED_AT_SINGLETON_VERSION_FIELD] = CHANGED_AT_VERSION
         expect(changedAtSingleton.value).toEqual({
           ...lastChangeDateOfTypesWithNestedInstances,
           ...expectedValues,
@@ -149,7 +154,9 @@ describe('createChangedAtSingletonInstanceFilter', () => {
         const filter = filterCreator({
           config: {
             ...defaultFilterContext,
-            lastChangeDateOfTypesWithNestedInstances,
+            lastChangeDateOfTypesWithNestedInstances: _.clone(
+              lastChangeDateOfTypesWithNestedInstances,
+            ),
           },
         }) as FilterWith<'onFetch'>
         fetchedElements = [metadataInstance, customObject, dataInstance]
@@ -168,6 +175,7 @@ describe('createChangedAtSingletonInstanceFilter', () => {
           [DATA_INSTANCES_CHANGED_AT_MAGIC]: {
             SBQQ__Template__c: CHANGED_AT,
           },
+          [CHANGED_AT_SINGLETON_VERSION_FIELD]: CHANGED_AT_VERSION,
         })
       })
     })

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -63,9 +63,12 @@ import {
   toCustomField,
   toCustomProperties,
   isCustomMetadataRecordTypeSync,
+  changedAtOutdated,
 } from '../../src/filters/utils'
 import {
   API_NAME,
+  CHANGED_AT_SINGLETON_VERSION_FIELD,
+  CHANGED_AT_VERSION,
   COMPOUND_FIELD_TYPE_NAMES,
   CUSTOM_OBJECT,
   CUSTOM_SETTINGS_TYPE,
@@ -510,6 +513,46 @@ describe('filter utils', () => {
         expect(
           await getChangedAtSingletonInstance(elementsSource),
         ).toBeUndefined()
+      })
+    })
+  })
+  describe('changedAtOutdated', () => {
+    let elementsSource: ReadOnlyElementsSource
+
+    describe('when the changed at version is up to date', () => {
+      let changedAtSingleton: InstanceElement
+      beforeEach(() => {
+        changedAtSingleton = mockInstances().ChangedAtSingleton
+        changedAtSingleton.value[CHANGED_AT_SINGLETON_VERSION_FIELD] =
+          CHANGED_AT_VERSION
+        elementsSource = buildElementsSourceFromElements([changedAtSingleton])
+      })
+      it('should return false', async () => {
+        expect(await changedAtOutdated(elementsSource)).toBeFalse()
+      })
+    })
+
+    describe('when the changed at version is outdated', () => {
+      let changedAtSingleton: InstanceElement
+      beforeEach(() => {
+        changedAtSingleton = mockInstances().ChangedAtSingleton
+        changedAtSingleton.value[CHANGED_AT_SINGLETON_VERSION_FIELD] =
+          CHANGED_AT_VERSION - 1
+        elementsSource = buildElementsSourceFromElements([changedAtSingleton])
+      })
+      it('should return true', async () => {
+        expect(await changedAtOutdated(elementsSource)).toBeTrue()
+      })
+    })
+
+    describe('when the ChangedAtSingleton instance does not exist in the elementsSource', () => {
+      beforeEach(() => {
+        elementsSource = buildElementsSourceFromElements([])
+      })
+      it('should return false', async () => {
+        // This is only the case so long as CHANGED_AT_VERSION is 0.
+        // Once we bump we should expect this to fail.
+        expect(await changedAtOutdated(elementsSource)).toBeFalse()
       })
     })
   })

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -63,7 +63,7 @@ import {
   toCustomField,
   toCustomProperties,
   isCustomMetadataRecordTypeSync,
-  changedAtOutdated,
+  isChangedAtSingletonOutdated,
 } from '../../src/filters/utils'
 import {
   API_NAME,
@@ -516,7 +516,7 @@ describe('filter utils', () => {
       })
     })
   })
-  describe('changedAtOutdated', () => {
+  describe('isChangedAtSingletonOutdated', () => {
     let elementsSource: ReadOnlyElementsSource
 
     describe('when the changed at version is up to date', () => {
@@ -528,7 +528,7 @@ describe('filter utils', () => {
         elementsSource = buildElementsSourceFromElements([changedAtSingleton])
       })
       it('should return false', async () => {
-        expect(await changedAtOutdated(elementsSource)).toBeFalse()
+        expect(await isChangedAtSingletonOutdated(elementsSource)).toBeFalse()
       })
     })
 
@@ -541,7 +541,21 @@ describe('filter utils', () => {
         elementsSource = buildElementsSourceFromElements([changedAtSingleton])
       })
       it('should return true', async () => {
-        expect(await changedAtOutdated(elementsSource)).toBeTrue()
+        expect(await isChangedAtSingletonOutdated(elementsSource)).toBeTrue()
+      })
+    })
+
+    describe('when the changed at version is missing', () => {
+      let changedAtSingleton: InstanceElement
+      beforeEach(() => {
+        changedAtSingleton = mockInstances().ChangedAtSingleton
+        changedAtSingleton.value[CHANGED_AT_SINGLETON_VERSION_FIELD] = undefined
+        elementsSource = buildElementsSourceFromElements([changedAtSingleton])
+      })
+      it('should return false', async () => {
+        // This is only the case so long as CHANGED_AT_VERSION is 0.
+        // Once we bump we should expect this to fail.
+        expect(await isChangedAtSingletonOutdated(elementsSource)).toBeFalse()
       })
     })
 
@@ -552,7 +566,7 @@ describe('filter utils', () => {
       it('should return false', async () => {
         // This is only the case so long as CHANGED_AT_VERSION is 0.
         // Once we bump we should expect this to fail.
-        expect(await changedAtOutdated(elementsSource)).toBeFalse()
+        expect(await isChangedAtSingletonOutdated(elementsSource)).toBeFalse()
       })
     })
   })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -959,6 +959,10 @@ export const mockInstances = () => ({
   [CHANGED_AT_SINGLETON]: new InstanceElement(
     ElemID.CONFIG_NAME,
     ArtificialTypes.ChangedAtSingleton,
+    {
+      // Using a version that is never valid to verify it gets overridden
+      [constants.CHANGED_AT_SINGLETON_VERSION_FIELD]: -1,
+    },
   ),
 })
 


### PR DESCRIPTION
Now when we make major changes to workspaces (usually around PROD tickets) we can bump the version to force the first fetch to be a full fetch and to force users to fetch before deploying.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce_:
- The first fetch after a major change to the adapter will be a full change even when change detections is requested.
- Deployments after a major change to the adapter will require a fetch.

---
_User Notifications_: 
None.
