### PR TITLE
salto-6450: (JIRA) Enable state criteria in fetch

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -60,6 +60,7 @@ type JiraDeployConfig = definitions.UserDeployConfig &
 
 type JiraFetchFilters = definitions.DefaultFetchCriteria & {
   type?: string
+  state?: string
 }
 
 type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFilters }> & {
@@ -349,6 +350,7 @@ const fetchFiltersType = createMatchingObjectType<JiraFetchFilters>({
   fields: {
     name: { refType: BuiltinTypes.STRING },
     type: { refType: BuiltinTypes.STRING },
+    state: { refType: BuiltinTypes.STRING },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/fetch_criteria.ts
+++ b/packages/jira-adapter/src/fetch_criteria.ts
@@ -22,4 +22,5 @@ const typeCriterion: elementUtils.query.QueryCriterion = ({ instance, value }): 
 export default {
   name: elementUtils.query.nameCriterion,
   type: typeCriterion,
+  state: elementUtils.query.fieldCriterionCreator('state'),
 }

--- a/packages/jira-adapter/test/fetch_criteria.test.ts
+++ b/packages/jira-adapter/test/fetch_criteria.test.ts
@@ -49,5 +49,25 @@ describe('fetch_criteria', () => {
       expect(fetchCriteria.type({ instance, value: '.ype' })).toBeTruthy()
       expect(fetchCriteria.type({ instance, value: 'ype' })).toBeFalsy()
     })
+    it('should not match if there is no schema field', () => {
+      const instance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        otherField: {
+          type: 'type',
+        },
+      })
+
+      expect(fetchCriteria.type({ instance, value: '.ype' })).toBeFalsy()
+      expect(fetchCriteria.type({ instance, value: 'ype' })).toBeFalsy()
+    })
+  })
+  describe('state', () => {
+    it('should match state field', () => {
+      const instance = new InstanceElement('instance', new ObjectType({ elemID: new ElemID('adapter', 'type') }), {
+        state: 'state',
+      })
+
+      expect(fetchCriteria.state({ instance, value: '.tate' })).toBeTruthy()
+      expect(fetchCriteria.state({ instance, value: 'tate' })).toBeFalsy()
+    })
   })
 })


### PR DESCRIPTION
_Enable the option to filter objects by `state` field in the fetch_

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
_Jira adapter:_
* Enable the option to filter objects by `state` field in the fetch
---
_User Notifications_: 
_None_
