### PR TITLE
SALTO-6305 allow adjust to return multiple items

### DIFF
--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -36,6 +36,8 @@ export {
   OptionsWithDefault,
   TransformFunction,
   AdjustFunction,
+  AdjustFunctionSingle,
+  AdjustFunctionMulti,
   ContextParams,
   GeneratedItem,
 } from './shared'

--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -49,9 +49,15 @@ export type SingleValueTransformationFunction<TContext = ContextParams, TSourceV
   item: GeneratedItem<ContextParams & TContext, TSourceVal>,
 ) => Promise<GeneratedItem<TContext, TTargetVal> | undefined>
 
-export type AdjustFunction<TContext = ContextParams, TSourceVal = unknown, TTargetVal = Values> = (
+export type AdjustFunctionSingle<TContext = ContextParams, TSourceVal = unknown, TTargetVal = Values> = (
   item: GeneratedItem<ContextParams & TContext, TSourceVal>,
 ) => Promise<types.PickyRequired<Partial<GeneratedItem<TContext, TTargetVal>>, 'value'>>
+export type AdjustFunctionMulti<TContext = ContextParams, TSourceVal = unknown, TTargetVal = Values> = (
+  item: GeneratedItem<ContextParams & TContext, TSourceVal>,
+) => Promise<types.PickyRequired<Partial<GeneratedItem<TContext, TTargetVal>>, 'value'>[]>
+export type AdjustFunction<TContext = ContextParams, TSourceVal = unknown, TTargetVal = Values> =
+  | AdjustFunctionSingle<TContext, TSourceVal, TTargetVal>
+  | AdjustFunctionMulti<TContext, TSourceVal, TTargetVal>
 
 /**
  * transformation steps:

--- a/packages/adapter-components/src/fetch/utils.ts
+++ b/packages/adapter-components/src/fetch/utils.ts
@@ -61,7 +61,9 @@ export const createValueTransformer = <TContext extends Record<string, unknown>,
       return transformedItems
     }
     return awu(transformedItems)
-      .map(async transformedItem => ({ ...transformedItem, ...(await adjust(transformedItem)) }))
+      .flatMap(async transformedItem =>
+        collections.array.makeArray(await adjust(transformedItem)).map(res => ({ ...transformedItem, ...res })),
+      )
       .toArray()
   }
   if (!def.single) {

--- a/packages/adapter-components/test/fetch/utils.test.ts
+++ b/packages/adapter-components/test/fetch/utils.test.ts
@@ -110,6 +110,46 @@ describe('fetch utils', () => {
           },
         ])
       })
+      it('should support returning multiple values from adjust', async () => {
+        const func = createValueTransformer({
+          adjust: async () => [{ value: { a: 1 } }, { value: { b: 2 } }, { value: { c: 3 } }],
+        })
+        expect(await func(item)).toEqual([
+          {
+            context: {},
+            typeName: 't',
+            value: { a: 1 },
+          },
+          {
+            context: {},
+            typeName: 't',
+            value: { b: 2 },
+          },
+          {
+            context: {},
+            typeName: 't',
+            value: { c: 3 },
+          },
+        ])
+      })
+      it('should support returning multiple items from adjust', async () => {
+        const func = createValueTransformer({
+          adjust: async () => [{ value: { a: 1 }, typeName: 'custom' }, { value: { b: 2 } }],
+        })
+        expect(await func(item)).toEqual([
+          {
+            context: {},
+            typeName: 'custom',
+            value: { a: 1 },
+          },
+          {
+            context: {},
+            typeName: 't',
+            value: { b: 2 },
+          },
+        ])
+      })
+
       it('should return a single item if single=true and item has single value', async () => {
         const func = createValueTransformer({ root: 'a', omit: ['z'], single: true })
         expect(await func(item)).toEqual({

--- a/packages/confluence-adapter/src/definitions/utils/label.ts
+++ b/packages/confluence-adapter/src/definitions/utils/label.ts
@@ -21,7 +21,7 @@ import { validateValue } from './generic'
 /**
  * AdjustFunction that converts labels object array to ids array.
  */
-export const adjustLabelsToIdsFunc: definitions.AdjustFunction = async item => {
+export const adjustLabelsToIdsFunc: definitions.AdjustFunctionSingle = async item => {
   const value = validateValue(item.value)
   const labels = _.get(value, 'labels')
   if (_.isEmpty(labels) || !Array.isArray(labels)) {

--- a/packages/confluence-adapter/src/definitions/utils/page.ts
+++ b/packages/confluence-adapter/src/definitions/utils/page.ts
@@ -65,7 +65,7 @@ const isNumber = (value: unknown): value is number => typeof value === 'number'
 /**
  * AdjustFunction that increases the version number of a page for deploy modification change.
  */
-const increasePageVersion: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async args => {
+const increasePageVersion: definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = async args => {
   const value = validateValue(args.value)
   const version = _.get(value, 'version')
   if (!values.isPlainRecord(version) || !isNumber(version.number)) {
@@ -110,7 +110,7 @@ export const putHomepageIdInAdditionContext = (args: definitions.deploy.ChangeAn
 /**
  * AdjustFunction that update the page id in case it is a homepage of a new deployed space.
  */
-const updateHomepageId: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async args => {
+const updateHomepageId: definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = async args => {
   const value = validateValue(args.value)
   const spaceChange = args.context.changeGroup.changes.find(c => getChangeData(c).elemID.typeName === SPACE_TYPE_NAME)
   if (spaceChange === undefined) {
@@ -129,7 +129,9 @@ const adjustUserReferencesOnPageReverse = createAdjustUserReferencesReverse(PAGE
 /**
  * AdjustFunction that runs all page modification adjust functions.
  */
-export const adjustPageOnModification: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async args => {
+export const adjustPageOnModification: definitions.AdjustFunctionSingle<
+  definitions.deploy.ChangeAndContext
+> = async args => {
   const value = validateValue(args.value)
   const argsWithValidatedValue = { ...args, value }
   return reduceAsync(

--- a/packages/confluence-adapter/src/definitions/utils/restriction.ts
+++ b/packages/confluence-adapter/src/definitions/utils/restriction.ts
@@ -54,7 +54,7 @@ export const shouldDeleteRestrictionOnPageModification = (args: definitions.depl
 /**
  * Update the restriction format and omit redundant fields
  */
-export const adjustRestriction: definitions.AdjustFunction = async ({ value }) => {
+export const adjustRestriction: definitions.AdjustFunctionSingle = async ({ value }) => {
   const userRestrictions = _.get(value, 'restrictions.user.results')
   return {
     value: {

--- a/packages/confluence-adapter/src/definitions/utils/space.ts
+++ b/packages/confluence-adapter/src/definitions/utils/space.ts
@@ -86,7 +86,7 @@ export const restructurePermissionsAndCreateInternalIdMap = (value: Record<strin
  * Adjust function for transforming space instances upon fetch.
  * We reconstruct the permissions so we use this function on resource and not on request.
  */
-export const spaceMergeAndTransformAdjust: definitions.AdjustFunction<{
+export const spaceMergeAndTransformAdjust: definitions.AdjustFunctionSingle<{
   fragments: definitions.GeneratedItem[]
 }> = async item => {
   const value = validateValue(item.value)

--- a/packages/confluence-adapter/src/definitions/utils/template.ts
+++ b/packages/confluence-adapter/src/definitions/utils/template.ts
@@ -20,7 +20,7 @@ import { validateValue } from './generic'
 /**
  * Add space.key to a template request
  */
-export const addSpaceKey: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async ({
+export const addSpaceKey: definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = async ({
   value,
   context,
 }) => ({

--- a/packages/confluence-adapter/src/definitions/utils/users.ts
+++ b/packages/confluence-adapter/src/definitions/utils/users.ts
@@ -23,24 +23,25 @@ import { validateValue } from './generic'
  * AdjustFunction that runs upon fetch and change user references structure
  * so object type will be aligned with the structure yield by "groups_and_users_filter".
  */
-export const createAdjustUserReferences: (typeName: string) => definitions.AdjustFunction = typeName => async args => {
-  const value = validateValue(args.value)
-  const userFields = TYPE_NAME_TO_USER_FIELDS[typeName]
-  userFields.forEach(field => {
-    value[field] = {
-      accountId: value[field],
-      displayName: value[field],
-    }
-  })
-  return { ...args, value }
-}
+export const createAdjustUserReferences: (typeName: string) => definitions.AdjustFunctionSingle =
+  typeName => async args => {
+    const value = validateValue(args.value)
+    const userFields = TYPE_NAME_TO_USER_FIELDS[typeName]
+    userFields.forEach(field => {
+      value[field] = {
+        accountId: value[field],
+        displayName: value[field],
+      }
+    })
+    return { ...args, value }
+  }
 
 /**
  * AdjustFunction that runs upon deploy and change user references structure to fit deploy api
  */
 export const createAdjustUserReferencesReverse: (
   typeName: string,
-) => definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = typeName => async args => {
+) => definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = typeName => async args => {
   const value = validateValue(args.value)
   const userFields = TYPE_NAME_TO_USER_FIELDS[typeName]
   userFields.forEach(field => {

--- a/packages/intercom-adapter/src/definitions/fetch/transforms/map_array_field_to_nested_values.ts
+++ b/packages/intercom-adapter/src/definitions/fetch/transforms/map_array_field_to_nested_values.ts
@@ -34,7 +34,7 @@ type FieldAdjustment = {
  */
 
 export const mapArrayFieldToNestedValues =
-  (fieldAdjustments: FieldAdjustment[]): definitions.AdjustFunction =>
+  (fieldAdjustments: FieldAdjustment[]): definitions.AdjustFunctionSingle =>
   async ({ value }) => {
     validateItemValue(value)
     const mapField = ({ fieldName, fromField, nestedField, fallbackValue }: FieldAdjustment): Value => {

--- a/packages/intercom-adapter/src/definitions/fetch/transforms/replace_field_with_nested_value.ts
+++ b/packages/intercom-adapter/src/definitions/fetch/transforms/replace_field_with_nested_value.ts
@@ -35,7 +35,7 @@ export const replaceFieldWithNestedValue =
     fieldName: string
     nestedField: string
     fallbackValue: Value
-  }): definitions.AdjustFunction =>
+  }): definitions.AdjustFunctionSingle =>
   async ({ value }) => {
     validateItemValue(value)
 

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/class.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/class.ts
@@ -25,7 +25,7 @@ const convertSiteObjectToSiteId = (value: Record<string, unknown>): void => {
  * Adjust function to convert site object to site id to make reference
  */
 
-export const adjust: definitions.AdjustFunction = async ({ value }) => {
+export const adjust: definitions.AdjustFunctionSingle = async ({ value }) => {
   if (!values.isPlainRecord(value)) {
     throw new Error('Expected value to be a record')
   }

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/configuration_profile.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/configuration_profile.ts
@@ -20,7 +20,7 @@ import { adjustCategoryObjectToCategoryId, adjustServiceIdToTopLevel, adjustSite
 /*
  * Adjust os or mobile configuration profile instance
  */
-export const adjust: definitions.AdjustFunction = async ({ value }) => {
+export const adjust: definitions.AdjustFunctionSingle = async ({ value }) => {
   if (!values.isPlainRecord(value)) {
     throw new Error('Expected value to be a record')
   }

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
@@ -35,7 +35,7 @@ const removeSelfServiceIcon = (value: Record<string, unknown>): void => {
 /*
  * Adjust policy instance
  */
-export const adjust: definitions.AdjustFunction = async ({ value }) => {
+export const adjust: definitions.AdjustFunctionSingle = async ({ value }) => {
   if (!values.isPlainRecord(value)) {
     throw new Error('Expected value to be a record')
   }

--- a/packages/okta-adapter/src/definitions/fetch/types/user_type.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/user_type.ts
@@ -55,7 +55,7 @@ const getUserSchemaId = (value: UserType): string => {
   throw new Error('Could not find id for UserSchema value')
 }
 
-export const extractSchemaIdFromUserType: definitions.AdjustFunction<
+export const extractSchemaIdFromUserType: definitions.AdjustFunctionSingle<
   definitions.ContextParams,
   unknown,
   string

--- a/packages/pagerduty-adapter/src/definitions/utils/schedule_layers.ts
+++ b/packages/pagerduty-adapter/src/definitions/utils/schedule_layers.ts
@@ -29,7 +29,9 @@ const addStartTime = (value: unknown): Record<string, unknown> => {
   return { ...value, start: value.rotation_virtual_start }
 }
 
-export const addStartToLayers: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async ({ value }) => {
+export const addStartToLayers: definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = async ({
+  value,
+}) => {
   if (!lowerdashValues.isPlainRecord(value)) {
     throw new Error('Can not adjust when the value is not an object')
   }
@@ -41,7 +43,7 @@ export const addStartToLayers: definitions.AdjustFunction<definitions.deploy.Cha
   return { value: _.set(value, 'schedule.schedule_layers', layers.map(addStartTime)) }
 }
 
-export const addTimeZone: definitions.AdjustFunction<definitions.deploy.ChangeAndContext> = async ({
+export const addTimeZone: definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext> = async ({
   value,
   context,
 }) => ({

--- a/packages/serviceplaceholder-adapter/src/definitions/fetch/transforms/business_hours_schedule.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/fetch/transforms/business_hours_schedule.ts
@@ -18,7 +18,7 @@ import { definitions } from '@salto-io/adapter-components'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 
 // TODO improve example in SALTO-5428
-export const transform: definitions.AdjustFunction = async ({ value }) => {
+export const transform: definitions.AdjustFunctionSingle = async ({ value }) => {
   if (!lowerdashValues.isPlainObject(value)) {
     throw new Error('unexpected value for business hour schedule holiday, not transforming')
   }


### PR DESCRIPTION
Allow the `adjust` function to return multiple items or values - needed for some more complex manipulations of returned responses

---

the "extended" `AdjustFunction` function can still be used, but since sometimes it helps to be able to rely on the returned type for further manipulation, converted most of the existing functions to `Single` (which was the only supported variant until this PR)

---
_Release Notes_: 
None

---
_User Notifications_: 
None