### PR TITLE
SALTO-6507: Salesforce Managed Apex Components Change Validator

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -44,6 +44,7 @@ import metadataTypes from './change_validators/metadata_types'
 import elementApiVersionValidator from './change_validators/element_api_version'
 import cpqBillingStartDate from './change_validators/cpq_billing_start_date'
 import cpqBillingTriggers from './change_validators/cpq_billing_triggers'
+import managedApexComponent from './change_validators/managed_apex_component'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, SalesforceConfig } from './types'
 
@@ -98,6 +99,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   elementApiVersion: () => elementApiVersionValidator,
   cpqBillingStartDate: () => cpqBillingStartDate,
   cpqBillingTriggers: () => cpqBillingTriggers,
+  managedApexComponent: () => managedApexComponent,
   ..._.mapValues(getDefaultChangeValidators(), validator => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/managed_apex_component.ts
+++ b/packages/salesforce-adapter/src/change_validators/managed_apex_component.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ChangeError, ChangeValidator, getChangeData, InstanceElement, isInstanceChange } from '@salto-io/adapter-api'
+import { apiNameSync } from '../filters/utils'
+
+const HIDDEN_CONTENT = '(hidden)'
+
+const isInstanceWithHiddenContent = (instance: InstanceElement): boolean => instance.value.content === HIDDEN_CONTENT
+
+const changeValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(isInstanceWithHiddenContent)
+    .map<ChangeError>(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Cannot deploy changes to a managed Apex Component.',
+      detailedMessage: `The ${apiNameSync(instance.getTypeSync())} ${apiNameSync(instance)} is not modifiable.`,
+    }))
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -157,6 +157,7 @@ export type ChangeValidatorName =
   | 'elementApiVersion'
   | 'cpqBillingStartDate'
   | 'cpqBillingTriggers'
+  | 'managedApexComponent'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -859,6 +860,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     elementApiVersion: { refType: BuiltinTypes.BOOLEAN },
     cpqBillingStartDate: { refType: BuiltinTypes.BOOLEAN },
     cpqBillingTriggers: { refType: BuiltinTypes.BOOLEAN },
+    managedApexComponent: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/managed_apex_components.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/managed_apex_components.test.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { InstanceElement, toChange } from '@salto-io/adapter-api'
+import changeValidator from '../../src/change_validators/managed_apex_component'
+import { mockInstances } from '../mock_elements'
+
+describe('Managed Apex Components Change Validator', () => {
+  const createInstance = (content: string): InstanceElement => {
+    const instance = mockInstances().ApexClass.clone()
+    instance.value.content = content
+    return instance
+  }
+  it('should return error when instance has hidden content', async () => {
+    const instanceWithHiddenContent = createInstance('(hidden)')
+    const errors = await changeValidator([toChange({ after: instanceWithHiddenContent })])
+    expect(errors).toHaveLength(1)
+  })
+
+  it('should not return error when instance has no hidden content', async () => {
+    const instanceWithNoHiddenContent = createInstance('non hidden')
+    const errors = await changeValidator([toChange({ after: instanceWithNoHiddenContent })])
+    expect(errors).toBeEmpty()
+  })
+})


### PR DESCRIPTION
Salesforce Managed Apex Components Change Validator

---

Here's how the Error looks like:
<img width="1728" alt="Screenshot 2024-08-20 at 15 20 02" src="https://github.com/user-attachments/assets/0106619b-024d-415e-82bd-5197829bb6d6">


---
_Release Notes_: 
_Salesforce Adapter_:
- Implemented a Change Validator that forbids deploying Apex Components with `hidden` content (managed).

---
_User Notifications_: 
_None_
