### PR TITLE
SALTO-6304 Cache queryWithDefault queries

### DIFF
--- a/packages/adapter-components/src/fetch/element/instance_element.ts
+++ b/packages/adapter-components/src/fetch/element/instance_element.ts
@@ -71,35 +71,46 @@ export const generateInstancesWithInitialTypes = <Options extends FetchApiDefini
         customNameMappingFunctions,
       })
 
-      const instances = entries
-        .map(value => recursiveNaclCase(value))
-        .map((entry, index) =>
-          createInstance({
-            entry,
-            type,
-            toElemName,
-            toPath,
-            // TODO pick better default name, include service id
-            defaultName: `unnamed_${index}`,
-            allowEmptyArrays: elementDef.topLevel?.allowEmptyArrays,
-          }),
-        )
-        .filter(isDefined)
+      const instances = log.timeTrace(
+        () =>
+          entries
+            .map(value => recursiveNaclCase(value))
+            .map((entry, index) =>
+              createInstance({
+                entry,
+                type,
+                toElemName,
+                toPath,
+                // TODO pick better default name, include service id
+                defaultName: `unnamed_${index}`,
+                allowEmptyArrays: elementDef.topLevel?.allowEmptyArrays,
+              }),
+            )
+            .filter(isDefined),
+        'generateInstancesWithInitialTypes: create instances for %s',
+        typeName,
+      )
 
       // TODO filter instances by fetch query before extracting standalone fields (SALTO-5425)
 
-      const instancesWithStandalone = extractStandaloneInstances({
-        adapterName,
-        instances,
-        defQuery,
-        getElemIdFunc,
-        customNameMappingFunctions,
-        definedTypes,
-      })
+      const instancesWithStandalone = log.timeTrace(
+        () =>
+          extractStandaloneInstances({
+            adapterName,
+            instances,
+            defQuery,
+            getElemIdFunc,
+            customNameMappingFunctions,
+            definedTypes,
+          }),
+        'generateInstancesWithInitialTypes: extractStandaloneInstances for %s',
+        typeName,
+      )
 
       return { types: [type, ...nestedTypes], instances: instancesWithStandalone }
     },
-    'generateInstancesWithInitialTypes for %s.%s',
+    'generateInstancesWithInitialTypes for %s.%s, %s entries',
     args.adapterName,
     args.typeName,
+    args.entries.length,
   )


### PR DESCRIPTION
The def query is used in many places, and runs some computations in order to return `.query(typeName)` results. specifically, it makes many such requests as part of the `extractStandaloneInstances` logic which runs recursively on instances - and has caused some slowdown in zendesk fetches post upgrade.

---

adding a cache as a first step for optimizing that flow - which seems to reduce it significantly on large environments.
also adding some additional logs - if needed, we can optimize this flow further, e.g. by "pruning" paths that cannot reach standalone instances.


---
_Release Notes_: 
None

---
_User Notifications_: 
None
