### PR TITLE
SALTO-6463: run e2e for dependant packages

### DIFF
--- a/.circleci/scripts/find_changed_packages.js
+++ b/.circleci/scripts/find_changed_packages.js
@@ -30,8 +30,7 @@ const getWorkspacesInfo = () => {
   const output = execSync('yarn workspaces list --json -v', { encoding: 'utf8' })
   const transformToObject = (array) => {
     return array.reduce((acc,item) => {
-      const { name, ...rest } = item
-      acc[name] = rest
+      acc[item.location] = item
       return acc
     }, {})
   }


### PR DESCRIPTION
This fixes a bug in the find_changed_packages script that caused it to not run e2e for dependant packages It would only run it for the current package.

---

_Additional context for reviewer_
Seems like a regression from the node18 commit.
The code in `generateDependencyMapping` is built with the assumption that the keys of `workspaceInfo` is the same thing that is in the array of `workspaceDependencies` (see line 48 in particular).
the info in `workspaceDependencies` is the package location, whereas the previous code had the package name is the key in `workspaceInfo`, so we didn't get any dependency calculation...

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_