### PR TITLE
SALTO-6109 Add service url (if present) to collision error

### DIFF
--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -13,17 +13,32 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import { ObjectType, ElemID, InstanceElement, ReferenceExpression, SaltoError } from '@salto-io/adapter-api'
+import {
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  ReferenceExpression,
+  SaltoError,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
 import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '../src/collisions'
 
 describe('collisions', () => {
   const instType = new ObjectType({
     elemID: new ElemID('salto', 'obj'),
   })
-  const instance = new InstanceElement('test', instType, {
-    title: 'test',
-    ref: new ReferenceExpression(new ElemID('salto', 'something'), 'some value'),
-  })
+  const instance = new InstanceElement(
+    'test',
+    instType,
+    {
+      title: 'test',
+      ref: new ReferenceExpression(new ElemID('salto', 'something'), 'some value'),
+    },
+    undefined,
+    {
+      [CORE_ANNOTATIONS.SERVICE_URL]: 'someUrl',
+    },
+  )
   const collidedInstance = new InstanceElement('test', instType, { title: 'test', val: 'val' })
   const differentInstance = new InstanceElement('test1', instType, { title: 'test1' })
   describe('getInstancesWithCollidingElemID', () => {
@@ -43,8 +58,8 @@ Current Salto ID configuration for obj is defined as [title].
 
 Breakdown per colliding Salto ID:
 - test:
-\t* Instance with Id - test
-\t* Instance with Id - test
+\t* Instance with Id - test. View in the service - someUrl
+\t* Instance with Id - test. View in the service - someUrl
 
 To resolve these collisions please take one of the following actions and fetch again:
 \t1. Change obj's unique fields to include all fields that uniquely identify the type's instances.

--- a/packages/zendesk-adapter/src/filters/guide_service_url.ts
+++ b/packages/zendesk-adapter/src/filters/guide_service_url.ts
@@ -26,6 +26,7 @@ import {
   GUIDE_SETTINGS_TYPE_NAME,
   BRAND_TYPE_NAME,
   GUIDE_LANGUAGE_SETTINGS_TYPE_NAME,
+  GUIDE_THEME_TYPE_NAME,
 } from '../constants'
 
 const PARAM_MATCH = /\{([\w_.]+)}/g
@@ -43,6 +44,7 @@ const SERVICE_URL_FOR_GUIDE: Record<string, string> = {
   [CATEGORY_TRANSLATION_TYPE_NAME]: '/hc/admin/categories/{_parent.0.value.value.id}/edit?translation_locale={locale}',
   [GUIDE_SETTINGS_TYPE_NAME]: '/hc/admin/general_settings',
   [GUIDE_LANGUAGE_SETTINGS_TYPE_NAME]: '/hc/admin/language_settings',
+  [GUIDE_THEME_TYPE_NAME]: '/theming/theme/{id}',
 }
 
 const replaceUrlParamsBrand = (url: string, instance: InstanceElement): string =>

--- a/packages/zendesk-adapter/test/filters/omit_collision.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_collision.test.ts
@@ -25,8 +25,12 @@ describe('collision errors', () => {
   let filter: FilterType
   const objType = new ObjectType({ elemID: new ElemID(ZENDESK, 'obj') })
   const inst = new InstanceElement('inst1', objType, { name: 'test', position: 1 })
-  const collidedInst = new InstanceElement('inst1', objType, { name: 'test', position: 2 })
-  const differentInst = new InstanceElement('inst2', objType, { name: 'test2', position: 3 })
+  const collidedInst = new InstanceElement('inst1', objType, { name: 'test', position: 2 }, undefined, {
+    [CORE_ANNOTATIONS.SERVICE_URL]: 'someUrl',
+  })
+  const differentInst = new InstanceElement('inst2', objType, { name: 'test2', position: 3 }, undefined, {
+    [CORE_ANNOTATIONS.SERVICE_URL]: 'someUrl',
+  })
   const childInst1 = new InstanceElement('childInst1', objType, { name: 'childInst1', position: 2 }, undefined, {
     [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(inst.elemID, inst),
   })
@@ -49,7 +53,7 @@ Current Salto ID configuration for obj is defined as [name].
 Breakdown per colliding Salto ID:
 - inst1:
 \t* Instance with Id - inst1
-\t* Instance with Id - inst1
+\t* Instance with Id - inst1. View in the service - someUrl
 
 To resolve these collisions please take one of the following actions and fetch again:
 \t1. Change obj's idFields to include all fields that uniquely identify the type's instances.


### PR DESCRIPTION
A link to the service will now appear if it exists to the ID collision errors.

The error looked (partially) like this before:
```
Breakdown per colliding Salto ID:
- Test_12672121723027:
        * Instance with Id - Test_12672121723027
        * Instance with Id - Test_12672121723027
```
and after: 
```
Breakdown per colliding Salto ID:
- Test_12672121723027:
        * Instance with Id - Test_12672121723027. View in the service - https://d3v-salto2.zendesk.com/knowledge/articles/31771664875155/en-us?brand_id=11442239212179
        * Instance with Id - Test_12672121723027. View in the service - https://d3v-salto2.zendesk.com/knowledge/articles/13536523381523/da?brand_id=11442239212179
```

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter:__
* In ID collision errors - a link to the service will now appear if it exists.

__Salesforce Adapter:__
* In ID collision errors - a link to the service will now appear if it exists.

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
