### PR TITLE
SALTO-5959 Jira should use bottleneck by default

### DIFF
--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -53,12 +53,12 @@ jira {
 ### Client configuration options
 
 | Name                                             | Default when undefined | Description                                                         |
-| ------------------------------------------------ | ---------------------- | ------------------------------------------------------------------- |
+| ------------------------------------------------ |------------------------| ------------------------------------------------------------------- |
 | [retry](#retry-configuration-options)            | `{}` (no overrides)    | Configuration for retrying on errors                                |
 | [rateLimit](#rate-limit-configuration-options)   | `{}` (no overrides)    | Limits on the number of concurrent requests of different types      |
 | [maxRequestsPerMinute]                           | unlimited              | Limits on the number of requests per minute                         |
-| [delayPerRequestMS]                              | 3                      | Delay waited between each request in milliseconds                   |
-| [useBottleneck]                                  | false                  | Flag indicating usage of Bottleneck package for rate limiting       |
+| [delayPerRequestMS]                              | 0                      | Delay waited between each request in milliseconds                   |
+| [useBottleneck]                                  | true                   | Flag indicating usage of Bottleneck package for rate limiting       |
 | usePrivateAPI                                    | true                   | Whether to use Jira Private API when fetching and deploying changes |
 | [timeout](#client-timeout-configuration-options) | `{}` (no overrides)    | Configuration for setting request timeouts                          |
 

--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -53,7 +53,7 @@ jira {
 ### Client configuration options
 
 | Name                                             | Default when undefined | Description                                                         |
-| ------------------------------------------------ |------------------------| ------------------------------------------------------------------- |
+| ------------------------------------------------ | ---------------------- | ------------------------------------------------------------------- |
 | [retry](#retry-configuration-options)            | `{}` (no overrides)    | Configuration for retrying on errors                                |
 | [rateLimit](#rate-limit-configuration-options)   | `{}` (no overrides)    | Limits on the number of concurrent requests of different types      |
 | [maxRequestsPerMinute]                           | unlimited              | Limits on the number of requests per minute                         |

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -41,8 +41,8 @@ const DEFAULT_PAGE_SIZE: Required<definitions.ClientPageSizeConfig> = {
 
 const RATE_LIMIT_HEADER_PREFIX = 'x-ratelimit-'
 
-export const USE_BOTTLENECK = false
-export const DELAY_PER_REQUEST_MS = 3
+export const USE_BOTTLENECK = true
+export const DELAY_PER_REQUEST_MS = 0
 
 export const GET_CLOUD_ID_URL = '/_edge/tenant_info'
 export const GQL_BASE_URL_GIRA = '/rest/gira/1'


### PR DESCRIPTION
SALTO-5959 Jira should use bottleneck by default

---

_Additional context for reviewer_
https://github.com/salto-io/salto/pull/6146/

---
_Release Notes_: 
none

---
_User Notifications_: 
none
