### PR TITLE
SALTO-5939 Google ws: ignore common errors 

### DIFF
--- a/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
@@ -148,6 +148,9 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     ],
     resource: {
       directFetch: false,
+      onError: {
+        action: 'ignoreError'
+      },
       recurseInto: {
         groupSettings: {
           typeName: 'group__groupSettings',
@@ -232,6 +235,12 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     },
   },
   label: {
+    resource: {
+    directFetch: false,
+    onError: {
+      action: 'ignoreError'
+      },
+    },
     requests: [
       {
         endpoint: {
@@ -259,6 +268,9 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       directFetch: false,
       // the id field in groupMember is not unique, as it the member id.
       serviceIDFields: [],
+      onError: {
+        action: 'ignoreError'
+      },
     },
     element: {
       topLevel: {
@@ -293,6 +305,9 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     resource: {
       directFetch: false,
       serviceIDFields: ['roleAssignmentId'],
+      onError: {
+        action: 'ignoreError'
+      },
     },
     element: {
       topLevel: {
@@ -321,6 +336,12 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     },
   },
   group__groupSettings: {
+    resource: {
+      directFetch: false,
+      onError: {
+        action: 'ignoreError'
+      },
+    },
     requests: [
       {
         endpoint: {

--- a/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/google-workspace-adapter/src/definitions/fetch/fetch.ts
@@ -149,7 +149,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     resource: {
       directFetch: false,
       onError: {
-        action: 'ignoreError'
+        action: 'ignoreError',
       },
       recurseInto: {
         groupSettings: {
@@ -236,9 +236,9 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
   },
   label: {
     resource: {
-    directFetch: false,
-    onError: {
-      action: 'ignoreError'
+      directFetch: false,
+      onError: {
+        action: 'ignoreError',
       },
     },
     requests: [
@@ -269,7 +269,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       // the id field in groupMember is not unique, as it the member id.
       serviceIDFields: [],
       onError: {
-        action: 'ignoreError'
+        action: 'ignoreError',
       },
     },
     element: {
@@ -306,7 +306,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       directFetch: false,
       serviceIDFields: ['roleAssignmentId'],
       onError: {
-        action: 'ignoreError'
+        action: 'ignoreError',
       },
     },
     element: {
@@ -339,7 +339,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     resource: {
       directFetch: false,
       onError: {
-        action: 'ignoreError'
+        action: 'ignoreError',
       },
     },
     requests: [


### PR DESCRIPTION
SALTO-5939 Google ws: ignore common errors 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
