### PR TITLE
SALTO-6350: Modify ./create_version_pr.sh script

### DIFF
--- a/build_utils/create_version_pr.sh
+++ b/build_utils/create_version_pr.sh
@@ -41,7 +41,7 @@ fi
 BUMP=${1:-patch}
 
 yarn lerna-version -y $BUMP
-yarn; yarn; yarn 
+yarn --immutable
 
 DIRTY_FILES=$(git diff-index --name-only HEAD)
 

--- a/build_utils/create_version_pr.sh
+++ b/build_utils/create_version_pr.sh
@@ -41,6 +41,7 @@ fi
 BUMP=${1:-patch}
 
 yarn lerna-version -y $BUMP
+yarn; yarn; yarn 
 
 DIRTY_FILES=$(git diff-index --name-only HEAD)
 


### PR DESCRIPTION
In this PR I modified ./create_version_pr.sh  script

---

_Additional context for reviewer_
@Eshed Gal-Or [PR](https://github.com/salto-io/salto/pull/6108) added dependency to our Salto release version in the yarn.lock

For example: 

"@salto-io/adapter-api": 0.3.60

Meaning that we should add yarn to modify this yarn.lock as part of the script of OSS release.

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
