### PR TITLE
SALTO-5692: Okta: Add HTTP recording tests for `BrandTheme` files (logo and favicon) deploy and remove old-infra config

### DIFF
--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -50,6 +50,7 @@ import {
 } from '../config'
 import { OktaUserConfig, ChangeValidatorName } from '../user_config'
 import { OktaOptions } from '../definitions/types'
+import { BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME } from '../constants'
 
 const {
   createCheckDeploymentBasedOnConfigValidator,
@@ -75,6 +76,7 @@ export default ({
     ...Object.keys(oldApiDefsConfig[API_DEFINITIONS_CONFIG].types),
     ...Object.keys(oldApiDefsConfig[PRIVATE_API_DEFINITIONS_CONFIG].types),
   ]
+  const typesHandledByFilters = [FAV_ICON_TYPE_NAME, BRAND_LOGO_TYPE_NAME]
   const typesDeployedWithNewInfra = definitionUtils.queryWithDefault(definitions.deploy?.instances ?? {}).allKeys()
   const validators: Record<ChangeValidatorName, ChangeValidator> = {
     ...getDefaultChangeValidators(),
@@ -83,11 +85,11 @@ export default ({
         oldApiDefsConfig[API_DEFINITIONS_CONFIG].types,
         oldApiDefsConfig[PRIVATE_API_DEFINITIONS_CONFIG].types,
       ),
-      typesWithNoDeploy: typesDeployedWithNewInfra,
+      typesWithNoDeploy: [...typesDeployedWithNewInfra, ...typesHandledByFilters],
     }),
     createCheckDeploymentBasedOnDefinitions: createCheckDeploymentBasedOnDefinitionsValidator<OktaOptions>({
       deployDefinitions: definitions.deploy ?? { instances: {} },
-      typesWithNoDeploy: typesDeployedWithOldInfra,
+      typesWithNoDeploy: [...typesDeployedWithOldInfra, ...typesHandledByFilters],
     }),
     appGroup: appGroupValidator,
     groupRuleStatus: groupRuleStatusValidator,

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -419,67 +419,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
-  BrandLogo: {
-    deployRequests: {
-      add: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/logo',
-        method: 'post',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-      },
-      modify: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/logo',
-        method: 'post',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-      },
-      remove: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/logo',
-        method: 'delete',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-        omitRequestBody: true,
-      },
-    },
-  },
-  /*
-  FavIcon: {
-    deployRequests: {
-      add: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/favicon',
-        method: 'post',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-      },
-      modify: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/favicon',
-        method: 'post',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-      },
-      remove: {
-        url: '/api/v1/brands/{brandId}/themes/{themeId}/favicon',
-        method: 'delete',
-        urlParamsToFields: {
-          themeId: '_parent.0.id',
-          brandId: '_parent.1.id',
-        },
-        omitRequestBody: true,
-      },
-    },
-  },
-
-   */
   Authenticator: {
     deployRequests: {
       add: {

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -448,6 +448,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
+  /*
   FavIcon: {
     deployRequests: {
       add: {
@@ -477,6 +478,8 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
+
+   */
   Authenticator: {
     deployRequests: {
       add: {

--- a/packages/okta-adapter/src/filters/brand_theme_files.ts
+++ b/packages/okta-adapter/src/filters/brand_theme_files.ts
@@ -58,7 +58,7 @@ const toSaltoError = (err: Error): SaltoError => ({
 })
 
 /**
- * Fetches and deploys brand theme fiels as static file.
+ * Fetches and deploys brand theme fields as static file.
  */
 const brandThemeFilesFilter: FilterCreator = ({ definitions }) => ({
   name: 'brandThemeFilesFilter',

--- a/packages/okta-adapter/test/mock_replies/brand_theme_files_remove.json
+++ b/packages/okta-adapter/test/mock_replies/brand_theme_files_remove.json
@@ -1,0 +1,26 @@
+[
+  {
+    "path": "/api/v1/brands/brand-fakeid1/themes/brandtheme-fakeid1/favicon",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "500",
+      "x-rate-limit-remaining": "495",
+      "x-rate-limit-reset": "1721570238"
+    }
+  },
+  {
+    "path": "/api/v1/brands/brand-fakeid1/themes/brandtheme-fakeid1/logo",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "500",
+      "x-rate-limit-remaining": "494",
+      "x-rate-limit-reset": "1721570238"
+    }
+  }
+]


### PR DESCRIPTION
`BrandTheme`-related static files (`BrandLogo` and `FavIcon`) don't really use the infra to deploy - all the work is done in the `brand_theme_files.ts` filter. In this PR I removed the dummy content from the old config and added these to an ignore list for the CV that verifies deploy definitions exist.

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None