### PR TITLE
SALTO-6298: fixed a crash for issue layout validator

### DIFF
--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -22,7 +22,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   collectCoverageFrom: ['!<rootDir>/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 90.77,
+      branches: 90.8,
       functions: 95,
       lines: 95,
       statements: 95,

--- a/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
+++ b/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
@@ -79,9 +79,11 @@ const getProjectIssueLayoutsScreensName = async (
   ) {
     return []
   }
-  const projectIssueTypesFullName = (await elementsSource.get(project.value.issueTypeScheme.elemID))?.value.issueTypeIds
-    ?.filter(isReferenceExpression)
-    ?.map((issueType: ReferenceExpression) => issueType.elemID.getFullName())
+  const projectIssueTypesFullName = (
+    (await elementsSource.get(project.value.issueTypeScheme.elemID))?.value.issueTypeIds ?? []
+  )
+    .filter(isReferenceExpression)
+    .map((issueType: ReferenceExpression) => issueType.elemID.getFullName())
 
   const relevantIssueTypeMappings = (
     (await Promise.all(
@@ -97,8 +99,8 @@ const getProjectIssueLayoutsScreensName = async (
         .filter(issueTypeMappingsElement =>
           isRelevantMapping(
             issueTypeMappingsElement.issueTypeId,
-            relevantIssueTypeMappings?.length ?? 0,
-            projectIssueTypesFullName?.length ?? 0,
+            relevantIssueTypeMappings.length,
+            projectIssueTypesFullName.length,
           ),
         )
         .filter(issueTypeMappingsElement => isReferenceExpression(issueTypeMappingsElement.screenSchemeId))

--- a/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
+++ b/packages/jira-adapter/src/change_validators/issue_layouts_validator.ts
@@ -97,8 +97,8 @@ const getProjectIssueLayoutsScreensName = async (
         .filter(issueTypeMappingsElement =>
           isRelevantMapping(
             issueTypeMappingsElement.issueTypeId,
-            relevantIssueTypeMappings.length,
-            projectIssueTypesFullName.length,
+            relevantIssueTypeMappings?.length ?? 0,
+            projectIssueTypesFullName?.length ?? 0,
           ),
         )
         .filter(issueTypeMappingsElement => isReferenceExpression(issueTypeMappingsElement.screenSchemeId))

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -156,15 +156,8 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
 }
 
 const verifyProjectDeleted = async (projectId: string, client: JiraClient): Promise<boolean> => {
-  try {
-    const res = await client.get({ url: `/rest/api/3/project/${projectId}` })
-    return res.status === 404
-  } catch (error) {
-    if (error instanceof clientUtils.HTTPError && error.response?.status === 404) {
-      return true
-    }
-    throw error
-  }
+  const res = await client.get({ url: `/rest/api/3/project/${projectId}` })
+  return res.status === 404
 }
 
 const deployLayoutChange = async (change: Change<InstanceElement>, client: JiraClient): Promise<void> => {

--- a/packages/jira-adapter/test/change_validators/issue_layout_validator.test.ts
+++ b/packages/jira-adapter/test/change_validators/issue_layout_validator.test.ts
@@ -550,4 +550,15 @@ describe('issue layouts validator', () => {
         'This issue layout references a screen (jira.Screen.instance.screen2) that is not associated with its project (jira.Project.instance.project1). Learn more at https://help.salto.io/en/articles/9306685-deploying-issue-layouts',
     })
   })
+  it('should return an error if the IssueTypeScheme has no issueTypeIds', async () => {
+    issueTypeSchemeInstance1.value.issueTypeIds = undefined
+    issueTypeScreenSchemeInstance1.value.issueTypeMappings = [
+      {
+        issueTypeId: 'default',
+        screenSchemeId: new ReferenceExpression(screenSchemeInstance2.elemID, screenSchemeInstance2),
+      },
+    ]
+    const errors = await validator([changeIssueLayout1], elementSource)
+    expect(errors).toHaveLength(1)
+  })
 })

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -858,6 +858,17 @@ describe('issue layout filter', () => {
       expect(deployResult.errors).toHaveLength(0)
       expect(deployResult.appliedChanges).toHaveLength(1)
     })
+    it('should return an error if project was removed and API throws non 404 error', async () => {
+      const change = toChange({ before: issueLayoutInstance })
+      const error = new clientUtils.HTTPError('message', {
+        status: 500,
+        data: { errorMessages: ['project does not exist.'] },
+      })
+      connection.get.mockRejectedValueOnce(error)
+      const { deployResult } = await layoutFilter.deploy([change])
+      expect(deployResult.errors).toHaveLength(1)
+      expect(deployResult.appliedChanges).toHaveLength(0)
+    })
     it('should return error if issue layout as removed but parent project still exits', async () => {
       const change = toChange({ before: issueLayoutInstance })
       connection.get.mockImplementation(async url => {


### PR DESCRIPTION
The issue type scheme can have no issue type ids

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that caused a change validator to fail a deploy operation

---
_User Notifications_: 
N/A