### PR TITLE
SALTO-6147: Adding meta types optional feature to SFDC

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -45,6 +45,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   hideTypesFolder: false,
   omitStandardFieldsNonDeployableValues: true,
   latestSupportedApiVersion: false,
+  metaTypes: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -124,6 +124,7 @@ export type OptionalFeatures = {
   hideTypesFolder?: boolean
   omitStandardFieldsNonDeployableValues?: boolean
   latestSupportedApiVersion?: boolean
+  metaTypes?: boolean
 }
 
 export type ChangeValidatorName =
@@ -816,6 +817,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },
     omitStandardFieldsNonDeployableValues: { refType: BuiltinTypes.BOOLEAN },
     latestSupportedApiVersion: { refType: BuiltinTypes.BOOLEAN },
+    metaTypes: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Adding in a separate PR so I can rely on this for both adding the meta types and the existing types rename.

---

_Additional context for reviewer_

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.