### PR TITLE
SALTO-3676: remove useChangesDetection from NS config

### DIFF
--- a/packages/netsuite-adapter/src/config/suggestions.ts
+++ b/packages/netsuite-adapter/src/config/suggestions.ts
@@ -34,6 +34,7 @@ import { emptyQueryParams, fullFetchConfig } from './config_creator'
 const DEPRECATED_CONFIGS_TO_REMOVE = [
   'fetch.skipResolvingAccountSpecificValuesToTypes',
   'suiteAppClient.maxRecordsPerSuiteQLTable',
+  'useChangesDetection',
 ]
 
 export const STOP_MANAGING_ITEMS_MSG =

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -225,7 +225,6 @@ export type NetsuiteConfig = {
   fetch: FetchParams
   fetchTarget?: NetsuiteQueryParameters
   skipList?: NetsuiteQueryParameters
-  useChangesDetection?: boolean // TODO remove this from config SALTO-3676
   withPartialDeletion?: boolean
   deployReferencedElements?: boolean
 }
@@ -246,7 +245,6 @@ export const CONFIG: lowerdashTypes.TypeKeysEnum<NetsuiteConfig> = {
   fetch: 'fetch',
   fetchTarget: 'fetchTarget',
   skipList: 'skipList',
-  useChangesDetection: 'useChangesDetection',
   withPartialDeletion: 'withPartialDeletion',
   deployReferencedElements: 'deployReferencedElements',
 }
@@ -769,9 +767,6 @@ export const configType = createMatchingObjectType<NetsuiteConfig>({
     },
     fetchTarget: {
       refType: queryConfigType,
-    },
-    useChangesDetection: {
-      refType: BuiltinTypes.BOOLEAN,
     },
     withPartialDeletion: {
       refType: BuiltinTypes.BOOLEAN,

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1470,7 +1470,7 @@ describe('Adapter', () => {
         })
       })
       it('should call getChangedObjects with the right date range', async () => {
-        await adapter.fetch(mockFetchOpts)
+        await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
         expect(getElementMock).toHaveBeenCalledWith(
           new ElemID(NETSUITE, SERVER_TIME_TYPE_NAME, 'instance', ElemID.CONFIG_NAME),
         )
@@ -1499,7 +1499,7 @@ describe('Adapter', () => {
 
       it('should pass the received query to the client', async () => {
         const getCustomObjectsMock = jest.spyOn(client, 'getCustomObjects')
-        await adapter.fetch(mockFetchOpts)
+        await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
 
         const passedQuery = getCustomObjectsMock.mock.calls[0][1].updatedFetchQuery
         expect(passedQuery.isObjectMatch({ instanceId: 'aaaa', type: 'workflow' })).toBeTruthy()
@@ -1534,7 +1534,6 @@ describe('Adapter', () => {
               },
               filePaths: [],
             },
-            useChangesDetection: false,
           },
           getElemIdFunc: mockGetElemIdFunc,
         })
@@ -1550,12 +1549,11 @@ describe('Adapter', () => {
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: {
             ...config,
-            useChangesDetection: true,
           },
           getElemIdFunc: mockGetElemIdFunc,
         })
 
-        await adapter.fetch(mockFetchOpts)
+        await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
         expect(getChangedObjectsMock).toHaveBeenCalled()
       })
     })

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -251,6 +251,7 @@ describe('netsuite config suggestions', () => {
     }
     Object.assign(config.fetch, { skipResolvingAccountSpecificValuesToTypes: [] })
     Object.assign(config.suiteAppClient ?? {}, { maxRecordsPerSuiteQLTable: [] })
+    Object.assign(config, { useChangesDetection: true })
 
     const configChange = getConfigFromConfigChanges(
       {
@@ -270,6 +271,7 @@ describe('netsuite config suggestions', () => {
       toRemovedDeprecatedConfigsMessage([
         'fetch.skipResolvingAccountSpecificValuesToTypes',
         'suiteAppClient.maxRecordsPerSuiteQLTable',
+        'useChangesDetection',
       ]),
     )
   })


### PR DESCRIPTION
_We fully support `withChangesDetection` in the SAAS, there is no need for a config flag_

---

None

---
_Release Notes_: 
Netsuite Adapter:
* _useChangesDetection in the NS is not longer supported. Use changed-based fetch._

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
