### PR TITLE
SALTO-6460: Don't fetch domainNameReferences in case the domain is Federated

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/fetch/fetch.ts
@@ -606,6 +606,13 @@ const graphV1Customizations: FetchCustomizations = {
               },
             },
           },
+          conditions: [
+            {
+              fromField: 'authenticationType',
+              // Exclude federated domains, as this api call does not support them
+              match: ['Managed'],
+            },
+          ],
         },
       },
       mergeAndTransform: {


### PR DESCRIPTION
When the domain is federated, we receive the following error from the service:
```
[microsoft_entra] Error caught while fetching domain__domainNameReferences: {"response":{"status":400,"data":{"error":{"code":"Request_UnsupportedQuery","message":"This API is not supported for federated domains."}}}
```

Therefore, we should avoid receiving this error by requesting the domain name references only if the domain is not federated.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
