### PR TITLE
SALTO-6447: (Jira) Fix custom fields deletion

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -312,6 +312,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
           data: e?.response?.data ?? data,
           status: e?.response?.status ?? 'undefined',
           headers: e?.response?.headers ?? headers,
+          requestPath: e?.response?.request?.path,
         },
         e,
       )
@@ -323,6 +324,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
           status: e.response.status,
           data: e.response.data,
           headers: this.extractHeaders(e.response.headers),
+          requestPath: e.response.request?.path,
         })
       }
       throw new Error(`Failed to ${method} ${url} with error: ${e}`)

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -40,6 +40,7 @@ export type Response<T> = {
   status: number
   statusText?: string
   headers?: Partial<AxiosResponseHeaders>
+  requestPath?: string
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -183,22 +183,6 @@ describe('fields_deployment', () => {
       const res = await filter.deploy([change])
       expect(res.deployResult.errors).toHaveLength(0)
     })
-    it('should return an error if the response is an error with status different from 401', async () => {
-      deployChangeMock.mockImplementation(async () => {
-        throw new clientUtils.HTTPError('error', { data: {}, status: 400, requestPath: '/rest/api/3/task/1000' })
-      })
-      const instance = new InstanceElement('instance', fieldType, {
-        id: 'field_1',
-      })
-      const change = toChange({ before: instance })
-      const res = await filter.deploy([change])
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.errors[0]).toEqual({
-        elemID: instance.elemID,
-        message: 'Error: error',
-        severity: 'Error',
-      })
-    })
     it('should return an error if the response is an error with status 401 but not a redirect', async () => {
       deployChangeMock.mockImplementation(async () => {
         throw new clientUtils.HTTPError('error', { data: {}, status: 401, requestPath: '/rest/api/3/field/1000' })

--- a/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_deployment.test.ts
@@ -171,4 +171,65 @@ describe('fields_deployment', () => {
     const res = await filter.deploy([change])
     expect(res.deployResult.errors).toHaveLength(1)
   })
+  describe('removal', () => {
+    it('should not return an error if the response was recieved from a redirect of a field deletion', async () => {
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('error', { data: {}, status: 401, requestPath: '/rest/api/3/task/1000' })
+      })
+      const instance = new InstanceElement('instance', fieldType, {
+        id: 'field_1',
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(0)
+    })
+    it('should return an error if the response is an error with status different from 401', async () => {
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('error', { data: {}, status: 400, requestPath: '/rest/api/3/task/1000' })
+      })
+      const instance = new InstanceElement('instance', fieldType, {
+        id: 'field_1',
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0]).toEqual({
+        elemID: instance.elemID,
+        message: 'Error: error',
+        severity: 'Error',
+      })
+    })
+    it('should return an error if the response is an error with status 401 but not a redirect', async () => {
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('error', { data: {}, status: 401, requestPath: '/rest/api/3/field/1000' })
+      })
+      const instance = new InstanceElement('instance', fieldType, {
+        id: 'field_1',
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0]).toEqual({
+        elemID: instance.elemID,
+        message: 'Error: error',
+        severity: 'Error',
+      })
+    })
+    it('should return an error if the response does not contain a requestPath', async () => {
+      deployChangeMock.mockImplementation(async () => {
+        throw new clientUtils.HTTPError('error', { data: {}, status: 401 })
+      })
+      const instance = new InstanceElement('instance', fieldType, {
+        id: 'field_1',
+      })
+      const change = toChange({ before: instance })
+      const res = await filter.deploy([change])
+      expect(res.deployResult.errors).toHaveLength(1)
+      expect(res.deployResult.errors[0]).toEqual({
+        elemID: instance.elemID,
+        message: 'Error: error',
+        severity: 'Error',
+      })
+    })
+  })
 })


### PR DESCRIPTION
The upgrade of Axios created a problem with deploying a deletion of a custom field.
The problem is happening because of a change in the way it handle redirection (it is no longer automatically pass the auth headers).

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
Jira adapter:
* Fix custom fields deletion

---
_User Notifications_: 
_None_
