### PR TITLE
SALTO-6048: Add Identity Provider deploy support (Okta)

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -61,6 +61,7 @@ import {
   DOMAIN_TYPE_NAME,
   GROUP_RULE_TYPE_NAME,
   GROUP_TYPE_NAME,
+  IDENTITY_PROVIDER_TYPE_NAME,
   INACTIVE_STATUS,
   NETWORK_ZONE_TYPE_NAME,
   ORG_SETTING_TYPE_NAME,
@@ -278,6 +279,13 @@ const createChangesForDeploy = async (types: ObjectType[], testSuffix: string): 
       removePoweredByOkta: true,
     },
   })
+  const identityProvider = createInstance({
+    typeName: IDENTITY_PROVIDER_TYPE_NAME,
+    types,
+    valuesOverride: {
+      name: createName(IDENTITY_PROVIDER_TYPE_NAME),
+    },
+  })
   return [
     toChange({ after: groupInstance }),
     toChange({ after: anotherGroupInstance }),
@@ -290,6 +298,7 @@ const createChangesForDeploy = async (types: ObjectType[], testSuffix: string): 
     toChange({ after: app }),
     toChange({ after: appGroupAssignment }),
     toChange({ after: brand }),
+    toChange({ after: identityProvider }),
   ]
 }
 

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -28,6 +28,7 @@ import {
   BRAND_TYPE_NAME,
   BRAND_THEME_TYPE_NAME,
   DOMAIN_TYPE_NAME,
+  IDENTITY_PROVIDER_TYPE_NAME,
 } from '../src/constants'
 
 export const mockDefaultValues: Record<string, Values> = {
@@ -221,5 +222,70 @@ export const mockDefaultValues: Record<string, Values> = {
   [DOMAIN_TYPE_NAME]: {
     certificateSourceType: 'OKTA_MANAGED',
     validationStatus: 'NOT_STARTED',
+  },
+  [IDENTITY_PROVIDER_TYPE_NAME]: {
+    issuerMode: 'DYNAMIC',
+    status: 'ACTIVE',
+    protocol: {
+      type: 'OIDC',
+      endpoints: {
+        authorization: {
+          url: 'https://idp.example.io/auth',
+          binding: 'HTTP-REDIRECT',
+        },
+        token: {
+          url: 'https://idp.example.io/token',
+          binding: 'HTTP-POST',
+        },
+        jwks: {
+          url: 'https://idp.example.io/jwk',
+          binding: 'HTTP-REDIRECT',
+        },
+      },
+      scopes: ['email', 'openid', 'profile'],
+      issuer: {
+        url: 'https://idp.example.io/login/test',
+      },
+      credentials: {
+        client: {
+          token_endpoint_auth_method: 'private_key_jwt',
+          client_id: 'dummyClientId',
+          pkce_required: true,
+        },
+        signing: {
+          algorithm: 'RS256',
+        },
+      },
+    },
+    policy: {
+      provisioning: {
+        action: 'AUTO',
+        profileMaster: false,
+        groups: {
+          action: 'NONE',
+        },
+        conditions: {
+          deprovisioned: {
+            action: 'NONE',
+          },
+          suspended: {
+            action: 'NONE',
+          },
+        },
+      },
+      accountLink: {
+        action: 'DISABLED',
+      },
+      subject: {
+        userNameTemplate: {
+          template: 'idpuser.email',
+        },
+        filter: '',
+        matchType: 'USERNAME',
+        matchAttribute: '',
+      },
+      maxClockSkew: 0,
+    },
+    type: 'OIDC',
   },
 }

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -46,7 +46,7 @@ import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
 import { CLIENT_CONFIG, FETCH_CONFIG, OLD_API_DEFINITIONS_CONFIG } from './config'
-import { configType, OktaUserConfig } from './user_config'
+import { configType, getExcludeJWKConfigSuggestion, OktaUserConfig, OktaUserFetchConfig } from './user_config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -83,6 +83,7 @@ import {
   APP_LOGO_TYPE_NAME,
   BRAND_LOGO_TYPE_NAME,
   FAV_ICON_TYPE_NAME,
+  JWK_TYPE_NAME,
   OKTA,
   POLICY_PRIORITY_TYPE_NAMES,
   POLICY_RULE_PRIORITY_TYPE_NAMES,
@@ -162,6 +163,24 @@ export interface OktaAdapterParams {
   adminClient?: OktaClient
 }
 
+/**
+ * Temporary adjusment to support migration of JsonWebKey type into the exclude list
+ */
+const createElementQueryWithJsonWebKey = (
+  fetchConfig: OktaUserFetchConfig,
+  criteria: Record<string, elementUtils.query.QueryCriterion>,
+): elementUtils.query.ElementQuery => {
+  const isJWKExcluded = fetchConfig.exclude.find(fetchEnrty => fetchEnrty.type === JWK_TYPE_NAME)
+  const isJWKIncluded = fetchConfig.include.find(fetchEntry => fetchEntry.type === JWK_TYPE_NAME)
+  const updatedConfig =
+    !isJWKExcluded && !isJWKIncluded
+      ? {
+          ...fetchConfig,
+          exclude: fetchConfig.exclude.concat({ type: JWK_TYPE_NAME }),
+        }
+      : fetchConfig
+  return elementUtils.query.createElementQuery(updatedConfig, criteria)
+}
 export default class OktaAdapter implements AdapterOperations {
   private createFiltersRunner: (usersPromise?: Promise<User[]>) => Required<Filter>
   private client: OktaClient
@@ -195,7 +214,7 @@ export default class OktaAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: paginate,
     })
-    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig.fetch, fetchCriteria)
+    this.fetchQuery = createElementQueryWithJsonWebKey(this.userConfig.fetch, fetchCriteria)
 
     const definitions = {
       // TODO - SALTO-5746 - only provide adminClient when it is defined
@@ -339,6 +358,7 @@ export default class OktaAdapter implements AdapterOperations {
     const configChanges = (getElementsConfigChanges ?? [])
       .concat(classicOrgConfigSuggestion ?? [])
       .concat(oauthConfigChange ?? [])
+      .concat(getExcludeJWKConfigSuggestion(this.configInstance) ?? [])
     const updatedConfig =
       !_.isEmpty(configChanges) && this.configInstance
         ? definitionsUtils.getUpdatedConfigFromConfigChanges({

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -41,6 +41,7 @@ import { dynamicOSVersionFeatureValidator } from './dynamic_os_version_feature'
 import { brandThemeRemovalValidator } from './brand_theme_removal'
 import { userStatusValidator } from './user_status'
 import { disabledAuthenticatorsInMfaPolicyValidator } from './disabled_authenticators_in_mfa'
+import { oidcIdentityProviderValidator } from './oidc_idp'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -116,6 +117,7 @@ export default ({
     domainModification: domainModificationValidator,
     userStatusChanges: userStatusValidator,
     disabledAuthenticatorsInMfaPolicy: disabledAuthenticatorsInMfaPolicyValidator,
+    oidcIdentityProvider: oidcIdentityProviderValidator,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/change_validators/oidc_idp.ts
+++ b/packages/okta-adapter/src/change_validators/oidc_idp.ts
@@ -29,15 +29,16 @@ const OIDC_IDP_TYPE = 'OIDC'
 const IDP_PROTOCOL_TYPE_PATH = ['protocol', 'type']
 const AUTH_METHOD_PATH = ['protocol', 'credentials', 'client', 'token_endpoint_auth_method']
 
+const isOIDCIdentityProvider = (instance: InstanceElement): boolean =>
+  instance.elemID.typeName === IDENTITY_PROVIDER_TYPE_NAME &&
+  _.get(instance.value, IDP_PROTOCOL_TYPE_PATH) === OIDC_IDP_TYPE
+
 const isModificationOfOIDCIdentityProvider = (change: Change<InstanceElement>): boolean =>
-  isModificationChange(change) &&
-  getChangeData(change).elemID.typeName === IDENTITY_PROVIDER_TYPE_NAME &&
-  _.get(getChangeData(change).value, IDP_PROTOCOL_TYPE_PATH) === OIDC_IDP_TYPE
+  isModificationChange(change) && isOIDCIdentityProvider(getChangeData(change))
 
 const isAdditionOfClientOIDCIdentityProvider = (change: Change<InstanceElement>): boolean =>
   isAdditionChange(change) &&
-  getChangeData(change).elemID.typeName === IDENTITY_PROVIDER_TYPE_NAME &&
-  _.get(getChangeData(change).value, IDP_PROTOCOL_TYPE_PATH) === OIDC_IDP_TYPE &&
+  isOIDCIdentityProvider(getChangeData(change)) &&
   _.get(getChangeData(change).value, AUTH_METHOD_PATH) !== 'private_key_jwt'
 
 /**

--- a/packages/okta-adapter/src/change_validators/oidc_idp.ts
+++ b/packages/okta-adapter/src/change_validators/oidc_idp.ts
@@ -1,0 +1,56 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import _ from 'lodash'
+import {
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+  InstanceElement,
+  Change,
+  isModificationChange,
+  isAdditionChange,
+} from '@salto-io/adapter-api'
+import { IDENTITY_PROVIDER_TYPE_NAME } from '../constants'
+
+const OIDC_IDP_TYPE = 'OIDC'
+const IDP_PROTOCOL_TYPE_PATH = ['protocol', 'type']
+const AUTH_METHOD_PATH = ['protocol', 'credentials', 'client', 'token_endpoint_auth_method']
+
+const isModificationOfOIDCIdentityProvider = (change: Change<InstanceElement>): boolean =>
+  isModificationChange(change) &&
+  getChangeData(change).elemID.typeName === IDENTITY_PROVIDER_TYPE_NAME &&
+  _.get(getChangeData(change).value, IDP_PROTOCOL_TYPE_PATH) === OIDC_IDP_TYPE
+
+const isAdditionOfClientOIDCIdentityProvider = (change: Change<InstanceElement>): boolean =>
+  isAdditionChange(change) &&
+  getChangeData(change).elemID.typeName === IDENTITY_PROVIDER_TYPE_NAME &&
+  _.get(getChangeData(change).value, IDP_PROTOCOL_TYPE_PATH) === OIDC_IDP_TYPE &&
+  _.get(getChangeData(change).value, AUTH_METHOD_PATH) !== 'private_key_jwt'
+
+/**
+ * Block additions of OIDC identity provider with client_secret auth method,
+ * and modifications of any OIDC identity provider, as we currently do not support it.
+ */
+export const oidcIdentityProviderValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(change => isAdditionOfClientOIDCIdentityProvider(change) || isModificationOfOIDCIdentityProvider(change))
+    .map(change => ({
+      elemID: getChangeData(change).elemID,
+      severity: 'Error',
+      message: 'Can not deploy OIDC Identity Provider',
+      detailedMessage: 'Operation is not supported for OIDC Identity Provider',
+    }))

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -239,7 +239,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<Credential
       return undefined
     }
     const URL_TO_OMIT_FUNC: Record<string, (key: string, val: unknown) => unknown> = {
-      '/api/v1/idps': key => (key === 'credentials' ? OMITTED_PLACEHODLER : undefined),
+      '/api/v1/idps': key => (key === 'client_secret' ? OMITTED_PLACEHODLER : undefined),
       '/api/v1/authenticators': key => (['sharedSecret', 'secretKey'].includes(key) ? OMITTED_PLACEHODLER : undefined),
       '/api/v1/users': cleanUsersData,
     }

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -55,6 +55,7 @@ export const MFA_POLICY_PRIORITY_TYPE_NAME = 'MultifactorEnrollmentPolicyPriorit
 export const PASSWORD_POLICY_PRIORITY_TYPE_NAME = 'PasswordPolicyPriority'
 export const AUTOMATION_TYPE_NAME = 'Automation'
 export const AUTOMATION_RULE_TYPE_NAME = 'AutomationRule'
+export const JWK_TYPE_NAME = 'JsonWebKey'
 export const ACTIVE_STATUS = 'ACTIVE'
 export const INACTIVE_STATUS = 'INACTIVE'
 export const POLICY_TYPE_NAMES = [

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -44,6 +44,8 @@ import {
   AUTHORIZATION_POLICY,
   APP_LOGO_TYPE_NAME,
   NETWORK_ZONE_TYPE_NAME,
+  IDENTITY_PROVIDER_TYPE_NAME,
+  JWK_TYPE_NAME,
 } from '../../constants'
 import {
   APP_POLICIES,
@@ -726,6 +728,83 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: { path: '/api/v1/users/{id}', method: 'delete' },
+              },
+            },
+          ],
+        },
+      },
+    },
+    [IDENTITY_PROVIDER_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps', method: 'post' },
+                transformation: { omit: ['status'] },
+              },
+              copyFromResponse: {
+                toSharedContext: simpleStatus.toSharedContext,
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/{id}', method: 'put' },
+              },
+              condition: simpleStatus.modificationCondition,
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/{id}', method: 'delete' },
+              },
+            },
+          ],
+          activate: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/{id}/lifecycle/activate', method: 'post' },
+              },
+              condition: {
+                custom: simpleStatus.activationCondition,
+              },
+            },
+          ],
+          deactivate: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/{id}/lifecycle/deactivate', method: 'post' },
+              },
+              condition: {
+                custom: simpleStatus.deactivationCondition,
+              },
+            },
+          ],
+        },
+      },
+      toActionNames: simpleStatus.toActionNames,
+      actionDependencies: simpleStatus.actionDependencies,
+    },
+    [JWK_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/credentials/keys', method: 'post' },
+                transformation: {
+                  pick: ['x5c'],
+                },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/idps/credentials/keys/{kid}', method: 'delete' },
               },
             },
           ],

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -752,6 +752,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: { path: '/api/v1/idps/{id}', method: 'put' },
+                transformation: { omit: ['status'] },
               },
               condition: simpleStatus.modificationCondition,
             },

--- a/packages/okta-adapter/src/definitions/deploy/utils/simple_status.ts
+++ b/packages/okta-adapter/src/definitions/deploy/utils/simple_status.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { ActionName, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { ActionName, getChangeData, isAdditionChange } from '@salto-io/adapter-api'
 import { definitions as definitionUtils } from '@salto-io/adapter-components'
 import { AdditionalAction } from '../../types'
 import { isActivationChange, isDeactivationChange } from './status'

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -31,6 +31,7 @@ import {
   AUTHENTICATOR_TYPE_NAME,
   PROFILE_ENROLLMENT_RULE_TYPE_NAME,
   GROUP_MEMBERSHIP_TYPE_NAME,
+  JWK_TYPE_NAME,
 } from '../../constants'
 import { isGroupPushEntry } from '../../filters/group_push'
 import { extractSchemaIdFromUserType } from './types/user_type'
@@ -1102,6 +1103,21 @@ const createCustomizations = ({
       },
     },
   },
+  [JWK_TYPE_NAME]: {
+    requests: [{ endpoint: { path: '/api/v1/idps/credentials/keys' }, transformation: { root: '.' } }],
+    resource: { directFetch: true, serviceIDFields: ['kid'] },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+        // hashed representation of the key
+        elemID: { parts: [{ fieldName: naclCase('x5t#S256') }] },
+      },
+      fieldCustomizations: {
+        kid: { hide: true },
+        expiresAt: { omit: true },
+      },
+    },
+  },
   // singleton types
   OrgSetting: {
     requests: [{ endpoint: { path: '/api/v1/org' }, transformation: { root: '.' } }],
@@ -1193,9 +1209,18 @@ const createCustomizations = ({
       },
     },
   },
-  Protocol: {
+  IdentityProviderCredentialsClient: {
     element: {
-      fieldCustomizations: { credentials: { omit: true } },
+      fieldCustomizations: {
+        client_secret: { omit: true },
+      },
+    },
+  },
+  IdentityProviderCredentialsSigning: {
+    element: {
+      fieldCustomizations: {
+        kid: { omit: true },
+      },
     },
   },
   AuthenticatorProviderConfiguration: {

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1104,7 +1104,7 @@ const createCustomizations = ({
     },
   },
   [JWK_TYPE_NAME]: {
-    requests: [{ endpoint: { path: '/api/v1/idps/credentials/keys' }, transformation: { root: '.' } }],
+    requests: [{ endpoint: { path: '/api/v1/idps/credentials/keys' } }],
     resource: { directFetch: true, serviceIDFields: ['kid'] },
     element: {
       topLevel: {

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -17,6 +17,12 @@ import { definitions } from '@salto-io/adapter-components'
 import { OktaOptions } from '../types'
 import { OktaUserConfig } from '../../user_config'
 
+const OMIT_STATUS_REQUEST_BODY = {
+  post: {
+    omitBody: true,
+  },
+}
+
 export const createClientDefinitions = (
   clients: Record<
     definitions.ResolveClientOptionsType<OktaOptions>,
@@ -73,41 +79,15 @@ export const createClientDefinitions = (
               },
             },
           },
-          '/api/v1/apps/{id}/lifecycle/activate': {
-            post: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/apps/{id}/lifecycle/deactivate': {
-            post: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/apps/{source}/policies/{target}': {
-            put: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/authorizationServers/{authorizationServerId}/policies/{id}/lifecycle/activate': {
-            post: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/authorizationServers/{authorizationServerId}/policies/{id}/lifecycle/deactivate': {
-            post: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/zones/{id}/lifecycle/activate': {
-            post: {
-              omitBody: true,
-            },
-          },
-          '/api/v1/zones/{id}/lifecycle/deactivate': {
-            post: {
-              omitBody: true,
-            },
-          },
+          '/api/v1/apps/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/apps/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/apps/{source}/policies/{target}': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/authorizationServers/{authorizationServerId}/policies/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/authorizationServers/{authorizationServerId}/policies/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/zones/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/zones/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/idps/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/idps/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
         },
       },
     },

--- a/packages/okta-adapter/src/filters/field_references.ts
+++ b/packages/okta-adapter/src/filters/field_references.ts
@@ -28,7 +28,7 @@ const filter: FilterCreator = ({ config, fetchQuery }) => ({
   onFetch: async (elements: Element[]) => {
     await referenceUtils.addReferences({
       elements,
-      fieldsToGroupBy: ['id', 'name', 'key', 'mappingRuleId'],
+      fieldsToGroupBy: ['id', 'name', 'key', 'mappingRuleId', 'kid'],
       defs: getReferenceDefs({
         enableMissingReferences: config[FETCH_CONFIG].enableMissingReferences,
         isUserTypeIncluded: fetchQuery.isTypeMatch(USER_TYPE_NAME),

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -36,12 +36,13 @@ import {
   APP_GROUP_ASSIGNMENT_TYPE_NAME,
   USER_TYPE_NAME,
   GROUP_MEMBERSHIP_TYPE_NAME,
+  JWK_TYPE_NAME,
 } from './constants'
 import { resolveUserSchemaRef } from './filters/expression_language'
 
 const { awu } = collections.asynciterable
 
-type OktaReferenceSerializationStrategyName = 'key' | 'mappingRuleId'
+type OktaReferenceSerializationStrategyName = 'key' | 'mappingRuleId' | 'kid'
 type OktaReferenceIndexName = OktaReferenceSerializationStrategyName
 const OktaReferenceSerializationStrategyLookup: Record<
   OktaReferenceSerializationStrategyName | referenceUtils.ReferenceSerializationStrategyName,
@@ -57,6 +58,11 @@ const OktaReferenceSerializationStrategyLookup: Record<
     serialize: ({ ref }) => ref.value.value.mappingRuleId,
     lookup: val => val,
     lookupIndexName: 'mappingRuleId',
+  },
+  kid: {
+    serialize: ({ ref }) => ref.value.value.kid,
+    lookup: val => val,
+    lookupIndexName: 'kid',
   },
 }
 
@@ -280,6 +286,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     src: { field: 'assignments', parentTypes: ['ProvisioningGroups'] },
     serializationStrategy: 'id',
     target: { type: GROUP_TYPE_NAME },
+  },
+  {
+    src: { field: 'kid', parentTypes: ['IdentityProviderCredentialsTrust'] },
+    serializationStrategy: 'kid',
+    target: { type: JWK_TYPE_NAME },
   },
 ]
 

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -141,23 +141,21 @@ export const getExcludeJWKConfigSuggestion = (
 ): definitions.ConfigChangeSuggestion | undefined => {
   const typesToExclude = userConfig?.value?.fetch?.exclude
   const typesToInclude = userConfig?.value?.fetch?.include
-  if (!Array.isArray(typesToExclude)) {
+  if (!Array.isArray(typesToExclude) || !Array.isArray(typesToInclude)) {
     log.error(
-      'failed creating config suggestion to exclude JsonWebKey type, expected fetch.exclude to be an array, but instead got %s',
-      safeJsonStringify(typesToExclude),
+      'failed creating config suggestion to exclude JsonWebKey type, expected fetch.exclude and fetch.include to be an array, but instead got %s',
+      safeJsonStringify({ exclude: typesToExclude, include: typesToInclude }),
     )
     return undefined
   }
-  if (Array.isArray(typesToInclude)) {
-    const isJWKExcluded = typesToExclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
-    const isJWKIncluded = typesToInclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
-    if (!isJWKExcluded && !isJWKIncluded) {
-      return {
-        type: 'typeToExclude',
-        value: JWK_TYPE_NAME,
-        reason:
-          'JsonWebKey type is excluded by default. To include it, explicitly add "JsonWebKey" type into the include list.',
-      }
+  const isJWKExcluded = typesToExclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
+  const isJWKIncluded = typesToInclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
+  if (!isJWKExcluded && !isJWKIncluded) {
+    return {
+      type: 'typeToExclude',
+      value: JWK_TYPE_NAME,
+      reason:
+        'JsonWebKey type is excluded by default. To include it, explicitly add "JsonWebKey" type into the include list.',
     }
   }
   return undefined

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -14,8 +14,12 @@
  * limitations under the License.
  */
 import { elements, definitions } from '@salto-io/adapter-components'
-import { BuiltinTypes, CORE_ANNOTATIONS, createRestriction } from '@salto-io/adapter-api'
-import { OKTA, USER_TYPE_NAME } from './constants'
+import { BuiltinTypes, CORE_ANNOTATIONS, InstanceElement, createRestriction } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { JWK_TYPE_NAME, OKTA, USER_TYPE_NAME } from './constants'
+
+const log = logger(module)
 
 type GetUsersStrategy = 'searchQuery' | 'allUsers'
 
@@ -69,6 +73,7 @@ const changeValidatorNames = [
   'schemaBaseChanges',
   'userStatusChanges',
   'disabledAuthenticatorsInMfaPolicy',
+  'oidcIdentityProvider',
 ] as const
 
 export type ChangeValidatorName = (typeof changeValidatorNames)[number]
@@ -85,7 +90,7 @@ export const DEFAULT_CONFIG: OktaUserConfig = {
   },
   fetch: {
     ...elements.query.INCLUDE_ALL_CONFIG,
-    exclude: [{ type: USER_TYPE_NAME }],
+    exclude: [{ type: USER_TYPE_NAME }, { type: JWK_TYPE_NAME }],
     hideTypes: true,
     convertUsersIds: DEFAULT_CONVERT_USERS_IDS_VALUE,
     enableMissingReferences: true,
@@ -127,3 +132,33 @@ export const configType = definitions.createUserConfigType({
   omitElemID: false,
   pathsToOmitFromDefaultConfig: ['fetch.enableMissingReferences', 'fetch.getUsersStrategy'],
 })
+
+/*
+ * Temporary config suggestion to migrate existing configs to exclude JWK type
+ */
+export const getExcludeJWKConfigSuggestion = (
+  userConfig: Readonly<InstanceElement> | undefined,
+): definitions.ConfigChangeSuggestion | undefined => {
+  const typesToExclude = userConfig?.value?.fetch?.exclude
+  const typesToInclude = userConfig?.value?.fetch?.include
+  if (!Array.isArray(typesToExclude)) {
+    log.error(
+      'failed creating config suggestion to exclude JsonWebKey type, expected fetch.exclude to be an array, but instead got %s',
+      safeJsonStringify(typesToExclude),
+    )
+    return undefined
+  }
+  if (Array.isArray(typesToInclude)) {
+    const isJWKExcluded = typesToExclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
+    const isJWKIncluded = typesToInclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
+    if (!isJWKExcluded && !isJWKIncluded) {
+      return {
+        type: 'typeToExclude',
+        value: JWK_TYPE_NAME,
+        reason:
+          'JsonWebKey type is excluded by default. To include it, explicitly add "JsonWebKey" type into the include list.',
+      }
+    }
+  }
+  return undefined
+}

--- a/packages/okta-adapter/test/change_validators/oidc_idp.test.ts
+++ b/packages/okta-adapter/test/change_validators/oidc_idp.test.ts
@@ -1,0 +1,115 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { oidcIdentityProviderValidator } from '../../src/change_validators/oidc_idp'
+import { OKTA, IDENTITY_PROVIDER_TYPE_NAME } from '../../src/constants'
+
+describe('oidcIdentityProviderValidator', () => {
+  const idpType = new ObjectType({ elemID: new ElemID(OKTA, IDENTITY_PROVIDER_TYPE_NAME) })
+  const clientSecretOIDCIdp = new InstanceElement('clientSecretOIDCIdp', idpType, {
+    type: 'OIDC',
+    status: 'ACTIVE',
+    protocol: {
+      type: 'OIDC',
+      credentials: {
+        client: {
+          client_id: 'client_id',
+        },
+      },
+    },
+  })
+  const privateKeyOIDCIdp = new InstanceElement('privateKeyOIDCIdp', idpType, {
+    type: 'OIDC',
+    status: 'ACTIVE',
+    protocol: {
+      type: 'OIDC',
+      credentials: {
+        client: {
+          client_id: 'client_id',
+          token_endpoint_auth_method: 'private_key_jwt',
+        },
+      },
+    },
+  })
+  const samlIdp = new InstanceElement('samlIdp', idpType, {
+    type: 'SAML2',
+    status: 'ACTIVE',
+    protocol: {
+      type: 'SAML2',
+    },
+  })
+
+  describe('addition changes', () => {
+    it('should return an error in case of client secret OIDC idp addition', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([toChange({ after: clientSecretOIDCIdp })])
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors).toEqual([
+        {
+          elemID: clientSecretOIDCIdp.elemID,
+          severity: 'Error',
+          message: 'Can not deploy OIDC Identity Provider',
+          detailedMessage: 'Operation is not supported for OIDC Identity Provider',
+        },
+      ])
+    })
+    it('should not return an error in case of private key OIDC idp addition', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([toChange({ after: privateKeyOIDCIdp })])
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should not return an error in case of SAML idp addition', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([toChange({ after: samlIdp })])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+  describe('modification changes', () => {
+    it('should return an error in case of any OIDC idp modification', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([
+        toChange({ before: privateKeyOIDCIdp, after: privateKeyOIDCIdp }),
+        toChange({ before: clientSecretOIDCIdp, after: clientSecretOIDCIdp }),
+      ])
+      expect(changeErrors).toHaveLength(2)
+      expect(changeErrors).toEqual([
+        {
+          elemID: privateKeyOIDCIdp.elemID,
+          severity: 'Error',
+          message: 'Can not deploy OIDC Identity Provider',
+          detailedMessage: 'Operation is not supported for OIDC Identity Provider',
+        },
+        {
+          elemID: clientSecretOIDCIdp.elemID,
+          severity: 'Error',
+          message: 'Can not deploy OIDC Identity Provider',
+          detailedMessage: 'Operation is not supported for OIDC Identity Provider',
+        },
+      ])
+    })
+
+    it('should not return an error in case of SAML idp modification', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([toChange({ before: samlIdp, after: samlIdp })])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+  describe('removal changes', () => {
+    it('should not return an error in case of any idp removal', async () => {
+      const changeErrors = await oidcIdentityProviderValidator([
+        toChange({ before: privateKeyOIDCIdp }),
+        toChange({ before: clientSecretOIDCIdp }),
+        toChange({ before: samlIdp }),
+      ])
+      expect(changeErrors).toHaveLength(0)
+    })
+  })
+})

--- a/packages/okta-adapter/test/client/client.test.ts
+++ b/packages/okta-adapter/test/client/client.test.ts
@@ -260,9 +260,11 @@ describe('client', () => {
         id: '123',
         protocol: {
           type: 'OIDC',
-          credentials: '<OMITTED>',
+          credentials: {
+            client: { client_id: 'test', client_secret: '<OMITTED>' },
+          },
         },
-        array: [{ credentials: '<OMITTED>' }, { somethingElse: 'b' }],
+        array: [{ credentials: 'a' }, { somethingElse: 'b' }],
       })
       expect(clearValuesFromResponseDataFunc).toHaveNthReturnedWith(2, [
         {

--- a/packages/okta-adapter/test/definitions/deploy/utils/simple_status.test.ts
+++ b/packages/okta-adapter/test/definitions/deploy/utils/simple_status.test.ts
@@ -1,0 +1,99 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { toActionNames } from '../../../../src/definitions/deploy/utils/simple_status'
+import { NETWORK_ZONE_TYPE_NAME } from '../../../../src/constants'
+
+describe('simple_status', () => {
+  const type = new ObjectType({
+    elemID: new ElemID('salto', NETWORK_ZONE_TYPE_NAME),
+  })
+  const activeInst = new InstanceElement('instance', type, { status: 'ACTIVE' })
+  const inactiveInst = new InstanceElement('instance', type, { status: 'INACTIVE' })
+
+  describe('toActionNames', () => {
+    describe('addition change', () => {
+      const additionChange = toChange({ after: activeInst })
+      it('should return the correct action names', () => {
+        expect(
+          toActionNames({
+            change: additionChange,
+            sharedContext: {},
+            changeGroup: { groupID: 'groupID', changes: [additionChange] },
+            elementSource: buildElementsSourceFromElements([]),
+          }),
+        ).toEqual(['add', 'deactivate', 'activate'])
+      })
+    })
+
+    describe('modification change', () => {
+      describe('activation change', () => {
+        const activationChange = toChange({ before: inactiveInst, after: activeInst })
+        it('should return the correct action names', () => {
+          expect(
+            toActionNames({
+              change: activationChange,
+              sharedContext: {},
+              changeGroup: { groupID: 'groupID', changes: [activationChange] },
+              elementSource: buildElementsSourceFromElements([]),
+            }),
+          ).toEqual(['modify', 'activate'])
+        })
+      })
+      describe('deactivation change', () => {
+        const deactivationChange = toChange({ before: activeInst, after: inactiveInst })
+        it('should return the correct action names', () => {
+          expect(
+            toActionNames({
+              change: deactivationChange,
+              sharedContext: {},
+              changeGroup: { groupID: 'groupID', changes: [deactivationChange] },
+              elementSource: buildElementsSourceFromElements([]),
+            }),
+          ).toEqual(['deactivate', 'modify'])
+        })
+      })
+      describe('no status change', () => {
+        const change = toChange({ before: activeInst, after: activeInst })
+        it('should return the correct action names', () => {
+          expect(
+            toActionNames({
+              change,
+              sharedContext: {},
+              changeGroup: { groupID: 'groupID', changes: [change] },
+              elementSource: buildElementsSourceFromElements([]),
+            }),
+          ).toEqual(['modify'])
+        })
+      })
+    })
+    describe('removal change', () => {
+      const removalChange = toChange({ before: activeInst })
+      it('should return the correct action names', () => {
+        expect(
+          toActionNames({
+            change: removalChange,
+            sharedContext: {},
+            changeGroup: { groupID: 'groupID', changes: [removalChange] },
+            elementSource: buildElementsSourceFromElements([]),
+          }),
+        ).toEqual(['remove'])
+      })
+    })
+  })
+})


### PR DESCRIPTION
Added support for Identity Provider type.

---

_Additional context for reviewer_
 
In order to support deployment of Identity Provider type, I made the following changes - 
- Add non secret fields that are required for deployment to Identity Provider type
- Added support in `JsonWebKey` type, that can be referenced from Identity Provider and must be added when adding a SAML IdentityProvider (only additions and removals are supported)
- Added a migration to the okta.nacl file to exclude `JsonWebKey` in order to reduce noise for existing environments
- Used @Nurdok's generalization utilities to handle additions / modifications with status changes (originally added here - https://github.com/salto-io/salto/pull/6348)
- Change validator to avoid deploying OIDC Identity Providers in scenarios that are currently not supported (due to the fact secrets are required)

---
_Release Notes_: 

_Okta_adapter_:
- Add deploy support for IdentityProvider type
- Add option support in Identity Provider JsonWebKey type (excluded by default for all users)

---
_User Notifications_: 

_Okta_adapter_:
- Additional fields will be added to IdentityProvider type
