### PR TITLE
SALT0-5323 add filterFunc to applyDetailedChanges

### DIFF
--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -32,7 +32,7 @@ type SubElementSearchResult = {
   path: ReadonlyArray<string>
 }
 
-export const isIndexPathPart = (key: string): boolean => !Number.isNaN(Number(key))
+export const isIndexPathPart = (key: string): boolean => key !== '' && !Number.isNaN(Number(key))
 
 export const getDeepInnerType = async (
   type: TypeElement,

--- a/packages/adapter-api/src/utils.ts
+++ b/packages/adapter-api/src/utils.ts
@@ -32,7 +32,7 @@ type SubElementSearchResult = {
   path: ReadonlyArray<string>
 }
 
-export const isIndexPathPart = (key: string): boolean => key !== '' && !Number.isNaN(Number(key))
+export const isIndexPathPart = (key: string): boolean => /^\d+$/.test(key)
 
 export const getDeepInnerType = async (
   type: TypeElement,

--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -207,8 +207,8 @@ const getAnnotationTypeChanges = ({
   afterId,
 }: {
   id: ElemID
-  before: Value
-  after: Value
+  before: Element
+  after: Element
   beforeId: ElemID
   afterId: ElemID
 }): DetailedChange[] => {

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -66,7 +66,7 @@ type ListChange =
     }
 
 export const getChangeRealId = (change: DetailedChange): ElemID =>
-  isRemovalChange(change) ? change.elemIDs?.before ?? change.id : change.elemIDs?.after ?? change.id
+  (isRemovalChange(change) ? change.elemIDs?.before : change.elemIDs?.after) ?? change.id
 
 /**
  * This function returns if a change contains a moving of a item in a list for one index to another

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -75,7 +75,7 @@ export const isOrderChange = (change: DetailedChange): boolean =>
   isIndexPathPart(change.id.name) &&
   isIndexPathPart(change.elemIDs?.before?.name ?? '') &&
   isIndexPathPart(change.elemIDs?.after?.name ?? '') &&
-  Number(change.elemIDs?.before?.name) !== Number(change.elemIDs?.after?.name)
+  change.elemIDs?.before?.name !== change.elemIDs?.after?.name
 
 /**
  * Calculate a string to represent an item in a list based on all of its values

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -99,7 +99,7 @@ const isValidLeafValue = (value: unknown): value is LeafValue =>
 /**
  * Note: this function ignores the value of compareReferencesByValue and always looks at the reference id
  */
-const getSingleValueKey = (value: FlatValue): string => {
+const getSingleValueKey = (value: LeafValue): string => {
   if (isReferenceExpression(value)) {
     return value.elemID.getFullName()
   }

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -41,7 +41,7 @@ const log = logger(module)
 
 type KeyFunction = (value: Value) => string
 
-type FlatValue = PrimitiveValue | ReferenceExpression | TemplateExpression | StaticFile
+type LeafValue = PrimitiveValue | ReferenceExpression | TemplateExpression | StaticFile
 
 type IndexMappingItem = {
   beforeIndex?: number
@@ -93,7 +93,7 @@ const getListItemExactKey: KeyFunction = value =>
     },
   })
 
-const isValidFlatValue = (value: unknown): value is FlatValue =>
+const isValidLeafValue = (value: unknown): value is LeafValue =>
   isPrimitiveValue(value) || isReferenceExpression(value) || isTemplateExpression(value) || isStaticFile(value)
 
 /**
@@ -114,25 +114,25 @@ const getSingleValueKey = (value: FlatValue): string => {
 
 /**
  * Calculate a string to represent an item in the list
- * based only on its flat values (without lists/objects)
+ * based only on its leaf values (without lists/objects)
  *
- * Based on experiments, we found looking only on the flat values
+ * Based on experiments, we found looking only on the leaf values
  * to be a good heuristic for representing an item in a list
  */
 const getListItemTopLevelKey: KeyFunction = value => {
   if (_.isPlainObject(value) || Array.isArray(value)) {
     return Object.keys(value)
-      .filter(key => isValidFlatValue(value[key]))
+      .filter(key => isValidLeafValue(value[key]))
       .sort()
       .flatMap(key => [key, ':', getSingleValueKey(value[key])])
       .join('')
   }
 
-  if (isValidFlatValue(value)) {
+  if (isValidLeafValue(value)) {
     return getSingleValueKey(value)
   }
 
-  // When there aren't any top level keys
+  // When there aren't any leaf values
   return ''
 }
 


### PR DESCRIPTION
Add a `filterFunc` to `applyDetailedChanges`, that tells the function which changes should be applied. The reason for this `filterFunc`, instead of passing in advance only the list of changes that you want to apply, is that in list item changes, the indexes should be fixed when you apply only part of the changes - if you want to ignore an addition/removal, the indexes of the following changes should be fixed, so the right order is kept.
Because of the complexity in applying only part of the reorder changes in a list, reorder changes will be applied only when all of the changes in that list should be applied.

---

_Additional context for reviewer_


---
_Release Notes_: 
Core:
- add `filterFunc` to `applyDetailedChanges`

---
_User Notifications_: 
None