### PR TITLE
SALTO-6455: (Salesforce) Log all records as part of bulkLoadOperation

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1064,7 +1064,13 @@ export default class SalesforceClient implements ISalesforceClient {
     operation: BulkLoadOperation,
     records: SalesforceRecord[],
   ): Promise<BatchResultInfo[]> {
-    log.trace('client.bulkLoadOperation: %s %d records of type %s: %o', operation, records.length, type, records)
+    log.trace(
+      'client.bulkLoadOperation: %s %d records of type %s: %S',
+      operation,
+      records.length,
+      type,
+      inspectValue(records, { maxArrayLength: null }),
+    )
     const batch = this.conn.bulk.load(
       type,
       operation,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1065,7 +1065,7 @@ export default class SalesforceClient implements ISalesforceClient {
     records: SalesforceRecord[],
   ): Promise<BatchResultInfo[]> {
     log.trace(
-      'client.bulkLoadOperation: %s %d records of type %s: %S',
+      'client.bulkLoadOperation: %s %d records of type %s: %s',
       operation,
       records.length,
       type,


### PR DESCRIPTION
Log all records as part of bulkLoadOperation

---

The previous log only outputted the first 100 Records.

---
_Release Notes_: 
Salesforce Adapter:
- Improved trace log of bulkLoadOperation to output all the records.

---
_User Notifications_: 
_None_