### PR TITLE
SALTO-6496: Add definitions override in Okta

### DIFF
--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -35,4 +35,5 @@ export {
   GeneratedItem,
 } from './shared'
 export { RequiredDefinitions } from './types'
+export { mergeDefinitionsWithOverrides } from './overrides'
 export * from './utils'

--- a/packages/okta-adapter/e2e_test/adapter.ts
+++ b/packages/okta-adapter/e2e_test/adapter.ts
@@ -39,6 +39,7 @@ export const realAdapter = ({ adapterParams, credentials, elementsSource }: Opts
     elementsSource,
     adminClient,
     isOAuthLogin: false,
+    accountName: 'okta',
   })
   return { client, adapter }
 }

--- a/packages/okta-adapter/src/adapter_creator.ts
+++ b/packages/okta-adapter/src/adapter_creator.ts
@@ -85,6 +85,7 @@ export const adapter: Adapter = {
       elementsSource: context.elementsSource,
       isOAuthLogin,
       adminClient: createAdminClient(credentials, config, isOAuthLogin),
+      accountName: context.accountName,
     })
 
     return {


### PR DESCRIPTION
Allow to override definitions in Okta using SALTO_DEFINITIONS_OVERRIDES env var

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
