### PR TITLE
SALTO-6403 Pagerduty remove direct fetch from recurseInto serviceOrchestration type

### DIFF
--- a/packages/pagerduty-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/pagerduty-adapter/src/definitions/fetch/fetch.ts
@@ -108,7 +108,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
       },
     ],
     resource: {
-      directFetch: true,
+      directFetch: false,
     },
     element: {
       topLevel: {

--- a/packages/pagerduty-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/pagerduty-adapter/src/definitions/fetch/fetch.ts
@@ -107,9 +107,6 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
       },
     ],
-    resource: {
-      directFetch: false,
-    },
     element: {
       topLevel: {
         isTopLevel: true,
@@ -247,9 +244,6 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
     },
   },
   [SCHEDULE_LAYERS_TYPE_NAME]: {
-    resource: {
-      directFetch: false,
-    },
     element: {
       topLevel: {
         isTopLevel: true,
@@ -318,9 +312,6 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
         },
       },
     ],
-    resource: {
-      directFetch: true,
-    },
     element: {
       topLevel: {
         isTopLevel: true,


### PR DESCRIPTION
SALTO-6403 Pagerduty remove direct fetch from recurseInto serviceOrchestration type
---

_Additional context for reviewer_

---
_Release Notes_: 
none

---
_User Notifications_: 
none