### PR TITLE
SALTO-5912: Support Assignee Type

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -75,6 +75,7 @@ import { missingExtensionsTransitionRulesChangeValidator } from './workflowsV2/m
 import { fieldContextOptionsValidator } from './field_contexts/field_context_options'
 import { ISSUE_TYPE_NAME, PORTAL_GROUP_TYPE, PROJECT_TYPE } from '../constants'
 import { assetsObjectFieldConfigurationAqlValidator } from './field_contexts/assets_object_field_configuration_aql'
+import { projectAssigneeTypeValidator } from './projects/project_assignee_type'
 
 const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator } =
   deployment.changeValidators
@@ -150,6 +151,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     jsmPermissions: jsmPermissionsValidator(config, client),
     fieldContextOptions: fieldContextOptionsValidator,
     assetsObjectFieldConfigurationAql: assetsObjectFieldConfigurationAqlValidator(client),
+    projectAssigneeType: projectAssigneeTypeValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/projects/project_assignee_type.ts
+++ b/packages/jira-adapter/src/change_validators/projects/project_assignee_type.ts
@@ -19,17 +19,18 @@ import { ASSIGNEE_TYPE_FIELD, PROJECT_TYPE } from '../../constants'
 
 const VALID_ASSIGNEE_TYPES = ['PROJECT_LEAD', 'UNASSIGNED']
 
+// this validator checks that the assignee type of a project as a valid value
 export const projectAssigneeTypeValidator: ChangeValidator = async changes =>
   changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
-    .filter(change => change.data.after.elemID.typeName === PROJECT_TYPE)
     .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === PROJECT_TYPE)
     .filter(project => project.value[ASSIGNEE_TYPE_FIELD] !== undefined)
     .filter(project => !VALID_ASSIGNEE_TYPES.includes(project.value[ASSIGNEE_TYPE_FIELD]))
-    .map(instance => ({
-      elemID: instance.elemID,
+    .map(project => ({
+      elemID: project.elemID,
       severity: 'Error',
       message: 'Invalid assignee type',
-      detailedMessage: `Project assignee type must be one of [${VALID_ASSIGNEE_TYPES.map(str => `'${str}'`).join(', ')}].`,
+      detailedMessage: `Project assignee type must be one of [${VALID_ASSIGNEE_TYPES.map(str => `'${str}'`).join(', ')}], got ${project.value[ASSIGNEE_TYPE_FIELD]}`,
     }))

--- a/packages/jira-adapter/src/change_validators/projects/project_assignee_type.ts
+++ b/packages/jira-adapter/src/change_validators/projects/project_assignee_type.ts
@@ -1,0 +1,35 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
+import { ASSIGNEE_TYPE_FIELD, PROJECT_TYPE } from '../../constants'
+
+const VALID_ASSIGNEE_TYPES = ['PROJECT_LEAD', 'UNASSIGNED']
+
+export const projectAssigneeTypeValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => change.data.after.elemID.typeName === PROJECT_TYPE)
+    .map(getChangeData)
+    .filter(project => project.value[ASSIGNEE_TYPE_FIELD] !== undefined)
+    .filter(project => !VALID_ASSIGNEE_TYPES.includes(project.value[ASSIGNEE_TYPE_FIELD]))
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Invalid assignee type',
+      detailedMessage: `Project assignee type must be one of [${VALID_ASSIGNEE_TYPES.map(str => `'${str}'`).join(', ')}].`,
+    }))

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -266,6 +266,7 @@ export type ChangeValidatorName =
   | 'fieldContextOptions'
   | 'uniqueFields'
   | 'assetsObjectFieldConfigurationAql'
+  | 'projectAssigneeType'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -331,6 +332,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     fieldContextOptions: { refType: BuiltinTypes.BOOLEAN },
     uniqueFields: { refType: BuiltinTypes.BOOLEAN },
     assetsObjectFieldConfigurationAql: { refType: BuiltinTypes.BOOLEAN },
+    projectAssigneeType: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -149,6 +149,7 @@ export const FIELD_TYPE = 'Field'
 export const FIELD_CONFIGURATION_SCHEME_TYPE = 'FieldConfigurationScheme'
 export const COMPONENTS = 'components'
 export const SCHEMA_VERSION = 'schemaVersion'
+export const ASSIGNEE_TYPE_FIELD = 'assigneeType'
 export const FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH = 255
 export const FIELD_CONFIGURATION_ITEM_DESCRIPTION_MAX_LENGTH = 1000
 export const AUTOMATION_RETRY_PERIODS = [0, 1000 * 60, 1000 * 60 * 5] // 0, 1 minute, 5 minutes, increasing exponentially

--- a/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
@@ -42,7 +42,7 @@ describe('projectAssigneeTypeValidator', () => {
       elemID: projectInstance.elemID,
       severity: 'Error',
       message: 'Invalid assignee type',
-      detailedMessage: "Project assignee type must be one of ['PROJECT_LEAD', 'UNASSIGNED'].",
+      detailedMessage: "Project assignee type must be one of ['PROJECT_LEAD', 'UNASSIGNED'], got INVALID",
     })
   })
 })

--- a/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
@@ -18,7 +18,7 @@ import { createEmptyType } from '../../utils'
 import { projectAssigneeTypeValidator } from '../../../src/change_validators/projects/project_assignee_type'
 import { ASSIGNEE_TYPE_FIELD } from '../../../src/constants'
 
-describe('projectCategoryValidator', () => {
+describe('projectAssigneeTypeValidator', () => {
   const projectType = createEmptyType('Project')
   let projectInstance: InstanceElement
 

--- a/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
+++ b/packages/jira-adapter/test/change_validators/projects/project_assignee_type.test.ts
@@ -1,0 +1,48 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { toChange, InstanceElement } from '@salto-io/adapter-api'
+import { createEmptyType } from '../../utils'
+import { projectAssigneeTypeValidator } from '../../../src/change_validators/projects/project_assignee_type'
+import { ASSIGNEE_TYPE_FIELD } from '../../../src/constants'
+
+describe('projectCategoryValidator', () => {
+  const projectType = createEmptyType('Project')
+  let projectInstance: InstanceElement
+
+  beforeEach(() => {
+    projectInstance = new InstanceElement('project', projectType, {})
+  })
+  it('should not return errors for valid assignee type', async () => {
+    projectInstance.value[ASSIGNEE_TYPE_FIELD] = 'PROJECT_LEAD'
+    const changeErrors = await projectAssigneeTypeValidator([toChange({ after: projectInstance })])
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should not return errors for undefined assignee type', async () => {
+    const changeErrors = await projectAssigneeTypeValidator([toChange({ after: projectInstance })])
+    expect(changeErrors).toHaveLength(0)
+  })
+  it('should return error for invalid assignee type', async () => {
+    projectInstance.value[ASSIGNEE_TYPE_FIELD] = 'INVALID'
+    const changeErrors = await projectAssigneeTypeValidator([toChange({ after: projectInstance })])
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: projectInstance.elemID,
+      severity: 'Error',
+      message: 'Invalid assignee type',
+      detailedMessage: "Project assignee type must be one of ['PROJECT_LEAD', 'UNASSIGNED'].",
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/project.test.ts
+++ b/packages/jira-adapter/test/filters/project.test.ts
@@ -255,6 +255,38 @@ describe('projectFilter', () => {
       await filter.onFetch([type, instance, SoftwareTypeInstance, JsmTypeInstance])
       expect(instance.path).toEqual([JIRA, elementUtils.RECORDS_PATH, 'Project', 'Other', 'instance', 'instance'])
     })
+    it('should add assigneeType field when exists in the response', async () => {
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          assigneeType: 'PROJECT_LEAD',
+        },
+      })
+      await filter.onFetch([type, instance])
+      expect(instance.value.assigneeType).toEqual('PROJECT_LEAD')
+    })
+    it('should not add assigneeType field when not exists in the response', async () => {
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: {
+          otherField: 'otherValue',
+        },
+      })
+      await filter.onFetch([type, instance])
+      expect(instance.value.assigneeType).toBeUndefined()
+    })
+    it('should not add assigneeType field when response is not a single element', async () => {
+      connection.get.mockResolvedValue({
+        status: 200,
+        data: [
+          {
+            assigneeType: 'PROJECT_LEAD',
+          },
+        ],
+      })
+      await filter.onFetch([type, instance])
+      expect(instance.value.assigneeType).toBeUndefined()
+    })
   })
 
   describe('When deploying a modification change', () => {


### PR DESCRIPTION
Added assignee type to projects with an additional API call

---

With the old infra of swagger, adding it with the API config will require too much 
It was done on top of Seggev's PR with its comments https://github.com/salto-io/salto/pull/6386

---
_Release Notes_: 
Jira Adapter:
* added support for assignee type in projects

---
_User Notifications_: 
Jira Adapter:
* projects will be added with assignee type
