### PR TITLE
BUGFIX: cli parameters being misidentified as 'required'

### DIFF
--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -155,12 +155,12 @@ const getLoginConfig = async (
   return newConfig
 }
 
-const createConfigFromLoginParameters =
+export const createConfigFromLoginParameters =
   (loginParameters: string[]) =>
   async (credentialsType: ObjectType): Promise<InstanceElement> => {
     const configValues = Object.fromEntries(loginParameters.map(entryFromRawLoginParameter))
     const requiredFields = Object.entries(credentialsType.fields)
-      .filter(([_fieldName, field]) => field.annotations[CORE_ANNOTATIONS.REQUIRED] !== false)
+      .filter(([_fieldName, field]) => field.annotations[CORE_ANNOTATIONS.REQUIRED] === true)
       .map(([fieldName]) => fieldName)
     const missingLoginParameters = requiredFields.filter(key => _.isUndefined(configValues[key]))
     if (!_.isEmpty(missingLoginParameters)) {

--- a/packages/cli/test/commands/account.test.ts
+++ b/packages/cli/test/commands/account.test.ts
@@ -13,11 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import {
-  AdapterAuthentication,
-  ObjectType,
-  ElemID,
-} from '@salto-io/adapter-api'
+import { AdapterAuthentication, ObjectType, ElemID, BuiltinTypes } from '@salto-io/adapter-api'
 import {
   addAdapter,
   installAdapter,
@@ -378,6 +374,19 @@ describe('account command group', () => {
           })
         })
         describe('when called with invalid login parameters', () => {
+          it('should fail when called with missing parameter', async () => {
+            const exitCode = await addAction({
+              ...cliCommandArgs,
+              input: {
+                serviceType: 'newAdapter',
+                authType: 'basic',
+                login: true,
+                loginParameters: ['username=testUser', 'password=testPassword', 'token=testToken'],
+              },
+              workspace,
+            })
+            expect(exitCode).toEqual(CliExitCode.AppError)
+          })
           it('should fail when called with malformed parameter', async () => {
             const exitCode = await addAction({
               ...cliCommandArgs,
@@ -595,20 +604,21 @@ describe('account command group', () => {
 
   describe('createConfigFromLoginParameters() helper', () => {
     describe('when login parameters are marked required', () => {
-      const credentialsType = {
-        elemID: new ElemID('MockAdaptorName'),
+      const credentialsType = new ObjectType({
+        elemID: new ElemID('MockAdapterName'),
         fields: {
           username: {
-            annotations: {
-            }
+            refType: BuiltinTypes.STRING,
+            annotations: {},
           },
           token: {
+            refType: BuiltinTypes.STRING,
             annotations: {
-              _required: true
-            }
-          }
-        }
-      }
+              _required: true,
+            },
+          },
+        },
+      })
 
       it('should work when the required param is present', async () => {
         const loginParameters = ['token=token456']

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -432,7 +432,12 @@ export const mockCredentialsType = (adapterName: string): AdapterAuthentication 
             refType: BuiltinTypes.STRING,
             annotations: {},
           },
-          sandbox: { refType: BuiltinTypes.BOOLEAN },
+          sandbox: {
+            refType: BuiltinTypes.BOOLEAN,
+            annotations: {
+              _required: true,
+            },
+          },
         },
       }),
     },


### PR DESCRIPTION
Noticed this while working with the `zendesk-adaptor` after the recent changes to add `token` to the cli options (for zendesk api token usage).

# Discovery

Attempting to add the `zendesk` service to an environment worked okay when using the interactive mode

`node ~/salto/packages/cli/dist/src/main.js account add zendesk`

However, trying to do this as a one-shot via the `--login-parameters` failed

`node ~/salto/packages/cli/dist/src/main.js account add zendesk --login-parameters username=chris token=abc123 subdomain=testdomain`
```
Error: Could not login to zendesk: Missing the following login parameters: password
```
# Root Cause

The comparison operator utilized in `createConfigFromLoginParameters()` (in `packages/cli/src/commands/account.ts`) scans the param field annotations looking for the **required** params using

`field.annotations[CORE_ANNOTATIONS.REQUIRED] !== false)`

rather than 

`field.annotations[CORE_ANNOTATIONS.REQUIRED] === true)`

Which means the current code considers fields with non-empty `annotations` - that do not have `_required` - as **required**

This appears to be an incorrect assumption based on this comment in `/packages/adapter-utils/test/element.test.ts`

```
// For fields that are not required the _required annotation is not mandatory
// so it is possible to have no annotations, annotations without required and required false
```
# Unit Tests

## New Test

Exported`createConfigFromLoginParameters()` and added a new test in `packages/adapter-utils/test/element.test.ts`

```
const credentialsType = {
  elemID: new ElemID('MockAdaptorName'),
  fields: {
    username: {
       annotations: {
      }
    },
    token: {
      annotations: {
        _required: true
      }
    }
  }
}
```

Results of new test: **Failure before change**
```
const loginParameters = ['token=token456']
```
```
account command group › createConfigFromLoginParameters() helper › when login parameters are marked required › should work when the required param is present

    Missing the following login parameters: username
```

Results of new test: **Success after change**
```
const loginParameters = ['token=token456']
const loginParameters = ['username=user123']
const loginParameters = ['password=password789']
```
```
      when login parameters are marked required
        ✓ should work when the required param is present (1 ms)
        ✓ should throw when the required param is missing - with other matches (6 ms)
        ✓ should throw when the required param is missing - with no other matches (2 ms)
```

## Modification of existing mock

A prev unit test was incorrectly depending on this behavior via the following mock

```
export const mockCredentialsType = (adapterName: string): AdapterAuthentication => {
  const configID = new ElemID(adapterName)
  return {
    basic: {
      credentialsType: new ObjectType({
        elemID: configID,
        fields: {
          username: { refType: BuiltinTypes.STRING },
          password: { refType: BuiltinTypes.STRING },
          token: {
            refType: BuiltinTypes.STRING,
            annotations: {},
          },
          sandbox: { refType: BuiltinTypes.BOOLEAN },
        },
      }),
    },
  }
}
```

And the test was assuming if `sandbox` was omitted then the options should be rejected as malformed. However, since no fields in this mock have the `_required` annotation - none of the parameters should be considered **required.**

Have adjusted the mock to annotate `sandbox` as **required** so that the test now works as intended (fails when a properly annotated **required** param is missing.

# Validation
## Build and Test
```
cd packages/cli

yarn format
yarn build
yarn test

Test Suites: 20 passed, 20 total
Tests:       459 passed, 459 total
Snapshots:   0 total
Time:        29.905 s, estimated 32 s
Ran all test suites.
```
## Original Use case
```
node ~/salto/packages/cli/dist/src/main.js account add zendesk --login-parameters username=chris token=abc123 subdomain=testdomain

✔ Login information successfully updated!

✔ zendesk was added to the environment
```