### PR TITLE
SALTO-6442: add dependency changer to allow deployment of MFA policy with authenticator

### DIFF
--- a/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
+++ b/packages/okta-adapter/src/change_validators/enabled_authenticators.ts
@@ -61,15 +61,20 @@ export const areAuthenticators = createSchemeGuard<Authenticator[]>(
   'Received an invalid value for authenticators',
 )
 
-// Options are taken from: https://developer.okta.com/docs/reference/api/policy/#policy-factor-enroll-object
-const ENABLED_AUTHENTICATORS = ['OPTIONAL', 'REQUIRED']
-
-const getAutheticatorsForPolicy = (instance: InstanceElement): PolicyToAuthenticator[] => {
+export const getAuthenticatorsFromMfaPolicy = (instance: InstanceElement): Authenticator[] => {
   const authenticators = instance.value.settings?.authenticators
   if (!areAuthenticators(authenticators)) {
     log.warn(`Received invalid authenticator for instance ${instance.elemID.getFullName()}`)
     return []
   }
+  return authenticators
+}
+
+// Options are taken from: https://developer.okta.com/docs/reference/api/policy/#policy-factor-enroll-object
+const ENABLED_AUTHENTICATORS = ['OPTIONAL', 'REQUIRED']
+
+const getAutheticatorsForPolicy = (instance: InstanceElement): PolicyToAuthenticator[] => {
+  const authenticators = getAuthenticatorsFromMfaPolicy(instance)
   return (
     authenticators
       // Indicates the authenticator is enabled for this policy

--- a/packages/okta-adapter/src/dependency_changers/authenticator_to_mfa_policy.ts
+++ b/packages/okta-adapter/src/dependency_changers/authenticator_to_mfa_policy.ts
@@ -1,0 +1,82 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import {
+  DependencyChanger,
+  InstanceElement,
+  ModificationChange,
+  dependencyChange,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  isModificationChange,
+} from '@salto-io/adapter-api'
+import { deployment } from '@salto-io/adapter-components'
+import { values } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { AUTHENTICATOR_TYPE_NAME, MFA_POLICY_TYPE_NAME } from '../constants'
+import { getAuthenticatorsFromMfaPolicy } from '../change_validators/enabled_authenticators'
+
+const log = logger(module)
+
+/*
+ * Add dependency from Authenticator change to MultifactorEnrollmentPolicy additions or modifications.
+ * Authenticator must be activated before it can be used by a MultifactorEnrollmentPolicy.
+ */
+export const addAuthenticatorToMfaPolicyDependency: DependencyChanger = async changes => {
+  const instanceChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter((change): change is deployment.dependency.ChangeWithKey<ModificationChange<InstanceElement>> =>
+      isInstanceChange(change.change),
+    )
+
+  const mfaChanges = instanceChanges
+    .filter(change => isAdditionOrModificationChange(change.change))
+    .filter(change => getChangeData(change.change).elemID.typeName === MFA_POLICY_TYPE_NAME)
+
+  const authenticatorChanges = instanceChanges
+    // authenticator addition changes are handled by addReferencesDependency in core
+    .filter(change => isModificationChange(change.change))
+    .filter(change => getChangeData(change.change).elemID.typeName === AUTHENTICATOR_TYPE_NAME)
+
+  if (_.isEmpty(mfaChanges) || _.isEmpty(authenticatorChanges)) {
+    return []
+  }
+
+  const authenticatorChangesById = _.keyBy(authenticatorChanges, change =>
+    getChangeData(change.change).elemID.getFullName(),
+  )
+
+  return mfaChanges
+    .flatMap(mfaChange => {
+      const usedAuthenticatorChanges = getAuthenticatorsFromMfaPolicy(getChangeData(mfaChange.change))
+        .map(authenticator => authenticator.key)
+        .map(reference => reference.elemID.getFullName())
+        .map(authenticatorId => authenticatorChangesById[authenticatorId])
+        .filter(values.isDefined)
+      const dependencies = usedAuthenticatorChanges.map(authenticator =>
+        dependencyChange('add', mfaChange.key, authenticator.key),
+      )
+      log.debug(
+        'addAuthenticatorToMfaPolicyDependency added the following dependencies: %s',
+        safeJsonStringify(dependencies.map(d => d.dependency)),
+      )
+      return dependencies
+    })
+    .filter(values.isDefined)
+}

--- a/packages/okta-adapter/src/dependency_changers/authenticator_to_mfa_policy.ts
+++ b/packages/okta-adapter/src/dependency_changers/authenticator_to_mfa_policy.ts
@@ -62,11 +62,14 @@ export const addAuthenticatorToMfaPolicyDependency: DependencyChanger = async ch
     getChangeData(change.change).elemID.getFullName(),
   )
 
+  const changedAuthenticatorsElemIDs = new Set(Object.keys(authenticatorChangesById))
+
   return mfaChanges
     .flatMap(mfaChange => {
       const usedAuthenticatorChanges = getAuthenticatorsFromMfaPolicy(getChangeData(mfaChange.change))
         .map(authenticator => authenticator.key)
         .map(reference => reference.elemID.getFullName())
+        .filter(authenticatorId => changedAuthenticatorsElemIDs.has(authenticatorId))
         .map(authenticatorId => authenticatorChangesById[authenticatorId])
         .filter(values.isDefined)
       const dependencies = usedAuthenticatorChanges.map(authenticator =>

--- a/packages/okta-adapter/src/dependency_changers/index.ts
+++ b/packages/okta-adapter/src/dependency_changers/index.ts
@@ -21,6 +21,7 @@ import { addAppGroupToAppDependency } from './app_group_assignment_to_app'
 import { removeProfileMappingAfterDeps } from './remove_profile_mapping_after_deps'
 import { changeDependenciesFromPoliciesAndRulesToPriority } from './policy_and_rules_to_priority'
 import { defaultMultifactorEnrollmentPolicyDependency } from './default_multi_factor_enrollment_policy'
+import { addAuthenticatorToMfaPolicyDependency } from './authenticator_to_mfa_policy'
 
 const { awu } = collections.asynciterable
 
@@ -31,6 +32,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   removeProfileMappingAfterDeps,
   changeDependenciesFromPoliciesAndRulesToPriority,
   defaultMultifactorEnrollmentPolicyDependency,
+  addAuthenticatorToMfaPolicyDependency,
 ]
 
 export const dependencyChanger: DependencyChanger = async (changes, deps) =>

--- a/packages/okta-adapter/test/dependency_changers/authenticator_to_mfa_policy.test.ts
+++ b/packages/okta-adapter/test/dependency_changers/authenticator_to_mfa_policy.test.ts
@@ -1,0 +1,99 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  toChange,
+  DependencyChange,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { OKTA, AUTHENTICATOR_TYPE_NAME, MFA_POLICY_TYPE_NAME } from '../../src/constants'
+import { addAuthenticatorToMfaPolicyDependency } from '../../src/dependency_changers/authenticator_to_mfa_policy'
+
+describe('addAuthenticatorToMfaPolicyDependency', () => {
+  let dependencyChanges: DependencyChange[]
+  const authenticatorType = new ObjectType({ elemID: new ElemID(OKTA, AUTHENTICATOR_TYPE_NAME) })
+  const mfaPolicyType = new ObjectType({ elemID: new ElemID(OKTA, MFA_POLICY_TYPE_NAME) })
+
+  const authenticator1 = new InstanceElement('authenticator1', authenticatorType, {
+    id: '1',
+    label: 'authenticator1',
+    status: 'INACTIVE',
+  })
+  const authenticator2 = new InstanceElement('authenticator2', authenticatorType, {
+    id: '2',
+    label: 'authenticator2',
+    status: 'ACTIVE',
+  })
+  const mfaPolicy = new InstanceElement('mfaPolicy', mfaPolicyType, {
+    id: 'ab',
+    priority: 1,
+    settings: {
+      type: 'AUTHENTICATOR',
+      authenticators: [
+        { key: new ReferenceExpression(authenticator1.elemID, authenticator1), enroll: { self: 'OPTIONAL' } },
+      ],
+    },
+  })
+  it('should add dependency from MultifactorEnrollmentPolicy addition to its used Authenticator modification changes', async () => {
+    const inputChanges = new Map([
+      ['mfaPolicy', toChange({ after: mfaPolicy })],
+      ['authenticator1', toChange({ before: authenticator1, after: authenticator1 })],
+      ['authenticator2', toChange({ before: authenticator2, after: authenticator2 })],
+    ])
+    dependencyChanges = [...(await addAuthenticatorToMfaPolicyDependency(inputChanges, new Map()))]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual('mfaPolicy')
+    expect(dependencyChanges[0].dependency.target).toEqual('authenticator1')
+  })
+
+  it('should add dependency from MultifactorEnrollmentPolicy modification to its used Authenticator modification changes', async () => {
+    const beforeMfa = new InstanceElement('mfaPolicy', mfaPolicyType, {
+      id: 'ab',
+      priority: 1,
+      settings: {
+        type: 'AUTHENTICATOR',
+        authenticators: [
+          { key: new ReferenceExpression(authenticator1.elemID, authenticator1), enroll: { self: 'OPTIONAL' } },
+          // this authenticator is removed from the policy, so no dependency should be added
+          { key: new ReferenceExpression(authenticator2.elemID, authenticator2), enroll: { self: 'REQUIRED' } },
+        ],
+      },
+    })
+    const inputChanges = new Map([
+      ['mfaPolicy', toChange({ before: beforeMfa, after: mfaPolicy })],
+      ['authenticator1', toChange({ before: authenticator1, after: authenticator1 })],
+      ['authenticator2', toChange({ before: authenticator2, after: authenticator2 })],
+    ])
+    dependencyChanges = [...(await addAuthenticatorToMfaPolicyDependency(inputChanges, new Map()))]
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual('mfaPolicy')
+    expect(dependencyChanges[0].dependency.target).toEqual('authenticator1')
+  })
+
+  it('should not add dependency from MultifactorEnrollmentPolicy to Authenticator that is not in used by the policy', async () => {
+    const inputChanges = new Map([
+      ['mfaPolicy', toChange({ after: mfaPolicy })],
+      ['authenticator2', toChange({ before: authenticator2, after: authenticator2 })],
+    ])
+    dependencyChanges = [...(await addAuthenticatorToMfaPolicyDependency(inputChanges, new Map()))]
+    expect(dependencyChanges).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Add dependency changes to make sure MFA policies are deployed after their authenticators are activated

---

_Additional context for reviewer_

Each MFA policy has a list used authenticators. Authenticator must be activated before it can be assigned to MFA policy. 
The dependency changer is fixing a bug caused when trying to activate authenticator together with adding it to the MFA policy - in this case we must activate the authenticator before deploying the MFA policy changes.

In the next PR I'll add a validator to verify no inactive authenticator is added to mfa policy.

---
_Release Notes_: 

_Okta_adapter_:
- Fix a bug in MultifactorEnrollmentPolicy when deployed with Authenticator

---
_User Notifications_: 
None
