### PR TITLE
SALTO-5891 Resolve the FlowDefinition type in preDeploy

### DIFF
--- a/packages/salesforce-adapter/src/filters/flows_filter.ts
+++ b/packages/salesforce-adapter/src/filters/flows_filter.ts
@@ -27,7 +27,7 @@ import {
   ObjectType,
   toChange,
 } from '@salto-io/adapter-api'
-import { findObjectType } from '@salto-io/adapter-utils'
+import { findObjectType, resolveTypeShallow } from '@salto-io/adapter-utils'
 import { values as lowerdashValues } from '@salto-io/lowerdash'
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import {
@@ -167,6 +167,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
       )
       return
     }
+    await resolveTypeShallow(flowDefinitionType, config.elementsSource)
     deactivatedFlowOnlyChanges
       .map(flowChange => createDeactivatedFlowDefinitionChange(flowChange, flowDefinitionType))
       .forEach(flowDefinitionChange => changes.push(flowDefinitionChange))


### PR DESCRIPTION
In order to deactivate a `Flow` instance, we create a `FlowDefinition` instance with `activeVersionNumber` of 0. We do it by getting the `FlowDefinition` type from the `elementsSource` and create the instance with that type. The problem was that the type's fields weren't resolved, so while running `transformElement` on the `FlowDefinition` instance we got the following error- `Can not resolve value of reference with ElemID serviceid without elementsSource because value does not exist`.
The solution is to resolve the `FieldDefinition` type's fields & annotations when we get it from the `elementsSource`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Salesforce:
- Fix the "Can not resolve ..." error on `Flow` deactivation changes.

---
_User Notifications_: 
None