### PR TITLE
SALTO-2392 Improve condition formula parsing for ASVs

### DIFF
--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -534,6 +534,26 @@ const getNameByInternalId = (
     .map(typeName => getSuiteQLTableInternalIdsMap(suiteQLTablesMap[typeName])[internalId])
     .find(res => res !== undefined)?.name
 
+const getParamLocations = ({
+  conditionFormula,
+  param,
+  startAtIndex = 0,
+  isFirstAppearance = true,
+}: {
+  conditionFormula: string
+  param: Values
+  startAtIndex?: number
+  isFirstAppearance?: boolean
+}): { param: Values; location: number; isFirstAppearance: boolean }[] => {
+  const location = conditionFormula.indexOf(`"${param.name}"`, startAtIndex)
+  if (location === -1) {
+    return []
+  }
+  return [{ param, location, isFirstAppearance }].concat(
+    getParamLocations({ conditionFormula, param, startAtIndex: location + 1, isFirstAppearance: false }),
+  )
+}
+
 const getParametersAccountSpecificValueToTransform = (
   instance: InstanceElement,
   value: Values,
@@ -544,13 +564,27 @@ const getParametersAccountSpecificValueToTransform = (
   const conditionFormula = value[INIT_CONDITION][FORMULA]
   const allParams = getConditionParameters(value[INIT_CONDITION])
   const params = allParams
-    // not only params with ACCOUNT_SPECIFIC_VALUE are represented with internalid in the formula (e.g roles)
-    // but only params that have selectrecordtype are represented with internalid in the formula
+    // not only params with ACCOUNT_SPECIFIC_VALUE are represented with internalid in the formula (e.g roles),
+    // but only params that have selectrecordtype are represented with internalid in the formula.
     .filter(param => param?.[SELECT_RECORD_TYPE] !== undefined)
-  const internalIds = Array.from(matchAll(formulaWithInternalIds, /-?\d+/g))
+    // params that have a constant string `value` (e.g "INVOICE") aren't represented with internalid in the formula.
+    .filter(param => typeof param.value === 'string' && !/^[A-Z]+$/.test(param.value))
+    // each param can appear more than once in the condition formula.
+    // in that case we're expecting to see it multiple times in formulaWithInternalIds.
+    .flatMap(param => getParamLocations({ conditionFormula, param }))
+  const internalIds = Array.from(matchAll(formulaWithInternalIds, /['"]?-?\d+(\.\d*)?['"]?/g))
     .map(res => res[0])
-    // 0 (zero) can be used in a formula (e.g 'arrayIndexOf(...) < 0'), but it's not an internalid
-    .filter(internalId => internalId !== '0')
+    .filter(
+      internalId =>
+        // ignore string numbers (e.g '1', "2")
+        isNumberStr(internalId) &&
+        // ignore non integers (e.g 1.5, 2.0)
+        !internalId.includes('.') &&
+        // ignore zero and invalid numbers
+        !internalId.startsWith('0') &&
+        !internalId.startsWith('-0'),
+    )
+
   if (params.length !== internalIds.length) {
     log.warn('params length %d do not match the internal ids extracted from the formula: %o', params.length, {
       formula: {
@@ -561,9 +595,9 @@ const getParametersAccountSpecificValueToTransform = (
     })
     return []
   }
-  const sortedParams = _.sortBy(params, param => conditionFormula.indexOf(`"${param.name}"`))
-  return sortedParams.flatMap((param, index) => {
-    if (param.value !== ACCOUNT_SPECIFIC_VALUE) {
+  const sortedParams = _.sortBy(params, param => param.location)
+  return sortedParams.flatMap(({ param, isFirstAppearance }, index) => {
+    if (param.value !== ACCOUNT_SPECIFIC_VALUE || !isFirstAppearance) {
       return []
     }
     const internalId = internalIds[index]

--- a/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
@@ -80,6 +80,11 @@ describe('workflow account specific values filter', () => {
           15: { name: 'Account 5' },
         },
       }),
+      new InstanceElement('subsidiary', suiteQLTableType, {
+        [INTERNAL_IDS_MAP]: {
+          38: { name: 'Some Company' },
+        },
+      }),
       new InstanceElement('partner', suiteQLTableType),
     ]
     customRecordType = new ObjectType({
@@ -265,9 +270,38 @@ describe('workflow account specific values filter', () => {
                     workflowaction66: {
                       [SCRIPT_ID]: 'workflowaction66',
                       [INIT_CONDITION]: {
-                        formula: '"Employee" IN ("Employee2")',
+                        formula:
+                          '((( "Total" > "0.0" AND "Preferred Language" IN ("Language1","Language2","Language3") AND "Type" IN ("Transaction Type1") AND "Employee" IN ("Employee2") ) OR ( "Type" IN ("Transaction Type1") AND "Preferred Language" IN ("Language2","Language1","Language3") ) AND "Employee" IN ("Employee2") ) AND "Subsidiary (Main)" IN ("{#Subsidiary#}1") )',
                         parameters: {
                           parameter: {
+                            'Preferred_Language@s': {
+                              name: 'Preferred Language',
+                              value: '[scriptid=custbody_rsm_klp_preferred_language]',
+                            },
+                            Language1: {
+                              name: 'Language1',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '2',
+                            },
+                            Language2: {
+                              name: 'Language2',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '13',
+                            },
+                            Language3: {
+                              name: 'Language3',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '60',
+                            },
+                            Type: {
+                              name: 'Type',
+                              value: 'STDBODYTRANTYPE',
+                            },
+                            'Transaction_Type1@s': {
+                              name: 'Transaction Type1',
+                              [SELECT_RECORD_TYPE]: '-100',
+                              value: 'INVOICE',
+                            },
                             Employee: {
                               name: 'Employee',
                               value: 'STDBODYEMPLOYEE',
@@ -275,6 +309,15 @@ describe('workflow account specific values filter', () => {
                             Employee2: {
                               name: 'Employee2',
                               [SELECT_RECORD_TYPE]: '-4',
+                              value: ACCOUNT_SPECIFIC_VALUE,
+                            },
+                            'Subsidiary__Main_@sjk': {
+                              name: 'Subsidiary (Main)',
+                              value: 'STDBODYSUBSIDIARY',
+                            },
+                            '__Subsidiary__1@_00123nn_00125': {
+                              name: '{#Subsidiary#}1',
+                              [SELECT_RECORD_TYPE]: '-117',
                               value: ACCOUNT_SPECIFIC_VALUE,
                             },
                           },
@@ -355,7 +398,8 @@ describe('workflow account specific values filter', () => {
                   {
                     body: {
                       [SCRIPT_ID]: 'workflowaction66',
-                      conditionformula: '{employee}=-2',
+                      conditionformula:
+                        "((({total} > '0.0' and {custbody_rsm_klp_preferred_language.id} in (2,13,60) and UPPER({type.id})=UPPER('CustInvc') and {employee}=-2) or (UPPER({type.id})=UPPER('CustInvc') and {custbody_rsm_klp_preferred_language.id} in (13,2,60)) {employee}=-2) and {subsidiary.id}=38)",
                     },
                     sublists: [],
                   },
@@ -594,9 +638,38 @@ describe('workflow account specific values filter', () => {
                       workflowaction66: {
                         [SCRIPT_ID]: 'workflowaction66',
                         [INIT_CONDITION]: {
-                          formula: '"Employee" IN ("Employee2")',
+                          formula:
+                            '((( "Total" > "0.0" AND "Preferred Language" IN ("Language1","Language2","Language3") AND "Type" IN ("Transaction Type1") AND "Employee" IN ("Employee2") ) OR ( "Type" IN ("Transaction Type1") AND "Preferred Language" IN ("Language2","Language1","Language3") ) AND "Employee" IN ("Employee2") ) AND "Subsidiary (Main)" IN ("{#Subsidiary#}1") )',
                           parameters: {
                             parameter: {
+                              'Preferred_Language@s': {
+                                name: 'Preferred Language',
+                                value: '[scriptid=custbody_rsm_klp_preferred_language]',
+                              },
+                              Language1: {
+                                name: 'Language1',
+                                [SELECT_RECORD_TYPE]: '-224',
+                                value: '2',
+                              },
+                              Language2: {
+                                name: 'Language2',
+                                [SELECT_RECORD_TYPE]: '-224',
+                                value: '13',
+                              },
+                              Language3: {
+                                name: 'Language3',
+                                [SELECT_RECORD_TYPE]: '-224',
+                                value: '60',
+                              },
+                              Type: {
+                                name: 'Type',
+                                value: 'STDBODYTRANTYPE',
+                              },
+                              'Transaction_Type1@s': {
+                                name: 'Transaction Type1',
+                                [SELECT_RECORD_TYPE]: '-100',
+                                value: 'INVOICE',
+                              },
                               Employee: {
                                 name: 'Employee',
                                 value: 'STDBODYEMPLOYEE',
@@ -605,6 +678,15 @@ describe('workflow account specific values filter', () => {
                                 name: 'Employee2',
                                 [SELECT_RECORD_TYPE]: '-4',
                                 value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 2)`,
+                              },
+                              'Subsidiary__Main_@sjk': {
+                                name: 'Subsidiary (Main)',
+                                value: 'STDBODYSUBSIDIARY',
+                              },
+                              '__Subsidiary__1@_00123nn_00125': {
+                                name: '{#Subsidiary#}1',
+                                [SELECT_RECORD_TYPE]: '-117',
+                                value: `${ACCOUNT_SPECIFIC_VALUE} (Some Company)`,
                               },
                             },
                           },
@@ -836,9 +918,38 @@ describe('workflow account specific values filter', () => {
                     workflowaction66: {
                       [SCRIPT_ID]: 'workflowaction66',
                       [INIT_CONDITION]: {
-                        formula: '"Employee" IN ("Employee2")',
+                        formula:
+                          '((( "Total" > "0.0" AND "Preferred Language" IN ("Language1","Language2","Language3") AND "Type" IN ("Transaction Type1") AND "Employee" IN ("Employee2") ) OR ( "Type" IN ("Transaction Type1") AND "Preferred Language" IN ("Language2","Language1","Language3") ) AND "Employee" IN ("Employee2") ) AND "Subsidiary (Main)" IN ("{#Subsidiary#}1") )',
                         parameters: {
                           parameter: {
+                            'Preferred_Language@s': {
+                              name: 'Preferred Language',
+                              value: '[scriptid=custbody_rsm_klp_preferred_language]',
+                            },
+                            Language1: {
+                              name: 'Language1',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '2',
+                            },
+                            Language2: {
+                              name: 'Language2',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '13',
+                            },
+                            Language3: {
+                              name: 'Language3',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '60',
+                            },
+                            Type: {
+                              name: 'Type',
+                              value: 'STDBODYTRANTYPE',
+                            },
+                            'Transaction_Type1@s': {
+                              name: 'Transaction Type1',
+                              [SELECT_RECORD_TYPE]: '-100',
+                              value: 'INVOICE',
+                            },
                             Employee: {
                               name: 'Employee',
                               value: 'STDBODYEMPLOYEE',
@@ -847,6 +958,15 @@ describe('workflow account specific values filter', () => {
                               name: 'Employee2',
                               [SELECT_RECORD_TYPE]: '-4',
                               value: `${ACCOUNT_SPECIFIC_VALUE} (Salto user 2)`,
+                            },
+                            'Subsidiary__Main_@sjk': {
+                              name: 'Subsidiary (Main)',
+                              value: 'STDBODYSUBSIDIARY',
+                            },
+                            '__Subsidiary__1@_00123nn_00125': {
+                              name: '{#Subsidiary#}1',
+                              [SELECT_RECORD_TYPE]: '-117',
+                              value: `${ACCOUNT_SPECIFIC_VALUE} (Some Company)`,
                             },
                           },
                         },
@@ -1040,9 +1160,38 @@ describe('workflow account specific values filter', () => {
                     workflowaction66: {
                       [SCRIPT_ID]: 'workflowaction66',
                       [INIT_CONDITION]: {
-                        formula: '"Employee" IN ("Employee2")',
+                        formula:
+                          '((( "Total" > "0.0" AND "Preferred Language" IN ("Language1","Language2","Language3") AND "Type" IN ("Transaction Type1") AND "Employee" IN ("Employee2") ) OR ( "Type" IN ("Transaction Type1") AND "Preferred Language" IN ("Language2","Language1","Language3") ) AND "Employee" IN ("Employee2") ) AND "Subsidiary (Main)" IN ("{#Subsidiary#}1") )',
                         parameters: {
                           parameter: {
+                            'Preferred_Language@s': {
+                              name: 'Preferred Language',
+                              value: '[scriptid=custbody_rsm_klp_preferred_language]',
+                            },
+                            Language1: {
+                              name: 'Language1',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '2',
+                            },
+                            Language2: {
+                              name: 'Language2',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '13',
+                            },
+                            Language3: {
+                              name: 'Language3',
+                              [SELECT_RECORD_TYPE]: '-224',
+                              value: '60',
+                            },
+                            Type: {
+                              name: 'Type',
+                              value: 'STDBODYTRANTYPE',
+                            },
+                            'Transaction_Type1@s': {
+                              name: 'Transaction Type1',
+                              [SELECT_RECORD_TYPE]: '-100',
+                              value: 'INVOICE',
+                            },
                             Employee: {
                               name: 'Employee',
                               value: 'STDBODYEMPLOYEE',
@@ -1051,6 +1200,15 @@ describe('workflow account specific values filter', () => {
                               name: 'Employee2',
                               [SELECT_RECORD_TYPE]: '-4',
                               value: '-2',
+                            },
+                            'Subsidiary__Main_@sjk': {
+                              name: 'Subsidiary (Main)',
+                              value: 'STDBODYSUBSIDIARY',
+                            },
+                            '__Subsidiary__1@_00123nn_00125': {
+                              name: '{#Subsidiary#}1',
+                              [SELECT_RECORD_TYPE]: '-117',
+                              value: '38',
                             },
                           },
                         },


### PR DESCRIPTION
Improve the condition formula parsing for resolving ASVs in workflows:

1. extract only non-zero integers as internal ids.
2. deal with formulas that have the same param/s more than once.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Improve condition formula parsing for ASVs

---
_User Notifications_: 
Netsuite Adapter:
- unresolved `[ACCOUNT_SPECIFIC_VALUE]` values may be resolved