### PR TITLE
SALTO-6395: fieldConfiguration in DC

### DIFF
--- a/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/field_configuration_deployment.ts
@@ -24,22 +24,37 @@ import {
 } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { JiraConfig } from '../../config/config'
 import { FilterCreator } from '../../filter'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+import JiraClient from '../../client/client'
 
 const FIELD_CONFIGURATION_TYPE_NAME = 'FieldConfiguration'
 
+const { awu } = collections.asynciterable
 const log = logger(module)
+
+const putFieldItemsChunk = async (
+  client: JiraClient,
+  parentId: string,
+  fieldsChunk: Values[],
+): Promise<clientUtils.Response<clientUtils.ResponseValue | clientUtils.ResponseValue[]>> =>
+  client.put({
+    url: `/rest/api/3/fieldconfiguration/${parentId}/fields`,
+    data: {
+      fieldConfigurationItems: fieldsChunk,
+    },
+  })
 
 const deployFieldConfigurationItems = async (
   instance: InstanceElement,
-  client: clientUtils.HTTPWriteClientInterface,
+  client: JiraClient,
   config: JiraConfig,
 ): Promise<void> => {
-  const fields = (instance.value.fields ?? [])
+  const fields: Values[] = (instance.value.fields ?? [])
     .filter((fieldConf: Values) => isResolvedReferenceExpression(fieldConf.id))
     .map((fieldConf: Values) => ({ ...fieldConf, id: fieldConf.id.value.value.id }))
 
@@ -47,16 +62,13 @@ const deployFieldConfigurationItems = async (
     return
   }
 
-  await Promise.all(
-    _.chunk(fields, config.client.fieldConfigurationItemsDeploymentLimit).map(async fieldsChunk =>
-      client.put({
-        url: `/rest/api/3/fieldconfiguration/${instance.value.id}/fields`,
-        data: {
-          fieldConfigurationItems: fieldsChunk,
-        },
-      }),
-    ),
-  )
+  const fieldChunks = _.chunk(fields, config.client.fieldConfigurationItemsDeploymentLimit)
+  if (client.isDataCenter) {
+    // in DC calling deploy in parallel for field configuration items causes deadlocks and data corruption
+    await awu(fieldChunks).forEach(async fieldsChunk => putFieldItemsChunk(client, instance.value.id, fieldsChunk))
+  } else {
+    await Promise.all(fieldChunks.map(async fieldsChunk => putFieldItemsChunk(client, instance.value.id, fieldsChunk)))
+  }
 }
 
 const filter: FilterCreator = ({ config, client }) => ({


### PR DESCRIPTION
Following a bug for a customer we limit deployment of field configurations to one at a time in Jira DC

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug with FieldConfiguration deployment in jira DC

---
_User Notifications_: 
None
