### PR TITLE
SALTO-6345_fix_space_deployment

### DIFF
--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -29,6 +29,7 @@ import {
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
+  GROUP_TYPE_NAME,
   LABEL_TYPE_NAME,
   PAGE_TYPE_NAME,
   PERMISSION_TYPE_NAME,
@@ -417,6 +418,35 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 endpoint: {
                   path: '/wiki/rest/api/space/{spaceKey}/permission/{id}',
                   method: 'delete',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    [GROUP_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: {
+                  path: '/wiki/rest/api/group',
+                  method: 'post',
+                },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: {
+                  path: '/wiki/rest/api/group/by-id',
+                  method: 'delete',
+                  queryArgs: {
+                    id: '{id}',
+                  },
                 },
               },
             },

--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -19,6 +19,7 @@ import { adjustLabelsToIdsFunc, adjustRestriction, createAdjustUserReferences } 
 import {
   BLOG_POST_TYPE_NAME,
   GLOBAL_TEMPLATE_TYPE_NAME,
+  GROUP_TYPE_NAME,
   LABEL_TYPE_NAME,
   PAGE_TYPE_NAME,
   PERMISSION_TYPE_NAME,
@@ -205,7 +206,7 @@ const createCustomizations = (
         },
         permissions: {
           sort: {
-            properties: [{ path: 'principalId' }, { path: 'type' }, { path: 'key' }, { path: 'targetType' }],
+            properties: [{ path: 'type' }, { path: 'key' }, { path: 'targetType' }],
           },
         },
       },
@@ -449,6 +450,35 @@ const createCustomizations = (
       },
       fieldCustomizations: {
         templateId: {
+          hide: true,
+        },
+      },
+    },
+  },
+  [GROUP_TYPE_NAME]: {
+    requests: [
+      {
+        endpoint: {
+          path: '/wiki/rest/api/group',
+        },
+        transformation: {
+          root: 'results',
+          omit: ['type'],
+        },
+      },
+    ],
+    resource: {
+      directFetch: true,
+    },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+        alias: {
+          aliasComponents: [{ fieldName: 'name' }],
+        },
+      },
+      fieldCustomizations: {
+        id: {
           hide: true,
         },
       },

--- a/packages/confluence-adapter/src/definitions/references.ts
+++ b/packages/confluence-adapter/src/definitions/references.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 import { definitions, references as referenceUtils } from '@salto-io/adapter-components'
-import { LABEL_TYPE_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME, TEMPLATE_TYPE_NAMES } from '../constants'
+import { GROUP_TYPE_NAME, LABEL_TYPE_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME, TEMPLATE_TYPE_NAMES } from '../constants'
 
 const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
   {
@@ -43,6 +43,11 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
     src: { field: 'homepageId', parentTypes: [SPACE_TYPE_NAME] },
     serializationStrategy: 'id',
     target: { type: PAGE_TYPE_NAME },
+  },
+  {
+    src: { field: 'principalId', parentTypes: ['space__permissions'] },
+    serializationStrategy: 'id',
+    target: { type: GROUP_TYPE_NAME },
   },
 ]
 

--- a/packages/confluence-adapter/src/definitions/utils/space.ts
+++ b/packages/confluence-adapter/src/definitions/utils/space.ts
@@ -25,6 +25,7 @@ import { SPACE_TYPE_NAME } from '../../constants'
 import { FetchCriteria, Options } from '../types'
 
 const log = logger(module)
+const PERMISSION_TYPES = ['group', 'user']
 
 const ALL_SPACE_TYPES = ['global', 'collaboration', 'knowledge_base', 'personal']
 const ALL_SPACE_STATUSES = ['current', 'archived']
@@ -36,8 +37,8 @@ export type PermissionObject = {
   targetType: string
 }
 
-export const createPermissionUniqueKey = ({ type, principalId, key, targetType }: PermissionObject): string =>
-  `${type}_${principalId}_${key}_${targetType}`
+export const createPermissionUniqueKey = ({ type, key, targetType }: PermissionObject): string =>
+  `${type}_${key}_${targetType}`
 
 export const isPermissionObject = (value: unknown): value is PermissionObject =>
   _.isString(_.get(value, 'type')) &&
@@ -63,6 +64,9 @@ export const transformPermissionAndUpdateIdMap = (
   const internalId = _.get(permission, 'id')
   if ([type, principalId, key, targetType].some(x => !_.isString(x)) || internalId === undefined) {
     log.warn('permission is not in expected format: %o, skipping', permission)
+    return undefined
+  }
+  if (!PERMISSION_TYPES.includes(type)) {
     return undefined
   }
   permissionInternalIdMap[createPermissionUniqueKey({ type, principalId, key, targetType })] = String(internalId)

--- a/packages/confluence-adapter/test/definitions/utils/space.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/space.test.ts
@@ -37,7 +37,7 @@ describe('space definitions utils', () => {
     {
       id: 'internalId1',
       principal: {
-        type: 'type1',
+        type: 'user',
         id: 'id1',
       },
       operation: {
@@ -48,7 +48,7 @@ describe('space definitions utils', () => {
     {
       id: 'internalId2',
       principal: {
-        type: 'type2',
+        type: 'group',
         id: 'id2',
       },
       operation: {
@@ -67,7 +67,7 @@ describe('space definitions utils', () => {
         targetType: 'targetType',
       }
       const uniqueKey = createPermissionUniqueKey(permissionObject)
-      expect(uniqueKey).toEqual('type_principalId_key_targetType')
+      expect(uniqueKey).toEqual('type_key_targetType')
     })
   })
 
@@ -99,7 +99,7 @@ describe('space definitions utils', () => {
       const permissionFromFetch = {
         id: 'internalId',
         principal: {
-          type: 'type',
+          type: 'user',
           id: 'id',
         },
         operation: {
@@ -117,6 +117,12 @@ describe('space definitions utils', () => {
           ),
         ).toBeUndefined()
       })
+      it('should return undefined when permission type is not valid', () => {
+        const permissionFromFetchInvalidType = _.merge({}, permissionFromFetch, { principal: { type: 'invalidType' } })
+        expect(
+          transformPermissionAndUpdateIdMap(permissionFromFetchInvalidType, permissionInternalIdMap, true),
+        ).toBeUndefined()
+      })
       it('should return undefined when there is no internal id', () => {
         expect(
           transformPermissionAndUpdateIdMap({ ...permissionFromFetch, id: undefined }, permissionInternalIdMap, true),
@@ -125,19 +131,19 @@ describe('space definitions utils', () => {
       it('should return restructured permission and update the id map', () => {
         const result = transformPermissionAndUpdateIdMap(permissionFromFetch, permissionInternalIdMap, true)
         expect(result).toEqual({
-          type: 'type',
+          type: 'user',
           principalId: 'id',
           key: 'key',
           targetType: 'targetType',
         })
-        expect(permissionInternalIdMap).toEqual({ type_id_key_targetType: 'internalId' })
+        expect(permissionInternalIdMap).toEqual({ user_key_targetType: 'internalId' })
       })
     })
     describe('on deploy', () => {
       const permissionFromFetch = {
         id: 'internalId',
         subject: {
-          type: 'type',
+          type: 'user',
           identifier: 'id',
         },
         operation: {
@@ -159,12 +165,12 @@ describe('space definitions utils', () => {
       it('should return restructured permission and update the id map', () => {
         const result = transformPermissionAndUpdateIdMap(permissionFromFetch, permissionInternalIdMap)
         expect(result).toEqual({
-          type: 'type',
+          type: 'user',
           principalId: 'id',
           key: 'key',
           targetType: 'target',
         })
-        expect(permissionInternalIdMap).toEqual({ type_id_key_target: 'internalId' })
+        expect(permissionInternalIdMap).toEqual({ user_key_target: 'internalId' })
       })
     })
   })
@@ -183,21 +189,21 @@ describe('space definitions utils', () => {
       expect(spaceClone.value).not.toEqual(space.value)
       expect(space.value.permissions).toEqual([
         {
-          type: 'type1',
+          type: 'user',
           principalId: 'id1',
           key: 'key1',
           targetType: 'targetType1',
         },
         {
-          type: 'type2',
+          type: 'group',
           principalId: 'id2',
           key: 'key2',
           targetType: 'targetType2',
         },
       ])
       expect(space.value.permissionInternalIdMap).toEqual({
-        type1_id1_key1_targetType1: 'internalId1',
-        type2_id2_key2_targetType2: 'internalId2',
+        user_key1_targetType1: 'internalId1',
+        group_key2_targetType2: 'internalId2',
       })
     })
   })
@@ -209,21 +215,21 @@ describe('space definitions utils', () => {
       expect(space.value).toEqual({
         permissions: [
           {
-            type: 'type1',
+            type: 'user',
             principalId: 'id1',
             key: 'key1',
             targetType: 'targetType1',
           },
           {
-            type: 'type2',
+            type: 'group',
             principalId: 'id2',
             key: 'key2',
             targetType: 'targetType2',
           },
         ],
         permissionInternalIdMap: {
-          type1_id1_key1_targetType1: 'internalId1',
-          type2_id2_key2_targetType2: 'internalId2',
+          user_key1_targetType1: 'internalId1',
+          group_key2_targetType2: 'internalId2',
         },
       })
     })

--- a/packages/confluence-adapter/test/filters/deploy_space_and_permissions.test.ts
+++ b/packages/confluence-adapter/test/filters/deploy_space_and_permissions.test.ts
@@ -132,12 +132,12 @@ describe('deploySpaceAndPermissions', () => {
               after: new InstanceElement('moc', notSpaceObjectType, {
                 id: 'superInternalId',
                 subject: {
-                  type: 'will',
-                  identifier: 'be',
+                  type: 'user',
+                  identifier: 'will',
                 },
                 operation: {
-                  key: 'added',
-                  target: 'yay',
+                  key: 'be',
+                  target: 'added',
                 },
               }),
             }),
@@ -149,42 +149,42 @@ describe('deploySpaceAndPermissions', () => {
         const spaceInstBefore = new InstanceElement('mock', spaceObjectType, {
           key: '111',
           permissionInternalIdMap: {
-            here_to_stay_yay: '1',
-            will_be_removed_Oy: '2',
+            group_to_stay: '1',
+            user_be_removed: '2',
           },
           permissions: [
             {
-              type: 'here',
-              principalId: 'to',
-              key: 'stay',
-              targetType: 'yay',
+              type: 'group',
+              principalId: 'here',
+              key: 'to',
+              targetType: 'stay',
             },
             {
-              type: 'will',
-              principalId: 'be',
-              key: 'removed',
-              targetType: 'Oy',
+              type: 'user',
+              principalId: 'will',
+              key: 'be',
+              targetType: 'removed',
             },
           ],
         })
         const spaceInstAfter = new InstanceElement('mock', spaceObjectType, {
           key: '222',
           permissionInternalIdMap: {
-            here_to_stay_yay: '1',
-            will_be_removed_Oy: '2',
+            group_to_stay: '1',
+            user_be_removed: '2',
           },
           permissions: [
             {
-              type: 'here',
-              principalId: 'to',
-              key: 'stay',
-              targetType: 'yay',
+              type: 'group',
+              principalId: 'here',
+              key: 'to',
+              targetType: 'stay',
             },
             {
-              type: 'will',
-              principalId: 'be',
-              key: 'added',
-              targetType: 'yay',
+              type: 'user',
+              principalId: 'will',
+              key: 'be',
+              targetType: 'added',
             },
           ],
         })
@@ -195,22 +195,22 @@ describe('deploySpaceAndPermissions', () => {
           leftoverChanges: [notSpaceChange],
         })
         expect((getChangeData(modificationChange) as InstanceElement).value.permissionInternalIdMap).toEqual({
-          here_to_stay_yay: '1',
-          will_be_removed_Oy: '2',
-          will_be_added_yay: 'superInternalId',
+          group_to_stay: '1',
+          user_be_removed: '2',
+          user_be_added: 'superInternalId',
         })
         expect((getChangeData(modificationChange) as InstanceElement).value.permissions).toEqual([
           {
-            type: 'here',
-            principalId: 'to',
-            key: 'stay',
-            targetType: 'yay',
+            type: 'group',
+            principalId: 'here',
+            key: 'to',
+            targetType: 'stay',
           },
           {
-            type: 'will',
-            principalId: 'be',
-            key: 'added',
-            targetType: 'yay',
+            type: 'user',
+            principalId: 'will',
+            key: 'be',
+            targetType: 'added',
           },
         ])
         // one for space, one for delete permissions and one for add permissions
@@ -234,12 +234,12 @@ describe('deploySpaceAndPermissions', () => {
             value: {
               id: 'addedDefaultPermissionInternalId',
               principal: {
-                type: 'default',
-                id: 'permission',
+                type: 'group',
+                id: 'defaultPermission',
               },
               operation: {
-                key: 'to',
-                targetType: 'stay',
+                key: 'key',
+                targetType: 'target',
               },
             },
           },
@@ -247,11 +247,11 @@ describe('deploySpaceAndPermissions', () => {
             value: {
               id: 'removeDefaultPermissionInternalId',
               principal: {
-                type: 'default',
-                id: 'permission',
+                type: 'user',
+                id: 'defaultPermission',
               },
               operation: {
-                key: 'to',
+                key: 'anotherKey',
                 targetType: 'remove',
               },
             },
@@ -263,12 +263,12 @@ describe('deploySpaceAndPermissions', () => {
               after: new InstanceElement('moc', notSpaceObjectType, {
                 id: 'superInternalId',
                 subject: {
-                  type: 'will',
-                  identifier: 'be',
+                  type: 'user',
+                  identifier: 'will',
                 },
                 operation: {
-                  key: 'added',
-                  target: 'yay',
+                  key: 'be',
+                  target: 'added',
                 },
               }),
             }),
@@ -281,16 +281,16 @@ describe('deploySpaceAndPermissions', () => {
           key: '222',
           permissions: [
             {
-              type: 'will',
-              principalId: 'be',
-              key: 'added',
-              targetType: 'yay',
-            },
-            {
-              type: 'default',
-              principalId: 'permission',
+              type: 'group',
+              principalId: 'here',
               key: 'to',
               targetType: 'stay',
+            },
+            {
+              type: 'user',
+              principalId: 'will',
+              key: 'be',
+              targetType: 'added',
             },
           ],
         })
@@ -301,22 +301,22 @@ describe('deploySpaceAndPermissions', () => {
           leftoverChanges: [notSpaceChange],
         })
         expect((getChangeData(additionChange) as InstanceElement).value.permissionInternalIdMap).toEqual({
-          default_permission_to_stay: 'addedDefaultPermissionInternalId',
-          will_be_added_yay: 'superInternalId',
-          default_permission_to_remove: 'removeDefaultPermissionInternalId',
+          group_key_target: 'addedDefaultPermissionInternalId',
+          user_be_added: 'superInternalId',
+          user_anotherKey_remove: 'removeDefaultPermissionInternalId',
         })
         expect((getChangeData(additionChange) as InstanceElement).value.permissions).toEqual([
           {
-            type: 'will',
-            principalId: 'be',
-            key: 'added',
-            targetType: 'yay',
-          },
-          {
-            type: 'default',
-            principalId: 'permission',
+            type: 'group',
+            principalId: 'here',
             key: 'to',
             targetType: 'stay',
+          },
+          {
+            type: 'user',
+            principalId: 'will',
+            key: 'be',
+            targetType: 'added',
           },
         ])
         expect(mockRequestAllForResource).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
- add support on fetch and deploy groups
- reference on groups permissions on space instance
- change logic of create key for permission (this key is used to store permission serviceId in an hidden map), new logic doesn't use the serviceId as part of the key (as groups internalIds are not multi env friendly, this was the root cause of failure in deploying space with its permissions between environment)

---

---

_Release Notes_: 
_Confluence Adapter_:
- Support fetch and deploy of groups
- Fix space deployment

---

_User Notifications_: 
_Confluence Adapter_:
- Support fetch and deploy of groups
- Fix space deployment