### PR TITLE
SALTO-5967: Avoid attempting to create cross-references when deploy is enabled is Workato

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -104,6 +104,7 @@ export default class WorkatoAdapter implements AdapterOperations {
           config: {
             fetch: config.fetch,
             apiDefinitions: config.apiDefinitions,
+            enableDeploySupport: config[ENABLE_DEPLOY_SUPPORT_FLAG],
           },
           getElemIdFunc,
           fetchQuery: this.fetchQuery,

--- a/packages/workato-adapter/src/config.ts
+++ b/packages/workato-adapter/src/config.ts
@@ -299,6 +299,7 @@ export const configType = new ObjectType({
 export type FilterContext = {
   [FETCH_CONFIG]: WorkatoFetchConfig
   [API_DEFINITIONS_CONFIG]: WorkatoApiConfig
+  [ENABLE_DEPLOY_SUPPORT_FLAG]: WorkatoConfig[typeof ENABLE_DEPLOY_SUPPORT_FLAG]
 }
 
 export const validateFetchConfig = (

--- a/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
+++ b/packages/workato-adapter/src/filters/cross_service/recipe_references.ts
@@ -26,7 +26,7 @@ import { fetch as fetchUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../../filter'
-import { FETCH_CONFIG } from '../../config'
+import { ENABLE_DEPLOY_SUPPORT_FLAG, FETCH_CONFIG } from '../../config'
 import { SALESFORCE, NETSUITE, ZUORA_BILLING, JIRA, ZENDESK } from '../../constants'
 import { addNetsuiteRecipeReferences } from './netsuite/reference_finder'
 import { addSalesforceRecipeReferences } from './salesforce/reference_finder'
@@ -146,6 +146,10 @@ const filter: FilterCreator = ({ config }) => ({
   }: PostFetchOptions): Promise<void> => {
     const { serviceConnectionNames } = config[FETCH_CONFIG]
     if (serviceConnectionNames === undefined || _.isEmpty(serviceConnectionNames)) {
+      return
+    }
+    if (config[ENABLE_DEPLOY_SUPPORT_FLAG] === true) {
+      log.warn('encountered cross references config while deploy is enabled, skipping creation of cross references')
       return
     }
     const supportedAdapters = Object.keys(accountToServiceNameMap ?? {})


### PR DESCRIPTION
Doing this before turning the default behavior for new envs to be with deploy 

---

_Additional context for reviewer_

---
_Release Notes_: 

_Workato_adapter_:
- When deploy is enabled, cross references to additional services will be disabled

---
_User Notifications_: 
None
