### PR TITLE
SALTO-6366: applyChangesToWorkspace - added Field change with hidden annotation refType bug-fix

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -206,7 +206,7 @@ export const removeHiddenFromElement = <T extends Element>(
 ): Promise<T> =>
   transformElement({
     element,
-    transformFunc: isInstanceElement(element) ? removeHiddenValue() : removeHidden(elementsSource),
+    transformFunc: isInstanceElement(element) || isField(element) ? removeHiddenValue() : removeHidden(elementsSource),
     strict: false,
     elementsSource,
     allowEmptyArrays: true,


### PR DESCRIPTION
applyChangesToWorkspace - added Field change with hidden annotation refType bug-fix

---

The bug is explained in details with steps to reproduce in the JIRA ticket. 
This bug was exposed due to the fact we recently made all the Salesforce metadata types hidden.

---
_Release Notes_: 

_Core_:
- applyChangesToWorkspace - added Field change with hidden annotation refType bug-fix

---
_User Notifications_: 
_None_
