### PR TITLE
SALTO-6129: Manually fix Entra TS build errors

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/deploy/types.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/types.ts
@@ -24,3 +24,4 @@ export type DeployCustomDefinitions = Record<string, InstanceDeployApiDefinition
 export type DeployRequestDefinition = definitions.deploy.DeployRequestDefinition<ClientOptions>
 export type DeployableRequestDefinition = definitions.deploy.DeployableRequestDefinition<ClientOptions>
 export type AdjustFunctionSingle = definitions.AdjustFunctionSingle<definitions.deploy.ChangeAndContext>
+export type AdjustFunction = definitions.AdjustFunction<definitions.deploy.ChangeAndContext>

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/types.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/types.ts
@@ -21,4 +21,4 @@ export type FetchApiDefinition = definitions.fetch.InstanceFetchApiDefinitions<O
 export type FetchCustomizations = Record<string, FetchApiDefinition>
 export type ElementFieldCustomization = definitions.fetch.ElementFieldCustomization
 export type FieldIDPart = definitions.fetch.FieldIDPart
-export type AdjustFunction = definitions.AdjustFunction
+export type AdjustFunctionSingle = definitions.AdjustFunctionSingle

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/utils/adjust_expanded_members.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/utils/adjust_expanded_members.ts
@@ -17,9 +17,9 @@
 import { validateArray, validatePlainObject } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { ODATA_TYPE_FIELD, SUPPORTED_DIRECTORY_OBJECT_ODATA_TYPE_NAME_TO_TYPE_NAME } from '../../../constants'
-import { AdjustFunction } from '../types'
+import { AdjustFunctionSingle } from '../types'
 
-export const adjustEntitiesWithExpandedMembers: AdjustFunction = async ({ value, typeName }) => {
+export const adjustEntitiesWithExpandedMembers: AdjustFunctionSingle = async ({ value, typeName }) => {
   validatePlainObject(value, typeName)
   const members = _.get(value, 'members', [])
   validateArray(members, `${typeName} members`)

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/utils/application.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/utils/application.ts
@@ -16,16 +16,16 @@
 
 import { validateArray, validatePlainObject } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { AdjustFunction } from '../types'
 import { addParentIdToAppRoles } from './app_role'
 import { APP_ROLES_FIELD_NAME, IDENTIFIER_URIS_FIELD_NAME } from '../../../constants'
+import { AdjustFunctionSingle } from '../types'
 
 /*
  * Adjust the application object.
  * 1. Remove the default identifier uri, as it's not deployable between envs.
  * 2. Add the parent id to the app roles.
  */
-export const adjustApplication: AdjustFunction = async ({ value }) => {
+export const adjustApplication: AdjustFunctionSingle = async ({ value }) => {
   validatePlainObject(value, 'application')
   const identifierUris = _.get(value, IDENTIFIER_URIS_FIELD_NAME, [])
   validateArray(identifierUris, IDENTIFIER_URIS_FIELD_NAME)

--- a/packages/microsoft-entra-adapter/test/deploy/utils/app_role_assignment.test.ts
+++ b/packages/microsoft-entra-adapter/test/deploy/utils/app_role_assignment.test.ts
@@ -14,9 +14,12 @@
  * limitations under the License.
  */
 
+import { collections } from '@salto-io/lowerdash'
 import { AdjustFunction } from '../../../src/definitions/deploy/types'
 import { createDefinitionForAppRoleAssignment } from '../../../src/definitions/deploy/utils'
 import { contextMock } from '../../mocks'
+
+const { makeArray } = collections.array
 
 describe(`${createDefinitionForAppRoleAssignment.name}`, () => {
   it('should return the correct definition using the parent resource name', () => {
@@ -58,7 +61,10 @@ describe(`${createDefinitionForAppRoleAssignment.name}`, () => {
         typeName: 'someType',
         context: contextMock,
       })
-      expect(adjustedItem?.value).toEqual({ someField: 'someValue', principalId: 'parent_id' })
+      // Just for TS reasons - since the adjust function can return an array or a single item
+      const adjustedItemAsArray = makeArray(adjustedItem)
+      expect(adjustedItemAsArray).toHaveLength(1)
+      expect(adjustedItemAsArray[0].value).toEqual({ someField: 'someValue', principalId: 'parent_id' })
     })
   })
 })

--- a/packages/microsoft-entra-adapter/test/deploy/utils/group_deployment_life_cycle_policy.test.ts
+++ b/packages/microsoft-entra-adapter/test/deploy/utils/group_deployment_life_cycle_policy.test.ts
@@ -15,12 +15,15 @@
  */
 
 import { ElemID, InstanceElement, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
 import {
   createDefinitionForGroupLifecyclePolicyGroupModification,
   getGroupLifecyclePolicyGroupModificationRequest,
 } from '../../../src/definitions/deploy/utils'
 import { contextMock, objectTypeMock } from '../../mocks'
 import { ADAPTER_NAME, GROUP_LIFE_CYCLE_POLICY_FIELD_NAME } from '../../../src/constants'
+
+const { makeArray } = collections.array
 
 const lifeCycleReference = new ReferenceExpression(new ElemID(ADAPTER_NAME, 'obj', 'instance', 'test'), {
   value: { id: 'testLifeCyclePolicyId' },
@@ -73,7 +76,10 @@ describe(`${getGroupLifecyclePolicyGroupModificationRequest.name}`, () => {
         typeName: 'group',
         context: contextMock,
       })
-      expect(adjustedItem?.value).toEqual({ groupId: 'id1' })
+      // Just for TS reasons - since the adjust function can return an array or a single item
+      const adjustedItemAsArray = makeArray(adjustedItem)
+      expect(adjustedItemAsArray).toHaveLength(1)
+      expect(adjustedItemAsArray[0].value).toEqual({ groupId: 'id1' })
     })
   })
 })

--- a/packages/microsoft-entra-adapter/test/fetch/utils/adjust_expanded_members.test.ts
+++ b/packages/microsoft-entra-adapter/test/fetch/utils/adjust_expanded_members.test.ts
@@ -16,23 +16,28 @@
 
 import { ODATA_TYPE_FIELD } from '../../../src/constants'
 import { adjustEntitiesWithExpandedMembers } from '../../../src/definitions/fetch/utils'
+import { contextMock } from '../../mocks'
 
 describe(`${adjustEntitiesWithExpandedMembers.name}`, () => {
   it('should throw an error when value is not an object', async () => {
     await expect(
-      adjustEntitiesWithExpandedMembers({ value: 'not an object', typeName: 'typeName', context: {} }),
+      adjustEntitiesWithExpandedMembers({ value: 'not an object', typeName: 'typeName', context: contextMock }),
     ).rejects.toThrow()
   })
 
   it('should throw an error when members is not an array', async () => {
     await expect(
-      adjustEntitiesWithExpandedMembers({ value: { members: 'not an array' }, typeName: 'typeName', context: {} }),
+      adjustEntitiesWithExpandedMembers({
+        value: { members: 'not an array' },
+        typeName: 'typeName',
+        context: contextMock,
+      }),
     ).rejects.toThrow()
   })
 
   it('should not throw an error when members field is missing', async () => {
     await expect(
-      adjustEntitiesWithExpandedMembers({ value: {}, typeName: 'typeName', context: {} }),
+      adjustEntitiesWithExpandedMembers({ value: {}, typeName: 'typeName', context: contextMock }),
     ).resolves.not.toThrow()
   })
 
@@ -41,7 +46,7 @@ describe(`${adjustEntitiesWithExpandedMembers.name}`, () => {
       adjustEntitiesWithExpandedMembers({
         value: { members: ['not an object'] },
         typeName: 'typeName',
-        context: {},
+        context: contextMock,
       }),
     ).rejects.toThrow()
   })
@@ -54,7 +59,7 @@ describe(`${adjustEntitiesWithExpandedMembers.name}`, () => {
     const { value } = await adjustEntitiesWithExpandedMembers({
       value: { members },
       typeName: 'typeName',
-      context: {},
+      context: contextMock,
     })
     expect(value.members).toEqual([
       { id: 'id1', [ODATA_TYPE_FIELD]: '#microsoft.graph.group' },
@@ -71,7 +76,7 @@ describe(`${adjustEntitiesWithExpandedMembers.name}`, () => {
     const { value } = await adjustEntitiesWithExpandedMembers({
       value: { members },
       typeName: 'typeName',
-      context: {},
+      context: contextMock,
     })
     expect(value.members).toEqual([
       { id: 'id1', [ODATA_TYPE_FIELD]: '#microsoft.graph.group' },

--- a/packages/microsoft-entra-adapter/test/fetch/utils/application.test.ts
+++ b/packages/microsoft-entra-adapter/test/fetch/utils/application.test.ts
@@ -16,10 +16,13 @@
 
 import { IDENTIFIER_URIS_FIELD_NAME } from '../../../src/constants'
 import { adjustApplication } from '../../../src/definitions/fetch/utils'
+import { contextMock } from '../../mocks'
 
 describe(`${adjustApplication.name}`, () => {
   it('should throw an error when value is not an object', async () => {
-    await expect(adjustApplication({ value: 'not an object', typeName: 'typeName', context: {} })).rejects.toThrow()
+    await expect(
+      adjustApplication({ value: 'not an object', typeName: 'typeName', context: contextMock }),
+    ).rejects.toThrow()
   })
 
   it('should throw an error when identifiersUri field is not an array', async () => {
@@ -27,13 +30,13 @@ describe(`${adjustApplication.name}`, () => {
       adjustApplication({
         value: { [IDENTIFIER_URIS_FIELD_NAME]: 'not an array' },
         typeName: 'typeName',
-        context: {},
+        context: contextMock,
       }),
     ).rejects.toThrow()
   })
 
   it('should not throw an error when identifierUris field is missing', async () => {
-    await expect(adjustApplication({ value: {}, typeName: 'typeName', context: {} })).resolves.not.toThrow()
+    await expect(adjustApplication({ value: {}, typeName: 'typeName', context: contextMock })).resolves.not.toThrow()
   })
 
   it('should filter out identifierUris with of the form api://<appId>', async () => {
@@ -42,7 +45,7 @@ describe(`${adjustApplication.name}`, () => {
     const result = await adjustApplication({
       value: { [IDENTIFIER_URIS_FIELD_NAME]: identifierUris, appId },
       typeName: 'typeName',
-      context: {},
+      context: contextMock,
     })
     expect(result.value[IDENTIFIER_URIS_FIELD_NAME]).toEqual(['otherUri', `api://not${appId}`])
   })

--- a/packages/microsoft-entra-adapter/test/filters/array_fields_deployment.test.ts
+++ b/packages/microsoft-entra-adapter/test/filters/array_fields_deployment.test.ts
@@ -132,10 +132,7 @@ describe('deploy array fields filter', () => {
         },
       },
     }
-    filter = deployArrayFieldsFilterCreator({
-      convertError: (_elemID, err) => err,
-      ...filterParams,
-    })({
+    filter = deployArrayFieldsFilterCreator(filterParams)({
       definitions: mockDefinitions,
       elementSource: buildElementsSourceFromElements([]),
       config: {},
@@ -149,10 +146,7 @@ describe('deploy array fields filter', () => {
 
   it('should return SaltoError if the deploy definitions are missing', async () => {
     const res = await (
-      deployArrayFieldsFilterCreator({
-        convertError: (_elemID, err) => err,
-        ...filterParams,
-      })({
+      deployArrayFieldsFilterCreator(filterParams)({
         definitions: {
           ...mockDefinitions,
           deploy: undefined,


### PR DESCRIPTION
There's currently a regression where TS build is not failing on test files.
Until it's resolved I manually fixed build errors under `entra-adapter` package.


---
_Release Notes_: 
None

---
_User Notifications_: 
None