### PR TITLE
SALTO-5949: (Jira) check relevant changes before using elementsSource in CVs

### DIFF
--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -260,7 +260,7 @@ export const accountIdValidator: (client: JiraClient, config: JiraConfig) => Cha
       .filter(isInstanceElement)
       .filter(isDeployableAccountIdType)
 
-    if (_.isEmpty(accountIdChangesData)) {
+    if (accountIdChangesData.length === 0) {
       return []
     }
 

--- a/packages/jira-adapter/src/change_validators/account_id.ts
+++ b/packages/jira-adapter/src/change_validators/account_id.ts
@@ -13,7 +13,7 @@ import {
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
-  isInstanceChange,
+  isInstanceElement,
 } from '@salto-io/adapter-api'
 import { definitions } from '@salto-io/adapter-components'
 import { walkOnElement } from '@salto-io/adapter-utils'
@@ -253,6 +253,17 @@ export const accountIdValidator: (client: JiraClient, config: JiraConfig) => Cha
     if (!(config.fetch.convertUsersIds ?? true)) {
       return []
     }
+
+    const accountIdChangesData = changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(isDeployableAccountIdType)
+
+    if (_.isEmpty(accountIdChangesData)) {
+      return []
+    }
+
     const { baseUrl, isDataCenter } = client
     const rawUserMap = await getUsersMap(elementsSource)
     if (rawUserMap === undefined) {
@@ -261,11 +272,7 @@ export const accountIdValidator: (client: JiraClient, config: JiraConfig) => Cha
     const userMap = getUsersMapByVisibleId(rawUserMap, client.isDataCenter)
 
     const defaultUserExist = doesDefaultUserExist(config.deploy.defaultMissingUserFallback, userMap, isDataCenter)
-    return changes
-      .filter(isAdditionOrModificationChange)
-      .filter(isInstanceChange)
-      .map(change => getChangeData(change))
-      .filter(isDeployableAccountIdType)
+    return accountIdChangesData
       .map(element =>
         createChangeErrorsForAccountIdIssues(element, userMap, baseUrl, isDataCenter, config, defaultUserExist),
       )

--- a/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
+++ b/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
@@ -12,11 +12,9 @@ import {
   SeverityLevel,
   isAdditionChange,
 } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
+import _ from 'lodash'
 import { PROJECT_TYPE, SERVICE_DESK } from '../constants'
 import { hasJiraServiceDeskLicense } from '../utils'
-
-const { awu } = collections.asynciterable
 
 /*
  * This validator prevents addition of jsm project when JSM is disabled in the service.
@@ -25,22 +23,23 @@ export const addJsmProjectValidator: ChangeValidator = async (changes, elementsS
   if (elementsSource === undefined) {
     return []
   }
-  if ((await hasJiraServiceDeskLicense(elementsSource)) === true) {
-    return []
-  }
 
-  return awu(changes)
+  const jsmProjectChangesData = changes
     .filter(isInstanceChange)
     .filter(isAdditionChange)
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
     .filter(project => project.value.projectTypeKey === SERVICE_DESK)
-    .map(instance => ({
-      elemID: instance.elemID,
-      severity: 'Error' as SeverityLevel,
-      message: 'JSM Project cannot be deployed to instance without JSM',
-      detailedMessage:
-        'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
-    }))
-    .toArray()
+
+  if (_.isEmpty(jsmProjectChangesData) || (await hasJiraServiceDeskLicense(elementsSource)) === true) {
+    return []
+  }
+
+  return jsmProjectChangesData.map(instance => ({
+    elemID: instance.elemID,
+    severity: 'Error' as SeverityLevel,
+    message: 'JSM Project cannot be deployed to instance without JSM',
+    detailedMessage:
+      'This JSM project can not be deployed, as JSM is not enabled in the target instance. Enable JSM on your target first, then try again.',
+  }))
 }

--- a/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
+++ b/packages/jira-adapter/src/change_validators/adding_jsm_project.ts
@@ -12,7 +12,6 @@ import {
   SeverityLevel,
   isAdditionChange,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { PROJECT_TYPE, SERVICE_DESK } from '../constants'
 import { hasJiraServiceDeskLicense } from '../utils'
 
@@ -31,7 +30,7 @@ export const addJsmProjectValidator: ChangeValidator = async (changes, elementsS
     .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
     .filter(project => project.value.projectTypeKey === SERVICE_DESK)
 
-  if (_.isEmpty(jsmProjectChangesData) || (await hasJiraServiceDeskLicense(elementsSource)) === true) {
+  if (jsmProjectChangesData.length === 0 || (await hasJiraServiceDeskLicense(elementsSource)) === true) {
     return []
   }
 

--- a/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
+++ b/packages/jira-adapter/src/change_validators/assets/label_attribute_removal.ts
@@ -28,12 +28,11 @@ export const deleteLabelAtttributeValidator: (config: JiraConfig) => ChangeValid
     if (elementsSource === undefined || !(config.fetch.enableJsmExperimental || config.fetch.enableJSMPremium)) {
       return []
     }
-    const objectTypeAttributeRemovalChanges = await awu(changes)
+    const objectTypeAttributeRemovalChanges = changes
       .filter(isInstanceChange)
       .filter(isRemovalChange)
       .map(getChangeData)
       .filter(instance => instance.elemID.typeName === OBJECT_TYPE_ATTRIBUTE_TYPE)
-      .toArray()
 
     if (objectTypeAttributeRemovalChanges.length === 0) {
       return []

--- a/packages/jira-adapter/src/change_validators/automation/automations.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automations.ts
@@ -12,7 +12,6 @@ import {
   isInstanceChange,
   SeverityLevel,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { AUTOMATION_TYPE } from '../../constants'
@@ -23,7 +22,7 @@ const log = logger(module)
 
 export const automationsValidator: ChangeValidator = async (changes, elementsSource) => {
   if (elementsSource === undefined) {
-    log.info('Skipping automationsValidator due to missing elements source')
+    log.warn('Skipping automationsValidator due to missing elements source')
     return []
   }
 
@@ -33,7 +32,7 @@ export const automationsValidator: ChangeValidator = async (changes, elementsSou
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
 
-  if (_.isEmpty(automationChangesData)) {
+  if (automationChangesData.length === 0) {
     return []
   }
 

--- a/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
@@ -15,6 +15,7 @@ import {
   isReferenceExpression,
   SeverityLevel,
 } from '@salto-io/adapter-api'
+import _ from 'lodash'
 import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -45,18 +46,24 @@ export const dashboardGadgetsValidator: ChangeValidator = async (changes, elemen
     return []
   }
 
+  const dashboardGadgetChangesData = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === DASHBOARD_GADGET_TYPE)
+
+  if (_.isEmpty(dashboardGadgetChangesData)) {
+    return []
+  }
+
   const gadgetsMap = await awu(await elementsSource.list())
     .filter(id => id.typeName === DASHBOARD_GADGET_TYPE && id.idType === 'instance')
     .map(id => elementsSource.get(id))
     .groupBy(getGadgetInstanceKey)
 
-  return awu(changes)
-    .filter(isInstanceChange)
-    .filter(isAdditionOrModificationChange)
-    .map(getChangeData)
-    .filter(instance => instance.elemID.typeName === DASHBOARD_GADGET_TYPE)
+  return dashboardGadgetChangesData
     .filter(instance => gadgetsMap[getGadgetInstanceKey(instance)]?.length > 1)
-    .map(async instance => ({
+    .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'Gadget position overlaps with existing gadgets',
@@ -67,5 +74,4 @@ export const dashboardGadgetsValidator: ChangeValidator = async (changes, elemen
         .map(gadget => gadget.elemID.getFullName())
         .join(', ')}. Change its position, or other gadgets’ position, and try again.`,
     }))
-    .toArray()
 }

--- a/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
+++ b/packages/jira-adapter/src/change_validators/dashboard_gadgets.ts
@@ -15,7 +15,6 @@ import {
   isReferenceExpression,
   SeverityLevel,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -52,7 +51,7 @@ export const dashboardGadgetsValidator: ChangeValidator = async (changes, elemen
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === DASHBOARD_GADGET_TYPE)
 
-  if (_.isEmpty(dashboardGadgetChangesData)) {
+  if (dashboardGadgetChangesData.length === 0) {
     return []
   }
 

--- a/packages/jira-adapter/src/change_validators/default_addition_queue.ts
+++ b/packages/jira-adapter/src/change_validators/default_addition_queue.ts
@@ -14,7 +14,6 @@ import {
   isReferenceExpression,
   isInstanceElement,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import { QUEUE_TYPE } from '../constants'
@@ -37,7 +36,7 @@ export const defaultAdditionQueueValidator: (config: JiraConfig) => ChangeValida
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === QUEUE_TYPE)
 
-    if (_.isEmpty(queueChangesData)) {
+    if (queueChangesData.length === 0) {
       return []
     }
 

--- a/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
+++ b/packages/jira-adapter/src/change_validators/issue_type_hierarchy.ts
@@ -20,7 +20,6 @@ import {
   isModificationChange,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import _ from 'lodash'
 import { ISSUE_TYPE_NAME } from '../constants'
 import { isJiraSoftwareFreeLicense } from '../utils'
 
@@ -80,11 +79,11 @@ const getIsuueTypeHierearchyWarningMessage = (instance: InstanceElement): Change
 
 export const issueTypeHierarchyValidator: ChangeValidator = async (changes, elementSource) => {
   if (elementSource === undefined) {
-    log.info('Skipping issueTypeHierarchyValidator as element source is undefined')
+    log.error('Skipping issueTypeHierarchyValidator as element source is undefined')
     return []
   }
   const relevantChanges = getIssueTypeWithHierachyChanges(changes)
-  if (_.isEmpty(relevantChanges)) {
+  if (relevantChanges.length === 0) {
     return []
   }
   const isLicenseFree = await isJiraSoftwareFreeLicense(elementSource)

--- a/packages/jira-adapter/src/change_validators/last_queue.ts
+++ b/packages/jira-adapter/src/change_validators/last_queue.ts
@@ -14,7 +14,6 @@ import {
   isInstanceElement,
   isReferenceExpression,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -31,7 +30,7 @@ const { awu } = collections.asynciterable
 export const deleteLastQueueValidator: (config: JiraConfig) => ChangeValidator =
   config => async (changes, elementsSource) => {
     if (elementsSource === undefined || !config.fetch.enableJSM) {
-      log.info('Skipping deleteLastQueueValidator due to missing elements source or JSM disabled')
+      log.warn('Skipping deleteLastQueueValidator due to missing elements source or JSM disabled')
       return []
     }
 
@@ -41,7 +40,7 @@ export const deleteLastQueueValidator: (config: JiraConfig) => ChangeValidator =
       .filter(isInstanceElement)
       .filter(instance => instance.elemID.typeName === QUEUE_TYPE)
 
-    if (_.isEmpty(queueChangesData)) {
+    if (queueChangesData.length === 0) {
       return []
     }
 

--- a/packages/jira-adapter/src/change_validators/permission_type.ts
+++ b/packages/jira-adapter/src/change_validators/permission_type.ts
@@ -19,7 +19,6 @@ import {
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import Joi from 'joi'
-import _ from 'lodash'
 import { PERMISSION_SCHEME_TYPE_NAME, PERMISSIONS, JIRA } from '../constants'
 
 const log = logger(module)
@@ -64,7 +63,7 @@ const getInvalidPermissionErrorMessage = (
 
 export const permissionTypeValidator: ChangeValidator = async (changes, elementsSource) => {
   if (elementsSource === undefined) {
-    log.info('Skipping permissionTypeValidator as elements source is undefined')
+    log.warn('Skipping permissionTypeValidator as elements source is undefined')
     return []
   }
   const permissionSchemeChangesData = changes
@@ -73,7 +72,7 @@ export const permissionTypeValidator: ChangeValidator = async (changes, elements
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === PERMISSION_SCHEME_TYPE_NAME)
 
-  if (_.isEmpty(permissionSchemeChangesData)) {
+  if (permissionSchemeChangesData.length === 0) {
     return []
   }
   const allowedPermissionTypes = await getAllowedPermissionTypes(elementsSource)
@@ -82,7 +81,7 @@ export const permissionTypeValidator: ChangeValidator = async (changes, elements
     return []
   }
   return permissionSchemeChangesData
-    .filter(instance => !_.isEmpty(getInvalidPermissions(instance, allowedPermissionTypes)))
+    .filter(instance => getInvalidPermissions(instance, allowedPermissionTypes).length > 0)
     .map(instance => ({
       elemID: instance.elemID,
       severity: 'Warning' as SeverityLevel,

--- a/packages/jira-adapter/src/change_validators/projects/project_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/projects/project_deletion.ts
@@ -56,7 +56,7 @@ export const doesProjectHaveIssues = async (instance: InstanceElement, client: J
 export const projectDeletionValidator: (client: JiraClient, config: JiraConfig) => ChangeValidator =
   (client, config) => async changes => {
     if (config.deploy.forceDelete) {
-      log.info('Force delete is enabled, skipping project deletion validator')
+      log.warn('Force delete is enabled, skipping project deletion validator')
       return []
     }
 

--- a/packages/jira-adapter/src/change_validators/workflows/workflow_scheme_dups.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/workflow_scheme_dups.ts
@@ -12,7 +12,6 @@ import {
   isInstanceElement,
   SeverityLevel,
 } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { WORKFLOW_SCHEME_TYPE_NAME } from '../../constants'
@@ -22,7 +21,7 @@ const { awu } = collections.asynciterable
 
 export const workflowSchemeDupsValidator: ChangeValidator = async (changes, elementSource) => {
   if (elementSource === undefined) {
-    log.info('Skipping workflowSchemeDupsValidator due to missing elements source')
+    log.warn('Skipping workflowSchemeDupsValidator due to missing elements source')
     return []
   }
 
@@ -32,7 +31,7 @@ export const workflowSchemeDupsValidator: ChangeValidator = async (changes, elem
     .filter(isInstanceElement)
     .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE_NAME)
 
-  if (_.isEmpty(workflowSchemeNameChangesData)) {
+  if (workflowSchemeNameChangesData.length === 0) {
     return []
   }
   const nameToInstance = await awu(await elementSource.list())

--- a/packages/jira-adapter/src/change_validators/workflows/workflow_scheme_dups.ts
+++ b/packages/jira-adapter/src/change_validators/workflows/workflow_scheme_dups.ts
@@ -9,29 +9,38 @@ import {
   ChangeValidator,
   getChangeData,
   isAdditionOrModificationChange,
-  isInstanceChange,
+  isInstanceElement,
   SeverityLevel,
 } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { WORKFLOW_SCHEME_TYPE_NAME } from '../../constants'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 
 export const workflowSchemeDupsValidator: ChangeValidator = async (changes, elementSource) => {
   if (elementSource === undefined) {
+    log.info('Skipping workflowSchemeDupsValidator due to missing elements source')
     return []
   }
 
+  const workflowSchemeNameChangesData = changes
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE_NAME)
+
+  if (_.isEmpty(workflowSchemeNameChangesData)) {
+    return []
+  }
   const nameToInstance = await awu(await elementSource.list())
     .filter(id => id.idType === 'instance' && id.typeName === WORKFLOW_SCHEME_TYPE_NAME)
     .map(id => elementSource.get(id))
     .groupBy(instance => instance.value.name?.toLowerCase())
 
-  return changes
-    .filter(isInstanceChange)
-    .filter(isAdditionOrModificationChange)
-    .map(getChangeData)
-    .filter(instance => instance.elemID.typeName === WORKFLOW_SCHEME_TYPE_NAME)
+  return workflowSchemeNameChangesData
     .filter(
       instance =>
         Object.prototype.hasOwnProperty.call(nameToInstance, instance.value.name?.toLowerCase()) &&

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -57,18 +57,21 @@ export const referencedWorkflowDeletionChangeValidator =
       return []
     }
     if (elementsSource === undefined) {
-      log.warn(
-        "Elements source was not passed to referencedWorkflowDeletionChangeValidator. Skipping 'referencedWorkflowDeletionChangeValidator'.",
-      )
+      log.warn('Skipping referencedWorkflowDeletionChangeValidator due to missing elements source')
       return []
     }
-    const workflowNameToReferencingWorkflowSchemes =
-      await mapWorkflowNameToReferencingWorkflowSchemesIDs(elementsSource)
-    return awu(changes)
+    const workflowChangesData = changes
       .filter(isInstanceChange)
       .filter(isRemovalChange)
       .map(getChangeData)
       .filter(isWorkflowV2Instance)
+
+    if (_.isEmpty(workflowChangesData)) {
+      return []
+    }
+    const workflowNameToReferencingWorkflowSchemes =
+      await mapWorkflowNameToReferencingWorkflowSchemesIDs(elementsSource)
+    return workflowChangesData
       .filter(workflow => !_.isEmpty(workflowNameToReferencingWorkflowSchemes[workflow.elemID.getFullName()]))
       .map(workflow => ({
         elemID: workflow.elemID,
@@ -76,5 +79,4 @@ export const referencedWorkflowDeletionChangeValidator =
         message: "Can't delete a referenced workflow.",
         detailedMessage: `Workflow is referenced by the following workflow schemes: ${[...workflowNameToReferencingWorkflowSchemes[workflow.elemID.getFullName()]].map(elemID => elemID.name).join(', ')}.`,
       }))
-      .toArray()
   }

--- a/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/referenced_workflow_deletion.ts
@@ -53,7 +53,7 @@ export const referencedWorkflowDeletionChangeValidator =
   (config: JiraConfig): ChangeValidator =>
   async (changes, elementsSource) => {
     if (!config.fetch.enableNewWorkflowAPI) {
-      log.info('New workflow api not enabled, skipping validator.')
+      log.warn('New workflow api not enabled, skipping validator.')
       return []
     }
     if (elementsSource === undefined) {
@@ -66,7 +66,7 @@ export const referencedWorkflowDeletionChangeValidator =
       .map(getChangeData)
       .filter(isWorkflowV2Instance)
 
-    if (_.isEmpty(workflowChangesData)) {
+    if (workflowChangesData.length === 0) {
       return []
     }
     const workflowNameToReferencingWorkflowSchemes =

--- a/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
+++ b/packages/jira-adapter/src/change_validators/wrong_user_permission_scheme.ts
@@ -13,6 +13,8 @@ import {
   isAdditionOrModificationChange,
   isInstanceChange,
 } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { isPermissionSchemeStructure, PermissionHolder } from '../filters/permission_scheme/omit_permissions_common'
 import { JIRA_USERS_PAGE, PERMISSION_SCHEME_TYPE_NAME } from '../constants'
 import JiraClient from '../client/client'
@@ -20,6 +22,7 @@ import { JiraConfig } from '../config/config'
 import { wrongUserPermissionSchemePredicateCreator } from '../filters/permission_scheme/wrong_user_permission_scheme_filter'
 import { getUsersMap, getUsersMapByVisibleId } from '../users'
 
+const log = logger(module)
 const createChangeError = (element: InstanceElement, permission: PermissionHolder, url: string): ChangeError => ({
   elemID: element.elemID,
   severity: 'Warning',
@@ -39,10 +42,23 @@ Check ${new URL(JIRA_USERS_PAGE, url).href} to see valid users and account IDs.`
  */
 export const wrongUserPermissionSchemeValidator: (client: JiraClient, config: JiraConfig) => ChangeValidator =
   (client, config) => async (changes, elementsSource) => {
-    if (!(config.fetch.convertUsersIds ?? true)) {
+    if (!(config.fetch.convertUsersIds ?? true) || elementsSource === undefined) {
+      log.info('Skipping wrongUserPermissionSchemeValidator due to missing config or elements source')
       return []
     }
     const { baseUrl } = client
+
+    const permissionsSchemeChangesData = changes
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(
+        element => element.elemID.typeName === PERMISSION_SCHEME_TYPE_NAME && element.value.permissions !== undefined,
+      )
+
+    if (_.isEmpty(permissionsSchemeChangesData)) {
+      return []
+    }
     const rawUserMap = await getUsersMap(elementsSource)
     if (rawUserMap === undefined) {
       return []
@@ -50,18 +66,11 @@ export const wrongUserPermissionSchemeValidator: (client: JiraClient, config: Ji
     const userMap = getUsersMapByVisibleId(rawUserMap, client.isDataCenter)
 
     const wrongUserPermissionSchemePredicate = wrongUserPermissionSchemePredicateCreator(userMap)
-    return changes
-      .filter(isInstanceChange)
-      .filter(isAdditionOrModificationChange)
-      .map(getChangeData)
-      .filter(
-        element => element.elemID.typeName === PERMISSION_SCHEME_TYPE_NAME && element.value.permissions !== undefined,
-      )
-      .flatMap(element =>
-        element.value.permissions.flatMap((permission: PermissionHolder) =>
-          isPermissionSchemeStructure(permission) && wrongUserPermissionSchemePredicate(permission)
-            ? createChangeError(element, permission, baseUrl)
-            : [],
-        ),
-      )
+    return permissionsSchemeChangesData.flatMap(element =>
+      element.value.permissions.flatMap((permission: PermissionHolder) =>
+        isPermissionSchemeStructure(permission) && wrongUserPermissionSchemePredicate(permission)
+          ? createChangeError(element, permission, baseUrl)
+          : [],
+      ),
+    )
   }

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -255,6 +255,7 @@ export type ChangeValidatorName =
   | 'addJsmProject'
   | 'deleteLabelAtttribute'
   | 'jsmPermissions'
+  | 'fieldContextOptions'
   | 'uniqueFields'
   | 'assetsObjectFieldConfigurationAql'
   | 'projectAssigneeType'
@@ -320,6 +321,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     addJsmProject: { refType: BuiltinTypes.BOOLEAN },
     deleteLabelAtttribute: { refType: BuiltinTypes.BOOLEAN },
     jsmPermissions: { refType: BuiltinTypes.BOOLEAN },
+    fieldContextOptions: { refType: BuiltinTypes.BOOLEAN },
     uniqueFields: { refType: BuiltinTypes.BOOLEAN },
     assetsObjectFieldConfigurationAql: { refType: BuiltinTypes.BOOLEAN },
     projectAssigneeType: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -255,7 +255,6 @@ export type ChangeValidatorName =
   | 'addJsmProject'
   | 'deleteLabelAtttribute'
   | 'jsmPermissions'
-  | 'fieldContextOptions'
   | 'uniqueFields'
   | 'assetsObjectFieldConfigurationAql'
   | 'projectAssigneeType'
@@ -321,7 +320,6 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     addJsmProject: { refType: BuiltinTypes.BOOLEAN },
     deleteLabelAtttribute: { refType: BuiltinTypes.BOOLEAN },
     jsmPermissions: { refType: BuiltinTypes.BOOLEAN },
-    fieldContextOptions: { refType: BuiltinTypes.BOOLEAN },
     uniqueFields: { refType: BuiltinTypes.BOOLEAN },
     assetsObjectFieldConfigurationAql: { refType: BuiltinTypes.BOOLEAN },
     projectAssigneeType: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/jira-adapter/test/change_validators/automations/automations.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automations.test.ts
@@ -54,4 +54,13 @@ describe('automationsValidator', () => {
 
     expect(await automationsValidator([toChange({ after: instance2 })], elementsSource)).toEqual([])
   })
+  it('should not return an error when there are no automations', async () => {
+    const otherInstance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'someType') }), {})
+    expect(
+      await automationsValidator(
+        [toChange({ after: otherInstance })],
+        buildElementsSourceFromElements([otherInstance]),
+      ),
+    ).toBeEmpty()
+  })
 })

--- a/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
+++ b/packages/jira-adapter/test/change_validators/dashboard_gadgets.test.ts
@@ -107,4 +107,13 @@ describe('dashboardGadgetsValidator', () => {
 
     expect(await dashboardGadgetsValidator([toChange({ after: instance2 })], elementsSource)).toEqual([])
   })
+  it('should not return an error when there are no gadgets', async () => {
+    const otherInstance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'someType') }), {})
+    expect(
+      await dashboardGadgetsValidator(
+        [toChange({ after: otherInstance })],
+        buildElementsSourceFromElements([otherInstance]),
+      ),
+    ).toBeEmpty()
+  })
 })

--- a/packages/jira-adapter/test/change_validators/default_addition_queue.test.ts
+++ b/packages/jira-adapter/test/change_validators/default_addition_queue.test.ts
@@ -6,10 +6,18 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { CORE_ANNOTATIONS, InstanceElement, ReferenceExpression, SeverityLevel, toChange } from '@salto-io/adapter-api'
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  SeverityLevel,
+  toChange,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { PROJECT_TYPE, QUEUE_TYPE } from '../../src/constants'
+import { JIRA, PROJECT_TYPE, QUEUE_TYPE } from '../../src/constants'
 import { createEmptyType } from '../utils'
 import { defaultAdditionQueueValidator } from '../../src/change_validators/default_addition_queue'
 import { JiraConfig, getDefaultConfig } from '../../src/config/config'
@@ -82,5 +90,12 @@ describe('defaultAdditionQueueValidator', () => {
       message: 'Cannot deploy queue, because queues names must be unique',
       detailedMessage: 'Cannot deploy this queue, as it has the same name as another queue in project project1.',
     })
+  })
+  it('should not return error if there are no queue changes', async () => {
+    const validator = defaultAdditionQueueValidator(config)
+    const otherInstance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'someType') }), {})
+    expect(
+      await validator([toChange({ after: otherInstance })], buildElementsSourceFromElements([otherInstance])),
+    ).toBeEmpty()
   })
 })

--- a/packages/jira-adapter/test/change_validators/permission_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/permission_type.test.ts
@@ -75,4 +75,13 @@ describe('permissionType change validator', () => {
     elementsSource = buildElementsSourceFromElements(elements)
     expect(await permissionTypeValidator([toChange({ after: noFieldPermissionScheme })], elementsSource)).toBeEmpty()
   })
+  it('should not return an error if there are no permission scheme changes', async () => {
+    const otherInstance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'someType') }), {})
+    expect(
+      await permissionTypeValidator(
+        [toChange({ after: otherInstance })],
+        buildElementsSourceFromElements([otherInstance]),
+      ),
+    ).toBeEmpty()
+  })
 })

--- a/packages/jira-adapter/test/change_validators/workflows/workflow_scheme_dups.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflows/workflow_scheme_dups.test.ts
@@ -107,4 +107,13 @@ describe('workflowSchemeDupsValidator', () => {
       ),
     ).toEqual([])
   })
+  it('should not return an error if there are no workflow scheme changes', async () => {
+    const otherInstance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(JIRA, 'someType') }), {})
+    expect(
+      await workflowSchemeDupsValidator(
+        [toChange({ after: otherInstance })],
+        buildElementsSourceFromElements([otherInstance]),
+      ),
+    ).toBeEmpty()
+  })
 })

--- a/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
+++ b/packages/jira-adapter/test/change_validators/wrong_user_permission_scheme.test.ts
@@ -117,4 +117,14 @@ Check ${url} to see valid users and account IDs.`,
     const validator2 = wrongUserPermissionSchemeValidator(client, config)
     await expect(validator2(changes, buildElementsSourceFromElements([]))).resolves.not.toThrow()
   })
+  it('should not return an error when there are no permission schemes changes', async () => {
+    const otherInstance = new InstanceElement(
+      'otherInstance',
+      new ObjectType({ elemID: new ElemID(JIRA, 'otherType') }),
+      {},
+    )
+    expect(
+      await validator([toChange({ after: otherInstance })], buildElementsSourceFromElements([otherInstance])),
+    ).toBeEmpty()
+  })
 })


### PR DESCRIPTION
To optimize the time we spend on CVs, we need to first check if there is a relevant change before using the elementsSource to get instances.
Added some checks to many CVs.

---

_Additional context for reviewer_
None

---
_Release Notes_: 
Jira Adapter:

- check relevant changes before using elementsSource in CVs

---
_User Notifications_: 
_None_
