### PR TITLE
SALTO-6415: Fix empty key for context options

### DIFF
--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -168,7 +168,8 @@ const transformOptionsToMap = (instance: InstanceElement): void => {
         if (option.value === '') {
           return '@'
         }
-        return naclCase(option.value)})
+        return naclCase(option.value)
+      })
     })
 }
 

--- a/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_structure_filter.ts
@@ -164,7 +164,11 @@ const transformOptionsToMap = (instance: InstanceElement): void => {
         position: position + 1,
       }))
 
-      context.options = _.keyBy(optionsWithIndex, option => naclCase(option.value))
+      context.options = _.keyBy(optionsWithIndex, option => {
+        if (option.value === '') {
+          return '@'
+        }
+        return naclCase(option.value)})
     })
 }
 

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -202,7 +202,7 @@ describe('fields_structure', () => {
             {
               id: 7,
               value: '',
-            }
+            },
           ],
         },
       ],
@@ -248,11 +248,11 @@ describe('fields_structure', () => {
             },
           },
         },
-        '@':{
+        '@': {
           id: 7,
           value: '',
           position: 3,
-        }
+        },
       },
     })
   })

--- a/packages/jira-adapter/test/filters/fields/field_structure.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_structure.test.ts
@@ -199,6 +199,10 @@ describe('fields_structure', () => {
               value: 'someValue6',
               optionId: '2',
             },
+            {
+              id: 7,
+              value: '',
+            }
           ],
         },
       ],
@@ -244,6 +248,11 @@ describe('fields_structure', () => {
             },
           },
         },
+        '@':{
+          id: 7,
+          value: '',
+          position: 3,
+        }
       },
     })
   })


### PR DESCRIPTION
In this PR, I modified the empty key in the context option to be saved as @ instead of an empty string.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter_:
* Fixed a bug that caused duplicate attributes due to an empty string in the context option's key.


---
_User Notifications_: 
_Jira Adapter_:
* The empty string inside the options field in `CustomFieldContext` will now be replaced by '@'.
