### PR TITLE
SALTO-6470: Fix dependsOn definition for groupLifeCyclePolicy

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/fetch/constants.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/constants.ts
@@ -93,3 +93,6 @@ export const NAME_ID_FIELD: FieldIDPart = { fieldName: 'displayName' }
 export const DEFAULT_ID_PARTS = [NAME_ID_FIELD]
 
 export const DEFAULT_TRANSFORMATION = { root: 'value' }
+
+// Values to that are added to the context of specific calls
+export const CONTEXT_LIFE_CYCLE_POLICY_MANAGED_GROUP_TYPES = 'lifeCyclePolicyManagedGroupTypes'

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -59,6 +59,7 @@ import {
 import { GRAPH_BETA_PATH, GRAPH_V1_PATH } from '../requests/clients'
 import { FetchCustomizations } from './types'
 import {
+  CONTEXT_LIFE_CYCLE_POLICY_MANAGED_GROUP_TYPES,
   DEFAULT_FIELD_CUSTOMIZATIONS,
   DEFAULT_ID_PARTS,
   DEFAULT_TRANSFORMATION,
@@ -114,7 +115,7 @@ const graphV1Customizations: FetchCustomizations = {
       context: {
         // We only need this dependency for the conditions under the group life cycle policy recurse definition
         dependsOn: {
-          [`${LIFE_CYCLE_POLICY_TYPE_NAME}_condition`]: {
+          [CONTEXT_LIFE_CYCLE_POLICY_MANAGED_GROUP_TYPES]: {
             parentTypeName: LIFE_CYCLE_POLICY_TYPE_NAME,
             transformation: {
               root: 'managedGroupTypes',
@@ -154,7 +155,7 @@ const graphV1Customizations: FetchCustomizations = {
           },
           conditions: [
             {
-              fromContext: `${LIFE_CYCLE_POLICY_TYPE_NAME}_condition`,
+              fromContext: CONTEXT_LIFE_CYCLE_POLICY_MANAGED_GROUP_TYPES,
               match: ['Selected'],
             },
           ],

--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -111,6 +111,17 @@ const graphV1Customizations: FetchCustomizations = {
           }
         },
       },
+      context: {
+        // We only need this dependency for the conditions under the group life cycle policy recurse definition
+        dependsOn: {
+          [`${LIFE_CYCLE_POLICY_TYPE_NAME}_condition`]: {
+            parentTypeName: LIFE_CYCLE_POLICY_TYPE_NAME,
+            transformation: {
+              root: 'managedGroupTypes',
+            },
+          },
+        },
+      },
       recurseInto: {
         [GROUP_ADDITIONAL_DATA_FIELD_NAME]: {
           typeName: GROUP_ADDITIONAL_DATA_TYPE_NAME,
@@ -141,6 +152,12 @@ const graphV1Customizations: FetchCustomizations = {
               },
             },
           },
+          conditions: [
+            {
+              fromContext: `${LIFE_CYCLE_POLICY_TYPE_NAME}_condition`,
+              match: ['Selected'],
+            },
+          ],
         },
       },
     },
@@ -210,23 +227,6 @@ const graphV1Customizations: FetchCustomizations = {
   [GROUP_LIFE_CYCLE_POLICY_TYPE_NAME]: {
     resource: {
       directFetch: false,
-      context: {
-        dependsOn: {
-          [LIFE_CYCLE_POLICY_TYPE_NAME]: {
-            parentTypeName: LIFE_CYCLE_POLICY_TYPE_NAME,
-            transformation: {
-              pick: ['managedGroupTypes'],
-            },
-          },
-        },
-        // TODO SALTO-6077: we currently overlook this definition. We should validate this definition after fixing the issue
-        conditions: [
-          {
-            fromContext: LIFE_CYCLE_POLICY_TYPE_NAME,
-            match: ['Selected'],
-          },
-        ],
-      },
     },
     requests: [
       {


### PR DESCRIPTION
We defined the group lifecycle policy as dependent on the lifecycle policy to perform a conditional request. However, setting a sub-resource as dependent on another resource, which is not its parent, is not supported. Instead, we should define the parent as dependent on whatever we need and use the conditions under the recurseInto definition.

---
_Release Notes_: 
_Microsoft Entra:_
* Fix dependsOn definition for groupLifeCyclePolicy

---
_User Notifications_: 
_Microsoft Entra:_
* groupLifeCyclePolicy will now be referenced from the group to which it applies.
