### PR TITLE
Remove empty values from NS fetch target

### DIFF
--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -94,8 +94,8 @@ const updatedFetchTarget = (config: NetsuiteConfig): NetsuiteQueryParameters | u
   return {
     types: {
       ...types,
-      [CUSTOM_RECORD_TYPE]: customRecordTypesQuery,
-      [CUSTOM_SEGMENT]: customSegmentsQuery,
+      ...(customRecordTypesQuery.length > 0 ? { [CUSTOM_RECORD_TYPE]: customRecordTypesQuery } : {}),
+      ...(customSegmentsQuery.length > 0 ? { [CUSTOM_SEGMENT]: customSegmentsQuery } : {}),
     },
     filePaths: updatedFilePaths,
     customRecords,

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -52,7 +52,6 @@ describe('netsuite config creator', () => {
         types: {
           addressForm: ['aaa.*', 'bbb.*'],
           customrecordtype: ['customrecord2', 'customrecord1'],
-          customsegment: [],
         },
         filePaths: [],
         customRecords: {
@@ -69,7 +68,6 @@ describe('netsuite config creator', () => {
       expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
         types: {
           customrecordtype: ['customrecord1'],
-          customsegment: [],
         },
         filePaths: [],
         customRecords: {
@@ -99,10 +97,7 @@ describe('netsuite config creator', () => {
         filePaths: ['/SuiteScripts/file.txt'],
       }
       expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
-        types: {
-          customrecordtype: [],
-          customsegment: [],
-        },
+        types: {},
         filePaths: ['/SuiteScripts/file.txt', '/SuiteScripts/'],
         customRecords: {},
       })
@@ -112,10 +107,7 @@ describe('netsuite config creator', () => {
         filePaths: ['.*\\.js'],
       }
       expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
-        types: {
-          customrecordtype: [],
-          customsegment: [],
-        },
+        types: {},
         filePaths: ['.*\\.js', '.*/'],
         customRecords: {},
       })
@@ -126,10 +118,7 @@ describe('netsuite config creator', () => {
         filePaths: ['/SuiteScripts/file.txt', '/Templates/[^/]*\\.html'],
       }
       expect(netsuiteConfigFromConfig(config).fetchTarget).toEqual({
-        types: {
-          customrecordtype: [],
-          customsegment: [],
-        },
+        types: {},
         filePaths: ['/SuiteScripts/file.txt', '/Templates/[^/]*\\.html', '/SuiteScripts/'],
         customRecords: {},
       })


### PR DESCRIPTION
Leaving empty values in fetch target makes us run `listObjects` on the types that we're not interested in.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None