### PR TITLE
SALTO-6513 Convert error to Unauthorized error for statuses 401 and 403 (WIP)

### DIFF
--- a/packages/adapter-components/src/fetch/errors.ts
+++ b/packages/adapter-components/src/fetch/errors.ts
@@ -15,11 +15,13 @@ export class AbortFetchOnFailure extends FatalError {
   }
 }
 
-export const getInsufficientPermissionsError: fetch.FetchResourceDefinition['onError'] = {
+export const createGetInsufficientPermissionsErrorFunction: (
+  statuses?: number[],
+) => fetch.FetchResourceDefinition['onError'] = (statuses = [403]) => ({
   custom:
     () =>
     ({ error, typeName }) => {
-      if (error instanceof HTTPError && error.response.status === 403) {
+      if (error instanceof HTTPError && statuses.includes(error.response.status)) {
         return {
           action: 'customSaltoError',
           value: {
@@ -34,4 +36,4 @@ export const getInsufficientPermissionsError: fetch.FetchResourceDefinition['onE
   // this is a workaround to overcome types checker, the "custom" function is applied any other values are ignored
   action: 'failEntireFetch',
   value: false,
-}
+})

--- a/packages/adapter-components/src/fetch/errors.ts
+++ b/packages/adapter-components/src/fetch/errors.ts
@@ -16,8 +16,8 @@ export class AbortFetchOnFailure extends FatalError {
 }
 
 export const createGetInsufficientPermissionsErrorFunction: (
-  statuses?: number[],
-) => fetch.FetchResourceDefinition['onError'] = (statuses = [403]) => ({
+  statuses: number[],
+) => fetch.FetchResourceDefinition['onError'] = statuses => ({
   custom:
     () =>
     ({ error, typeName }) => {

--- a/packages/adapter-components/test/fetch/errors.test.ts
+++ b/packages/adapter-components/test/fetch/errors.test.ts
@@ -9,21 +9,22 @@ import { HTTPError } from '../../src/client'
 import { createGetInsufficientPermissionsErrorFunction } from '../../src/fetch/errors'
 
 describe('createGetInsufficientPermissionsErrorFunction', () => {
-  describe('when no statuses are provided', () => {
-    beforeEach(() => {
-      expect(createGetInsufficientPermissionsErrorFunction).toBeDefined()
-      expect(createGetInsufficientPermissionsErrorFunction()).toMatchObject({
-        custom: expect.any(Function),
-        action: 'failEntireFetch',
-        value: false,
-      })
+  const statuses = [111, 222]
+  beforeEach(() => {
+    expect(createGetInsufficientPermissionsErrorFunction).toBeDefined()
+    expect(createGetInsufficientPermissionsErrorFunction(statuses)).toMatchObject({
+      custom: expect.any(Function),
+      action: 'failEntireFetch',
+      value: false,
     })
+  })
 
-    describe('custom', () => {
-      const customFn = createGetInsufficientPermissionsErrorFunction()?.custom?.({})
+  describe('custom', () => {
+    const customFn = createGetInsufficientPermissionsErrorFunction(statuses)?.custom?.({})
 
-      it('should return customSaltoError when HTTPError with status 403', () => {
-        const error = new HTTPError('error', { data: {}, status: 403 })
+    statuses.forEach(status =>
+      it(`should return customSaltoError when HTTPError with status ${status}`, () => {
+        const error = new HTTPError('error', { data: {}, status })
         const typeName = 'myType'
         const result = customFn?.({ error, typeName })
         expect(result).toEqual({
@@ -33,51 +34,14 @@ describe('createGetInsufficientPermissionsErrorFunction', () => {
             severity: 'Info',
           },
         })
-      })
+      }),
+    )
 
-      it('should return failEntireFetch false when other error', () => {
-        const error = new Error('An error occurred')
-        const typeName = 'myType'
-        const result = customFn?.({ error, typeName })
-        expect(result).toEqual({ action: 'failEntireFetch', value: false })
-      })
-    })
-  })
-  describe('when statuses are provided', () => {
-    const statuses = [111, 222]
-    beforeEach(() => {
-      expect(createGetInsufficientPermissionsErrorFunction).toBeDefined()
-      expect(createGetInsufficientPermissionsErrorFunction(statuses)).toMatchObject({
-        custom: expect.any(Function),
-        action: 'failEntireFetch',
-        value: false,
-      })
-    })
-
-    describe('custom', () => {
-      const customFn = createGetInsufficientPermissionsErrorFunction(statuses)?.custom?.({})
-
-      statuses.forEach(status =>
-        it(`should return customSaltoError when HTTPError with status ${status}`, () => {
-          const error = new HTTPError('error', { data: {}, status })
-          const typeName = 'myType'
-          const result = customFn?.({ error, typeName })
-          expect(result).toEqual({
-            action: 'customSaltoError',
-            value: {
-              message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
-              severity: 'Info',
-            },
-          })
-        }),
-      )
-
-      it('should return failEntireFetch false when other error', () => {
-        const error = new Error('An error occurred')
-        const typeName = 'myType'
-        const result = customFn?.({ error, typeName })
-        expect(result).toEqual({ action: 'failEntireFetch', value: false })
-      })
+    it('should return failEntireFetch false when other error', () => {
+      const error = new Error('An error occurred')
+      const typeName = 'myType'
+      const result = customFn?.({ error, typeName })
+      expect(result).toEqual({ action: 'failEntireFetch', value: false })
     })
   })
 })

--- a/packages/adapter-components/test/fetch/errors.test.ts
+++ b/packages/adapter-components/test/fetch/errors.test.ts
@@ -6,39 +6,78 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { HTTPError } from '../../src/client'
-import { getInsufficientPermissionsError } from '../../src/fetch/errors'
+import { createGetInsufficientPermissionsErrorFunction } from '../../src/fetch/errors'
 
-describe('getInsufficientPermissionsError', () => {
-  beforeEach(() => {
-    expect(getInsufficientPermissionsError).toBeDefined()
-    expect(getInsufficientPermissionsError).toMatchObject({
-      custom: expect.any(Function),
-      action: 'failEntireFetch',
-      value: false,
-    })
-  })
-
-  describe('custom', () => {
-    const customFn = getInsufficientPermissionsError?.custom?.({})
-
-    it('should return customSaltoError when HTTPError with status 403', () => {
-      const error = new HTTPError('error', { data: {}, status: 403 })
-      const typeName = 'myType'
-      const result = customFn?.({ error, typeName })
-      expect(result).toEqual({
-        action: 'customSaltoError',
-        value: {
-          message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
-          severity: 'Info',
-        },
+describe('createGetInsufficientPermissionsErrorFunction', () => {
+  describe('when no statuses are provided', () => {
+    beforeEach(() => {
+      expect(createGetInsufficientPermissionsErrorFunction).toBeDefined()
+      expect(createGetInsufficientPermissionsErrorFunction()).toMatchObject({
+        custom: expect.any(Function),
+        action: 'failEntireFetch',
+        value: false,
       })
     })
 
-    it('should return failEntireFetch false when other error', () => {
-      const error = new Error('An error occurred')
-      const typeName = 'myType'
-      const result = customFn?.({ error, typeName })
-      expect(result).toEqual({ action: 'failEntireFetch', value: false })
+    describe('custom', () => {
+      const customFn = createGetInsufficientPermissionsErrorFunction()?.custom?.({})
+
+      it('should return customSaltoError when HTTPError with status 403', () => {
+        const error = new HTTPError('error', { data: {}, status: 403 })
+        const typeName = 'myType'
+        const result = customFn?.({ error, typeName })
+        expect(result).toEqual({
+          action: 'customSaltoError',
+          value: {
+            message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
+            severity: 'Info',
+          },
+        })
+      })
+
+      it('should return failEntireFetch false when other error', () => {
+        const error = new Error('An error occurred')
+        const typeName = 'myType'
+        const result = customFn?.({ error, typeName })
+        expect(result).toEqual({ action: 'failEntireFetch', value: false })
+      })
+    })
+  })
+  describe('when statuses are provided', () => {
+    const statuses = [111, 222]
+    beforeEach(() => {
+      expect(createGetInsufficientPermissionsErrorFunction).toBeDefined()
+      expect(createGetInsufficientPermissionsErrorFunction(statuses)).toMatchObject({
+        custom: expect.any(Function),
+        action: 'failEntireFetch',
+        value: false,
+      })
+    })
+
+    describe('custom', () => {
+      const customFn = createGetInsufficientPermissionsErrorFunction(statuses)?.custom?.({})
+
+      statuses.forEach(status =>
+        it(`should return customSaltoError when HTTPError with status ${status}`, () => {
+          const error = new HTTPError('error', { data: {}, status })
+          const typeName = 'myType'
+          const result = customFn?.({ error, typeName })
+          expect(result).toEqual({
+            action: 'customSaltoError',
+            value: {
+              message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
+              severity: 'Info',
+            },
+          })
+        }),
+      )
+
+      it('should return failEntireFetch false when other error', () => {
+        const error = new Error('An error occurred')
+        const typeName = 'myType'
+        const result = customFn?.({ error, typeName })
+        expect(result).toEqual({ action: 'failEntireFetch', value: false })
+      })
     })
   })
 })

--- a/packages/jamf-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/fetch.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { definitions } from '@salto-io/adapter-components'
+import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import { UserFetchConfig } from '../../config'
 import { Options } from '../types'
 import {
@@ -517,6 +517,7 @@ export const createFetchDefinitions = (
     default: {
       resource: {
         serviceIDFields: ['id'],
+        onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([401, 403]),
       },
       element: {
         fieldCustomizations: DEFAULT_FIELD_CUSTOMIZATIONS,

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1319,7 +1319,7 @@ export const createFetchDefinitions = ({
       default: {
         resource: {
           serviceIDFields: ['id'],
-          onError: fetchUtils.errors.getInsufficientPermissionsError,
+          onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([403]),
         },
         element: {
           topLevel: {

--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -1838,7 +1838,7 @@ export const createFetchDefinitions = (
       default: {
         resource: {
           serviceIDFields: ['id'],
-          onError: fetchUtils.errors.getInsufficientPermissionsError,
+          onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction(),
         },
         element: {
           topLevel: { elemID: { parts: DEFAULT_ID_PARTS } },

--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -1838,7 +1838,7 @@ export const createFetchDefinitions = (
       default: {
         resource: {
           serviceIDFields: ['id'],
-          onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction(),
+          onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([403]),
         },
         element: {
           topLevel: { elemID: { parts: DEFAULT_ID_PARTS } },


### PR DESCRIPTION
- Change `getInsufficientPermissionsError` to `createGetInsufficientPermissionsErrorFunction` with the same logic but able to get a list of statuses.

- Use `createGetInsufficientPermissionsErrorFunction` in Jamf for statuses [401, 403]

---



---

_Release Notes_: 
_Jamf Adapter_:
- Convert error to Unauthorized error for statuses 401 and 403 

---

_User Notifications_: 
_Jamf Adapter_:
- Convert error to Unauthorized error for statuses 401 and 403 
