### PR TITLE
SALTO-6367: Adjust migrated MFA policies to Identity Engine format in Okta

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/index.ts
+++ b/packages/okta-adapter/src/definitions/fetch/index.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export { createFetchDefinitions, CLASSIC_ENGINE_UNSUPPORTED_TYPES } from './fetch'
+export { createFetchDefinitions } from './fetch'

--- a/packages/okta-adapter/src/definitions/fetch/types/mfa_policy.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/mfa_policy.ts
@@ -1,0 +1,89 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Joi from 'joi'
+import _ from 'lodash'
+import { createSchemeGuard, inspectValue, validatePlainObject } from '@salto-io/adapter-utils'
+import { definitions } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { MFA_POLICY_TYPE_NAME } from '../../../constants'
+
+const log = logger(module)
+
+const MFA_FACTORS_SCHEMA = Joi.object({
+  settings: Joi.object({
+    factors: Joi.object()
+      .pattern(
+        Joi.string(),
+        Joi.object({
+          enroll: Joi.object({
+            self: Joi.string(),
+          }).unknown(true),
+        }).unknown(true),
+      )
+      .required(),
+  })
+    .unknown(true)
+    .required(),
+})
+  .required()
+  .unknown(true)
+
+export type MfaFactorSchema = {
+  enroll: {
+    self: string
+  }
+}
+type MfaFactorsSchema = {
+  settings: {
+    factors: Record<string, MfaFactorSchema>
+  }
+}
+
+const isClassicEngineMfaPolicy = createSchemeGuard<MfaFactorsSchema>(MFA_FACTORS_SCHEMA)
+
+/*
+ * MFA policies in Okta identity Engine migrated from classic engine has factors object instead of authenticators array.
+ * On the first change to the policy, factors object is automatically converted to authenticators.
+ * This function converts the factors object to authenticators array for Okta identity Engine, in order to create references and allow deploy.
+ * For reference, see https://developer.okta.com/docs/reference/api/policy/#policy-factor-enroll-object
+ */
+export const createMfaFactorsAdjustFunc: ({
+  isClassicEngine,
+}: {
+  isClassicEngine?: boolean
+}) => definitions.AdjustFunctionSingle =
+  ({ isClassicEngine = false }) =>
+  async ({ value }) => {
+    validatePlainObject(value, MFA_POLICY_TYPE_NAME)
+    if (isClassicEngine || !isClassicEngineMfaPolicy(value)) {
+      return { value }
+    }
+    log.trace('adjusting MFA factors schema: %s', inspectValue(value.settings.factors))
+    const adjustedFactors = Object.entries(value.settings.factors).map(([key, factor]) => ({
+      key,
+      ...factor,
+    }))
+    return {
+      value: {
+        ...value,
+        settings: {
+          ..._.omit(value.settings, 'factors'),
+          type: 'AUTHENTICATORS',
+          authenticators: adjustedFactors,
+        },
+      },
+    }
+  }

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -183,7 +183,7 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'key', parentTypes: ['MultifactorEnrollmentPolicyAuthenticatorSettings'] },
     serializationStrategy: 'key',
-    missingRefStrategy: 'typeAndValue',
+    // no missingRefStrategy as non-existing authenticators are allowed
     target: { type: AUTHENTICATOR_TYPE_NAME },
   },
   {

--- a/packages/okta-adapter/test/definitions/fetch/types/mfa_policy.test.ts
+++ b/packages/okta-adapter/test/definitions/fetch/types/mfa_policy.test.ts
@@ -1,0 +1,67 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import { MFA_POLICY_TYPE_NAME } from '../../../../src/constants'
+import { createMfaFactorsAdjustFunc } from '../../../../src/definitions/fetch/types/mfa_policy'
+
+describe('createMfaFactorsAdjustFunc', () => {
+  const identityEngineMfa = {
+    id: '111',
+    name: 'test',
+    settings: {
+      type: 'AUTHENTICATORS',
+      authenticators: [
+        {
+          key: 'okta_otp',
+          enroll: { self: 'OPTIONAL' },
+        },
+        {
+          key: 'password',
+          enroll: { self: 'REQUIRED' },
+        },
+      ],
+    },
+  }
+  const classicEngineMfa = {
+    id: '111',
+    name: 'test',
+    settings: {
+      factors: {
+        okta_otp: {
+          enroll: { self: 'OPTIONAL' },
+        },
+        password: {
+          enroll: { self: 'REQUIRED' },
+        },
+      },
+    },
+  }
+  it('should do nothing if org is classic engine', async () => {
+    const func = createMfaFactorsAdjustFunc({ isClassicEngine: true })
+    const result = await func({ typeName: MFA_POLICY_TYPE_NAME, value: _.cloneDeep(classicEngineMfa), context: {} })
+    expect(result.value).toEqual(classicEngineMfa)
+  })
+  it('should convert MFA policy structure when okta is identity engine but the MFA format contains "factors"', async () => {
+    const func = createMfaFactorsAdjustFunc({ isClassicEngine: false })
+    const result = await func({ typeName: MFA_POLICY_TYPE_NAME, value: _.cloneDeep(classicEngineMfa), context: {} })
+    expect(result.value).toEqual(identityEngineMfa)
+  })
+  it('should do nothing when the MFA policy structure is already in the correct format', async () => {
+    const func = createMfaFactorsAdjustFunc({ isClassicEngine: false })
+    const result = await func({ typeName: MFA_POLICY_TYPE_NAME, value: _.cloneDeep(identityEngineMfa), context: {} })
+    expect(result.value).toEqual(identityEngineMfa)
+  })
+})


### PR DESCRIPTION
Adjust MFA policies on fetch 

---

_Additional context for reviewer_
The change is needed to - 
1. Parse references correctly to authenticators
2. The nacl at its current state is not deployable for Identity Engine accounts

---
_Release Notes_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
