### PR TITLE
SALTO-6478: deploy dc component with lead id

### DIFF
--- a/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
+++ b/packages/jira-adapter/src/filters/account_id/user_id_filter.ts
@@ -25,7 +25,7 @@ import _ from 'lodash'
 import { FilterCreator } from '../../filter'
 import { walkOnUsers, WalkOnUsersCallback } from './account_id_filter'
 import { UserMap, getUsersMap } from '../../users'
-import { PROJECT_TYPE } from '../../constants'
+import { PROJECT_COMPONENT_TYPE, PROJECT_TYPE } from '../../constants'
 
 const { awu } = collections.asynciterable
 
@@ -95,7 +95,7 @@ const filter: FilterCreator = ({ client, config, getUserMapFunc, elementsSource 
       .filter(isInstanceChange)
       .filter(isAdditionOrModificationChange)
       .map(getChangeData)
-      .filter(instance => instance.elemID.typeName !== PROJECT_TYPE)
+      .filter(instance => ![PROJECT_TYPE, PROJECT_COMPONENT_TYPE].includes(instance.elemID.typeName))
       .forEach(element => walkOnElement({ element, func: walkOnUsers(convertUserNameToId(preDeployUserMap), config) }))
   },
   onDeploy: async changes => {


### PR DESCRIPTION
The deployment of project components with lead ID did not work- we send the id but we need to send the user name

---

None

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug that prevented deployment of components with lead ID in dc

---
_User Notifications_: 
None
