### PR TITLE
SALTO-6423: statusMapping change validator should relies on elemID instead of name

### DIFF
--- a/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/status_mappings.test.ts
@@ -81,7 +81,7 @@ describe('status mappings', () => {
     issueType3 = new InstanceElement('issueType3', createEmptyType(ISSUE_TYPE_NAME))
     issueType4 = new InstanceElement('issueType4', createEmptyType(ISSUE_TYPE_NAME))
     workflowInstance = new InstanceElement('workflowInstance', createEmptyType(WORKFLOW_CONFIGURATION_TYPE), {
-      name: 'workflowInstance',
+      name: 'workflow instance',
       statuses: [
         {
           statusReference: new ReferenceExpression(status1.elemID, status1),


### PR DESCRIPTION
_statusMapping change validator should relies on elemID instead of name_

---

_Additional context for reviewer_

---
_Release Notes_: 
Jira Adapter: 
* fix a bug in statusMapping change validator

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
