### PR TITLE
SALTO-6037 Extract string lexer, consolidate usage with template static file

### DIFF
--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -32,7 +32,7 @@ import {
   positionAtStart,
   positionAtEnd,
 } from '../helpers'
-import { TOKEN_TYPES, LexerToken, TRUE, FALSE } from '../lexer'
+import { TOKEN_TYPES, LexerToken, TRUE, FALSE, stringLexer } from '../lexer'
 import {
   missingComma,
   unknownFunction,
@@ -66,15 +66,18 @@ const consumeWord: Consumer<string> = context => {
   }
 }
 
-const defaultStringTokenTransformFunc = (context: ParseContext, token: Required<Token>): string => {
+const createSimpleStringValue = (
+  context: Pick<ParseContext, 'errors' | 'filename'>,
+  tokens: Required<Token>[],
+): string => {
   try {
-    return JSON.parse(`"${unescapeTemplateMarker(token.text)}"`)
+    return JSON.parse(`"${unescapeTemplateMarker(tokens.map(token => token.text).join(''))}"`)
   } catch (e) {
     context.errors.push(
       invalidStringChar(
         {
-          start: positionAtStart(token),
-          end: positionAtEnd(token),
+          start: positionAtStart(tokens[0]),
+          end: positionAtEnd(tokens[tokens.length - 1]),
           filename: context.filename,
         },
         e.message,
@@ -84,16 +87,13 @@ const defaultStringTokenTransformFunc = (context: ParseContext, token: Required<
   }
 }
 
-const createSimpleStringValue = (
-  context: ParseContext,
-  tokens: Required<Token>[],
-  transformFunc: (context: ParseContext, token: Required<Token>) => string = defaultStringTokenTransformFunc,
-): string => tokens.map(token => transformFunc(context, token)).join('')
-
 const createTemplateExpressions = (
-  context: ParseContext,
+  context: Pick<ParseContext, 'errors' | 'filename'>,
   tokens: Required<Token>[],
-  transformFunc: (context: ParseContext, token: Required<Token>) => string = defaultStringTokenTransformFunc,
+  createSimpleStringValueFunc: (
+    context: Pick<ParseContext, 'errors' | 'filename'>,
+    tokens: Required<Token>[],
+  ) => string,
 ): TemplateExpression =>
   createTemplateExpression({
     parts: tokens.map(token => {
@@ -101,19 +101,21 @@ const createTemplateExpressions = (
         const ref = createReferenceExpression(token.value)
         return ref instanceof IllegalReference ? token.text : ref
       }
-      return transformFunc(context, token)
+      return createSimpleStringValueFunc(context, [token])
     }),
   })
 
-const createStringValue = (
-  context: ParseContext,
+export const createStringValue = (
+  context: Pick<ParseContext, 'errors' | 'filename'>,
   tokens: Required<Token>[],
-  transformFunc?: (context: ParseContext, token: Required<Token>) => string,
+  createSimpleStringValueFunc = createSimpleStringValue,
 ): string | TemplateExpression => {
-  const simpleString = _.every(tokens, token => [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE].includes(token.type))
+  const simpleString = _.every(tokens, token =>
+    [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE, TOKEN_TYPES.NEWLINE].includes(token.type),
+  )
   return simpleString
-    ? createSimpleStringValue(context, tokens, transformFunc)
-    : createTemplateExpressions(context, tokens, transformFunc)
+    ? createSimpleStringValueFunc(context, tokens)
+    : createTemplateExpressions(context, tokens, createSimpleStringValueFunc)
 }
 
 const consumeStringData = (context: ParseContext): ConsumerReturnType<Required<Token>[]> => {
@@ -148,9 +150,10 @@ const consumeStringData = (context: ParseContext): ConsumerReturnType<Required<T
       }),
     )
   }
+  const stringTokens = stringLexer(tokens, start)
   return {
     range: { start, end },
-    value: tokens,
+    value: stringTokens,
   }
 }
 
@@ -250,6 +253,9 @@ const unescapeMultilineMarker = (prim: string): string => prim.replace(/\\'''/g,
 
 const unescapeMultilineString = (text: string): string => unescapeMultilineMarker(unescapeTemplateMarker(text))
 
+const createMultilineSimpleStringValue = (_context: unknown, tokens: Required<Token>[]): string =>
+  unescapeMultilineString(tokens.map(token => token.text).join(''))
+
 const consumeMultilineString: Consumer<string | TemplateExpression> = context => {
   // Getting the position of the start marker
   const start = positionAtStart(context.lexer.next())
@@ -265,7 +271,8 @@ const consumeMultilineString: Consumer<string | TemplateExpression> = context =>
 
   // Getting the position of the end marker
   const end = positionAtEnd(context.lexer.next())
-  const value = createStringValue(context, tokens, (_c, t) => unescapeMultilineString(t.text))
+  const stringTokens = stringLexer(tokens, start)
+  const value = createStringValue(context, stringTokens, createMultilineSimpleStringValue)
   return {
     value,
     range: { start, end },

--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -110,7 +110,7 @@ export const createStringValue = (
   tokens: Required<Token>[],
   createSimpleStringValueFunc = createSimpleStringValue,
 ): string | TemplateExpression => {
-  const simpleString = _.every(tokens, token =>
+  const isSimpleString = _.every(tokens, token =>
     [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE, TOKEN_TYPES.NEWLINE].includes(token.type),
   )
   return simpleString

--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -113,7 +113,7 @@ export const createStringValue = (
   const isSimpleString = _.every(tokens, token =>
     [TOKEN_TYPES.CONTENT, TOKEN_TYPES.ESCAPE, TOKEN_TYPES.NEWLINE].includes(token.type),
   )
-  return simpleString
+  return isSimpleString
     ? createSimpleStringValueFunc(context, tokens)
     : createTemplateExpressions(context, tokens, createSimpleStringValueFunc)
 }

--- a/packages/parser/test/template_static_file.test.ts
+++ b/packages/parser/test/template_static_file.test.ts
@@ -46,7 +46,8 @@ describe('template static file', () => {
 
   const singleLineWithTemplateMarkerTemplate = createTemplateExpression({
     parts: [
-      '/hc/test\\${/test/articles/',
+      // eslint-disable-next-line no-template-curly-in-string
+      '/hc/test ${ test-articles }',
       new ReferenceExpression(article.elemID),
       // eslint-disable-next-line no-template-curly-in-string
       '/test ${hc/test/test/articles/}',
@@ -144,7 +145,7 @@ describe('template static file', () => {
       await testTemplateExpressionToStaticFile(
         singleLineWithTemplateMarkerTemplate,
         // eslint-disable-next-line no-template-curly-in-string
-        '/hc/test\\\\${/test/articles/${ zendesk.article.instance.article }/test \\${hc/test/test/articles/}${ zendesk.macro.instance.macro1 }/test}',
+        '/hc/test \\${ test-articles }${ zendesk.article.instance.article }/test \\${hc/test/test/articles/}${ zendesk.macro.instance.macro1 }/test}',
       )
     })
     it('should create static files correctly for singleLineRefAtBeginningAndEnd', async () => {


### PR DESCRIPTION
This PR wants to have a single string parser both for the regular flow and for template static files. 

Regarding the `values.ts` changes - I had to change the way the string value was created, as the parser now works for both single line and multi line strings. This means that multi line strings have escapes as tokens. So unescaping multiline strings doesn't work for escaped tokens, as they split the `\'''` into `\'` and `''`.

---

_Additional context for reviewer_

---
_Release Notes_: 
__Core:__
* Fixed a bug parsing template static files with string interpolations.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
