### PR TITLE
SALTO-6416: (Jira) validate uniqueness in Project's name and key

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
+++ b/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
@@ -89,19 +89,19 @@ const getErrorForChange = (
   fieldNames: string[],
   fieldValueCount: Record<string, Record<string, number>>,
 ): ChangeError | undefined => {
-  const changeData = getChangeData(change)
+  const instance = getChangeData(change)
   const nonUniqueFieldValues = fieldNames.filter(fieldName => {
-    const fieldValue = getFieldValue(changeData, fieldName)
+    const fieldValue = getFieldValue(instance, fieldName)
     return fieldValue !== undefined && fieldValueCount[fieldName][fieldValue] > 1
   })
   if (nonUniqueFieldValues.length === 0) {
     return undefined
   }
   return {
-    elemID: changeData.elemID,
+    elemID: instance.elemID,
     severity: 'Error',
-    message: `The ${fieldNames.length > 1 ? 'fields' : 'field'} ${fieldNames.map(str => `'${str}'`).join(',')} in type ${changeData.elemID.typeName} must have ${fieldNames.length > 1 ? 'unique values' : 'a unique value'}`,
-    detailedMessage: `This instance cannot be deployed due to non unique values in the following fields: ${nonUniqueFieldValues.join(',')}.`,
+    message: `The ${fieldNames.length > 1 ? 'fields' : 'field'} ${fieldNames.map(str => `'${str}'`).join(', ')} in type ${instance.elemID.typeName} must have ${fieldNames.length > 1 ? 'unique values' : 'a unique value'}`,
+    detailedMessage: `This instance cannot be deployed due to non unique values in the following fields: ${nonUniqueFieldValues.map(str => `'${str}'`).join(', ')}.`,
   }
 }
 

--- a/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
+++ b/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
@@ -25,7 +25,6 @@ import {
   isInstanceChange,
   ModificationChange,
   ReadOnlyElementsSource,
-  SeverityLevel,
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
@@ -39,12 +38,12 @@ const { isDefined } = values
 type TypeInfo = {
   changesOfType: (ModificationChange<InstanceElement> | AdditionChange<InstanceElement>)[]
   instancesOfType: InstanceElement[]
-  uniqueFieldName: string
+  uniqueFieldNames: string[]
 }
 
 const createTypeToChangesRecord = (
   changes: readonly Change<ChangeDataType>[],
-  typeToFieldRecord: Record<string, string>,
+  typeToFieldRecord: Record<string, string[]>,
 ): Record<string, (ModificationChange<InstanceElement> | AdditionChange<InstanceElement>)[]> => {
   const relevantChanges = changes
     .filter(isAdditionOrModificationChange)
@@ -64,7 +63,7 @@ const createTypeToInstancesRecord = async (
 const createTypeInfos = async (
   changes: readonly Change<ChangeDataType>[],
   elementsSource: ReadOnlyElementsSource,
-  typeToFieldRecord: Record<string, string>,
+  typeToFieldRecord: Record<string, string[]>,
 ): Promise<TypeInfo[]> => {
   const typeToChangesRecord = createTypeToChangesRecord(changes, typeToFieldRecord)
   const relevantTypes = Object.keys(typeToChangesRecord)
@@ -72,7 +71,7 @@ const createTypeInfos = async (
   return relevantTypes.map(typeName => ({
     changesOfType: typeToChangesRecord[typeName],
     instancesOfType: typeToInstancesRecord[typeName],
-    uniqueFieldName: typeToFieldRecord[typeName],
+    uniqueFieldNames: typeToFieldRecord[typeName],
   }))
 }
 
@@ -87,41 +86,39 @@ const getFieldValue = (instance: InstanceElement, fieldName: string): string | u
 
 const getErrorForChange = (
   change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
-  fieldName: string,
-  fieldValueToInstancesRecord: Record<string, InstanceElement[]>,
+  fieldNames: string[],
+  fieldValueCount: Record<string, Record<string, number>>,
 ): ChangeError | undefined => {
-  const fieldValue = getFieldValue(getChangeData(change), fieldName)
-  if (fieldValue === undefined) {
-    return undefined
-  }
-  const otherInstance = fieldValueToInstancesRecord[fieldValue].find(
-    instance => !instance.elemID.isEqual(getChangeData(change).elemID),
-  )
-  if (otherInstance === undefined) {
+  const changeData = getChangeData(change)
+  const nonUniqueFieldValues = fieldNames.filter(fieldName => {
+    const fieldValue = getFieldValue(changeData, fieldName)
+    return fieldValue !== undefined && fieldValueCount[fieldName][fieldValue] > 1
+  })
+  if (nonUniqueFieldValues.length === 0) {
     return undefined
   }
   return {
-    elemID: getChangeData(change).elemID,
-    severity: 'Error' as SeverityLevel,
-    message: `The field '${fieldName}' in type ${otherInstance.elemID.typeName} must have a unique value`,
-    detailedMessage: `This ${otherInstance.elemID.typeName} have the same '${fieldName}' as the instance ${otherInstance.elemID.getFullName()}, and can not be deployed.`,
+    elemID: changeData.elemID,
+    severity: 'Error',
+    message: `The ${fieldNames.length > 1 ? 'fields' : 'field'} ${fieldNames.map(str => `'${str}'`).join(',')} in type ${changeData.elemID.typeName} must have ${fieldNames.length > 1 ? 'unique values' : 'a unique value'}`,
+    detailedMessage: `This instance cannot be deployed due to non unique values in the following fields: ${nonUniqueFieldValues.join(',')}.`,
   }
 }
 
 export const uniqueFieldsChangeValidatorCreator =
-  (typeNameToUniqueFieldRecord: Record<string, string>): ChangeValidator =>
+  (typeNameToUniqueFieldRecord: Record<string, string[]>): ChangeValidator =>
   async (changes, elementsSource) => {
     if (elementsSource === undefined) {
       log.info("Didn't run unique fields validator as elementsSource is undefined")
       return []
     }
     return (await createTypeInfos(changes, elementsSource, typeNameToUniqueFieldRecord)).flatMap(typeInfo => {
-      const { changesOfType, instancesOfType, uniqueFieldName } = typeInfo
-      const fieldValueToInstancesRecord = _.groupBy(instancesOfType, instance =>
-        getFieldValue(instance, uniqueFieldName),
-      )
-      return changesOfType
-        .map(change => getErrorForChange(change, uniqueFieldName, fieldValueToInstancesRecord))
-        .filter(isDefined)
+      const { changesOfType, instancesOfType, uniqueFieldNames } = typeInfo
+      const fieldValueCount: Record<string, Record<string, number>> = {}
+      uniqueFieldNames.forEach(fieldName => {
+        const fieldValueToInstances = _.groupBy(instancesOfType, instance => getFieldValue(instance, fieldName))
+        fieldValueCount[fieldName] = _.mapValues(fieldValueToInstances, instances => instances.length)
+      })
+      return changesOfType.map(change => getErrorForChange(change, uniqueFieldNames, fieldValueCount)).filter(isDefined)
     })
   }

--- a/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
@@ -135,7 +135,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
     })
   })
   it('should return an error for multiple changes with the same field', async () => {
@@ -159,14 +159,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: relevantInstance2After.elemID,
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
     })
   })
   it('should return errors for multiple relevant types and reference them correctly', async () => {
@@ -186,14 +186,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: otherRelevantInstance2.elemID,
       severity: 'Error',
       message: "The field 'otherUniqueField' in type otherRelevantType must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: otherUniqueField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'otherUniqueField'.",
     })
   })
   it('should return an error for the same unique inner field value', async () => {
@@ -205,7 +205,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'field.uniqueInnerField' in type uniqueInnerField must have a unique value",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: field.uniqueInnerField.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'field.uniqueInnerField'.",
     })
   })
   it('should return an error for the same unique values in multiple fields', async () => {
@@ -224,9 +224,9 @@ describe('unique fields', () => {
     expect(changeErrors[0]).toEqual({
       elemID: multiFieldsInstance2.elemID,
       severity: 'Error',
-      message: "The fields 'uniqueField1','uniqueField2' in type multiFieldsType must have unique values",
+      message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField1,uniqueField2.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField1', 'uniqueField2'.",
     })
   })
   it('should return an error for multiple fields type with only one non unique value', async () => {
@@ -245,9 +245,9 @@ describe('unique fields', () => {
     expect(changeErrors[0]).toEqual({
       elemID: multiFieldsInstance2.elemID,
       severity: 'Error',
-      message: "The fields 'uniqueField1','uniqueField2' in type multiFieldsType must have unique values",
+      message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        'This instance cannot be deployed due to non unique values in the following fields: uniqueField1.',
+        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField1'.",
     })
   })
   it('should not return an error when the elementsSource is undefined', async () => {

--- a/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
@@ -35,11 +35,13 @@ describe('unique fields', () => {
   const irrelevantObjectType = new ObjectType({ elemID: new ElemID('adapter', 'irrelevantType') })
   const otherRelevantObjectType = new ObjectType({ elemID: new ElemID('adapter', 'otherRelevantType') })
   const uniqueInnerFieldObjectType = new ObjectType({ elemID: new ElemID('adapter', 'uniqueInnerField') })
+  const multiFieldsObjectType = new ObjectType({ elemID: new ElemID('adapter', 'multiFieldsType') })
 
   const changeValidator = uniqueFieldsChangeValidatorCreator({
-    [relevantObjectType.elemID.typeName]: 'uniqueField',
-    [otherRelevantObjectType.elemID.typeName]: 'otherUniqueField',
-    [uniqueInnerFieldObjectType.elemID.typeName]: 'field.uniqueInnerField',
+    [relevantObjectType.elemID.typeName]: ['uniqueField'],
+    [otherRelevantObjectType.elemID.typeName]: ['otherUniqueField'],
+    [uniqueInnerFieldObjectType.elemID.typeName]: ['field.uniqueInnerField'],
+    [multiFieldsObjectType.elemID.typeName]: ['uniqueField1', 'uniqueField2'],
   })
 
   beforeEach(() => {
@@ -133,7 +135,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This relevantType have the same 'uniqueField' as the instance adapter.relevantType.instance.relevantInstance1, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
     })
   })
   it('should return an error for multiple changes with the same field', async () => {
@@ -157,14 +159,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This relevantType have the same 'uniqueField' as the instance adapter.relevantType.instance.relevantInstance2, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
     })
     expect(changeErrors[1]).toEqual({
       elemID: relevantInstance2After.elemID,
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This relevantType have the same 'uniqueField' as the instance adapter.relevantType.instance.relevantInstance1, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
     })
   })
   it('should return errors for multiple relevant types and reference them correctly', async () => {
@@ -184,14 +186,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This relevantType have the same 'uniqueField' as the instance adapter.relevantType.instance.relevantInstance1, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField.',
     })
     expect(changeErrors[1]).toEqual({
       elemID: otherRelevantInstance2.elemID,
       severity: 'Error',
       message: "The field 'otherUniqueField' in type otherRelevantType must have a unique value",
       detailedMessage:
-        "This otherRelevantType have the same 'otherUniqueField' as the instance adapter.otherRelevantType.instance.otherRelevantInstance1, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: otherUniqueField.',
     })
   })
   it('should return an error for the same unique inner field value', async () => {
@@ -203,7 +205,53 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'field.uniqueInnerField' in type uniqueInnerField must have a unique value",
       detailedMessage:
-        "This uniqueInnerField have the same 'field.uniqueInnerField' as the instance adapter.uniqueInnerField.instance.uniqueInnerFieldInstance1, and can not be deployed.",
+        'This instance cannot be deployed due to non unique values in the following fields: field.uniqueInnerField.',
     })
+  })
+  it('should return an error for the same unique values in multiple fields', async () => {
+    const multiFieldsInstance1 = new InstanceElement('multiFieldsInstance1', multiFieldsObjectType, {
+      uniqueField1: 'same',
+      uniqueField2: 'same',
+    })
+    const multiFieldsInstance2 = new InstanceElement('multiFieldsInstance2', multiFieldsObjectType, {
+      uniqueField1: 'same',
+      uniqueField2: 'same',
+    })
+
+    const elementSource = buildElementsSourceFromElements([multiFieldsInstance1, multiFieldsInstance2])
+    const changeErrors = await changeValidator([toChange({ after: multiFieldsInstance2 })], elementSource)
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: multiFieldsInstance2.elemID,
+      severity: 'Error',
+      message: "The fields 'uniqueField1','uniqueField2' in type multiFieldsType must have unique values",
+      detailedMessage:
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField1,uniqueField2.',
+    })
+  })
+  it('should return an error for multiple fields type with only one non unique value', async () => {
+    const multiFieldsInstance1 = new InstanceElement('multiFieldsInstance1', multiFieldsObjectType, {
+      uniqueField1: 'same',
+      uniqueField2: 'same',
+    })
+    const multiFieldsInstance2 = new InstanceElement('multiFieldsInstance2', multiFieldsObjectType, {
+      uniqueField1: 'same',
+      uniqueField2: 'other',
+    })
+
+    const elementSource = buildElementsSourceFromElements([multiFieldsInstance1, multiFieldsInstance2])
+    const changeErrors = await changeValidator([toChange({ after: multiFieldsInstance2 })], elementSource)
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: multiFieldsInstance2.elemID,
+      severity: 'Error',
+      message: "The fields 'uniqueField1','uniqueField2' in type multiFieldsType must have unique values",
+      detailedMessage:
+        'This instance cannot be deployed due to non unique values in the following fields: uniqueField1.',
+    })
+  })
+  it('should not return an error when the elementsSource is undefined', async () => {
+    const changeErrors = await changeValidator([toChange({ after: relevantInstance1 })], undefined)
+    expect(changeErrors).toHaveLength(0)
   })
 })

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -73,15 +73,16 @@ import { jsmPermissionsValidator } from './jsm/jsm_permissions'
 import { referencedWorkflowDeletionChangeValidator } from './workflowsV2/referenced_workflow_deletion'
 import { missingExtensionsTransitionRulesChangeValidator } from './workflowsV2/missing_extensions_transition_rules'
 import { fieldContextOptionsValidator } from './field_contexts/field_context_options'
-import { ISSUE_TYPE_NAME, PORTAL_GROUP_TYPE, SLA_TYPE_NAME } from '../constants'
+import { ISSUE_TYPE_NAME, PORTAL_GROUP_TYPE, PROJECT_TYPE, SLA_TYPE_NAME } from '../constants'
 
 const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator } =
   deployment.changeValidators
 
 const TYPE_TO_UNIQUE_FIELD = {
-  [ISSUE_TYPE_NAME]: 'name',
-  [PORTAL_GROUP_TYPE]: 'name',
-  [SLA_TYPE_NAME]: 'name',
+  [ISSUE_TYPE_NAME]: ['name'],
+  [PORTAL_GROUP_TYPE]: ['name'],
+  [SLA_TYPE_NAME]: ['name'],
+  [PROJECT_TYPE]: ['name', 'key'],
 }
 
 export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.Paginator): ChangeValidator => {


### PR DESCRIPTION
Validate the uniqueness of the fields `name` and `key` within project type elements
Changed the unique values CV to handle multiple fields within a type

---

_Additional context for reviewer_
None

---
_Release Notes_: 
_Jira adapter:_
* validate uniqueness in Project's name and key

---
_User Notifications_: 
_None_
