### PR TITLE
SALTO-6368: add try catch to assetsObjectTypePath filter

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
@@ -15,6 +15,7 @@
  */
 
 import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { DAG } from '@salto-io/dag'
 import { pathNaclCase } from '@salto-io/adapter-utils'
@@ -22,6 +23,7 @@ import { FilterCreator } from '../../filter'
 import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
+const log = logger(module)
 
 const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
   const graph = new DAG<InstanceElement>()
@@ -34,17 +36,23 @@ const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
     graph.addNode(objectType.elemID.name, dependencies, objectType)
   })
   await awu(graph.evaluationOrder()).forEach(graphNode => {
-    const instance = graph.getData(graphNode.toString())
-    const parentPath = instance.value.parentObjectTypeId.value.path
-    instance.path =
-      instance.value.parentObjectTypeId.elemID.typeName === OBJECT_SCHEMA_TYPE
-        ? [
-            ...parentPath.slice(0, -1),
-            'objectTypes',
-            pathNaclCase(instance.value.name),
-            pathNaclCase(instance.elemID.name),
-          ]
-        : [...parentPath.slice(0, -1), pathNaclCase(instance.value.name), pathNaclCase(instance.elemID.name)]
+    try {
+      const instance = graph.getData(graphNode.toString())
+      const parentPath = instance.value.parentObjectTypeId.value.path
+      instance.path =
+        instance.value.parentObjectTypeId.elemID.typeName === OBJECT_SCHEMA_TYPE
+          ? [
+              ...parentPath.slice(0, -1),
+              'objectTypes',
+              pathNaclCase(instance.value.name),
+              pathNaclCase(instance.elemID.name),
+            ]
+          : [...parentPath.slice(0, -1), pathNaclCase(instance.value.name), pathNaclCase(instance.elemID.name)]
+    } catch (e) {
+      const errorObjectType =
+        objectTypes.find(instance => instance.elemID.name === graphNode.toString()) ?? graphNode.toString()
+      log.error('Failed to create path for object type %o, error: %o', errorObjectType, e.message)
+    }
   })
 }
 

--- a/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
@@ -38,6 +38,7 @@ const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
   await awu(graph.evaluationOrder()).forEach(graphNode => {
     try {
       const instance = graph.getData(graphNode.toString())
+      console.log('instance: ', instance)
       const parentPath = instance.value.parentObjectTypeId.value.path
       instance.path =
         instance.value.parentObjectTypeId.elemID.typeName === OBJECT_SCHEMA_TYPE
@@ -49,9 +50,11 @@ const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
             ]
           : [...parentPath.slice(0, -1), pathNaclCase(instance.value.name), pathNaclCase(instance.elemID.name)]
     } catch (e) {
+      console.log('faild on: ', graphNode.toString())
+      console.log('error: ', e)
       const errorObjectType =
         objectTypes.find(instance => instance.elemID.name === graphNode.toString()) ?? graphNode.toString()
-      log.error('Failed to create path for object type %o, error: %o', errorObjectType, e.message)
+      log.error('Failed to create path for objectType instance %o, error: %o', errorObjectType, e.message)
     }
   })
 }

--- a/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_path.ts
@@ -38,7 +38,6 @@ const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
   await awu(graph.evaluationOrder()).forEach(graphNode => {
     try {
       const instance = graph.getData(graphNode.toString())
-      console.log('instance: ', instance)
       const parentPath = instance.value.parentObjectTypeId.value.path
       instance.path =
         instance.value.parentObjectTypeId.elemID.typeName === OBJECT_SCHEMA_TYPE
@@ -50,8 +49,6 @@ const createPaths = async (objectTypes: InstanceElement[]): Promise<void> => {
             ]
           : [...parentPath.slice(0, -1), pathNaclCase(instance.value.name), pathNaclCase(instance.elemID.name)]
     } catch (e) {
-      console.log('faild on: ', graphNode.toString())
-      console.log('error: ', e)
       const errorObjectType =
         objectTypes.find(instance => instance.elemID.name === graphNode.toString()) ?? graphNode.toString()
       log.error('Failed to create path for objectType instance %o, error: %o', errorObjectType, e.message)

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_path.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_path.test.ts
@@ -162,11 +162,50 @@ describe('assetsObjectTypePathsFilter', () => {
         'grandsonTwoInstance',
       ])
     })
-    it('should not fail the fetch if throws an error', async () => {
-      getDataSpy.mockImplementation(() => {
+    it('should not fail the fetch if one instance throws an error', async () => {
+      getDataSpy.mockImplementationOnce(() => {
+        getDataSpy.mockClear()
         throw new Error('failed to get data')
       })
       await expect(filter.onFetch(elements)).resolves.not.toThrow()
+      expect(sonOneInstance.path).toEqual([
+        JIRA,
+        adapterElements.RECORDS_PATH,
+        'ObjectSchema',
+        'assetsSchema1',
+        'objectTypes',
+        'sonOneInstance',
+        'sonOneInstance',
+      ])
+      expect(sonTwoInstance.path).toEqual([
+        JIRA,
+        adapterElements.RECORDS_PATH,
+        'ObjectSchema',
+        'assetsSchema1',
+        'objectTypes',
+        'sonTwoInstance',
+        'sonTwoInstance',
+      ])
+      expect(grandsonOneInstance.path).toEqual([
+        JIRA,
+        adapterElements.RECORDS_PATH,
+        'ObjectSchema',
+        'assetsSchema1',
+        'objectTypes',
+        'sonOneInstance',
+        'grandsonOneInstance',
+        'grandsonOneInstance',
+      ])
+      expect(grandsonTwoInstance.path).toEqual([
+        JIRA,
+        adapterElements.RECORDS_PATH,
+        'ObjectSchema',
+        'assetsSchema1',
+        'objectTypes',
+        'sonOneInstance',
+        'grandsonTwoInstance',
+        'grandsonTwoInstance',
+      ])
       expect(logErrorSpy).toHaveBeenCalled()
     })
   })

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_path.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_path.test.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 import { filterUtils, elements as adapterElements } from '@salto-io/adapter-components'
+import { DAG } from '@salto-io/dag'
+import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { InstanceElement, ReferenceExpression, Element } from '@salto-io/adapter-api'
 import { getDefaultConfig } from '../../../src/config/config'
@@ -30,6 +32,9 @@ describe('assetsObjectTypePathsFilter', () => {
   let sonTwoInstance: InstanceElement
   let grandsonOneInstance: InstanceElement
   let grandsonTwoInstance: InstanceElement
+  let getDataSpy: jest.SpyInstance
+  let logErrorSpy: jest.SpyInstance
+
   const assetSchemaInstance = new InstanceElement(
     'assetsSchema1',
     createEmptyType(OBJECT_SCHEMA_TYPE),
@@ -41,6 +46,9 @@ describe('assetsObjectTypePathsFilter', () => {
   )
   describe('on fetch', () => {
     beforeEach(async () => {
+      getDataSpy = jest.spyOn(DAG.prototype, 'getData')
+      const logging = logger('jira-adapter/src/filters/assets/assets_object_type_path')
+      logErrorSpy = jest.spyOn(logging, 'error')
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
       config.fetch.enableJsmExperimental = true
@@ -153,6 +161,13 @@ describe('assetsObjectTypePathsFilter', () => {
         'grandsonTwoInstance',
         'grandsonTwoInstance',
       ])
+    })
+    it('should not fail the fetch if throws an error', async () => {
+      getDataSpy.mockImplementation(() => {
+        throw new Error('failed to get data')
+      })
+      await expect(filter.onFetch(elements)).resolves.not.toThrow()
+      expect(logErrorSpy).toHaveBeenCalled()
     })
   })
 })


### PR DESCRIPTION
_add try catch to assetsObjectTypePath filter_


---

_Additional context for reviewer_
* add try catch to not fail the whole fetch as happened in [INCIDENT-20592](https://salto-io.atlassian.net/browse/INCIDENT-20592)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_


[INCIDENT-20592]: https://salto-io.atlassian.net/browse/INCIDENT-20592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ