### PR TITLE
SALTO-6319: Add the ability to ignore errors during fetch

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -30,11 +30,13 @@ type FailEntireFetch = {
 type CustomSaltoError = {
   action: 'customSaltoError'
   value: SaltoError
+  ignore: boolean
 }
 
 type ConfigSuggestion = {
   action: 'configSuggestion'
   value: ConfigChangeSuggestion
+  ignore: boolean
 }
 
 export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion

--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -30,16 +30,18 @@ type FailEntireFetch = {
 type CustomSaltoError = {
   action: 'customSaltoError'
   value: SaltoError
-  ignore: boolean
 }
 
 type ConfigSuggestion = {
   action: 'configSuggestion'
   value: ConfigChangeSuggestion
-  ignore: boolean
 }
 
-export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion
+type IgnoreError = {
+  action: 'ignoreError'
+}
+
+export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion | IgnoreError
 
 type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error; typeName: string }>
 

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -95,21 +95,22 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
     const onErrorResult = onError?.custom?.(onError)({ error, typeName }) ?? onError
     switch (onErrorResult?.action) {
       case 'customSaltoError':
-        if (onErrorResult.ignore) {
-          log.debug('suppressing type failure for %s:%s, generating custom Salto error', adapterName, typeName)
-        } else {
-          log.error('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)
-        }
+        log.warn('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)
         customSaltoErrors.push(onErrorResult.value)
         break
       case 'configSuggestion':
-        if (onErrorResult.ignore) {
-          log.debug('suppressing type failure for %s:%s, generating config suggestions', adapterName, typeName)
-        } else {
-          log.error('failed to fetch type %s:%s, generating config suggestions', adapterName, typeName)
-        }
+        log.warn('failed to fetch type %s:%s, generating config suggestions', adapterName, typeName)
         configSuggestions.push(onErrorResult.value)
         break
+      case 'ignoreError': {
+        log.debug(
+          'failed to fetch type %s:%s, suppressing error with no action: %s',
+          adapterName,
+          typeName,
+          error.message,
+        )
+        break
+      }
       case 'failEntireFetch': {
         if (onErrorResult.value) {
           throw new AbortFetchOnFailure({ adapterName, typeName, message: error.message })

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -95,11 +95,19 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
     const onErrorResult = onError?.custom?.(onError)({ error, typeName }) ?? onError
     switch (onErrorResult?.action) {
       case 'customSaltoError':
-        log.warn('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)
+        if (onErrorResult.ignore) {
+          log.debug('suppressing type failure for %s:%s, generating custom Salto error', adapterName, typeName)
+        } else {
+          log.error('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)
+        }
         customSaltoErrors.push(onErrorResult.value)
         break
       case 'configSuggestion':
-        log.warn('failed to fetch type %s:%s, generating config suggestions', adapterName, typeName)
+        if (onErrorResult.ignore) {
+          log.debug('suppressing type failure for %s:%s, generating config suggestions', adapterName, typeName)
+        } else {
+          log.error('failed to fetch type %s:%s, generating config suggestions', adapterName, typeName)
+        }
         configSuggestions.push(onErrorResult.value)
         break
       case 'failEntireFetch': {
@@ -110,7 +118,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
       // eslint-disable-next-line no-fallthrough
       case undefined:
       default:
-        log.warn('failed to fetch type %s:%s: %s', adapterName, typeName, error.message)
+        log.error('failed to fetch type %s:%s: %s', adapterName, typeName, error.message)
     }
   }
 

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -119,7 +119,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
       // eslint-disable-next-line no-fallthrough
       case undefined:
       default:
-        log.error('failed to fetch type %s:%s: %s', adapterName, typeName, error.message)
+        log.error('unexpectedly failed to fetch type %s:%s: %s', adapterName, typeName, error.message)
     }
   }
 

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -295,7 +295,9 @@ describe('element', () => {
           generator.handleError({ typeName: 'myType', error: fetchError })
           generator.generate()
           expect(logErrorSpy).toHaveBeenCalledWith(
-            'failed to fetch type %s:%s, generating custom Salto error', expect.any(String), expect.any(String)
+            'failed to fetch type %s:%s, generating custom Salto error',
+            expect.any(String),
+            expect.any(String),
           )
         })
 
@@ -343,7 +345,7 @@ describe('element', () => {
                     onError: {
                       action: 'configSuggestion',
                       value: configSuggestion,
-                      ignore: false
+                      ignore: false,
                     },
                   },
                 },
@@ -368,7 +370,7 @@ describe('element', () => {
                     onError: {
                       action: 'configSuggestion',
                       value: configSuggestion,
-                      ignore: false
+                      ignore: false,
                     },
                   },
                 },
@@ -378,7 +380,9 @@ describe('element', () => {
           generator.handleError({ typeName: 'myType', error: fetchError })
           generator.generate()
           expect(logErrorSpy).toHaveBeenCalledWith(
-            'failed to fetch type %s:%s, generating config suggestions', expect.any(String), expect.any(String)
+            'failed to fetch type %s:%s, generating config suggestions',
+            expect.any(String),
+            expect.any(String),
           )
         })
 
@@ -394,7 +398,7 @@ describe('element', () => {
                     onError: {
                       action: 'configSuggestion',
                       value: configSuggestion,
-                      ignore: true
+                      ignore: true,
                     },
                   },
                 },
@@ -462,7 +466,10 @@ describe('element', () => {
           generator.handleError({ typeName: 'myType', error: fetchError })
           generator.generate()
           expect(logErrorSpy).toHaveBeenCalledWith(
-            'failed to fetch type %s:%s: %s', expect.any(String), expect.any(String), fetchError.message
+            'failed to fetch type %s:%s: %s',
+            expect.any(String),
+            expect.any(String),
+            fetchError.message,
           )
         })
       })

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -445,11 +445,11 @@ describe('element', () => {
           expect(res.configChanges).toHaveLength(0)
         })
 
-        it('should log "failed to fetch type" error by default', () => {
+        it('should log "unexpectedly failed to fetch type" error by default', () => {
           generator.handleError({ typeName: 'myType', error: fetchError })
           generator.generate()
           expect(logErrorSpy).toHaveBeenCalledWith(
-            'failed to fetch type %s:%s: %s',
+            'unexpectedly failed to fetch type %s:%s: %s',
             expect.any(String),
             expect.any(String),
             fetchError.message,

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -23,6 +23,7 @@ import {
   isInstanceElement,
   isObjectType,
 } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { getElementGenerator } from '../../../src/fetch/element/element'
 import { AbortFetchOnFailure } from '../../../src/fetch/errors'
 import { ConfigChangeSuggestion, queryWithDefault } from '../../../src/definitions'
@@ -209,90 +210,232 @@ describe('element', () => {
 
     describe('handleError', () => {
       const fetchError = new Error('failed to fetch')
-      it('should throw an error when failEntireFetch is true', () => {
-        const generator = getElementGenerator({
-          adapterName: 'myAdapter',
-          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-            customizations: {
-              myType: {
-                element: { topLevel: { isTopLevel: true } },
-                resource: {
-                  directFetch: true,
-                  onError: {
-                    action: 'failEntireFetch',
-                    value: true,
+      const logging = logger('adapter-components/src/fetch/element/element')
+      const logErrorSpy = jest.spyOn(logging, 'error')
+
+      beforeEach(() => {
+        jest.clearAllMocks()
+      })
+
+      describe('when onError defined with failEntireFetch', () => {
+        it('should throw an error when failEntireFetch is true', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'failEntireFetch',
+                      value: true,
+                    },
                   },
                 },
               },
-            },
-          }),
-          customNameMappingFunctions: {},
+            }),
+            customNameMappingFunctions: {},
+          })
+          expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
         })
-        expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
       })
 
-      it('should generate custom error that returned from onError', () => {
+      describe('when onError defined with customSaltoError', () => {
         const customSaltoError: SaltoError = {
           message: 'custom error',
           severity: 'Warning',
           type: 'unresolvedReferences',
         }
 
-        const generator = getElementGenerator({
-          adapterName: 'myAdapter',
-          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-            customizations: {
-              myType: {
-                element: { topLevel: { isTopLevel: true } },
-                resource: {
-                  directFetch: true,
-                  onError: {
-                    action: 'customSaltoError',
-                    value: customSaltoError,
+        it('should generate custom error that returned from onError', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'customSaltoError',
+                      value: customSaltoError,
+                      ignore: false,
+                    },
                   },
                 },
               },
-            },
-          }),
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          const res = generator.generate()
+          expect(res.errors).toHaveLength(1)
+          expect(res.errors?.[0]).toEqual(customSaltoError)
         })
-        generator.handleError({ typeName: 'myType', error: fetchError })
-        const res = generator.generate()
-        expect(res.errors).toHaveLength(1)
-        expect(res.errors?.[0]).toEqual(customSaltoError)
+
+        it('should log "failed to fetch type" error when provided with ignore = false', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'customSaltoError',
+                      value: customSaltoError,
+                      ignore: false,
+                    },
+                  },
+                },
+              },
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).toHaveBeenCalledWith(
+            'failed to fetch type %s:%s, generating custom Salto error', expect.any(String), expect.any(String)
+          )
+        })
+
+        it('should not error when provided with ignore = true', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'customSaltoError',
+                      value: customSaltoError,
+                      ignore: true,
+                    },
+                  },
+                },
+              },
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).not.toHaveBeenCalled()
+        })
       })
 
-      it('should generate config change suggestion that returned from onError', () => {
+      describe('when onError defined with configSuggestion', () => {
         const configSuggestion: ConfigChangeSuggestion = {
           reason: 'test',
           type: 'typeToExclude',
           value: 'valueToExclude',
         }
 
-        const generator = getElementGenerator({
-          adapterName: 'myAdapter',
-          defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
-            customizations: {
-              myType: {
-                element: { topLevel: { isTopLevel: true } },
-                resource: {
-                  directFetch: true,
-                  onError: {
-                    action: 'configSuggestion',
-                    value: configSuggestion,
+        it('should generate config change suggestion that returned from onError', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'configSuggestion',
+                      value: configSuggestion,
+                      ignore: false
+                    },
                   },
                 },
               },
-            },
-          }),
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          const res = generator.generate()
+          expect(res.configChanges).toHaveLength(1)
+          expect(res.configChanges?.[0]).toEqual(configSuggestion)
         })
-        generator.handleError({ typeName: 'myType', error: fetchError })
-        const res = generator.generate()
-        expect(res.configChanges).toHaveLength(1)
-        expect(res.configChanges?.[0]).toEqual(configSuggestion)
+
+        it('should log "failed to fetch type" error when provided with ignore = false', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'configSuggestion',
+                      value: configSuggestion,
+                      ignore: false
+                    },
+                  },
+                },
+              },
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).toHaveBeenCalledWith(
+            'failed to fetch type %s:%s, generating config suggestions', expect.any(String), expect.any(String)
+          )
+        })
+
+        it('should not log error when provided with ignore = true', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                    onError: {
+                      action: 'configSuggestion',
+                      value: configSuggestion,
+                      ignore: true
+                    },
+                  },
+                },
+              },
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).not.toHaveBeenCalled()
+        })
       })
 
-      it('should call custom error handler if defined', () => {
-        const customErrorHandler = jest.fn().mockReturnValue({ action: 'failEntireFetch', value: true })
+      describe('when using a custom error handler', () => {
+        it('should call custom error handler if defined', () => {
+          const customErrorHandler = jest.fn().mockReturnValue({ action: 'failEntireFetch', value: true, ignore: true })
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                  },
+                },
+              },
+              default: {
+                resource: {
+                  onError: {
+                    custom: () => customErrorHandler,
+                  },
+                },
+              },
+            }),
+          })
+          expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
+          expect(customErrorHandler).toHaveBeenCalledWith({ error: fetchError, typeName: 'myType' })
+        })
+      })
+
+      describe('when onError is not provided', () => {
         const generator = getElementGenerator({
           adapterName: 'myAdapter',
           defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
@@ -304,17 +447,24 @@ describe('element', () => {
                 },
               },
             },
-            default: {
-              resource: {
-                onError: {
-                  custom: () => customErrorHandler,
-                },
-              },
-            },
           }),
         })
-        expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
-        expect(customErrorHandler).toHaveBeenCalledWith({ error: fetchError, typeName: 'myType' })
+
+        it('should not return any error', () => {
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          const res = generator.generate()
+          expect(res.elements).toHaveLength(0)
+          expect(res.errors).toHaveLength(0)
+          expect(res.configChanges).toHaveLength(0)
+        })
+
+        it('should log "failed to fetch type" error by default', () => {
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).toHaveBeenCalledWith(
+            'failed to fetch type %s:%s: %s', expect.any(String), expect.any(String), fetchError.message
+          )
+        })
       })
     })
   })

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1179,6 +1179,7 @@ const getInsufficientPermissionsError: definitions.fetch.FetchResourceDefinition
             message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
             severity: 'Info',
           },
+          ignore: true,
         }
       }
       return { action: 'failEntireFetch', value: false }

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1179,7 +1179,6 @@ const getInsufficientPermissionsError: definitions.fetch.FetchResourceDefinition
             message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
             severity: 'Info',
           },
-          ignore: true,
         }
       }
       return { action: 'failEntireFetch', value: false }


### PR DESCRIPTION
Added the option to ignore known errors during fetch and suppress them 

---

_Additional context for reviewer_

changes - 
- By default, all errors will not ignored and will trigger `log.error` (even when not providing error handler) with "failed to fetch type".
- When customizing `onError`, returning `ignoreError` will make the error to be suppressed (to debug level).

---
_Release Notes_: 
None

---
_User Notifications_: 
None
