### PR TITLE
SALTO-5724: Avoid failing the entire plan for circular dependency error

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -105,11 +105,17 @@ export type DependencyError = ChangeError & {
   causeID: ElemID
 }
 
+export type CircularDependencyChangeError = ChangeError & {
+  cycleIDs: ElemID[]
+}
+
 export type UnresolvedReferenceError = ChangeError & {
   unresolvedElemIds: ElemID[]
 }
 
 export const isDependencyError = (err: ChangeError): err is DependencyError => 'causeID' in err
+
+export const isCircularDependencyChangeError = (err: ChangeError): err is CircularDependencyChangeError => 'cycleIDs' in err
 
 export const isUnresolvedReferenceError = (err: ChangeError): err is UnresolvedReferenceError =>
   err.type === 'unresolvedReferences' && 'unresolvedElemIds' in err

--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -115,7 +115,8 @@ export type UnresolvedReferenceError = ChangeError & {
 
 export const isDependencyError = (err: ChangeError): err is DependencyError => 'causeID' in err
 
-export const isCircularDependencyChangeError = (err: ChangeError): err is CircularDependencyChangeError => 'cycleIDs' in err
+export const isCircularDependencyChangeError = (err: ChangeError): err is CircularDependencyChangeError =>
+  'cycleIDs' in err
 
 export const isUnresolvedReferenceError = (err: ChangeError): err is UnresolvedReferenceError =>
   err.type === 'unresolvedReferences' && 'unresolvedElemIds' in err

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -13,6 +13,7 @@ export const CORE_FLAGS = {
   skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
   autoMergeListsDisabled: 'AUTO_MERGE_LISTS_DISABLE',
   dumpStateWithLegacyFormat: 'DUMP_STATE_WITH_LEGACY_FORMAT',
+  failPlanOnCircularDependencies: 'FAIL_PLAN_ON_CIRCULAR_DEPENDENCY',
 } as const
 
 type CoreFlagName = types.ValueOf<typeof CORE_FLAGS>

--- a/packages/core/src/core/plan/filter.ts
+++ b/packages/core/src/core/plan/filter.ts
@@ -166,9 +166,9 @@ const buildValidDiffGraph = (
 
   const nodesToOmitWithDependents = Object.values(dependenciesMap).flatMap(nodeIds => [...nodeIds])
 
-  const circularDependencyIDs = new Set(invalidChanges
-  .filter(error => isCircularDependencyChangeError(error))
-  .map(error => error.elemID.getFullName()))
+  const circularDependencyIDs = new Set(
+    invalidChanges.filter(error => isCircularDependencyChangeError(error)).map(error => error.elemID.getFullName()),
+  )
 
   const dependencyErrors = Object.entries(dependenciesMap)
     .map(

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -120,7 +120,7 @@ export const buildGroupedGraphFromDiffGraph = (
   diffGraph: DataNodeMap<Change>,
   customGroupKeys?: Map<ChangeId, ChangeGroupId>,
   disjointGroups?: Set<ChangeGroupId>,
-): GroupDAG<Change> => {
+): { graph: GroupDAG<Change>; removedCycles: collections.set.SetId[][] } => {
   const groupKey = (nodeId: NodeId): string => {
     const customKey = customGroupKeys?.get(nodeId)
     if (customKey !== undefined) {

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -135,7 +135,10 @@ export const buildGroupedGraphFromDiffGraph = (
 
   const diffGraphWithoutRedundantFieldNodes = removeRedundantFieldNodes(diffGraph, groupKey)
   const shouldFailOnCircularDependency = getCoreFlagBool(CORE_FLAGS.failPlanOnCircularDependencies)
-  log.debug('building acyclic grouped graph with failPlanOnCircularDependencies value: %s', shouldFailOnCircularDependency)
+  log.debug(
+    'building acyclic grouped graph with failPlanOnCircularDependencies value: %s',
+    shouldFailOnCircularDependency,
+  )
   return buildAcyclicGroupedGraph({
     source: diffGraphWithoutRedundantFieldNodes,
     groupKey,

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -21,6 +21,7 @@ import {
   isObjectTypeChange,
   isFieldChange,
 } from '@salto-io/adapter-api'
+import { CORE_FLAGS, getCoreFlagBool } from '../flags'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -133,5 +134,10 @@ export const buildGroupedGraphFromDiffGraph = (
   }
 
   const diffGraphWithoutRedundantFieldNodes = removeRedundantFieldNodes(diffGraph, groupKey)
-  return buildAcyclicGroupedGraph(diffGraphWithoutRedundantFieldNodes, groupKey, disjointGroups)
+  return buildAcyclicGroupedGraph({
+    source: diffGraphWithoutRedundantFieldNodes,
+    groupKey,
+    shouldFailOnCircularDependency: getCoreFlagBool(CORE_FLAGS.failPlanOnCircularDependencies),
+    disjointGroups,
+  })
 }

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -134,10 +134,12 @@ export const buildGroupedGraphFromDiffGraph = (
   }
 
   const diffGraphWithoutRedundantFieldNodes = removeRedundantFieldNodes(diffGraph, groupKey)
+  const shouldFailOnCircularDependency = getCoreFlagBool(CORE_FLAGS.failPlanOnCircularDependencies)
+  log.debug('building acyclic grouped graph with failPlanOnCircularDependencies value: %s', shouldFailOnCircularDependency)
   return buildAcyclicGroupedGraph({
     source: diffGraphWithoutRedundantFieldNodes,
     groupKey,
-    shouldFailOnCircularDependency: getCoreFlagBool(CORE_FLAGS.failPlanOnCircularDependencies),
+    shouldFailOnCircularDependency,
     disjointGroups,
   })
 }

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -132,5 +132,6 @@ export const buildGroupedGraphFromDiffGraph = (
     return groupElement.elemID.getFullName()
   }
 
-  return buildAcyclicGroupedGraph(removeRedundantFieldNodes(diffGraph, groupKey), groupKey, disjointGroups)
+  const diffGraphWithoutRedundantFieldNodes = removeRedundantFieldNodes(diffGraph, groupKey)
+  return buildAcyclicGroupedGraph(diffGraphWithoutRedundantFieldNodes, groupKey, disjointGroups)
 }

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -34,14 +34,16 @@ import {
   areReferencesEqual,
   CompareOptions,
   compareElementIDs,
+  getChangeData,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, GroupDAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
 import { expressions } from '@salto-io/workspace'
 import { collections, values } from '@salto-io/lowerdash'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { PlanItem, addPlanItemAccessors, PlanItemId } from './plan_item'
 import { buildGroupedGraphFromDiffGraph, getCustomGroupIds } from './group'
-import { filterInvalidChanges } from './filter'
+import { createCircularDependencyError, filterInvalidChanges, getChangeErrors, FilterResult } from './filter'
 import {
   addNodeDependencies,
   addFieldToObjectDependency,
@@ -416,6 +418,81 @@ const buildDiffGraph = (...transforms: ReadonlyArray<PlanTransformer>): Promise<
     Promise.resolve(new DataNodeMap<DiffNode<ChangeDataType>>()),
   )
 
+const buildGroupedGraphFromFilterResult = async (
+  before: ReadOnlyElementsSource,
+  after: ReadOnlyElementsSource,
+  filterResult: FilterResult,
+  customGroupIdFunctions: Record<string, ChangeGroupIdFunction>,
+): Promise<{ groupedGraph: GroupDAG<Change>; removedCycles: collections.set.SetId[][] }> => {
+  // If the graph was replaced during filtering we need to resolve the graph again to account
+  // for nodes that may have changed during the filter.
+  if (filterResult.replacedGraph) {
+    // Note - using "after" here may be incorrect because filtering could create different
+    // "after" elements
+    await resolveNodeElements(before, after)(filterResult.validDiffGraph)
+  }
+
+  const { changeGroupIdMap, disjointGroups } = await getCustomGroupIds(
+    filterResult.validDiffGraph,
+    customGroupIdFunctions,
+  )
+
+  const { graph: groupedGraph, removedCycles } = buildGroupedGraphFromDiffGraph(
+    filterResult.validDiffGraph,
+    changeGroupIdMap,
+    disjointGroups,
+  )
+  return { groupedGraph, removedCycles }
+}
+
+const createGroupedGraphAndChangeErrors = async (
+  before: ReadOnlyElementsSource,
+  after: ReadOnlyElementsSource,
+  filterResult: FilterResult,
+  customGroupIdFunctions: Record<string, ChangeGroupIdFunction>,
+): Promise<{ groupGraph: GroupDAG<Change>; changeErrors: ChangeError[] }> => {
+  const { groupedGraph: firstIterationGraph, removedCycles } = await buildGroupedGraphFromFilterResult(
+    before,
+    after,
+    filterResult,
+    customGroupIdFunctions,
+  )
+  if (removedCycles.length === 0) {
+    return { groupGraph: firstIterationGraph, changeErrors: filterResult.changeErrors }
+  }
+
+  // circular dependencies detected in the first iteration, build the graph again after all cycles were removed
+
+  const circularDependencyErrors = removedCycles.flatMap(cycle => {
+    const cycleIds = cycle.map(id => getChangeData(filterResult.validDiffGraph.getData(id)).elemID)
+    return cycleIds.map(id => createCircularDependencyError(id, cycleIds))
+  })
+
+  const filteredCircularNodesResult = await filterInvalidChanges(
+    before,
+    after,
+    filterResult.validDiffGraph,
+    circularDependencyErrors,
+  )
+
+  const { groupedGraph: secondIterationGraph, removedCycles: additionalCycles } =
+    await buildGroupedGraphFromFilterResult(before, after, filteredCircularNodesResult, customGroupIdFunctions)
+
+  // shouldn't happen, as all cycles were removed in the first iteration
+  if (additionalCycles.length > 0) {
+    log.error(
+      'detected circular dependencies in plan after cycles were removed in the first iteration. detected cycles: %s. failing plan',
+      safeJsonStringify(additionalCycles),
+    )
+    throw new Error('Failed to remove circular dependencies from plan')
+  }
+
+  return {
+    groupGraph: secondIterationGraph,
+    changeErrors: filterResult.changeErrors.concat(filteredCircularNodesResult.changeErrors),
+  }
+}
+
 export const defaultDependencyChangers = [
   addAfterRemoveDependency,
   addTypeDependency,
@@ -457,24 +534,18 @@ export const getPlan = async ({
         resolveNodeElements(before, after),
         addNodeDependencies(dependencyChangers),
       )
-      const filterResult = await filterInvalidChanges(before, after, diffGraph, changeValidators)
+      const validatorsErrors = await getChangeErrors(after, diffGraph, changeValidators)
+      const filterResult = await filterInvalidChanges(before, after, diffGraph, validatorsErrors)
 
-      // If the graph was replaced during filtering we need to resolve the graph again to account
-      // for nodes that may have changed during the filter.
-      if (filterResult.replacedGraph) {
-        // Note - using "after" here may be incorrect because filtering could create different
-        // "after" elements
-        await resolveNodeElements(before, after)(filterResult.validDiffGraph)
-      }
-
-      const { changeGroupIdMap, disjointGroups } = await getCustomGroupIds(
-        filterResult.validDiffGraph,
+      // build graph and add additional errors
+      const { groupGraph, changeErrors } = await createGroupedGraphAndChangeErrors(
+        before,
+        after,
+        filterResult,
         customGroupIdFunctions,
       )
-      // build graph
-      const groupedGraph = buildGroupedGraphFromDiffGraph(filterResult.validDiffGraph, changeGroupIdMap, disjointGroups)
       // build plan
-      return addPlanFunctions(groupedGraph, filterResult.changeErrors, compareOptions)
+      return addPlanFunctions(groupGraph, changeErrors, compareOptions)
     },
     'get plan with %o -> %o elements',
     numBeforeElements,

--- a/packages/core/test/common/plan_generator.ts
+++ b/packages/core/test/common/plan_generator.ts
@@ -25,6 +25,7 @@ import {
 import * as mock from './elements'
 import { getPlan, Plan } from '../../src/core/plan'
 import { createElementSource } from './helpers'
+import { addFieldToObjectDependency } from '../../src/core/plan/dependency'
 
 export type PlanGenerators = {
   planWithTypeChanges: () => Promise<[Plan, ObjectType]>
@@ -254,7 +255,7 @@ export const planGenerators = (allElements: ReadonlyArray<Element>): PlanGenerat
     return getPlan({
       before: createElementSource([]),
       after: createElementSource(afterElements),
-      dependencyChangers: [depChanger],
+      dependencyChangers: [depChanger, addFieldToObjectDependency],
       changeValidators: withValidator ? { salto: async () => [] } : {},
     })
   },

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -20,6 +20,7 @@ import {
   VariableExpression,
   TemplateExpression,
   isDependencyError,
+  isCircularDependencyChangeError,
 } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
 import wu from 'wu'
@@ -193,12 +194,24 @@ describe('getPlan', () => {
         // Without change validators
         const planWithNoValidators = await planWithDependencyCycle(false)
         const planWithNoValidatorsItems = [...planWithNoValidators.itemsByEvalOrder()]
-        expect(planWithNoValidatorsItems).toHaveLength(6)
-
+        expect(planWithNoValidatorsItems).toHaveLength(4)
+        const circularDependencyErrors = planWithNoValidators.changeErrors.filter(isCircularDependencyChangeError)
+        expect(circularDependencyErrors).toHaveLength(2)
+        expect(circularDependencyErrors.map(err => err.elemID.getFullName())).toEqual([
+          'salto.employee',
+          'salto.office',
+        ])
+        
         // With change validators
         const plainWithValidators = await planWithDependencyCycle(true)
         const planWithValidatorsItems = [...plainWithValidators.itemsByEvalOrder()]
-        expect(planWithValidatorsItems).toHaveLength(6)
+        expect(planWithValidatorsItems).toHaveLength(4)
+        const circularDependencyErrorsWithValidators = planWithNoValidators.changeErrors.filter(isCircularDependencyChangeError)
+        expect(circularDependencyErrorsWithValidators).toHaveLength(2)
+        expect(circularDependencyErrorsWithValidators.map(err => err.elemID.getFullName())).toEqual([
+          'salto.employee',
+          'salto.office',
+        ])
       })
 
       afterAll(() => {

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -201,12 +201,14 @@ describe('getPlan', () => {
           'salto.employee',
           'salto.office',
         ])
-        
+
         // With change validators
         const plainWithValidators = await planWithDependencyCycle(true)
         const planWithValidatorsItems = [...plainWithValidators.itemsByEvalOrder()]
         expect(planWithValidatorsItems).toHaveLength(4)
-        const circularDependencyErrorsWithValidators = planWithNoValidators.changeErrors.filter(isCircularDependencyChangeError)
+        const circularDependencyErrorsWithValidators = planWithNoValidators.changeErrors.filter(
+          isCircularDependencyChangeError,
+        )
         expect(circularDependencyErrorsWithValidators).toHaveLength(2)
         expect(circularDependencyErrorsWithValidators.map(err => err.elemID.getFullName())).toEqual([
           'salto.employee',

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -205,7 +205,10 @@ const buildAcyclicGroupedGraphImpl = <T>(
   } catch (error) {
     if (error instanceof CircularDependencyError) {
       const { causingNodeIds } = error
-      log.debug('detected circular dependency in group graph, removing the following nodes: %s', causingNodeIds.map(toString).join(', ') )
+      log.debug(
+        'detected circular dependency in group graph, removing the following nodes: %s',
+        causingNodeIds.map(toString).join(', '),
+      )
       causingNodeIds.forEach(nodeId => source.deleteNode(nodeId))
       return buildAcyclicGroupedGraphImpl(source, groupKey, origGroupKey, removedCycles.concat([causingNodeIds]))
     }

--- a/packages/dag/src/group.ts
+++ b/packages/dag/src/group.ts
@@ -217,9 +217,8 @@ const buildAcyclicGroupedGraphImpl = <T>(
         'detected circular dependency in group graph, removing the following nodes: %s',
         causingNodeIds.join(', '),
       )
-      causingNodeIds.forEach(nodeId => source.deleteNode(nodeId))
       return buildAcyclicGroupedGraphImpl(
-        source,
+        source.cloneWithout(new Set(causingNodeIds)),
         groupKey,
         origGroupKey,
         removedCycles.concat([causingNodeIds]),

--- a/packages/dag/test/group.test.ts
+++ b/packages/dag/test/group.test.ts
@@ -183,7 +183,7 @@ describe('buildGroupGraph', () => {
         ['n2', 'n3'],
         ['n3', 'n4'],
         ['n4', 'n2'],
-        ['n1', 'n5']
+        ['n1', 'n5'],
       ]
 
       const [srcGraph, groupKeyFunc] = buildSrcGraphAndGroupKeyFunc(groups, edges)


### PR DESCRIPTION
When encounter circular dependencies in the grouped graph plan, remove the cycle from graph and create a valid plan without it.

---

_Additional context for reviewer_

Today, when the plan contains a circular dependency, we throw error and fail the entire plan, even for elements that could have been deployed. This PR changes this behavior, by removing the cycles from plan and creating change errors for the removed elements.

When first building the grouped graph, every cycle detected is removed from graph until no more cycles can be found.
After the first iteration of the grouped graph, we need to rerun the filter in order to adjust types and create additional (non circular, regular) dependency errors based on the dropped elements.
Then we try to build the group graph again, this time (hopefully), no cycles should exist.

The whole thing is controlled via `SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY` env var 

---
_Release Notes_: 

_Core_:

- When deploy plan include elements which has circular dependency, the elements involved in the cycle will be removed from plan.

---
_User Notifications_: 
None
