### PR TITLE
SALTO-6421: Support Development Field In Issue Layout

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/jsm/request_type.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/jsm/request_type.ts
@@ -42,6 +42,14 @@ export const createrequestTypeValues = (name: string, allElements: Element[]): V
     issueLayoutConfig: {
       items: [
         {
+          type: 'PANEL',
+          sectionType: 'PRIMARY',
+          key: 'SLA_PANEL',
+          data: {
+            name: 'SLAs',
+          },
+        },
+        {
           type: 'FIELD',
           sectionType: 'PRIMARY',
           key: createReference(new ElemID(JIRA, 'Field', 'instance', 'Assignee__user'), allElements),

--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -196,6 +196,15 @@ const deployLayoutChange = async (change: Change<InstanceElement>, client: JiraC
           },
         }
       }
+      if (item.type === 'PANEL') {
+        // Panel that is not a reference Expression
+        return {
+          type: item.type,
+          sectionType: item.sectionType.toLocaleLowerCase(),
+          key: item.key,
+          data: item.data,
+        }
+      }
       return undefined
     })
     .filter(isDefined)

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -136,13 +136,13 @@ const fromLayoutConfigRespToLayoutConfig = (layoutConfig: IssueLayoutConfigurati
     .flatMap(container =>
       container.items.nodes.map(node => {
         const dataKey = node.panelItemId ?? node.fieldItemId
-        if (!dataKey) {
+        if (dataKey === undefined) {
           return undefined
         }
         return {
           type: node.fieldItemId ? 'FIELD' : 'PANEL',
           sectionType: container.containerType,
-          key: node.panelItemId ?? node.fieldItemId,
+          key: dataKey,
           data: fieldItemIdToMetaData[dataKey],
         }
       }),

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -125,16 +125,27 @@ const fromLayoutConfigRespToLayoutConfig = (layoutConfig: IssueLayoutConfigurati
   const fieldItemIdToMetaData: Record<string, Value> = Object.fromEntries(
     (layoutConfig.metadata?.configuration.items.nodes ?? [])
       .filter(node => !_.isEmpty(node))
-      .map(node => [node.fieldItemId, _.omit(node, 'fieldItemId')]),
+      .map(node => {
+        if (node.fieldItemId) {
+          return [node.fieldItemId, _.omit(node, 'fieldItemId')]
+        }
+        return [node.panelItemId, _.omit(node, 'panelItemId')]
+      }),
   )
   const items = containers
     .flatMap(container =>
-      container.items.nodes.map(node => ({
-        type: 'FIELD',
-        sectionType: container.containerType,
-        key: node.fieldItemId,
-        data: fieldItemIdToMetaData[node.fieldItemId],
-      })),
+      container.items.nodes.map(node => {
+        const dataKey = node.panelItemId ?? node.fieldItemId
+        if (!dataKey) {
+          return undefined
+        }
+        return {
+          type: node.fieldItemId ? 'FIELD' : 'PANEL',
+          sectionType: container.containerType,
+          key: node.panelItemId ?? node.fieldItemId,
+          data: fieldItemIdToMetaData[dataKey],
+        }
+      }),
     )
     .filter(isLayoutConfigItem)
 

--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -86,7 +86,7 @@ export type ContainerIssueLayoutResponse = {
   containerType: string
   items: {
     nodes: {
-      fieldItemId: string
+      fieldItemId?: string
       panelItemId?: string
     }[]
   }
@@ -118,7 +118,8 @@ export type IssueLayoutConfiguration = {
     configuration: {
       items: {
         nodes: {
-          fieldItemId: string
+          fieldItemId?: string
+          panelItemId?: string
         }[]
       }
     }
@@ -130,7 +131,7 @@ export type IssueLayoutResponse = {
 }
 
 export type LayoutConfigItem = {
-  type: string
+  type: 'FIELD' | 'PANEL'
   sectionType: 'PRIMARY' | 'SECONDARY' | 'CONTENT' | 'REQUEST'
   key: string
   data:
@@ -141,7 +142,7 @@ export type LayoutConfigItem = {
 }
 
 export const ISSUE_LAYOUT_CONFIG_ITEM_SCHEME = Joi.object({
-  type: Joi.string().required(),
+  type: Joi.string().valid('FIELD', 'PANEL').required(),
   sectionType: Joi.string().valid('PRIMARY', 'SECONDARY', 'CONTENT', 'REQUEST').required(),
   key: Joi.string().required(),
   data: Joi.object({

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -148,6 +148,9 @@ const deployRequestTypeLayout = async (
           data: item.data,
         }
       }
+      log.error(
+        `Failed to deploy request type: ${requestType.elemID.getFullName()}'s ${fieldName} due to bad reference expression`,
+      )
       return undefined
     })
     .filter(isDefined)

--- a/packages/jira-adapter/src/filters/request_type.ts
+++ b/packages/jira-adapter/src/filters/request_type.ts
@@ -123,26 +123,32 @@ const deployRequestTypeLayout = async (
   const layout = requestType.value[fieldName]
   const items = layout.issueLayoutConfig.items
     .map((item: LayoutConfigItem) => {
-      if (!isResolvedReferenceExpression(item.key)) {
-        log.error(
-          `Failed to deploy request type: ${requestType.elemID.getFullName()}'s ${fieldName} due to bad reference expression`,
-        )
-        throw new Error(`Failed to deploy requestType ${fieldName} due to a bad item key: ${item.key}`)
+      if (isResolvedReferenceExpression(item.key)) {
+        const key = item.key.value.value.id
+        return {
+          type: item.type,
+          sectionType: item.sectionType.toLowerCase(),
+          key,
+          data: {
+            name: item.key.value.value.name,
+            type:
+              item.key.value.value.type ??
+              item.key.value.value.schema?.system ??
+              item.key.value.value.name.toLowerCase?.(),
+            ...item.data,
+          },
+        }
       }
-      const key = item.key.value.value.id
-      return {
-        type: item.type,
-        sectionType: item.sectionType.toLowerCase(),
-        key,
-        data: {
-          name: item.key.value.value.name,
-          type:
-            item.key.value.value.type ??
-            item.key.value.value.schema?.system ??
-            item.key.value.value.name.toLowerCase?.(),
-          ...item.data,
-        },
+      if (item.type === 'PANEL') {
+        // Panel that is not a reference Expression
+        return {
+          type: item.type,
+          sectionType: item.sectionType.toLocaleLowerCase(),
+          key: item.key,
+          data: item.data,
+        }
       }
+      return undefined
     })
     .filter(isDefined)
 

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1194,7 +1194,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'key', parentTypes: ['issueLayoutItem'] },
     serializationStrategy: 'id',
-    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },
   },
   {

--- a/packages/jira-adapter/test/filters/layouts/create_references_issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/create_references_issue_layout.test.ts
@@ -170,9 +170,6 @@ describe('createReferencesIssueLayoutFilter', () => {
   it('should add key as missing ref if there is no field', async () => {
     fieldInstance1.value.id = 'testField3'
     await filter.onFetch(elements)
-    expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].key).toBeInstanceOf(ReferenceExpression)
-    expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].key.elemID.getFullName()).toEqual(
-      'jira.Field.instance.missing_testField1',
-    )
+    expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].key).toEqual('testField1')
   })
 })

--- a/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/issue_layout.test.ts
@@ -163,6 +163,9 @@ describe('issue layout filter', () => {
                     {
                       fieldItemId: 'testField1',
                     },
+                    {
+                      panelItemId: 'devSummary',
+                    },
                   ],
                 },
               },
@@ -187,6 +190,9 @@ describe('issue layout filter', () => {
                   },
                   {
                     fieldItemId: 'testField2',
+                  },
+                  {
+                    panelItemId: 'devSummary',
                   },
                 ],
               },
@@ -492,6 +498,29 @@ describe('issue layout filter', () => {
       expect(issueLayout?.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
         'https://ori-salto-test.atlassian.net/plugins/servlet/project-config/projKey/issuelayout?screenId=11',
       )
+      expect(issueLayout?.value).toEqual({
+        extraDefinerId: '11',
+        id: '11111_11',
+        issueLayoutConfig: {
+          items: [
+            {
+              type: 'FIELD',
+              sectionType: 'PRIMARY',
+              key: 'testField1',
+            },
+            {
+              type: 'PANEL',
+              sectionType: 'PRIMARY',
+              key: 'devSummary',
+            },
+            {
+              type: 'FIELD',
+              sectionType: 'SECONDARY',
+              key: 'testField2',
+            },
+          ],
+        },
+      })
     })
     it('should not crash if the adapterContext.layoutsPromise is empty', async () => {
       adapterContext.layoutsPromise = {}
@@ -705,6 +734,14 @@ describe('issue layout filter', () => {
         sectionType: 'PRIMARY',
         key: new ReferenceExpression(fieldInstance3.elemID, fieldInstance3),
       }
+      afterIssueLayoutInstance.value.issueLayoutConfig.items[3] = {
+        type: 'PANEL',
+        sectionType: 'PRIMARY',
+        key: 'devSummary',
+        data: {
+          name: 'Development',
+        },
+      }
       const res = await layoutFilter.deploy([
         { action: 'modify', data: { before: issueLayoutInstance, after: afterIssueLayoutInstance } },
       ])
@@ -750,6 +787,14 @@ describe('issue layout filter', () => {
                 data: {
                   name: 'TestField3',
                   type: 'testField3',
+                },
+              },
+              {
+                key: 'devSummary',
+                sectionType: 'primary',
+                type: 'PANEL',
+                data: {
+                  name: 'Development',
                 },
               },
             ],

--- a/packages/jira-adapter/test/filters/request_type.test.ts
+++ b/packages/jira-adapter/test/filters/request_type.test.ts
@@ -422,16 +422,6 @@ describe('requestType filter', () => {
         'Failed to deploy request type workflow statuses due to bad workflow statuses',
       )
     })
-    it('should not deploy addition of bad request form', async () => {
-      const requestTypeAfter = requestTypeInstance.clone()
-      requestTypeAfter.value.requestForm.issueLayoutConfig.items[0].key = 'not a reference'
-      const res = await filter.deploy([{ action: 'add', data: { after: requestTypeAfter } }])
-      expect(res.leftoverChanges).toHaveLength(0)
-      expect(res.deployResult.errors).toHaveLength(1)
-      expect(res.deployResult.errors[0].message).toContain(
-        'Error: Failed to deploy requestType requestForm due to a bad item key: not a reference',
-      )
-    })
     it('should not deploy requestType if bad issue Layout response', async () => {
       mockGet.mockImplementation(() => {
         throw new Error('Err')


### PR DESCRIPTION
In this PR I support fetching and deploying development field in issue Layout

---

_Additional context for reviewer_
1. As we can see in the gira response we get from jira - there are two types of fields: `FIELD` and `PANEL`. 
Currently we supported only fields of type `FIELD` and I expended it to support also `PANEL` fields.  

---
_Release Notes_: 
_Jira Adapter:_
* [SALTO-6421](https://salto-io.atlassian.net/browse/SALTO-6421): Now support fetching and deploying development field in issueLayout. 

---
_User Notifications_: 
_Jira Adapter:_
* One or more fields of type `PANEL` will be added to the issueLayout type. 


[SALTO-6421]: https://salto-io.atlassian.net/browse/SALTO-6421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ