### PR TITLE
SALTO-6468: Fix assetsObjectFieldConfigurationAqlValidator

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_contexts/assets_object_field_configuration_aql.ts
+++ b/packages/jira-adapter/src/change_validators/field_contexts/assets_object_field_configuration_aql.ts
@@ -14,15 +14,9 @@
  * limitations under the License.
  */
 
-import {
-  ChangeValidator,
-  getChangeData,
-  InstanceElement,
-  isAdditionOrModificationChange,
-  isInstanceChange,
-} from '@salto-io/adapter-api'
+import { ChangeValidator, getChangeData, isAdditionOrModificationChange, isInstanceChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { getParent } from '@salto-io/adapter-utils'
+import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import JiraClient from '../../client/client'
 import { FIELD_CONTEXT_TYPE_NAME } from '../../filters/fields/constants'
 import { removeCustomFieldPrefix } from '../../filters/jql/template_expression_generator'
@@ -34,8 +28,8 @@ const isAqlHasPlaceholder = (aql: string): boolean => {
   return matches !== null && matches.length > 0
 }
 
-const getFieldContextsUrl = (instance: InstanceElement, client: JiraClient): URL => {
-  const customFieldId = removeCustomFieldPrefix(getParent(instance).value.id)
+const getFieldContextsUrl = (id: string, client: JiraClient): URL => {
+  const customFieldId = removeCustomFieldPrefix(id)
   const fieldContextsUrlSuffix = `secure/admin/ConfigureCustomField!default.jspa?customFieldId=${customFieldId}`
   return new URL(fieldContextsUrlSuffix, client.baseUrl)
 }
@@ -49,21 +43,27 @@ export const assetsObjectFieldConfigurationAqlValidator: (client: JiraClient) =>
       .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
       .filter(instance => _.isString(instance.value.assetsObjectFieldConfiguration?.issueScopeFilterQuery))
       .filter(instance => isAqlHasPlaceholder(instance.value.assetsObjectFieldConfiguration.issueScopeFilterQuery))
-      .map(instance => ({
-        elemID: instance.elemID.createNestedID('assetsObjectFieldConfiguration', 'issueScopeFilterQuery'),
-        severity: 'Warning',
-        message: 'AQL placeholders are not supported.',
-        detailedMessage:
-          'This AQL expression will be deployed as is. You may need to manually edit the ids later to match the target environment.',
-        deployActions: {
-          postAction: {
-            title: 'Edit AQL placeholders manually',
-            subActions: [
-              `Go to ${getFieldContextsUrl(instance, client)}`,
-              `Under the context "${instance.value.name}", click on "Edit Assets object/s field configuration"`,
-              'Inside "Filter issue scope" section, fix the placeholder with the correct value',
-              'Click "Save"',
-            ],
+      .filter(hasValidParent)
+      .map(instance => {
+        const fieldParent = getParent(instance)
+        return {
+          elemID: instance.elemID.createNestedID('assetsObjectFieldConfiguration', 'issueScopeFilterQuery'),
+          severity: 'Warning',
+          message: 'AQL placeholders are not supported.',
+          detailedMessage:
+            'This AQL expression will be deployed as is. You may need to manually edit the ids later to match the target environment.',
+          deployActions: {
+            postAction: {
+              title: 'Edit AQL placeholders manually',
+              subActions: [
+                fieldParent.value.id
+                  ? `Go to ${getFieldContextsUrl(fieldParent.value.id, client)}`
+                  : `Go to ${fieldParent.value.name} field configuration`,
+                `Under the context "${instance.value.name}", click on "Edit Assets object/s field configuration"`,
+                'Inside "Filter issue scope" section, fix the placeholder with the correct value',
+                'Click "Save"',
+              ],
+            },
           },
-        },
-      }))
+        }
+      })


### PR DESCRIPTION
In this PR I fixed `assetsObjectFieldConfigurationAqlValidator`

---

_Additional context for reviewer_
There's an issue with the assetsObjectFieldConfigurationAqlValidator.

When we add both the context and its field parent, the field parent doesn't have an id attribute at this stage. However, we're trying to access this attribute, which leads to the undefined error.

For field and context additions we will add a general action item instead of specific URL.
I also validated that there is valid parent. 

---
_Release Notes_: 
_Jira Adapter:_
* Fixed Bug in `assetsObjectFieldConfigurationAqlValidator` when we are reading startsWith of an undefined object. 
---
_User Notifications_: 
None