### PR TITLE
SALTO-6419: Fix Axios error message

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -224,7 +224,7 @@ export const axiosConnection = <TCredentials>({
       if (e.response?.status === 401 || e instanceof UnauthorizedError) {
         throw new UnauthorizedError('Unauthorized - update credentials and try again')
       }
-      throw new Error(`Login failed with error: ${e}`)
+      throw new Error(`Login failed with error: ${e.message ?? e}`)
     }
   }
 

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -90,7 +90,7 @@ describe('client_http_connection', () => {
               }),
           },
         ),
-      ).rejects.toThrow(new Error('Login failed with error: Error: aaa'))
+      ).rejects.toThrow(new Error('Login failed with error: aaa'))
     })
   })
   describe('createRetryOptions', () => {


### PR DESCRIPTION
In this PR I removed the HTTP errors that are thrown with the string `AxiosError` and are user visible.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
