### PR TITLE
SALTO-6317: Move Jsm forms to official api

### DIFF
--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -210,13 +210,42 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
     }
     throw new Error('Failed to get GQL response')
   }
-
-  public async atlassianApiSendRequest(
-    method: keyof clientUtils.HttpMethodToClientParams,
+  
+  public async atlassianApiGet(
     args: clientUtils.ClientDataParams,
   ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
     const cloudId = await this.getCloudId()
-    return this.sendRequest(method, {
+    return this.get({
+      ...args,
+      url: `https://api.atlassian.com/jira/forms/cloud/${cloudId}/${args.url}`,
+    })
+  }
+
+  public async atlassianApiPost(
+    args: clientUtils.ClientDataParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    const cloudId = await this.getCloudId()
+    return this.post({
+      ...args,
+      url: `https://api.atlassian.com/jira/forms/cloud/${cloudId}/${args.url}`,
+    })
+  }
+
+  public async atlassianApiPut(
+    args: clientUtils.ClientDataParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    const cloudId = await this.getCloudId()
+    return this.put({
+      ...args,
+      url: `https://api.atlassian.com/jira/forms/cloud/${cloudId}/${args.url}`,
+    })
+  }
+
+  public async atlassianApiDelete(
+    args: clientUtils.ClientDataParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    const cloudId = await this.getCloudId()
+    return this.delete({
       ...args,
       url: `https://api.atlassian.com/jira/forms/cloud/${cloudId}/${args.url}`,
     })

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -211,6 +211,17 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
     throw new Error('Failed to get GQL response')
   }
 
+  public async atlassianApiSendRequest(
+    method: keyof clientUtils.HttpMethodToClientParams,
+    args: clientUtils.ClientDataParams,
+  ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {
+    const cloudId = await this.getCloudId()
+    return this.sendRequest(method, {
+      ...args,
+      url: `https://api.atlassian.com/jira/forms/cloud/${cloudId}/${args.url}`,
+    })
+  }
+
   public async getPrivate(
     args: clientUtils.ClientBaseParams,
   ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {

--- a/packages/jira-adapter/src/client/client.ts
+++ b/packages/jira-adapter/src/client/client.ts
@@ -210,7 +210,7 @@ export default class JiraClient extends clientUtils.AdapterHTTPClient<Credential
     }
     throw new Error('Failed to get GQL response')
   }
-  
+
   public async atlassianApiGet(
     args: clientUtils.ClientDataParams,
   ): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> {

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -66,7 +66,7 @@ const deployForms = async (change: Change<InstanceElement>, client: JiraClient):
       )
     }
     if (isAdditionChange(change)) {
-      const resp = await client.atlassianApiSendRequest('post', {
+      const resp = await client.atlassianApiPost({
         url: `project/${project.value.id}/form`,
         data,
       })
@@ -75,13 +75,13 @@ const deployForms = async (change: Change<InstanceElement>, client: JiraClient):
       }
       form.value.id = resp.data.id
     } else {
-      await client.atlassianApiSendRequest('put', {
+      await client.atlassianApiPut({
         url: `project/${project.value.id}/form/${form.value.id}`,
         data,
       })
     }
   } else {
-    await client.atlassianApiSendRequest('delete', {
+    await client.atlassianApiDelete({
       url: `project/${project.value.id}/form/${form.value.id}`,
     })
   }
@@ -119,7 +119,7 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
       await Promise.all(
         jsmProjects.flatMap(async project => {
           try {
-            const res = await client.atlassianApiSendRequest('get', {
+            const res = await client.atlassianApiGet({
               url: `project/${project.value.id}/form`,
             })
             if (!isFormsResponse(res)) {
@@ -130,7 +130,7 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
             }
             return await Promise.all(
               res.data.map(async formResponse => {
-                const detailedRes = await client.atlassianApiSendRequest('get', {
+                const detailedRes = await client.atlassianApiGet({
                   url: `project/${project.value.id}/form/${formResponse.id}`,
                 })
                 if (!isDetailedFormsResponse(detailedRes.data)) {

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -56,21 +56,7 @@ const deployForms = async (change: Change<InstanceElement>, client: JiraClient):
   if (form.value.design?.settings?.name === undefined) {
     throw new Error('Form name is missing')
   }
-  const cloudId = await client.getCloudId()
   if (isAdditionOrModificationChange(change)) {
-    if (isAdditionChange(change)) {
-      const resp = await client.post({
-        url: `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms`,
-        data: {
-          name: form.value.design.settings.name,
-        },
-      })
-      if (!isCreateFormResponse(resp.data)) {
-        throw new Error('Failed to create form')
-      }
-      form.value.id = resp.data.id
-      form.value.design.settings.templateId = resp.data.id
-    }
     const resolvedForm = await resolveValues(form, getLookUpName)
     const data = mapKeysRecursive(resolvedForm.value, ({ key }) => invertNaclCase(key))
     // RequestType Id is a string, but the forms API expects a number
@@ -79,13 +65,24 @@ const deployForms = async (change: Change<InstanceElement>, client: JiraClient):
         Number(id),
       )
     }
-    await client.put({
-      url: `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${form.value.id}`,
-      data,
-    })
+    if (isAdditionChange(change)) {
+      const resp = await client.atlassianApiSendRequest('post', {
+        url: `project/${project.value.id}/form`,
+        data,
+      })
+      if (!isCreateFormResponse(resp.data)) {
+        throw new Error('Failed to create form')
+      }
+      form.value.id = resp.data.id
+    } else {
+      await client.atlassianApiSendRequest('put', {
+        url: `project/${project.value.id}/form/${form.value.id}`,
+        data,
+      })
+    }
   } else {
-    await client.delete({
-      url: `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms/${form.value.id}`,
+    await client.atlassianApiSendRequest('delete', {
+      url: `project/${project.value.id}/form/${form.value.id}`,
     })
   }
 }
@@ -100,7 +97,6 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
     if (!config.fetch.enableJSM || client.isDataCenter || !fetchQuery.isTypeMatch(FORM_TYPE)) {
       return { errors: [] }
     }
-    const cloudId = await client.getCloudId()
     const { formType, subTypes } = createFormType()
     setTypeDeploymentAnnotations(formType)
     await addAnnotationRecursively(formType, CORE_ANNOTATIONS.CREATABLE)
@@ -123,8 +119,9 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
       await Promise.all(
         jsmProjects.flatMap(async project => {
           try {
-            const url = `/gateway/api/proforma/cloudid/${cloudId}/api/1/projects/${project.value.id}/forms`
-            const res = await client.get({ url })
+            const res = await client.atlassianApiSendRequest('get', {
+              url: `project/${project.value.id}/form`,
+            })
             if (!isFormsResponse(res)) {
               log.debug(
                 `Didn't fetch forms for project ${project.value.name} with the following response: ${inspectValue(res)}`,
@@ -133,8 +130,9 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
             }
             return await Promise.all(
               res.data.map(async formResponse => {
-                const detailedUrl = `/gateway/api/proforma/cloudid/${cloudId}/api/2/projects/${project.value.id}/forms/${formResponse.id}`
-                const detailedRes = await client.get({ url: detailedUrl })
+                const detailedRes = await client.atlassianApiSendRequest('get', {
+                  url: `project/${project.value.id}/form/${formResponse.id}`,
+                })
                 if (!isDetailedFormsResponse(detailedRes.data)) {
                   projectsWithUntitledForms.add(project.elemID.name)
                   return undefined

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -21,16 +21,14 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { JIRA, FORM_TYPE } from '../../constants'
 
 type DetailedFormDataResponse = {
-  uuid: string
+  id: string
   design: {
     settings: {
-      templateId: string
       name: string
       submit: {
         lock: boolean
         pdf: boolean
       }
-      templateFormUuid: string
     }
     questions: {}
     sections: {}
@@ -39,7 +37,7 @@ type DetailedFormDataResponse = {
 }
 
 type FormResponse = {
-  id: number
+  id: string
   name?: string
 }
 
@@ -50,7 +48,7 @@ type FormsResponse = {
 export const FORMS_RESPONSE_SCHEME = Joi.object({
   data: Joi.array().items(
     Joi.object({
-      id: Joi.number().required(),
+      id: Joi.string().required(),
       name: Joi.string().allow(''),
     })
       .unknown(true)
@@ -61,10 +59,9 @@ export const FORMS_RESPONSE_SCHEME = Joi.object({
   .required()
 
 export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
-  uuid: Joi.string().required(),
+  id: Joi.string().required(),
   design: Joi.object({
     settings: Joi.object({
-      templateId: Joi.number().required(),
       name: Joi.string().required(),
       submit: Joi.object({
         lock: Joi.boolean().required(),
@@ -72,7 +69,6 @@ export const DETAILED_FORM_RESPONSE_SCHEME = Joi.object({
       })
         .unknown(true)
         .required(),
-      templateFormUuid: Joi.string(),
     })
       .unknown(true)
       .required(),
@@ -105,19 +101,11 @@ export const createFormType = (): {
   const formSettingsType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormSettings'),
     fields: {
-      templateId: {
-        refType: BuiltinTypes.NUMBER,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
-      },
       name: {
         refType: BuiltinTypes.STRING,
       },
       submit: {
         refType: formSubmitType,
-      },
-      templateFormUuid: {
-        refType: BuiltinTypes.STRING,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
     },
   })
@@ -219,10 +207,6 @@ export const createFormType = (): {
     elemID: new ElemID(JIRA, FORM_TYPE),
     fields: {
       id: {
-        refType: BuiltinTypes.NUMBER,
-        annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
-      },
-      uuid: {
         refType: BuiltinTypes.SERVICE_ID,
         annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
       },
@@ -262,7 +246,7 @@ type createFormResponse = {
 }
 
 const CREATE_FORM_RESPONSE_SCHEME = Joi.object({
-  id: Joi.number().required(),
+  id: Joi.string().required(),
 })
   .unknown(true)
   .required()

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -396,7 +396,7 @@ describe('forms filter', () => {
       jest.clearAllMocks()
     })
     it("should return single saltoError when failed to fetch form because it doesn't have a title", async () => {
-      mockAtlassianApiGet.mockImplementation(async (params) => {
+      mockAtlassianApiGet.mockImplementation(async params => {
         if (params.url === 'project/11111/form') {
           return {
             status: 200,
@@ -440,7 +440,7 @@ describe('forms filter', () => {
       )
     })
     it('should return single saltoError when failed to fetch form because data is empty', async () => {
-      mockAtlassianApiGet.mockImplementation(async (params) => {
+      mockAtlassianApiGet.mockImplementation(async params => {
         if (params.url === 'project/11111/form') {
           throw new clientUtils.HTTPError('insufficient permissions', {
             status: 403,
@@ -462,7 +462,7 @@ describe('forms filter', () => {
       )
     })
     it('should add form1 to the elements and add saltoError when failed to fetch form2 data for projectTwo', async () => {
-      mockAtlassianApiGet.mockImplementation(async (params) => {
+      mockAtlassianApiGet.mockImplementation(async params => {
         if (params.url === 'project/11111/form') {
           return {
             status: 200,
@@ -660,7 +660,7 @@ describe('forms filter', () => {
         },
       )
       mockAtlassianApiPost = jest.spyOn(client, 'atlassianApiPost')
-      mockAtlassianApiPost.mockImplementation(async (params) => {
+      mockAtlassianApiPost.mockImplementation(async params => {
         if (params.url === 'project/11111/form') {
           return {
             status: 200,
@@ -720,7 +720,7 @@ describe('forms filter', () => {
       expect(mockAtlassianApiPost).toHaveBeenCalledTimes(0)
     })
     it('should throw error if bad response in form creation from jira', async () => {
-      mockAtlassianApiPost.mockImplementation(async (params) => {
+      mockAtlassianApiPost.mockImplementation(async params => {
         if (params.url === 'project/11111/form') {
           return {
             status: 200,


### PR DESCRIPTION
In this PR I moved the Form type in Jira to the new API 

---

_Additional context for reviewer_
The values ​​remained the same except for 3 new fields which I will add Noise Reduction.

![image](https://github.com/user-attachments/assets/e11d3afe-317b-44b7-bed2-60e592102a79)

  
From what I see through the CLI - fetch, create, modify and remove all worked great! 
It is important to note some point:
1. The id changed from a number to a string which is actually a uuid and I'm not sure if it has certain meanings or not
since the uuid was deleted, so the ServiceID changed to the id field. Whats going to happen in the next Fetch? 

---
_Release Notes_: 
_Jira Adapter_:
* Moved JSM forms to the new API. 

---
_User Notifications_: 
_Jira Adapter:_
* Changes will be applied in Form instances:
The fields `issueRequestTypeIds`, `newIssueIssueTypeIds`, `newIssueRequestTypeIds` will be replaced by  `recommendedIssueRequestTypeIds`, `issueCreateIssueTypeIds`, `issueCreateRequestTypeIds`.