### PR TITLE
SALTO-6400: Add reference from UserSchema properties sourced by apps to Application type (Okta)

### DIFF
--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -73,7 +73,7 @@ const getProfileMappingRefByType: referenceUtils.ContextValueMapperFunc = val =>
 const getProfileMappingRefByName: referenceUtils.ContextValueMapperFunc = val =>
   val.endsWith('_idp') ? IDENTITY_PROVIDER_TYPE_NAME : undefined
 
-const getUserSchemaPropertyOverrideType: referenceUtils.ContextValueMapperFunc = val => 
+const getUserSchemaPropertyOverrideType: referenceUtils.ContextValueMapperFunc = val =>
   val === 'APP' ? APPLICATION_TYPE_NAME : undefined
 
 export type ReferenceContextStrategyName = 'profileMappingType' | 'profileMappingName' | 'UserSchemaPropertyAppOverride'

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -76,7 +76,7 @@ const getProfileMappingRefByName: referenceUtils.ContextValueMapperFunc = val =>
 const getUserSchemaPropertyOverrideType: referenceUtils.ContextValueMapperFunc = val =>
   val === 'APP' ? APPLICATION_TYPE_NAME : undefined
 
-export type ReferenceContextStrategyName = 'profileMappingType' | 'profileMappingName' | 'UserSchemaPropertyAppOverride'
+export type ReferenceContextStrategyName = 'profileMappingType' | 'profileMappingName' | 'userSchemaPropertyAppOverride'
 
 export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   profileMappingType: referenceUtils.neighborContextGetter({
@@ -89,7 +89,7 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
     getLookUpName: async ({ ref }) => ref.elemID.name,
     contextValueMapper: getProfileMappingRefByName,
   }),
-  UserSchemaPropertyAppOverride: referenceUtils.neighborContextGetter({
+  userSchemaPropertyAppOverride: referenceUtils.neighborContextGetter({
     contextFieldName: 'type',
     getLookUpName: async ({ ref }) => ref.elemID.name,
     contextValueMapper: getUserSchemaPropertyOverrideType,
@@ -262,7 +262,7 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'value', parentTypes: ['UserSchemaAttributeMasterPriority'] },
     serializationStrategy: 'id',
-    target: { typeContext: 'UserSchemaPropertyAppOverride' },
+    target: { typeContext: 'userSchemaPropertyAppOverride' },
   },
   {
     src: { field: 'userGroupId', parentTypes: [GROUP_PUSH_TYPE_NAME] },

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -73,7 +73,10 @@ const getProfileMappingRefByType: referenceUtils.ContextValueMapperFunc = val =>
 const getProfileMappingRefByName: referenceUtils.ContextValueMapperFunc = val =>
   val.endsWith('_idp') ? IDENTITY_PROVIDER_TYPE_NAME : undefined
 
-export type ReferenceContextStrategyName = 'profileMappingType' | 'profileMappingName'
+const getUserSchemaPropertyOverrideType: referenceUtils.ContextValueMapperFunc = val => 
+  val === 'APP' ? APPLICATION_TYPE_NAME : undefined
+
+export type ReferenceContextStrategyName = 'profileMappingType' | 'profileMappingName' | 'UserSchemaPropertyAppOverride'
 
 export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   profileMappingType: referenceUtils.neighborContextGetter({
@@ -85,6 +88,11 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
     contextFieldName: 'name',
     getLookUpName: async ({ ref }) => ref.elemID.name,
     contextValueMapper: getProfileMappingRefByName,
+  }),
+  UserSchemaPropertyAppOverride: referenceUtils.neighborContextGetter({
+    contextFieldName: 'type',
+    getLookUpName: async ({ ref }) => ref.elemID.name,
+    contextValueMapper: getUserSchemaPropertyOverrideType,
   }),
 }
 
@@ -250,6 +258,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',
     target: { type: BRAND_TYPE_NAME },
+  },
+  {
+    src: { field: 'value', parentTypes: ['UserSchemaAttributeMasterPriority'] },
+    serializationStrategy: 'id',
+    target: { typeContext: 'UserSchemaPropertyAppOverride' },
   },
   {
     src: { field: 'userGroupId', parentTypes: [GROUP_PUSH_TYPE_NAME] },


### PR DESCRIPTION
Add reference from `UserSchema` to `Application`

---

_Additional context for reviewer_
I used context strategy cause the reference should only be created with `type = 'APP'`
This is a noisy change, will followup with noise reduction / prod ticket

---
_Release Notes_: 

_Okta_adapter_:
- Add reference from UserSchema type to `Application` type

---
_User Notifications_: 

_Okta_adapter_:
- `UserSchema` instances with properties sourced by external app will have `Application` reference added