### PR TITLE
SALTO-6453: Add missing standalone definition for appRoleAssignments

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -347,6 +347,13 @@ const graphV1Customizations: FetchCustomizations = {
           },
         },
         [APP_ROLES_FIELD_NAME]: APP_ROLES_FIELD_CUSTOMIZATIONS,
+        [APP_ROLE_ASSIGNMENT_FIELD_NAME]: {
+          standalone: {
+            typeName: SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME,
+            nestPathUnderParent: true,
+            referenceFromParent: false,
+          },
+        },
       },
     },
   },

--- a/packages/microsoft-entra-adapter/src/definitions/references.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/references.ts
@@ -45,6 +45,7 @@ import {
   ODATA_TYPE_FIELD_NACL_CASE,
   PRE_AUTHORIZED_APPLICATIONS_FIELD_NAME,
   ROLE_DEFINITION_TYPE_NAME,
+  SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME,
   SERVICE_PRINCIPAL_TYPE_NAME,
   SUPPORTED_DIRECTORY_OBJECT_ODATA_TYPE_NAME_TO_TYPE_NAME,
 } from '../constants'
@@ -82,7 +83,14 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<
 >[] = [
   ...createMicrosoftAuthenticatorReferences(),
   {
-    src: { field: 'resourceId', parentTypes: [GROUP_APP_ROLE_ASSIGNMENT_TYPE_NAME, OAUTH2_PERMISSION_GRANT_TYPE_NAME] },
+    src: {
+      field: 'resourceId',
+      parentTypes: [
+        GROUP_APP_ROLE_ASSIGNMENT_TYPE_NAME,
+        SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME,
+        OAUTH2_PERMISSION_GRANT_TYPE_NAME,
+      ],
+    },
     target: { type: SERVICE_PRINCIPAL_TYPE_NAME },
     serializationStrategy: 'id',
   },
@@ -134,7 +142,10 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<
     serializationStrategy: 'appId',
   },
   {
-    src: { field: 'appRoleId', parentTypes: [GROUP_APP_ROLE_ASSIGNMENT_TYPE_NAME] },
+    src: {
+      field: 'appRoleId',
+      parentTypes: [GROUP_APP_ROLE_ASSIGNMENT_TYPE_NAME, SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME],
+    },
     target: { type: APP_ROLE_TYPE_NAME },
     serializationStrategy: 'id',
   },


### PR DESCRIPTION
Fix definitions for servicePrincipal - appRoleAssignments:
1. Define as standalone
2. Add reference definition

---
The `appRoleAssignments` defined on the Service Principal is supposed to be a standalone element (`isTopLevel: true` in the type definition) but this definition is missing on the paren't `fieldCustomization` field.
When reproducing this issue I also noticed that we're missing its reference definition as well.

---
_Release Notes_: 
_Microsoft Entra:_
* Fix issue with appRoleAssignments definition - set them as `standalone`

---
_User Notifications_: 
_Microsoft Entra:_
* Service Principal's `appRoleAssignments` instances will be added with references to the `appRole` + `resource`.
