### PR TITLE
SALTO-6473: Support changing fields with unknown type

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -343,7 +343,6 @@ For more details see the DeployOptions section in the [salesforce documentation 
 | managedPackage               | true                   | Disallow changes to objects and fields that are part of a managed package                         |
 | picklistStandardField        | true                   | It is forbidden to modify a picklist on a standard field. Only StandardValueSet is allowed        |
 | customObjectInstances        | true                   | Validate permissions of creating / update data records                                            |
-| unknownField                 | true                   | Disallow deploying an unknown field type                                                          |
 | customFieldType              | true                   | Ensure the type given to a custom field is a valid type for custom fields                         |
 | standardFieldLabel           | true                   | Disallow changing a label of a standard field                                                     |
 | mapKeys                      | true                   | Ensure proper structure of profiles before deploying                                              |

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -12,7 +12,6 @@ import { deployment } from '@salto-io/adapter-components'
 import packageValidator from './change_validators/package'
 import picklistStandardFieldValidator from './change_validators/picklist_standard_field'
 import customObjectInstancesValidator from './change_validators/custom_object_instances'
-import unknownFieldValidator from './change_validators/unknown_field'
 import customFieldTypeValidator from './change_validators/custom_field_type'
 import standardFieldLabelValidator from './change_validators/standard_field_label'
 import mapKeysValidator from './change_validators/map_keys'
@@ -67,7 +66,6 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   managedPackage: () => packageValidator,
   picklistStandardField: () => picklistStandardFieldValidator,
   customObjectInstances: () => customObjectInstancesValidator,
-  unknownField: () => unknownFieldValidator,
   customFieldType: () => customFieldTypeValidator,
   standardFieldLabel: () => standardFieldLabelValidator,
   mapKeys: () => mapKeysValidator,

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -117,7 +117,7 @@ export interface LookupFilter {
 export class CustomField implements MetadataInfo {
   // Common field annotations
   readonly label?: string
-  readonly type: string
+  readonly type?: string
   readonly required?: boolean
   readonly defaultValue?: string
   // For formula fields
@@ -173,7 +173,7 @@ export class CustomField implements MetadataInfo {
 
   constructor(
     public fullName: string,
-    type: string,
+    type: string | undefined,
     required = false,
     defaultVal?: string,
     defaultValFormula?: string,
@@ -244,7 +244,7 @@ export class CustomField implements MetadataInfo {
     } else if (type === FIELD_TYPE_NAMES.CHECKBOX && !formula) {
       // For Checkbox the default value comes from defaultVal and not defaultValFormula
       this.defaultValue = defaultVal
-    } else if (isRelationshipFieldName(type)) {
+    } else if (type !== undefined && isRelationshipFieldName(type)) {
       this.relationshipName = relationshipName
       // "Can not specify 'referenceTo' for a CustomField of type Hierarchy" Error will be thrown
       // if we try sending the `referenceTo` value to Salesforce.
@@ -267,7 +267,7 @@ export class CustomField implements MetadataInfo {
           FIELD_TYPE_NAMES.AUTONUMBER,
           FIELD_TYPE_NAMES.LONGTEXTAREA,
           FIELD_TYPE_NAMES.RICHTEXTAREA,
-        ] as string[]
+        ] as (string | undefined)[]
       ).includes(this.type) &&
       !formula
     ) {

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -91,11 +91,19 @@ export const COMPOUND_FIELDS_SOAP_TYPE_NAMES: Record<string, COMPOUND_FIELD_TYPE
   // name is handled differently with nameField
 }
 
-// target types for creating / updating custom fields:
-export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES: string[] = [
+// target types for creating / updating custom fields
+// we can create fields of these types or update the types of existing fields to these types
+export const CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES: (string | undefined)[] = [
   ...Object.values(FIELD_TYPE_NAMES),
   COMPOUND_FIELD_TYPE_NAMES.LOCATION,
   COMPOUND_FIELD_TYPE_NAMES.ADDRESS,
+]
+
+export const CUSTOM_FIELD_DEPLOYABLE_TYPES: (string | undefined)[] = [
+  ...CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES,
+  // We cannot create new fields with an unknown type or modify a field to have an unknown type
+  // but if a field is already of an unknown type, we can deploy it as long as we do not specify the type explicitly
+  undefined,
 ]
 
 export const FIELD_SOAP_TYPE_NAMES: Record<string, ALL_FIELD_TYPE_NAMES> = {

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -80,6 +80,7 @@ import {
   STANDARD_OBJECT_META_TYPE,
   CUSTOM_OBJECT_META_TYPE,
   CUSTOM_SETTINGS_META_TYPE,
+  CUSTOM_FIELD_DEPLOYABLE_TYPES,
 } from '../constants'
 import { FilterContext, LocalFilterCreator } from '../filter'
 import {
@@ -664,6 +665,7 @@ const getNestedCustomObjectValues = async (
     getDataFromChanges(dataField, await awu(changes).filter(shouldIncludeFieldChange(fieldsToSkip)).toArray()),
   )
     .map(field => toCustomField(field as Field))
+    .filter(field => CUSTOM_FIELD_DEPLOYABLE_TYPES.includes(field.type))
     .toArray(),
 })
 

--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -85,7 +85,7 @@ import {
   UNIX_TIME_ZERO_STRING,
   VALUE_SET_FIELDS,
   LAST_MODIFIED_DATE,
-  CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES,
+  CUSTOM_FIELD_DEPLOYABLE_TYPES,
   VALUE_SET_DEFINITION_FIELDS,
   DEFAULT_VALUE_FORMULA,
   FORMULA,
@@ -920,7 +920,7 @@ const getCustomFields = (element: ObjectType, skipFields: string[]): Promise<Cus
     .filter(field => !transformer.isLocalOnly(field))
     .map(field => toCustomField(field))
     .filter(field => !skipFields.includes(field.fullName))
-    .filter(field => CUSTOM_FIELD_UPDATE_CREATE_ALLOWED_TYPES.includes(field.type))
+    .filter(field => CUSTOM_FIELD_DEPLOYABLE_TYPES.includes(field.type))
     .toArray()
 
 export const toCustomProperties = async (

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -198,12 +198,15 @@ export const apiName = async (elem: Readonly<Element>, relative = false): Promis
 
 export const formulaTypeName = (baseTypeName: FIELD_TYPE_NAMES): string => `${FORMULA_TYPE_NAME}${baseTypeName}`
 
-export const fieldTypeName = (typeName: string): string => {
+export const fieldTypeName = (typeName: string): string | undefined => {
   if (typeName.startsWith(FORMULA_TYPE_NAME)) {
     return typeName.slice(FORMULA_TYPE_NAME.length)
   }
   if (typeName === LOCATION_INTERNAL_COMPOUND_FIELD_TYPE_NAME) {
     return COMPOUND_FIELD_TYPE_NAMES.LOCATION
+  }
+  if (typeName === INTERNAL_FIELD_TYPE_NAMES.UNKNOWN) {
+    return undefined
   }
   return typeName
 }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -125,7 +125,6 @@ export type ChangeValidatorName =
   | 'managedPackage'
   | 'picklistStandardField'
   | 'customObjectInstances'
-  | 'unknownField'
   | 'customFieldType'
   | 'standardFieldLabel'
   | 'mapKeys'
@@ -826,7 +825,6 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     managedPackage: { refType: BuiltinTypes.BOOLEAN },
     picklistStandardField: { refType: BuiltinTypes.BOOLEAN },
     customObjectInstances: { refType: BuiltinTypes.BOOLEAN },
-    unknownField: { refType: BuiltinTypes.BOOLEAN },
     customFieldType: { refType: BuiltinTypes.BOOLEAN },
     standardFieldLabel: { refType: BuiltinTypes.BOOLEAN },
     mapKeys: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/custom_field_type.test.ts
@@ -77,5 +77,28 @@ describe('custom field type change validator', () => {
       const changeErrors = await runChangeValidator(undefined, field)
       expect(changeErrors).toHaveLength(0)
     })
+    it('should have error when field type changed to unknown modification', async () => {
+      const beforeField = createField(customObj, Types.primitiveDataTypes.Date, 'Something')
+      const afterField = createField(customObj, Types.primitiveDataTypes.Unknown, 'Something')
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(beforeField.elemID)
+      expect(changeError.severity).toEqual('Error')
+    })
+    it('should have error for unknown field creation', async () => {
+      const field = createField(customObj, Types.primitiveDataTypes.Unknown, 'Something')
+      const changeErrors = await runChangeValidator(undefined, field)
+      expect(changeErrors).toHaveLength(1)
+      const [changeError] = changeErrors
+      expect(changeError.elemID).toEqual(field.elemID)
+      expect(changeError.severity).toEqual('Error')
+    })
+    it('should not have error when field type remains unknown in a modification', async () => {
+      const beforeField = createField(customObj, Types.primitiveDataTypes.Unknown, 'Something')
+      const afterField = beforeField.clone({ modifyMe: 'changed' })
+      const changeErrors = await runChangeValidator(beforeField, afterField)
+      expect(changeErrors).toHaveLength(0)
+    })
   })
 })

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -1054,6 +1054,18 @@ describe('filter utils', () => {
         expect(customField[FIELD_ANNOTATIONS.METADATA_RELATIONSHIP_CONTROLLING_FIELD]).toEqual(CONTROLLING_FIELD)
       })
     })
+    describe('with unknown field type', () => {
+      it('should keep the type attribute undefined', async () => {
+        const unknownField = new Field(
+          new ObjectType({ elemID: new ElemID('salesforce', 'test__c') }),
+          'unknwon__c',
+          Types.primitiveDataTypes.Unknown,
+          { [API_NAME]: 'test__c.unknown__c' },
+        )
+        const customField = await toCustomField(unknownField)
+        expect(customField.type).toBeUndefined()
+      })
+    })
   })
 
   describe('await toCustomProperties', () => {


### PR DESCRIPTION
The metadata API technically supports deploying fields with unknown type if the type was already unknown This change:
- Removes the change validator that would prevent modifying existing fields with unknown type
- Moves the logic of putting an error on unknown field types to the custom_field_type validator to avoid having double warnings
- Fixes the deployment code / filters to not explicitly specify the field type when it is unknown

---

_Additional context for reviewer_
Manually tested with:
- Deploying a new object with a field that has an unknown type (the field with the unknown type is not deployed, deployment succeeds)
- Adding a field with an unknown type (gets change validation error)
- Modifying a field with an unknown type (adding a "description") - works

---
_Release Notes_: 
_Salesforce Adapter_
- Added support for deploying changes to fields with unknown type
- Removed double change validator when a field has an invalid type, leaving only one validation error

---
_User Notifications_: 
_None_