### PR TITLE
SALTO-6490: support group references change in automations

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -854,6 +854,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: GROUP_TYPE_NAME },
   },
   {
+    src: { field: 'value', parentTypes: [AUTOMATION_EMAIL_RECIPENT, AUTOMATION_CONDITION_CRITERIA, AUTOMATION_GROUP] },
+    serializationStrategy: 'groupId',
+    target: { type: GROUP_TYPE_NAME },
+  },
+  {
     src: { field: 'field', parentTypes: [AUTOMATION_CONDITION] },
     serializationStrategy: 'id',
     target: { type: 'Field' },


### PR DESCRIPTION
Following a change in the service, the group references are now IDs instead of names. Keeping both in case they revert

---

[Noise reduction](https://github.com/salto-io/salto_private/pull/9118)
None

---
_Release Notes_: 
Jira Adapter:
* Support Atlassian change in automation's email recipients from group name to group id
---
_User Notifications_: 
Jira Adapter:
* Automations with email group recipients will return to be references
