### PR TITLE
SALTO-5984: Okta: Omit `EmailDomain` instances marked as `DELETED`

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -38,6 +38,7 @@ import { extractSchemaIdFromUserType } from './types/user_type'
 import { isNotMappingToAuthenticatorApp } from './types/profile_mapping'
 import { assignPolicyIdsToApplication } from './types/application'
 import { shouldConvertUserIds } from '../../user_utils'
+import { isNotDeletedEmailDomain } from './types/email_domain'
 
 const NAME_ID_FIELD: definitions.fetch.FieldIDPart = { fieldName: 'name' }
 const DEFAULT_ID_PARTS = [NAME_ID_FIELD]
@@ -916,6 +917,7 @@ const createCustomizations = ({
         isTopLevel: true,
         serviceUrl: { path: '/admin/email/domains' },
         elemID: { parts: [{ fieldName: 'displayName' }] },
+        valueGuard: isNotDeletedEmailDomain,
       },
       fieldCustomizations: { id: { hide: true } },
     },

--- a/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
@@ -1,0 +1,42 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { Values } from '@salto-io/adapter-api'
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+
+// This is a partial schema with only the field we access below.
+const EMAIL_DOMAIN_SCHEMA = Joi.object({
+  validationStatus: Joi.string().required(),
+}).unknown(true)
+
+type EmailDomain = {
+  validationStatus: string
+}
+
+const hasValidationStatus = createSchemeGuard<EmailDomain>(EMAIL_DOMAIN_SCHEMA)
+
+/**
+ * Omit email domains with a DELETED status.
+ *
+ * When deleting an email domain, Okta marks it as deleted instead of removing it. This can cause a merge bug when
+ * recreating the email domain with the same name.
+ */
+export const isNotDeletedEmailDomain = (value: unknown): value is Values => {
+  if (hasValidationStatus(value)) {
+    return value.validationStatus !== 'DELETED'
+  }
+  return false
+}

--- a/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
@@ -16,6 +16,9 @@
 import { Values } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+
+const log = logger(module)
 
 // This is a partial schema with only the field we access below.
 const EMAIL_DOMAIN_SCHEMA = Joi.object({
@@ -38,5 +41,6 @@ export const isNotDeletedEmailDomain = (value: unknown): value is Values => {
   if (hasValidationStatus(value)) {
     return value.validationStatus !== 'DELETED'
   }
+  log.error('Email domain is missing a validationStatus field, this is unexpected: %o', value)
   return false
 }

--- a/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/email_domain.ts
@@ -31,7 +31,7 @@ const hasValidationStatus = createSchemeGuard<EmailDomain>(EMAIL_DOMAIN_SCHEMA)
 /**
  * Omit email domains with a DELETED status.
  *
- * When deleting an email domain, Okta marks it as deleted instead of removing it. This can cause a merge bug when
+ * When deleting an email domain, Okta marks it as deleted instead of removing it. This can cause a merge error when
  * recreating the email domain with the same name.
  */
 export const isNotDeletedEmailDomain = (value: unknown): value is Values => {

--- a/packages/okta-adapter/test/definitions/fetch/types/email_domain.test.ts
+++ b/packages/okta-adapter/test/definitions/fetch/types/email_domain.test.ts
@@ -28,6 +28,9 @@ describe('isNotDeletedEmailDomain', () => {
     id: '222',
     validationStatus: 'DELETED',
   }
+  const noValidationStatusEmailDomain = {
+    id: '333',
+  }
 
   it('should return true when value is an EmailDomain with status ACTIVE', () => {
     expect(isNotDeletedEmailDomain(activeEmailDomain)).toBeTruthy()
@@ -36,5 +39,9 @@ describe('isNotDeletedEmailDomain', () => {
 
   it('should return false when value is an EmailDomain with status DELETED', () => {
     expect(isNotDeletedEmailDomain(deletedEmailDomain)).toBeFalsy()
+  })
+
+  it('should return false when value is not an EmailDomain', () => {
+    expect(isNotDeletedEmailDomain(noValidationStatusEmailDomain)).toBeFalsy()
   })
 })

--- a/packages/okta-adapter/test/definitions/fetch/types/email_domain.test.ts
+++ b/packages/okta-adapter/test/definitions/fetch/types/email_domain.test.ts
@@ -1,0 +1,40 @@
+/*
+ *                      Copyright 2024 Salto Labs Ltd.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { isNotDeletedEmailDomain } from '../../../../src/definitions/fetch/types/email_domain'
+
+describe('isNotDeletedEmailDomain', () => {
+  const activeEmailDomain = {
+    id: '111',
+    validationStatus: 'ACTIVE',
+  }
+  const notStartedEmailDomain = {
+    id: '111',
+    validationStatus: 'ACTIVE',
+  }
+  const deletedEmailDomain = {
+    id: '222',
+    validationStatus: 'DELETED',
+  }
+
+  it('should return true when value is an EmailDomain with status ACTIVE', () => {
+    expect(isNotDeletedEmailDomain(activeEmailDomain)).toBeTruthy()
+    expect(isNotDeletedEmailDomain(notStartedEmailDomain)).toBeTruthy()
+  })
+
+  it('should return false when value is an EmailDomain with status DELETED', () => {
+    expect(isNotDeletedEmailDomain(deletedEmailDomain)).toBeFalsy()
+  })
+})


### PR DESCRIPTION
This PR fixes a bug when fetching EmailDomain instances:

When deleting an email domain through the UI, the API still returns it, but with `validationStatus = "DELETED"`.

When recreating the same email domain through the UI (same email address and sender name), the API will now return two entries with the same details (one `DELETED` and one not)

When Salto performs a fetch, we get

```
Error merging okta.EmailDomain.instance.Team_Rachum@s: duplicate key <somekey>
[..]
dropped elements: okta.EmailDomain.instance.Team_Rachum@s
```

We solve this by omitting entries with DELETED status on fetch.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Okta adapter_:
Fixed a bug where email domains are dropped after being deleted and recreated, by omitting all currently-deleted email domains in fetch

---
_User Notifications_: 
_Okta adapter_:
- Email domains that have `validationStatus = "DELETED"` will be omitted in future fetches.