### PR TITLE
SALTO-6451: Support JSM workflow approvals

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -209,6 +209,7 @@ import fieldContextOptionsSplitFilter from './filters/fields/field_context_optio
 import fieldContextOptionsDeploymentFilter from './filters/fields/context_options_deployment_filter'
 import fieldContextOptionsDeploymentOrderFilter from './filters/fields/context_options_order_deployment_filter'
 import contextDefaultValueDeploymentFilter from './filters/fields/context_default_value_deployment_filter'
+import statusPropertiesReferencesFilter from './filters/workflowV2/status_properties_references'
 
 const { getAllElements, addRemainingTypes } = elementUtils.ducktype
 const { findDataField } = elementUtils
@@ -279,6 +280,8 @@ export const DEFAULT_FILTERS = [
   workflowPropertiesFilter,
   // must run after scriptRunnerWorkflowListsFilter and workflowPropertiesFilter
   scriptRunnerWorkflowReferencesFilter,
+  // must run before workflowTransitionIdsFilter
+  statusPropertiesReferencesFilter,
   // must run after scriptRunnerWorkflowReferencesFilter
   workflowTransitionIdsFilter,
   transitionIdsFilter,

--- a/packages/jira-adapter/src/change_validators/workflowsV2/missing_extensions_transition_rules.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/missing_extensions_transition_rules.ts
@@ -36,7 +36,7 @@ import {
   getRuleTypeFromWorkflowTransitionRule,
   RuleType,
   getExtensionIdFromWorkflowTransitionRule,
-} from '../../common/workflow/transition_rules'
+} from '../../common/workflow/transitions'
 
 const { awu } = collections.asynciterable
 const log = logger(module)

--- a/packages/jira-adapter/src/filters/workflowV2/status_properties_references.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/status_properties_references.ts
@@ -1,0 +1,112 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import {
+  getChangeData,
+  isAdditionOrModificationChange,
+  // getChangeData,
+  // isAdditionOrModificationChange,
+  // isInstanceChange,
+  isInstanceElement,
+  isReferenceExpression,
+  Value,
+} from '@salto-io/adapter-api'
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../../filter'
+import { isWorkflowV2Instance } from './types'
+import { createTransitionReference, getTransitionIdToKeyMap } from '../../common/workflow/transitions'
+
+const TRANSITION_KEYS = (): string[] => ['approval.transition.approved', 'approval.transition.rejected']
+
+type KeyValue = {
+  key: string
+  value: string
+}
+
+const KEY_VALUE_SCHEME = Joi.object({
+  key: Joi.string().required(),
+  value: Joi.string().required(),
+})
+
+const isKeyValue = createSchemeGuard<KeyValue>(KEY_VALUE_SCHEME)
+
+// this filter adds transition references to status properties. Currently the infra does not support it in the reference mapping
+const filter: FilterCreator = ({ config }) => ({
+  name: 'statusPropertiesReferencesFilter',
+  onFetch: async elements => {
+    elements
+      .filter(isInstanceElement)
+      .filter(isWorkflowV2Instance)
+      .forEach(workflowInstance => {
+        const transitionIdsToKeyMap = getTransitionIdToKeyMap(workflowInstance)
+        workflowInstance.value.statuses.forEach(status => {
+          status.properties
+            ?.filter(isKeyValue)
+            .filter((property: KeyValue) => TRANSITION_KEYS().includes(property.key))
+            .forEach((property: Value) => {
+              property.value = createTransitionReference({
+                workflowInstance,
+                transitionId: property.value,
+                enableMissingReferences: config.fetch.enableMissingReferences ?? true,
+                transitionKey: transitionIdsToKeyMap.get(property.value),
+              })
+            })
+        })
+      })
+  },
+  preDeploy: async changes => {
+    changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(isWorkflowV2Instance)
+      .forEach(workflowInstance => {
+        workflowInstance.value.statuses.forEach(status => {
+          status.properties
+            ?.filter((property: Value) => TRANSITION_KEYS().includes(property.key))
+            .filter((property: Value) => isReferenceExpression(property.value))
+            .forEach((property: Value) => {
+              property.value = workflowInstance.value.transitions[property.value.elemID.name].id
+            })
+        })
+      })
+  },
+  onDeploy: async changes => {
+    changes
+      .filter(isAdditionOrModificationChange)
+      .map(getChangeData)
+      .filter(isInstanceElement)
+      .filter(isWorkflowV2Instance)
+      .forEach(workflowInstance => {
+        const transitionIdsToKeyMap = getTransitionIdToKeyMap(workflowInstance)
+        workflowInstance.value.statuses.forEach(status => {
+          status.properties
+            ?.filter(isKeyValue)
+            .filter((property: KeyValue) => TRANSITION_KEYS().includes(property.key))
+            .forEach((property: Value) => {
+              property.value = createTransitionReference({
+                workflowInstance,
+                transitionId: property.value,
+                enableMissingReferences: config.fetch.enableMissingReferences ?? true,
+                transitionKey: transitionIdsToKeyMap.get(property.value),
+              })
+            })
+        })
+      })
+  },
+})
+
+export default filter

--- a/packages/jira-adapter/src/filters/workflowV2/status_properties_references.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/status_properties_references.ts
@@ -16,9 +16,6 @@
 import {
   getChangeData,
   isAdditionOrModificationChange,
-  // getChangeData,
-  // isAdditionOrModificationChange,
-  // isInstanceChange,
   isInstanceElement,
   isReferenceExpression,
   Value,

--- a/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
+++ b/packages/jira-adapter/src/fix_elements/remove_missing_extension_transition_rules.ts
@@ -25,7 +25,7 @@ import {
   WorkflowV2TransitionRule,
   isWorkflowV2Instance,
 } from '../filters/workflowV2/types'
-import { getExtensionIdFromWorkflowTransitionRule } from '../common/workflow/transition_rules'
+import { getExtensionIdFromWorkflowTransitionRule } from '../common/workflow/transitions'
 import { SeverityLevel } from '../../../adapter-api/src/error'
 
 const { awu } = collections.asynciterable

--- a/packages/jira-adapter/src/references/workflow_properties.ts
+++ b/packages/jira-adapter/src/references/workflow_properties.ts
@@ -25,6 +25,8 @@ const KEY_ID_REGEX_TO_TYPE = {
   'jira\\.permission\\..*\\.userCF': FIELD_TYPE_NAME,
   [RESOLUTION_KEY_PATTERN]: RESOLUTION_TYPE_NAME,
   'jira\\.permission\\..*\\.group': GROUP_TYPE_NAME,
+  'approval\\.field\\.id': FIELD_TYPE_NAME,
+  'approval\\.pre-populated\\.field\\.id': FIELD_TYPE_NAME,
 }
 
 export const getRefType = (key: string): string | undefined =>

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_properties.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_properties.test.ts
@@ -1,0 +1,307 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { InstanceElement, ReferenceExpression, toChange, Value } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { FilterResult } from '../../../src/filter'
+import statusPropertiesReferencesFilter from '../../../src/filters/workflowV2/status_properties_references'
+import { createEmptyType, getFilterParams } from '../../utils'
+import { WORKFLOW_CONFIGURATION_TYPE, WORKFLOW_TYPE_NAME } from '../../../src/constants'
+import { getDefaultConfig } from '../../../src/config/config'
+import { getRefType } from '../../../src/references/workflow_properties'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+
+describe('status properties references filter', () => {
+  let filter: filterUtils.FilterWith<'onFetch' | 'preDeploy' | 'onDeploy', FilterResult>
+  let instance: InstanceElement
+  let instanceBody: Value
+  beforeEach(() => {
+    filter = statusPropertiesReferencesFilter(getFilterParams()) as filterUtils.FilterWith<
+      'onFetch' | 'preDeploy' | 'onDeploy',
+      FilterResult
+    >
+    instanceBody = {
+      name: 'name',
+      scope: {
+        type: 'global',
+      },
+      statuses: [
+        {
+          name: 'status1',
+          properties: [
+            {
+              key: 'approval.transition.approved',
+              value: '2',
+            },
+            {
+              key: 'approval.transition.rejected',
+              value: '1',
+            },
+          ],
+        },
+        {
+          name: 'status2',
+          properties: [
+            {
+              key: 'approval.transition.approved',
+              value: '3',
+            },
+            {
+              key: 'approval.transition.rejected',
+              value: '2',
+            },
+          ],
+        },
+      ],
+      transitions: {
+        transition1: {
+          type: 'DIRECTED',
+          name: 'transition1',
+          id: '1',
+        },
+        transition2: {
+          type: 'DIRECTED',
+          name: 'transition2',
+          id: '2',
+        },
+        transition3: {
+          type: 'DIRECTED',
+          name: 'transition3',
+          id: '3',
+        },
+      },
+    }
+    instance = new InstanceElement('instance', createEmptyType(WORKFLOW_CONFIGURATION_TYPE), instanceBody)
+  })
+  describe('on fetch', () => {
+    it('should replace transition ids with references', async () => {
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+      expect(instance.value.statuses[0].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition1'),
+          instance.value.transitions.transition1,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition3'),
+          instance.value.transitions.transition3,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+    })
+    it('should not replace non transition ids', async () => {
+      instance.value.statuses[0].properties[0].value = 'invalid'
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(instance.elemID.createNestedID('transitions', 'missing_invalid')),
+      )
+    })
+    it('should not replace non transition keys', async () => {
+      instance.value.statuses[0].properties[0].key = 'invalid'
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('2')
+    })
+    it('should not create missing references if disabled', async () => {
+      instance.value.statuses[0].properties[0].value = 'invalid'
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+      config.fetch.enableMissingReferences = false
+      filter = statusPropertiesReferencesFilter(getFilterParams({ config })) as filterUtils.FilterWith<
+        'onFetch' | 'preDeploy' | 'onDeploy',
+        FilterResult
+      >
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('invalid')
+    })
+    it('should not create missing references if config value does not exist', async () => {
+      instance.value.statuses[0].properties[0].value = 'invalid'
+      const config = _.cloneDeep(getDefaultConfig({ isDataCenter: true }))
+      delete config.fetch.enableMissingReferences
+      filter = statusPropertiesReferencesFilter(getFilterParams({ config })) as filterUtils.FilterWith<
+        'onFetch' | 'preDeploy' | 'onDeploy',
+        FilterResult
+      >
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(instance.elemID.createNestedID('transitions', 'missing_invalid')),
+      )
+    })
+    it('should not crash if there are no properties', async () => {
+      delete instance.value.statuses[0].properties
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties).toBeUndefined()
+    })
+    it('should not crash if there are no statuses', async () => {
+      delete instance.value.statuses
+      await filter.onFetch([instance])
+      expect(instance.value.statuses).toBeUndefined()
+    })
+    it('should not run on workflow v1', async () => {
+      instance = new InstanceElement('instance', createEmptyType(WORKFLOW_TYPE_NAME), instanceBody)
+      await filter.onFetch([instance])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('2')
+    })
+  })
+  describe('pre deploy', () => {
+    beforeEach(() => {
+      instance.value.statuses[0].properties[0].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition2'),
+      )
+      instance.value.statuses[0].properties[1].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition1'),
+      )
+      instance.value.statuses[1].properties[0].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition3'),
+      )
+      instance.value.statuses[1].properties[1].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition2'),
+      )
+    })
+    it('should replace with references with transitionIds for addition', async () => {
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('2')
+      expect(instance.value.statuses[0].properties[1].value).toEqual('1')
+      expect(instance.value.statuses[1].properties[0].value).toEqual('3')
+      expect(instance.value.statuses[1].properties[1].value).toEqual('2')
+    })
+    it('should replace with references with transitionIds for modification', async () => {
+      const instanceBefore = instance.clone()
+      instanceBefore.value.statuses[0].properties[0].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition1'),
+      )
+      await filter.preDeploy([toChange({ before: instanceBefore, after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('2')
+    })
+    it('should not replace in removal', async () => {
+      await filter.preDeploy([toChange({ before: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(instance.elemID.createNestedID('transitions', 'transition2')),
+      )
+    })
+    it('should not replace non reference values', async () => {
+      instance.value.statuses[0].properties[0].value = 'invalid'
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual('invalid')
+    })
+    it('should not replace non transition keys', async () => {
+      instance.value.statuses[0].properties[0].key = 'invalid'
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(instance.elemID.createNestedID('transitions', 'transition2')),
+      )
+    })
+    it('should not crash if there are no properties', async () => {
+      delete instance.value.statuses[0].properties
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties).toBeUndefined()
+    })
+    it('should not crash if there are no statuses', async () => {
+      delete instance.value.statuses
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses).toBeUndefined()
+    })
+    it('should not run on workflow v1', async () => {
+      const oldInstanceElemID = instance.elemID
+      instance = new InstanceElement('instance', createEmptyType(WORKFLOW_TYPE_NAME), instanceBody)
+      await filter.preDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(oldInstanceElemID.createNestedID('transitions', 'transition2')),
+      )
+    })
+  })
+  describe('on deploy', () => {
+    it('should replace references with transitionIds for addition', async () => {
+      await filter.onDeploy([toChange({ after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+      expect(instance.value.statuses[0].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition1'),
+          instance.value.transitions.transition1,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition3'),
+          instance.value.transitions.transition3,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+    })
+    it('should replace references with transitionIds for modification', async () => {
+      const instanceBefore = instance.clone()
+      instanceBefore.value.statuses[0].properties[0].value = new ReferenceExpression(
+        instance.elemID.createNestedID('transitions', 'transition1'),
+      )
+      await filter.onDeploy([toChange({ before: instanceBefore, after: instance })])
+      expect(instance.value.statuses[0].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+      expect(instance.value.statuses[0].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition1'),
+          instance.value.transitions.transition1,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[0].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition3'),
+          instance.value.transitions.transition3,
+        ),
+      )
+      expect(instance.value.statuses[1].properties[1].value).toEqual(
+        new ReferenceExpression(
+          instance.elemID.createNestedID('transitions', 'transition2'),
+          instance.value.transitions.transition2,
+        ),
+      )
+    })
+    it('should not crash if no properties', () => {
+      delete instance.value.statuses[0].properties
+      expect(() => filter.onDeploy([toChange({ after: instance })])).not.toThrow()
+    })
+  })
+})
+
+describe('workflow properties  filter', () => {
+  it('should not fail', () => {
+    expect(getRefType('approval.field.id')).toEqual(FIELD_TYPE_NAME)
+    expect(getRefType('none')).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Added support for JSM workflow approvals
---
Changed a common file name and added a function to it.

It can be tested on a JSM instance.

Noise reduction will be added
---
_Release Notes_: 
Jira Adapter:
* Added support for JSM workflow approvals

---
_User Notifications_: 
None
