### PR TITLE
SALTO-6341: Salesforce QuickAction Field Overrides References

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -452,6 +452,11 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {
+    src: { field: 'field', parentTypes: ['FieldOverride'] },
+    serializationStrategy: 'relativeApiName',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
     src: { field: 'targetField', parentTypes: ['AnalyticSnapshot'] },
     target: { type: CUSTOM_FIELD },
   },


### PR DESCRIPTION
Add reference from Salesforce QuickAction `fieldOverrides` to their respective fields.

---

Before value:
```
fieldOverrides = [
    {
      field = "SLA__c"
      literalValue = "Gold"
    },
  ]
```

After value:
```
fieldOverrides = [
    {
      field = salesforce.Account.field.SLA__c
      literalValue = "Gold"
    },
  ]
```

---
_Release Notes_: 
_Salesforce Adapter_:
- Add references for QuickAction fieldOverrides.

---
_User Notifications_: 
Salesforce:
- Existing QuickAction instances may have changes from strings to References.
