### PR TITLE
SAAS-11750: CPQ Rules and Conditions Filter creates invalid TemplateExpressions when no conditions are fetched for Rule

### DIFF
--- a/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
@@ -26,6 +26,7 @@ import {
   TemplatePart,
 } from '@salto-io/adapter-api'
 import {
+  compactTemplate,
   createTemplateExpression,
   inspectValue,
   replaceTemplatesWithValues,
@@ -177,21 +178,23 @@ const setCustomConditionReferences = ({
   if (rawParts == null || rawParts.every(part => _.isNaN(Number(part)))) {
     return 0
   }
-  rule.value[def.rule.customConditionField] = createTemplateExpression({
-    parts: rawParts.map(part => {
-      const index = Number(part)
-      if (index == null) {
-        return part
-      }
-      const condition = conditionsByIndex[index]
-      if (condition === undefined) {
-        log.warn(`Could not find condition with index ${index} for rule ${rule.elemID.getFullName()}`)
-        return part
-      }
-      createdReferences += 1
-      return new ReferenceExpression(condition.elemID, condition)
+  rule.value[def.rule.customConditionField] = compactTemplate(
+    createTemplateExpression({
+      parts: rawParts.map(part => {
+        const index = Number(part)
+        if (index == null) {
+          return part
+        }
+        const condition = conditionsByIndex[index]
+        if (condition === undefined) {
+          log.warn(`Could not find condition with index ${index} for rule ${rule.elemID.getFullName()}`)
+          return part
+        }
+        createdReferences += 1
+        return new ReferenceExpression(condition.elemID, condition)
+      }),
     }),
-  })
+  )
   return createdReferences
 }
 

--- a/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
@@ -182,7 +182,7 @@ const setCustomConditionReferences = ({
     createTemplateExpression({
       parts: rawParts.map(part => {
         const index = Number(part)
-        if (index == null) {
+        if (Number.isNaN(index)) {
           return part
         }
         const condition = conditionsByIndex[index]

--- a/packages/salesforce-adapter/test/filters/cpq/rules_and_conditions_refs.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/rules_and_conditions_refs.test.ts
@@ -121,5 +121,9 @@ describe('CPQ Rules and Conditions References', () => {
       expect(advancedConditionAfterDeploy).toSatisfy(isTemplateExpression)
       expect(advancedConditionAfterDeploy.parts).toEqual(clonedAdvancedConditionParts)
     })
+    it('should not convert advanced conditions to TemplateExpressions if no conditions are fetched for rule', async () => {
+      await filter.onFetch([ruleInstance])
+      expect(ruleInstance.value[CPQ_ADVANCED_CONDITION_FIELD]).toEqual(ADVANCED_CONDITION)
+    })
   })
 })


### PR DESCRIPTION
CPQ Rules and Conditions Filter creates invalid TemplateExpressions when no conditions are fetched for Rule

---

When a `TemplateExpression` contains a single part that is string, the env will have non-semantic pending changes. (As we compare `TemplateExpression` with a string)

This is an edge-case that the filter can reach when no conditions were fetched for the `Custom Rule`.

---
_Release Notes_: 
Salesforce Adapter:
- Bugfix: CPQ Rules and Conditions Filter creates invalid TemplateExpressions when no conditions are fetched for Rule.

---
_User Notifications_: 
_None_
