### PR TITLE
SALTO-6398: Add syncWorkspaceToFolder API

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -193,7 +193,7 @@ export type LoadElementsFromFolderArgs = {
 
 export type DumpElementsToFolderArgs = {
   baseDir: string
-  changes: Change[]
+  changes: ReadonlyArray<Change>
   elementsSource: ReadOnlyElementsSource
 }
 

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -78,3 +78,4 @@ export {
 } from './src/local-workspace/remote_map'
 export { NoWorkspaceConfig } from './src/local-workspace/errors'
 export * from './src/types'
+export { calculatePatch, syncWorkspaceToFolder } from './src/core/adapter_format'

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -1,0 +1,228 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { Adapter, AdapterOperationsContext, ChangeDataType, Element, SaltoError, toChange } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { collections } from '@salto-io/lowerdash'
+import { merger, Workspace, ElementSelector, expressions, elementSource } from '@salto-io/workspace'
+import { FetchResult } from '../types'
+import { adapterCreators } from './adapters'
+import { MergeErrorWithElements, getFetchAdapterAndServicesSetup, calcFetchChanges } from './fetch'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+const { makeArray } = collections.array
+
+type GetAdapterAndContextArgs = {
+  workspace: Workspace
+  accountName: string
+  ignoreStateElemIdMapping?: boolean
+  ignoreStateElemIdMappingForSelectors?: ElementSelector[]
+}
+
+type GetAdapterAndContextResult = {
+  adapter: Adapter
+  adapterContext: AdapterOperationsContext
+  resolvedElements: Element[]
+}
+
+const getAdapterAndContext = async ({
+  workspace,
+  accountName,
+  ignoreStateElemIdMapping,
+  ignoreStateElemIdMappingForSelectors,
+}: GetAdapterAndContextArgs): Promise<GetAdapterAndContextResult> => {
+  const adapterName = workspace.getServiceFromAccountName(accountName)
+  if (adapterName !== accountName) {
+    throw new Error('Account name that is different from the adapter name is not supported')
+  }
+  const workspaceElements = await workspace.elements()
+  const resolvedElements = await expressions.resolve(
+    await awu(await workspaceElements.getAll()).toArray(),
+    workspaceElements,
+  )
+  const { adaptersCreatorConfigs } = await getFetchAdapterAndServicesSetup({
+    workspace,
+    fetchAccounts: [accountName],
+    accountToServiceNameMap: { [accountName]: adapterName },
+    elementsSource: elementSource.createInMemoryElementSource(resolvedElements),
+    ignoreStateElemIdMapping,
+    ignoreStateElemIdMappingForSelectors,
+  })
+  const adapterContext = adaptersCreatorConfigs[accountName]
+  const adapter = adapterCreators[adapterName]
+  return { adapter, adapterContext, resolvedElements }
+}
+
+const loadElementsAndMerge = async (
+  dir: string,
+  loadElementsFromFolder: NonNullable<Adapter['loadElementsFromFolder']>,
+  adapterContext: AdapterOperationsContext,
+): Promise<{
+  elements: Element[]
+  loadErrors?: SaltoError[]
+  mergeErrors: MergeErrorWithElements[]
+  mergedElements: Element[]
+}> => {
+  const { elements, errors } = await loadElementsFromFolder({ baseDir: dir, ...adapterContext })
+  const mergeResult = await merger.mergeElements(awu(elements))
+  return {
+    elements,
+    loadErrors: errors,
+    mergeErrors: await awu(mergeResult.errors.values()).flat().toArray(),
+    mergedElements: await awu(mergeResult.merged.values()).toArray(),
+  }
+}
+
+type CalculatePatchArgs = {
+  workspace: Workspace
+  fromDir: string
+  toDir: string
+  accountName: string
+  ignoreStateElemIdMapping?: boolean
+  ignoreStateElemIdMappingForSelectors?: ElementSelector[]
+}
+
+export const calculatePatch = async ({
+  workspace,
+  fromDir,
+  toDir,
+  accountName,
+  ignoreStateElemIdMapping,
+  ignoreStateElemIdMappingForSelectors,
+}: CalculatePatchArgs): Promise<FetchResult> => {
+  const { adapter, adapterContext } = await getAdapterAndContext({
+    workspace,
+    accountName,
+    ignoreStateElemIdMapping,
+    ignoreStateElemIdMappingForSelectors,
+  })
+  const { loadElementsFromFolder } = adapter
+  if (loadElementsFromFolder === undefined) {
+    throw new Error(`Account ${accountName}'s adapter does not support loading a non-nacl format`)
+  }
+
+  const {
+    loadErrors: beforeLoadErrors,
+    mergeErrors: beforeMergeErrors,
+    mergedElements: mergedBeforeElements,
+  } = await loadElementsAndMerge(fromDir, loadElementsFromFolder, adapterContext)
+  if (beforeMergeErrors.length > 0) {
+    return {
+      changes: [],
+      mergeErrors: beforeMergeErrors,
+      fetchErrors: [],
+      success: false,
+      updatedConfig: {},
+    }
+  }
+  const {
+    elements: afterElements,
+    loadErrors: afterLoadErrors,
+    mergeErrors: afterMergeErrors,
+    mergedElements: mergedAfterElements,
+  } = await loadElementsAndMerge(toDir, loadElementsFromFolder, adapterContext)
+  if (afterMergeErrors.length > 0) {
+    return {
+      changes: [],
+      mergeErrors: afterMergeErrors,
+      fetchErrors: [],
+      success: false,
+      updatedConfig: {},
+    }
+  }
+  const { changes } = await calcFetchChanges(
+    afterElements,
+    mergedAfterElements,
+    elementSource.createInMemoryElementSource(mergedBeforeElements),
+    await workspace.elements(false),
+    new Map([[accountName, {}]]),
+    new Set([accountName]),
+  )
+  return {
+    changes,
+    mergeErrors: [],
+    fetchErrors: [...(beforeLoadErrors ?? []), ...(afterLoadErrors ?? [])],
+    success: true,
+    updatedConfig: {},
+  }
+}
+
+type SyncWorkspaceToFolderArgs = {
+  workspace: Workspace
+  accountName: string
+  baseDir: string
+  ignoreStateElemIdMapping?: boolean
+  ignoreStateElemIdMappingForSelectors?: ElementSelector[]
+}
+
+export type SyncWorkspaceToFolderResult = {
+  errors: ReadonlyArray<SaltoError>
+}
+export const syncWorkspaceToFolder = async ({
+  workspace,
+  accountName,
+  baseDir,
+  ignoreStateElemIdMapping,
+  ignoreStateElemIdMappingForSelectors,
+}: SyncWorkspaceToFolderArgs): Promise<SyncWorkspaceToFolderResult> => {
+  const { resolvedElements, adapter, adapterContext } = await getAdapterAndContext({
+    workspace,
+    accountName,
+    ignoreStateElemIdMapping,
+    ignoreStateElemIdMappingForSelectors,
+  })
+  const { loadElementsFromFolder, dumpElementsToFolder } = adapter
+  if (loadElementsFromFolder === undefined) {
+    throw new Error(`Account ${accountName}'s adapter does not support loading a non-nacl format`)
+  }
+  if (dumpElementsToFolder === undefined) {
+    throw new Error(`Account ${accountName}'s adapter does not support writing a non-nacl format`)
+  }
+
+  log.debug('Loading elements from folder %s', baseDir)
+  const loadResult = await loadElementsAndMerge(baseDir, loadElementsFromFolder, adapterContext)
+  if (!_.isEmpty(loadResult.loadErrors) || !_.isEmpty(loadResult.mergeErrors)) {
+    return {
+      errors: makeArray(loadResult.loadErrors).concat(loadResult.mergeErrors.map(mergeError => mergeError.error)),
+    }
+  }
+
+  const workspaceElementIDs = new Set(resolvedElements.map(elem => elem.elemID.getFullName()))
+
+  const deleteChanges = loadResult.elements
+    .filter(elem => !workspaceElementIDs.has(elem.elemID.getFullName()))
+    .map(elem => toChange({ before: elem as ChangeDataType }))
+
+  const folderElementsByID = _.keyBy(loadResult.elements, elem => elem.elemID.getFullName())
+
+  const changes = deleteChanges.concat(
+    resolvedElements.map(elem =>
+      toChange({
+        before: folderElementsByID[elem.elemID.getFullName()] as ChangeDataType,
+        after: elem as ChangeDataType,
+      }),
+    ),
+  )
+
+  log.debug(
+    'Loaded %d elements from folder %s, applying %d delete changes and %d addition changes to folder %s',
+    loadResult.elements.length,
+    deleteChanges.length,
+    resolvedElements.length,
+  )
+  return dumpElementsToFolder({ baseDir, changes, elementsSource: adapterContext.elementsSource })
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -18,9 +18,12 @@ import {
   AuthorInformation,
   Change,
   DetailedChangeWithBaseChange,
+  InstanceElement,
   SaltoElementError,
   SaltoError,
 } from '@salto-io/adapter-api'
+import { MergeErrorWithElements } from './core/fetch'
+import { Plan } from './core/plan'
 
 export type FetchChangeMetadata = AuthorInformation
 export type FetchChange = {
@@ -32,6 +35,16 @@ export type FetchChange = {
   pendingChanges?: DetailedChangeWithBaseChange[]
   // Metadata information about the change.
   metadata?: FetchChangeMetadata
+}
+
+export type FetchResult = {
+  changes: FetchChange[]
+  mergeErrors: MergeErrorWithElements[]
+  fetchErrors: SaltoError[]
+  success: boolean
+  configChanges?: Plan
+  updatedConfig: Record<string, InstanceElement[]>
+  accountNameToConfigMessage?: Record<string, string>
 }
 
 export type GroupProperties = AdapterGroupProperties & {

--- a/packages/core/test/api.test.ts
+++ b/packages/core/test/api.test.ts
@@ -47,7 +47,6 @@ import {
 import * as workspace from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
-import { adapter as salesforceAdapter, loadElementsFromFolder } from '@salto-io/salesforce-adapter'
 import * as api from '../src/api'
 import { getAdapterConfigOptionsType, getAdditionalReferences, getLoginStatuses } from '../src/api'
 import * as plan from '../src/core/plan/plan'
@@ -129,21 +128,6 @@ jest.mock('../src/core/diff', () => ({
       : detailedChanges
   }),
 }))
-
-jest.mock('@salto-io/salesforce-adapter', () => {
-  const actual = jest.requireActual('@salto-io/salesforce-adapter')
-  return {
-    ...actual,
-    adapter: {
-      ...actual.adapter,
-      loadElementsFromFolder: jest.fn().mockImplementation(actual.adapter.loadElementsFromFolder),
-    },
-  }
-})
-
-const mockLoadElementsFromFolder = salesforceAdapter.loadElementsFromFolder as jest.MockedFunction<
-  typeof loadElementsFromFolder
->
 
 describe('api.ts', () => {
   const mockAdapterOps = {
@@ -1179,175 +1163,6 @@ describe('api.ts', () => {
           }),
         ]),
       )
-    })
-  })
-
-  describe('calculatePatch', () => {
-    const type = new ObjectType({
-      elemID: new ElemID('salesforce', 'type'),
-      fields: {
-        f: { refType: BuiltinTypes.STRING },
-      },
-    })
-
-    const instance = new InstanceElement('instance', type, { f: 'v' })
-    const instanceWithHidden = new InstanceElement('instance', type, { f: 'v', _service_id: 123 })
-    const instanceState = new InstanceElement('instanceState', type, { f: 'v' })
-    const instanceNacl = instanceState.clone()
-    instanceNacl.value.f = 'v2'
-
-    const ws = mockWorkspace({
-      elements: [type, instanceWithHidden, instanceNacl],
-      elementsWithoutHidden: [type, instance, instanceNacl],
-      stateElements: [type, instanceWithHidden, instanceState],
-      name: 'workspace',
-      accounts: ['salesforce'],
-      accountToServiceName: { salesforce: 'salesforce' },
-    })
-
-    adapterCreators.salesforce = salesforceAdapter
-
-    beforeEach(() => {
-      mockLoadElementsFromFolder.mockClear()
-    })
-
-    describe('when there is a difference between the folders', () => {
-      it('should return the changes with no errors', async () => {
-        const afterModifyInstance = instance.clone()
-        afterModifyInstance.value.f = 'v3'
-        const afterNewInstance = new InstanceElement('instance2', type, { f: 'v' })
-        const beforeElements = [instance]
-        const afterElements = [afterModifyInstance, afterNewInstance]
-        mockLoadElementsFromFolder
-          .mockResolvedValueOnce({ elements: beforeElements })
-          .mockResolvedValueOnce({ elements: afterElements })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeTruthy()
-        expect(res.fetchErrors).toHaveLength(0)
-        expect(res.mergeErrors).toHaveLength(0)
-        expect(res.changes).toHaveLength(2)
-      })
-    })
-
-    describe('when an element is added and also exists in ws', () => {
-      it('should not return changes for hidden values', async () => {
-        const afterModifyInstance = instance.clone()
-        afterModifyInstance.value.f = 'v3'
-        const beforeElements: Element[] = []
-        const afterElements = [afterModifyInstance]
-        mockLoadElementsFromFolder
-          .mockResolvedValueOnce({ elements: beforeElements })
-          .mockResolvedValueOnce({ elements: afterElements })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeTruthy()
-        expect(res.fetchErrors).toHaveLength(0)
-        expect(res.mergeErrors).toHaveLength(0)
-        expect(res.changes).toHaveLength(1)
-        expect(res.changes[0].change.id.name).toEqual('f')
-      })
-    })
-
-    describe('when there is no difference between the folders', () => {
-      it('should return with no changes and no errors', async () => {
-        const beforeElements = [instance]
-        const afterElements = [instance]
-        mockLoadElementsFromFolder
-          .mockResolvedValueOnce({ elements: beforeElements })
-          .mockResolvedValueOnce({ elements: afterElements })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeTruthy()
-        expect(res.fetchErrors).toHaveLength(0)
-        expect(res.mergeErrors).toHaveLength(0)
-        expect(res.changes).toHaveLength(0)
-      })
-    })
-
-    describe('when there is a merge error', () => {
-      it('should return with merge error and success false', async () => {
-        const beforeElements = [instance, instance]
-        mockLoadElementsFromFolder.mockResolvedValueOnce({ elements: beforeElements })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeFalsy()
-        expect(res.fetchErrors).toHaveLength(0)
-        expect(res.changes).toHaveLength(0)
-        expect(res.mergeErrors).toHaveLength(1)
-      })
-    })
-
-    describe('when there is a fetch error', () => {
-      it('should return with changes and fetch errors', async () => {
-        const afterModifyInstance = instance.clone()
-        afterModifyInstance.value.f = 'v3'
-        const beforeElements = [instance]
-        const afterElements = [afterModifyInstance]
-        mockLoadElementsFromFolder
-          .mockResolvedValueOnce({ elements: beforeElements })
-          .mockResolvedValueOnce({ elements: afterElements, errors: [{ message: 'err', severity: 'Warning' }] })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeTruthy()
-        expect(res.changes).toHaveLength(1)
-        expect(res.mergeErrors).toHaveLength(0)
-        expect(res.fetchErrors).toHaveLength(1)
-      })
-    })
-
-    describe('when there are conflicts', () => {
-      it('should return the changes with pendingChanges', async () => {
-        const beforeConflictInstance = instanceState.clone()
-        beforeConflictInstance.value.f = 'v5'
-        const afterConflictInstance = instanceState.clone()
-        afterConflictInstance.value.f = 'v4'
-        const beforeElements = [beforeConflictInstance]
-        const afterElements = [afterConflictInstance]
-        mockLoadElementsFromFolder
-          .mockResolvedValueOnce({ elements: beforeElements })
-          .mockResolvedValueOnce({ elements: afterElements })
-        const res = await api.calculatePatch({
-          workspace: ws,
-          fromDir: 'before',
-          toDir: 'after',
-          accountName: 'salesforce',
-        })
-        expect(res.success).toBeTruthy()
-        expect(res.fetchErrors).toHaveLength(0)
-        expect(res.mergeErrors).toHaveLength(0)
-        expect(res.changes).toHaveLength(1)
-        const firstChange = (await awu(res.changes).toArray())[0]
-        expect(firstChange.pendingChanges).toHaveLength(1)
-      })
-    })
-
-    describe('when used with an account that does not support loadElementsFromFolder', () => {
-      it('Should throw an error', async () => {
-        await expect(
-          api.calculatePatch({ workspace: ws, fromDir: 'before', toDir: 'after', accountName: 'notSalesforce' }),
-        ).rejects.toThrow()
-      })
     })
   })
 

--- a/packages/core/test/core/adapter_format.test.ts
+++ b/packages/core/test/core/adapter_format.test.ts
@@ -1,0 +1,343 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  ObjectType,
+  ElemID,
+  BuiltinTypes,
+  InstanceElement,
+  Element,
+  Adapter,
+  toChange,
+  SaltoError,
+} from '@salto-io/adapter-api'
+import { Workspace } from '@salto-io/workspace'
+import { collections } from '@salto-io/lowerdash'
+import { adapterCreators } from '../../src/core/adapters'
+import { mockWorkspace } from '../common/workspace'
+import { createMockAdapter } from '../common/helpers'
+import { calculatePatch, syncWorkspaceToFolder, SyncWorkspaceToFolderResult } from '../../src/core/adapter_format'
+
+const { awu } = collections.asynciterable
+
+describe('calculatePatch', () => {
+  const mockAdapterName = 'mock'
+  const type = new ObjectType({
+    elemID: new ElemID(mockAdapterName, 'type'),
+    fields: {
+      f: { refType: BuiltinTypes.STRING },
+    },
+  })
+
+  const instance = new InstanceElement('instance', type, { f: 'v' })
+  const instanceWithHidden = new InstanceElement('instance', type, { f: 'v', _service_id: 123 })
+  const instanceState = new InstanceElement('instanceState', type, { f: 'v' })
+  const instanceNacl = instanceState.clone()
+  instanceNacl.value.f = 'v2'
+
+  let mockAdapter: ReturnType<typeof createMockAdapter>
+  let workspace: Workspace
+  beforeEach(() => {
+    mockAdapter = createMockAdapter(mockAdapterName)
+    adapterCreators[mockAdapterName] = mockAdapter
+
+    workspace = mockWorkspace({
+      elements: [type, instanceWithHidden, instanceNacl],
+      elementsWithoutHidden: [type, instance, instanceNacl],
+      stateElements: [type, instanceWithHidden, instanceState],
+      name: 'workspace',
+      accounts: [mockAdapterName],
+      accountToServiceName: { [mockAdapterName]: mockAdapterName },
+    })
+  })
+  afterEach(() => {
+    delete adapterCreators[mockAdapterName]
+  })
+
+  describe('when there is a difference between the folders', () => {
+    it('should return the changes with no errors', async () => {
+      const afterModifyInstance = instance.clone()
+      afterModifyInstance.value.f = 'v3'
+      const afterNewInstance = new InstanceElement('instance2', type, { f: 'v' })
+      const beforeElements = [instance]
+      const afterElements = [afterModifyInstance, afterNewInstance]
+      mockAdapter.loadElementsFromFolder
+        .mockResolvedValueOnce({ elements: beforeElements })
+        .mockResolvedValueOnce({ elements: afterElements })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeTruthy()
+      expect(res.fetchErrors).toHaveLength(0)
+      expect(res.mergeErrors).toHaveLength(0)
+      expect(res.changes).toHaveLength(2)
+    })
+  })
+
+  describe('when an element is added and also exists in ws', () => {
+    it('should not return changes for hidden values', async () => {
+      const afterModifyInstance = instance.clone()
+      afterModifyInstance.value.f = 'v3'
+      const beforeElements: Element[] = []
+      const afterElements = [afterModifyInstance]
+      mockAdapter.loadElementsFromFolder
+        .mockResolvedValueOnce({ elements: beforeElements })
+        .mockResolvedValueOnce({ elements: afterElements })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeTruthy()
+      expect(res.fetchErrors).toHaveLength(0)
+      expect(res.mergeErrors).toHaveLength(0)
+      expect(res.changes).toHaveLength(1)
+      expect(res.changes[0].change.id.name).toEqual('f')
+    })
+  })
+
+  describe('when there is no difference between the folders', () => {
+    it('should return with no changes and no errors', async () => {
+      const beforeElements = [instance]
+      const afterElements = [instance]
+      mockAdapter.loadElementsFromFolder
+        .mockResolvedValueOnce({ elements: beforeElements })
+        .mockResolvedValueOnce({ elements: afterElements })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeTruthy()
+      expect(res.fetchErrors).toHaveLength(0)
+      expect(res.mergeErrors).toHaveLength(0)
+      expect(res.changes).toHaveLength(0)
+    })
+  })
+
+  describe('when there is a merge error', () => {
+    it('should return with merge error and success false', async () => {
+      const beforeElements = [instance, instance]
+      mockAdapter.loadElementsFromFolder.mockResolvedValueOnce({ elements: beforeElements })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeFalsy()
+      expect(res.fetchErrors).toHaveLength(0)
+      expect(res.changes).toHaveLength(0)
+      expect(res.mergeErrors).toHaveLength(1)
+    })
+  })
+
+  describe('when there is a fetch error', () => {
+    it('should return with changes and fetch errors', async () => {
+      const afterModifyInstance = instance.clone()
+      afterModifyInstance.value.f = 'v3'
+      const beforeElements = [instance]
+      const afterElements = [afterModifyInstance]
+      mockAdapter.loadElementsFromFolder
+        .mockResolvedValueOnce({ elements: beforeElements })
+        .mockResolvedValueOnce({ elements: afterElements, errors: [{ message: 'err', severity: 'Warning' }] })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeTruthy()
+      expect(res.changes).toHaveLength(1)
+      expect(res.mergeErrors).toHaveLength(0)
+      expect(res.fetchErrors).toHaveLength(1)
+    })
+  })
+
+  describe('when there are conflicts', () => {
+    it('should return the changes with pendingChanges', async () => {
+      const beforeConflictInstance = instanceState.clone()
+      beforeConflictInstance.value.f = 'v5'
+      const afterConflictInstance = instanceState.clone()
+      afterConflictInstance.value.f = 'v4'
+      const beforeElements = [beforeConflictInstance]
+      const afterElements = [afterConflictInstance]
+      mockAdapter.loadElementsFromFolder
+        .mockResolvedValueOnce({ elements: beforeElements })
+        .mockResolvedValueOnce({ elements: afterElements })
+      const res = await calculatePatch({
+        workspace,
+        fromDir: 'before',
+        toDir: 'after',
+        accountName: mockAdapterName,
+      })
+      expect(res.success).toBeTruthy()
+      expect(res.fetchErrors).toHaveLength(0)
+      expect(res.mergeErrors).toHaveLength(0)
+      expect(res.changes).toHaveLength(1)
+      const firstChange = (await awu(res.changes).toArray())[0]
+      expect(firstChange.pendingChanges).toHaveLength(1)
+    })
+  })
+
+  describe('when used with an account that does not support loadElementsFromFolder', () => {
+    it('Should throw an error', async () => {
+      delete (mockAdapter as Adapter).loadElementsFromFolder
+      await expect(
+        calculatePatch({ workspace, fromDir: 'before', toDir: 'after', accountName: mockAdapterName }),
+      ).rejects.toThrow()
+    })
+  })
+})
+
+describe('syncWorkspaceToFolder', () => {
+  const mockAdapterName = 'mock'
+
+  let mockAdapter: ReturnType<typeof createMockAdapter>
+
+  beforeEach(() => {
+    mockAdapter = createMockAdapter(mockAdapterName)
+    adapterCreators[mockAdapterName] = mockAdapter
+  })
+  afterEach(() => {
+    delete adapterCreators[mockAdapterName]
+  })
+  describe('when the folder has different elements from the workspace', () => {
+    let separateInstanceInFolder: InstanceElement
+    let separateInstanceInWorkspace: InstanceElement
+    let sameInstanceInFolder: InstanceElement
+    let sameInstanceInWorkspace: InstanceElement
+
+    let workspace: Workspace
+    beforeEach(() => {
+      const type = new ObjectType({ elemID: new ElemID(mockAdapterName, 'type') })
+      separateInstanceInFolder = new InstanceElement('folderInst', type, { value: 'folder' })
+      separateInstanceInWorkspace = new InstanceElement('workspaceInst', type, { value: 'ws' })
+      sameInstanceInFolder = new InstanceElement('sameInst', type, { value: 'folder' })
+      sameInstanceInWorkspace = new InstanceElement('sameInst', type, { value: 'ws' })
+
+      const workspaceElements = [type, separateInstanceInWorkspace, sameInstanceInWorkspace]
+      const folderElements = [type, separateInstanceInFolder, sameInstanceInFolder]
+
+      workspace = mockWorkspace({
+        elements: workspaceElements,
+        name: 'workspace',
+        accounts: [mockAdapterName],
+        accountToServiceName: { [mockAdapterName]: mockAdapterName },
+      })
+      mockAdapter.loadElementsFromFolder.mockResolvedValue({ elements: folderElements })
+    })
+    describe('when adapter supports all required actions', () => {
+      let result: SyncWorkspaceToFolderResult
+      beforeEach(async () => {
+        result = await syncWorkspaceToFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      })
+      it('should return no errors', () => {
+        expect(result.errors).toBeEmpty()
+      })
+      it('should apply deletion changes for elements that exist in the folder and not the workspace', () => {
+        expect(mockAdapter.dumpElementsToFolder).toHaveBeenCalledWith({
+          baseDir: 'dir',
+          changes: expect.arrayContaining([toChange({ before: separateInstanceInFolder })]),
+          elementsSource: expect.anything(),
+        })
+      })
+      it('should apply modification changes for elements that exist in both the workspace and the folder', () => {
+        // Note - we currently do not expect the function to filter out changes for elements that are identical
+        expect(mockAdapter.dumpElementsToFolder).toHaveBeenCalledWith({
+          baseDir: 'dir',
+          changes: expect.arrayContaining([toChange({ before: sameInstanceInFolder, after: sameInstanceInWorkspace })]),
+          elementsSource: expect.anything(),
+        })
+      })
+      it('should apply addition changes for elements that exist in the workspace and not the folder', () => {
+        expect(mockAdapter.dumpElementsToFolder).toHaveBeenCalledWith({
+          baseDir: 'dir',
+          changes: expect.arrayContaining([toChange({ after: separateInstanceInWorkspace })]),
+          elementsSource: expect.anything(),
+        })
+      })
+    })
+
+    describe('when adapter does not support loading from folder', () => {
+      let result: Promise<SyncWorkspaceToFolderResult>
+      beforeEach(() => {
+        delete (mockAdapter as Adapter).loadElementsFromFolder
+        result = syncWorkspaceToFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      })
+      it('should throw an error', async () => {
+        await expect(result).rejects.toThrow()
+      })
+    })
+    describe('when adapter does not support dumping to folder', () => {
+      let result: Promise<SyncWorkspaceToFolderResult>
+      beforeEach(() => {
+        delete (mockAdapter as Adapter).dumpElementsToFolder
+        result = syncWorkspaceToFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      })
+      it('should throw an error', async () => {
+        await expect(result).rejects.toThrow()
+      })
+    })
+
+    describe('when loading elements from folder returns an error', () => {
+      let result: SyncWorkspaceToFolderResult
+      let errors: SaltoError[]
+      beforeEach(async () => {
+        errors = [{ severity: 'Error', message: 'something failed' }]
+        mockAdapter.loadElementsFromFolder.mockResolvedValue({ elements: [], errors })
+        result = await syncWorkspaceToFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      })
+      it('should return the error without trying to update the folder', () => {
+        expect(result.errors).toEqual(errors)
+        expect(mockAdapter.dumpElementsToFolder).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('when dumping elements to folder returns an error', () => {
+      let result: SyncWorkspaceToFolderResult
+      let errors: SaltoError[]
+      beforeEach(async () => {
+        errors = [{ severity: 'Error', message: 'something failed' }]
+        mockAdapter.dumpElementsToFolder.mockResolvedValue({ errors, unappliedChanges: [] })
+        result = await syncWorkspaceToFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      })
+      it('should return the error in the result', () => {
+        expect(result.errors).toEqual(errors)
+      })
+    })
+  })
+  describe('when the account name is not the same as the adapter name', () => {
+    let result: Promise<SyncWorkspaceToFolderResult>
+    beforeEach(() => {
+      const accountName = 'account'
+      const workspace = mockWorkspace({
+        name: 'workspace',
+        elements: [],
+        accounts: [accountName],
+        accountToServiceName: { [accountName]: mockAdapterName },
+      })
+      result = syncWorkspaceToFolder({ workspace, accountName, baseDir: 'dir' })
+    })
+    it('should throw an error', async () => {
+      await expect(result).rejects.toThrow()
+    })
+  })
+})


### PR DESCRIPTION
Add a new core API that syncs the elements from a workspace to a folder in an adapter format (SFDX) This also refactors the existing "calculatePatch" function which also deals with adapter formatted folders

---

_Additional context for reviewer_
No release notes yet since this is not an exposed command.
will add to the release notes once the CLI command is added

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_