### PR TITLE
SALTO-6492: fix fieldConfigurationDescriptionLengthValidator bug

### DIFF
--- a/packages/jira-adapter/src/change_validators/field_configuration/field_configuration_description_length.ts
+++ b/packages/jira-adapter/src/change_validators/field_configuration/field_configuration_description_length.ts
@@ -20,7 +20,7 @@ export const fieldConfigurationDescriptionLengthValidator: ChangeValidator = asy
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(inst => inst.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
-    .filter(inst => inst.value.description.length > FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH)
+    .filter(inst => inst.value.description?.length > FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH)
     .map(inst => ({
       elemID: inst.elemID,
       severity: 'Error' as SeverityLevel,

--- a/packages/jira-adapter/test/change_validators/field_configuration/field_configuration_description_length.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_configuration/field_configuration_description_length.test.ts
@@ -14,6 +14,7 @@ describe('fieldConfigurationDescriptionLengthValidator', () => {
   let fieldConfigurationInstance: InstanceElement
   const INITIAL_DESCRIPTION = 'initial description'
   const EMPTY_DESCRIPTION = '*'.repeat(0)
+  const UNDEFINED_DESCRIPTION = undefined
   const SHORT_DESCRIPTION = '*'.repeat(1)
   const AVERAGE_DESCRIPTION = '*'.repeat(Math.floor(FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH / 2))
   const MAX_DESCRIPTION = '*'.repeat(FIELD_CONFIGURATION_DESCRIPTION_MAX_LENGTH)
@@ -32,7 +33,7 @@ describe('fieldConfigurationDescriptionLengthValidator', () => {
     })
   })
 
-  it.each([EMPTY_DESCRIPTION, SHORT_DESCRIPTION, AVERAGE_DESCRIPTION, MAX_DESCRIPTION])(
+  it.each([EMPTY_DESCRIPTION, SHORT_DESCRIPTION, AVERAGE_DESCRIPTION, MAX_DESCRIPTION, UNDEFINED_DESCRIPTION])(
     'Should succeed because field configuration description length is lower than maximum.',
     async updatedDescription => {
       const afterInstance = fieldConfigurationInstance.clone()


### PR DESCRIPTION
_fix fieldConfigurationDescriptionLengthValidator bug_

---

_Additional context for reviewer_
* the bug is that the validator fails when there is no description

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
