### PR TITLE
SALTO-6357 fix serviceId is visible on target environment after deployment

### DIFF
--- a/packages/adapter-api/src/builtins.ts
+++ b/packages/adapter-api/src/builtins.ts
@@ -27,7 +27,7 @@ import {
 import { TypeReference } from './values'
 import { BUILTIN_TYPE_NAMES, CORE_ANNOTATIONS } from './constants'
 
-export { CORE_ANNOTATIONS }
+export { CORE_ANNOTATIONS, BUILTIN_TYPE_NAMES }
 
 const StandardBuiltinTypes = {
   STRING: new PrimitiveType({

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -225,6 +225,8 @@ export const markServiceIdField = (
   }
 }
 
+// Verify that field is not undefined if it is a serviceId or field we want to hide.
+// This is to prevent writing to nacl (copyFromResponse on deployment) fields that supposed to be hidden.
 const overrideServiceIdOrHiddenFieldIfNotDefined = ({
   definedTypes,
   type,
@@ -239,7 +241,6 @@ const overrideServiceIdOrHiddenFieldIfNotDefined = ({
   isHiddenField?: boolean
 }): void => {
   if (type.fields[fieldName] === undefined) {
-    // we don't want field to be undefined if it is a serviceId or field we want to hide
     if (isServiceIdField) {
       overrideFieldType({
         type,

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -248,14 +248,21 @@ export const overrideFieldTypes = <Options extends FetchApiDefinitionsOptions>({
 
       Object.entries(elementDef?.fieldCustomizations ?? {}).forEach(([fieldName, customization]) => {
         const { fieldType, restrictions, hide } = customization
-        if (type.fields[fieldName] === undefined && hide) {
-          overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: BUILTIN_TYPE_NAMES.UNKNOWN })
-        }
-        if (type.fields[fieldName] === undefined && resourceDef?.serviceIDFields?.includes(fieldName)) {
-          overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: BUILTIN_TYPE_NAMES.SERVICEID })
-        }
         if (fieldType !== undefined) {
           overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: fieldType })
+        }
+        if (type.fields[fieldName] === undefined) {
+          // we don't want field to be undefined if it is a serviceId or field we want to hide
+          if (resourceDef?.serviceIDFields?.includes(fieldName)) {
+            overrideFieldType({
+              type,
+              definedTypes,
+              fieldName,
+              fieldTypeName: BUILTIN_TYPE_NAMES.STRING, // fallback to string serviceId
+            })
+          } else if (hide) {
+            overrideFieldType({ type, definedTypes, fieldName, fieldTypeName: BUILTIN_TYPE_NAMES.UNKNOWN })
+          }
         }
         if (type.fields[fieldName] === undefined) {
           return


### PR DESCRIPTION
- when creating type from entries and definitions. If there are no entries contains fields that defined to be hidden in the definitions: 
- Create field with type `unknown` and `_hidden_value` annotation
- If field is defined as `serviceIdField` in `resource` definitions, mark it as `serviceId` field instead of `unknown`


---


---

_Release Notes_: 
- Fix hidden fields are written to the nacl after deploy of first instance from a type

---
_User Notifications_: 
None
