### PR TITLE
SALTO-6411: Add reference from IdP type to Group type (Okta)

### DIFF
--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -131,7 +131,7 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     target: { type: USERTYPE_TYPE_NAME },
   },
   {
-    src: { field: 'include', parentTypes: ['GroupCondition'] },
+    src: { field: 'include', parentTypes: ['GroupCondition', 'PolicyAccountLinkFilterGroups'] },
     serializationStrategy: 'id',
     target: { type: GROUP_TYPE_NAME },
   },
@@ -263,6 +263,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: GROUP_PUSH_RULE_TYPE_NAME },
   },
+  {
+    src: { field: 'assignments', parentTypes: ['ProvisioningGroups'] },
+    serializationStrategy: 'id',
+    target: { type: GROUP_TYPE_NAME },
+  }
 ]
 
 const userReferenceRules: OktaFieldReferenceDefinition[] = [

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -267,7 +267,7 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     src: { field: 'assignments', parentTypes: ['ProvisioningGroups'] },
     serializationStrategy: 'id',
     target: { type: GROUP_TYPE_NAME },
-  }
+  },
 ]
 
 const userReferenceRules: OktaFieldReferenceDefinition[] = [


### PR DESCRIPTION
Add 2 rules in order to parse references to `Group` type from inner types in `IdentityProviderType`

---

_Additional context for reviewer_
This is a noisy change, will follow up with noise reduction / prod ticket

---
_Release Notes_: 

_Okta_adapter_:
- References to groups will be added to Identity Provider instances with assigned groups

---
_User Notifications_: 

_Okta_adapter_:
- References to groups will be added to Identity Provider instances with assigned groups
