### PR TITLE
SALTO-6472: Omit value set name annotation on object / field addition

### DIFF
--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -22,27 +22,25 @@ import {
   Field,
   ReferenceExpression,
   isObjectType,
-  isModificationChange,
-  isFieldChange,
-  getChangeData,
-  Change,
+  isAdditionOrModificationChange,
+  isField,
   getAllChangeData,
-  ModificationChange,
+  isObjectTypeChange,
+  isFieldChange,
+  Change,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { collections, promises, types, values as lowerdashValues } from '@salto-io/lowerdash'
+import { collections, types } from '@salto-io/lowerdash'
 
 import { FilterResult, RemoteFilterCreator } from '../filter'
 import { FIELD_ANNOTATIONS, VALUE_SET_FIELDS } from '../constants'
-import { metadataType, apiName, isCustomObject, Types, isCustom } from '../transformers/transformer'
-import { extractFullNamesFromValueList, isInstanceOfTypeSync } from './utils'
+import { metadataType, isCustomObject, Types, isCustom } from '../transformers/transformer'
+import { apiNameSync, extractFullNamesFromValueList, isInstanceOfTypeSync } from './utils'
 import { ConfigChangeSuggestion } from '../types'
 import { fetchMetadataInstances } from '../fetch'
 
-const { mapValuesAsync } = promises.object
-const { awu, keyByAsync } = collections.asynciterable
+const { awu } = collections.asynciterable
 const { makeArray } = collections.array
-const { isDefined } = lowerdashValues
 
 export const STANDARD_VALUE_SET = 'StandardValueSet'
 export const STANDARD_VALUE = 'standardValue'
@@ -129,21 +127,21 @@ const svsValuesToRef = (svsInstances: InstanceElement[]): StandardValueSetsLooku
       }),
   )
 
-const isStandardPickList = async (f: Field): Promise<boolean> => {
-  const apiNameResult = await apiName(f)
+const isStandardPickList = (field: Field): boolean => {
+  const apiNameResult = apiNameSync(field)
   return apiNameResult
-    ? (f.refType.elemID.isEqual(Types.primitiveDataTypes.Picklist.elemID) ||
-        f.refType.elemID.isEqual(Types.primitiveDataTypes.MultiselectPicklist.elemID)) &&
+    ? (field.refType.elemID.isEqual(Types.primitiveDataTypes.Picklist.elemID) ||
+        field.refType.elemID.isEqual(Types.primitiveDataTypes.MultiselectPicklist.elemID)) &&
         !isCustom(apiNameResult)
     : false
 }
 
-const calculatePicklistFieldsToUpdate = async (
+const calculatePicklistFieldsToUpdate = (
   customObjectFields: Record<string, Field>,
   svsValuesToName: StandardValueSetsLookup,
-): Promise<Record<string, Field>> =>
-  mapValuesAsync(customObjectFields, async field => {
-    if (!(await isStandardPickList(field)) || _.isEmpty(field.annotations[FIELD_ANNOTATIONS.VALUE_SET])) {
+): Record<string, Field> =>
+  _.mapValues(customObjectFields, field => {
+    if (!isStandardPickList(field) || _.isEmpty(field.annotations[FIELD_ANNOTATIONS.VALUE_SET])) {
       return field
     }
 
@@ -170,8 +168,8 @@ const updateSVSReferences = async (
 ): Promise<void> => {
   const svsValuesToName = svsValuesToRef(svsInstances)
 
-  await awu(objects).forEach(async customObjType => {
-    const fieldsToUpdate = await calculatePicklistFieldsToUpdate(customObjType.fields, svsValuesToName)
+  objects.forEach(customObjType => {
+    const fieldsToUpdate = calculatePicklistFieldsToUpdate(customObjType.fields, svsValuesToName)
     _.assign(customObjType, { fields: fieldsToUpdate })
   })
 }
@@ -189,18 +187,14 @@ const emptyFileProperties = (fullName: string): FileProperties => ({
   type: STANDARD_VALUE_SET,
 })
 
-const toDeployableStandardPicklistFieldChange = (change: ModificationChange<Field>): ModificationChange<Field> => {
-  const [deployableBefore, deployableAfter] = getAllChangeData(change).map(field => field.clone())
-  delete deployableBefore.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
-  delete deployableAfter.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
-  return {
-    data: {
-      before: deployableBefore,
-      after: deployableAfter,
-    },
-    action: 'modify',
-  }
-}
+const getAllStandardPicklistFields = (changes: Change[]): Field[] =>
+  changes
+    .filter(isAdditionOrModificationChange)
+    .filter(change => isObjectTypeChange(change) || isFieldChange(change))
+    .flatMap(getAllChangeData)
+    .flatMap(elem => (isObjectType(elem) ? Object.values(elem.fields) : elem))
+    .filter(isField)
+    .filter(isStandardPickList)
 
 /**
  * Declare the StandardValueSets filter that
@@ -210,7 +204,7 @@ const toDeployableStandardPicklistFieldChange = (change: ModificationChange<Fiel
 export const makeFilter =
   (standardValueSetNames: StandardValuesSets): RemoteFilterCreator =>
   ({ client, config }) => {
-    let originalChanges: Record<string, Change>
+    const fieldToRemovedValueSetName = new Map<string, string>()
     return {
       name: 'standardValueSetFilter',
       remote: true,
@@ -256,28 +250,25 @@ export const makeFilter =
         }
       },
       preDeploy: async changes => {
-        const standardPicklistFieldChanges = await awu(changes)
-          .filter(isModificationChange)
-          .filter(isFieldChange)
-          .filter(change => isStandardPickList(getChangeData(change)))
-          .toArray()
-        originalChanges = await keyByAsync(standardPicklistFieldChanges, change => apiName(getChangeData(change)))
-        const deployableChanges = standardPicklistFieldChanges.map(toDeployableStandardPicklistFieldChange)
-        _.pullAll(changes, standardPicklistFieldChanges)
-        changes.push(...deployableChanges)
+        getAllStandardPicklistFields(changes).forEach(field => {
+          const svsName = field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
+          if (svsName !== undefined) {
+            fieldToRemovedValueSetName.set(field.elemID.getFullName(), svsName)
+            delete field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]
+          }
+        })
       },
       onDeploy: async changes => {
-        const appliedStandardPicklistFieldChanges = await awu(changes)
-          .filter(isModificationChange)
-          .filter(isFieldChange)
-          .filter(change => isStandardPickList(getChangeData(change)))
-          .toArray()
-        const appliedApiNames = await awu(changes)
-          .map(change => apiName(getChangeData(change)))
-          .toArray()
-        const appliedOriginalChanges = appliedApiNames.map(name => originalChanges[name]).filter(isDefined)
-        _.pullAll(changes, appliedStandardPicklistFieldChanges)
-        appliedOriginalChanges.forEach(change => changes.push(change))
+        if (fieldToRemovedValueSetName.size === 0) {
+          return
+        }
+
+        getAllStandardPicklistFields(changes).forEach(field => {
+          const svsName = fieldToRemovedValueSetName.get(field.elemID.getFullName())
+          if (svsName !== undefined) {
+            field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME] = svsName
+          }
+        })
       },
     }
   }

--- a/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
+++ b/packages/salesforce-adapter/test/filters/standard_value_sets.test.ts
@@ -15,13 +15,17 @@
  */
 import {
   Change,
+  cloneDeepWithoutRefs,
   CORE_ANNOTATIONS,
   Element,
   ElemID,
   Field,
   getAllChangeData,
   InstanceElement,
+  isAdditionChange,
   isField,
+  isFieldChange,
+  isObjectTypeChange,
   ObjectType,
   ReferenceExpression,
   toChange,
@@ -36,7 +40,7 @@ import { makeFilter, STANDARD_VALUE, STANDARD_VALUE_SET } from '../../src/filter
 import SalesforceClient from '../../src/client/client'
 import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import { extractFullNamesFromValueList } from '../../src/filters/utils'
-import { defaultFilterContext } from '../utils'
+import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { mockInstances, mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
@@ -260,42 +264,88 @@ describe('Standard Value Sets filter', () => {
   })
 
   describe('deploy flow', () => {
-    let originalChange: Change<Field>
-    let afterPreDeployChanges: Change<Field>[]
-    let afterOnDeployChanges: Change<Field>[]
+    describe('with modification of existing field', () => {
+      let originalChange: Change<Field>
+      let afterPreDeployChanges: Change<Field>[]
+      let afterOnDeployChanges: Change<Field>[]
 
-    beforeEach(async () => {
-      const beforePicklistStandardField = new Field(
-        mockTypes.Profile,
-        'StandardPicklist',
-        Types.primitiveDataTypes.Picklist,
-        {
-          [API_NAME]: 'Profile.StandardPicklist',
+      beforeEach(async () => {
+        const beforePicklistStandardField = new Field(
+          mockTypes.Account,
+          'StandardPicklist',
+          Types.primitiveDataTypes.Picklist,
+          {
+            [API_NAME]: 'Account.StandardPicklist',
+            [VALUE_SET_FIELDS.VALUE_SET_NAME]: 'StandardPicklistValueSet',
+            description: 'before',
+          },
+        )
+        const afterPicklistStandardField = beforePicklistStandardField.clone({
+          ...beforePicklistStandardField.annotations,
+          description: 'after',
+        })
+        originalChange = toChange({
+          before: beforePicklistStandardField,
+          after: afterPicklistStandardField,
+        })
+        afterPreDeployChanges = [cloneDeepWithoutRefs(originalChange)]
+        await filter.preDeploy(afterPreDeployChanges)
+        afterOnDeployChanges = cloneDeepWithoutRefs(afterPreDeployChanges)
+        await filter.onDeploy(afterOnDeployChanges)
+      })
+      it('should omit the valueSetName annotation on preDeploy', () => {
+        expect(afterPreDeployChanges).toHaveLength(1)
+        expect(getAllChangeData(afterPreDeployChanges[0])).toSatisfyAll(field =>
+          _.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]),
+        )
+      })
+      it('should restore to original change on onDeploy', () => {
+        expect(afterOnDeployChanges).toEqual([originalChange])
+      })
+    })
+    describe('with addition of field or standard object', () => {
+      // This case is relevant mostly for the flow of dumpElementsToFolder since there is no way
+      // to actually deploy an addition of a standard object
+      let originalChanges: Change[]
+      let afterPreDeployChanges: Change[]
+      let afterOnDeployChanges: Change[]
+      beforeEach(async () => {
+        const newField = new Field(mockTypes.Account, 'StandardPicklist', Types.primitiveDataTypes.Picklist, {
+          [API_NAME]: 'Account.StandardPicklist',
           [VALUE_SET_FIELDS.VALUE_SET_NAME]: 'StandardPicklistValueSet',
-          description: 'before',
-        },
-      )
-      const afterPicklistStandardField = beforePicklistStandardField.clone({
-        ...beforePicklistStandardField.annotations,
-        description: 'after',
+        })
+        const newObject = createCustomObjectType('Case', {
+          fields: {
+            StandardPicklist: {
+              refType: Types.primitiveDataTypes.Picklist,
+              annotations: {
+                [API_NAME]: 'Case.StandardPicklist',
+                [VALUE_SET_FIELDS.VALUE_SET_NAME]: 'StandardPicklistValueSet',
+              },
+            },
+          },
+        })
+        originalChanges = [toChange({ after: newField }), toChange({ after: newObject })]
+        afterPreDeployChanges = cloneDeepWithoutRefs(originalChanges)
+        await filter.preDeploy(afterPreDeployChanges)
+        afterOnDeployChanges = cloneDeepWithoutRefs(afterPreDeployChanges)
+        await filter.onDeploy(afterOnDeployChanges)
       })
-      originalChange = toChange({
-        before: beforePicklistStandardField,
-        after: afterPicklistStandardField,
+      it('should omit the valueSetName annotation from field addition on preDeploy', () => {
+        const fieldAddition = afterPreDeployChanges.filter(isAdditionChange).find(isFieldChange)
+        expect(fieldAddition).toBeDefined()
+        expect(fieldAddition?.data.after.annotations).not.toHaveProperty(VALUE_SET_FIELDS.VALUE_SET_NAME)
       })
-      afterPreDeployChanges = [originalChange]
-      await filter.preDeploy(afterPreDeployChanges)
-      afterOnDeployChanges = [...afterPreDeployChanges]
-      await filter.onDeploy(afterOnDeployChanges)
-    })
-    it('should omit the valueSetName annotation on preDeploy', () => {
-      expect(afterPreDeployChanges).toHaveLength(1)
-      expect(getAllChangeData(afterPreDeployChanges[0])).toSatisfyAll(field =>
-        _.isUndefined(field.annotations[VALUE_SET_FIELDS.VALUE_SET_NAME]),
-      )
-    })
-    it('should restore to original change on onDeploy', () => {
-      expect(afterOnDeployChanges).toEqual([originalChange])
+      it('should omit the valueSetName annotation from fields inside the added object type', () => {
+        const objAddtion = afterPreDeployChanges.filter(isAdditionChange).find(isObjectTypeChange)
+        expect(objAddtion).toBeDefined()
+        expect(objAddtion?.data.after.fields.StandardPicklist.annotations).not.toHaveProperty(
+          VALUE_SET_FIELDS.VALUE_SET_NAME,
+        )
+      })
+      it('should restore to original change on onDeploy', () => {
+        expect(afterOnDeployChanges).toEqual(originalChanges)
+      })
     })
   })
 })


### PR DESCRIPTION
Currently we only omit the value set name annotation on field modification This extends this behavior to field addition and to all fields inside an object addition

---

_Additional context for reviewer_
These new scenarios can't really happen in a real deployment (we cannot deploy a standard object / new standard field) but they can happen in a "dumpElementsToFolder" flow 

Manual tests:
- Tested setting / removing description on a standard picklist field (Account.Type), checked the change is deployed, the nacl does not change and there are no pending changes after the deploy 

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_