### PR TITLE
SALTO-6324: Fix - default `custom` error handler overrides any type specific error handler definition

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -15,7 +15,7 @@
  */
 import { SaltoError } from '@salto-io/adapter-api'
 import { ContextCombinationDefinition, RecurseIntoDefinition } from './dependencies'
-import { AdjustFunction, ArgsWithCustomizer, GeneratedItem, TransformDefinition } from '../shared'
+import { AdjustFunction, GeneratedItem, TransformDefinition } from '../shared'
 import { ConfigChangeSuggestion } from '../../user'
 
 export type ResourceTransformFunc = AdjustFunction<{ fragments: GeneratedItem[] }>
@@ -39,7 +39,14 @@ type ConfigSuggestion = {
 
 export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion
 
-type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error; typeName: string }>
+// Defining the custom handling option with the same structure as the predefined options above allows it to
+// be overridden by a predefined option when merging with defaults.
+type CustomErrorHandler = {
+  action: 'customized'
+  value: (args: { error: Error; typeName: string }) => OnErrorHandlerAction
+}
+
+type OnErrorHandler = OnErrorHandlerAction | CustomErrorHandler
 
 export type FetchResourceDefinition = {
   // set to true if the resource should be fetched on its own. set to false for types only fetched via recurseInto

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -92,7 +92,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
     const { resource: resourceDef } = defQuery.query(typeName) ?? {}
     const onError = resourceDef?.onError
 
-    const onErrorResult = onError?.custom?.(onError)({ error, typeName }) ?? onError
+    const onErrorResult = onError?.action === 'customized' ? onError.value({ error, typeName }) : onError
     switch (onErrorResult?.action) {
       case 'customSaltoError':
         log.warn('failed to fetch type %s:%s, generating custom Salto error', adapterName, typeName)

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -307,7 +307,8 @@ describe('element', () => {
             default: {
               resource: {
                 onError: {
-                  custom: () => customErrorHandler,
+                  action: 'customized',
+                  value: () => customErrorHandler,
                 },
               },
             },

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1169,24 +1169,19 @@ export const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [
 ]
 
 const getInsufficientPermissionsError: definitions.fetch.FetchResourceDefinition['onError'] = {
-  custom:
-    () =>
-    ({ error, typeName }) => {
-      if (error instanceof clientUtils.HTTPError && error.response.status === 403) {
-        return {
-          action: 'customSaltoError',
-          value: {
-            message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
-            severity: 'Info',
-          },
-        }
+  action: 'customized',
+  value: ({ error, typeName }) => {
+    if (error instanceof clientUtils.HTTPError && error.response.status === 403) {
+      return {
+        action: 'customSaltoError',
+        value: {
+          message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
+          severity: 'Info',
+        },
       }
-      return { action: 'failEntireFetch', value: false }
-    },
-  // TODO SALTO-6004 remove
-  // this is a workaround to overcome types checker, the "custom" function is applied any other values are ignored
-  action: 'failEntireFetch',
-  value: false,
+    }
+    return { action: 'failEntireFetch', value: false }
+  },
 }
 
 export const createFetchDefinitions = (


### PR DESCRIPTION
**Problem:**
If a _custom_ error handler is defined as the default behavior in the fetch definition, and another non customized `onError` behavior is defined on a specific type - the latter should be used, not the default one. But it is not the case since nothing overrides the 'custom' field.

**Solution:**
Use the same structure of 'action' and 'value' for the customized handler as for the predefined ones. This way, the 'custom' field will be overridden the same way as the predefined ones.

---

_Additional context for reviewer_

---
_Release Notes_: 

---
_User Notifications_: 
