### PR TITLE
SALTO-6424: (Jira) Support unique field checks within parent scope

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/index.ts
+++ b/packages/adapter-components/src/deployment/change_validators/index.ts
@@ -13,4 +13,4 @@ export { createSkipParentsOfSkippedInstancesValidator } from './skip_parents_of_
 export { createOutgoingUnresolvedReferencesValidator } from './outgoing_unresolved_references'
 export { getDefaultChangeValidators, DEFAULT_CHANGE_VALIDATORS } from './default_change_validators'
 export { createChangeValidator, ValidatorsActivationConfig } from './create_change_validator'
-export { uniqueFieldsChangeValidatorCreator } from './unique_fields'
+export { uniqueFieldsChangeValidatorCreator, ScopeAndUniqueFields, SCOPE } from './unique_fields'

--- a/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
+++ b/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
@@ -107,7 +107,7 @@ const getErrorForChange = (
     elemID: instance.elemID,
     severity: 'Error',
     message: `The ${fieldNames.length > 1 ? 'fields' : 'field'} ${fieldNames.map(str => `'${str}'`).join(', ')} in type ${instance.elemID.typeName} must have ${fieldNames.length > 1 ? 'unique values' : 'a unique value'}`,
-    detailedMessage: `This instance cannot be deployed due to non unique values, within the ${scope} scope, in the following fields: ${nonUniqueFieldValues.map(str => `'${str}'`).join(', ')}.`,
+    detailedMessage: `This instance cannot be deployed due to non-unique values within the ${scope === SCOPE.parent ? 'children of the same parent' : 'entire environment'} in the following fields: ${nonUniqueFieldValues.map(str => `'${str}'`).join(', ')}.`,
   }
 }
 

--- a/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
+++ b/packages/adapter-components/src/deployment/change_validators/unique_fields.ts
@@ -20,22 +20,34 @@ import {
 } from '@salto-io/adapter-api'
 import { values } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { getInstancesFromElementSource, resolvePath } from '@salto-io/adapter-utils'
+import { getInstancesFromElementSource, getParentElemID, resolvePath } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 
 const log = logger(module)
 
 const { isDefined } = values
 
+type Scope = 'global' | 'parent'
+export const SCOPE: { [K in Scope]: K } = {
+  global: 'global',
+  parent: 'parent',
+}
+
+export type ScopeAndUniqueFields = {
+  scope: Scope
+  uniqueFields: string[]
+}
+
 type TypeInfo = {
+  scope: Scope
+  uniqueFieldNames: string[]
   changesOfType: (ModificationChange<InstanceElement> | AdditionChange<InstanceElement>)[]
   instancesOfType: InstanceElement[]
-  uniqueFieldNames: string[]
 }
 
 const createTypeToChangesRecord = (
   changes: readonly Change<ChangeDataType>[],
-  typeToFieldRecord: Record<string, string[]>,
+  typeToFieldRecord: Record<string, ScopeAndUniqueFields>,
 ): Record<string, (ModificationChange<InstanceElement> | AdditionChange<InstanceElement>)[]> => {
   const relevantChanges = changes
     .filter(isAdditionOrModificationChange)
@@ -55,35 +67,37 @@ const createTypeToInstancesRecord = async (
 const createTypeInfos = async (
   changes: readonly Change<ChangeDataType>[],
   elementsSource: ReadOnlyElementsSource,
-  typeToFieldRecord: Record<string, string[]>,
+  typeToFieldRecord: Record<string, ScopeAndUniqueFields>,
 ): Promise<TypeInfo[]> => {
   const typeToChangesRecord = createTypeToChangesRecord(changes, typeToFieldRecord)
   const relevantTypes = Object.keys(typeToChangesRecord)
   const typeToInstancesRecord = await createTypeToInstancesRecord(elementsSource, relevantTypes)
   return relevantTypes.map(typeName => ({
+    scope: typeToFieldRecord[typeName].scope,
+    uniqueFieldNames: typeToFieldRecord[typeName].uniqueFields,
     changesOfType: typeToChangesRecord[typeName],
     instancesOfType: typeToInstancesRecord[typeName],
-    uniqueFieldNames: typeToFieldRecord[typeName],
   }))
 }
 
-const getFieldValue = (instance: InstanceElement, fieldName: string): string | undefined => {
+const getFieldValueWithScope = (instance: InstanceElement, fieldName: string, scope: Scope): string | undefined => {
   const fieldValue = resolvePath(instance, instance.elemID.createNestedID(...fieldName.split('.')))
   if (!_.isString(fieldValue)) {
     log.warn('Unique field value is not a string')
     return undefined
   }
-  return fieldValue
+  return scope === SCOPE.parent ? `${getParentElemID(instance).getFullName()}.${fieldValue}` : fieldValue
 }
 
 const getErrorForChange = (
   change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
   fieldNames: string[],
   fieldValueCount: Record<string, Record<string, number>>,
+  scope: Scope,
 ): ChangeError | undefined => {
   const instance = getChangeData(change)
   const nonUniqueFieldValues = fieldNames.filter(fieldName => {
-    const fieldValue = getFieldValue(instance, fieldName)
+    const fieldValue = getFieldValueWithScope(instance, fieldName, scope)
     return fieldValue !== undefined && fieldValueCount[fieldName][fieldValue] > 1
   })
   if (nonUniqueFieldValues.length === 0) {
@@ -93,24 +107,28 @@ const getErrorForChange = (
     elemID: instance.elemID,
     severity: 'Error',
     message: `The ${fieldNames.length > 1 ? 'fields' : 'field'} ${fieldNames.map(str => `'${str}'`).join(', ')} in type ${instance.elemID.typeName} must have ${fieldNames.length > 1 ? 'unique values' : 'a unique value'}`,
-    detailedMessage: `This instance cannot be deployed due to non unique values in the following fields: ${nonUniqueFieldValues.map(str => `'${str}'`).join(', ')}.`,
+    detailedMessage: `This instance cannot be deployed due to non unique values, within the ${scope} scope, in the following fields: ${nonUniqueFieldValues.map(str => `'${str}'`).join(', ')}.`,
   }
 }
 
 export const uniqueFieldsChangeValidatorCreator =
-  (typeNameToUniqueFieldRecord: Record<string, string[]>): ChangeValidator =>
+  (typeNameToUniqueFieldRecord: Record<string, ScopeAndUniqueFields>): ChangeValidator =>
   async (changes, elementsSource) => {
     if (elementsSource === undefined) {
       log.info("Didn't run unique fields validator as elementsSource is undefined")
       return []
     }
     return (await createTypeInfos(changes, elementsSource, typeNameToUniqueFieldRecord)).flatMap(typeInfo => {
-      const { changesOfType, instancesOfType, uniqueFieldNames } = typeInfo
+      const { scope, uniqueFieldNames, changesOfType, instancesOfType } = typeInfo
       const fieldValueCount: Record<string, Record<string, number>> = {}
       uniqueFieldNames.forEach(fieldName => {
-        const fieldValueToInstances = _.groupBy(instancesOfType, instance => getFieldValue(instance, fieldName))
+        const fieldValueToInstances = _.groupBy(instancesOfType, instance =>
+          getFieldValueWithScope(instance, fieldName, scope),
+        )
         fieldValueCount[fieldName] = _.mapValues(fieldValueToInstances, instances => instances.length)
       })
-      return changesOfType.map(change => getErrorForChange(change, uniqueFieldNames, fieldValueCount)).filter(isDefined)
+      return changesOfType
+        .map(change => getErrorForChange(change, uniqueFieldNames, fieldValueCount, scope))
+        .filter(isDefined)
     })
   }

--- a/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
@@ -145,7 +145,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField'.",
     })
   })
   it('should return an error for multiple changes with the same field', async () => {
@@ -169,14 +169,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: relevantInstance2After.elemID,
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField'.",
     })
   })
   it('should return errors for multiple relevant types and reference them correctly', async () => {
@@ -196,14 +196,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: otherRelevantInstance2.elemID,
       severity: 'Error',
       message: "The field 'otherUniqueField' in type otherRelevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'otherUniqueField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'otherUniqueField'.",
     })
   })
   it('should return an error for the same unique inner field value', async () => {
@@ -215,7 +215,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'field.uniqueInnerField' in type uniqueInnerField must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'field.uniqueInnerField'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'field.uniqueInnerField'.",
     })
   })
   it('should return an error for the same unique values in multiple fields', async () => {
@@ -236,7 +236,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField1', 'uniqueField2'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField1', 'uniqueField2'.",
     })
   })
   it('should return an error for multiple fields type with only one non unique value', async () => {
@@ -257,7 +257,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField1'.",
+        "This instance cannot be deployed due to non-unique values within the entire environment in the following fields: 'uniqueField1'.",
     })
   })
   it('should not return an error when the elementsSource is undefined', async () => {
@@ -281,7 +281,7 @@ describe('unique fields', () => {
         severity: 'Error',
         message: "The field 'uniqueField' in type parentScopeType must have a unique value",
         detailedMessage:
-          "This instance cannot be deployed due to non unique values, within the parent scope, in the following fields: 'uniqueField'.",
+          "This instance cannot be deployed due to non-unique values within the children of the same parent in the following fields: 'uniqueField'.",
       })
     })
     it('should not return an error for the same unique values in different parents', async () => {

--- a/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/unique_fields.test.ts
@@ -5,9 +5,16 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import {
+  toChange,
+  ObjectType,
+  ElemID,
+  InstanceElement,
+  ReferenceExpression,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { uniqueFieldsChangeValidatorCreator } from '../../../src/deployment/change_validators/unique_fields'
+import { SCOPE, uniqueFieldsChangeValidatorCreator } from '../../../src/deployment/change_validators/unique_fields'
 
 describe('unique fields', () => {
   let relevantInstance1: InstanceElement
@@ -23,17 +30,22 @@ describe('unique fields', () => {
   let uniqueInnerFieldInstance1: InstanceElement
   let uniqueInnerFieldInstance2: InstanceElement
 
+  let parentScopeInstance1: InstanceElement
+  let parentScopeInstance2: InstanceElement
+
   const relevantObjectType = new ObjectType({ elemID: new ElemID('adapter', 'relevantType') })
   const irrelevantObjectType = new ObjectType({ elemID: new ElemID('adapter', 'irrelevantType') })
   const otherRelevantObjectType = new ObjectType({ elemID: new ElemID('adapter', 'otherRelevantType') })
   const uniqueInnerFieldObjectType = new ObjectType({ elemID: new ElemID('adapter', 'uniqueInnerField') })
   const multiFieldsObjectType = new ObjectType({ elemID: new ElemID('adapter', 'multiFieldsType') })
+  const parentScopeObjectType = new ObjectType({ elemID: new ElemID('adapter', 'parentScopeType') })
 
   const changeValidator = uniqueFieldsChangeValidatorCreator({
-    [relevantObjectType.elemID.typeName]: ['uniqueField'],
-    [otherRelevantObjectType.elemID.typeName]: ['otherUniqueField'],
-    [uniqueInnerFieldObjectType.elemID.typeName]: ['field.uniqueInnerField'],
-    [multiFieldsObjectType.elemID.typeName]: ['uniqueField1', 'uniqueField2'],
+    [relevantObjectType.elemID.typeName]: { scope: SCOPE.global, uniqueFields: ['uniqueField'] },
+    [otherRelevantObjectType.elemID.typeName]: { scope: SCOPE.global, uniqueFields: ['otherUniqueField'] },
+    [uniqueInnerFieldObjectType.elemID.typeName]: { scope: SCOPE.global, uniqueFields: ['field.uniqueInnerField'] },
+    [multiFieldsObjectType.elemID.typeName]: { scope: SCOPE.global, uniqueFields: ['uniqueField1', 'uniqueField2'] },
+    [parentScopeObjectType.elemID.typeName]: { scope: SCOPE.parent, uniqueFields: ['uniqueField'] },
   })
 
   beforeEach(() => {
@@ -70,6 +82,12 @@ describe('unique fields', () => {
       field: {
         uniqueInnerField: 'same',
       },
+    })
+    parentScopeInstance1 = new InstanceElement('parentScopeInstance1', parentScopeObjectType, {
+      uniqueField: 'same',
+    })
+    parentScopeInstance2 = new InstanceElement('parentScopeInstance2', parentScopeObjectType, {
+      uniqueField: 'same',
     })
   })
 
@@ -127,7 +145,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
     })
   })
   it('should return an error for multiple changes with the same field', async () => {
@@ -151,14 +169,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: relevantInstance2After.elemID,
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
     })
   })
   it('should return errors for multiple relevant types and reference them correctly', async () => {
@@ -178,14 +196,14 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'uniqueField' in type relevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField'.",
     })
     expect(changeErrors[1]).toEqual({
       elemID: otherRelevantInstance2.elemID,
       severity: 'Error',
       message: "The field 'otherUniqueField' in type otherRelevantType must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'otherUniqueField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'otherUniqueField'.",
     })
   })
   it('should return an error for the same unique inner field value', async () => {
@@ -197,7 +215,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The field 'field.uniqueInnerField' in type uniqueInnerField must have a unique value",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'field.uniqueInnerField'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'field.uniqueInnerField'.",
     })
   })
   it('should return an error for the same unique values in multiple fields', async () => {
@@ -218,7 +236,7 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField1', 'uniqueField2'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField1', 'uniqueField2'.",
     })
   })
   it('should return an error for multiple fields type with only one non unique value', async () => {
@@ -239,11 +257,77 @@ describe('unique fields', () => {
       severity: 'Error',
       message: "The fields 'uniqueField1', 'uniqueField2' in type multiFieldsType must have unique values",
       detailedMessage:
-        "This instance cannot be deployed due to non unique values in the following fields: 'uniqueField1'.",
+        "This instance cannot be deployed due to non unique values, within the global scope, in the following fields: 'uniqueField1'.",
     })
   })
   it('should not return an error when the elementsSource is undefined', async () => {
-    const changeErrors = await changeValidator([toChange({ after: relevantInstance1 })], undefined)
+    const changeErrors = await changeValidator(
+      [toChange({ after: relevantInstance1 }), toChange({ after: relevantInstance2 })],
+      undefined,
+    )
     expect(changeErrors).toHaveLength(0)
+  })
+  describe('parent scope', () => {
+    const parentInstance1 = new InstanceElement('parentInstance1', irrelevantObjectType, {})
+    const parentInstance2 = new InstanceElement('parentInstance2', irrelevantObjectType, {})
+    it('should return an error for the same unique values in the same parent', async () => {
+      parentScopeInstance1.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance1.elemID)
+      parentScopeInstance2.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance1.elemID)
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1, parentScopeInstance2])
+      const changeErrors = await changeValidator([toChange({ after: parentScopeInstance1 })], elementSource)
+      expect(changeErrors).toHaveLength(1)
+      expect(changeErrors[0]).toEqual({
+        elemID: parentScopeInstance1.elemID,
+        severity: 'Error',
+        message: "The field 'uniqueField' in type parentScopeType must have a unique value",
+        detailedMessage:
+          "This instance cannot be deployed due to non unique values, within the parent scope, in the following fields: 'uniqueField'.",
+      })
+    })
+    it('should not return an error for the same unique values in different parents', async () => {
+      parentScopeInstance1.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance1.elemID)
+      parentScopeInstance2.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance2.elemID)
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1, parentScopeInstance2])
+      const changeErrors = await changeValidator(
+        [toChange({ before: parentScopeInstance1, after: parentScopeInstance1 })],
+        elementSource,
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should not return an error for different unique values in the same parent', async () => {
+      parentScopeInstance1.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance1.elemID)
+      parentScopeInstance2.annotations[CORE_ANNOTATIONS.PARENT] = new ReferenceExpression(parentInstance1.elemID)
+      parentScopeInstance2.value.uniqueField = 'other'
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1, parentScopeInstance2])
+      const changeErrors = await changeValidator(
+        [toChange({ before: parentScopeInstance1, after: parentScopeInstance2 })],
+        elementSource,
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
+    it('should throw an error when the parent is not a reference expression', async () => {
+      parentScopeInstance1.annotations[CORE_ANNOTATIONS.PARENT] = 'some string'
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1])
+      await expect(changeValidator([toChange({ after: parentScopeInstance1 })], elementSource)).rejects.toThrow(
+        'Expected adapter.parentScopeType.instance.parentScopeInstance1 parent to be a reference expression',
+      )
+    })
+    it('should throw an error when there is no parent', async () => {
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1])
+      await expect(changeValidator([toChange({ after: parentScopeInstance1 })], elementSource)).rejects.toThrow(
+        'Expected adapter.parentScopeType.instance.parentScopeInstance1 to have exactly one parent, found 0',
+      )
+    })
+    it('should not return an error if the field is undefined or is not a string', async () => {
+      parentScopeInstance1.value.uniqueField = undefined
+      parentScopeInstance2.value.uniqueField = [1, 2, 3]
+
+      const elementSource = buildElementsSourceFromElements([parentScopeInstance1, parentScopeInstance2])
+      const changeErrors = await changeValidator(
+        [toChange({ after: relevantInstance1 }), toChange({ after: relevantInstance2 })],
+        elementSource,
+      )
+      expect(changeErrors).toHaveLength(0)
+    })
   })
 })

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -948,6 +948,19 @@ export const getParent = (instance: Element): InstanceElement => {
   return parents[0].value
 }
 
+// This method is used to get the parent's elemID when the references are not neccessarily resolved
+export const getParentElemID = (instance: Element): ElemID => {
+  const parents = getParents(instance)
+  if (parents.length !== 1) {
+    throw new Error(`Expected ${instance.elemID.getFullName()} to have exactly one parent, found ${parents.length}`)
+  }
+  const parent = parents[0]
+  if (!isReferenceExpression(parent)) {
+    throw new Error(`Expected ${instance.elemID.getFullName()} parent to be a reference expression`)
+  }
+  return parent.elemID
+}
+
 export const hasValidParent = (element: Element): boolean => {
   try {
     return getParent(element) !== undefined

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -82,6 +82,7 @@ import {
   getInstancesFromElementSource,
   validatePlainObject,
   validateArray,
+  getParentElemID,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -2782,6 +2783,39 @@ describe('Test utils.ts', () => {
     it('should throw when having a non instance parent', () => {
       child.annotations[CORE_ANNOTATIONS.PARENT] = [new ReferenceExpression(parent.elemID, 'a')]
       expect(() => getParent(child)).toThrow()
+    })
+  })
+  describe('getParentElemID', () => {
+    let parent: InstanceElement
+    let child: InstanceElement
+
+    beforeEach(() => {
+      const obj = new ObjectType({ elemID: new ElemID('test', 'test') })
+      parent = new InstanceElement('parent', obj, {})
+      child = new InstanceElement('child', obj, {}, [], {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID)],
+      })
+    })
+
+    it('should return the parent elemID when there is a single reference parent', () => {
+      expect(getParentElemID(child)).toEqual(parent.elemID)
+    })
+
+    it('should throw when having more than one parent', () => {
+      child.annotations[CORE_ANNOTATIONS.PARENT] = [
+        new ReferenceExpression(parent.elemID, parent),
+        new ReferenceExpression(parent.elemID, parent),
+      ]
+      expect(() => getParentElemID(child)).toThrow(
+        'Expected test.test.instance.child to have exactly one parent, found 2',
+      )
+    })
+
+    it('should throw when having a non reference parent', () => {
+      child.annotations[CORE_ANNOTATIONS.PARENT] = ['some string']
+      expect(() => getParentElemID(child)).toThrow(
+        'Expected test.test.instance.child parent to be a reference expression',
+      )
     })
   })
 

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -65,19 +65,20 @@ import { jsmPermissionsValidator } from './jsm/jsm_permissions'
 import { referencedWorkflowDeletionChangeValidator } from './workflowsV2/referenced_workflow_deletion'
 import { missingExtensionsTransitionRulesChangeValidator } from './workflowsV2/missing_extensions_transition_rules'
 import { fieldContextOptionsValidator } from './field_contexts/field_context_options'
-import { ISSUE_TYPE_NAME, PORTAL_GROUP_TYPE, PROJECT_TYPE } from '../constants'
+import { ISSUE_TYPE_NAME, PORTAL_GROUP_TYPE, PROJECT_TYPE, SLA_TYPE_NAME } from '../constants'
 import { assetsObjectFieldConfigurationAqlValidator } from './field_contexts/assets_object_field_configuration_aql'
 import { projectAssigneeTypeValidator } from './projects/project_assignee_type'
+import { FIELD_CONTEXT_TYPE_NAME } from '../filters/fields/constants'
 
-const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator } =
+const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator, SCOPE } =
   deployment.changeValidators
 
-const TYPE_TO_UNIQUE_FIELD = {
-  [ISSUE_TYPE_NAME]: ['name'],
-  [PORTAL_GROUP_TYPE]: ['name'],
-  // TODO SALTO-6424 uncomment when we add Scope to unique fields filter.
-  // [SLA_TYPE_NAME]: ['name'],
-  [PROJECT_TYPE]: ['name', 'key'],
+const TYPE_TO_UNIQUE_FIELD: Record<string, deployment.changeValidators.ScopeAndUniqueFields> = {
+  [ISSUE_TYPE_NAME]: { scope: SCOPE.global, uniqueFields: ['name'] },
+  [PORTAL_GROUP_TYPE]: { scope: SCOPE.global, uniqueFields: ['name'] },
+  [SLA_TYPE_NAME]: { scope: SCOPE.parent, uniqueFields: ['name'] },
+  [PROJECT_TYPE]: { scope: SCOPE.global, uniqueFields: ['name', 'key'] },
+  [FIELD_CONTEXT_TYPE_NAME]: { scope: SCOPE.parent, uniqueFields: ['name'] },
 }
 
 export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.Paginator): ChangeValidator => {


### PR DESCRIPTION
Change the unique fields CV to support uniqueness in different scopes.
We will support global and parent scopes.

Added types that need the parent scope check in Jira.

---

_Additional context for reviewer_
_None_

---
_Release Notes_: 
_Adapter Components:_
* Added a scope option in the unique fields CV

_Jira adapter:_
* Check unique names in SLAs and field contexts

---
_User Notifications_: 
_None_
