### PR TITLE
SALTO-5893: Salesforce: Exclude `ManagedEventSubscription` by default

### DIFF
--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -128,7 +128,7 @@ export const configWithCPQ = new InstanceElement(ElemID.CONFIG_NAME, configType,
         },
         {
           metadataType: 'ManagedEventSubscription',
-        }
+        },
       ],
     },
     data: {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -126,6 +126,9 @@ export const configWithCPQ = new InstanceElement(ElemID.CONFIG_NAME, configType,
         {
           metadataType: 'Translations',
         },
+        {
+          metadataType: 'ManagedEventSubscription',
+        }
       ],
     },
     data: {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -962,7 +962,7 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
               },
               {
                 metadataType: 'ManagedEventSubscription',
-              }
+              },
             ],
           },
           [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -960,6 +960,9 @@ export const configType = createMatchingObjectType<SalesforceConfig>({
               {
                 metadataType: 'Translations',
               },
+              {
+                metadataType: 'ManagedEventSubscription',
+              }
             ],
           },
           [SHOULD_FETCH_ALL_CUSTOM_SETTINGS]: false,


### PR DESCRIPTION
See title

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce adapter_:
- `ManagedEventSubscription` is now excluded by default for new accounts.

---
_User Notifications_: 
None