### PR TITLE
SALTO-6457: Inconsistent beahvior on field tracking history in deploy filter

### DIFF
--- a/packages/salesforce-adapter/src/filters/centralize_tracking_info.ts
+++ b/packages/salesforce-adapter/src/filters/centralize_tracking_info.ts
@@ -129,7 +129,7 @@ const isHistoryTrackedField = (field: Field, trackingDef: TrackedFieldsDefinitio
   trackedFields(field.parent, trackingDef).includes(field.name)
 
 const deleteFieldHistoryTrackingAnnotation = (field: Field, trackingDef: TrackedFieldsDefinition): void => {
-  if (field !== undefined) {
+  if (field?.annotations[trackingDef.fieldLevelEnable] !== undefined) {
     delete field.annotations[trackingDef.fieldLevelEnable]
   }
 }
@@ -248,6 +248,7 @@ const filter: LocalFilterCreator = () => {
           .map(getChangeData)
           .filter(isField)
           .filter(isFieldOfCustomObject)
+          .filter(field => isHistoryTrackingEnabled(field.parent, trackingDef))
           .toArray()
 
         fieldsThatChanged.forEach(field => {

--- a/packages/salesforce-adapter/test/filters/centralize_tracking_info.test.ts
+++ b/packages/salesforce-adapter/test/filters/centralize_tracking_info.test.ts
@@ -489,8 +489,8 @@ describe('historyTracking', () => {
             await filter.preDeploy(changes)
             field = getChangeData(changes[0])
           })
-          it("should add 'trackHistory=false'", async () => {
-            expect(field.annotations).toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY, false)
+          it('should not set the trackHistory annotation on the fields', async () => {
+            expect(field.annotations).not.toHaveProperty(FIELD_ANNOTATIONS.TRACK_HISTORY)
           })
         })
       })

--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
@@ -221,8 +221,6 @@ describe('dumpElementsToFolder', () => {
     <type>Text</type>
     <length>80</length>
     <required>false</required>
-    <trackHistory>false</trackHistory>
-    <trackFeedHistory>false</trackFeedHistory>
 </CustomField>
 `)
       })


### PR DESCRIPTION
Avoid setting history tracking on fields if the feature is disabled on the object This was already the behavior when adding objects, but the behavior when adding / modifying fields was different

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_