### PR TITLE
SALTO-6509 Add rename capability to transformation definitions

### DIFF
--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -51,10 +51,17 @@ export type AdjustFunction<TContext = ContextParams, TSourceVal = unknown, TTarg
   | AdjustFunctionSingle<TContext, TSourceVal, TTargetVal>
   | AdjustFunctionMulti<TContext, TSourceVal, TTargetVal>
 
+// note: "from" and "to" can contain nested paths (e.g. a.b.c)
 export type TransformationRenameDefinition = {
   from: string
   to: string
+  // behavior when the target already exists:
+  // - override: move "from" to "to" and lose the old "to" value
+  // - skip: keep the value in "from" and do not override "to"
+  // - omit: lose the value in "from" and keep the value in "to"
+  onConflict: 'override' | 'skip' | 'omit'
 }
+
 /**
  * transformation steps:
  * - if rename is specified, each "from" path is moved to the corresponding "to" path. Notes:

--- a/packages/adapter-components/src/definitions/system/shared/transformation.ts
+++ b/packages/adapter-components/src/definitions/system/shared/transformation.ts
@@ -51,8 +51,15 @@ export type AdjustFunction<TContext = ContextParams, TSourceVal = unknown, TTarg
   | AdjustFunctionSingle<TContext, TSourceVal, TTargetVal>
   | AdjustFunctionMulti<TContext, TSourceVal, TTargetVal>
 
+export type TransformationRenameDefinition = {
+  from: string
+  to: string
+}
 /**
  * transformation steps:
+ * - if rename is specified, each "from" path is moved to the corresponding "to" path. Notes:
+ *     - renames are done in order, so the "from" values should be based on the most recent state
+ *     - existing values will be overwritten
  * - if root is specified, look at the value under that path instead of the entire object
  * - if pick is specified, pick the specified paths
  * - if omit is specified, omit the specified paths
@@ -63,7 +70,7 @@ export type AdjustFunction<TContext = ContextParams, TSourceVal = unknown, TTarg
  *   (and undefined will be returned if the array is empty). if single is false, the result will be returned as-is.
  */
 export type TransformDefinition<TContext = ContextParams, TTargetVal = Values | Value> = {
-  // return field name (can customize e.g. to "type => types")
+  rename?: TransformationRenameDefinition[]
   root?: string
   pick?: string[]
   omit?: string[]

--- a/packages/adapter-components/test/fetch/utils.test.ts
+++ b/packages/adapter-components/test/fetch/utils.test.ts
@@ -41,7 +41,7 @@ describe('fetch utils', () => {
           nestUnderField: 'b',
           pick: ['x', 'y', 'z', 'moved'],
           omit: ['z'],
-          rename: [{ from: 'moveMe', to: 'a.moved' }],
+          rename: [{ from: 'moveMe', to: 'a.moved', alwaysOverride: true }],
         })
         expect(await func(item)).toEqual([
           {
@@ -88,6 +88,50 @@ describe('fetch utils', () => {
           },
         ])
       })
+      it('should not override value on rename if onConflict = skip', async () => {
+        const func = createValueTransformer({
+          rename: [{ from: 'a', to: 'b', onConflict: 'skip' }],
+        })
+        expect(await func({ value: { a: 'a', b: 'b' }, typeName: 'a', context: {} })).toEqual([
+          {
+            context: {},
+            typeName: 'a',
+            value: {
+              a: 'a',
+              b: 'b',
+            },
+          },
+        ])
+      })
+      it('should override value on rename if onConflict = override', async () => {
+        const func = createValueTransformer({
+          rename: [{ from: 'a', to: 'b', onConflict: 'override' }],
+        })
+        expect(await func({ value: { a: 'a', b: 'b' }, typeName: 'a', context: {} })).toEqual([
+          {
+            context: {},
+            typeName: 'a',
+            value: {
+              b: 'a',
+            },
+          },
+        ])
+      })
+      it('should omit "from" value on rename if onConflict = omit', async () => {
+        const func = createValueTransformer({
+          rename: [{ from: 'a', to: 'b', onConflict: 'omit' }],
+        })
+        expect(await func({ value: { a: 'a', b: 'b' }, typeName: 'a', context: {} })).toEqual([
+          {
+            context: {},
+            typeName: 'a',
+            value: {
+              b: 'b',
+            },
+          },
+        ])
+      })
+
       it('should give precedence to properties returned from adjust', async () => {
         const func = createValueTransformer({
           adjust: async ({ value, context, typeName }) => ({

--- a/packages/adapter-components/test/fetch/utils.test.ts
+++ b/packages/adapter-components/test/fetch/utils.test.ts
@@ -27,13 +27,22 @@ describe('fetch utils', () => {
               },
             ],
           },
+          moveMe: {
+            val: 'val',
+          },
           other: 'other',
         },
       }
     })
     describe('when def combines multiple args', () => {
       it('should transform values based on the provided definitions', async () => {
-        const func = createValueTransformer({ root: 'a', nestUnderField: 'b', pick: ['x', 'y', 'z'], omit: ['z'] })
+        const func = createValueTransformer({
+          root: 'a',
+          nestUnderField: 'b',
+          pick: ['x', 'y', 'z', 'moved'],
+          omit: ['z'],
+          rename: [{ from: 'moveMe', to: 'a.moved' }],
+        })
         expect(await func(item)).toEqual([
           {
             context: {},
@@ -41,6 +50,9 @@ describe('fetch utils', () => {
             value: {
               b: {
                 x: 'X',
+                moved: {
+                  val: 'val',
+                },
               },
             },
           },
@@ -98,6 +110,9 @@ describe('fetch utils', () => {
                 ],
               },
               OTHER: 'other',
+              MOVEME: {
+                val: 'val',
+              },
             },
           },
         ])


### PR DESCRIPTION
Add `rename` capability to the transformation definitions.

Adding it before setting the `root`, so that it will be possible to nest neighboring fields under the field that is going to be used as the root.

---

_Release Notes_: 
None

---
_User Notifications_: 
None