### PR TITLE
SALTO-6335: Excluding MutingPermissionSets and PermissionSetGroups by default

### DIFF
--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -80,6 +80,12 @@ export const configWithCPQ = new InstanceElement(ElemID.CONFIG_NAME, configType,
           metadataType: 'PermissionSet',
         },
         {
+          metadataType: 'MutingPermissionSet',
+        },
+        {
+          metadataType: 'PermissionSetGroup',
+        },
+        {
           metadataType: 'SiteDotCom',
         },
         {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -928,6 +928,8 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
               { metadataType: 'DocumentFolder' },
               { metadataType: 'Profile' },
               { metadataType: 'PermissionSet' },
+              { metadataType: 'MutingPermissionSet' },
+              { metadataType: 'PermissionSetGroup' },
               { metadataType: 'SiteDotCom' },
               {
                 metadataType: 'EmailTemplate',


### PR DESCRIPTION
They come together with permission sets, doesn't make much sense to exclude only permission sets and not these.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce_:
* Excluding MutingPermissionSets and PermissionSetGroups by default for new accounts.

---
_User Notifications_: 
None.
