### PR TITLE
SALTO-5323 add compareOptions to createDiffChanges params

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -33,6 +33,8 @@ export interface Values {
 
 export type CompareOptions = {
   compareByValue?: boolean
+  createFieldChanges?: boolean
+  compareListItems?: boolean
 }
 
 export const calculateStaticFileHash = (content: Buffer): string => hashUtils.toMD5(content)

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -44,11 +44,6 @@ import { applyListChanges, getArrayIndexMapping } from './list_comparison'
 
 const log = logger(module)
 
-export type DetailedCompareOptions = CompareOptions & {
-  createFieldChanges?: boolean
-  compareListItems?: boolean
-}
-
 const compareListWithOrderMatching = ({
   id,
   before,
@@ -62,7 +57,7 @@ const compareListWithOrderMatching = ({
   after: Value
   beforeId: ElemID | undefined
   afterId: ElemID | undefined
-  options: DetailedCompareOptions | undefined
+  options: CompareOptions | undefined
 }): DetailedChange[] =>
   log.timeDebug(() => {
     const indexMapping = getArrayIndexMapping(before, after)
@@ -124,7 +119,7 @@ export const getValuesChanges = ({
   after: Value
   beforeId: ElemID | undefined
   afterId: ElemID | undefined
-  options?: DetailedCompareOptions
+  options?: CompareOptions
 }): DetailedChange[] => {
   if (isElement(before) && isElement(after) && isEqualElements(before, after, options)) {
     return []
@@ -253,7 +248,7 @@ export const detailedCompare = (
   // This function supports all types of Elements, but doesn't necessarily support Variable (SALTO-4363)
   before: Element,
   after: Element,
-  compareOptions?: DetailedCompareOptions,
+  compareOptions?: CompareOptions,
 ): DetailedChangeWithBaseChange[] => {
   const baseChange = toChange({ before, after })
   const createFieldChanges = compareOptions?.createFieldChanges ?? false

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -604,24 +604,24 @@ export async function diff(
   const toElements = useState ? workspace.state(toEnv) : await workspace.elements(includeHidden, toEnv)
 
   if (resultType === 'changes') {
-    return createDiffChanges(
-      toElements,
-      fromElements,
-      await workspace.getReferenceSourcesIndex(),
+    return createDiffChanges({
+      toElementsSrc: toElements,
+      fromElementsSrc: fromElements,
+      referenceSourcesIndex: await workspace.getReferenceSourcesIndex(),
       elementSelectors,
-      accountIDFilter,
-      'changes',
-    )
+      topLevelFilters: accountIDFilter,
+      resultType: 'changes',
+    })
   }
 
-  const diffChanges = await createDiffChanges(
-    toElements,
-    fromElements,
-    await workspace.getReferenceSourcesIndex(),
+  const diffChanges = await createDiffChanges({
+    toElementsSrc: toElements,
+    fromElementsSrc: fromElements,
+    referenceSourcesIndex: await workspace.getReferenceSourcesIndex(),
     elementSelectors,
-    accountIDFilter,
-    'detailedChanges',
-  )
+    topLevelFilters: accountIDFilter,
+    resultType: 'detailedChanges',
+  })
   return diffChanges.map(change => ({ change, serviceChanges: [change] }))
 }
 

--- a/packages/core/src/core/restore.ts
+++ b/packages/core/src/core/restore.ts
@@ -87,14 +87,14 @@ export async function createRestoreChanges(
   resultType: 'changes' | 'detailedChanges' = 'detailedChanges',
 ): Promise<DetailedChangeWithBaseChange[] | ChangeWithDetails[]> {
   if (resultType === 'changes') {
-    const changes = await createDiffChanges(
-      workspaceElements,
-      state,
+    const changes = await createDiffChanges({
+      toElementsSrc: workspaceElements,
+      fromElementsSrc: state,
       referenceSourcesIndex,
       elementSelectors,
-      [id => (accounts?.includes(id.adapter) ?? true) || id.adapter === ElemID.VARIABLES_NAMESPACE],
-      'changes',
-    )
+      topLevelFilters: [id => (accounts?.includes(id.adapter) ?? true) || id.adapter === ElemID.VARIABLES_NAMESPACE],
+      resultType: 'changes',
+    })
     return awu(changes)
       .map(async change => {
         const detailedChangesByPath = (
@@ -107,14 +107,14 @@ export async function createRestoreChanges(
       .toArray()
   }
 
-  const detailedChanges = await createDiffChanges(
-    workspaceElements,
-    state,
+  const detailedChanges = await createDiffChanges({
+    toElementsSrc: workspaceElements,
+    fromElementsSrc: state,
     referenceSourcesIndex,
     elementSelectors,
-    [id => (accounts?.includes(id.adapter) ?? true) || id.adapter === ElemID.VARIABLES_NAMESPACE],
-    'detailedChanges',
-  )
+    topLevelFilters: [id => (accounts?.includes(id.adapter) ?? true) || id.adapter === ElemID.VARIABLES_NAMESPACE],
+    resultType: 'detailedChanges',
+  })
   return awu(detailedChanges)
     .flatMap(change => splitDetailedChangeByPath(change, index))
     .toArray()

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -111,14 +111,14 @@ jest.mock('../src/core/restore', () => ({
 }))
 
 jest.mock('../src/core/diff', () => ({
-  createDiffChanges: jest.fn((...args) => {
+  createDiffChanges: jest.fn(args => {
     const detailedChanges = [
       {
         action: 'add',
         data: { after: 'value' },
       },
     ]
-    return args[5] === 'changes'
+    return args.resultType === 'changes'
       ? [
           {
             action: 'add',


### PR DESCRIPTION
change the API of `createDiffChanges` to receive an object param, and add it `compareOptions`, that are used in the elements comparison.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Change the API of `createDiffChanges` to receive an object param, and add it `compareOptions`, that are used in the elements comparison.

---
_User Notifications_: 
None