### PR TITLE
 SALTO-2392 recognize more types for ASVs 

### DIFF
--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -59,6 +59,7 @@ export const BIN = 'bin'
 export const TAX_SCHEDULE = 'taxSchedule'
 export const PROJECT_EXPENSE_TYPE = 'projectExpenseType'
 export const ALLOCATION_TYPE = 'allocationType'
+export const SUPPORT_CASE_PROFILE = 'supportCaseProfile'
 
 // Type Annotations
 export const SOURCE = 'source'

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -538,7 +538,7 @@ const getSavedSearchInternalIdsMapFromColumn =
     return internalIdsMap
   }
 
-const ADDITIONAL_QUERIES: Record<AdditionalQueryName, ReturnType<typeof getSavedSearchInternalIdsMap>> = {
+export const ADDITIONAL_QUERIES: Record<AdditionalQueryName, ReturnType<typeof getSavedSearchInternalIdsMap>> = {
   [TAX_SCHEDULE]: getSavedSearchInternalIdsMap(TAX_SCHEDULE),
   [PROJECT_EXPENSE_TYPE]: getSavedSearchInternalIdsMap(PROJECT_EXPENSE_TYPE),
   [ALLOCATION_TYPE]: getSavedSearchInternalIdsMapFromColumn('resourceAllocation', ALLOCATION_TYPE),

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import Ajv from 'ajv'
+import Ajv, { Schema } from 'ajv'
 import { logger } from '@salto-io/logging'
 import {
   CORE_ANNOTATIONS,
@@ -20,7 +20,7 @@ import {
 } from '@salto-io/adapter-api'
 import NetsuiteClient from '../client/client'
 import { NetsuiteConfig } from '../config/types'
-import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, TAX_SCHEDULE } from '../constants'
+import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, SUPPORT_CASE_PROFILE, TAX_SCHEDULE } from '../constants'
 import { SuiteQLTableName } from './types'
 
 const log = logger(module)
@@ -28,7 +28,7 @@ const log = logger(module)
 export const SUITEQL_TABLE = 'suiteql_table'
 export const INTERNAL_IDS_MAP = 'internalIdsMap'
 
-const ALLOCATION_TYPE_QUERY_LIMIT = 50
+const COLUMN_QUERY_LIMIT = 50
 const ITEMS_PER_QUERY_LIMIT = 200
 
 export type MissingInternalId = {
@@ -36,7 +36,11 @@ export type MissingInternalId = {
   name: string
 }
 
-export type AdditionalQueryName = typeof TAX_SCHEDULE | typeof PROJECT_EXPENSE_TYPE | typeof ALLOCATION_TYPE
+export type AdditionalQueryName =
+  | typeof TAX_SCHEDULE
+  | typeof PROJECT_EXPENSE_TYPE
+  | typeof ALLOCATION_TYPE
+  | typeof SUPPORT_CASE_PROFILE
 
 type InternalIdsMap = Record<string, { name: string }>
 
@@ -56,14 +60,15 @@ type SavedSearchInternalIdsResult = {
   name: string
 }
 
-type AllocationTypeSearchResult = {
-  [ALLOCATION_TYPE]: [
+type ColumnSearchResult = Record<
+  string,
+  [
     {
       value: string
       text: string
     },
   ]
-}
+>
 
 const SAVED_SEARCH_INTERNAL_IDS_RESULT_SCHEMA = {
   type: 'array',
@@ -92,13 +97,13 @@ const SAVED_SEARCH_INTERNAL_IDS_RESULT_SCHEMA = {
   },
 }
 
-const ALLOCATION_TYPE_SEARCH_RESULT_SCHEMA = {
+const getColumnSearchResultSchema = (searchColumn: string): Schema => ({
   type: 'array',
   items: {
     type: 'object',
-    required: [ALLOCATION_TYPE],
+    required: [searchColumn],
     properties: {
-      [ALLOCATION_TYPE]: {
+      [searchColumn]: {
         type: 'array',
         maxItems: 1,
         minItems: 1,
@@ -117,7 +122,7 @@ const ALLOCATION_TYPE_SEARCH_RESULT_SCHEMA = {
       },
     },
   },
-}
+})
 
 export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undefined> = {
   item: {
@@ -380,6 +385,22 @@ export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undef
     internalIdField: 'id',
     nameField: 'name',
   },
+  accountingBook: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  shipItem: {
+    internalIdField: 'id',
+    nameField: 'itemid',
+  },
+  employeeStatus: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
+  jobResourceRole: {
+    internalIdField: 'id',
+    nameField: 'name',
+  },
 
   // could not find table
   address: undefined,
@@ -439,7 +460,7 @@ export const getSuiteQLTableInternalIdsMap = (instance: InstanceElement): Intern
   return instance.value[INTERNAL_IDS_MAP]
 }
 
-const getSavedSearchInternlIdsMap =
+const getSavedSearchInternalIdsMap =
   (searchType: string) =>
   async (client: NetsuiteClient, queryBy: QueryBy, items: string[]): Promise<InternalIdsMap> => {
     const result = await Promise.all(
@@ -471,54 +492,57 @@ const getSavedSearchInternlIdsMap =
     return Object.fromEntries(result.map(res => [res.internalid[0].value, { name: res.name }]))
   }
 
-const getAllocationTypeInternalIdsMap = async (
-  client: NetsuiteClient,
-  queryBy: QueryBy,
-  items: string[],
-): Promise<InternalIdsMap> => {
-  const ajv = new Ajv({ allErrors: true, strict: false })
-  const getAllocationTypes = async (exclude: string[] = []): Promise<Record<string, { name: string }>> => {
-    const anyOfFilter = [[ALLOCATION_TYPE, 'anyof', ..._.difference(items, exclude)]]
-    const noneOfFilter = exclude.length > 0 ? [[ALLOCATION_TYPE, 'noneof', ...exclude]] : []
-    const result = await client.runSavedSearchQuery(
-      {
-        type: 'resourceAllocation',
-        columns: [ALLOCATION_TYPE],
-        // we can't filter by name, so we query all allocation types when queryBy='name'
-        filters: queryBy === 'internalId' ? anyOfFilter : noneOfFilter,
-      },
-      ALLOCATION_TYPE_QUERY_LIMIT,
-    )
-    if (result === undefined) {
-      log.warn('failed to search %s using saved search query', ALLOCATION_TYPE)
-      return {}
+const getSavedSearchInternalIdsMapFromColumn =
+  (searchType: string, searchColumn: string) =>
+  async (client: NetsuiteClient, queryBy: QueryBy, items: string[]): Promise<InternalIdsMap> => {
+    const ajv = new Ajv({ allErrors: true, strict: false })
+    const getColumnValues = async (exclude: string[] = []): Promise<Record<string, { name: string }>> => {
+      const anyOfFilter = [[searchColumn, 'anyof', ..._.difference(items, exclude)]]
+      const noneOfFilter = exclude.length > 0 ? [[searchColumn, 'noneof', ...exclude]] : []
+      const result = await client.runSavedSearchQuery(
+        {
+          type: searchType,
+          columns: [searchColumn],
+          // we can't filter by name, so we query all column values when queryBy='name'
+          filters: queryBy === 'internalId' ? anyOfFilter : noneOfFilter,
+        },
+        COLUMN_QUERY_LIMIT,
+      )
+      if (result === undefined) {
+        log.warn('failed to search %s using saved search query', searchColumn)
+        return {}
+      }
+      if (!ajv.validate<ColumnSearchResult[]>(getColumnSearchResultSchema(searchColumn), result)) {
+        log.error(
+          'Got invalid results from %s saved search query: %s',
+          `${searchType}.${searchColumn}`,
+          ajv.errorsText(),
+        )
+        return {}
+      }
+      const internalIdToName = Object.fromEntries(
+        result.map(row => [row[searchColumn][0].value, { name: row[searchColumn][0].text }]),
+      )
+      if (result.length < COLUMN_QUERY_LIMIT) {
+        return internalIdToName
+      }
+      return {
+        ...internalIdToName,
+        ...(await getColumnValues(Object.keys(internalIdToName).concat(exclude))),
+      }
     }
-    if (!ajv.validate<AllocationTypeSearchResult[]>(ALLOCATION_TYPE_SEARCH_RESULT_SCHEMA, result)) {
-      log.error('Got invalid results from %s saved search query: %s', ALLOCATION_TYPE, ajv.errorsText())
-      return {}
+    const internalIdsMap = await getColumnValues()
+    if (queryBy === 'name') {
+      return _.pickBy(internalIdsMap, row => items.includes(row.name))
     }
-    const internalIdToName = Object.fromEntries(
-      result.map(row => [row[ALLOCATION_TYPE][0].value, { name: row[ALLOCATION_TYPE][0].text }]),
-    )
-    if (result.length < ALLOCATION_TYPE_QUERY_LIMIT) {
-      return internalIdToName
-    }
-    return {
-      ...internalIdToName,
-      ...(await getAllocationTypes(Object.keys(internalIdToName).concat(exclude))),
-    }
+    return internalIdsMap
   }
-  const internalIdsMap = await getAllocationTypes()
-  if (queryBy === 'name') {
-    return _.pickBy(internalIdsMap, row => items.includes(row.name))
-  }
-  return internalIdsMap
-}
 
-const ADDITIONAL_QUERIES: Record<AdditionalQueryName, ReturnType<typeof getSavedSearchInternlIdsMap>> = {
-  [TAX_SCHEDULE]: getSavedSearchInternlIdsMap(TAX_SCHEDULE),
-  [PROJECT_EXPENSE_TYPE]: getSavedSearchInternlIdsMap(PROJECT_EXPENSE_TYPE),
-  [ALLOCATION_TYPE]: getAllocationTypeInternalIdsMap,
+const ADDITIONAL_QUERIES: Record<AdditionalQueryName, ReturnType<typeof getSavedSearchInternalIdsMap>> = {
+  [TAX_SCHEDULE]: getSavedSearchInternalIdsMap(TAX_SCHEDULE),
+  [PROJECT_EXPENSE_TYPE]: getSavedSearchInternalIdsMap(PROJECT_EXPENSE_TYPE),
+  [ALLOCATION_TYPE]: getSavedSearchInternalIdsMapFromColumn('resourceAllocation', ALLOCATION_TYPE),
+  [SUPPORT_CASE_PROFILE]: getSavedSearchInternalIdsMapFromColumn('supportCase', 'profile'),
 }
 
 const getInternalIdsMap = async (

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -175,6 +175,10 @@ const ADDITIONAL_TABLES = [
   'revenueRecognitionRule',
   'incoterm',
   'approvalStatus',
+  'accountingBook',
+  'shipItem',
+  'employeeStatus',
+  'jobResourceRole',
 ] as const
 
 export type SuiteQLTableName = keyof typeof ALL_TABLE_TO_INTERNAL_ID | (typeof ADDITIONAL_TABLES)[number]

--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -116,6 +116,16 @@ type ResolvedAccountSpecificValuesResult = {
   missingInternalIds: MissingInternalId[]
 }
 
+const ADDITIONAL_INTERNAL_ID_TO_TYPES: Record<string, SuiteQLTableName | AdditionalQueryName> = {
+  '-192': 'shipItem',
+  '-3': 'vendor',
+  '-104': 'entityStatus',
+  '-320': 'supportCaseStatus',
+  '-166': 'employeeStatus',
+  '-253': 'accountingBook',
+  '-517': 'jobResourceRole',
+}
+
 const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, SuiteQLTableName | AdditionalQueryName> = {
   // STDBODY fields
   STDBODYACCOUNT: 'account',
@@ -365,6 +375,9 @@ const getQueryRecordType = (path: ElemID): QueryRecordType | undefined => {
   return QUERY_RECORD_TYPES[path.createParentID().name as QueryRecordType]
 }
 
+const getTypesFromInternalId = (typeInternalId: string): string[] =>
+  INTERNAL_ID_TO_TYPES[typeInternalId] ?? ADDITIONAL_INTERNAL_ID_TO_TYPES[typeInternalId] ?? []
+
 const getQueryRecordFieldType = (
   instance: InstanceElement,
   value: Values,
@@ -405,7 +418,7 @@ const getQueryRecordFieldType = (
   const suiteQLTableName =
     suiteQLTablesMap[fieldType] !== undefined
       ? fieldType
-      : (INTERNAL_ID_TO_TYPES[fieldType] ?? []).find(typeName => suiteQLTablesMap[typeName] !== undefined)
+      : getTypesFromInternalId(fieldType).find(typeName => suiteQLTablesMap[typeName] !== undefined)
 
   if (suiteQLTableName === undefined) {
     log.warn('could not find SuiteQL table instance %s', fieldType)

--- a/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/suiteql_table_elements.test.ts
@@ -18,6 +18,7 @@ import {
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import NetsuiteClient from '../../src/client/client'
 import {
+  ADDITIONAL_QUERIES,
   INTERNAL_IDS_MAP,
   QUERIES_BY_TABLE_NAME,
   SUITEQL_TABLE,
@@ -28,10 +29,11 @@ import { ALLOCATION_TYPE, NETSUITE, TAX_SCHEDULE } from '../../src/constants'
 import { NetsuiteConfig } from '../../src/config/types'
 import { fullFetchConfig } from '../../src/config/config_creator'
 
+const NUM_OF_TYPES = 1
 export const NUM_OF_SUITEQL_ELEMENTS =
   Object.values(QUERIES_BY_TABLE_NAME).filter(query => query !== undefined).length +
-  // additional elements are the type, and instances from getAdditionalInstances
-  4
+  Object.keys(ADDITIONAL_QUERIES).length +
+  NUM_OF_TYPES
 
 const runSuiteQLMock = jest.fn()
 const runSavedSearchQueryMock = jest.fn()


### PR DESCRIPTION
Add mapping between missing type internal ids (from the `selectrecordtype` field) and their SuiteQL tables.

This PR is rebased on https://github.com/salto-io/salto/pull/6311 .

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Recognize more types for ASVs 

---
_User Notifications_: 
 Netsuite Adapter:
- unresolved `[ACCOUNT_SPECIFIC_VALUE]` values may be resolved
