### PR TITLE
SALTO-6299 fix fixElements of form fields that reference objects with appid

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -749,9 +749,11 @@ export default class SdfClient {
       },
       executor,
     )
-    return results.data.map(({ type, scriptId }: { type: string; scriptId: string }) => ({
+    const instancesIds = results.data as Array<{ type: string; scriptId: string }>
+    return instancesIds.map(({ type, scriptId }) => ({
       type: SdfClient.fixTypeName(type),
       instanceId: scriptId,
+      suiteAppId,
     }))
   }
 

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -56,6 +56,7 @@ export type InstanceLimiterFunc = (type: string, instanceCount: number) => boole
 export interface ObjectID {
   type: string
   instanceId: string
+  suiteAppId?: string
 }
 
 export type NetsuiteTypesQueryParams = Record<string, string[]>

--- a/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
@@ -51,6 +51,8 @@ const { awu } = collections.asynciterable
 
 type MappedList = Record<string, { index: number; [key: string]: Value }>
 
+const NO_APPID = ''
+
 const formTypeNames = new Set([ADDRESS_FORM, ENTRY_FORM, TRANSACTION_FORM])
 
 const isFormInstanceElement = (element: Value): element is InstanceElement =>
@@ -119,7 +121,7 @@ const isUnresolvedNetsuiteReference = (
   const capture = captureServiceIdInfo(value)
   return capture.some(serviceId => {
     const objectServiceId = serviceId.serviceId.split('.')[0]
-    const suiteAppId = serviceId.appid ?? ''
+    const suiteAppId = serviceId.appid ?? NO_APPID
     return (
       !generatedDependencies.has(objectServiceId) &&
       envScriptIdsBySuiteAppId[suiteAppId] !== undefined &&
@@ -264,7 +266,7 @@ const removeUnresolvedFieldElements: WeakReferencesHandler<{
   ({ elementsSource }): FixElementsFunc =>
   async elements => {
     const envScriptIdsBySuiteAppId = _(await getObjectIdList(elementsSource))
-      .groupBy(objectId => objectId.suiteAppId ?? '')
+      .groupBy(objectId => objectId.suiteAppId ?? NO_APPID)
       .mapValues(objectIds => new Set(objectIds.map(objectId => objectId.instanceId)))
       .value()
 

--- a/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
+++ b/packages/netsuite-adapter/src/custom_references/weak_references/fields_references.ts
@@ -114,19 +114,25 @@ const isUnresolvedReferenceExpression = async (
 const isUnresolvedNetsuiteReference = (
   value: string,
   generatedDependencies: Set<string>,
-  envScriptIds: Set<string>,
+  envScriptIdsBySuiteAppId: Record<string, Set<string>>,
 ): boolean => {
   const capture = captureServiceIdInfo(value)
-  return capture
-    .map(serviceIdInfo => serviceIdInfo.serviceId.split('.')[0])
-    .some(serviceId => !generatedDependencies.has(serviceId) && !envScriptIds.has(serviceId))
+  return capture.some(serviceId => {
+    const objectServiceId = serviceId.serviceId.split('.')[0]
+    const suiteAppId = serviceId.appid ?? ''
+    return (
+      !generatedDependencies.has(objectServiceId) &&
+      envScriptIdsBySuiteAppId[suiteAppId] !== undefined &&
+      !envScriptIdsBySuiteAppId[suiteAppId].has(objectServiceId)
+    )
+  })
 }
 
 const getPathsToRemove = async (
   form: InstanceElement,
   generatedDependencies: Set<string>,
   elementsSource: ReadOnlyElementsSource,
-  envScriptIds: Set<string>,
+  envScriptIdsBySuiteAppId: Record<string, Set<string>>,
 ): Promise<ElemID[]> => {
   const pathsToRemove: ElemID[] = []
 
@@ -141,7 +147,7 @@ const getPathsToRemove = async (
     if (isReferenceExpression(id) && (await isUnresolvedReferenceExpression(id, elementsSource))) {
       pathsToRemove.push(path)
     }
-    if (_.isString(id) && isUnresolvedNetsuiteReference(id, generatedDependencies, envScriptIds)) {
+    if (_.isString(id) && isUnresolvedNetsuiteReference(id, generatedDependencies, envScriptIdsBySuiteAppId)) {
       pathsToRemove.push(path)
     }
     return value
@@ -227,13 +233,13 @@ const fixIndexes = (form: InstanceElement, pathsToRemove: ElemID[]): void => {
 const getFixedElementAndPaths = async (
   form: InstanceElement,
   elementsSource: ReadOnlyElementsSource,
-  envScriptIds: Set<string>,
+  envScriptIdsBySuiteAppId: Record<string, Set<string>>,
 ): Promise<{ instance: InstanceElement; relatedPaths: ElemID[] } | undefined> => {
   const fixedForm = form.clone()
 
   const { generatedDependencies, scriptIds } = await getResolvedGeneratedDependencies(fixedForm, elementsSource)
 
-  const pathsToRemove = await getPathsToRemove(fixedForm, scriptIds, elementsSource, envScriptIds)
+  const pathsToRemove = await getPathsToRemove(fixedForm, scriptIds, elementsSource, envScriptIdsBySuiteAppId)
 
   if (pathsToRemove.length === 0) {
     return undefined
@@ -243,7 +249,11 @@ const getFixedElementAndPaths = async (
 
   fixIndexes(fixedForm, pathsToRemove)
 
-  fixedForm.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = generatedDependencies
+  if (generatedDependencies.length > 0) {
+    fixedForm.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES] = generatedDependencies
+  } else {
+    delete fixedForm.annotations[CORE_ANNOTATIONS.GENERATED_DEPENDENCIES]
+  }
 
   return { instance: fixedForm, relatedPaths: pathsToRemove }
 }
@@ -253,10 +263,14 @@ const removeUnresolvedFieldElements: WeakReferencesHandler<{
 }>['removeWeakReferences'] =
   ({ elementsSource }): FixElementsFunc =>
   async elements => {
-    const envScriptIds = new Set<string>((await getObjectIdList(elementsSource)).map(objectid => objectid.instanceId))
+    const envScriptIdsBySuiteAppId = _(await getObjectIdList(elementsSource))
+      .groupBy(objectId => objectId.suiteAppId ?? '')
+      .mapValues(objectIds => new Set(objectIds.map(objectId => objectId.instanceId)))
+      .value()
+
     const fixedFormsWithPaths = await awu(elements)
       .filter(isFormInstanceElement)
-      .map(form => getFixedElementAndPaths(form, elementsSource, envScriptIds))
+      .map(form => getFixedElementAndPaths(form, elementsSource, envScriptIdsBySuiteAppId))
       .filter(values.isDefined)
       .toArray()
 

--- a/packages/netsuite-adapter/src/scriptid_list.ts
+++ b/packages/netsuite-adapter/src/scriptid_list.ts
@@ -26,6 +26,7 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
+import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { NETSUITE } from './constants'
 import { ObjectID } from './config/types'
 
@@ -39,12 +40,13 @@ const OBJECT_ID_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_TYPE_NAME)
 const OBJECT_ID_LIST_TYPE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME)
 const OBJECT_ID_LIST_INSTANCE_ID = new ElemID(NETSUITE, OBJECT_ID_LIST_TYPE_NAME, 'instance', ElemID.CONFIG_NAME)
 
-const objectIdType = new ObjectType({
+const objectIdType = createMatchingObjectType<ObjectID>({
   elemID: OBJECT_ID_TYPE_ID,
   isSettings: true,
   fields: {
-    instanceId: { refType: BuiltinTypes.STRING },
-    type: { refType: BuiltinTypes.STRING },
+    instanceId: { refType: BuiltinTypes.STRING, annotations: { _required: true } },
+    type: { refType: BuiltinTypes.STRING, annotations: { _required: true } },
+    suiteAppId: { refType: BuiltinTypes.STRING },
   },
   annotations: {
     [CORE_ANNOTATIONS.HIDDEN]: true,


### PR DESCRIPTION
in case that a form field reference an object with `appid`, we should check if that app id is even being fetched, otherwise the object won't be in the `objectid_list` instance, and we'll remove it.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- fix fixElements of form fields that reference objects with appid

---
_User Notifications_: 
None