### PR TITLE
SALTO-6330 allow adjusting serializations for query arg combinations

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -54,6 +54,13 @@ export type ClientBaseParams = {
   headers?: Record<string, string>
   responseType?: ResponseType
   params?: Record<string, Values>
+  // when multiple query args are provided:
+  queryParamsSerializer?: {
+    // false (default): &arg[]=val1&arg[]=val2
+    // true: &arg[0]=val1&arg[1]=val2
+    // null: &arg=val1&arg=val2
+    indexes?: boolean | null
+  }
 }
 
 export type ClientDataParams = ClientBaseParams & {
@@ -238,7 +245,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
       throw new Error(`uninitialized ${this.clientName} client`)
     }
 
-    const { url, queryParams, headers, responseType } = params
+    const { url, queryParams, headers, responseType, queryParamsSerializer: paramsSerializer } = params
     const data = isMethodWithData(params) ? params.data : undefined
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -277,11 +284,12 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
     }
 
     try {
-      const requestConfig = [queryParams, headers, responseType].some(values.isDefined)
+      const requestConfig = [queryParams, headers, responseType, paramsSerializer].some(values.isDefined)
         ? {
             params: queryParams,
             headers,
             responseType,
+            paramsSerializer,
           }
         : undefined
 

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -30,8 +30,15 @@ export type HTTPEndpointIdentifier<ClientOptions extends string> = {
 
 export type RequestArgs = {
   headers?: Record<string, string>
-  queryArgs?: Record<string, string>
+  queryArgs?: Record<string, string | string[]>
   params?: Record<string, Values>
+  queryParamsSerializer?: {
+    // when multiple query args are provided:
+    // false (default): &arg[]=val1&arg[]=val2
+    // true: &arg[0]=val1&arg[1]=val2
+    // null: &arg=val1&arg=val2
+    indexes?: boolean | null
+  }
   // TODO support x-www-form-urlencoded + URLSearchParams
   body?: unknown
 }

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -151,7 +151,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
         typeName,
       )
 
-    const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params'])
+    const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params', 'queryParamsSerializer'])
     const callArgs = mergedEndpointDef.omitBody ? _.omit(mergedEndpointDef, 'body') : allCallArgs
 
     log.trace(

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -152,7 +152,7 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
       )
 
     const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params', 'queryParamsSerializer'])
-    const callArgs = mergedEndpointDef.omitBody ? _.omit(mergedEndpointDef, 'body') : allCallArgs
+    const callArgs = mergedEndpointDef.omitBody ? _.omit(allCallArgs, 'body') : allCallArgs
 
     log.trace(
       'traversing pages for adapter %s client %s endpoint %s.%s',

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -80,10 +80,14 @@ describe('client_http_client', () => {
         accountId: 'ACCOUNT_ID',
       })
       mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
-      mockAxiosAdapter.onGet('/ep2', { a: 'AAA' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
+      mockAxiosAdapter.onGet('/ep2', { a: ['AAA', 'BBB'] }).replyOnce(200, { c: 'd' }, { hh: 'header' })
 
       const getRes = await client.get({ url: '/ep' })
-      const getRes2 = await client.get({ url: '/ep2', queryParams: { a: 'AAA' } })
+      const getRes2 = await client.get({
+        url: '/ep2',
+        queryParams: { a: ['AAA', 'BBB'] },
+        queryParamsSerializer: { indexes: null },
+      })
       expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { 'X-Rate-Limit': '456', 'Retry-After': '93' } })
       expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: {} })
       expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
@@ -100,6 +104,9 @@ describe('client_http_client', () => {
       )
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(3, new AxiosHeaders({ hh: 'header' }))
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(4, new AxiosHeaders({ hh: 'header' }))
+      const request = mockAxiosAdapter.history.get[2]
+      expect(request.url).toEqual('/ep2')
+      expect(request.paramsSerializer).toEqual({ indexes: null })
     })
 
     it('should throw Unauthorized on login 401', async () => {


### PR DESCRIPTION
Allow serializing combinations of the same query arg in different ways using axios - 
`arg=val1&arg=val2`
`arg[]=val1&arg[]=val2`
`arg[0]=val1&arg[1]=val2`

for use in https://github.com/salto-io/salto/pull/6217

---
_Release Notes_: 
None

---
_User Notifications_: 
None