### PR TITLE
SALTO-6359: enable enableNewWorkflowAPI config flag by default

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.ts
+++ b/packages/jira-adapter/e2e_test/adapter.ts
@@ -52,6 +52,7 @@ export const realAdapter = (
   })
   const config = jiraConfig ?? getDefaultConfig({ isDataCenter })
   config.fetch.enableScriptRunnerAddon = enableScriptRunner
+  config.fetch.enableNewWorkflowAPI = true
   config.fetch.enableIssueLayouts = true
   config.fetch.enableJSM = true
   config.fetch.enableJsmExperimental = true

--- a/packages/jira-adapter/e2e_test/instances/cloud/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/index.ts
@@ -52,7 +52,7 @@ import {
   SECURITY_LEVEL_TYPE,
   SECURITY_SCHEME_TYPE,
   SLA_TYPE_NAME,
-  WORKFLOW_TYPE_NAME,
+  WORKFLOW_CONFIGURATION_TYPE,
 } from '../../../src/constants'
 import { createSecurityLevelValues, createSecuritySchemeValues } from './securityScheme'
 import { createIssueTypeSchemeValues } from './issueTypeScheme'
@@ -83,6 +83,7 @@ import { createObjectSchemaStatusValues } from './jsm/objectSchemaStatus'
 import { createObjectSchemaGlobalStatusValues } from './jsm/objectSchemaGlobalStatus'
 import { createObjectTypeValues } from './jsm/objectType'
 import { createObjectTypeAttributeValues } from './jsm/objectTypeAttribute'
+import { createWorkflowSchemeValues } from './workflowScheme'
 
 const ISSUE_LAYOUT_NAME = 'Test_Project_TP__Kanban_Default_Issue_Screen@sufssss'
 
@@ -131,8 +132,14 @@ export const createInstances = (
 
   const workflow = new InstanceElement(
     randomString,
-    findType(WORKFLOW_TYPE_NAME, fetchedElements),
+    findType(WORKFLOW_CONFIGURATION_TYPE, fetchedElements),
     createWorkflowValues(randomString, fetchedElements),
+  )
+
+  const workflowScheme = new InstanceElement(
+    randomString,
+    findType('WorkflowScheme', fetchedElements),
+    createWorkflowSchemeValues(randomString, fetchedElements),
   )
 
   const fieldConfiguration = new InstanceElement(
@@ -319,6 +326,7 @@ export const createInstances = (
     [dashboardGadget2],
     [issueTypeScheme],
     [workflow],
+    [workflowScheme],
     [fieldConfiguration],
     [securityScheme, securityLevel],
     [notificationScheme],

--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -17,423 +17,346 @@ import { ElemID, Values, Element } from '@salto-io/adapter-api'
 import { naclCase } from '@salto-io/adapter-utils'
 import { createReference } from '../../utils'
 import { JIRA, STATUS_TYPE_NAME } from '../../../src/constants'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 export const createWorkflowValues = (name: string, allElements: Element[]): Values => ({
+  scope: {
+    type: 'GLOBAL',
+  },
   name,
   description: name,
+  isEditable: true,
+  startPointLayout: {
+    x: 784,
+    y: 92.4,
+  },
   transitions: {
     [naclCase('Build Broken::From: any status::Global')]: {
       name: 'Build Broken',
       description: '',
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-      type: 'global',
-      rules: {
-        triggers: [
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:branch-created-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:commit-created-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-created-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-declined-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-merged-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:pull-request-reopened-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-abandoned-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-approval-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-closed-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-rejected-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-started-trigger',
-          },
-          {
-            key: 'com.atlassian.jira.plugins.jira-development-integration-plugin:review-summarized-trigger',
-          },
-        ],
-        postFunctions: [
-          {
-            type: 'FireIssueEventFunction',
-            configuration: {
-              event: {
-                id: createReference(new ElemID(JIRA, 'IssueEvent', 'instance', 'Issue_Assigned@s'), allElements),
-              },
-            },
-          },
-          {
-            type: 'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
-            configuration: {
-              scriptRunner: {
-                className: 'com.adaptavist.sr.cloud.workflow.AssignToUserInGroup',
-                uuid: 'e9c3d0ec-0d9d-4b1f-b010-3c0e3a18111a',
-                enabled: true,
-                executionUser: 'ADD_ON',
-                condition: 'issue.fields.assignee != null',
-                description: 'Assign Issue',
-                groupName: createReference(
-                  new ElemID(JIRA, 'Group', 'instance', 'system_administrators@b'),
-                  allElements,
-                  ['name'],
-                ),
-                roleId: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-              },
-            },
-          },
-        ],
+      to: {
+        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+        port: 7,
       },
+      type: 'GLOBAL',
+      triggers: [
+        {
+          ruleKey: 'system:development-triggers',
+          parameters: {
+            enabledTriggers: [
+              'branch-created-trigger',
+              'commit-created-trigger',
+              'pull-request-created-trigger',
+              'pull-request-declined-trigger',
+              'pull-request-merged-trigger',
+              'pull-request-reopened-trigger',
+              'review-started-trigger',
+              'review-approval-trigger',
+              'review-rejected-trigger',
+              'review-abandoned-trigger',
+              'review-closed-trigger',
+              'review-summarized-trigger',
+            ],
+          },
+        },
+      ],
+      actions: [
+        {
+          ruleKey: 'connect:remote-workflow-function',
+          parameters: {
+            appKey: 'com.onresolve.jira.groovy.groovyrunner__script-postfunction',
+            id: 'd1738503-2939-425e-9018-0532c0a62bac',
+            disabled: 'false',
+            scriptRunner: {
+              className: 'com.adaptavist.sr.cloud.workflow.AssignToUserInGroup',
+              uuid: '4238d79d-c63a-4e28-9ba7-27e0876bf2de',
+              enabled: true,
+              executionUser: 'ADD_ON',
+              condition: 'issue.fields.assignee != null',
+              description: 'Assign Issue',
+              groupName: createReference(
+                new ElemID(JIRA, 'Group', 'instance', 'system_administrators@b'),
+                allElements,
+                ['name'],
+              ),
+              roleId: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
+            },
+          },
+        },
+      ],
     },
     [naclCase('Create::From: none::Initial')]: {
       name: 'Create',
       description: '',
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-      type: 'initial',
-      from: [
+      to: {
+        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+        port: 7,
+      },
+      type: 'INITIAL',
+      validators: [
         {
-          sourceAngle: 33.45,
-          targetAngle: 99.89,
+          ruleKey: 'system:check-permission-validator',
+          parameters: {
+            permissionKey: 'CREATE_ISSUES',
+          },
         },
       ],
-      rules: {
-        validators: [
-          {
-            type: 'PermissionValidator',
-            configuration: {
-              permissionKey: 'CREATE_ISSUES',
-            },
+      actions: [
+        {
+          ruleKey: 'system:change-assignee',
+          parameters: {
+            type: 'to-unassigned',
           },
-        ],
-        postFunctions: [
-          {
-            type: 'AssignToCurrentUserFunction',
+        },
+        {
+          ruleKey: 'system:update-field',
+          parameters: {
+            field: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment__string'), allElements),
+            value: 'ww',
+            mode: 'replace',
           },
-          {
-            type: 'AssignToLeadFunction',
+        },
+        {
+          ruleKey: 'system:set-security-level-from-role',
+          parameters: {
+            roleId: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
           },
-          {
-            type: 'AssignToReporterFunction',
+        },
+        {
+          ruleKey: 'system:copy-value-from-other-field',
+          parameters: {
+            sourceFieldKey: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
+            targetFieldKey: createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator__user'), allElements),
+            issueSource: 'PARENT',
           },
-          {
-            type: 'ClearFieldValuePostFunction',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment__string'), allElements),
-            },
+        },
+        {
+          ruleKey: 'system:update-field',
+          parameters: {
+            field: createReference(new ElemID(JIRA, 'Field', 'instance', 'Environment__string'), allElements),
           },
-          {
-            type: 'CopyValueFromOtherFieldPostFunction',
-            configuration: {
-              sourceFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
-              destinationFieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Creator__user'), allElements),
-              copyType: 'parent',
-            },
+        },
+        {
+          ruleKey: 'system:change-assignee',
+          parameters: {
+            type: 'to-current-user',
           },
-          {
-            type: 'CreateCommentFunction',
+        },
+        {
+          ruleKey: 'system:change-assignee',
+          parameters: {
+            type: 'to-lead',
           },
-          {
-            type: 'FireIssueEventFunction',
-            configuration: {
-              event: {
-                id: createReference(new ElemID(JIRA, 'IssueEvent', 'instance', 'Issue_Assigned@s'), allElements),
-              },
-            },
+        },
+        {
+          ruleKey: 'system:change-assignee',
+          parameters: {
+            type: 'to-reporter',
           },
-          {
-            type: 'IssueStoreFunction',
-          },
-          {
-            type: 'SetIssueSecurityFromRoleFunction',
-            configuration: {
-              projectRole: {
-                id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-              },
-            },
-          },
-          {
-            type: 'UpdateIssueCustomFieldPostFunction',
-            configuration: {
-              mode: 'replace',
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
-              fieldValue: 'ww',
-            },
-          },
-          {
-            type: 'UpdateIssueFieldFunction',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
-              fieldValue: '',
-            },
-          },
-          {
-            type: 'UpdateIssueStatusFunction',
-          },
-        ],
-      },
+        },
+      ],
     },
     [naclCase('TransitionToShared::From: Done::Directed')]: {
       name: 'TransitionToShared',
       description: '',
       from: [
         {
-          id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-          sourceAngle: 12.45,
-          targetAngle: 67.89,
+          statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+          port: 1,
         },
       ],
-      to: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-      type: 'directed',
-      rules: {
-        validators: [
+      to: {
+        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+        port: 7,
+      },
+      type: 'DIRECTED',
+      validators: [
+        {
+          ruleKey: 'system:validate-field-value',
+          parameters: {
+            ruleType: 'dateFieldComparison',
+            date1FieldKey: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
+            date2FieldKey: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
+            includeTime: 'false',
+            conditionSelected: '>',
+          },
+        },
+        {
+          ruleKey: 'system:validate-field-value',
+          parameters: {
+            ruleType: 'fieldRequired',
+            fieldsRequired: [createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements)],
+            ignoreContext: 'true',
+            errorMessage: 'bla bla bla',
+          },
+        },
+        {
+          ruleKey: 'system:validate-field-value',
+          parameters: {
+            ruleType: 'fieldHasSingleValue',
+            fieldKey: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed__datetime@suu'), allElements),
+            excludeSubtasks: 'false',
+          },
+        },
+        {
+          ruleKey: 'system:validate-field-value',
+          parameters: {
+            ruleType: 'fieldHasSingleValue',
+            fieldKey: createReference(
+              new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'),
+              allElements,
+            ),
+            excludeSubtasks: 'true',
+          },
+        },
+        {
+          ruleKey: 'system:parent-or-child-blocking-validator',
+          parameters: {
+            blocker: 'PARENT',
+            statusIds: [createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'in_progress@s'), allElements)],
+          },
+        },
+        {
+          ruleKey: 'system:check-permission-validator',
+          parameters: {
+            permissionKey: 'MODIFY_REPORTER',
+          },
+        },
+        {
+          ruleKey: 'system:previous-status-validator',
+          parameters: {
+            previousStatusIds: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+            mostRecentStatusOnly: 'false',
+          },
+        },
+        {
+          ruleKey: 'system:check-permission-validator',
+          parameters: {
+            permissionKey: 'MODIFY_REPORTER',
+          },
+        },
+        {
+          ruleKey: 'system:validate-field-value',
+          parameters: {
+            ruleType: 'windowDateComparison',
+            date1FieldKey: createReference(
+              new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Created__datetime'),
+              allElements,
+            ),
+            date2FieldKey: createReference(
+              new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Created__datetime'),
+              allElements,
+            ),
+            numberOfDays: '2',
+          },
+        },
+      ],
+      conditions: {
+        operation: 'ALL',
+        conditions: [
           {
-            type: 'DateFieldValidator',
-            configuration: {
-              comparator: '>',
-              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
-              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
-              includeTime: false,
+            ruleKey: 'system:restrict-issue-transition',
+            parameters: {
+              accountIds: 'allow-assignee',
             },
           },
           {
-            type: 'FieldHasSingleValueValidator',
-            configuration: {
-              fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Last_Viewed__datetime@suu'), allElements),
-              excludeSubtasks: false,
+            ruleKey: 'system:restrict-issue-transition',
+            parameters: {
+              accountIds: 'allow-reporter',
             },
           },
           {
-            type: 'FieldHasSingleValueValidator',
-            configuration: {
-              fieldId: createReference(
-                new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'),
-                allElements,
-              ),
-              excludeSubtasks: true,
+            ruleKey: 'system:restrict-from-all-users',
+            parameters: {
+              restrictMode: 'usersAndAPI',
             },
           },
           {
-            type: 'FieldRequiredValidator',
-            configuration: {
-              ignoreContext: true,
-              errorMessage: 'wwww',
-              fieldIds: [createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements)],
+            ruleKey: 'system:block-in-progress-approval',
+          },
+          {
+            ruleKey: 'system:restrict-issue-transition',
+            parameters: {
+              roleIds: [createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements)],
             },
           },
           {
-            type: 'ParentStatusValidator',
-            configuration: {
-              parentStatuses: [
-                {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'in_progress@s'), allElements),
-                },
+            ruleKey: 'system:restrict-issue-transition',
+            parameters: {
+              permissionKeys: 'DELETE_ISSUES',
+            },
+          },
+          {
+            ruleKey: 'system:previous-status-condition',
+            parameters: {
+              previousStatusIds: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+              not: 'true',
+              mostRecentStatusOnly: 'true',
+              includeCurrentStatus: 'true',
+              ignoreLoopTransitions: 'true',
+            },
+          },
+          {
+            ruleKey: 'system:separation-of-duties',
+            parameters: {
+              fromStatusId: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+              toStatusId: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+            },
+          },
+          {
+            ruleKey: 'system:parent-or-child-blocking-condition',
+            parameters: {
+              blocker: 'CHILD',
+              statusIds: [
+                createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+                createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
               ],
             },
           },
           {
-            type: 'PermissionValidator',
-            configuration: {
-              permissionKey: 'MODIFY_REPORTER',
+            ruleKey: 'system:restrict-issue-transition',
+            parameters: {
+              denyUserCustomFields: createReference(
+                new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Created__datetime'),
+                allElements,
+              ),
             },
           },
           {
-            type: 'PreviousStatusValidator',
-            configuration: {
-              mostRecentStatusOnly: false,
-              previousStatus: {
-                id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-              },
-            },
-          },
-          {
-            type: 'UserPermissionValidator',
-            configuration: {
-              permissionKey: 'VIEW_DEV_TOOLS',
-              nullAllowed: true,
-              username: 'aaa',
-            },
-          },
-          {
-            type: 'WindowsDateValidator',
-            configuration: {
-              date1: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
-              date2: createReference(new ElemID(JIRA, 'Field', 'instance', 'Created__datetime'), allElements),
-              windowsDays: 2,
+            ruleKey: 'system:check-field-value',
+            parameters: {
+              fieldId: createReference(
+                new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'),
+                allElements,
+              ),
+              fieldValue: '["val"]',
+              comparator: '>',
+              comparisonType: 'STRING',
             },
           },
         ],
-        postFunctions: [
-          {
-            type: 'FireIssueEventFunction',
-            configuration: {
-              event: {
-                id: createReference(new ElemID(JIRA, 'IssueEvent', 'instance', 'Issue_Assigned@s'), allElements),
-              },
-            },
-          },
-        ],
-        conditions: {
-          operator: 'AND',
-          conditions: [
-            {
-              type: 'AllowOnlyAssignee',
-            },
-            {
-              type: 'AllowOnlyReporter',
-            },
-            {
-              type: 'AlwaysFalseCondition',
-            },
-            {
-              type: 'AlwaysFalseCondition',
-            },
-            {
-              type: 'BlockInProgressApprovalCondition',
-            },
-            {
-              type: 'InAnyProjectRoleCondition',
-              configuration: {
-                projectRoles: [
-                  {
-                    id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-                  },
-                ],
-              },
-            },
-            {
-              type: 'InProjectRoleCondition',
-              configuration: {
-                projectRole: {
-                  id: createReference(new ElemID(JIRA, 'ProjectRole', 'instance', 'Administrators'), allElements),
-                },
-              },
-            },
-            {
-              type: 'OnlyBambooNotificationsCondition',
-            },
-            {
-              type: 'PermissionCondition',
-              configuration: {
-                permissionKey: 'DELETE_ISSUES',
-              },
-            },
-            {
-              type: 'PreviousStatusCondition',
-              configuration: {
-                ignoreLoopTransitions: true,
-                includeCurrentStatus: true,
-                mostRecentStatusOnly: true,
-                reverseCondition: true,
-                previousStatus: {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-                },
-              },
-            },
-            {
-              type: 'RemoteOnlyCondition',
-            },
-            {
-              type: 'SeparationOfDutiesCondition',
-              configuration: {
-                toStatus: {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-                },
-                fromStatus: {
-                  id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-                },
-              },
-            },
-            {
-              type: 'SubTaskBlockingCondition',
-              configuration: {
-                statuses: [
-                  {
-                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-                  },
-                  {
-                    id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-                  },
-                ],
-              },
-            },
-            {
-              type: 'UserInAnyGroupCondition',
-              configuration: {
-                groups: [
-                  createReference(new ElemID(JIRA, 'Group', 'instance', 'system_administrators@b'), allElements, [
-                    'name',
-                  ]),
-                ],
-              },
-            },
-            {
-              type: 'UserIsInCustomFieldCondition',
-              configuration: {
-                allowUserInField: false,
-                fieldId: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),
-              },
-            },
-            {
-              type: 'ValueFieldCondition',
-              configuration: {
-                fieldId: createReference(
-                  new ElemID(JIRA, 'Field', 'instance', 'Remaining_Estimate__number@suu'),
-                  allElements,
-                ),
-                fieldValue: 'val',
-                comparisonType: 'STRING',
-                comparator: '>',
-              },
-            },
-          ],
-        },
       },
     },
   },
   statuses: [
     {
-      id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-      name: 'Backlog',
-      properties: [
-        {
-          key: 'jira.issue.editable',
-          value: 'true',
-        },
-      ],
-      location: {
+      statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+      layout: {
         x: 12.34,
         y: 56.78,
       },
+      deprecated: false,
+      name: 'Backlog',
     },
     {
-      id: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-      name: 'Done',
-      properties: [
-        {
-          key: 'jira.issue.editable',
-          value: 'true',
-        },
-      ],
-      location: {
+      statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
+      layout: {
         x: 67.89,
         y: 20.78,
       },
+      deprecated: false,
+      name: 'Done',
     },
   ],
-  diagramInitialEntry: {
-    x: 12.34,
-    y: 34.12,
-  },
 })

--- a/packages/jira-adapter/e2e_test/instances/cloud/workflowScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflowScheme.ts
@@ -1,0 +1,30 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Values, Element, ElemID } from '@salto-io/adapter-api'
+import { createReference } from '../../utils'
+import { ISSUE_TYPE_NAME, JIRA, WORKFLOW_CONFIGURATION_TYPE } from '../../../src/constants'
+
+export const createWorkflowSchemeValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  description: name,
+  defaultWorkflow: createReference(new ElemID(JIRA, WORKFLOW_CONFIGURATION_TYPE, 'instance', 'jira'), allElements),
+  items: [
+    {
+      issueType: createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Bug'), allElements),
+      workflow: createReference(new ElemID(JIRA, WORKFLOW_CONFIGURATION_TYPE, 'instance', 'jira'), allElements),
+    },
+  ],
+})

--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -22,6 +22,7 @@ import { createFieldConfigurationValues } from './fieldConfiguration'
 import { createFilterValues } from './filter'
 import { createPrioritySchemeValues } from './priorityScheme'
 import { createWorkflowValues } from './workflow'
+import { createWorkflowSchemeValues } from './workflowScheme'
 
 export const createInstances = (randomString: string, fetchedElements: Element[]): InstanceElement[][] => {
   const fieldConfiguration = new InstanceElement(
@@ -45,6 +46,12 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     randomString,
     findType(WORKFLOW_TYPE_NAME, fetchedElements),
     createWorkflowValues(randomString, fetchedElements),
+  )
+
+  const workflowScheme = new InstanceElement(
+    randomString,
+    findType('WorkflowScheme', fetchedElements),
+    createWorkflowSchemeValues(randomString, fetchedElements),
   )
 
   const kanbanBoard = new InstanceElement(
@@ -75,6 +82,7 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
     [fieldConfiguration],
     [automation],
     [workflow],
+    [workflowScheme],
     [kanbanBoard],
     [issueType],
     [scrumBoard],

--- a/packages/jira-adapter/e2e_test/instances/datacenter/workflowScheme.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/workflowScheme.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import { Values, Element, ElemID } from '@salto-io/adapter-api'
-import { createReference } from '../utils'
-import { ISSUE_TYPE_NAME, JIRA, WORKFLOW_TYPE_NAME } from '../../src/constants'
+import { createReference } from '../../utils'
+import { ISSUE_TYPE_NAME, JIRA, WORKFLOW_TYPE_NAME } from '../../../src/constants'
 
 export const createWorkflowSchemeValues = (name: string, allElements: Element[]): Values => ({
   name,

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -30,7 +30,6 @@ import { createContextValues, createFieldValues } from './field'
 import { createFieldConfigurationSchemeValues } from './fieldConfigurationScheme'
 import { createIssueTypeScreenSchemeValues } from './issueTypeScreenScheme'
 import { createScreenValues } from './screen'
-import { createWorkflowSchemeValues } from './workflowScheme'
 import { createWebhookValues } from './webhook'
 import { createStatusValues } from './status'
 import { createInstances as createDataCenterInstances, modifyDataCenterInstances } from './datacenter'
@@ -59,12 +58,6 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     randomString,
     findType('Screen', fetchedElements),
     createScreenValues(randomString, fetchedElements),
-  )
-
-  const workflowScheme = new InstanceElement(
-    randomString,
-    findType('WorkflowScheme', fetchedElements),
-    createWorkflowSchemeValues(randomString, fetchedElements),
   )
 
   const screenScheme = new InstanceElement(randomString, findType('ScreenScheme', fetchedElements), {
@@ -125,7 +118,6 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     [field],
     [fieldContext],
     [screen],
-    [workflowScheme],
     [screenScheme],
     [issueTypeScreenScheme],
     [fieldConfigurationScheme],

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -162,7 +162,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     removeDuplicateProjectRoles: true,
     addAlias: true,
     enableIssueLayouts: true,
-    enableNewWorkflowAPI: false,
+    enableNewWorkflowAPI: true,
     enableAssetsObjectFieldConfiguration: false,
   },
   deploy: {

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -177,8 +177,16 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
   },
 }
 
-export const getDefaultConfig = ({ isDataCenter }: { isDataCenter: boolean }): JiraConfig => ({
+const getPartialDefaultConfig = (isDataCenter: boolean): Omit<JiraConfig, 'apiDefinitions'> => ({
   ...PARTIAL_DEFAULT_CONFIG,
+  fetch: {
+    ...PARTIAL_DEFAULT_CONFIG.fetch,
+    enableNewWorkflowAPI: !isDataCenter,
+  },
+})
+
+export const getDefaultConfig = ({ isDataCenter }: { isDataCenter: boolean }): JiraConfig => ({
+  ...getPartialDefaultConfig(isDataCenter),
   apiDefinitions: getProductSettings({ isDataCenter }).defaultApiDefinitions,
   [SCRIPT_RUNNER_API_DEFINITIONS]: getProductSettings({ isDataCenter }).defaultScriptRunnerApiDefinitions,
   [JSM_DUCKTYPE_API_DEFINITIONS]: getProductSettings({ isDataCenter }).defaultDuckTypeApiDefinitions,

--- a/packages/jira-adapter/src/filters/workflowV2/workflowV1_removal.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflowV1_removal.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 import _ from 'lodash'
-import { Element } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../../filter'
 import { WORKFLOW_TYPE_NAME } from '../../constants'
 
-const filter: FilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config, client }) => ({
   name: 'workflowV1RemovalFilter',
   onFetch: async (elements: Element[]) => {
-    if (config.fetch.enableNewWorkflowAPI) {
-      _.remove(elements, element => element.elemID.typeName === WORKFLOW_TYPE_NAME)
+    if (!client.isDataCenter && config.fetch.enableNewWorkflowAPI) {
+      _.remove(elements, element => isInstanceElement(element) && element.elemID.typeName === WORKFLOW_TYPE_NAME)
     }
   },
 })

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -728,7 +728,7 @@ const filter: FilterCreator = ({ config, client, paginator, fetchQuery, elements
       if (workflowConfiguration === undefined) {
         log.error('WorkflowConfiguration type was not found')
         return {
-          errors: [workflowFetchError()],
+          errors: [],
         }
       }
       setTypeDeploymentAnnotations(workflowConfiguration)

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -717,7 +717,11 @@ const filter: FilterCreator = ({ config, client, paginator, fetchQuery, elements
   return {
     name: 'workflowFilter',
     onFetch: async (elements: Element[]) => {
-      if (!config.fetch.enableNewWorkflowAPI || !fetchQuery.isTypeMatch(WORKFLOW_CONFIGURATION_TYPE)) {
+      if (
+        client.isDataCenter ||
+        !config.fetch.enableNewWorkflowAPI ||
+        !fetchQuery.isTypeMatch(WORKFLOW_CONFIGURATION_TYPE)
+      ) {
         return { errors: [] }
       }
       const workflowConfiguration = findObject(elements, WORKFLOW_CONFIGURATION_TYPE)

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_cloud.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_cloud.test.ts
@@ -66,17 +66,19 @@ describe('ScriptRunner cloud Workflow', () => {
   beforeEach(() => {
     const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
     const configOff = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    const configWithNewWorkflowAPI = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    configWithNewWorkflowAPI.fetch.enableNewWorkflowAPI = true
-    configWithNewWorkflowAPI.fetch.enableScriptRunnerAddon = true
+    const configWithOutNewWorkflowAPI = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    configWithOutNewWorkflowAPI.fetch.enableNewWorkflowAPI = false
+    configWithOutNewWorkflowAPI.fetch.enableScriptRunnerAddon = true
     config.fetch.enableScriptRunnerAddon = true
-    filter = workflowFilter(getFilterParams({ config })) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filter = workflowFilter(getFilterParams({ config: configWithOutNewWorkflowAPI })) as filterUtils.FilterWith<
+      'onFetch' | 'preDeploy' | 'onDeploy'
+    >
     filterOff = workflowFilter(getFilterParams({ config: configOff })) as filterUtils.FilterWith<
       'onFetch' | 'preDeploy' | 'onDeploy'
     >
-    filterWithNewWorkflowAPI = workflowFilter(
-      getFilterParams({ config: configWithNewWorkflowAPI }),
-    ) as filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
+    filterWithNewWorkflowAPI = workflowFilter(getFilterParams({ config })) as filterUtils.FilterWith<
+      'onFetch' | 'preDeploy' | 'onDeploy'
+    >
   })
   describe('post functions', () => {
     let accountAndGroupArrayed: Values

--- a/packages/jira-adapter/test/filters/workflowV2/workflowV1_removal.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflowV1_removal.test.ts
@@ -52,8 +52,8 @@ describe('workflow filter', () => {
         }),
       ) as typeof filter
       await filter.onFetch(elements)
-      expect(elements).toHaveLength(2)
-      expect(elements).toEqual([workflowV2Instance, notWorkflowInstance])
+      expect(elements).toHaveLength(3)
+      expect(elements).toEqual([workflowType, workflowV2Instance, notWorkflowInstance])
     })
 
     it('should not remove workflowV1 instances when enableNewWorkflowAPI is false', async () => {

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -364,13 +364,10 @@ describe('workflow filter', () => {
       await filter.onFetch(elements)
       expect(elements).toHaveLength(2)
     })
-    it('should fail when WorkflowConfiguration type is not found', async () => {
+    it('should not fail when WorkflowConfiguration type is not found', async () => {
       const filterResult = (await filter.onFetch([])) as FilterResult
       const errors = filterResult.errors ?? []
-      expect(errors).toBeDefined()
-      expect(errors).toHaveLength(1)
-      expect(errors[0].message).toEqual('Failed to fetch Workflows.')
-      expect(errors[0].severity).toEqual('Error')
+      expect(errors).toEqual([])
     })
     it('should fail when id response data is not valid', async () => {
       mockPaginator = mockFunction<clientUtils.Paginator>().mockImplementation(async function* get() {


### PR DESCRIPTION
_enable enableNewWorkflowAPI config flag by default_

---

_Additional context for reviewer_

* The enable required to add WorkflowV2 to Jira E2E

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
