### PR TITLE
SALTO-5431: adjust definitions override logs

### DIFF
--- a/packages/adapter-components/src/definitions/system/overrides.ts
+++ b/packages/adapter-components/src/definitions/system/overrides.ts
@@ -7,7 +7,7 @@
  */
 import _ from 'lodash'
 import { Value, Values } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { RequiredDefinitions } from './types'
 import { APIDefinitionsOptions } from './api'
@@ -77,6 +77,6 @@ export const mergeDefinitionsWithOverrides = <Options extends APIDefinitionsOpti
     return obj
   }
   const afterRemoveNullObjects = removeNullObjects(merged)
-  log.debug('Merged definitions with overrides: %s', safeJsonStringify(afterRemoveNullObjects))
+  log.debug('Merged definitions with overrides: %s', inspectValue(afterRemoveNullObjects, { depth: 7}))
   return afterRemoveNullObjects
 }


### PR DESCRIPTION
replaced `safeJsonStringify` with `inspect` cause we're logging all the `rateLimiters` config which contains a lot of informative data

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
