### PR TITLE
SALTO-6264: Renaming CustomObject and CustomMetadata types

### DIFF
--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -61,7 +61,7 @@ export const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentia
       }
     },
     typeName: 'salesforce',
-    globalProp: envName ? `salesforce_${envName}` : 'salseforce',
+    globalProp: envName ? `salesforce_${envName}` : 'salesforce',
   }
 }
 

--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -61,7 +61,7 @@ export const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentia
       }
     },
     typeName: 'salesforce',
-    globalProp: envName ? `salesforce_${envName}` : 'salesforce',
+    globalProp: envName ? `salesforce_${envName}` : 'salseforce',
   }
 }
 

--- a/packages/salesforce-adapter/src/change_validators/metadata_types.ts
+++ b/packages/salesforce-adapter/src/change_validators/metadata_types.ts
@@ -24,7 +24,14 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { apiNameSync, metadataTypeSync } from '../filters/utils'
-import { API_NAME, CUSTOM_METADATA, CUSTOM_OBJECT, METADATA_TYPE } from '../constants'
+import {
+  API_NAME,
+  CUSTOM_METADATA,
+  CUSTOM_METADATA_TYPE_NAME,
+  CUSTOM_OBJECT,
+  CUSTOM_OBJECT_TYPE_NAME,
+  METADATA_TYPE,
+} from '../constants'
 
 const { isDefined } = values
 
@@ -53,12 +60,12 @@ const isMetadataType = (objectType: ObjectType): boolean => {
   }
   // CustomObject Metadata Type
   if (metadataTypeSync(objectType) === CUSTOM_OBJECT) {
-    return objectType.elemID.typeName === CUSTOM_OBJECT && objectType.annotations[API_NAME] === undefined
+    return objectType.elemID.typeName === CUSTOM_OBJECT_TYPE_NAME && objectType.annotations[API_NAME] === undefined
   }
   // CustomMetadata Metadata Type
   if (metadataTypeSync(objectType) === CUSTOM_METADATA) {
     return (
-      objectType.elemID.typeName === CUSTOM_METADATA && objectType.annotations[API_NAME] === undefined // this would be the 'CustomObject' metadata type
+      objectType.elemID.typeName === CUSTOM_METADATA_TYPE_NAME && objectType.annotations[API_NAME] === undefined // this would be the 'CustomObject' metadata type
     )
   }
   return true

--- a/packages/salesforce-adapter/src/change_validators/metadata_types.ts
+++ b/packages/salesforce-adapter/src/change_validators/metadata_types.ts
@@ -24,14 +24,7 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import { apiNameSync, metadataTypeSync } from '../filters/utils'
-import {
-  API_NAME,
-  CUSTOM_METADATA,
-  CUSTOM_METADATA_TYPE_NAME,
-  CUSTOM_OBJECT,
-  CUSTOM_OBJECT_TYPE_NAME,
-  METADATA_TYPE,
-} from '../constants'
+import { API_NAME, CUSTOM_METADATA, CUSTOM_OBJECT, CUSTOM_OBJECT_TYPE_NAME, METADATA_TYPE } from '../constants'
 
 const { isDefined } = values
 
@@ -65,11 +58,12 @@ const isMetadataType = (objectType: ObjectType): boolean => {
   // CustomMetadata Metadata Type
   if (metadataTypeSync(objectType) === CUSTOM_METADATA) {
     return (
-      objectType.elemID.typeName === CUSTOM_METADATA_TYPE_NAME && objectType.annotations[API_NAME] === undefined // this would be the 'CustomObject' metadata type
+      objectType.annotations[API_NAME] === undefined // this would be the 'CustomObject' metadata type
     )
   }
   return true
 }
+
 const changeValidator: ChangeValidator = async changes =>
   changes
     .map(change => getAffectedType(change))

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -22,7 +22,10 @@ export const { RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS } = clientUtils
 
 export const UNIX_TIME_ZERO_STRING = '1970-01-01T00:00:00.000Z'
 
+// Adapter name
 export const SALESFORCE = 'salesforce'
+
+// Service constants
 export const CUSTOM_FIELD = 'CustomField'
 export const CUSTOM_OBJECT = 'CustomObject'
 export const INSTANCE_FULL_NAME_FIELD = 'fullName'
@@ -35,6 +38,8 @@ export const ADMIN_PROFILE = 'Admin'
 export const NAMESPACE_SEPARATOR = '__'
 export const API_NAME_SEPARATOR = '.'
 export const CUSTOM_OBJECT_ID_FIELD = 'Id'
+
+// Internal constants
 export const INTERNAL_ID_FIELD = 'internalId'
 export const XML_ATTRIBUTE_PREFIX = 'attr_'
 export const DEFAULT_NAMESPACE = 'standard'
@@ -339,6 +344,10 @@ export const DefaultSoqlQueryLimits: SoqlQueryLimits = {
   maxQueryLength: 100000,
   maxWhereClauseLength: 2000,
 }
+
+// Renamed types
+export const CUSTOM_OBJECT_TYPE_NAME = '_CustomObject'
+export const CUSTOM_METADATA_TYPE_NAME = '_CustomMetadata'
 
 // Fields and Values
 export const CURRENCY_ISO_CODE = 'CurrencyIsoCode'

--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -27,17 +27,29 @@ import {
   isObjectTypeChange,
   ObjectType,
 } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterContext, LocalFilterCreator } from '../filter'
-import { CUSTOM_METADATA, CUSTOM_METADATA_SUFFIX, CUSTOM_OBJECT, SALESFORCE } from '../constants'
+import {
+  CUSTOM_METADATA,
+  CUSTOM_METADATA_SUFFIX,
+  CUSTOM_METADATA_TYPE_NAME,
+  CUSTOM_OBJECT,
+  SALESFORCE,
+} from '../constants'
 import { createCustomObjectChange, createCustomTypeFromCustomObjectInstance } from './custom_objects_to_object_type'
 import { apiName } from '../transformers/transformer'
-import { buildElementsSourceForFetch, isCustomMetadataRecordType, isInstanceOfTypeChange } from './utils'
+import {
+  apiNameSync,
+  buildElementsSourceForFetch,
+  isCustomMetadataRecordType,
+  isInstanceOfTypeChangeSync,
+} from './utils'
 
 const log = logger(module)
 
+const { isDefined } = values
 const { awu, groupByAsync } = collections.asynciterable
 
 const createCustomMetadataRecordType = async (
@@ -77,7 +89,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
     name: 'customMetadataToObjectTypeFilter',
     onFetch: async elements => {
       const customMetadataType: unknown = await buildElementsSourceForFetch(elements, config).get(
-        new ElemID(SALESFORCE, CUSTOM_METADATA),
+        new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
       )
       if (!isObjectType(customMetadataType)) {
         log.warn('Could not find CustomMetadata ObjectType. Skipping filter.')
@@ -109,13 +121,12 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
       deployableChanges.forEach(c => changes.push(c))
     },
     onDeploy: async changes => {
-      const relatedAppliedChangesApiNames = await awu(changes)
-        .filter(isInstanceOfTypeChange(CUSTOM_OBJECT))
+      const relatedAppliedChangesApiNames = changes
+        .filter(isInstanceOfTypeChangeSync(CUSTOM_OBJECT))
         .filter(c => getChangeData(c).elemID.name.endsWith(CUSTOM_METADATA_SUFFIX))
-        .toArray()
-      const appliedChangesApiNames = await awu(relatedAppliedChangesApiNames)
-        .map(c => apiName(getChangeData(c)))
-        .toArray()
+      const appliedChangesApiNames = relatedAppliedChangesApiNames
+        .map(c => apiNameSync(getChangeData(c)))
+        .filter(isDefined)
 
       const appliedOriginalChanges = appliedChangesApiNames.flatMap(name => groupedOriginalChangesByApiName[name] ?? [])
 

--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -16,14 +16,12 @@
 import {
   Change,
   Element,
-  ElemID,
   Field,
   getChangeData,
   InstanceElement,
   isField,
   isFieldChange,
   isInstanceElement,
-  isObjectType,
   isObjectTypeChange,
   ObjectType,
 } from '@salto-io/adapter-api'
@@ -31,20 +29,15 @@ import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { FilterContext, LocalFilterCreator } from '../filter'
-import {
-  CUSTOM_METADATA,
-  CUSTOM_METADATA_SUFFIX,
-  CUSTOM_METADATA_TYPE_NAME,
-  CUSTOM_OBJECT,
-  SALESFORCE,
-} from '../constants'
+import { CUSTOM_METADATA, CUSTOM_METADATA_SUFFIX, CUSTOM_OBJECT } from '../constants'
 import { createCustomObjectChange, createCustomTypeFromCustomObjectInstance } from './custom_objects_to_object_type'
-import { apiName } from '../transformers/transformer'
+import { apiName, isMetadataObjectType } from '../transformers/transformer'
 import {
   apiNameSync,
   buildElementsSourceForFetch,
   isCustomMetadataRecordType,
   isInstanceOfTypeChangeSync,
+  metadataTypeSync,
 } from './utils'
 
 const log = logger(module)
@@ -88,14 +81,14 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
   return {
     name: 'customMetadataToObjectTypeFilter',
     onFetch: async elements => {
-      const customMetadataType: unknown = await buildElementsSourceForFetch(elements, config).get(
-        new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
-      )
-      if (!isObjectType(customMetadataType)) {
+      const customMetadataType = await awu(await buildElementsSourceForFetch(elements, config).getAll())
+        .filter(isMetadataObjectType)
+        .find(elem => metadataTypeSync(elem) === CUSTOM_METADATA)
+      if (customMetadataType === undefined) {
         log.warn('Could not find CustomMetadata ObjectType. Skipping filter.')
         return
       }
-      // The CustomObject instances that will  be converted to ObjectTypes.
+      // The CustomObject instances that will be converted to ObjectTypes.
       const customMetadataInstances = elements
         .filter(isInstanceElement)
         .filter(e => e.elemID.name.endsWith(CUSTOM_METADATA_SUFFIX))

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -84,6 +84,7 @@ import {
   FLEXI_PAGE_TYPE,
   KEY_PREFIX,
   PLURAL_LABEL,
+  CUSTOM_OBJECT_TYPE_NAME,
 } from '../constants'
 import { FilterContext, LocalFilterCreator } from '../filter'
 import {
@@ -116,7 +117,6 @@ import {
   parentApiName,
   getDataFromChanges,
   isInstanceOfTypeChange,
-  isInstanceOfType,
   isMasterDetailField,
   buildElementsSourceForFetch,
   addKeyPrefix,
@@ -126,6 +126,8 @@ import {
   isInstanceOfTypeSync,
   toCustomField,
   toCustomProperties,
+  isInstanceOfTypeChangeSync,
+  apiNameSync,
 } from './utils'
 import { convertList } from './convert_lists'
 import { DEPLOY_WRAPPER_INSTANCE_MARKER } from '../metadata_deploy'
@@ -188,7 +190,7 @@ type TypesFromInstance = {
   nestedMetadataTypes: Record<string, ObjectType>
 }
 
-export const CUSTOM_OBJECT_TYPE_ID = new ElemID(SALESFORCE, CUSTOM_OBJECT)
+export const CUSTOM_OBJECT_TYPE_ID = new ElemID(SALESFORCE, CUSTOM_OBJECT_TYPE_NAME)
 
 const CUSTOM_ONLY_ANNOTATION_TYPE_NAMES = [
   'allowInChatterGroups',
@@ -641,41 +643,42 @@ const getNestedCustomObjectValues = async (
     .toArray(),
 })
 
-const createCustomObjectInstance = (values: MetadataValues): InstanceElement => {
-  const customFieldType = new ObjectType({
-    elemID: new ElemID(SALESFORCE, CUSTOM_FIELD),
-    annotations: { [METADATA_TYPE]: CUSTOM_FIELD },
-  })
-  const customObjectType = new ObjectType({
-    elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT),
-    annotationRefsOrTypes: _.clone(metadataAnnotationTypes),
-    annotations: {
-      metadataType: CUSTOM_OBJECT,
-      dirName: 'objects',
-      suffix: 'object',
-    } as MetadataTypeAnnotations,
-    fields: {
-      [DEPLOY_WRAPPER_INSTANCE_MARKER]: {
-        refType: BuiltinTypes.BOOLEAN,
-        annotations: {
-          [FIELD_ANNOTATIONS.LOCAL_ONLY]: true,
-        },
+const customObjectTypeForDeploy = new ObjectType({
+  elemID: CUSTOM_OBJECT_TYPE_ID,
+  annotationRefsOrTypes: _.clone(metadataAnnotationTypes),
+  annotations: {
+    metadataType: CUSTOM_OBJECT,
+    dirName: 'objects',
+    suffix: 'object',
+  } as MetadataTypeAnnotations,
+  fields: {
+    [DEPLOY_WRAPPER_INSTANCE_MARKER]: {
+      refType: BuiltinTypes.BOOLEAN,
+      annotations: {
+        [FIELD_ANNOTATIONS.LOCAL_ONLY]: true,
       },
-      fields: {
-        refType: new ListType(customFieldType),
-      },
-      ..._.mapValues(NESTED_INSTANCE_VALUE_TO_TYPE_NAME, fieldType => ({
-        refType: new ListType(
-          new ObjectType({
-            elemID: new ElemID(SALESFORCE, fieldType),
-            annotations: { [METADATA_TYPE]: fieldType },
-          }),
-        ),
-      })),
     },
-  })
-  return createInstanceElement(values, customObjectType)
-}
+    fields: {
+      refType: new ListType(
+        new ObjectType({
+          elemID: new ElemID(SALESFORCE, CUSTOM_FIELD),
+          annotations: { [METADATA_TYPE]: CUSTOM_FIELD },
+        }),
+      ),
+    },
+    ..._.mapValues(NESTED_INSTANCE_VALUE_TO_TYPE_NAME, fieldType => ({
+      refType: new ListType(
+        new ObjectType({
+          elemID: new ElemID(SALESFORCE, fieldType),
+          annotations: { [METADATA_TYPE]: fieldType },
+        }),
+      ),
+    })),
+  },
+})
+
+const createCustomObjectInstance = (values: MetadataValues): InstanceElement =>
+  createInstanceElement(values, customObjectTypeForDeploy)
 
 const getCustomObjectFromChange = async (change: Change): Promise<ObjectType> => {
   const elem = getChangeData(change)
@@ -888,7 +891,7 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
       const fieldsToSkip = config.unsupportedSystemFields
 
       const customObjectInstances = removeDuplicateElements(
-        await awu(elements).filter(isInstanceElement).filter(isInstanceOfType(CUSTOM_OBJECT)).toArray(),
+        elements.filter(isInstanceElement).filter(isInstanceOfTypeSync(CUSTOM_OBJECT)),
       )
 
       await awu(customObjectInstances)
@@ -900,7 +903,9 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
 
       // Remove CustomObject instances & hide the CustomObject metadata type
       _.remove(elements, isInstanceOfTypeSync(CUSTOM_OBJECT))
-      const customObjectType = elements.filter(isMetadataObjectType).find(type => type.elemID.name === CUSTOM_OBJECT)
+      const customObjectType = elements
+        .filter(isMetadataObjectType)
+        .find(type => type.elemID.isEqual(CUSTOM_OBJECT_TYPE_ID))
       if (customObjectType !== undefined) {
         customObjectType.annotations[CORE_ANNOTATIONS.HIDDEN] = true
       }
@@ -946,17 +951,17 @@ const filterCreator: LocalFilterCreator = ({ config }) => {
     },
 
     onDeploy: async changes => {
-      const appliedCustomObjectApiNames = await awu(changes)
-        .filter(isInstanceOfTypeChange(CUSTOM_OBJECT))
-        .map(change => apiName(getChangeData(change)))
-        .toArray()
+      const appliedCustomObjectApiNames = changes
+        .filter(isInstanceOfTypeChangeSync(CUSTOM_OBJECT))
+        .map(change => apiNameSync(getChangeData(change)))
+        .filter(isDefined)
 
       const appliedOriginalChanges = appliedCustomObjectApiNames.flatMap(
         objectApiName => originalChanges[objectApiName] ?? [],
       )
 
       // Remove the changes we generated in preDeploy and replace them with the original changes
-      await removeAsync(changes, isInstanceOfTypeChange(CUSTOM_OBJECT))
+      _.remove(changes, isInstanceOfTypeChangeSync(CUSTOM_OBJECT))
       changes.push(...appliedOriginalChanges)
     },
   }

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -17,7 +17,7 @@ import { Element, Field, ReferenceExpression, ObjectType, isObjectType } from '@
 import _ from 'lodash'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { LocalFilterCreator } from '../filter'
-import { FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN, CUSTOM_OBJECT } from '../constants'
+import { FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN, CUSTOM_OBJECT, CUSTOM_OBJECT_TYPE_NAME } from '../constants'
 import { apiName, metadataType, isMetadataObjectType, isCustomObject } from '../transformers/transformer'
 import { apiNameSync, buildElementsSourceForFetch } from './utils'
 
@@ -43,7 +43,7 @@ const convertAnnotationsToReferences = async (
   const resolveTypeReference = (ref: string | ReferenceExpression): string | ReferenceExpression => {
     if (_.isString(ref)) {
       // Try finding a metadata type and fallback to finding a custom object
-      const referenceElement = nameToElement.get(ref, ref) ?? nameToElement.get(CUSTOM_OBJECT, ref)
+      const referenceElement = nameToElement.get(ref, ref) ?? nameToElement.get(CUSTOM_OBJECT_TYPE_NAME, ref)
       // SALTO-5064
       if (referenceElement !== undefined && apiNameSync(referenceElement) !== CUSTOM_OBJECT) {
         return new ReferenceExpression(referenceElement.elemID, referenceElement)

--- a/packages/salesforce-adapter/src/metadata_deploy.ts
+++ b/packages/salesforce-adapter/src/metadata_deploy.ts
@@ -52,7 +52,7 @@ import { apiNameSync, fullApiName } from './filters/utils'
 import {
   API_NAME_SEPARATOR,
   CUSTOM_FIELD,
-  CUSTOM_OBJECT,
+  CUSTOM_OBJECT_TYPE_NAME,
   GLOBAL_VALUE_SET_SUFFIX,
   INSTANCE_FULL_NAME_FIELD,
   SalesforceArtifacts,
@@ -224,7 +224,7 @@ const processDeployResponse = (
       log.debug('Unable to match deploy message for %s[%s] with an ElemID.', fullName, componentType)
       return undefined
     }
-    if (rawElemId.typeName === CUSTOM_OBJECT) {
+    if (rawElemId.typeName === CUSTOM_OBJECT_TYPE_NAME) {
       // When there's a deploy error for a custom object, we receive componentType = 'CustomObject',
       // fullName = (e.g.) 'Account'. By this point in the flow, custom objects are converted back into instances of
       // 'CustomObject', so we end up mapping the deploy errors to (e.g.) salesforce.CustomObject.instance.Account

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1461,9 +1461,9 @@ type ObjectTypeCtorParam = ConstructorParameters<typeof ObjectType>[0]
 type CreateMetadataObjectTypeParams = Omit<ObjectTypeCtorParam, 'elemID'> & {
   annotations: MetadataTypeAnnotations
 }
-export const createMetadataObjectType = (params: CreateMetadataObjectTypeParams, name?: string): MetadataObjectType =>
+export const createMetadataObjectType = (params: CreateMetadataObjectTypeParams): MetadataObjectType =>
   new ObjectType({
-    elemID: new ElemID(SALESFORCE, name ?? params.annotations.metadataType),
+    elemID: new ElemID(SALESFORCE, params.annotations.metadataType),
     ...params,
     fields: {
       [INSTANCE_FULL_NAME_FIELD]: {

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -111,8 +111,6 @@ import {
   INTERNAL_ID_ANNOTATION,
   SALESFORCE_DATE_PLACEHOLDER,
   CUSTOM_OBJECT_TYPE_NAME,
-  CUSTOM_METADATA,
-  CUSTOM_METADATA_TYPE_NAME,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -286,7 +284,8 @@ const restrictedNumberTypes = _.mapValues(
 
 export const METADATA_TYPES_TO_RENAME: Map<string, string> = new Map([
   [CUSTOM_OBJECT, CUSTOM_OBJECT_TYPE_NAME],
-  [CUSTOM_METADATA, CUSTOM_METADATA_TYPE_NAME],
+  // TODO (SALTO-6264): Uncomment this once hide types is enabled.
+  // [CUSTOM_METADATA, CUSTOM_METADATA_TYPE_NAME],
   ['FlexiPage', 'LightningPage'],
   ['FlexiPageRegion', 'LightningPageRegion'],
   ['FlexiPageTemplateInstance', 'LightningPageTemplateInstance'],

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -110,6 +110,9 @@ import {
   LOCATION_INTERNAL_COMPOUND_FIELD_TYPE_NAME,
   INTERNAL_ID_ANNOTATION,
   SALESFORCE_DATE_PLACEHOLDER,
+  CUSTOM_OBJECT_TYPE_NAME,
+  CUSTOM_METADATA,
+  CUSTOM_METADATA_TYPE_NAME,
 } from '../constants'
 import SalesforceClient from '../client/client'
 import { allMissingSubTypes } from './salesforce_types'
@@ -282,6 +285,8 @@ const restrictedNumberTypes = _.mapValues(
 )
 
 export const METADATA_TYPES_TO_RENAME: Map<string, string> = new Map([
+  [CUSTOM_OBJECT, CUSTOM_OBJECT_TYPE_NAME],
+  [CUSTOM_METADATA, CUSTOM_METADATA_TYPE_NAME],
   ['FlexiPage', 'LightningPage'],
   ['FlexiPageRegion', 'LightningPageRegion'],
   ['FlexiPageTemplateInstance', 'LightningPageTemplateInstance'],
@@ -1456,9 +1461,9 @@ type ObjectTypeCtorParam = ConstructorParameters<typeof ObjectType>[0]
 type CreateMetadataObjectTypeParams = Omit<ObjectTypeCtorParam, 'elemID'> & {
   annotations: MetadataTypeAnnotations
 }
-export const createMetadataObjectType = (params: CreateMetadataObjectTypeParams): MetadataObjectType =>
+export const createMetadataObjectType = (params: CreateMetadataObjectTypeParams, name?: string): MetadataObjectType =>
   new ObjectType({
-    elemID: new ElemID(SALESFORCE, params.annotations.metadataType),
+    elemID: new ElemID(SALESFORCE, name ?? params.annotations.metadataType),
     ...params,
     fields: {
       [INSTANCE_FULL_NAME_FIELD]: {

--- a/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
@@ -16,7 +16,14 @@
 import { ChangeError, InstanceElement, toChange, BuiltinTypes, ObjectType, ElemID } from '@salto-io/adapter-api'
 import deployNonDeployableTypes from '../../src/change_validators/metadata_types'
 import { createMetadataObjectType } from '../../src/transformers/transformer'
-import { CUSTOM_METADATA, CUSTOM_OBJECT, METADATA_TYPE, SALESFORCE } from '../../src/constants'
+import {
+  CUSTOM_METADATA,
+  CUSTOM_METADATA_TYPE_NAME,
+  CUSTOM_OBJECT,
+  CUSTOM_OBJECT_TYPE_NAME,
+  METADATA_TYPE,
+  SALESFORCE,
+} from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { createField } from '../utils'
 
@@ -70,16 +77,22 @@ describe('deployNonDeployableTypes', () => {
     })
   })
   describe('When deploying the CustomObject and CustomMetadata metadata types', () => {
-    const customObjectMetadataType = createMetadataObjectType({
-      annotations: {
-        [METADATA_TYPE]: CUSTOM_OBJECT,
+    const customObjectMetadataType = createMetadataObjectType(
+      {
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_OBJECT,
+        },
       },
-    })
-    const customMetadataMetadataType = createMetadataObjectType({
-      annotations: {
-        [METADATA_TYPE]: CUSTOM_METADATA,
+      CUSTOM_OBJECT_TYPE_NAME,
+    )
+    const customMetadataMetadataType = createMetadataObjectType(
+      {
+        annotations: {
+          [METADATA_TYPE]: CUSTOM_METADATA,
+        },
       },
-    })
+      CUSTOM_METADATA_TYPE_NAME,
+    )
     beforeEach(async () => {
       validatorResult = await deployNonDeployableTypes([
         toChange({ after: customObjectMetadataType }),

--- a/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/metadata_types.test.ts
@@ -21,6 +21,7 @@ import {
   CUSTOM_METADATA_TYPE_NAME,
   CUSTOM_OBJECT,
   CUSTOM_OBJECT_TYPE_NAME,
+  INSTANCE_FULL_NAME_FIELD,
   METADATA_TYPE,
   SALESFORCE,
 } from '../../src/constants'
@@ -77,22 +78,28 @@ describe('deployNonDeployableTypes', () => {
     })
   })
   describe('When deploying the CustomObject and CustomMetadata metadata types', () => {
-    const customObjectMetadataType = createMetadataObjectType(
-      {
-        annotations: {
-          [METADATA_TYPE]: CUSTOM_OBJECT,
+    const customObjectMetadataType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, CUSTOM_OBJECT_TYPE_NAME),
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_OBJECT,
+      },
+      fields: {
+        [INSTANCE_FULL_NAME_FIELD]: {
+          refType: BuiltinTypes.SERVICE_ID,
         },
       },
-      CUSTOM_OBJECT_TYPE_NAME,
-    )
-    const customMetadataMetadataType = createMetadataObjectType(
-      {
-        annotations: {
-          [METADATA_TYPE]: CUSTOM_METADATA,
+    })
+    const customMetadataMetadataType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
+      annotations: {
+        [METADATA_TYPE]: CUSTOM_METADATA,
+      },
+      fields: {
+        [INSTANCE_FULL_NAME_FIELD]: {
+          refType: BuiltinTypes.SERVICE_ID,
         },
       },
-      CUSTOM_METADATA_TYPE_NAME,
-    )
+    })
     beforeEach(async () => {
       validatorResult = await deployNonDeployableTypes([
         toChange({ after: customObjectMetadataType }),

--- a/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
@@ -303,9 +303,7 @@ describe('CustomMetadata filter', () => {
       })
       it('should convert deployed instance type to CustomMetadata', async () => {
         const instanceType = await afterPreDeployInstance.getType()
-        expect(instanceType.elemID).toEqual(
-          new ElemID(SALESFORCE, CUSTOM_METADATA),
-        )
+        expect(instanceType.elemID).toEqual(new ElemID(SALESFORCE, CUSTOM_METADATA))
       })
       it('should add XML namespace attributes', () => {
         expect(afterPreDeployInstance.value).toHaveProperty(

--- a/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata.test.ts
@@ -303,7 +303,9 @@ describe('CustomMetadata filter', () => {
       })
       it('should convert deployed instance type to CustomMetadata', async () => {
         const instanceType = await afterPreDeployInstance.getType()
-        expect(instanceType.elemID).toEqual(mockTypes.CustomMetadata.elemID)
+        expect(instanceType.elemID).toEqual(
+          new ElemID(SALESFORCE, CUSTOM_METADATA),
+        )
       })
       it('should add XML namespace attributes', () => {
         expect(afterPreDeployInstance.value).toHaveProperty(

--- a/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
@@ -44,10 +44,7 @@ import {
 } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { apiName, Types } from '../../src/transformers/transformer'
-import {
-  apiNameSync,
-  isInstanceOfTypeChangeSync,
-} from '../../src/filters/utils'
+import { apiNameSync, isInstanceOfTypeChangeSync } from '../../src/filters/utils'
 import { FilterWith } from './mocks'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 

--- a/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
@@ -44,7 +44,10 @@ import {
 } from '../../src/constants'
 import { mockTypes } from '../mock_elements'
 import { apiName, Types } from '../../src/transformers/transformer'
-import { apiNameSync, isInstanceOfTypeChange } from '../../src/filters/utils'
+import {
+  apiNameSync,
+  isInstanceOfTypeChangeSync,
+} from '../../src/filters/utils'
 import { FilterWith } from './mocks'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 
@@ -59,21 +62,21 @@ describe('customMetadataToObjectTypeFilter', () => {
 
   let filter: FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
 
+  beforeEach(() => {
+    filter = filterCreator({
+      config: {
+        ...defaultFilterContext,
+        fetchProfile: buildFetchProfile({
+          fetchParams: { optionalFeatures: { skipAliases: false } },
+        }),
+      },
+    }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+  })
+
   describe('onFetch', () => {
     let customMetadataRecordType: ObjectType
     let afterOnFetchElements: Element[]
     let customMetadataInstance: InstanceElement
-
-    beforeEach(() => {
-      filter = filterCreator({
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({
-            fetchParams: { optionalFeatures: { skipAliases: false } },
-          }),
-        },
-      }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
-    })
 
     beforeEach(async () => {
       const checkboxField = {
@@ -229,10 +232,10 @@ describe('customMetadataToObjectTypeFilter', () => {
       await filter.onDeploy(afterOnDeployChanges)
     })
 
-    it('should create a deployable CustomObject instance on preDeploy', async () => {
-      const customObjectChange = (await awu(afterPreDeployChanges)
+    it('should create a deployable CustomObject instance on preDeploy', () => {
+      const customObjectChange = afterPreDeployChanges
         .filter(isInstanceChange)
-        .find(isInstanceOfTypeChange(CUSTOM_OBJECT))) as Change<InstanceElement>
+        .find(isInstanceOfTypeChangeSync(CUSTOM_OBJECT))
 
       expect(customObjectChange).toBeDefined()
       expect(afterPreDeployChanges).toHaveLength(1)

--- a/packages/salesforce-adapter/test/filters/custom_type_split.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_type_split.test.ts
@@ -18,7 +18,6 @@ import _ from 'lodash'
 import { values } from '@salto-io/lowerdash'
 import { BuiltinTypes, Element, ElemID, ObjectType } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/custom_type_split'
-import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects_to_object_type'
 import {
   API_NAME,
   CUSTOM_OBJECT,
@@ -43,6 +42,8 @@ const getElementPaths = (elements: Element[]): string[] =>
 
 describe('Custom Object Split filter', () => {
   describe('when using default file split', () => {
+    const TYPE_NAME = 'ObjectRandom'
+    const TYPE_ID = new ElemID(SALESFORCE, TYPE_NAME)
     const CUSTOM_METADATA_RECORD_TYPE_NAME = 'MDType__mdt'
     const filter = (): FilterType =>
       filterCreator({
@@ -55,7 +56,7 @@ describe('Custom Object Split filter', () => {
       return elements
     }
     const noNameSpaceObject = new ObjectType({
-      elemID: CUSTOM_OBJECT_TYPE_ID,
+      elemID: TYPE_ID,
       fields: {
         standard: {
           refType: BuiltinTypes.STRING,
@@ -76,7 +77,7 @@ describe('Custom Object Split filter', () => {
       },
     })
     const namespaceObject = new ObjectType({
-      elemID: CUSTOM_OBJECT_TYPE_ID,
+      elemID: TYPE_ID,
       fields: {
         standard: {
           refType: BuiltinTypes.STRING,
@@ -116,7 +117,7 @@ describe('Custom Object Split filter', () => {
 
       it('should create annotations object', () => {
         const annotationsObj = elements.find(obj =>
-          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations']),
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}Annotations`]),
         ) as ObjectType
         expect(annotationsObj).toBeDefined()
         expect(Object.values(annotationsObj.fields).length).toEqual(0)
@@ -125,7 +126,7 @@ describe('Custom Object Split filter', () => {
 
       it('should create standard fields object', () => {
         const standardFieldsObj = elements.find(obj =>
-          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields']),
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}StandardFields`]),
         ) as ObjectType
         expect(standardFieldsObj).toBeDefined()
         expect(Object.values(standardFieldsObj.annotations).length).toEqual(0)
@@ -135,7 +136,7 @@ describe('Custom Object Split filter', () => {
 
       it('should create custom fields object with all custom fields', () => {
         const customFieldsObj = elements.find(obj =>
-          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields']),
+          _.isEqual(obj.path, [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}CustomFields`]),
         ) as ObjectType
         expect(customFieldsObj).toBeDefined()
         expect(Object.values(customFieldsObj.annotations).length).toEqual(0)
@@ -161,8 +162,8 @@ describe('Custom Object Split filter', () => {
             INSTALLED_PACKAGES_PATH,
             'namespace',
             OBJECTS_PATH,
-            'CustomObject',
-            'CustomObjectAnnotations',
+            TYPE_NAME,
+            `${TYPE_NAME}Annotations`,
           ]),
         ) as ObjectType
         expect(annotationsObj).toBeDefined()
@@ -177,8 +178,8 @@ describe('Custom Object Split filter', () => {
             INSTALLED_PACKAGES_PATH,
             'namespace',
             OBJECTS_PATH,
-            'CustomObject',
-            'CustomObjectStandardFields',
+            TYPE_NAME,
+            `${TYPE_NAME}StandardFields`,
           ]),
         ) as ObjectType
         expect(standardFieldsObj).toBeDefined()
@@ -194,8 +195,8 @@ describe('Custom Object Split filter', () => {
             INSTALLED_PACKAGES_PATH,
             'namespace',
             OBJECTS_PATH,
-            'CustomObject',
-            'CustomObjectCustomFields',
+            TYPE_NAME,
+            `${TYPE_NAME}CustomFields`,
           ]),
         ) as ObjectType
         expect(customFieldsObj).toBeDefined()
@@ -217,7 +218,7 @@ describe('Custom Object Split filter', () => {
 
       it('should filter out empty standard fields object', async () => {
         const objectWithNoStandardFields = new ObjectType({
-          elemID: CUSTOM_OBJECT_TYPE_ID,
+          elemID: TYPE_ID,
           fields: {
             custom__c: {
               refType: BuiltinTypes.STRING,
@@ -236,13 +237,13 @@ describe('Custom Object Split filter', () => {
         })
         const splitElementsPaths = await getSplitElementsPaths(objectWithNoStandardFields)
         expect(splitElementsPaths).toIncludeSameMembers([
-          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectCustomFields'],
-          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+          [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}CustomFields`],
+          [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}Annotations`],
         ])
       })
       it('should filter out empty custom fields object', async () => {
         const objectWithNoCustomFields = new ObjectType({
-          elemID: CUSTOM_OBJECT_TYPE_ID,
+          elemID: TYPE_ID,
           fields: {
             standard: {
               refType: BuiltinTypes.STRING,
@@ -255,8 +256,8 @@ describe('Custom Object Split filter', () => {
         })
         const splitElementsPaths = await getSplitElementsPaths(objectWithNoCustomFields)
         expect(splitElementsPaths).toIncludeSameMembers([
-          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectStandardFields'],
-          [SALESFORCE, OBJECTS_PATH, 'CustomObject', 'CustomObjectAnnotations'],
+          [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}StandardFields`],
+          [SALESFORCE, OBJECTS_PATH, TYPE_NAME, `${TYPE_NAME}Annotations`],
         ])
       })
     })

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -354,16 +354,19 @@ export const mockTypes = {
       dirName: 'territory2Models',
     },
   }),
-  CustomMetadata: createMetadataObjectType(
-    {
-      annotations: {
-        metadataType: 'CustomMetadata',
-        dirName: 'customMetadata',
-        suffix: 'md',
+  CustomMetadata: new ObjectType({
+    elemID: new ElemID(SALESFORCE, constants.CUSTOM_METADATA_TYPE_NAME),
+    annotations: {
+      metadataType: 'CustomMetadata',
+      dirName: 'customMetadata',
+      suffix: 'md',
+    },
+    fields: {
+      [INSTANCE_FULL_NAME_FIELD]: {
+        refType: BuiltinTypes.SERVICE_ID,
       },
     },
-    constants.CUSTOM_METADATA_TYPE_NAME,
-  ),
+  }),
   EmailTemplate: createMetadataObjectType({
     annotations: {
       metadataType: 'EmailTemplate',

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -354,13 +354,16 @@ export const mockTypes = {
       dirName: 'territory2Models',
     },
   }),
-  CustomMetadata: createMetadataObjectType({
-    annotations: {
-      metadataType: 'CustomMetadata',
-      dirName: 'customMetadata',
-      suffix: 'md',
+  CustomMetadata: createMetadataObjectType(
+    {
+      annotations: {
+        metadataType: 'CustomMetadata',
+        dirName: 'customMetadata',
+        suffix: 'md',
+      },
     },
-  }),
+    constants.CUSTOM_METADATA_TYPE_NAME,
+  ),
   EmailTemplate: createMetadataObjectType({
     annotations: {
       metadataType: 'EmailTemplate',


### PR DESCRIPTION
Added an underscore before so we can free these element IDs up for meta types.
Also syncified some logic during debugging which is nice to have generally.
The rename for the type `CustomMetadata` is behind the meta types feature flag because it isn't hidden (yet).
This is round 2 of #6232.

---

_Additional context for reviewer_
I tested fetching and deploying and also deploying without fetching.
The latter works fine is because all of the places we rely on the new names are either during fetch (in which case we always already have them) or during deploy where we create them artificially and don't rely on what we got in fetch.

---
_Release Notes_: 
_Salesforce_:
* Renamed the internal and hidden `CustomObject` and `CustomMetadata` types to `_CustomObject` and `_CustomMetadata`.

---
_User Notifications_: 
None.
