### PR TITLE
SALTO-6479 Fix PrimitiveValue type to include null & undefined

### DIFF
--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -22,7 +22,7 @@ import { ElemID } from './element_id'
 // There is a real cycle here and alternatively elements.ts should be defined in the same file
 import { Element, ReadOnlyElementsSource, PlaceholderObjectType, TypeElement, isVariable } from './elements'
 
-export type PrimitiveValue = string | boolean | number
+export type PrimitiveValue = string | boolean | number | null | undefined
 
 /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
 export type Value = any

--- a/packages/adapter-utils/src/list_comparison.ts
+++ b/packages/adapter-utils/src/list_comparison.ts
@@ -109,7 +109,7 @@ const getSingleValueKey = (value: LeafValue): string => {
   if (isTemplateExpression(value)) {
     return value.parts.map(getSingleValueKey).join('')
   }
-  return value.toString()
+  return value?.toString() ?? ''
 }
 
 /**

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -425,6 +425,61 @@ describe('detailedCompare', () => {
           },
         ])
       })
+
+      it('should work with null values in the list', () => {
+        beforeInst.value.list = [
+          null,
+          {
+            val: null,
+          },
+          {
+            val: undefined,
+          },
+        ]
+
+        afterInst.value.list = [
+          {
+            val: null,
+          },
+          {
+            val: undefined,
+          },
+          null,
+        ]
+        const listChanges = detailedCompare(beforeInst, afterInst, { compareListItems: true })
+        expect(listChanges).toEqual([
+          {
+            id: listID.createNestedID('0'),
+            data: { before: { val: null }, after: { val: null } },
+            action: 'modify',
+            elemIDs: {
+              before: listID.createNestedID('1'),
+              after: listID.createNestedID('0'),
+            },
+            baseChange,
+          },
+          {
+            id: listID.createNestedID('1'),
+            data: { before: { val: undefined }, after: { val: undefined } },
+            action: 'modify',
+            elemIDs: {
+              before: listID.createNestedID('2'),
+              after: listID.createNestedID('1'),
+            },
+            baseChange,
+          },
+          {
+            id: listID.createNestedID('2'),
+            data: { before: null, after: null },
+            action: 'modify',
+            elemIDs: {
+              before: listID.createNestedID('0'),
+              after: listID.createNestedID('2'),
+            },
+            baseChange,
+          },
+        ])
+      })
     })
   })
 

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1232,9 +1232,9 @@ export const transformPrimitive: TransformFuncSync = ({ value, path, field }) =>
     case PrimitiveTypes.NUMBER:
       return Number(value)
     case PrimitiveTypes.BOOLEAN:
-      return value.toString().toLowerCase() === 'true'
+      return String(value).toLowerCase() === 'true'
     case PrimitiveTypes.STRING:
-      return value.toString()
+      return String(value)
     default:
       return value
   }

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1228,13 +1228,16 @@ export const transformPrimitive: TransformFuncSync = ({ value, path, field }) =>
   if (!isPrimitiveType(fieldType) || !isPrimitiveValue(value)) {
     return value
   }
+  if (value === null || value === undefined) {
+    return undefined
+  }
   switch (fieldType.primitive) {
     case PrimitiveTypes.NUMBER:
       return Number(value)
     case PrimitiveTypes.BOOLEAN:
-      return String(value).toLowerCase() === 'true'
+      return value.toString().toLowerCase() === 'true'
     case PrimitiveTypes.STRING:
-      return String(value)
+      return value.toString()
     default:
       return value
   }

--- a/packages/salesforce-adapter/test/transformers/transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/transformer.test.ts
@@ -2084,10 +2084,26 @@ describe('transformer', () => {
           }),
         ).toEqual('true')
       })
-      it('should omit null values', () => {
+      it('should omit null representing object', () => {
         expect(
           transformPrimitive({
             value: { $: { 'xsi:nil': 'true' } },
+            field: mockObjType.fields.bool,
+          }),
+        ).toBeUndefined()
+      })
+      it('should omit null value', () => {
+        expect(
+          transformPrimitive({
+            value: null,
+            field: mockObjType.fields.bool,
+          }),
+        ).toBeUndefined()
+      })
+      it('should omit undefined value', () => {
+        expect(
+          transformPrimitive({
+            value: undefined,
             field: mockObjType.fields.bool,
           }),
         ).toBeUndefined()

--- a/packages/zendesk-adapter/src/filters/guide_service_url.ts
+++ b/packages/zendesk-adapter/src/filters/guide_service_url.ts
@@ -59,7 +59,7 @@ const replaceUrlParamsBrand = (url: string, instance: InstanceElement): string =
     if (!isPrimitiveValue(replacement)) {
       throw new Error(`Cannot replace param ${val} in ${url} with non-primitive value ${replacement}`)
     }
-    return replacement.toString()
+    return String(replacement)
   })
 
 const createServiceUrl = (instance: InstanceElement, baseUrl: string): void => {

--- a/packages/zendesk-adapter/src/filters/guide_service_url.ts
+++ b/packages/zendesk-adapter/src/filters/guide_service_url.ts
@@ -52,14 +52,14 @@ const replaceUrlParamsBrand = (url: string, instance: InstanceElement): string =
     let replacement
     if (val.slice(1, -1).startsWith('_')) {
       // meaning that it refers to an annotation
-      replacement = _.get(instance.annotations, val.slice(1, -1)) ?? val
+      replacement = _.get(instance.annotations, val.slice(1, -1))
     } else {
-      replacement = instance.value[val.slice(1, -1)] ?? val
+      replacement = instance.value[val.slice(1, -1)]
     }
     if (!isPrimitiveValue(replacement)) {
       throw new Error(`Cannot replace param ${val} in ${url} with non-primitive value ${replacement}`)
     }
-    return String(replacement)
+    return replacement?.toString() ?? val
   })
 
 const createServiceUrl = (instance: InstanceElement, baseUrl: string): void => {

--- a/packages/zendesk-adapter/test/filters/guide_service_url.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_service_url.test.ts
@@ -80,14 +80,27 @@ describe('guide service_url filter', () => {
     id: 1,
     brand: 123,
   })
+  const sectionInstanceWithoutBrand = new InstanceElement('instance', sectionType, {
+    id: 1,
+    brand: null,
+  })
   const categoryInstance = new InstanceElement('instance', categoryType, {
     id: 2,
+    brand: 123,
+  })
+  const categoryInstanceWithoutId = new InstanceElement('instance', categoryType, {
+    id: null,
     brand: 123,
   })
   const articleInstance = new InstanceElement('instance', articleType, {
     id: 3,
     brand: 123,
     source_locale: 'en-us',
+  })
+  const articleInstanceWithObjectLocale = new InstanceElement('instance', articleType, {
+    id: 3,
+    brand: 123,
+    source_locale: { value: 'en-us' },
   })
   const articleTranslationInstance = new InstanceElement('instance', articleTranslationType, {
     brand: 123,
@@ -142,6 +155,13 @@ describe('guide service_url filter', () => {
         'https://free-tifder.zendesk.com/hc/admin/general_settings',
         'https://free-tifder.zendesk.com/hc/admin/language_settings',
       ])
+    })
+    it('should not create service urls when there are invalid params', async () => {
+      const elements = [sectionInstanceWithoutBrand, categoryInstanceWithoutId, articleInstanceWithObjectLocale]
+      await filter.onFetch(elements)
+      elements.forEach(elem => {
+        expect(elem.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
+      })
     })
   })
 })


### PR DESCRIPTION
`isPrimitiveValue` returns true for `null`, `undefined`, but those weren't part of the the `PrimitiveValue` type.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- List items comparison will not throw when there's `null` / `undefined` in an item.

---
_User Notifications_: 
None
