### PR TITLE
SALTO-6269 Add selected macros restriction ids sorting

### DIFF
--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -301,7 +301,7 @@ const sortSelectedMacros = (selectedMacros: { restriction?: MacroRestriction }[]
 
 const orderSelectedMacros = (workspace: InstanceElement): void => {
   const selectedMacros = workspace.value.selected_macros
-  if (_.isArray(selectedMacros) && selectedMacros.every(macro => macro.id !== undefined)) {
+  if (_.isArray(selectedMacros) && selectedMacros.every(macro => _.isPlainObject(macro) && macro.id !== undefined)) {
     sortSelectedMacros(selectedMacros)
     workspace.value.selected_macros = _.sortBy(selectedMacros, macro => {
       if (isReferenceExpression(macro.id)) {

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -22,7 +22,7 @@ import {
   ReferenceExpression,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { inspectValue, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
 import { DYNAMIC_CONTENT_ITEM_VARIANT_TYPE_NAME } from './dynamic_content'
 import {
@@ -294,6 +294,7 @@ const sortSelectedMacros = (selectedMacros: { restriction?: MacroRestriction }[]
         macro.restriction.ids = _.sortBy(restrictionIds, ref => ref.elemID.getFullName())
       } else {
         log.warn(`could not sort restriction ids for restriction ${macro.restriction}`)
+        log.trace(`restriction ids are: ${inspectValue(restrictionIds, { maxArrayLength: null })}`)
       }
     }
   })

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -291,7 +291,7 @@ const sortSelectedMacros = (selectedMacros: { restriction?: MacroRestriction }[]
     if (macro.restriction !== undefined && _.isObject(macro.restriction) && 'ids' in macro.restriction) {
       const restrictionIds = _.get(macro, 'restriction.ids')
       if (_.isArray(restrictionIds) && restrictionIds.every(isReferenceExpression)) {
-        macro.restriction.ids = _.sortBy(restrictionIds, 'value.value.name')
+        macro.restriction.ids = _.sortBy(restrictionIds, ref => ref.elemID.getFullName())
       } else {
         log.warn(`could not sort restriction ids for restriction ${macro.restriction}`)
       }

--- a/packages/zendesk-adapter/src/filters/unordered_lists.ts
+++ b/packages/zendesk-adapter/src/filters/unordered_lists.ts
@@ -281,9 +281,27 @@ const orderMacroIds = (workspace: InstanceElement): void => {
     log.trace(`macro_ids in workspace ${workspace.elemID.getFullName()} is not an array`)
   }
 }
+
+type MacroRestriction = {
+  ids?: ReferenceExpression[]
+}
+
+const sortSelectedMacros = (selectedMacros: { restriction?: MacroRestriction }[]): void =>
+  selectedMacros.forEach(macro => {
+    if (macro.restriction !== undefined && _.isObject(macro.restriction) && 'ids' in macro.restriction) {
+      const restrictionIds = _.get(macro, 'restriction.ids')
+      if (_.isArray(restrictionIds) && restrictionIds.every(isReferenceExpression)) {
+        macro.restriction.ids = _.sortBy(restrictionIds, 'value.value.name')
+      } else {
+        log.warn(`could not sort restriction ids for restriction ${macro.restriction}`)
+      }
+    }
+  })
+
 const orderSelectedMacros = (workspace: InstanceElement): void => {
   const selectedMacros = workspace.value.selected_macros
   if (_.isArray(selectedMacros) && selectedMacros.every(macro => macro.id !== undefined)) {
+    sortSelectedMacros(selectedMacros)
     workspace.value.selected_macros = _.sortBy(selectedMacros, macro => {
       if (isReferenceExpression(macro.id)) {
         return macro.id.elemID.getFullName()

--- a/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
+++ b/packages/zendesk-adapter/test/filters/unordered_lists.test.ts
@@ -318,6 +318,13 @@ describe('Unordered lists filter', () => {
         },
         {
           id: 'd',
+          restriction: {
+            ids: [
+              new ReferenceExpression(groupOneInstance.elemID, groupOneInstance),
+              new ReferenceExpression(groupThreeInstance.elemID, groupThreeInstance),
+              new ReferenceExpression(groupTwoInstance.elemID, groupTwoInstance),
+            ],
+          },
         },
         {
           id: referenceB,
@@ -657,6 +664,15 @@ describe('Unordered lists filter', () => {
       expect(instance.value.selected_macros[1].id.elemID.name).toEqual('a')
       expect(instance.value.selected_macros[2].id.elemID.name).toEqual('b')
       expect(instance.value.selected_macros[3].id.elemID.name).toEqual('c')
+    })
+    it('should sort selected macros restrictions correctly', async () => {
+      ;[instance] = allWorkspaces.filter(e => e.elemID.name === 'workspaceWithMacros')
+      expect(instance.value.selected_macros).toHaveLength(4)
+      expect(instance.value.selected_macros[0].id).toEqual('d')
+      const restrictionIds = instance.value.selected_macros[0].restriction.ids
+      expect(restrictionIds[0].elemID.name).toEqual('groupA')
+      expect(restrictionIds[1].elemID.name).toEqual('groupB')
+      expect(restrictionIds[2].elemID.name).toEqual('groupC')
     })
     it('should do nothing if selected macros is invalid', async () => {
       ;[instance] = allWorkspaces.filter(e => e.elemID.name === 'invalidWorkspaceWithMacros')


### PR DESCRIPTION
Add selected macros restriction ids sorting

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk Adapter:__
* Workspace selected macros restriction ids are now sorted, as these cannot be updated by users.

---
_User Notifications_: 
__Zendesk Adapter:__
* Workspace selected macros restriction ids are now sorted, as these cannot be updated by users.