### PR TITLE
SALTO-3621: Allow meta types for settings

### DIFF
--- a/packages/parser/src/parser/internal/native/errors.ts
+++ b/packages/parser/src/parser/internal/native/errors.ts
@@ -33,6 +33,9 @@ export const unknownPrimitiveTypeError = (range: SourceRange, token?: string): P
     token ? `Unknown primitive type '${token}'.` : 'Expected a primitive type definition, using unknown.',
   )
 
+export const primitiveSettingsError = (range: SourceRange): ParseError =>
+  createError(range, 'Primitive settings type', 'Settings types cannot be primitive.')
+
 export const invalidMetaTypeError = (range: SourceRange, token: string): ParseError =>
   createError(range, 'Invalid meta type', `Meta type ${token} is invalid, must be an object type.`)
 

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -314,6 +314,24 @@ describe('Salto parser', () => {
         })
       })
 
+      describe('when meta type is dropped', () => {
+        const body = `
+          type salesforce.object is {
+          }
+        `
+
+        beforeEach(async () => {
+          ;({ elements, sourceMap, errors } = await parseBody(body))
+        })
+
+        it('should have an error', () => {
+          expect(errors).toHaveLength(1)
+          const error = errors[0]
+          expect(error.summary).toEqual('Invalid type definition')
+          expect(elements).toHaveLength(0)
+        })
+      })
+
       describe('with invalid name', () => {
         const body = `
           type salesforce.someType.a {
@@ -566,7 +584,30 @@ describe('Salto parser', () => {
 
   describe('with a settings definition', () => {
     describe('labels', () => {
-      describe('when the definition is valid', () => {
+      describe("with explicit 'is object'", () => {
+        const body = `
+          settings salesforce.global is object {
+          }
+        `
+
+        beforeEach(async () => {
+          ;({ elements, sourceMap, errors } = await parseBody(body))
+        })
+
+        it('should parse settings', () => {
+          expect(elements).toHaveLength(1)
+          const settings = elements[0] as ObjectType
+          expect(isObjectType(settings)).toBe(true)
+          expect(settings.isSettings).toBe(true)
+          expect(settings.elemID).toEqual(new ElemID('salesforce', 'global'))
+        })
+
+        it('should contain all elements in source map', validateSourceMap)
+
+        it('should have no errors', checkNoErrors)
+      })
+
+      describe('with implicit definition', () => {
         const body = `
           settings salesforce.global {
           }
@@ -589,7 +630,66 @@ describe('Salto parser', () => {
         it('should have no errors', checkNoErrors)
       })
 
-      describe("with 'is' keyword", () => {
+      describe('with meta type', () => {
+        const body = `
+          settings salesforce.global is salesforce.StandardSettings {
+          }
+        `
+
+        beforeEach(async () => {
+          ;({ elements, sourceMap, errors } = await parseBody(body))
+        })
+
+        it('should parse settings', () => {
+          expect(elements).toHaveLength(1)
+          const settings = elements[0] as ObjectType
+          expect(isObjectType(settings)).toBe(true)
+          expect(settings.isSettings).toBe(true)
+          expect(settings.elemID).toEqual(new ElemID('salesforce', 'global'))
+          expect(settings.metaType?.elemID).toEqual(new ElemID('salesforce', 'StandardSettings'))
+        })
+
+        it('should contain all elements in source map', validateSourceMap)
+
+        it('should have no errors', checkNoErrors)
+      })
+
+      describe('with invalid meta type', () => {
+        const body = `
+          settings salesforce.object is salesforce.StandardSettings.field.name {
+          }
+        `
+
+        beforeEach(async () => {
+          ;({ elements, sourceMap, errors } = await parseBody(body))
+        })
+
+        it('should have an error', () => {
+          expect(errors).toHaveLength(1)
+          expect(errors[0].summary).toEqual('Invalid meta type')
+          expect(elements).toHaveLength(0)
+        })
+      })
+
+      describe("when 'is' keyword is dropped", () => {
+        const body = `
+          settings salesforce.global object {
+          }
+        `
+
+        beforeEach(async () => {
+          ;({ elements, sourceMap, errors } = await parseBody(body))
+        })
+
+        it('should have an error', () => {
+          expect(errors).toHaveLength(1)
+          const error = errors[0]
+          expect(error.summary).toEqual('Invalid settings type definition')
+          expect(elements).toHaveLength(0)
+        })
+      })
+
+      describe('when meta type is dropped', () => {
         const body = `
           settings salesforce.global is {
           }
@@ -620,8 +720,8 @@ describe('Salto parser', () => {
         it('should have an error', () => {
           expect(errors).toHaveLength(1)
           const error = errors[0]
-          expect(error.summary).toEqual('Invalid settings type definition')
-          expect(elements).toHaveLength(0)
+          expect(error.summary).toEqual('Primitive settings type')
+          expect(elements).toHaveLength(1)
         })
       })
     })


### PR DESCRIPTION
No reason to not allow and we have a use for this in SFDC.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
