### PR TITLE
SALTO-5692: Okta: Add HTTP recording tests for `NetworkZone`

### DIFF
--- a/packages/okta-adapter/test/mock_replies/network_zone_activate.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_activate.json
@@ -1,0 +1,92 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:04:22.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "95",
+      "x-rate-limit-reset": "1722845121"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:04:49.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "94",
+      "x-rate-limit-reset": "1722845121"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_activate.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_activate.json
@@ -22,13 +22,13 @@
       "proxies": null,
       "_links": {
         "self": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1",
           "hints": {
             "allow": ["GET", "PUT", "DELETE"]
           }
         },
         "deactivate": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
           "hints": {
             "allow": ["POST"]
           }
@@ -69,13 +69,13 @@
       "proxies": null,
       "_links": {
         "self": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1",
           "hints": {
             "allow": ["GET", "PUT", "DELETE"]
           }
         },
         "deactivate": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
           "hints": {
             "allow": ["POST"]
           }

--- a/packages/okta-adapter/test/mock_replies/network_zone_add_active.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_add_active.json
@@ -11,13 +11,13 @@
       "status": "ACTIVE",
       "_links": {
         "self": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1",
           "hints": {
             "allow": ["GET", "PUT", "DELETE"]
           }
         },
         "deactivate": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
           "hints": {
             "allow": ["POST"]
           }

--- a/packages/okta-adapter/test/mock_replies/network_zone_add_active.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_add_active.json
@@ -1,0 +1,37 @@
+[
+  {
+    "path": "/api/v1/zones",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "_links": {
+        "self": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {
+      "name": "my_zone",
+      "status": "ACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1722844893"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_add_inactive.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_add_inactive.json
@@ -21,13 +21,13 @@
       "proxies": null,
       "_links": {
         "self": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1",
           "hints": {
             "allow": ["GET", "PUT", "DELETE"]
           }
         },
         "deactivate": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
           "hints": {
             "allow": ["POST"]
           }
@@ -66,13 +66,13 @@
       "proxies": null,
       "_links": {
         "activate": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
           "hints": {
             "allow": ["POST"]
           }
         },
         "self": {
-          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "href": "https://<sanitized>.okta.com/api/v1/zones/networkzone-fakeid1",
           "hints": {
             "allow": ["GET", "PUT", "DELETE"]
           }

--- a/packages/okta-adapter/test/mock_replies/network_zone_add_inactive.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_add_inactive.json
@@ -1,0 +1,89 @@
+[
+  {
+    "path": "/api/v1/zones",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:01:12.000Z",
+      "lastUpdated": "2024-08-05T08:01:12.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-100.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {
+      "name": "my_zone",
+      "status": "INACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "96",
+      "x-rate-limit-reset": "1722844893"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "INACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:01:12.000Z",
+      "lastUpdated": "2024-08-05T08:01:13.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-100.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://dev-91042815.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "95",
+      "x-rate-limit-reset": "1722844893"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_deactivate.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_deactivate.json
@@ -1,0 +1,92 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "INACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:04:22.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1722845121"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:04:22.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "INACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "97",
+      "x-rate-limit-reset": "1722845121"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_modify.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_modify.json
@@ -1,0 +1,49 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:00:33.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "networkzone-fakeid1",
+      "name": "your_zone",
+      "status": "ACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1722844981"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_modify_and_activate.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_modify_and_activate.json
@@ -1,0 +1,92 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:03:35.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "networkzone-fakeid1",
+      "name": "your_zone",
+      "status": "ACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "92",
+      "x-rate-limit-reset": "1722845054"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "ACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:03:54.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        },
+        "deactivate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "91",
+      "x-rate-limit-reset": "1722845054"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_modify_and_deactivate.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_modify_and_deactivate.json
@@ -1,0 +1,92 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "INACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:03:34.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-200.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "95",
+      "x-rate-limit-reset": "1722845054"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone",
+      "status": "INACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:00:33.000Z",
+      "lastUpdated": "2024-08-05T08:03:34.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-100.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "networkzone-fakeid1",
+      "name": "your_zone",
+      "status": "INACTIVE"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "94",
+      "x-rate-limit-reset": "1722845054"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/network_zone_remove.json
+++ b/packages/okta-adapter/test/mock_replies/network_zone_remove.json
@@ -1,0 +1,57 @@
+[
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1/lifecycle/deactivate",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "type": "IP",
+      "id": "networkzone-fakeid1",
+      "name": "my_zone2",
+      "status": "INACTIVE",
+      "usage": "POLICY",
+      "created": "2024-08-05T08:01:12.000Z",
+      "lastUpdated": "2024-08-05T08:05:12.000Z",
+      "system": false,
+      "gateways": [
+        {
+          "type": "RANGE",
+          "value": "100.100.100.100-100.100.100.100"
+        }
+      ],
+      "proxies": null,
+      "_links": {
+        "activate": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1/lifecycle/activate",
+          "hints": {
+            "allow": ["POST"]
+          }
+        },
+        "self": {
+          "href": "https://<omitted>.okta.com/api/v1/zones/networkzone-fakeid1",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "92",
+      "x-rate-limit-reset": "1722845121"
+    }
+  },
+  {
+    "path": "/api/v1/zones/networkzone-fakeid1",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "91",
+      "x-rate-limit-reset": "1722845121"
+    }
+  }
+]


### PR DESCRIPTION
See title.

---

_Additional context for reviewer_
This PR is just the tests, not the upgrade yet.

---
_Release Notes_: 
None

---
_User Notifications_: 
None