### PR TITLE
SALTO-6501 use extractHeaders in error log

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -303,7 +303,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
         {
           data: e?.response?.data ?? data,
           status: e?.response?.status ?? 'undefined',
-          headers: e?.response?.headers ?? headers,
+          headers: this.extractHeaders(e?.response?.headers ?? headers),
           requestPath: e?.response?.request?.path,
         },
         e,


### PR DESCRIPTION
we should only log the extracted headers
seems this was added in https://github.com/salto-io/salto/pull/5614/files#diff-6208129eee6ab17f3e8123438554138652e9750654f5af9a6903d8e07b8adf16R303 (and I missed it in the review)


---
_Release Notes_: 
None

---
_User Notifications_: 
None