### PR TITLE
SALTO-6342: fix updateNaclFiles to count static file changes

### DIFF
--- a/packages/core/test/common/workspace.ts
+++ b/packages/core/test/common/workspace.ts
@@ -148,10 +148,12 @@ export const mockWorkspace = ({
       filepath,
       encoding,
       isTemplate,
+      hash,
     }: {
       filepath: string
       encoding: BufferEncoding
       isTemplate?: boolean
-    }) => (staticFilesSource ? staticFilesSource.getStaticFile({ filepath, encoding, isTemplate }) : undefined),
+      hash?: string
+    }) => (staticFilesSource ? staticFilesSource.getStaticFile({ filepath, encoding, isTemplate, hash }) : undefined),
   } as unknown as workspace.Workspace
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -180,22 +180,23 @@ const buildMultiEnvSource = (
     isTemplate?: boolean
     hash?: string
   }): Promise<StaticFile> => {
+    const { env, filePath, encoding, isTemplate, hash } = args
     const sourcesFiles = (
       await Promise.all(
-        Object.values(getActiveSources(args.env)).map(src =>
+        Object.values(getActiveSources(env)).map(src =>
           src.getStaticFile({
-            filePath: args.filePath,
-            encoding: args.encoding,
-            isTemplate: _.isObject(args) ? args.isTemplate : undefined,
-            hash: args.hash,
+            filePath,
+            encoding,
+            isTemplate,
+            hash,
           }),
         ),
       )
     ).filter(values.isDefined)
     if (sourcesFiles.length > 1 && !_.every(sourcesFiles, sf => sf.hash === sourcesFiles[0].hash)) {
-      log.warn(`Found different hashes for static file ${args.filePath}`)
+      log.warn(`Found different hashes for static file ${filePath}`)
     }
-    return sourcesFiles[0] ?? new MissingStaticFile(args.filePath)
+    return sourcesFiles[0] ?? new MissingStaticFile(filePath)
   }
 
   const buildStateForSingleEnv = async (envName: string): Promise<SingleState> => {

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -313,15 +313,7 @@ const createNaclFilesState = async (
     await remoteMapCreator<Element>({
       namespace: getRemoteMapNamespace('merged', sourceName),
       serialize: async element => serialize([element], 'keepRef'),
-      deserialize: async data =>
-        deserializeSingleElement(data, async sf =>
-          staticFilesSource.getStaticFile({
-            filepath: sf.filepath,
-            encoding: sf.encoding,
-            isTemplate: sf.isTemplate,
-            hash: sf.hash,
-          }),
-        ),
+      deserialize: async data => deserializeSingleElement(data, async sf => staticFilesSource.getStaticFile(sf)),
       persistent,
     }),
   ),
@@ -812,7 +804,7 @@ const buildNaclFilesSource = (
     const naclFiles = _.uniq(
       await awu(changes)
         .map(change => change.id)
-        .flatMap(async elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))
+        .flatMap(elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))
         .toArray(),
     )
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -324,6 +324,7 @@ export type Workspace = {
     encoding: BufferEncoding
     env?: string
     isTemplate?: boolean
+    hash?: string
   }): Promise<StaticFile | undefined>
   getStaticFilePathsByElemIds(elementIds: ElemID[], envName?: string): Promise<string[]>
   getElemIdsByStaticFilePaths(filePaths?: Set<string>, envName?: string): Promise<Record<string, string>>
@@ -573,6 +574,7 @@ export const loadWorkspace = async (
                           encoding: staticFile.encoding,
                           env: envName,
                           isTemplate: staticFile.isTemplate,
+                          hash: staticFile.hash,
                         })) ?? staticFile,
                     ),
                   persistent,
@@ -1648,8 +1650,8 @@ export const loadWorkspace = async (
     getElementSourceOfPath: async (filePath, includeHidden = true) =>
       adaptersConfig.isConfigFile(filePath) ? adaptersConfig.getElements() : elementsImpl(includeHidden),
     getFileEnvs: filePath => naclFilesSource.getFileEnvs(filePath),
-    getStaticFile: async ({ filepath, encoding, env, isTemplate }) =>
-      naclFilesSource.getStaticFile({ filePath: filepath, encoding, env: env ?? currentEnv(), isTemplate }),
+    getStaticFile: async ({ filepath, encoding, env, isTemplate, hash }) =>
+      naclFilesSource.getStaticFile({ filePath: filepath, encoding, env: env ?? currentEnv(), isTemplate, hash }),
     getChangedElementsBetween,
     getStaticFilePathsByElemIds,
     getElemIdsByStaticFilePaths,

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -278,53 +278,59 @@ type salesforce.inconsistent_case {
 `,
 }
 
-export const mockDirStore = (
+export const mockDirStore = <T extends Buffer | string>(
   exclude: string[] = ['error.nacl', 'dup.nacl', 'reference_error.nacl'],
   empty = false,
-  files?: Record<string, string>,
-): MockInterface<DirectoryStore<string>> => {
-  const naclFiles: Map<string, File<string>> = empty
+  files?: Record<string, T>,
+): MockInterface<DirectoryStore<T>> => {
+  const naclFiles: Map<string, File<T>> = empty
     ? new Map()
-    : new Map(Object.entries(files ?? workspaceFiles).map(([filename, buffer]) => [filename, { filename, buffer }]))
+    : new Map(
+        Object.entries(files ?? workspaceFiles).map(([filename, buffer]) => [
+          filename,
+          { filename, buffer, timestamp: Date.now() },
+        ]),
+      )
   return {
-    list: mockFunction<DirectoryStore<string>['list']>().mockImplementation(async () =>
+    list: mockFunction<DirectoryStore<T>['list']>().mockImplementation(async () =>
       Array.from(naclFiles.keys()).filter(name => !exclude.includes(name)),
     ),
-    isEmpty: mockFunction<DirectoryStore<string>['isEmpty']>().mockResolvedValue(naclFiles.size === 0),
-    get: mockFunction<DirectoryStore<string>['get']>().mockImplementation(async filename => naclFiles.get(filename)),
-    set: mockFunction<DirectoryStore<string>['set']>().mockImplementation(async file => {
+    isEmpty: mockFunction<DirectoryStore<T>['isEmpty']>().mockResolvedValue(naclFiles.size === 0),
+    get: mockFunction<DirectoryStore<T>['get']>().mockImplementation(async filename => naclFiles.get(filename)),
+    set: mockFunction<DirectoryStore<T>['set']>().mockImplementation(async file => {
+      file.timestamp = Date.now()
       naclFiles.set(file.filename, file)
     }),
-    delete: mockFunction<DirectoryStore<string>['delete']>().mockImplementation(async fileName => {
+    delete: mockFunction<DirectoryStore<T>['delete']>().mockImplementation(async fileName => {
       naclFiles.delete(fileName)
     }),
-    clear: mockFunction<DirectoryStore<string>['clear']>().mockImplementation(async () => naclFiles.clear()),
-    rename: mockFunction<DirectoryStore<string>['rename']>().mockImplementation(() => Promise.resolve()),
-    renameFile: mockFunction<DirectoryStore<string>['renameFile']>().mockImplementation(async (filename, newName) => {
+    clear: mockFunction<DirectoryStore<T>['clear']>().mockImplementation(async () => naclFiles.clear()),
+    rename: mockFunction<DirectoryStore<T>['rename']>().mockImplementation(() => Promise.resolve()),
+    renameFile: mockFunction<DirectoryStore<T>['renameFile']>().mockImplementation(async (filename, newName) => {
       const origFile = naclFiles.get(filename)
       if (origFile !== undefined) {
         naclFiles.set(newName, origFile)
         naclFiles.delete(filename)
       }
     }),
-    flush: mockFunction<DirectoryStore<string>['flush']>().mockImplementation(() => Promise.resolve()),
-    mtimestamp: mockFunction<DirectoryStore<string>['mtimestamp']>().mockResolvedValue(0),
-    getFiles: mockFunction<DirectoryStore<string>['getFiles']>().mockImplementation(async filenames =>
+    flush: mockFunction<DirectoryStore<T>['flush']>().mockImplementation(() => Promise.resolve()),
+    mtimestamp: mockFunction<DirectoryStore<T>['mtimestamp']>().mockImplementation(
+      async fileName => naclFiles.get(fileName)?.timestamp,
+    ),
+    getFiles: mockFunction<DirectoryStore<T>['getFiles']>().mockImplementation(async filenames =>
       filenames.map(name => naclFiles.get(name)),
     ),
-    getTotalSize: mockFunction<DirectoryStore<string>['getTotalSize']>().mockResolvedValue(0),
-    clone: mockFunction<DirectoryStore<string>['clone']>().mockImplementation(() =>
+    getTotalSize: mockFunction<DirectoryStore<T>['getTotalSize']>().mockResolvedValue(0),
+    clone: mockFunction<DirectoryStore<T>['clone']>().mockImplementation(() =>
       mockDirStore(
         exclude,
         empty,
         Object.fromEntries(Array.from(naclFiles.entries()).map(([name, file]) => [name, file.buffer])),
       ),
     ),
-    getFullPath: mockFunction<DirectoryStore<string>['getFullPath']>().mockImplementation(filename => filename),
-    isPathIncluded: mockFunction<DirectoryStore<string>['isPathIncluded']>().mockReturnValue(true),
-    exists: mockFunction<DirectoryStore<string>['exists']>().mockImplementation(async filename =>
-      naclFiles.has(filename),
-    ),
+    getFullPath: mockFunction<DirectoryStore<T>['getFullPath']>().mockImplementation(filename => filename),
+    isPathIncluded: mockFunction<DirectoryStore<T>['isPathIncluded']>().mockReturnValue(true),
+    exists: mockFunction<DirectoryStore<T>['exists']>().mockImplementation(async filename => naclFiles.has(filename)),
   }
 }
 

--- a/packages/workspace/test/workspace/config_source.test.ts
+++ b/packages/workspace/test/workspace/config_source.test.ts
@@ -119,6 +119,7 @@ describe('configSource', () => {
   a = 2
 }
 `,
+        timestamp: expect.anything(),
       })
     })
   })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -58,6 +58,8 @@ import { ConfigSource } from '../../src/workspace/config_source'
 import { naclFilesSource, NaclFilesSource, ChangeSet } from '../../src/workspace/nacl_files'
 import { State } from '../../src/workspace/state'
 import { createMockNaclFileSource } from '../common/nacl_file_source'
+import { buildStaticFilesCache } from '../../src/workspace/static_files/static_files_cache'
+import * as remoteMap from '../../src/workspace/remote_map'
 import { DirectoryStore } from '../../src/workspace/dir_store'
 import {
   Workspace,
@@ -83,7 +85,7 @@ import {
   UnknownAccountError,
   InvalidAccountNameError,
 } from '../../src/workspace/errors'
-import { MissingStaticFile } from '../../src/workspace/static_files'
+import { buildStaticFilesSource, MissingStaticFile } from '../../src/workspace/static_files'
 import { mockDirStore } from '../common/nacl_file_store'
 import { EnvConfig, StateConfig } from '../../src/workspace/config/workspace_config_types'
 import { resolve } from '../../src/expressions'
@@ -113,6 +115,7 @@ const changedNaclFile = {
   buffer: `type salesforce.lead {
     salesforce.text new_base {}
   }`,
+  timestamp: expect.anything(),
 }
 const changedConfFile = {
   filename: 'salto.config/adapters/salesforce.nacl',
@@ -127,6 +130,7 @@ const emptyNaclFile = {
 const newNaclFile = {
   filename: 'new.nacl',
   buffer: 'type salesforce.new {}',
+  timestamp: expect.anything(),
 }
 const services = ['salesforce']
 
@@ -704,7 +708,7 @@ describe('workspace', () => {
   })
 
   describe('setNaclFiles', () => {
-    const naclFileStore = mockDirStore()
+    const naclFileStore = mockDirStore<string>()
     let workspace: Workspace
     let elemMap: Record<string, Element>
     let changes: Record<string, ChangeSet<Change<Element>>>
@@ -876,6 +880,100 @@ describe('workspace', () => {
         ])
 
         expect((await ws.errors()).merge).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('updateNaclFiles with static files', () => {
+    let workspace: Workspace
+    const staticFileInstanceType = new ObjectType({
+      elemID: new ElemID('salesforce', 'staticFile'),
+      annotations: {
+        [CORE_ANNOTATIONS.HIDDEN]: true,
+      },
+      path: ['salesforce', 'Types', 'staticFile'],
+      isSettings: false,
+    })
+
+    staticFileInstanceType.fields.staticFile = new Field(staticFileInstanceType, 'staticFile', BuiltinTypes.STRING)
+
+    const beforeStaticFile = new StaticFile({
+      content: Buffer.from('I am a little static file'),
+      filepath: 'static1.nacl',
+    })
+
+    const afterStaticFile = new StaticFile({
+      content: Buffer.from('I am a little static file2'),
+      filepath: 'static1.nacl',
+    })
+
+    const staticFileInstanceBefore = new InstanceElement(
+      'staticFileInstance',
+      staticFileInstanceType,
+      {
+        staticFile: beforeStaticFile,
+      },
+      ['Records', 'staticFile', 'staticFileInstance'],
+    )
+    it('should have right number of results when there is only a change in 1 static file', async () => {
+      const maps = new Map<string, remoteMap.RemoteMap<unknown>>()
+      const inMemRemoteMapCreator =
+        (): remoteMap.RemoteMapCreator =>
+        async <T, K extends string = string>(opts: remoteMap.CreateRemoteMapParams<T>) => {
+          const map = maps.get(opts.namespace) ?? new remoteMap.InMemoryRemoteMap<T, K>()
+          if (!maps.has(opts.namespace)) {
+            maps.set(opts.namespace, map)
+          }
+          return map as remoteMap.RemoteMap<T, K>
+        }
+      const staticFilesCache = buildStaticFilesCache('test', inMemRemoteMapCreator(), true)
+      const defaultFilePath = 'static1.nacl'
+      const otherStaticFiles = { [defaultFilePath]: Buffer.from('I am a little static file') }
+      const mockStaticFileDirStore = mockDirStore(undefined, undefined, otherStaticFiles)
+      const staticFilesSource = buildStaticFilesSource(mockStaticFileDirStore, staticFilesCache)
+      const otherChanges: DetailedChange[] = [
+        // modify static file
+        {
+          id: new ElemID('salesforce', 'staticFile', 'instance', 'staticFileInstance', 'staticFile'),
+          action: 'modify',
+          data: {
+            before: beforeStaticFile,
+            after: afterStaticFile,
+          },
+        },
+      ]
+      const otherNaclFiles = {
+        'staticFile.nacl': `
+        
+type salesforce.staticFile {
+  string staticFile {
+  }
+}
+
+salesforce.staticFile staticFileInstance {
+  staticFile = file("static1.nacl")
+}
+        `,
+      }
+
+      const otherDirStore = mockDirStore(undefined, undefined, otherNaclFiles)
+      const state = createState([...Object.values(BuiltinTypes), staticFileInstanceType, staticFileInstanceBefore])
+
+      workspace = await createWorkspace(
+        otherDirStore,
+        state,
+        undefined,
+        undefined,
+        undefined,
+        staticFilesSource,
+        undefined,
+        inMemRemoteMapCreator(),
+      )
+
+      const otherUpdateNaclFileResults = await workspace.updateNaclFiles(otherChanges)
+      expect(otherUpdateNaclFileResults).toEqual({
+        naclFilesChangesCount: 1,
+        stateOnlyChangesCount: 0,
       })
     })
   })
@@ -1584,7 +1682,7 @@ describe('workspace', () => {
     let elemMapWithHidden: Record<string, Element>
     let workspace: Workspace
     let updateNaclFileResults: UpdateNaclFilesResult
-    const dirStore = mockDirStore()
+    const dirStore = mockDirStore<string>()
 
     beforeAll(async () => {
       const helperWorkspace = await createWorkspace(dirStore, createState([]))
@@ -2462,7 +2560,7 @@ describe('workspace', () => {
     const naclFileStore = mockDirStore(undefined, undefined, {
       'firstFile.nacl': firstFile,
     })
-    const emptyFileStore = mockDirStore(undefined, undefined, {})
+    const emptyFileStore = mockDirStore<string>(undefined, undefined, {})
     describe('empty index', () => {
       beforeEach(async () => {
         workspace = await createWorkspace(emptyFileStore, undefined, undefined, undefined, undefined, undefined, {
@@ -5072,7 +5170,7 @@ describe('isValidEnvName', () => {
 describe('update nacl files with invalid state cache', () => {
   let workspace: Workspace
   beforeAll(async () => {
-    const dirStore = mockDirStore()
+    const dirStore = mockDirStore<string>()
     const changes: DetailedChange[] = [
       {
         action: 'remove',

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -915,7 +915,7 @@ describe('workspace', () => {
       },
       ['Records', 'staticFile', 'staticFileInstance'],
     )
-    it('should have right number of results when there is only a change in 1 static file', async () => {
+    const setUp = async (): Promise<void> => {
       const maps = new Map<string, remoteMap.RemoteMap<unknown>>()
       const inMemRemoteMapCreator =
         (): remoteMap.RemoteMapCreator =>
@@ -931,17 +931,6 @@ describe('workspace', () => {
       const otherStaticFiles = { [defaultFilePath]: Buffer.from('I am a little static file') }
       const mockStaticFileDirStore = mockDirStore(undefined, undefined, otherStaticFiles)
       const staticFilesSource = buildStaticFilesSource(mockStaticFileDirStore, staticFilesCache)
-      const otherChanges: DetailedChange[] = [
-        // modify static file
-        {
-          id: new ElemID('salesforce', 'staticFile', 'instance', 'staticFileInstance', 'staticFile'),
-          action: 'modify',
-          data: {
-            before: beforeStaticFile,
-            after: afterStaticFile,
-          },
-        },
-      ]
       const otherNaclFiles = {
         'staticFile.nacl': `
         
@@ -969,8 +958,21 @@ salesforce.staticFile staticFileInstance {
         undefined,
         inMemRemoteMapCreator(),
       )
-
-      const otherUpdateNaclFileResults = await workspace.updateNaclFiles(otherChanges)
+    }
+    it('should have right number of results when there is only a change in 1 static file', async () => {
+      await setUp()
+      const changes: DetailedChange[] = [
+        // modify static file
+        {
+          id: new ElemID('salesforce', 'staticFile', 'instance', 'staticFileInstance', 'staticFile'),
+          action: 'modify',
+          data: {
+            before: beforeStaticFile,
+            after: afterStaticFile,
+          },
+        },
+      ]
+      const otherUpdateNaclFileResults = await workspace.updateNaclFiles(changes)
       expect(otherUpdateNaclFileResults).toEqual({
         naclFilesChangesCount: 1,
         stateOnlyChangesCount: 0,


### PR DESCRIPTION
fix updateNaclFiles to count static file changes

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
