### PR TITLE
Fix actualStaticFile.isEqual error

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1043,7 +1043,7 @@ const fixStaticFilesForFromStateChanges = async (
         env,
         isTemplate: staticFile.isTemplate,
       })
-      if (!actualStaticFile?.isEqual(staticFile)) {
+      if (!isStaticFile(actualStaticFile) || !actualStaticFile.isEqual(staticFile)) {
         invalidChangeIDs.add(change.id.getFullName())
         log.warn(
           'Static files mismatch in fetch from state for change in elemID %s. (stateHash=%s naclHash=%s)',


### PR DESCRIPTION
For some reason the following error occurred - `TypeError: actualStaticFile.isEqual is not a function` . This is a quick fix that should make sure that we're dealing with a `StaticFile`, and not other empty or non empty object.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fix `actualStaticFile.isEqual` error

---
_User Notifications_: 
None
