### PR TITLE
SALTO-6304 fix lookup for implicitly-defined types

### DIFF
--- a/packages/adapter-components/src/definitions/system/utils.ts
+++ b/packages/adapter-components/src/definitions/system/utils.ts
@@ -92,9 +92,6 @@ export const queryWithDefault = <T, K extends string = string>(
   return {
     allKeys: () => query.allKeys(),
     query: key => {
-      if (all !== undefined) {
-        return all[key]
-      }
       if (!Object.prototype.hasOwnProperty.call(cache, key)) {
         cache[key] = query.query(key)
       }


### PR DESCRIPTION
`getAll` only returns defined types - `query()` can also be run on types that are not defined explicitly, and merge them with the defaults

---
_Release Notes_: 
None

---
_User Notifications_: 
None