### PR TITLE
SALTO-6452: DC null scripts

### DIFF
--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_dc.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_dc.ts
@@ -52,7 +52,8 @@ const decodeScriptObject = (base64: string): unknown => {
     const value = JSON.parse(script)
     if (value.scriptPath === null) {
       delete value.scriptPath
-    } else if (value.script === null) {
+    }
+    if (value.script === null) {
       delete value.script
     }
     return value

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
@@ -43,6 +43,7 @@ describe('Scriptrunner DC Workflow', () => {
   const goodBase64 = 'YCFgZGVtbyBzdHJpbmc=' // YCFg followed by base64 of 'demo string'
   const objectNoNullsBase64 = 'YCFgeyJhIjoxfQ==' // YCFg followed by base64 of '{"a":1}'
   const objectScriptOnlyBase64 = 'YCFgeyJzY3JpcHQiOjEsInNjcmlwdFBhdGgiOm51bGx9' // YCFg followed by base64 of '{"script":1,"scriptPath":null}'
+  const twoNulls = 'YCFgeyJzY3JpcHQiOm51bGwsICJzY3JpcHRQYXRoIjpudWxsfQ==' // YCFg followed by base64 of '{"script":null, "scriptPath":null}'
   const objectPathOnlyBase64 = 'YCFgeyJzY3JpcHQiOm51bGwsInNjcmlwdFBhdGgiOjF9'
   const FIELD_NAMES_STRINGS = [
     'FIELD_NOTES',
@@ -182,6 +183,13 @@ describe('Scriptrunner DC Workflow', () => {
         expect(
           instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
         ).toBeUndefined()
+      })
+      it('should not return null if both script and path are null', async () => {
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = twoNulls
+        await filter.onFetch([instance])
+        expect(
+          instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT,
+        ).toEqual({})
       })
     })
     describe('pre deploy', () => {


### PR DESCRIPTION
DC can have both script and path nulls. When it happens, we keep the null, and bad things happen
---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a scriptrunner bug that caused unwanted values in deployment

---
_User Notifications_: 
None
