### PR TITLE
SALTO-6314: Fix issue with User type pagination

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -985,8 +985,7 @@ const createCustomizations = ({
     requests: [
       {
         endpoint: {
-          // The search query is needed to fetch deprovisioned users
-          path: '/api/v1/users?search=id+pr',
+          path: '/api/v1/users',
         },
       },
     ],

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -61,9 +61,12 @@ export const createClientDefinitions = (
               queryArgs: { limit: '200' }, // maximum page size allowed
             },
           },
-          User: {
+          '/api/v1/users': {
             get: {
-              queryArgs: { limit: '200' }, // maximum page size allowed
+              queryArgs: { 
+                limit: '200', // maximum page size allowed
+                search: 'id pr' // The search query is needed to fetch deprovisioned users
+              },
             },
           },
         },

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -63,9 +63,9 @@ export const createClientDefinitions = (
           },
           '/api/v1/users': {
             get: {
-              queryArgs: { 
+              queryArgs: {
                 limit: '200', // maximum page size allowed
-                search: 'id pr' // The search query is needed to fetch deprovisioned users
+                search: 'id pr', // The search query is needed to fetch deprovisioned users
               },
             },
           },


### PR DESCRIPTION
Fix pagination bug

---

_Additional context for reviewer_

The issue caused by the `search` query param that was part of the `endpoint` instead of being passes as `query` arg
This somehow caused calculating a wrong url for the next page which caused the entire type to fail

The fix is removing it from the `endpoint` and pass it as a query arg 

---
_Release Notes_: 

_Okta_adapter_:
- Fix bug in pagination for `User` type

---
_User Notifications_: 
None
