### PR TITLE
SALTO-6319: add log tags to failed types error

### DIFF
--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -119,7 +119,10 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
       // eslint-disable-next-line no-fallthrough
       case undefined:
       default:
-        log.error('unexpectedly failed to fetch type %s:%s: %s', adapterName, typeName, error.message, { adapterName, typeName })
+        log.error('unexpectedly failed to fetch type %s:%s: %s', adapterName, typeName, error.message, {
+          adapterName,
+          typeName,
+        })
     }
   }
 

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -119,7 +119,7 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
       // eslint-disable-next-line no-fallthrough
       case undefined:
       default:
-        log.error('unexpectedly failed to fetch type %s:%s: %s', adapterName, typeName, error.message)
+        log.error('unexpectedly failed to fetch type %s:%s: %s', adapterName, typeName, error.message, { adapterName, typeName })
     }
   }
 

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -485,6 +485,7 @@ describe('element', () => {
             expect.any(String),
             expect.any(String),
             fetchError.message,
+            { adapterName: 'myAdapter', typeName: 'myType' },
           )
         })
       })


### PR DESCRIPTION
adding log tags 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
