### PR TITLE
SALTO-6376: Add config creator with enable deploy option to Workato

### DIFF
--- a/packages/adapter-utils/src/config_options.ts
+++ b/packages/adapter-utils/src/config_options.ts
@@ -13,20 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-export * from './src/change'
-export * from './src/compare'
-export * from './src/decorators'
-export * from './src/dependencies'
-export * from './src/element_source'
-export * from './src/element'
-export * as filter from './src/filter'
-export * from './src/nacl_case_utils'
-export * from './src/utils'
-export * from './src/template'
-export * from './src/walk_element'
-export * from './src/collisions'
-export * as references from './src/references'
-export * from './src/elem_id_discrepancy'
-export * from './src/important_values'
-export * from './src/additional_properties'
-export * from './src/config_options'
+
+import { ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
+
+export const isOptionsTypeInstance = <T>(
+  instance: InstanceElement,
+  optionsElemId: ElemID,
+): instance is InstanceElement & { value: T } => {
+  if (instance.refType.elemID.isEqual(optionsElemId)) {
+    return true
+  }
+  log.error(
+    `Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`,
+  )
+  return false
+}

--- a/packages/adapter-utils/src/config_options.ts
+++ b/packages/adapter-utils/src/config_options.ts
@@ -19,15 +19,14 @@ import { logger } from '@salto-io/logging'
 
 const log = logger(module)
 
-export const createOptionsTypeGuard = <T>(
-  optionsElemID: ElemID
-): ((instance: InstanceElement) => instance is InstanceElement & { value: T }) => 
+export const createOptionsTypeGuard =
+  <T>(optionsElemID: ElemID): ((instance: InstanceElement) => instance is InstanceElement & { value: T }) =>
   (instance): instance is InstanceElement & { value: T } => {
-  if (instance.refType.elemID.isEqual(optionsElemID)) {
-    return true
+    if (instance.refType.elemID.isEqual(optionsElemID)) {
+      return true
+    }
+    log.error(
+      `Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`,
+    )
+    return false
   }
-  log.error(
-    `Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`,
-  )
-  return false
-}

--- a/packages/adapter-utils/src/config_options.ts
+++ b/packages/adapter-utils/src/config_options.ts
@@ -19,11 +19,11 @@ import { logger } from '@salto-io/logging'
 
 const log = logger(module)
 
-export const isOptionsTypeInstance = <T>(
-  instance: InstanceElement,
-  optionsElemId: ElemID,
-): instance is InstanceElement & { value: T } => {
-  if (instance.refType.elemID.isEqual(optionsElemId)) {
+export const createOptionsTypeGuard = <T>(
+  optionsElemID: ElemID
+): ((instance: InstanceElement) => instance is InstanceElement & { value: T }) => 
+  (instance): instance is InstanceElement & { value: T } => {
+  if (instance.refType.elemID.isEqual(optionsElemID)) {
     return true
   }
   log.error(

--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -15,7 +15,7 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
+import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
 import { configType } from './config/config'
 import * as constants from './constants'
 
@@ -36,7 +36,7 @@ export const optionsType = createMatchingObjectType<ConfigOptionsType>({
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options !== undefined && isOptionsTypeInstance<ConfigOptionsType>(options, optionsElemId)) {
+  if (options !== undefined && createOptionsTypeGuard<ConfigOptionsType>(optionsElemId)(options)) {
     if (options.value.enableScriptRunnerAddon) {
       defaultConf.value.fetch.enableScriptRunnerAddon = true
     }

--- a/packages/jira-adapter/src/config_creator.ts
+++ b/packages/jira-adapter/src/config_creator.ts
@@ -15,7 +15,11 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
+import {
+  createDefaultInstanceFromType,
+  createMatchingObjectType,
+  createOptionsTypeGuard,
+} from '@salto-io/adapter-utils'
 import { configType } from './config/config'
 import * as constants from './constants'
 

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -23,7 +23,7 @@ import {
   InstanceElement,
   ListType,
 } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
+import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
 import { configType } from './types'
 import * as constants from './constants'
 import { CPQ_NAMESPACE, CUSTOM_OBJECT_ID_FIELD } from './constants'
@@ -211,7 +211,7 @@ export const optionsType = createMatchingObjectType<SalesforceConfigOptionsType>
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance<SalesforceConfigOptionsType>(options, optionsElemId)) {
+  if (options === undefined || !createOptionsTypeGuard<SalesforceConfigOptionsType>(optionsElemId)(options)) {
     return defaultConf
   }
   if (options.value.cpq === true || options.value.managedPackages?.includes(CPQ_MANAGED_PACKAGE)) {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -23,13 +23,10 @@ import {
   InstanceElement,
   ListType,
 } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
+import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
 import { configType } from './types'
 import * as constants from './constants'
 import { CPQ_NAMESPACE, CUSTOM_OBJECT_ID_FIELD } from './constants'
-
-const log = logger(module)
 
 export const configWithCPQ = new InstanceElement(ElemID.CONFIG_NAME, configType, {
   fetch: {
@@ -211,21 +208,10 @@ export const optionsType = createMatchingObjectType<SalesforceConfigOptionsType>
     },
   },
 })
-const isOptionsTypeInstance = (
-  instance: InstanceElement,
-): instance is InstanceElement & { value: SalesforceConfigOptionsType } => {
-  if (instance.refType.elemID.isEqual(optionsElemId)) {
-    return true
-  }
-  log.error(
-    `Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`,
-  )
-  return false
-}
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance(options)) {
+  if (options === undefined || !isOptionsTypeInstance<SalesforceConfigOptionsType>(options, optionsElemId)) {
     return defaultConf
   }
   if (options.value.cpq === true || options.value.managedPackages?.includes(CPQ_MANAGED_PACKAGE)) {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -23,7 +23,11 @@ import {
   InstanceElement,
   ListType,
 } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
+import {
+  createDefaultInstanceFromType,
+  createMatchingObjectType,
+  createOptionsTypeGuard,
+} from '@salto-io/adapter-utils'
 import { configType } from './types'
 import * as constants from './constants'
 import { CPQ_NAMESPACE, CUSTOM_OBJECT_ID_FIELD } from './constants'

--- a/packages/workato-adapter/src/adapter_creator.ts
+++ b/packages/workato-adapter/src/adapter_creator.ts
@@ -29,6 +29,7 @@ import {
 } from './config'
 import WorkatoClient from './client/client'
 import { createConnection } from './client/connection'
+import { configCreator } from './config_creator'
 
 const log = logger(module)
 const { validateCredentials } = clientUtils
@@ -96,4 +97,5 @@ export const adapter: Adapter = {
     },
   },
   configType,
+  configCreator,
 }

--- a/packages/workato-adapter/src/config_creator.ts
+++ b/packages/workato-adapter/src/config_creator.ts
@@ -15,7 +15,11 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
+import {
+  createDefaultInstanceFromType,
+  createMatchingObjectType,
+  createOptionsTypeGuard,
+} from '@salto-io/adapter-utils'
 import { ENABLE_DEPLOY_SUPPORT_FLAG, configType } from './config'
 import { WORKATO } from './constants'
 

--- a/packages/workato-adapter/src/config_creator.ts
+++ b/packages/workato-adapter/src/config_creator.ts
@@ -15,7 +15,7 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
+import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
 import { ENABLE_DEPLOY_SUPPORT_FLAG, configType } from './config'
 import { WORKATO } from './constants'
 
@@ -33,7 +33,7 @@ export const optionsType = createMatchingObjectType<ConfigOptionsType>({
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConfig = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance<ConfigOptionsType>(options, optionsElemId)) {
+  if (options === undefined || !createOptionsTypeGuard<ConfigOptionsType>(optionsElemId)(options)) {
     return defaultConfig
   }
   if (options.value.enableDeploy !== undefined) {

--- a/packages/workato-adapter/test/config_creator.test.ts
+++ b/packages/workato-adapter/test/config_creator.test.ts
@@ -1,0 +1,56 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID, InstanceElement, ObjectType } from '@salto-io/adapter-api'
+import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
+import { getConfig, configCreator, optionsType } from '../src/config_creator'
+import { ENABLE_DEPLOY_SUPPORT_FLAG, configType } from '../src/config'
+import { WORKATO } from '../src/constants'
+
+describe('config creator', () => {
+  let options: InstanceElement
+  beforeEach(async () => {
+    options = new InstanceElement('instance', optionsType, { enableDeploy: true })
+  })
+  it('should return config creator', async () => {
+    const config = configCreator
+    expect(config).toEqual({
+      optionsType,
+      getConfig,
+    })
+  })
+  it('should return default config when options are not provided', async () => {
+    const config = await getConfig()
+    expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
+  })
+  it('should return config with deploy disabled when enableDeploy option is false', async () => {
+    options.value.enableDeploy = false
+    const config = await getConfig(options)
+    expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(false)
+  })
+  it('should return config with deploy enabled when enableDeploy option is true', async () => {
+    options.value.enableDeploy = true
+    const config = await getConfig(options)
+    expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(true)
+  })
+  it('get config should return default config when wrong type', async () => {
+    options = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(WORKATO, 'Foo') }), {
+      enableScripRunnerAddon: true,
+    })
+    const config = await getConfig(options)
+    expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
+  })
+})

--- a/packages/zendesk-adapter/src/config_creator.ts
+++ b/packages/zendesk-adapter/src/config_creator.ts
@@ -15,13 +15,10 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
+import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
 import { configType } from './config'
 import * as constants from './constants'
 import { Themes } from './user_config'
-
-const log = logger(module)
 
 const optionsElemId = new ElemID(constants.ZENDESK, 'configOptionsType')
 
@@ -36,17 +33,6 @@ export const optionsType = createMatchingObjectType<ConfigOptionsType>({
     enableGuideThemes: { refType: BuiltinTypes.BOOLEAN },
   },
 })
-const isOptionsTypeInstance = (
-  instance: InstanceElement,
-): instance is InstanceElement & { value: ConfigOptionsType } => {
-  if (instance.refType.elemID.isEqual(optionsElemId)) {
-    return true
-  }
-  log.error(
-    `Received an invalid instance for config options. Received instance with refType ElemId full name: ${instance.refType.elemID.getFullName()}`,
-  )
-  return false
-}
 
 export const DEFAULT_GUIDE_THEME_CONFIG: { themes: Themes } = {
   themes: {
@@ -63,7 +49,7 @@ export const DEFAULT_GUIDE_THEME_CONFIG: { themes: Themes } = {
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance(options)) {
+  if (options === undefined || !isOptionsTypeInstance<ConfigOptionsType>(options, optionsElemId)) {
     return defaultConf
   }
   if (options.value.enableGuide === true || options.value.enableGuideThemes === true) {

--- a/packages/zendesk-adapter/src/config_creator.ts
+++ b/packages/zendesk-adapter/src/config_creator.ts
@@ -15,7 +15,7 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, isOptionsTypeInstance } from '@salto-io/adapter-utils'
+import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
 import { configType } from './config'
 import * as constants from './constants'
 import { Themes } from './user_config'
@@ -49,7 +49,7 @@ export const DEFAULT_GUIDE_THEME_CONFIG: { themes: Themes } = {
 
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   const defaultConf = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
-  if (options === undefined || !isOptionsTypeInstance<ConfigOptionsType>(options, optionsElemId)) {
+  if (options === undefined || !createOptionsTypeGuard<ConfigOptionsType>(optionsElemId)(options)) {
     return defaultConf
   }
   if (options.value.enableGuide === true || options.value.enableGuideThemes === true) {

--- a/packages/zendesk-adapter/src/config_creator.ts
+++ b/packages/zendesk-adapter/src/config_creator.ts
@@ -15,7 +15,11 @@
  */
 
 import { BuiltinTypes, ConfigCreator, ElemID, InstanceElement } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, createMatchingObjectType, createOptionsTypeGuard } from '@salto-io/adapter-utils'
+import {
+  createDefaultInstanceFromType,
+  createMatchingObjectType,
+  createOptionsTypeGuard,
+} from '@salto-io/adapter-utils'
 import { configType } from './config'
 import * as constants from './constants'
 import { Themes } from './user_config'


### PR DESCRIPTION
Add config creator to workato to allow controlling deploy settings

---

_Additional context for reviewer_
Also added some code to adapter utils 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
