### PR TITLE
Return nicer SOAP deploy error messages

### DIFF
--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -51,7 +51,7 @@ import {
   SuiteAppType,
   SuiteQLQueryArgs,
 } from './suiteapp_client/types'
-import { CustomRecordResponse, RecordResponse } from './suiteapp_client/soap_client/types'
+import { CustomRecordResponse, SoapDeployResult, RecordResponse } from './suiteapp_client/soap_client/types'
 import {
   DeployableChange,
   FeaturesMap,
@@ -585,7 +585,7 @@ export default class NetsuiteClient {
     elements: InstanceElement[],
     groupID: string,
     hasElemID: HasElemIDFunc,
-  ): Promise<(number | Error)[]> {
+  ): Promise<SoapDeployResult[]> {
     if (this.suiteAppClient === undefined) {
       throw new Error(`Salto SuiteApp is not configured and therefore changes group "${groupID}" cannot be deployed`)
     }

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -72,6 +72,16 @@ export const isWriteResponseSuccess = (result: WriteResponse): result is WriteRe
 export const isWriteResponseError = (result: WriteResponse): result is WriteResponseError =>
   result.status.attributes.isSuccess === 'false'
 
+export type SoapDeployResult =
+  | {
+      isSuccess: true
+      internalId: string
+    }
+  | {
+      isSuccess: false
+      errorMessage: string
+    }
+
 export type DeployListSuccess = {
   writeResponseList: {
     writeResponse: WriteResponse[]

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -72,7 +72,7 @@ import { SUITEAPP_CONFIG_RECORD_TYPES } from '../../types'
 import { DEFAULT_AXIOS_TIMEOUT_IN_MINUTES, DEFAULT_CONCURRENCY } from '../../config/constants'
 import { CONSUMER_KEY, CONSUMER_SECRET, INSUFFICIENT_PERMISSION_ERROR } from './constants'
 import SoapClient from './soap_client/soap_client'
-import { CustomRecordResponse, RecordResponse } from './soap_client/types'
+import { CustomRecordResponse, SoapDeployResult, RecordResponse } from './soap_client/types'
 import {
   ReadFileEncodingError,
   ReadFileError,
@@ -728,19 +728,19 @@ export default class SuiteAppClient {
 
   public async updateFileCabinetInstances(
     fileCabinetInstances: ExistingFileCabinetInstanceDetails[],
-  ): Promise<(number | Error)[]> {
+  ): Promise<SoapDeployResult[]> {
     return this.soapClient.updateFileCabinetInstances(fileCabinetInstances)
   }
 
   public async addFileCabinetInstances(
     fileCabinetInstances: FileCabinetInstanceDetails[],
-  ): Promise<(number | Error)[]> {
+  ): Promise<SoapDeployResult[]> {
     return this.soapClient.addFileCabinetInstances(fileCabinetInstances)
   }
 
   public async deleteFileCabinetInstances(
     fileCabinetInstances: ExistingFileCabinetInstanceDetails[],
-  ): Promise<(number | Error)[]> {
+  ): Promise<SoapDeployResult[]> {
     return this.soapClient.deleteFileCabinetInstances(fileCabinetInstances)
   }
 
@@ -756,19 +756,19 @@ export default class SuiteAppClient {
     return this.soapClient.getCustomRecords(customRecordTypes)
   }
 
-  public async updateInstances(instances: InstanceElement[], hasElemID: HasElemIDFunc): Promise<(number | Error)[]> {
+  public async updateInstances(instances: InstanceElement[], hasElemID: HasElemIDFunc): Promise<SoapDeployResult[]> {
     return this.soapClient.updateInstances(instances, hasElemID)
   }
 
-  public async addInstances(instances: InstanceElement[], hasElemID: HasElemIDFunc): Promise<(number | Error)[]> {
+  public async addInstances(instances: InstanceElement[], hasElemID: HasElemIDFunc): Promise<SoapDeployResult[]> {
     return this.soapClient.addInstances(instances, hasElemID)
   }
 
-  public async deleteInstances(instances: InstanceElement[]): Promise<(number | Error)[]> {
+  public async deleteInstances(instances: InstanceElement[]): Promise<SoapDeployResult[]> {
     return this.soapClient.deleteInstances(instances)
   }
 
-  public async deleteSdfInstances(instances: InstanceElement[]): Promise<(number | Error)[]> {
+  public async deleteSdfInstances(instances: InstanceElement[]): Promise<SoapDeployResult[]> {
     return this.soapClient.deleteSdfInstances(instances)
   }
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -47,6 +47,7 @@ import { NetsuiteQuery } from '../../config/query'
 import { isFileCabinetType, isFileInstance } from '../../types'
 import { filterFilePathsInFolders, filterFolderPathsInFolders, largeFoldersToExclude } from '../file_cabinet_utils'
 import { getDeployResultFromSuiteAppResult, toElementError, toError } from '../utils'
+import { SoapDeployResult } from './soap_client/types'
 
 const log = logger(module)
 
@@ -610,7 +611,7 @@ export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClie
   const deployInstances = async (
     instances: FileCabinetInstanceDetails[],
     type: DeployType,
-  ): Promise<(number | Error)[]> => {
+  ): Promise<SoapDeployResult[]> => {
     if (type === 'add') {
       return suiteAppClient.addFileCabinetInstances(instances)
     }

--- a/packages/netsuite-adapter/src/client/utils.ts
+++ b/packages/netsuite-adapter/src/client/utils.ts
@@ -42,6 +42,7 @@ import { ConfigRecord } from './suiteapp_client/types'
 import { isFileCabinetInstance } from '../types'
 import { getServiceIdsToElemIds } from '../service_id_info'
 import { ATTRIBUTE_PREFIX } from './constants'
+import { SoapDeployResult } from './suiteapp_client/soap_client/types'
 
 const log = logger(module)
 const { matchAll } = strings
@@ -124,7 +125,7 @@ export const toDependencyError = (dependency: { elemId: ElemID; dependOn: ElemID
 
 export const getDeployResultFromSuiteAppResult = <T extends Change>(
   changes: T[],
-  results: (number | Error)[],
+  results: SoapDeployResult[],
 ): {
   appliedChanges: T[]
   errors: SaltoElementError[]
@@ -141,11 +142,11 @@ export const getDeployResultFromSuiteAppResult = <T extends Change>(
       return
     }
     const { elemID } = getChangeData(change)
-    if (typeof result === 'number') {
+    if (result.isSuccess) {
       appliedChanges.push(change)
-      elemIdToInternalId[elemID.getFullName()] = result.toString()
+      elemIdToInternalId[elemID.getFullName()] = result.internalId
     } else {
-      errors.push(toElementError(elemID, result.message))
+      errors.push(toElementError(elemID, result.errorMessage))
     }
   })
 

--- a/packages/netsuite-adapter/test/client/client.test.ts
+++ b/packages/netsuite-adapter/test/client/client.test.ts
@@ -1093,7 +1093,10 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
         })
       })
       it('should use updateInstances for data instances modifications', async () => {
-        updateInstancesMock.mockResolvedValue([1, new Error('error')])
+        updateInstancesMock.mockResolvedValue([
+          { isSuccess: true, internalId: '1' },
+          { isSuccess: false, errorMessage: 'error' },
+        ])
         const results = await client.deploy(
           [change1, change2],
           SUITEAPP_UPDATING_RECORDS_GROUP_ID,
@@ -1106,7 +1109,10 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       })
 
       it('should use addInstances for data instances creations', async () => {
-        addInstancesMock.mockResolvedValue([1, new Error('error')])
+        addInstancesMock.mockResolvedValue([
+          { isSuccess: true, internalId: '1' },
+          { isSuccess: false, errorMessage: 'error' },
+        ])
         const results = await client.deploy(
           [toChange({ after: instance1 }), toChange({ after: instance2 })],
           SUITEAPP_CREATING_RECORDS_GROUP_ID,
@@ -1119,7 +1125,10 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       })
 
       it('should use deleteInstances for data instances deletions', async () => {
-        deleteInstancesMock.mockResolvedValue([1, new Error('error')])
+        deleteInstancesMock.mockResolvedValue([
+          { isSuccess: true, internalId: '1' },
+          { isSuccess: false, errorMessage: 'error' },
+        ])
         const results = await client.deploy(
           [toChange({ before: instance1 }), toChange({ before: instance2 })],
           SUITEAPP_DELETING_RECORDS_GROUP_ID,
@@ -1156,7 +1165,10 @@ File: ~/Objects/custimport_xepi_subscriptionimport.xml`
       })
 
       it('should use deleteInstances for sdf instances deletions', async () => {
-        deleteSdfInstancesMock.mockResolvedValue([1, new Error('error')])
+        deleteSdfInstancesMock.mockResolvedValue([
+          { isSuccess: true, internalId: '1' },
+          { isSuccess: false, errorMessage: 'error' },
+        ])
         const results = await client.deploy(
           [toChange({ before: instance1 }), toChange({ before: instance2 })],
           SDF_DELETE_GROUP_ID,

--- a/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
@@ -272,10 +272,8 @@ describe('soap_client', () => {
           },
         ]),
       ).toEqual([
-        6233,
-        new Error(
-          'SOAP api call to update file cabinet instance somePath2 failed. error code: MEDIA_NOT_FOUND, error message: Media item not found 62330',
-        ),
+        { isSuccess: true, internalId: '6233' },
+        { isSuccess: false, errorMessage: 'Media item not found 62330' },
       ])
     })
 
@@ -428,10 +426,8 @@ describe('soap_client', () => {
           },
         ]),
       ).toEqual([
-        6334,
-        new Error(
-          'SOAP api call to add file cabinet instance addedFile2 failed. error code: INVALID_KEY_OR_REF, error message: Invalid folder reference key -600',
-        ),
+        { isSuccess: true, internalId: '6334' },
+        { isSuccess: false, errorMessage: 'Invalid folder reference key -600' },
       ])
     })
 
@@ -568,10 +564,8 @@ describe('soap_client', () => {
           },
         ] as ExistingFileCabinetInstanceDetails[]),
       ).toEqual([
-        7148,
-        new Error(
-          'SOAP api call to delete file cabinet instance somePath2 failed. error code: MEDIA_NOT_FOUND, error message: Media item not found 99999',
-        ),
+        { isSuccess: true, internalId: '7148' },
+        { isSuccess: false, errorMessage: 'Media item not found 99999' },
       ])
     })
 
@@ -1173,10 +1167,8 @@ describe('soap_client', () => {
 
       const instance2 = new InstanceElement('instance2', subsidiaryType, { name: 'name' })
       expect(await client.updateInstances([instance1, instance2], async () => true)).toEqual([
-        1,
-        new Error(
-          `SOAP api call updateList for instance ${instance2.elemID.getFullName()} failed. error code: SOME_ERROR, error message: Some Error Message`,
-        ),
+        { isSuccess: true, internalId: '1' },
+        { isSuccess: false, errorMessage: 'Some Error Message' },
       ])
     })
 
@@ -1270,11 +1262,9 @@ describe('soap_client', () => {
       const customRecord = new InstanceElement('custrecord_record1', customRecordType, { name: 'record1' })
 
       expect(await client.addInstances([instance1, instance2, customRecord], async () => true)).toEqual([
-        1,
-        new Error(
-          `SOAP api call addList for instance ${instance2.elemID.getFullName()} failed. error code: SOME_ERROR, error message: Some Error Message`,
-        ),
-        3,
+        { isSuccess: true, internalId: '1' },
+        { isSuccess: false, errorMessage: 'Some Error Message' },
+        { isSuccess: true, internalId: '3' },
       ])
     })
 
@@ -1386,11 +1376,9 @@ describe('soap_client', () => {
       })
 
       expect(await client.deleteInstances([instance1, instance2, customRecord])).toEqual([
-        1,
-        new Error(
-          `SOAP api call deleteList for instance ${instance2.elemID.getFullName()} failed. error code: SOME_ERROR, error message: Some Error Message`,
-        ),
-        3,
+        { isSuccess: true, internalId: '1' },
+        { isSuccess: false, errorMessage: 'Some Error Message' },
+        { isSuccess: true, internalId: '3' },
       ])
     })
 
@@ -1806,7 +1794,9 @@ describe('soap_client', () => {
         .mockResolvedValueOnce([writeResponseListError1])
         .mockResolvedValueOnce([writeResponseListSuccess])
 
-      expect(await client.updateInstances([instance], elementsSource.has)).toEqual([1])
+      expect(await client.updateInstances([instance], elementsSource.has)).toEqual([
+        { isSuccess: true, internalId: '1' },
+      ])
       expect(updateListAsyncMock).toHaveBeenCalledTimes(2)
       expect(updateListAsyncMock).toHaveBeenNthCalledWith(2, instanceWithoutOneField)
     })
@@ -1816,7 +1806,7 @@ describe('soap_client', () => {
         .mockResolvedValueOnce([writeResponseListError1])
         .mockResolvedValueOnce([writeResponseListSuccess])
 
-      expect(await client.addInstances([instance], elementsSource.has)).toEqual([1])
+      expect(await client.addInstances([instance], elementsSource.has)).toEqual([{ isSuccess: true, internalId: '1' }])
       expect(addListAsyncMock).toHaveBeenCalledTimes(2)
       expect(addListAsyncMock).toHaveBeenNthCalledWith(2, instanceWithoutOneField)
     })
@@ -1827,7 +1817,9 @@ describe('soap_client', () => {
         .mockResolvedValueOnce([writeResponseListError2])
         .mockResolvedValueOnce([writeResponseListSuccess])
 
-      expect(await client.updateInstances([instance], elementsSource.has)).toEqual([1])
+      expect(await client.updateInstances([instance], elementsSource.has)).toEqual([
+        { isSuccess: true, internalId: '1' },
+      ])
       expect(updateListAsyncMock).toHaveBeenCalledTimes(3)
       expect(updateListAsyncMock).toHaveBeenNthCalledWith(2, instanceWithoutOneField)
       expect(updateListAsyncMock).toHaveBeenNthCalledWith(3, instanceWithoutBothFields)
@@ -1838,10 +1830,7 @@ describe('soap_client', () => {
       jest.spyOn(filterUneditableLockedFieldModule, 'removeUneditableLockedField').mockResolvedValue(true)
 
       expect(await client.updateInstances([instance], elementsSource.has)).toEqual([
-        new Error(
-          `SOAP api call updateList for instance ${instance.elemID.getFullName()} failed.` +
-            ` error code: ${INSUFFICIENT_PERMISSION_ERROR}, error message: ${errorMessage1}`,
-        ),
+        { isSuccess: false, errorMessage: errorMessage1 },
       ])
       expect(updateListAsyncMock).toHaveBeenCalledTimes(6)
     })

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -779,13 +779,13 @@ describe('suiteapp_file_cabinet', () => {
   describe('deploy', () => {
     beforeEach(() => {
       mockSuiteAppClient.updateFileCabinetInstances.mockImplementation(async fileCabinetInstances =>
-        fileCabinetInstances.map(({ id }: { id: number }) => id),
+        fileCabinetInstances.map(({ id }: { id: number }) => ({ isSuccess: true, internalId: String(id) })),
       )
       mockSuiteAppClient.addFileCabinetInstances.mockImplementation(async fileCabinetInstances =>
-        fileCabinetInstances.map(() => _.random(101, 200)),
+        fileCabinetInstances.map(() => ({ isSuccess: true, internalId: String(_.random(101, 200)) })),
       )
       mockSuiteAppClient.deleteFileCabinetInstances.mockImplementation(async fileCabinetInstances =>
-        fileCabinetInstances.map(({ id }: { id: number }) => id),
+        fileCabinetInstances.map(({ id }: { id: number }) => ({ isSuccess: true, internalId: String(id) })),
       )
     })
 
@@ -823,7 +823,10 @@ describe('suiteapp_file_cabinet', () => {
       })
 
       it('should return applied changes for successful updates and errors for others', async () => {
-        mockSuiteAppClient.updateFileCabinetInstances.mockResolvedValue([0, new Error('someError')])
+        mockSuiteAppClient.updateFileCabinetInstances.mockResolvedValue([
+          { isSuccess: true, internalId: '0' },
+          { isSuccess: false, errorMessage: 'someError' },
+        ])
         const { appliedChanges, errors } = await createSuiteAppFileCabinetOperations(suiteAppClient).deploy(
           changes.slice(0, 2),
           'update',
@@ -963,7 +966,7 @@ describe('suiteapp_file_cabinet', () => {
           }),
         ]
         mockSuiteAppClient.addFileCabinetInstances.mockImplementation(async fileCabinetInstances =>
-          fileCabinetInstances.map(() => new Error('some error')),
+          fileCabinetInstances.map(() => ({ isSuccess: false, errorMessage: 'some error' })),
         )
         const { appliedChanges, errors } = await createSuiteAppFileCabinetOperations(suiteAppClient).deploy(
           changes,


### PR DESCRIPTION
Since each deploy error is attached to the failed change id, the error message we're returning for data instances deploy can be more friendly to the user:
instead of `SOAP api call <...> for instance <...> failed. error code: <...>, error message: <...>` we can just return the error message from SOAP. it will be much more readable for users.

In addition, make SOAP deploy return a nicer return type - `SoapDeployResult` instead of `number | Error`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Return nicer SOAP deploy error messages

---
_User Notifications_: 
None