### PR TITLE
SALTO-6351: Okta: Add logs for `isCustomApp` matching methods.

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/types/application.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/application.ts
@@ -65,8 +65,34 @@ export const assignPolicyIdsToApplication = (value: unknown): Value => {
   }
 }
 
-export const isCustomApp = (value: Values, subdomain: string): boolean =>
-  [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) &&
-  value.name !== undefined &&
-  // custom app names starts with subdomain and '_'
-  _.startsWith(value.name, `${subdomain}_`)
+const endsWithNumberRegex = new RegExp(/_\d+$/)
+
+export const isCustomApp = (value: Values, subdomain: string): boolean => {
+  const subdomainMatch =
+    value.name !== undefined &&
+    // custom app names starts with subdomain and '_'
+    _.startsWith(value.name, `${subdomain}_`)
+
+  const endsWithNumberMatch =
+    value.name !== undefined &&
+    // custom app names ends with a number
+    endsWithNumberRegex.test(value.name)
+
+  if (subdomainMatch !== endsWithNumberMatch) {
+    log.warn(
+      'isCustomApp matching methods disagree for %s: subdomainMatch=%s, endsWithNumberMatch=%s',
+      value.name,
+      subdomainMatch,
+      endsWithNumberMatch,
+    )
+  } else {
+    log.info(
+      'isCustomApp matching methods agree for %s: subdomainMatch=%s, endsWithNumberMatch=%s',
+      value.name,
+      subdomainMatch,
+      endsWithNumberMatch,
+    )
+  }
+
+  return [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) && subdomainMatch
+}

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -520,7 +520,7 @@ describe('adapter', () => {
       const orgSettingType = new ObjectType({
         elemID: new ElemID(OKTA, ORG_SETTING_TYPE_NAME),
       })
-      const orgSetting = new InstanceElement('_config', orgSettingType, { subdomain: 'subdomain.example.com' })
+      const orgSetting = new InstanceElement('_config', orgSettingType, { subdomain: 'subdomain' })
 
       operations = adapter.operations({
         credentials: new InstanceElement('config', accessTokenCredentialsType, {
@@ -1211,7 +1211,7 @@ describe('adapter', () => {
         const instance = getChangeData(result.appliedChanges[0] as Change<InstanceElement>)
         expect(instance.value.id).toEqual('app-fakeid1')
         // This is based on the orgSettings subdomain and the service returned "name" field value
-        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain.example.com_app1')
+        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain_app1_1')
         expect(instance.value.name).toBeUndefined()
         expect(nock.pendingMocks()).toHaveLength(0)
       })
@@ -1235,9 +1235,9 @@ describe('adapter', () => {
         expect(result.appliedChanges).toHaveLength(1)
         const instance = getChangeData(result.appliedChanges[0] as Change<InstanceElement>)
         expect(instance.value.id).toEqual('app-fakeid1')
-        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain.example.com_app1')
+        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain_app1_1')
         // This is based on the orgSettings subdomain and the service returned "name" field value
-        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain.example.com_app1')
+        expect(_.get(instance.value, CUSTOM_NAME_FIELD)).toEqual('subdomain_app1_1')
         expect(instance.value.name).toBeUndefined()
         expect(nock.pendingMocks()).toHaveLength(0)
       })
@@ -1248,7 +1248,7 @@ describe('adapter', () => {
           id: 'app-fakeid1',
           label: 'app1',
           status: INACTIVE_STATUS,
-          [CUSTOM_NAME_FIELD]: 'subdomain.example.com',
+          [CUSTOM_NAME_FIELD]: 'subdomain_app1_1',
           profileEnrollment: new ReferenceExpression(profileEnrollmentPolicy1.elemID, profileEnrollmentPolicy1),
           accessPolicy: new ReferenceExpression(accessPolicy.elemID, accessPolicy),
         })
@@ -1283,7 +1283,7 @@ describe('adapter', () => {
           id: 'app-fakeid1',
           label: 'app1',
           status: ACTIVE_STATUS,
-          [CUSTOM_NAME_FIELD]: 'subdomain.example.com',
+          [CUSTOM_NAME_FIELD]: 'subdomain_app1_1',
           profileEnrollment: new ReferenceExpression(profileEnrollmentPolicy1.elemID, profileEnrollmentPolicy1),
           accessPolicy: new ReferenceExpression(accessPolicy.elemID, accessPolicy),
         })
@@ -1314,7 +1314,7 @@ describe('adapter', () => {
           id: 'app-fakeid1',
           label: 'app1',
           status: ACTIVE_STATUS,
-          [CUSTOM_NAME_FIELD]: 'subdomain.example.com',
+          [CUSTOM_NAME_FIELD]: 'subdomain_app1_1',
           profileEnrollment: new ReferenceExpression(profileEnrollmentPolicy1.elemID, profileEnrollmentPolicy1),
           accessPolicy: new ReferenceExpression(accessPolicy.elemID, accessPolicy),
         })
@@ -1348,7 +1348,7 @@ describe('adapter', () => {
           id: 'app-fakeid1',
           label: 'app1',
           status: INACTIVE_STATUS,
-          [CUSTOM_NAME_FIELD]: 'subdomain.example.com',
+          [CUSTOM_NAME_FIELD]: 'subdomain_app1_1',
         })
         const result = await operations.deploy({
           changeGroup: {
@@ -1368,7 +1368,7 @@ describe('adapter', () => {
           id: 'app-fakeid1',
           label: 'app1',
           status: ACTIVE_STATUS,
-          [CUSTOM_NAME_FIELD]: 'subdomain.example.com',
+          [CUSTOM_NAME_FIELD]: 'subdomain_app1_1',
         })
         const result = await operations.deploy({
           changeGroup: {

--- a/packages/okta-adapter/test/mock_replies/application_add_custom_active.json
+++ b/packages/okta-adapter/test/mock_replies/application_add_custom_active.json
@@ -6,7 +6,7 @@
     "status": 200,
     "response": {
       "id": "app-fakeid1",
-      "name": "subdomain.example.com_app1",
+      "name": "subdomain_app1_1",
       "label": "app1",
       "status": "INACTIVE",
       "lastUpdated": "2024-07-08T06:59:58.000Z",

--- a/packages/okta-adapter/test/mock_replies/application_add_custom_inactive.json
+++ b/packages/okta-adapter/test/mock_replies/application_add_custom_inactive.json
@@ -6,7 +6,7 @@
     "status": 200,
     "response": {
       "id": "app-fakeid1",
-      "name": "subdomain.example.com_app1",
+      "name": "subdomain_app1_1",
       "label": "app1",
       "status": "INACTIVE",
       "lastUpdated": "2024-07-08T06:59:58.000Z",

--- a/packages/okta-adapter/test/mock_replies/application_add_regular_inactive.json
+++ b/packages/okta-adapter/test/mock_replies/application_add_regular_inactive.json
@@ -6,7 +6,7 @@
     "status": 200,
     "response": {
       "id": "app-fakeid1",
-      "name": "salto_testtest3_2",
+      "name": "subdomain_app1_1",
       "label": "app1",
       "status": "INACTIVE",
       "lastUpdated": "2024-07-08T06:59:58.000Z",

--- a/packages/okta-adapter/test/mock_replies/application_modify_custom_active_unchanged_policies.json
+++ b/packages/okta-adapter/test/mock_replies/application_modify_custom_active_unchanged_policies.json
@@ -6,7 +6,7 @@
     "status": 200,
     "response": {
       "id": "app-fakeid1",
-      "name": "salto_testtest3_1",
+      "name": "subdomain_app1_1",
       "label": "test test4",
       "status": "ACTIVE",
       "lastUpdated": "2024-07-07T12:23:56.000Z",
@@ -24,7 +24,7 @@
           "web": false
         },
         "appLinks": {
-          "salto_testtest3_1_link": true
+          "subdomain_app1_1_link": true
         }
       },
       "features": [],
@@ -100,8 +100,8 @@
         },
         "appLinks": [
           {
-            "name": "salto_testtest3_1_link",
-            "href": "https://<sanitized>/home/salto_testtest3_1/app-fakeid1/alnginpawzL1kLm3j697",
+            "name": "subdomain_app1_1_link",
+            "href": "https://<sanitized>/home/subdomain_app1_1/app-fakeid1/alnginpawzL1kLm3j697",
             "type": "text/html"
           }
         ],
@@ -138,7 +138,7 @@
     "body": {
       "label": "app2",
       "status": "ACTIVE",
-      "name": "subdomain.example.com",
+      "name": "subdomain_app1_1",
       "settings": null
     },
     "reqHeaders": {

--- a/packages/okta-adapter/test/mock_replies/application_modify_custom_inactive_with_changed_policies.json
+++ b/packages/okta-adapter/test/mock_replies/application_modify_custom_inactive_with_changed_policies.json
@@ -19,7 +19,7 @@
     "status": 200,
     "response": {
       "id": "app-fakeid1",
-      "name": "salto_testtest3_1",
+      "name": "subdomain_app1_1",
       "label": "test test4",
       "status": "ACTIVE",
       "lastUpdated": "2024-07-07T12:23:56.000Z",
@@ -37,7 +37,7 @@
           "web": false
         },
         "appLinks": {
-          "salto_testtest3_1_link": true
+          "subdomain_app1_1_link": true
         }
       },
       "features": [],
@@ -113,8 +113,8 @@
         },
         "appLinks": [
           {
-            "name": "salto_testtest3_1_link",
-            "href": "https://<sanitized>/home/salto_testtest3_1/app-fakeid1/alnginpawzL1kLm3j697",
+            "name": "subdomain_app1_1_link",
+            "href": "https://<sanitized>/home/subdomain_app1_1/app-fakeid1/alnginpawzL1kLm3j697",
             "type": "text/html"
           }
         ],
@@ -151,7 +151,7 @@
     "body": {
       "label": "app2",
       "status": "INACTIVE",
-      "name": "subdomain.example.com",
+      "name": "subdomain_app1_1",
       "settings": null
     },
     "reqHeaders": {


### PR DESCRIPTION
There is a bug in the current `isCustomApp` detection method when subdomains are changed. We suspect that checking for a suffix of underscore + counter (`_1`, `_2` etc.) would be sufficient and work around this bug. This PR adds some logs so we can gather some data on this.

---

_Additional context for reviewer_:
I've also modified some tests to match what we know about custom app names.

---
_Release Notes_: 
None

---
_User Notifications_: 
None