### PR TITLE
SALTO-5323 Support auto-merge for lists

### DIFF
--- a/packages/adapter-utils/index.ts
+++ b/packages/adapter-utils/index.ts
@@ -15,6 +15,7 @@
  */
 export * from './src/change'
 export * from './src/compare'
+export * from './src/list_comparison'
 export * from './src/decorators'
 export * from './src/dependencies'
 export * from './src/element_source'

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -45,7 +45,7 @@ type KeyFunction = (value: Value) => string
  *
  * Note: this function ignores the value of compareReferencesByValue and always looks at the reference id
  */
-const getListItemExactKey: KeyFunction = value =>
+export const getListItemExactKey: KeyFunction = value =>
   objectHash(value, {
     replacer: val => {
       if (isReferenceExpression(val)) {

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -263,6 +263,10 @@ const autoMergeChange: ChangeTransformFunction = async change => {
     return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
   if (_.isArray(current) && _.isArray(incoming) && isTypeOfOrUndefined(base, _.isArray)) {
+    if (getCoreFlagBool(CORE_FLAGS.autoMergeListsDisabled)) {
+      log.debug('skipping list auto merge since the autoMergeListsDisabled core flag is true')
+      return [change]
+    }
     const merged = mergeLists(changeId, { current, base, incoming })
     return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
@@ -302,6 +306,11 @@ const toListModificationChange = ({
   serviceChanges: types.NonEmptyArray<DetailedChangeWithBaseChange>
   pendingChanges: DetailedChangeWithBaseChange[]
 }): FetchChange | undefined => {
+  if (getCoreFlagBool(CORE_FLAGS.autoMergeListsDisabled)) {
+    log.debug('skip creating list modification change since the autoMergeListsDisabled core flag is true')
+    return undefined
+  }
+
   if (!types.isNonEmptyArray(pendingChanges)) {
     return undefined
   }

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -95,7 +95,7 @@ import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
 import { IDFilter } from './plan/plan'
 import { getAdaptersCreatorConfigs } from './adapters'
-import { mergeStaticFiles, mergeStrings } from './merge_content'
+import { mergeLists, mergeStaticFiles, mergeStrings } from './merge_content'
 import { FetchChange, FetchChangeMetadata } from '../types'
 
 const { awu, groupByAsync } = collections.asynciterable
@@ -232,7 +232,7 @@ const isMergeableDiffChange = (change: FetchChange): change is MergeableDiffChan
   isAdditionOrModificationChange(change.serviceChanges[0]) &&
   isAdditionOrModificationChange(change.pendingChanges[0])
 
-const toMergedTextChange = (change: FetchChange, after: string | StaticFile): FetchChange => ({
+const toMergedChange = (change: FetchChange, after: Value): FetchChange => ({
   ...change,
   change: {
     ...change.change,
@@ -244,7 +244,7 @@ const toMergedTextChange = (change: FetchChange, after: string | StaticFile): Fe
   pendingChanges: [],
 })
 
-const autoMergeTextChange: ChangeTransformFunction = async change => {
+const autoMergeChange: ChangeTransformFunction = async change => {
   if (getCoreFlagBool(CORE_FLAGS.autoMergeDisabled) || !isMergeableDiffChange(change)) {
     return [change]
   }
@@ -256,11 +256,15 @@ const autoMergeTextChange: ChangeTransformFunction = async change => {
 
   if (isStaticFile(current) && isStaticFile(incoming) && isTypeOfOrUndefined(base, isStaticFile)) {
     const merged = await mergeStaticFiles(changeId, { current, base, incoming })
-    return [merged !== undefined ? toMergedTextChange(change, merged) : change]
+    return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
   if (_.isString(current) && _.isString(incoming) && isTypeOfOrUndefined(base, _.isString)) {
     const merged = mergeStrings(changeId, { current, base, incoming })
-    return [merged !== undefined ? toMergedTextChange(change, merged) : change]
+    return [merged !== undefined ? toMergedChange(change, merged) : change]
+  }
+  if (_.isArray(current) && _.isArray(incoming) && isTypeOfOrUndefined(base, _.isArray)) {
+    const merged = mergeLists(changeId, { current, base, incoming })
+    return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
   return [change]
 }
@@ -277,6 +281,72 @@ const omitNoConflictCoreAnnotationsPendingChanges: ChangeTransformFunction = asy
     return [{ ...change, pendingChanges: [] }]
   }
   return [change]
+}
+
+/**
+ * Creates a list modification change in a given id, when there's a list in that id in all sources.
+ * This is required because that when the list in two of the sources have the same length, then one
+ * of `wsChanges`/`serviceChanges`/`pendingChanges` will have changes on the list items, instead of the
+ * whole list, that we need in order to auto-merge the list later.
+ * This logic is skipped when the list's length is the same in all sources (so there will be changes on
+ * each list item separately) or when `pendingChanges` is empty (and there's no conflict to auto-merge).
+ */
+const toListModificationChange = ({
+  elemId,
+  wsChanges,
+  serviceChanges,
+  pendingChanges,
+}: {
+  elemId: ElemID
+  wsChanges: types.NonEmptyArray<DetailedChangeWithBaseChange>
+  serviceChanges: types.NonEmptyArray<DetailedChangeWithBaseChange>
+  pendingChanges: DetailedChangeWithBaseChange[]
+}): FetchChange | undefined => {
+  if (!types.isNonEmptyArray(pendingChanges)) {
+    return undefined
+  }
+
+  const { baseChange } = wsChanges[0]
+  const baseServiceChange = serviceChanges[0].baseChange
+  const basePendingChange = pendingChanges[0].baseChange
+
+  if (!isAdditionOrModificationChange(baseServiceChange) || !isAdditionOrModificationChange(basePendingChange)) {
+    return undefined
+  }
+
+  const serviceElement = baseServiceChange.data.after
+  const stateElement = isModificationChange(baseServiceChange) ? baseServiceChange.data.before : undefined
+  const workspaceElement = basePendingChange.data.after
+
+  const serviceValue = resolvePath(serviceElement, elemId)
+  const stateValue = stateElement ? resolvePath(stateElement, elemId) : undefined
+  const workspaceValue = resolvePath(workspaceElement, elemId)
+
+  if (!_.isArray(workspaceValue) || !_.isArray(serviceValue) || !isTypeOfOrUndefined(stateValue, _.isArray)) {
+    return undefined
+  }
+
+  return {
+    change: {
+      id: elemId,
+      baseChange,
+      ...toChange({ before: workspaceValue, after: serviceValue }),
+    },
+    serviceChanges: [
+      {
+        id: elemId,
+        baseChange: baseServiceChange,
+        ...toChange({ before: stateValue, after: serviceValue }),
+      },
+    ],
+    pendingChanges: [
+      {
+        id: elemId,
+        baseChange: basePendingChange,
+        ...toChange({ before: stateValue, after: workspaceValue }),
+      },
+    ],
+  }
 }
 
 const getChangesNestedUnderID = (
@@ -304,7 +374,7 @@ const toFetchChanges = (
 
       const elemId = ElemID.fromFullName(id)
       const wsChanges = getChangesNestedUnderID(elemId, workspaceToServiceChanges).map(({ change }) => change)
-      if (wsChanges.length === 0) {
+      if (!types.isNonEmptyArray(wsChanges)) {
         // If we get here it means there is a difference between the account and the state
         // but there is no difference between the account and the workspace. this can happen
         // when the nacl files are updated externally (from git usually) with the change that
@@ -322,7 +392,7 @@ const toFetchChanges = (
         changeList => changeList.map(change => change.change),
       )
 
-      if (serviceChanges.length === 0) {
+      if (!types.isNonEmptyArray(serviceChanges)) {
         // If nothing changed in the account, we don't want to do anything
         return undefined
       }
@@ -336,6 +406,11 @@ const toFetchChanges = (
           serviceChanges.map(change => `${change.action} ${change.id.getFullName()}`),
           pendingChanges.map(change => `${change.action} ${change.id.getFullName()}`),
         )
+      }
+
+      const listModificationChange = toListModificationChange({ elemId, wsChanges, serviceChanges, pendingChanges })
+      if (listModificationChange !== undefined) {
+        return [listModificationChange]
       }
 
       const createFetchChange = (change: DetailedChangeWithBaseChange): FetchChange => {
@@ -824,7 +899,7 @@ export const calcFetchChanges = async (
 
   const changes = await awu(fetchChanges)
     .flatMap(omitNoConflictCoreAnnotationsPendingChanges)
-    .flatMap(autoMergeTextChange)
+    .flatMap(autoMergeChange)
     .flatMap(toChangesWithPath(async name => serviceElementsMap[name.getFullName()] ?? []))
     .flatMap(addFetchChangeMetadata(partialFetchElementSource))
     .toArray()

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -20,6 +20,7 @@ export const CORE_FLAG_PREFIX = 'SALTO_'
 export const CORE_FLAGS = {
   skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
   autoMergeDisabled: 'AUTO_MERGE_DISABLE',
+  autoMergeListsDisabled: 'AUTO_MERGE_LISTS_DISABLE',
 } as const
 
 type CoreFlagName = types.ValueOf<typeof CORE_FLAGS>

--- a/packages/core/src/core/merge_content.ts
+++ b/packages/core/src/core/merge_content.ts
@@ -204,13 +204,18 @@ export const mergeStaticFiles = async (
     : undefined
 }
 
-const toHashedListItems = (list: Value[]): { hashedList: string[]; hashToItemMap: Record<string, Value> } => {
-  const hashedList = list.map(getListItemExactKey)
-  return {
-    hashedList,
-    hashToItemMap: Object.fromEntries(list.map((item, index) => [hashedList[index], item])),
-  }
-}
+const toHashedListItems = (list: Value[]): { hashedList: string[]; hashToItemMap: Record<string, Value> } =>
+  log.timeDebug(
+    () => {
+      const hashedList = list.map(getListItemExactKey)
+      return {
+        hashedList,
+        hashToItemMap: Object.fromEntries(list.map((item, index) => [hashedList[index], item])),
+      }
+    },
+    'hashing list with %d items',
+    list.length,
+  )
 
 export const mergeLists = (
   changeId: string,

--- a/packages/core/src/core/merge_content.ts
+++ b/packages/core/src/core/merge_content.ts
@@ -18,12 +18,14 @@ import * as diff3 from '@salto-io/node-diff3'
 import { isBinary } from 'istextorbinary'
 import { logger } from '@salto-io/logging'
 import { strings } from '@salto-io/lowerdash'
-import { StaticFile } from '@salto-io/adapter-api'
+import { StaticFile, Value } from '@salto-io/adapter-api'
+import { getListItemExactKey } from '@salto-io/adapter-utils'
 
 const log = logger(module)
 const { humanFileSize } = strings
 
 const MAX_MERGE_CONTENT_SIZE = 10 * 1024 * 1024
+const MAX_MERGE_LIST_LENGTH = 10_000
 const MERGE_TIMEOUT = 10 * 1000
 
 type LineWithTerminator = string & { terminator: string }
@@ -70,14 +72,10 @@ const joinLinesWithTerminators = (lines: LineWithTerminator[]): string =>
     return res.concat(line, line.terminator ?? '\n')
   }, '')
 
-const isConflictChunk = (chunk: diff3.ICommResult<LineWithTerminator>): boolean =>
+const isConflictChunk = (chunk: diff3.ICommResult<string>): boolean =>
   !('common' in chunk) && chunk.buffer1.length > 0 && chunk.buffer2.length > 0
 
-const mergeTwoStrings = (
-  first: LineWithTerminator[],
-  second: LineWithTerminator[],
-  timeout: number,
-): { conflict: boolean; result: LineWithTerminator[] } => {
+const mergeDiff2 = <T extends string>(first: T[], second: T[], timeout: number): { conflict: boolean; result: T[] } => {
   const result = diff3.diffComm(first, second, timeout)
   if (result.some(isConflictChunk)) {
     return { conflict: true, result: [] }
@@ -87,6 +85,44 @@ const mergeTwoStrings = (
     result: result.flatMap(chunk => ('common' in chunk ? chunk.common : chunk.buffer1.concat(chunk.buffer2))),
   }
 }
+
+const mergeDiff = <T extends string>(
+  changeId: string,
+  {
+    current,
+    base,
+    incoming,
+  }: {
+    current: T[]
+    base: T[] | undefined
+    incoming: T[]
+  },
+): T[] | undefined =>
+  log.timeDebug(
+    () => {
+      try {
+        const { conflict, result } =
+          base !== undefined
+            ? diff3.mergeDiff3(current, base, incoming, { excludeFalseConflicts: true }, MERGE_TIMEOUT)
+            : mergeDiff2(current, incoming, MERGE_TIMEOUT)
+        if (conflict) {
+          log.debug('conflict found in %s', changeId)
+        } else {
+          log.debug('merged %s successfully', changeId)
+          return result as T[]
+        }
+      } catch (e) {
+        if (e instanceof diff3.TimeoutError) {
+          log.warn('merging %s reached timeout', changeId)
+        } else {
+          log.warn('merging %s failed with error %o', changeId, e)
+        }
+      }
+      return undefined
+    },
+    'mergeDiff for %s',
+    changeId,
+  )
 
 export const mergeStrings = (
   changeId: string,
@@ -99,56 +135,24 @@ export const mergeStrings = (
     base: string | undefined
     incoming: string
   },
-): string | undefined =>
-  log.timeDebug(
-    () => {
-      const contents = [current, base ?? '', incoming]
-      log.debug(
-        'trying to merge contents of %s - sizes: %s',
-        changeId,
-        contents.map(item => humanFileSize(item.length)).join(', '),
-      )
-      if (contents.some(item => item.length > MAX_MERGE_CONTENT_SIZE)) {
-        log.warn(
-          'skipping merge since contents size has reached the limit of %s',
-          humanFileSize(MAX_MERGE_CONTENT_SIZE),
-        )
-        return undefined
-      }
-      const options = { excludeFalseConflicts: true }
-      try {
-        const { conflict, result } =
-          base !== undefined
-            ? diff3.mergeDiff3(
-                splitToLinesWithTerminators(current),
-                splitToLinesWithTerminators(base),
-                splitToLinesWithTerminators(incoming),
-                options,
-                MERGE_TIMEOUT,
-              )
-            : mergeTwoStrings(
-                splitToLinesWithTerminators(current),
-                splitToLinesWithTerminators(incoming),
-                MERGE_TIMEOUT,
-              )
-        if (conflict) {
-          log.debug('conflict found in %s', changeId)
-        } else {
-          log.debug('merged %s successfully', changeId)
-          return joinLinesWithTerminators(result as LineWithTerminator[])
-        }
-      } catch (e) {
-        if (e instanceof diff3.TimeoutError) {
-          log.warn('merging %s reached timeout', changeId)
-        } else {
-          log.warn('merging %s failed with error %o', changeId, e)
-        }
-      }
-      return undefined
-    },
-    'mergeStrings for %s',
+): string | undefined => {
+  const contents = [current, base ?? '', incoming]
+  log.debug(
+    'trying to merge contents of %s - sizes: %s',
     changeId,
+    contents.map(item => humanFileSize(item.length)).join(', '),
   )
+  if (contents.some(item => item.length > MAX_MERGE_CONTENT_SIZE)) {
+    log.warn('skipping merge since contents size has reached the limit of %s', humanFileSize(MAX_MERGE_CONTENT_SIZE))
+    return undefined
+  }
+  const merged = mergeDiff(changeId, {
+    current: splitToLinesWithTerminators(current),
+    base: base !== undefined ? splitToLinesWithTerminators(base) : undefined,
+    incoming: splitToLinesWithTerminators(incoming),
+  })
+  return merged !== undefined ? joinLinesWithTerminators(merged) : undefined
+}
 
 export const mergeStaticFiles = async (
   changeId: string,
@@ -198,4 +202,54 @@ export const mergeStaticFiles = async (
   return merged !== undefined
     ? new StaticFile({ filepath, encoding, content: Buffer.from(merged, encoding) })
     : undefined
+}
+
+const toHashedListItems = (list: Value[]): { hashedList: string[]; hashToItemMap: Record<string, Value> } => {
+  const hashedList = list.map(getListItemExactKey)
+  return {
+    hashedList,
+    hashToItemMap: Object.fromEntries(list.map((item, index) => [hashedList[index], item])),
+  }
+}
+
+export const mergeLists = (
+  changeId: string,
+  {
+    current: currentList,
+    base: baseList,
+    incoming: incomingList,
+  }: {
+    current: Value[]
+    base: Value[] | undefined
+    incoming: Value[]
+  },
+): Value[] | undefined => {
+  const lists = [currentList, baseList ?? [], incomingList]
+  log.debug('trying to merge list items of %s - lists length: %s', changeId, lists.map(item => item.length).join(', '))
+  if (lists.some(item => item.length > MAX_MERGE_LIST_LENGTH)) {
+    log.warn('skipping merge since lists length has reached the limit of %d', MAX_MERGE_LIST_LENGTH)
+    return undefined
+  }
+
+  const current = toHashedListItems(currentList)
+  const incoming = toHashedListItems(incomingList)
+  const base = baseList !== undefined ? toHashedListItems(baseList) : undefined
+
+  const merged = mergeDiff(changeId, {
+    current: current.hashedList,
+    base: base?.hashedList,
+    incoming: incoming.hashedList,
+  })
+
+  if (merged === undefined) {
+    return undefined
+  }
+
+  const mergedHashToItemMap = {
+    ...current.hashToItemMap,
+    ...incoming.hashToItemMap,
+    ...base?.hashToItemMap,
+  }
+
+  return merged.map(itemHash => mergedHashToItemMap[itemHash])
 }

--- a/packages/core/test/core/merge_content.test.ts
+++ b/packages/core/test/core/merge_content.test.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 import * as diff3 from '@salto-io/node-diff3'
-import { StaticFile } from '@salto-io/adapter-api'
-import { mergeStaticFiles, mergeStrings } from '../../src/core/merge_content'
+import { ElemID, ReferenceExpression, StaticFile } from '@salto-io/adapter-api'
+import { mergeLists, mergeStaticFiles, mergeStrings } from '../../src/core/merge_content'
 
 jest.mock('@salto-io/node-diff3', () => ({
   __esModule: true,
@@ -152,6 +152,140 @@ describe('merge contents', () => {
       expect(
         await mergeStaticFiles(changeId, { current: currentFile, base: baseFile, incoming: binaryFileContent }),
       ).toBeUndefined()
+    })
+  })
+
+  describe('merge lists', () => {
+    describe('list of primitives', () => {
+      const baseList = [1, 2, 3]
+      const currentList = [1, 2, 3, 4]
+      const incomingMergeableList = [0, 2, 1, 3]
+      const incomingUnmergeableList = [1, 2, 3, 5]
+      const incomingAddedList = [0, 1, 2, 5, 3]
+
+      const modifiedMergedList = [0, 2, 1, 3, 4]
+      const addedMergedList = [0, 1, 2, 5, 3, 4]
+
+      it('should merge modified list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingMergeableList })).toEqual(
+          modifiedMergedList,
+        )
+      })
+      it('should merge added list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingAddedList })).toEqual(
+          addedMergedList,
+        )
+      })
+      it('should not merge unmergeable modified list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
+      it('should not merge unmergeable added list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
+    })
+    describe('list of references', () => {
+      const baseList = [
+        new ReferenceExpression(new ElemID('salto', 'test1'), 1),
+        new ReferenceExpression(new ElemID('salto', 'test2'), 2),
+        new ReferenceExpression(new ElemID('salto', 'test3'), 3),
+      ]
+      const currentList = [
+        new ReferenceExpression(new ElemID('salto', 'test1'), 1.1),
+        new ReferenceExpression(new ElemID('salto', 'test2'), 2.2),
+        new ReferenceExpression(new ElemID('salto', 'test3'), 3.3),
+        new ReferenceExpression(new ElemID('salto', 'test4'), 4.4),
+      ]
+      const incomingMergeableList = [
+        new ReferenceExpression(new ElemID('salto', 'test0'), 0),
+        new ReferenceExpression(new ElemID('salto', 'test2'), 2.5),
+        new ReferenceExpression(new ElemID('salto', 'test1'), 1.5),
+        new ReferenceExpression(new ElemID('salto', 'test3'), 3.5),
+      ]
+      const incomingUnmergeableList = [
+        new ReferenceExpression(new ElemID('salto', 'test1'), 1.5),
+        new ReferenceExpression(new ElemID('salto', 'test2'), 2.5),
+        new ReferenceExpression(new ElemID('salto', 'test3'), 3.5),
+        new ReferenceExpression(new ElemID('salto', 'test5'), 5.5),
+      ]
+      const incomingAddedList = [
+        new ReferenceExpression(new ElemID('salto', 'test0'), 0),
+        new ReferenceExpression(new ElemID('salto', 'test1'), 1.5),
+        new ReferenceExpression(new ElemID('salto', 'test2'), 2.5),
+        new ReferenceExpression(new ElemID('salto', 'test5'), 5.5),
+        new ReferenceExpression(new ElemID('salto', 'test3'), 3.5),
+      ]
+
+      const modifiedMergedList = [
+        new ReferenceExpression(new ElemID('salto', 'test0'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test2'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test1'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test3'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test4'), expect.any(Number)),
+      ]
+      const addedMergedList = [
+        new ReferenceExpression(new ElemID('salto', 'test0'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test1'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test2'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test5'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test3'), expect.any(Number)),
+        new ReferenceExpression(new ElemID('salto', 'test4'), expect.any(Number)),
+      ]
+
+      it('should merge modified list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingMergeableList })).toEqual(
+          modifiedMergedList,
+        )
+      })
+      it('should merge added list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingAddedList })).toEqual(
+          addedMergedList,
+        )
+      })
+      it('should not merge unmergeable modified list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
+      it('should not merge unmergeable added list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
+    })
+    describe('list of objects', () => {
+      const baseList = [{ num: 1 }, { num: 2 }, { num: 3 }]
+      const currentList = [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4 }]
+      const incomingMergeableList = [{ num: 0 }, { num: 1, inner: [1, 2] }, { num: 2 }, { num: 3 }]
+      const incomingUnmergeableList = [{ num: 1 }, { num: 2 }, { num: 3 }, { num: 4, inner: [1, 2] }]
+      const incomingAddedList = [{ num: 0 }, { num: 1 }, { num: 2 }, { num: 5 }, { num: 3 }]
+
+      const modifiedMergedList = [{ num: 0 }, { num: 1, inner: [1, 2] }, { num: 2 }, { num: 3 }, { num: 4 }]
+      const addedMergedList = [{ num: 0 }, { num: 1 }, { num: 2 }, { num: 5 }, { num: 3 }, { num: 4 }]
+
+      it('should merge modified list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingMergeableList })).toEqual(
+          modifiedMergedList,
+        )
+      })
+      it('should merge added list', () => {
+        expect(mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingAddedList })).toEqual(
+          addedMergedList,
+        )
+      })
+      it('should not merge unmergeable modified list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: baseList, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
+      it('should not merge unmergeable added list', () => {
+        expect(
+          mergeLists(changeId, { current: currentList, base: undefined, incoming: incomingUnmergeableList }),
+        ).toBeUndefined()
+      })
     })
   })
 })


### PR DESCRIPTION
Try auto merging lists, by replacing each list item with its hash and running the `diff3` algorithm on the hashed list, then mapping the items back in the merged list.

This can be disabled using the `SALTO_AUTO_MERGE_LISTS_DISABLE` env var.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Support auto-merge for lists

---
_User Notifications_: 
None