### PR TITLE
SALTO-6417: Change question type in forms

### DIFF
--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, ListType } from '@salto-io/adapter-api'
+import { ObjectType, ElemID, BuiltinTypes, CORE_ANNOTATIONS, ListType, MapType } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { elements as adapterElements } from '@salto-io/adapter-components'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
@@ -181,7 +181,7 @@ export const createFormType = (): {
         refType: BuiltinTypes.UNKNOWN,
       },
       questions: {
-        refType: new ListType(questionType),
+        refType: new MapType(questionType),
       },
     },
   })


### PR DESCRIPTION
We recently changed the API to fetch forms and the question field changes from ListType to mapType which resulted in not adding references. In this PR I fixed it. 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* Inside `Form` type, the `jiraField` will change from string to reference. 

---
_User Notifications_: 
_Jira Adapter:_
* Inside `Form` type, the `jiraField` will change from string to reference. 

