### PR TITLE
SALTO-6313: Fix page size params for Okta endpoints 

### DIFF
--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -36,27 +36,27 @@ export const createClientDefinitions = (
           },
         },
         customizations: {
-          Group: {
+          '/api/v1/groups': {
             get: {
               queryArgs: { limit: '10000' }, // maximum page size allowed
             },
           },
-          Application: {
+          '/api/v1/apps': {
             get: {
               queryArgs: { limit: '200' }, // maximum page size allowed
             },
           },
-          GroupRule: {
+          '/api/v1/groups/rules': {
             get: {
               queryArgs: { limit: '200' }, // maximum page size allowed
             },
           },
-          ApplicationGroupAssignment: {
+          '/api/v1/apps/{appId}/groups': {
             get: {
               queryArgs: { limit: '200' }, // maximum page size allowed
             },
           },
-          ProfileMapping: {
+          '/api/v1/mappings': {
             get: {
               queryArgs: { limit: '200' }, // maximum page size allowed
             },


### PR DESCRIPTION
We were adding the page size query param to the wrong thing

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
