### PR TITLE
SALTO-5692: Okta: Upgrade `AppLogo` deploy definitions to new infra

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -233,24 +233,6 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: OktaSwaggerApiConfig['types'] = {
       },
     },
   },
-  AppLogo: {
-    deployRequests: {
-      add: {
-        url: '/api/v1/apps/{appId}/logo',
-        method: 'post',
-        urlParamsToFields: {
-          appId: '_parent.0.id',
-        },
-      },
-      modify: {
-        url: '/api/v1/apps/{appId}/logo',
-        method: 'post',
-        urlParamsToFields: {
-          appId: '_parent.0.id',
-        },
-      },
-    },
-  },
   UserSchema: {
     deployRequests: {
       add: {

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -41,6 +41,7 @@ import {
   ID_FIELD,
   BRAND_THEME_TYPE_NAME,
   APP_GROUP_ASSIGNMENT_TYPE_NAME,
+  APP_LOGO_TYPE_NAME,
 } from '../../constants'
 import {
   APP_POLICIES,
@@ -339,6 +340,29 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 context: {
                   appId: '{_parent.0.id}',
                 },
+              },
+            },
+          ],
+        },
+      },
+    },
+    [APP_LOGO_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          // AppLogo deployment is handled by a filter.
+          // We define actions here to avoid "action not supported" CV error. AppLogo doesn't support "remove" action,
+          // so we can't add it to the CV ignore list.
+          add: [
+            {
+              request: {
+                earlySuccess: true,
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                earlySuccess: true,
               },
             },
           ],

--- a/packages/okta-adapter/test/filters/app_logo.test.ts
+++ b/packages/okta-adapter/test/filters/app_logo.test.ts
@@ -98,7 +98,7 @@ describe('app logo filter', () => {
         }),
       })
     })
-    it('should not create AppLogo instance if file type is forbiden and should create error', async () => {
+    it('should not create AppLogo instance if file type is forbidden and should create error', async () => {
       const clonedAppInstance = appInstance.clone()
       clonedAppInstance.value[LINKS_FIELD].logo[0].type = 'image/svg+xml'
       const elements = [appType, clonedAppInstance]


### PR DESCRIPTION
See title.

---

_Additional context for reviewer_:
This PR includes both the tests and the actual upgrade, because filters still do all the work (config change is just a hack to keep the "operation not supported" CV from reporting this type).

---
_Release Notes_: 
None

---
_User Notifications_: 
None