### PR TITLE
SALTO-6418: support more than one resolution in transition properties

### DIFF
--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -108,6 +108,7 @@ export type WorkflowV2Transition = {
   actions?: WorkflowV2TransitionRule[]
   conditions?: WorkflowV2TransitionConditionGroup
   validators?: WorkflowV2TransitionRule[]
+  properties?: Values
 }
 
 type WorkflowDataResponse = {
@@ -169,6 +170,7 @@ const TRANSITION_SCHEME = Joi.object({
   }),
   conditions: TRANSITION_CONDITION_GROUP_SCHEME.optional(),
   validators: Joi.array().items(TRANSITION_RULE_SCHEME).optional(),
+  properties: Joi.alternatives(Joi.array().items(Joi.object()), Joi.object()).optional(),
 })
   .unknown(true)
   .required()


### PR DESCRIPTION
_support more than one resolution in transition properties_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
