### PR TITLE
SALTO-2392 Fix bug in workflow ASV resolving

### DIFF
--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -116,14 +116,14 @@ type ResolvedAccountSpecificValuesResult = {
   missingInternalIds: MissingInternalId[]
 }
 
-const ADDITIONAL_INTERNAL_ID_TO_TYPES: Record<string, SuiteQLTableName | AdditionalQueryName> = {
-  '-192': 'shipItem',
-  '-3': 'vendor',
-  '-104': 'entityStatus',
-  '-320': 'supportCaseStatus',
-  '-166': 'employeeStatus',
-  '-253': 'accountingBook',
-  '-517': 'jobResourceRole',
+const ADDITIONAL_INTERNAL_ID_TO_TYPES: Record<string, (SuiteQLTableName | AdditionalQueryName)[]> = {
+  '-192': ['shipItem'],
+  '-3': ['vendor'],
+  '-104': ['entityStatus'],
+  '-320': ['supportCaseStatus'],
+  '-166': ['employeeStatus'],
+  '-253': ['accountingBook'],
+  '-517': ['jobResourceRole'],
 }
 
 const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, SuiteQLTableName | AdditionalQueryName> = {


### PR DESCRIPTION
An error was thrown because we ran `string.find()` instead of `string[].find()`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix bug in workflow ASV resolving

---
_User Notifications_: 
None
