### PR TITLE
SALTO-6323 always support none pagination in endpoints

### DIFF
--- a/packages/adapter-components/src/definitions/system/api.ts
+++ b/packages/adapter-components/src/definitions/system/api.ts
@@ -34,7 +34,7 @@ export type ResolveClientOptionsType<Options extends Pick<APIDefinitionsOptions,
   Options['clientOptions'] extends string ? Options['clientOptions'] : 'main'
 
 export type ResolvePaginationOptionsType<Options extends Pick<APIDefinitionsOptions, 'paginationOptions'>> =
-  Options['paginationOptions'] extends string ? Options['paginationOptions'] : 'none'
+  Options['paginationOptions'] extends string ? Options['paginationOptions'] | 'none' : 'none'
 
 export type ResolveCustomNameMappingOptionsType<
   Options extends Pick<APIDefinitionsOptions, 'customNameMappingOptions'>,
@@ -72,7 +72,10 @@ export type ApiDefinitions<Options extends APIDefinitionsOptions = {}> = {
   >
 
   // supported pagination options. when missing, no pagination is used (TODO add warning)
-  pagination: Record<ResolvePaginationOptionsType<Options>, PaginationDefinitions<ResolveClientOptionsType<Options>>>
+  pagination: Record<
+    Exclude<ResolvePaginationOptionsType<Options>, 'none'>,
+    PaginationDefinitions<ResolveClientOptionsType<Options>>
+  >
 
   // rules for reference extraction (during fetch) and serialization (during deploy)
   references?: ReferenceDefinitions<

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -28,6 +28,7 @@ import { computeArgCombinations } from '../resource/request_parameters'
 import {
   APIDefinitionsOptions,
   HTTPEndpointDetails,
+  PaginationDefinitions,
   ResolveClientOptionsType,
   ResolvePaginationOptionsType,
 } from '../../definitions/system'
@@ -126,11 +127,16 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
     // * add promises for in-flight requests, to avoid making the same request multiple times in parallel
     const { merged: mergedRequestDef, clientName } = getMergedRequestDefinition(requestDef)
 
-    const paginationOption = mergedRequestDef.endpoint.pagination
-    const paginationDef =
-      paginationOption !== undefined
-        ? pagination[paginationOption]
-        : { funcCreator: noPagination, clientArgs: undefined }
+    const paginationOption = mergedRequestDef.endpoint.pagination ?? 'none'
+    const nonePaginationDef: PaginationDefinitions<ResolveClientOptionsType<Options>> = {
+      funcCreator: noPagination,
+      clientArgs: undefined,
+    }
+    const paginationWithNone = {
+      ...pagination,
+      none: nonePaginationDef,
+    } as Record<ResolvePaginationOptionsType<Options>, PaginationDefinitions<ResolveClientOptionsType<Options>>>
+    const paginationDef = paginationWithNone[paginationOption]
 
     const { clientArgs } = paginationDef
     // order of precedence in case of overlaps: pagination defaults < endpoint < resource-specific request

--- a/packages/confluence-adapter/src/definitions/index.ts
+++ b/packages/confluence-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/confluence-adapter/src/definitions/requests/clients.ts
+++ b/packages/confluence-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/confluence-adapter/src/definitions/requests/pagination.ts
+++ b/packages/confluence-adapter/src/definitions/requests/pagination.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { cursorPagination, itemOffsetPagination } = fetchUtils.request.pagination
 
 export const USERS_PAGE_SIZE = '1000'
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       cursorPagination({

--- a/packages/confluence-adapter/src/definitions/types.ts
+++ b/packages/confluence-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main' | 'users_client'
-export type PaginationOptions = 'cursor' | 'usersPagination'
+type PaginationOptions = 'cursor' | 'usersPagination'
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions

--- a/packages/google-workspace-adapter/src/definitions/index.ts
+++ b/packages/google-workspace-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/google-workspace-adapter/src/definitions/requests/clients.ts
+++ b/packages/google-workspace-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/google-workspace-adapter/src/definitions/requests/pagination.ts
+++ b/packages/google-workspace-adapter/src/definitions/requests/pagination.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { tokenPagination } = fetchUtils.request.pagination
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       tokenPagination({

--- a/packages/google-workspace-adapter/src/definitions/types.ts
+++ b/packages/google-workspace-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main' | 'groupSettings' | 'cloudIdentity'
-export type PaginationOptions = 'cursor'
+type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = 'roleId' | 'orgUnitId' | 'buildingId' | 'email'
 

--- a/packages/intercom-adapter/src/definitions/index.ts
+++ b/packages/intercom-adapter/src/definitions/index.ts
@@ -16,4 +16,4 @@
 
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/intercom-adapter/src/definitions/requests/clients.ts
+++ b/packages/intercom-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/intercom-adapter/src/definitions/requests/pagination.ts
+++ b/packages/intercom-adapter/src/definitions/requests/pagination.ts
@@ -15,7 +15,7 @@
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 type PaginationFunction = definitions.PaginationFunction
 const { cursorPagination } = fetchUtils.request.pagination
@@ -46,7 +46,7 @@ export const scrollingPagination = ({
   return nextPageScrollingPages
 }
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       cursorPagination({

--- a/packages/intercom-adapter/src/definitions/types.ts
+++ b/packages/intercom-adapter/src/definitions/types.ts
@@ -16,7 +16,7 @@
 import { definitions } from '@salto-io/adapter-components'
 
 export type ClientOptions = 'main'
-export type PaginationOptions = 'cursor' | 'scroll'
+type PaginationOptions = 'cursor' | 'scroll'
 export type ReferenceContextStrategies = 'parentType'
 
 export type Options = definitions.APIDefinitionsOptions & {

--- a/packages/jamf-adapter/src/definitions/index.ts
+++ b/packages/jamf-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/jamf-adapter/src/definitions/requests/clients.ts
+++ b/packages/jamf-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/jamf-adapter/src/definitions/requests/pagination.ts
+++ b/packages/jamf-adapter/src/definitions/requests/pagination.ts
@@ -16,11 +16,11 @@
 import { definitions } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const log = logger(module)
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   increasePageUntilEmpty: {
     funcCreator:
       () =>

--- a/packages/jamf-adapter/src/definitions/types.ts
+++ b/packages/jamf-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main' | 'classicApi'
-export type PaginationOptions = 'increasePageUntilEmpty'
+type PaginationOptions = 'increasePageUntilEmpty'
 
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = 'idAndNameObject'

--- a/packages/microsoft-entra-adapter/src/definitions/index.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/microsoft-entra-adapter/src/definitions/requests/clients.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/requests/clients.ts
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const GRAPH_V1_PATH = '/v1.0'
 export const GRAPH_BETA_PATH = '/beta'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/microsoft-entra-adapter/src/definitions/requests/pagination.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/requests/pagination.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { cursorPagination } = fetchUtils.request.pagination
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       cursorPagination({

--- a/packages/microsoft-entra-adapter/src/definitions/types.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main'
-export type PaginationOptions = 'cursor'
+type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = 'ODataType'
 export type CustomReferenceSerializationStrategyName = 'appId'
 export type CustomIndexField = CustomReferenceSerializationStrategyName

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, OktaOptions, PaginationOptions } from '../types'
+import { OktaOptions } from '../types'
 import { OktaUserConfig } from '../../user_config'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
+  clients: Record<
+    definitions.ResolveClientOptionsType<OktaOptions>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<OktaOptions>>['httpClient']
+  >,
 ): definitions.ApiDefinitions<OktaOptions>['clients'] => ({
   default: 'main',
   options: {

--- a/packages/okta-adapter/src/definitions/requests/pagination.ts
+++ b/packages/okta-adapter/src/definitions/requests/pagination.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { OktaOptions } from '../types'
 
 const { cursorPagination, defaultPathChecker, cursorHeaderPagination } = fetchUtils.request.pagination
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<OktaOptions>['pagination'] = {
   cursorHeader: {
     funcCreator: () => cursorHeaderPagination({ pathChecker: defaultPathChecker }),
   },

--- a/packages/okta-adapter/src/definitions/types.ts
+++ b/packages/okta-adapter/src/definitions/types.ts
@@ -16,7 +16,7 @@
 export type StatusActionName = 'activate' | 'deactivate'
 export type AdditionalAction = StatusActionName
 export type ClientOptions = 'main' | 'private'
-export type PaginationOptions = 'cursorHeader' | 'cursor'
+type PaginationOptions = 'cursorHeader' | 'cursor'
 export type OktaOptions = {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions

--- a/packages/pagerduty-adapter/src/definitions/index.ts
+++ b/packages/pagerduty-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/pagerduty-adapter/src/definitions/requests/clients.ts
+++ b/packages/pagerduty-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/pagerduty-adapter/src/definitions/requests/pagination.ts
+++ b/packages/pagerduty-adapter/src/definitions/requests/pagination.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { offsetAndLimitPagination } = fetchUtils.request.pagination
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   offset: {
     funcCreator: () => offsetAndLimitPagination(),
   },

--- a/packages/pagerduty-adapter/src/definitions/types.ts
+++ b/packages/pagerduty-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main'
-export type PaginationOptions = 'offset'
+type PaginationOptions = 'offset'
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions

--- a/packages/serviceplaceholder-adapter/src/definitions/index.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/index.ts
@@ -17,4 +17,4 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/serviceplaceholder-adapter/src/definitions/requests/clients.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/requests/clients.ts
@@ -14,13 +14,16 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 // TODO adjust, remove unnecessary customizations
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {
@@ -39,7 +42,7 @@ export const createClientDefinitions = (
         customizations: {
           // '/api/v2/groups': {
           //   get: {
-          //     pagination: 'offset',
+          //     pagination: 'none',
           //     queryArgs: { type: 'a' },
           //   },
           // },

--- a/packages/serviceplaceholder-adapter/src/definitions/requests/pagination.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/requests/pagination.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { cursorPagination } = fetchUtils.request.pagination
 
 // TODO adjust - replace with the correct pagination function(s), remove unneeded ones
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       cursorPagination({ pathChecker: fetchUtils.request.pagination.defaultPathChecker, paginationField: 'next' }),

--- a/packages/serviceplaceholder-adapter/src/definitions/types.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/types.ts
@@ -19,7 +19,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main'
-export type PaginationOptions = 'cursor'
+type PaginationOptions = 'cursor'
 // TODO set these to never if not needed
 export type ReferenceContextStrategies = 'parentType'
 export type CustomReferenceSerializationStrategyName = 'otherFieldName'

--- a/packages/stripe-adapter/src/definitions/requests/clients.ts
+++ b/packages/stripe-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/stripe-adapter/src/definitions/requests/pagination.ts
+++ b/packages/stripe-adapter/src/definitions/requests/pagination.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 const { cursorPagination } = fetchUtils.request.pagination
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   cursor: {
     funcCreator: () =>
       cursorPagination({ pathChecker: fetchUtils.request.pagination.defaultPathChecker, paginationField: 'next' }),

--- a/packages/stripe-adapter/src/definitions/types.ts
+++ b/packages/stripe-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main'
-export type PaginationOptions = 'cursor'
+type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = never
 export type CustomIndexField = CustomReferenceSerializationStrategyName

--- a/packages/zendesk-adapter/src/definitions/index.ts
+++ b/packages/zendesk-adapter/src/definitions/index.ts
@@ -16,4 +16,4 @@
 
 export * from './fetch'
 export * from './requests'
-export { ClientOptions, PaginationOptions } from './types'
+export { ClientOptions } from './types'

--- a/packages/zendesk-adapter/src/definitions/requests/clients.ts
+++ b/packages/zendesk-adapter/src/definitions/requests/clients.ts
@@ -14,11 +14,14 @@
  * limitations under the License.
  */
 import { definitions } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 
 export const createClientDefinitions = (
-  clients: Record<ClientOptions, definitions.RESTApiClientDefinition<PaginationOptions>['httpClient']>,
-): definitions.ApiDefinitions<{ clientOptions: ClientOptions; paginationOptions: PaginationOptions }>['clients'] => ({
+  clients: Record<
+    definitions.ResolveClientOptionsType<Options>,
+    definitions.RESTApiClientDefinition<definitions.ResolvePaginationOptionsType<Options>>['httpClient']
+  >,
+): definitions.ApiDefinitions<Options>['clients'] => ({
   default: 'main',
   options: {
     main: {

--- a/packages/zendesk-adapter/src/definitions/requests/pagination.ts
+++ b/packages/zendesk-adapter/src/definitions/requests/pagination.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
-import { ClientOptions, PaginationOptions } from '../types'
+import { Options } from '../types'
 import { CURSOR_BASED_PAGINATION_FIELD, PAGE_SIZE } from '../../config'
 
 const { cursorPagination } = fetchUtils.request.pagination
@@ -22,7 +22,7 @@ const { cursorPagination } = fetchUtils.request.pagination
 export const pathChecker: fetchUtils.request.pagination.PathCheckerFunc = (current, next) =>
   next === `${current}.json` || next === `${current}`
 
-export const PAGINATION: Record<PaginationOptions, definitions.PaginationDefinitions<ClientOptions>> = {
+export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {
   basic_cursor: {
     funcCreator: () => cursorPagination({ pathChecker, paginationField: 'next_page' }),
   },

--- a/packages/zendesk-adapter/src/definitions/types.ts
+++ b/packages/zendesk-adapter/src/definitions/types.ts
@@ -17,7 +17,7 @@ import { definitions } from '@salto-io/adapter-components'
 
 export type AdditionalAction = never
 export type ClientOptions = 'main' | 'guide'
-export type PaginationOptions = 'basic_cursor' | 'basic_cursor_with_args' | 'links' | 'settings'
+type PaginationOptions = 'basic_cursor' | 'basic_cursor_with_args' | 'links' | 'settings'
 export type ReferenceContextStrategies = 'never'
 export type CustomReferenceSerializationStrategyName = 'never'
 export type CustomIndexField = CustomReferenceSerializationStrategyName


### PR DESCRIPTION
The default defined on the `Options` resolve functions did not support none when other pagination functions are defined, so there was no good way to "override" the pagination for specific endpoints (or to set it as the default while also supporting other functions).

---

Also cleaning up the use of the option in the adapter definitions - this can also be done for the other exported types but will do it separately.

---
_Release Notes_: 
None

---
_User Notifications_: 
None