### PR TITLE
SALTO-6378: Fix - combined addition of Application and its Service Principal fails

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
@@ -209,6 +209,9 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
               toSharedContext: {
                 pick: ['id'],
               },
+              additional: {
+                pick: ['appId'],
+              },
             },
           },
           {

--- a/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
@@ -210,6 +210,8 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
                 pick: ['id'],
               },
               additional: {
+                // The appId is hidden, so it won't exist on addition.
+                // However, it is used to reference the application from other instances, so we should copy it to the applied change.
                 pick: ['appId'],
               },
             },

--- a/packages/microsoft-entra-adapter/src/definitions/deploy/utils/app_role.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/utils/app_role.ts
@@ -15,7 +15,6 @@
  */
 
 import { validateArray, validatePlainObject } from '@salto-io/adapter-utils'
-import { v4 as uuid4 } from 'uuid'
 import _ from 'lodash'
 import { APP_ROLES_FIELD_NAME, PARENT_ID_FIELD_NAME } from '../../../constants'
 import { AdjustFunctionSingle } from '../types'
@@ -32,11 +31,7 @@ export const adjustParentWithAppRoles: AdjustFunctionSingle = omitReadOnlyFields
   validateArray(appRoles, `${typeName}.${APP_ROLES_FIELD_NAME}`)
   const adjustedAppRoles = appRoles.map(appRole => {
     validatePlainObject(appRole, `${typeName}.${APP_ROLES_FIELD_NAME}`)
-    return {
-      // We must specify an id for each appRole on addition. If the appRole already has an id, it will be preserved.
-      id: uuid4(),
-      ..._.omit(appRole, PARENT_ID_FIELD_NAME),
-    }
+    return _.omit(appRole, PARENT_ID_FIELD_NAME)
   })
   return {
     value: {

--- a/packages/microsoft-entra-adapter/src/filters/app_role.ts
+++ b/packages/microsoft-entra-adapter/src/filters/app_role.ts
@@ -245,7 +245,7 @@ const deployAppRoleChangesViaParent = async ({
           appliedParentChangesFullNames.includes(getChangeData(parentChange).elemID.getFullName()),
       )
       .map(({ parentChange }) =>
-        // We add the app roles field to the parent change in place, but we don't want to copy it to the workspace.
+        // We add the app roles field to the parent change in place, but we don't include it in the applied change.
         // So we remove it before returning it as an applied change.
         // The reason we modify the change in place is that the `copy from response` flow works on the original change,
         // and in case where we add an application we need to copy its id and appId.

--- a/packages/microsoft-entra-adapter/test/deploy/utils/app_role.test.ts
+++ b/packages/microsoft-entra-adapter/test/deploy/utils/app_role.test.ts
@@ -42,27 +42,6 @@ describe(`${adjustParentWithAppRoles.name}`, () => {
     expect(result.value).toEqual(appRolesParent)
   })
 
-  it('should add a uuid to each appRole that does not have an id', async () => {
-    const appRolesParent = {
-      appRoles: [
-        {
-          id: 'id1',
-          name: 'name1',
-        },
-        {
-          name: 'name2',
-        },
-      ],
-    }
-    const result = await adjustParentWithAppRoles({
-      value: appRolesParent,
-      typeName: PARENT_TYPE_NAME,
-      context: contextMock,
-    })
-    expect(result.value.appRoles[1].id).toBeDefined()
-    expect(result.value.appRoles[0].id).toBe('id1')
-  })
-
   it('should remove the parent_id field from each appRole', async () => {
     const appRolesParent = {
       appRoles: [

--- a/packages/microsoft-entra-adapter/test/filters/app_role.test.ts
+++ b/packages/microsoft-entra-adapter/test/filters/app_role.test.ts
@@ -22,6 +22,7 @@ import {
   toChange,
   getChangeData,
   ModificationChange,
+  Change,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { filterUtils, client as clientUtils, definitions, fetch } from '@salto-io/adapter-components'
@@ -235,16 +236,24 @@ describe('app roles filter', () => {
     })
 
     describe('when there is a change in one of the app roles', () => {
-      const applicationInstance = new InstanceElement('app', applicationType, { id: 'app' })
-      const appRoleInstanceA = new InstanceElement('appRoleA', appRoleType, { id: 'appRoleA' }, undefined, {
-        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(applicationInstance.elemID, applicationInstance),
+      let applicationInstance: InstanceElement
+      let appRoleInstanceA: InstanceElement
+      let appRoleInstanceB: InstanceElement
+      let appRoleObjectType: ObjectType
+      let appRoleObjectTypeChange: Change<ObjectType>
+
+      beforeEach(() => {
+        applicationInstance = new InstanceElement('app', applicationType, { id: 'app' })
+        appRoleInstanceA = new InstanceElement('appRoleA', appRoleType, { id: 'appRoleA' }, undefined, {
+          [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(applicationInstance.elemID, applicationInstance),
+        })
+        appRoleInstanceB = new InstanceElement('appRoleB', appRoleType, { id: 'appRoleB' }, undefined, {
+          [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(applicationInstance.elemID, applicationInstance),
+        })
+        appRoleObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, APP_ROLE_TYPE_NAME) })
+        // Used to check that we handle properly non instance changes
+        appRoleObjectTypeChange = toChange({ after: appRoleObjectType })
       })
-      const appRoleInstanceB = new InstanceElement('appRoleB', appRoleType, { id: 'appRoleB' }, undefined, {
-        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(applicationInstance.elemID, applicationInstance),
-      })
-      const appRoleObjectType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, APP_ROLE_TYPE_NAME) })
-      // Used to check that we handle properly non instance changes
-      const appRoleObjectTypeChange = toChange({ after: appRoleObjectType })
 
       beforeEach(() => {
         mockDeployChanges.mockResolvedValueOnce({

--- a/packages/microsoft-entra-adapter/test/filters/app_role.test.ts
+++ b/packages/microsoft-entra-adapter/test/filters/app_role.test.ts
@@ -332,9 +332,7 @@ describe('app roles filter', () => {
           const changesParam = mockDeployChanges.mock.calls[0][0].changes
           expect(changesParam).toHaveLength(1)
           expect(changesParam[0].action).toEqual('add')
-          expect(_.get(getChangeData(changesParam[0]), `value.${APP_ROLES_FIELD_NAME}`)).toEqual(
-            expect.arrayContaining([appRoleInstanceA.value, appRoleInstanceB.value]),
-          )
+          expect(changesParam[0]).toEqual(applicationChange)
 
           expect(result.deployResult.appliedChanges).toEqual([applicationChange, appRoleChange])
           expect(result.deployResult.errors).toHaveLength(0)

--- a/packages/microsoft-entra-adapter/test/mocks.ts
+++ b/packages/microsoft-entra-adapter/test/mocks.ts
@@ -17,7 +17,6 @@
 import {
   AdditionChange,
   CORE_ANNOTATIONS,
-  Change,
   ChangeGroup,
   ElemID,
   InstanceElement,
@@ -25,7 +24,6 @@ import {
   ObjectType,
   ReferenceExpression,
   RemovalChange,
-  toChange,
 } from '@salto-io/adapter-api'
 import { definitions } from '@salto-io/adapter-components'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
@@ -72,14 +70,6 @@ export const removalChangeMock: RemovalChange<InstanceElement> = {
     before: instanceElementMock,
   },
 }
-
-export const objectTypeElementMock = new ObjectType({
-  elemID: new ElemID(ADAPTER_NAME, 'testType'),
-})
-
-export const objectTypeChangeMock: Change<ObjectType> = toChange({
-  after: objectTypeElementMock,
-})
 
 export const changeGroupMock: ChangeGroup = {
   groupID: 'testGroup',


### PR DESCRIPTION
1. On `application` addition - copy the `appId` from the response.
2. On `appRole` addition - generate internal id directly on the changes.

---
1. The `Service Principal` addition requires its corresponding `appId`, which is hidden on the `Application` instance.
We don't copy it automatically from the response, since it's not a serviceId, so when attempting to add the `Service Principal` right after adding the `Application` we can't resolve the `appId` ref.
When fixing it I found out that the `copyFromResponse` flow works on the original change, which means I had to adjust the `app_role` filter to not create a new `Application` change with the `appRole` field, but rather modify it in-place. 
2. In a similar way - when adding an instance that depends on an `appRole` - we have to get its `id`, which is hidden. Since the `appRole` is deployed as part of its parent we don't get the `copyFromResponse` behavior "for free" on the original changes, so we need to manually add the generated ids to the changes.

---
_Release Notes_: 
_Microsoft Entra_:
* Fix bug in combined addition of Application and its Service Principal.

---
_User Notifications_: 
_Microsoft Entra_:
* It's now possible to deploy addition of Application and its Service Principal in the same deployment.