### PR TITLE
SALTO-6265 Order restricted brand ids

### DIFF
--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -406,6 +406,15 @@ const createCustomizations = (): Record<
         name: { hide: true },
         id: { fieldType: 'number', hide: true },
         display_name: { omit: true },
+        restricted_brand_ids: {
+          sort: { properties: [{ path: 'name' }] },
+        },
+        end_user_conditions: {
+          sort: { properties: [{ path: 'parent_field_id.name' }] },
+        },
+        agent_conditions: {
+          sort: { properties: [{ path: 'parent_field_id.name' }] },
+        },
       },
     },
   },

--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -409,12 +409,6 @@ const createCustomizations = (): Record<
         restricted_brand_ids: {
           sort: { properties: [{ path: 'name' }] },
         },
-        end_user_conditions: {
-          sort: { properties: [{ path: 'parent_field_id.name' }] },
-        },
-        agent_conditions: {
-          sort: { properties: [{ path: 'parent_field_id.name' }] },
-        },
       },
     },
   },

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -3222,7 +3222,7 @@ describe('adapter', () => {
         // eslint-disable-next-line
         const createClientSpy = jest.spyOn(zendeskAdapter as any, 'createClientBySubdomain')
         // eslint-disable-next-line
-        const createFiltersRunnerSpy = jest.spyOn(zendeskAdapter as any, 'createFiltersRunner')
+        const deprecatedCreateFiltersRunnerSpy = jest.spyOn(zendeskAdapter as any, 'deprecatedCreateFiltersRunner')
         await zendeskAdapter.deploy({
           changeGroup: {
             groupID: '1',
@@ -3241,10 +3241,10 @@ describe('adapter', () => {
         })
 
         expect(createClientSpy).toHaveBeenCalledTimes(2)
-        expect(createFiltersRunnerSpy).toHaveBeenCalledTimes(3)
-        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(1, {}) // Regular deploy
-        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(2, guideFilterRunnerCall) // guide deploy
-        expect(createFiltersRunnerSpy).toHaveBeenNthCalledWith(3, guideFilterRunnerCall) // guide deploy
+        expect(deprecatedCreateFiltersRunnerSpy).toHaveBeenCalledTimes(3)
+        expect(deprecatedCreateFiltersRunnerSpy).toHaveBeenNthCalledWith(1, {}) // Regular deploy
+        expect(deprecatedCreateFiltersRunnerSpy).toHaveBeenNthCalledWith(2, guideFilterRunnerCall) // guide deploy
+        expect(deprecatedCreateFiltersRunnerSpy).toHaveBeenNthCalledWith(3, guideFilterRunnerCall) // guide deploy
       })
       it('should use the same client for all guide requests of the same subdomain', async () => {
         const zendeskAdapter = new ZendeskAdapter({


### PR DESCRIPTION
* Use new infra filters to allow sort config.
* Add sorting to restricted brand ids in ticket forms
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
__Zendesk Adapter:__
* Ticket form `restricted_brand_ids` will now be sorted to avoid unneeded diffs.