### PR TITLE
SALTO-6442: Validate all authenticators in MFA are enabled

### DIFF
--- a/packages/adapter-utils/src/element.ts
+++ b/packages/adapter-utils/src/element.ts
@@ -22,6 +22,8 @@ import {
   PrimitiveTypes,
   TypeElement,
   TypeReference,
+  Element,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import { types } from '@salto-io/lowerdash'
 
@@ -63,3 +65,6 @@ type ObjectTypeCtorForType<T> = Omit<ConstructorParameters<typeof ObjectType>[0]
  * Create an object type with fields that match a typescript type
  */
 export const createMatchingObjectType = <T>(params: ObjectTypeCtorForType<T>): ObjectType => new ObjectType(params)
+
+export const getElementPrettyName = (element: Element): string =>
+  element.annotations[CORE_ANNOTATIONS.ALIAS] ?? element.elemID.name

--- a/packages/okta-adapter/src/change_validators/disabled_authenticators_in_mfa.ts
+++ b/packages/okta-adapter/src/change_validators/disabled_authenticators_in_mfa.ts
@@ -41,8 +41,8 @@ export const disabledAuthenticatorsInMfaPolicyValidator: ChangeValidator = async
   const mfaInstances = changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
-    .filter(change => getChangeData(change).elemID.typeName === MFA_POLICY_TYPE_NAME)
     .map(getChangeData)
+    .filter(({ elemID }) => elemID.typeName === MFA_POLICY_TYPE_NAME)
 
   const disabledAuthenticatorsByMfaElemID: Record<string, InstanceElement[]> = Object.fromEntries(
     await awu(mfaInstances)
@@ -50,11 +50,9 @@ export const disabledAuthenticatorsInMfaPolicyValidator: ChangeValidator = async
         const disabledAuthenticators = await awu(getAuthenticatorsFromMfaPolicy(policy))
           .map(async ({ key }) => key.getResolvedValue(elementSource))
           .filter(isInstanceElement)
+          .filter(({ value }) => value.status === INACTIVE_STATUS)
           .toArray()
-        return [
-          policy.elemID.getFullName(),
-          disabledAuthenticators.filter(({ value }) => value.status === INACTIVE_STATUS),
-        ]
+        return [policy.elemID.getFullName(), disabledAuthenticators]
       })
       .toArray(),
   )

--- a/packages/okta-adapter/src/change_validators/disabled_authenticators_in_mfa.ts
+++ b/packages/okta-adapter/src/change_validators/disabled_authenticators_in_mfa.ts
@@ -1,0 +1,73 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { logger } from '@salto-io/logging'
+import {
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+  isAdditionOrModificationChange,
+  isInstanceElement,
+  InstanceElement,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { getElementPrettyName } from '@salto-io/adapter-utils'
+import { INACTIVE_STATUS, MFA_POLICY_TYPE_NAME } from '../constants'
+import { getAuthenticatorsFromMfaPolicy } from './enabled_authenticators'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+/**
+ * Verify all used authenticators in MFA policy are enabled
+ */
+export const disabledAuthenticatorsInMfaPolicyValidator: ChangeValidator = async (changes, elementSource) => {
+  if (elementSource === undefined) {
+    log.error('Failed to run disabledAuthenticatorsInMfaPolicy because element source is undefined')
+    return []
+  }
+  const mfaInstances = changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === MFA_POLICY_TYPE_NAME)
+    .map(getChangeData)
+
+  const disabledAuthenticatorsByMfaElemID: Record<string, InstanceElement[]> = Object.fromEntries(
+    await awu(mfaInstances)
+      .map(async policy => {
+        const disabledAuthenticators = await awu(getAuthenticatorsFromMfaPolicy(policy))
+          .map(async ({ key }) => key.getResolvedValue(elementSource))
+          .filter(isInstanceElement)
+          .toArray()
+        return [
+          policy.elemID.getFullName(),
+          disabledAuthenticators.filter(({ value }) => value.status === INACTIVE_STATUS),
+        ]
+      })
+      .toArray(),
+  )
+
+  return mfaInstances
+    .filter(instance => disabledAuthenticatorsByMfaElemID[instance.elemID.getFullName()].length > 0)
+    .map(instance => {
+      const disabledAuthenticators = disabledAuthenticatorsByMfaElemID[instance.elemID.getFullName()]
+      return {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'Cannot use disabled authenticators in authenticator enrollment policy.',
+        detailedMessage: `The following authenticators are disabled and can not be used in the configured policy: ${disabledAuthenticators.map(inst => getElementPrettyName(inst)).join(', ')}. To continue with this deployment, enabled those authenticators.`,
+      }
+    })
+}

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -40,6 +40,7 @@ import { domainModificationValidator } from './domain_modification'
 import { dynamicOSVersionFeatureValidator } from './dynamic_os_version_feature'
 import { brandThemeRemovalValidator } from './brand_theme_removal'
 import { userStatusValidator } from './user_status'
+import { disabledAuthenticatorsInMfaPolicyValidator } from './disabled_authenticators_in_mfa'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -114,6 +115,7 @@ export default ({
     domainAddition: domainAdditionValidator,
     domainModification: domainModificationValidator,
     userStatusChanges: userStatusValidator,
+    disabledAuthenticatorsInMfaPolicy: disabledAuthenticatorsInMfaPolicyValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -68,6 +68,7 @@ const changeValidatorNames = [
   'domainModification',
   'schemaBaseChanges',
   'userStatusChanges',
+  'disabledAuthenticatorsInMfaPolicy',
 ] as const
 
 export type ChangeValidatorName = (typeof changeValidatorNames)[number]

--- a/packages/okta-adapter/test/change_validators/disabled_authenticators_in_mfa.test.ts
+++ b/packages/okta-adapter/test/change_validators/disabled_authenticators_in_mfa.test.ts
@@ -1,0 +1,101 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  toChange,
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { disabledAuthenticatorsInMfaPolicyValidator } from '../../src/change_validators/disabled_authenticators_in_mfa'
+import { OKTA, MFA_POLICY_TYPE_NAME, AUTHENTICATOR_TYPE_NAME } from '../../src/constants'
+
+describe('disabledAuthenticatorsInMfaPolicyValidator', () => {
+  const message = 'Cannot use disabled authenticators in authenticator enrollment policy.'
+  const policyType = new ObjectType({ elemID: new ElemID(OKTA, MFA_POLICY_TYPE_NAME) })
+  const authType = new ObjectType({ elemID: new ElemID(OKTA, AUTHENTICATOR_TYPE_NAME) })
+  const auth1 = new InstanceElement('a', authType, { key: 'google_otp', status: 'INACTIVE' }, undefined, {
+    [CORE_ANNOTATIONS.ALIAS]: 'aa',
+  })
+  const auth2 = new InstanceElement('b', authType, { key: 'security_question', status: 'ACTIVE' })
+  const MFA1 = new InstanceElement('mfa1', policyType, {
+    name: 'policy',
+    status: 'ACTIVE',
+    system: false,
+    type: 'MFA_POLICY',
+    settings: {
+      authenticators: [
+        { key: new ReferenceExpression(auth1.elemID, auth1), enroll: { self: 'OPTIONAL' } },
+        { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' }, extraField: 'field' },
+      ],
+    },
+  })
+  const MFA2 = new InstanceElement('mfa2', policyType, {
+    name: 'policy',
+    status: 'ACTIVE',
+    system: true,
+    type: 'MFA_POLICY',
+    settings: {
+      authenticators: [
+        { key: new ReferenceExpression(auth1.elemID, auth1), enroll: { self: 'REQUIRED' } },
+        { key: new ReferenceExpression(auth2.elemID, auth2), enroll: { self: 'NOT_ALLOWED' } },
+      ],
+    },
+  })
+  const elementSource = buildElementsSourceFromElements([policyType, authType, MFA1, MFA2, auth1, auth2])
+
+  it('should return error when disabled authenticator is used in MFA policy', async () => {
+    const changeErrors = await disabledAuthenticatorsInMfaPolicyValidator(
+      [toChange({ after: MFA1 }), toChange({ before: MFA2, after: MFA2 })],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(2)
+    expect(changeErrors).toEqual([
+      {
+        elemID: MFA1.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage:
+          'The following authenticators are disabled and can not be used in the configured policy: aa. To continue with this deployment, enabled those authenticators.',
+      },
+      {
+        elemID: MFA2.elemID,
+        severity: 'Error',
+        message,
+        detailedMessage:
+          'The following authenticators are disabled and can not be used in the configured policy: aa. To continue with this deployment, enabled those authenticators.',
+      },
+    ])
+  })
+  it('should not return error when all used authenticators are enabled', async () => {
+    auth1.value.status = 'ACTIVE'
+    const changeErrors = await disabledAuthenticatorsInMfaPolicyValidator(
+      [toChange({ after: MFA1 }), toChange({ after: auth1 })],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return error on MFA removals even when using disabled authenticators', async () => {
+    const changeErrors = await disabledAuthenticatorsInMfaPolicyValidator([toChange({ before: MFA1 })], elementSource)
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should do nothing when element source is missing', async () => {
+    const changeErrors = await disabledAuthenticatorsInMfaPolicyValidator([toChange({ after: MFA1 })], undefined)
+    expect(changeErrors).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
Add change validator to block deployments of `MultifactorEnrollmentPolicy` with disabled Authenticators 

---

_Additional context for reviewer_
This rebased on top of https://github.com/salto-io/salto/pull/6370
**Please only review the second commits**  

---
_Release Notes_: 

_Okta_Adapter_:
- Add validation to prevent deployment of MultifactorEnrollmentPolicy with disabled Authenticator

---
_User Notifications_: 
None
