### PR TITLE
SALTO-6376: Adjust Workato config options type

### DIFF
--- a/packages/workato-adapter/src/config_creator.ts
+++ b/packages/workato-adapter/src/config_creator.ts
@@ -20,7 +20,6 @@ import {
   ConfigCreator,
   ElemID,
   InstanceElement,
-  ListType,
   createRestriction,
 } from '@salto-io/adapter-api'
 import {
@@ -28,11 +27,8 @@ import {
   createMatchingObjectType,
   createOptionsTypeGuard,
 } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
 import { ENABLE_DEPLOY_SUPPORT_FLAG, configType } from './config'
 import { WORKATO } from './constants'
-
-const log = logger(module)
 
 const optionsElemId = new ElemID(WORKATO, 'configOptionsType')
 
@@ -40,15 +36,16 @@ const WORKATO_DEPLOY_OPTION = 'Deploy'
 const WORKATO_IMPACT_ANALYSIS_OPTION = 'Impact Analysis'
 
 type ConfigOptionsType = {
-  useCase?: string[]
+  useCase?: string
 }
 
 export const optionsType = createMatchingObjectType<ConfigOptionsType>({
   elemID: optionsElemId,
   fields: {
     useCase: {
-      refType: new ListType(BuiltinTypes.STRING),
+      refType: BuiltinTypes.STRING,
       annotations: {
+        [CORE_ANNOTATIONS.DEFAULT]: WORKATO_DEPLOY_OPTION,
         [CORE_ANNOTATIONS.REQUIRED]: true,
         [CORE_ANNOTATIONS.ALIAS]: 'Choose your Workato use case',
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
@@ -80,12 +77,9 @@ export const getConfig = async (options?: InstanceElement): Promise<InstanceElem
     return defaultConfig
   }
   if (options.value.useCase !== undefined) {
-    if (options.value.useCase.length !== 1) {
-      log.error('unexpected usecase options value')
-      return defaultConfig
-    }
     const clonedConfig = defaultConfig.clone()
-    clonedConfig.value[ENABLE_DEPLOY_SUPPORT_FLAG] = options.value.useCase[0] === WORKATO_DEPLOY_OPTION
+    // fallback to enable deploy support
+    clonedConfig.value[ENABLE_DEPLOY_SUPPORT_FLAG] = options.value.useCase !== WORKATO_IMPACT_ANALYSIS_OPTION
     return clonedConfig
   }
   return defaultConfig

--- a/packages/workato-adapter/src/config_creator.ts
+++ b/packages/workato-adapter/src/config_creator.ts
@@ -51,7 +51,6 @@ export const optionsType = createMatchingObjectType<ConfigOptionsType>({
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           values: [WORKATO_DEPLOY_OPTION, WORKATO_IMPACT_ANALYSIS_OPTION],
           enforce_value: true,
-          max_list_length: 1,
         }),
         [CORE_ANNOTATIONS.DESCRIPTION]: `## Customize Your Workato Use Case
 

--- a/packages/workato-adapter/test/config_creator.test.ts
+++ b/packages/workato-adapter/test/config_creator.test.ts
@@ -36,13 +36,13 @@ describe('config creator', () => {
     const config = await getConfig()
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
-  it('should return config with deploy disabled when enableDeploy option is false', async () => {
-    options.value.enableDeploy = false
+  it('should return config with deploy disabled when provided usecase is Impact Analysis', async () => {
+    options.value.useCase = ['Impact Analysis']
     const config = await getConfig(options)
     expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(false)
   })
-  it('should return config with deploy enabled when enableDeploy option is true', async () => {
-    options.value.enableDeploy = true
+  it('should return config with deploy enabled when provided usecase is Deploy', async () => {
+    options.value.useCase = ['Deploy']
     const config = await getConfig(options)
     expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(true)
   })

--- a/packages/workato-adapter/test/config_creator.test.ts
+++ b/packages/workato-adapter/test/config_creator.test.ts
@@ -23,7 +23,7 @@ import { WORKATO } from '../src/constants'
 describe('config creator', () => {
   let options: InstanceElement
   beforeEach(async () => {
-    options = new InstanceElement('instance', optionsType, { enableDeploy: true })
+    options = new InstanceElement('instance', optionsType, { useCase: 'Deploy' })
   })
   it('should return config creator', async () => {
     const config = configCreator
@@ -37,16 +37,16 @@ describe('config creator', () => {
     expect(config).toEqual(await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType))
   })
   it('should return config with deploy disabled when provided usecase is Impact Analysis', async () => {
-    options.value.useCase = ['Impact Analysis']
+    options.value.useCase = 'Impact Analysis'
     const config = await getConfig(options)
     expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(false)
   })
   it('should return config with deploy enabled when provided usecase is Deploy', async () => {
-    options.value.useCase = ['Deploy']
+    options.value.useCase = 'Deploy'
     const config = await getConfig(options)
     expect(config.value[ENABLE_DEPLOY_SUPPORT_FLAG]).toEqual(true)
   })
-  it('get config should return default config when wrong type', async () => {
+  it('get config should return default config when provided with the wrong type', async () => {
     options = new InstanceElement('instance', new ObjectType({ elemID: new ElemID(WORKATO, 'Foo') }), {
       enableScripRunnerAddon: true,
     })


### PR DESCRIPTION
Adjust Workato config object type 

---

_Additional context for reviewer_
We allow working with Workato in 2 modes - deploy support or impact analysis. each have implications on the adapter config, nacls structure, and more.
The object type should reflect this selection.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
