### PR TITLE
SALTO-5692: Okta: Allow HTTP 404 as valid response for `delete` endpoints by default

### DIFF
--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -35,6 +35,7 @@ export const createClientDefinitions = (
             readonly: true,
           },
           delete: {
+            additionalValidStatuses: [404],
             omitBody: true,
           },
         },
@@ -85,11 +86,6 @@ export const createClientDefinitions = (
           '/api/v1/apps/{source}/policies/{target}': {
             put: {
               omitBody: true,
-            },
-          },
-          '/api/v1/apps/{appId}/groups/{id}': {
-            delete: {
-              additionalValidStatuses: [404],
             },
           },
         },


### PR DESCRIPTION
Okta endpoints return 404 for `delete` endpoints where the instance was already deleted. Many Okta instances are deleted automatically with their parent, so we allow 404 as response by default for cases where we delete both parent and child together.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None