### PR TITLE
SALTO-6354 definition overrides env var work by account name

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -164,6 +164,7 @@ type AdapterBaseContext = {
 
 export type AdapterOperationsContext = {
   credentials: InstanceElement
+  accountName?: string
 } & AdapterBaseContext
 
 export type AdapterSuccessInstallResult = { success: true; installedVersion: string }

--- a/packages/adapter-components/src/adapter-wrapper/adapter_creator.ts
+++ b/packages/adapter-components/src/adapter-wrapper/adapter_creator.ts
@@ -127,7 +127,7 @@ export const createAdapter = <
         }),
       )
       const adapterDefinitions = definitionsCreator({ clients, userConfig: config, credentials })
-      const definitions = mergeDefinitionsWithOverrides(adapterDefinitions)
+      const definitions = mergeDefinitionsWithOverrides(adapterDefinitions, context.accountName)
       const resolverCreator = getResolverCreator(definitions)
       const fixElements = customizeFixElements
         ? combineElementFixers(customizeFixElements({ config, elementsSource: context.elementsSource }))

--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -63,7 +63,7 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
   }
   log.debug('starting to merge definitions with overrides')
   const overrides = getParsedDefinitionsOverrides(account)
-  if (_.isEmpty(overrides)) {account
+  if (_.isEmpty(overrides)) {
     return definitions
   }
   log.debug('Definitions overrides: %s', safeJsonStringify(overrides))

--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -23,12 +23,12 @@ import { APIDefinitionsOptions } from './api'
 const log = logger(module)
 export const DEFINITIONS_OVERRIDES = 'SALTO_DEFINITIONS_OVERRIDES'
 
-const getParsedDefinitionsOverrides = (): Values => {
+const getParsedDefinitionsOverrides = (account: string): Values => {
   const overrides = process.env[DEFINITIONS_OVERRIDES]
   try {
     const parsedOverrides = overrides === undefined ? undefined : JSON.parse(overrides)
     if (parsedOverrides !== undefined && typeof parsedOverrides === 'object') {
-      return parsedOverrides as Values
+      return parsedOverrides[account] as Values
     }
   } catch (e) {
     if (e instanceof SyntaxError) {
@@ -50,6 +50,7 @@ const getParsedDefinitionsOverrides = (): Values => {
  */
 export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOptions>(
   definitions: RequiredDefinitions<Options>,
+  account?: string
 ): RequiredDefinitions<Options> => {
   const customMerge = (objValue: Value, srcValue: Value): Value => {
     if (_.isArray(objValue)) {
@@ -57,9 +58,12 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
     }
     return undefined
   }
+  if (account === undefined) {
+    return definitions
+  }
   log.debug('starting to merge definitions with overrides')
-  const overrides = getParsedDefinitionsOverrides()
-  if (_.isEmpty(overrides)) {
+  const overrides = getParsedDefinitionsOverrides(account)
+  if (_.isEmpty(overrides)) {account
     return definitions
   }
   log.debug('Definitions overrides: %s', safeJsonStringify(overrides))

--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -23,12 +23,16 @@ import { APIDefinitionsOptions } from './api'
 const log = logger(module)
 export const DEFINITIONS_OVERRIDES = 'SALTO_DEFINITIONS_OVERRIDES'
 
-const getParsedDefinitionsOverrides = (account: string): Values => {
+const getParsedDefinitionsOverrides = (accountName: string): Values => {
   const overrides = process.env[DEFINITIONS_OVERRIDES]
   try {
     const parsedOverrides = overrides === undefined ? undefined : JSON.parse(overrides)
-    if (parsedOverrides !== undefined && typeof parsedOverrides === 'object') {
-      return parsedOverrides[account] as Values
+    if (
+      parsedOverrides !== undefined &&
+      parsedOverrides[accountName] !== undefined &&
+      typeof parsedOverrides === 'object'
+    ) {
+      return parsedOverrides[accountName] as Values
     }
   } catch (e) {
     if (e instanceof SyntaxError) {
@@ -50,7 +54,7 @@ const getParsedDefinitionsOverrides = (account: string): Values => {
  */
 export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOptions>(
   definitions: RequiredDefinitions<Options>,
-  account?: string
+  accountName?: string,
 ): RequiredDefinitions<Options> => {
   const customMerge = (objValue: Value, srcValue: Value): Value => {
     if (_.isArray(objValue)) {
@@ -58,11 +62,12 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
     }
     return undefined
   }
-  if (account === undefined) {
+  if (accountName === undefined) {
+    log.error('Account name is undefined, cannot merge definitions with overrides')
     return definitions
   }
   log.debug('starting to merge definitions with overrides')
-  const overrides = getParsedDefinitionsOverrides(account)
+  const overrides = getParsedDefinitionsOverrides(accountName)
   if (_.isEmpty(overrides)) {
     return definitions
   }

--- a/packages/adapter-components/test/definitions/system/overrides.test.ts
+++ b/packages/adapter-components/test/definitions/system/overrides.test.ts
@@ -141,7 +141,7 @@ describe('overrides', () => {
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should add a type to the fetch config', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions, 'account')
         expect(merged.fetch.instances.customizations?.group).toBeDefined()
         expect(merged.fetch.instances.customizations?.team).toBeDefined()
       })
@@ -178,7 +178,7 @@ describe('overrides', () => {
         expect(
           mockedDefinitions.fetch.instances.customizations?.team?.requests?.[0].transformation?.adjust,
         ).toBeDefined()
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions, 'account')
         expect(merged.fetch.instances.customizations?.team?.element).toEqual(
           mockedDefinitions.fetch.instances.customizations?.team?.element,
         )
@@ -259,7 +259,7 @@ describe('overrides', () => {
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should remove a type from the fetch config', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions, 'account')
         expect(merged.fetch.instances.customizations?.team).toBeUndefined()
       })
     })

--- a/packages/adapter-components/test/definitions/system/overrides.test.ts
+++ b/packages/adapter-components/test/definitions/system/overrides.test.ts
@@ -101,28 +101,37 @@ describe('overrides', () => {
       })
     })
 
+    describe('when the account name is not provided', () => {
+      it('should return the original definitions', () => {
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        expect(merged).toEqual(mockedDefinitions)
+      })
+    })
+
     describe('when adding a new type to the fetch definition', () => {
       const jsonString = `{
-        "fetch": {
-          "instances": {
-            "customizations": {
-              "group": {
-                "requests": [
-                  {
-                    "endpoint": {
-                      "path": "/groups"
-                    },
-                    "transformation": {
-                      "root": "groups"
+        "account": {
+          "fetch": {
+            "instances": {
+              "customizations": {
+                "group": {
+                  "requests": [
+                    {
+                      "endpoint": {
+                        "path": "/groups"
+                      },
+                      "transformation": {
+                        "root": "groups"
+                      }
                     }
-                  }
-                ],
-                "resource": {
-                  "directFetch": true
-                },
-                "element": {
-                  "topLevel": {
-                    "isTopLevel": true
+                  ],
+                  "resource": {
+                    "directFetch": true
+                  },
+                  "element": {
+                    "topLevel": {
+                      "isTopLevel": true
+                    }
                   }
                 }
               }
@@ -132,30 +141,32 @@ describe('overrides', () => {
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should add a type to the fetch config', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
         expect(merged.fetch.instances.customizations?.group).toBeDefined()
         expect(merged.fetch.instances.customizations?.team).toBeDefined()
       })
     })
     describe('when providing a new array field in the request fetch definition', () => {
       const jsonString = `{
-        "fetch": {
-          "instances": {
-            "customizations": {
-              "team": {
-                "requests": [
-                  {
-                    "endpoint": {
-                      "path": "/teams",
-                      "queryArgs": {
-                        "wow": "wee"
+        "account": {
+          "fetch": {
+            "instances": {
+              "customizations": {
+                "team": {
+                  "requests": [
+                    {
+                      "endpoint": {
+                        "path": "/teams",
+                        "queryArgs": {
+                          "wow": "wee"
+                        }
+                      },
+                      "transformation": {
+                        "root": "teams"
                       }
-                    },
-                    "transformation": {
-                      "root": "teams"
                     }
-                  }
-                ]
+                  ]
+                }
               }
             }
           }
@@ -167,7 +178,7 @@ describe('overrides', () => {
         expect(
           mockedDefinitions.fetch.instances.customizations?.team?.requests?.[0].transformation?.adjust,
         ).toBeDefined()
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
         expect(merged.fetch.instances.customizations?.team?.element).toEqual(
           mockedDefinitions.fetch.instances.customizations?.team?.element,
         )
@@ -182,40 +193,44 @@ describe('overrides', () => {
     })
     describe('when providing a new reference rule', () => {
       const jsonString = `{
-        "references": {
-          "rules": [
-            {
-              "src": {
-                "field": "id",
-                "parentTypes": ["parent2"]
-              },
-              "serializationStrategy": "id",
-              "target": {
-                "type": "myType"
+        "account": {
+          "references": {
+            "rules": [
+              {
+                "src": {
+                  "field": "id",
+                  "parentTypes": ["parent2"]
+                },
+                "serializationStrategy": "id",
+                "target": {
+                  "type": "myType"
+                }
               }
-            }
-          ]
+            ]
+          }
         }
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should override the reference parent type', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions, 'account')
         expect(merged.references?.rules[0].src.parentTypes).toEqual(['parent2'])
       })
     })
     describe('when editing an object field in the fetch definition', () => {
       const jsonString = `{
-        "fetch": {
-          "instances": {
-            "default": {
-              "element": {
-                "topLevel": {
-                  "elemID": {
-                    "parts": [
-                      {
-                        "fieldName": "newName"
-                      }
-                    ]
+        "account": {
+          "fetch": {
+            "instances": {
+              "default": {
+                "element": {
+                  "topLevel": {
+                    "elemID": {
+                      "parts": [
+                        {
+                          "fieldName": "newName"
+                        }
+                      ]
+                    }
                   }
                 }
               }
@@ -225,24 +240,26 @@ describe('overrides', () => {
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should edit the elemId field only', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions, 'account')
         expect(merged.fetch.instances.default?.element?.topLevel?.elemID).toEqual({ parts: [{ fieldName: 'newName' }] })
         expect(merged.fetch.instances.default?.element?.topLevel?.singleton).toBeTruthy()
       })
     })
     describe('when setting an existing field to null', () => {
       const jsonString = `{
-        "fetch": {
-          "instances": {
-            "customizations": {
-              "team": null
+        "account": {
+          "fetch": {
+            "instances": {
+              "customizations": {
+                "team": null
+              }
             }
           }
         }
       }`
       setupEnvVar(overridesEnvVar, jsonString)
       it('should remove a type from the fetch config', () => {
-        const merged = mergeDefinitionsWithOverrides(mockedDefinitions)
+        const merged = mergeDefinitionsWithOverrides(mockedDefinitions,'account')
         expect(merged.fetch.instances.customizations?.team).toBeUndefined()
       })
     })

--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -270,6 +270,7 @@ export const getAdaptersCreatorConfigs = async (
             config: await getConfig(account, defaultConfig),
             elementsSource: elementsSourceForAdapter,
             getElemIdFunc: elemIdGetters[account],
+            accountName: account,
           },
         ]
       }),


### PR DESCRIPTION
SALTO-6354 defention overrides env var work by account name
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none