### PR TITLE
SALTO-6265 Add ticket form restricted_brand_ids sorting

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -22,7 +22,7 @@ import {
   ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { inspectValue, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from './dynamic_content'
 import {
@@ -234,6 +234,7 @@ const sortRestrictedBrands = (formInstances: InstanceElement[]): void => {
       form.value.restricted_brand_ids = _.sortBy(restrictedBrands, brand => brand.elemID.getFullName())
     } else {
       log.warn(`could not sort restricted brands for ${form.elemID.getFullName()}`)
+      log.trace('restricted brands are: %s', inspectValue(restrictedBrands, { maxArrayLength: null }))
     }
   })
 }

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -231,7 +231,7 @@ const sortRestrictedBrands = (formInstances: InstanceElement[]): void => {
   formInstances.forEach(form => {
     const restrictedBrands = form.value.restricted_brand_ids
     if (_.isArray(restrictedBrands) && restrictedBrands.every(isReferenceExpression)) {
-      form.value.restricted_brand_ids = _.sortBy(restrictedBrands, brand => brand.value.value.name)
+      form.value.restricted_brand_ids = _.sortBy(restrictedBrands, brand => brand.elemID.getFullName())
     } else {
       log.warn(`could not sort restricted brands for ${form.elemID.getFullName()}`)
     }

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -227,6 +227,17 @@ const sortChildFields = (formInstances: InstanceElement[], ticketFieldById: Reco
   })
 }
 
+const sortRestrictedBrands = (formInstances: InstanceElement[]): void => {
+  formInstances.forEach(form => {
+    const restrictedBrands = form.value.restricted_brand_ids
+    if (_.isArray(restrictedBrands) && restrictedBrands.every(isReferenceExpression)) {
+      form.value.restricted_brand_ids = _.sortBy(restrictedBrands, brand => brand.value.value.name)
+    } else {
+      log.warn(`could not sort restricted brands for ${form.elemID.getFullName()}`)
+    }
+  })
+}
+
 const orderFormCondition = (instances: InstanceElement[]): void => {
   const formInstances = instances.filter(e => e.refType.elemID.name === TICKET_FORM_TYPE_NAME)
   const formAgentInstances = formInstances.filter(form => !_.isEmpty(form.value.agent_conditions))
@@ -238,6 +249,7 @@ const orderFormCondition = (instances: InstanceElement[]): void => {
   sortConditions(formAgentInstances, 'agent_conditions', customFieldById)
   sortConditions(formUserInstances, 'end_user_conditions', customFieldById)
   sortChildFields(formInstances, ticketFieldById)
+  sortRestrictedBrands(formInstances)
 }
 
 // The order is irrelevant and cannot be changed

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import {
+  BRAND_TYPE_NAME,
   GROUP_TYPE_NAME,
   MACRO_TYPE_NAME,
   ROUTING_ATTRIBUTE_TYPE_NAME,
@@ -58,11 +59,14 @@ describe('Unordered lists filter', () => {
     const dynamicContentItemVariantType = new ObjectType({
       elemID: new ElemID(ZENDESK, DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME),
     })
+    const brandType = new ObjectType({ elemID: new ElemID(ZENDESK, BRAND_TYPE_NAME) })
     const ticketFieldOneInstance = new InstanceElement('fieldA', ticketFieldType, { raw_title: 'a' })
     const ticketFieldThreeInstance = new InstanceElement('fieldC', ticketFieldType, { raw_title: 'c' })
     const invalidTicketFieldInstance = new InstanceElement('invalid field', ticketFieldType, {})
     const customOneInstance = new InstanceElement('customA', ticketCustomFieldType, { value: 'a' })
     const customThreeInstance = new InstanceElement('customC', ticketCustomFieldType, { value: 'c' })
+    const brandOneInstance = new InstanceElement('zzzBrand', brandType, { name: 'zzzBrand' })
+    const brandTwoInstance = new InstanceElement('heyBrand', brandType, { name: 'heyBrand' })
     const validTicketFormInstance = new InstanceElement('valid form', ticketFormType, {
       agent_conditions: [
         {
@@ -109,6 +113,10 @@ describe('Unordered lists filter', () => {
         {
           value: 'b',
         },
+      ],
+      restricted_brand_ids: [
+        new ReferenceExpression(brandOneInstance.elemID, brandOneInstance),
+        new ReferenceExpression(brandTwoInstance.elemID, brandTwoInstance),
       ],
     })
     const invalidTicketFormInstance = new InstanceElement('invalid form', ticketFormType, {
@@ -516,6 +524,9 @@ describe('Unordered lists filter', () => {
       expect(instances[0].value.end_user_conditions[0].child_fields).toHaveLength(2)
       expect(instances[0].value.end_user_conditions[0].child_fields[0].id.elemID.name).toEqual('fieldA')
       expect(instances[0].value.end_user_conditions[0].child_fields[1].id.elemID.name).toEqual('fieldC')
+      expect(instances[0].value.restricted_brand_ids).toHaveLength(2)
+      expect(instances[0].value.restricted_brand_ids[0].elemID.name).toEqual('heyBrand')
+      expect(instances[0].value.restricted_brand_ids[1].elemID.name).toEqual('zzzBrand')
     })
     it('should not change order the form is invalid', async () => {
       const instances = elements.filter(isInstanceElement).filter(e => e.elemID.name === 'invalid form')


### PR DESCRIPTION
Add ticket form restricted_brand_ids sorting

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter:__
* Ticket form `restricted_brand_ids` are now sorted, as these cannot be updated by users.

---
_User Notifications_: 
__Zendesk Adapter:__
* Ticket form `restricted_brand_ids` are now sorted, as these cannot be updated by users.