### PR TITLE
SALTO-6462: Fetch only OAuth2 Permission Grants for all users

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -402,6 +402,9 @@ const graphV1Customizations: FetchCustomizations = {
       {
         endpoint: {
           path: '/oauth2PermissionGrants',
+          queryArgs: {
+            $filter: "consentType eq 'AllPrincipals'",
+          },
         },
         transformation: DEFAULT_TRANSFORMATION,
       },
@@ -413,7 +416,6 @@ const graphV1Customizations: FetchCustomizations = {
           parts: [
             { fieldName: 'clientId', isReference: true },
             { fieldName: 'resourceId', isReference: true },
-            { fieldName: 'consentType' },
           ],
         },
       },


### PR DESCRIPTION
We discovered potential collisions with the elemIDs of `OAuth2PermissionGrant` instances when the `consentType` is `Principal` and the same permission is granted to different users. To address this, we've chosen to filter out these permissions in the request, as we currently don't manage users at all.

---
_Release Notes_: 
_Microsoft Entra:_
* Filter out `OAuth2PermissionGrant` instances that grant permissions to specific users.

---
_User Notifications_: 
_Microsoft Entra:_
* Filter out `OAuth2PermissionGrant` instances that grant permissions to specific users.
* Modify the elemID of `OAuth2PermissionGrant` by removing `consentType` from it.