### PR TITLE
SALTO-6441: remove cv for workflow transition properties

### DIFF
--- a/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_properties_filter.ts
@@ -91,6 +91,11 @@ const filter: FilterCreator = () => {
           workflowTransitionType,
           'properties',
           new ListType(propertyType),
+          {
+            [CORE_ANNOTATIONS.CREATABLE]: true,
+            [CORE_ANNOTATIONS.UPDATABLE]: true,
+            [CORE_ANNOTATIONS.DELETABLE]: true,
+          },
         )
       }
 


### PR DESCRIPTION
See description

---

None

---
_Release Notes_: 
Jira Adapter:
* Removed a cv that warned about deployment of workflow transition's properties

---
_User Notifications_: 
None