### PR TITLE
SALTO-6261: include all required node_modules in vscode package

### DIFF
--- a/packages/vscode/scripts/package.sh
+++ b/packages/vscode/scripts/package.sh
@@ -26,9 +26,9 @@ mkdir -p extension/node_modules/
 rsync -a ../../../node_modules/ extension/node_modules/
 # Copy the current salto packages as if they were installed
 mkdir -p extension/node_modules/@salto-io
-yarn workspaces list --json | jq -r 'select(.name | startswith("@salto-io")) | "../../../\(.location) ./extension/node_modules/\(.name)"' | while read -r src dst; do
-    rm -rf $dst;
-    rsync -a --include /dist --include "/dist/***" --include /package.json --exclude "*" $src/ $dst/;
+yarn workspaces list --json | jq -r 'select(.name | startswith("@salto-io")) | "\(.location) \(.name)"' | while read -r src dst; do
+    rm -rf "./extension/node_modules/$dst";
+    rsync -a --include /dist --include "/dist/***" --include /package.json --exclude "*" "../../../$src/" "./extension/node_modules/$dst/";
 done
 
 zip -ur salto.vsix extension

--- a/packages/vscode/scripts/package.sh
+++ b/packages/vscode/scripts/package.sh
@@ -23,7 +23,14 @@ mkdir -p ./tmp_pkg && cp ../../LICENSE . && vsce package --yarn -o ./tmp_pkg/sal
 pushd ./tmp_pkg 
 unzip salto.vsix
 mkdir -p extension/node_modules/
-rsync -a --exclude '@salto-io' ../../../node_modules extension/node_modules/
+rsync -a ../../../node_modules/ extension/node_modules/
+# Copy the current salto packages as if they were installed
+mkdir -p extension/node_modules/@salto-io
+yarn workspaces list --json | jq -r 'select(.name | startswith("@salto-io")) | "../../../\(.location) ./extension/node_modules/\(.name)"' | while read -r src dst; do
+    rm -rf $dst;
+    rsync -a --include /dist --include "/dist/***" --include /package.json --exclude "*" $src/ $dst/;
+done
+
 zip -ur salto.vsix extension
 popd
 


### PR DESCRIPTION
Fix the package.sh script to put all the required dependencies in the right paths

---

_Additional context for reviewer_
There was a missing trailing `/` in the `rsync` command which made it create the node modules folder under `extension/node_modules/node_modules`
Also, since we are dealing with a monorepo and the salto-io packages are there with a symbolic link, they would get excluded from the zip, so added a separate step to copy all the salto-io pacakges.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_