### PR TITLE
SALTO-6456: avoid creating disabled topics instance when not needed

### DIFF
--- a/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
+++ b/packages/salesforce-adapter/test/filters/topics_for_objects.test.ts
@@ -27,12 +27,12 @@ import {
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { apiName, MetadataTypeAnnotations } from '../../src/transformers/transformer'
+import { MetadataTypeAnnotations } from '../../src/transformers/transformer'
 import * as constants from '../../src/constants'
 import filterCreator from '../../src/filters/topics_for_objects'
 import { defaultFilterContext, emptyLastChangeDateOfTypesWithNestedInstances } from '../utils'
 import { FilterWith } from './mocks'
-import { isInstanceOfTypeSync } from '../../src/filters/utils'
+import { isInstanceOfTypeChangeSync, isInstanceOfTypeSync } from '../../src/filters/utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { buildMetadataQueryForFetchWithChangesDetection } from '../../src/fetch_profile/metadata_query'
 import { mockInstances } from '../mock_elements'
@@ -178,6 +178,10 @@ describe('Topics for objects filter', () => {
             before: mockObject('Test4__c'),
             after: mockObject('Test4__c'),
           }),
+          toChange({
+            before: mockObject('Test5__c'),
+            after: mockObject('Test5__c', false),
+          }),
         ]
         await filter.preDeploy(changes)
       })
@@ -189,20 +193,74 @@ describe('Topics for objects filter', () => {
       it('should not add topics to existing types that do not have it', () => {
         expect(getChangeData(changes[3]).annotations).not.toHaveProperty(TOPICS_FOR_OBJECTS_ANNOTATION)
       })
-      it('should add instance change to types that have changed topics enabled value', async () => {
-        expect(changes).toHaveLength(6)
-        const topicsInstanceChanges = changes.slice(4)
-        expect(topicsInstanceChanges.map(change => change.action)).toEqual(['add', 'add'])
-        const instances = topicsInstanceChanges.map(getChangeData) as InstanceElement[]
-        expect(await Promise.all(instances.map(inst => apiName(inst)))).toEqual(['Test2__c', 'Test3__c'])
-        expect(instances.map(inst => inst.value.enableTopics)).toEqual([true, false])
-
-        const topicsForObjectsType = await instances[0].getType()
-        expect(topicsForObjectsType.annotations).toMatchObject({
+      it('should add topic instance changes with a valid metadata type', () => {
+        const topicInstanceChange = changes.find(isInstanceOfTypeChangeSync(TOPICS_FOR_OBJECTS_METADATA_TYPE))
+        expect(topicInstanceChange).toBeDefined()
+        const topicInstance = getChangeData(topicInstanceChange as Change<InstanceElement>)
+        expect(topicInstance.getTypeSync().annotations).toMatchObject({
           metadataType: TOPICS_FOR_OBJECTS_METADATA_TYPE,
           dirName: 'topicsForObjects',
           suffix: 'topicsForObjects',
         } as MetadataTypeAnnotations)
+      })
+      it('should add topic instance change for new types that have topics enabled', () => {
+        expect(changes).toContainEqual(
+          expect.objectContaining({
+            action: 'add',
+            data: expect.objectContaining({
+              after: expect.objectContaining({
+                value: expect.objectContaining({
+                  enableTopics: true,
+                  entityApiName: 'Test2__c',
+                  fullName: 'Test2__c',
+                }),
+              }),
+            }),
+          }),
+        )
+      })
+      it('should add topic instance change for types that had the annotation value changed', () => {
+        expect(changes).toContainEqual(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              after: expect.objectContaining({
+                value: expect.objectContaining({
+                  enableTopics: false,
+                  entityApiName: 'Test3__c',
+                  fullName: 'Test3__c',
+                }),
+              }),
+            }),
+          }),
+        )
+      })
+      it('should not add topic instance for new types that do not have topics enabled', () => {
+        expect(changes).not.toContainEqual(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              after: expect.objectContaining({
+                value: expect.objectContaining({
+                  entityApiName: 'Test1__c',
+                  fullName: 'Test1__c',
+                }),
+              }),
+            }),
+          }),
+        )
+      })
+      it('should not add topic instance for types where the value did not semantically change', () => {
+        expect(changes).not.toContainEqual(
+          expect.objectContaining({
+            data: expect.objectContaining({
+              after: expect.objectContaining({
+                value: expect.objectContaining({
+                  entityApiName: 'Test5__c',
+                  fullName: 'Test5__c',
+                }),
+              }),
+            }),
+          }),
+        )
       })
     })
 
@@ -211,7 +269,6 @@ describe('Topics for objects filter', () => {
         await filter.onDeploy(changes)
       })
       it('should remove topics instance changes', () => {
-        expect(changes).toHaveLength(4)
         expect(changes.filter(isInstanceChange)).toHaveLength(0)
       })
     })


### PR DESCRIPTION
Change behavior of topics for objects filter to be more consistent - avoid creating topics instances if they are not enabled or changed

---

_Additional context for reviewer_
Not sure if the correct way to make this consistent is to actually always create the instance, but making this change felt less risky since it will not affect most scenarios

Tested manually with:
- Adding a new object with topics (unspecified, disabled, enabled)
- Updating topics on existing object
  - From true to false
  - From true to undefined
  - From undefined to false
  - From false to true

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_