### PR TITLE
Fix saved search query filters

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -497,8 +497,8 @@ const getSavedSearchInternalIdsMapFromColumn =
   async (client: NetsuiteClient, queryBy: QueryBy, items: string[]): Promise<InternalIdsMap> => {
     const ajv = new Ajv({ allErrors: true, strict: false })
     const getColumnValues = async (exclude: string[] = []): Promise<Record<string, { name: string }>> => {
-      const itemsWithoutExcluded = _.difference(items, exclude)
-      const anyOfFilter = itemsWithoutExcluded.length > 0 ? [[searchColumn, 'anyof', ...itemsWithoutExcluded]] : undefined
+      const include = _.difference(items, exclude)
+      const anyOfFilter = include.length > 0 ? [[searchColumn, 'anyof', ...include]] : undefined
       const noneOfFilter = exclude.length > 0 ? [[searchColumn, 'noneof', ...exclude]] : []
       // we can't filter by name, so we query all column values when queryBy='name'
       const queryFilters = queryBy === 'internalId' ? anyOfFilter : noneOfFilter

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -497,14 +497,19 @@ const getSavedSearchInternalIdsMapFromColumn =
   async (client: NetsuiteClient, queryBy: QueryBy, items: string[]): Promise<InternalIdsMap> => {
     const ajv = new Ajv({ allErrors: true, strict: false })
     const getColumnValues = async (exclude: string[] = []): Promise<Record<string, { name: string }>> => {
-      const anyOfFilter = [[searchColumn, 'anyof', ..._.difference(items, exclude)]]
+      const itemsWithoutExcluded = _.difference(items, exclude)
+      const anyOfFilter = itemsWithoutExcluded.length > 0 ? [[searchColumn, 'anyof', ...itemsWithoutExcluded]] : undefined
       const noneOfFilter = exclude.length > 0 ? [[searchColumn, 'noneof', ...exclude]] : []
+      // we can't filter by name, so we query all column values when queryBy='name'
+      const queryFilters = queryBy === 'internalId' ? anyOfFilter : noneOfFilter
+      if (queryFilters === undefined) {
+        return {}
+      }
       const result = await client.runSavedSearchQuery(
         {
           type: searchType,
           columns: [searchColumn],
-          // we can't filter by name, so we query all column values when queryBy='name'
-          filters: queryBy === 'internalId' ? anyOfFilter : noneOfFilter,
+          filters: queryFilters,
         },
         COLUMN_QUERY_LIMIT,
       )


### PR DESCRIPTION
If there are no items to query using "anyof" filter in saved search- return empty result.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
