### PR TITLE
SALTO-6420: Remove unused field `assetSchema` from ObjectTypeOrder

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_type_order.ts
@@ -71,10 +71,6 @@ const createOrderType = (): ObjectType =>
         refType: new ListType(BuiltinTypes.NUMBER),
         annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
       },
-      assetsSchema: {
-        refType: BuiltinTypes.NUMBER,
-        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
-      },
     },
     path: [JIRA, adapterElements.TYPES_PATH, OBJECT_TYPE_ORDER_TYPE],
     annotations: {
@@ -89,16 +85,6 @@ const createAssetsObjectTypeOrder = (
   orderType: ObjectType,
   treeParent: InstanceElement,
 ): InstanceElement | undefined => {
-  const schema =
-    treeParent.elemID?.typeName === OBJECT_TYPE_TYPE
-      ? treeParent.annotations[CORE_ANNOTATIONS.PARENT]?.[0]
-      : new ReferenceExpression(treeParent.elemID, treeParent)
-  if (schema.elemID?.typeName !== OBJECT_SCHEMA_TYPE) {
-    log.error(
-      `Failed to create ${OBJECT_TYPE_ORDER_TYPE} for ${treeParent.elemID.getFullName()} because it's parent is not ${OBJECT_SCHEMA_TYPE}`,
-    )
-    return undefined
-  }
   const name = naclCase(`${invertNaclCase(treeParent.elemID.name)}_childOrder`)
   const subFolder = treeParent.elemID.typeName === OBJECT_TYPE_TYPE ? [] : ['objectTypes']
   return new InstanceElement(
@@ -108,7 +94,6 @@ const createAssetsObjectTypeOrder = (
       objectTypes: assetsObjectTypes
         .sort((a, b) => a.value.position - b.value.position)
         .map(inst => new ReferenceExpression(inst.elemID, inst)),
-      assetsSchema: schema,
     },
     [...(treeParent.path ?? []).slice(0, -1), ...subFolder, pathNaclCase(name)],
     {

--- a/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
+++ b/packages/jira-adapter/test/filters/assets/assets_object_type_order.test.ts
@@ -171,7 +171,6 @@ describe('assetsObjectTypeOrderFilter', () => {
             new ReferenceExpression(assetsObjectTypeInstanceTwo.elemID, assetsObjectTypeInstanceTwo),
             new ReferenceExpression(assetsObjectTypeInstanceThree.elemID, assetsObjectTypeInstanceThree),
           ],
-          assetSchema: new ReferenceExpression(assetSchema.elemID, assetSchema),
         },
         undefined,
         {


### PR DESCRIPTION
In this PR I removed unused field `assetSchema` from ObjectTypeOrder

---

_Additional context for reviewer_
* Will add noise reduction. 

---
_Release Notes_: 
_Jira Adapter:_
* ObjectTypeOrder instances will no longer have `assetSchema` field.

---
_User Notifications_: 
_Jira Adapter:_
* ObjectTypeOrder instances will no longer have `assetSchema` field.
