### PR TITLE
SALTO-5932: added getParentAsync to adapter utils and fixed Jira e2e

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -1113,6 +1113,24 @@ export const formatConfigSuggestionsReasons = (reasons: string[]): string => {
 export const isResolvedReferenceExpression = (value: unknown): value is ReferenceExpression =>
   isReferenceExpression(value) && !(value.value instanceof UnresolvedReference) && value.value !== undefined
 
+export const getParentAsyncWithElementsSource = async (
+  instance: Element,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<InstanceElement> => {
+  const parents = getParents(instance)
+  if (parents.length !== 1) {
+    throw new Error(`Expected ${instance.elemID.getFullName()} to have exactly one parent, found ${parents.length}`)
+  }
+  const parentReference = parents[0]
+  const parent = isResolvedReferenceExpression(parentReference)
+    ? parentReference.value
+    : await elementsSource.get(parentReference.elemID)
+  if (!isInstanceElement(parent)) {
+    throw new Error(`Expected ${instance.elemID.getFullName()} parent to be an instance`)
+  }
+  return parent
+}
+
 export const getInstancesFromElementSource = async (
   elementSource: ReadOnlyElementsSource,
   typeNames: string[],

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -38,11 +38,7 @@ import { findInstance } from './utils'
 import { getLookUpName } from '../src/reference_mapping'
 import { getDefaultConfig } from '../src/config/config'
 import { BEHAVIOR_TYPE } from '../src/constants'
-import {
-  FIELD_CONTEXT_OPTION_TYPE_NAME,
-  FIELD_CONTEXT_TYPE_NAME,
-  FIELD_TYPE_NAME,
-} from '../src/filters/fields/constants'
+import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../src/filters/fields/constants'
 
 const { awu } = collections.asynciterable
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
@@ -248,9 +244,6 @@ each([
         .filter(isAdditionChange)
         .map(change => toChange({ before: getChangeData(change) }))
         .filter(isInstanceChange)
-        .filter(change => getChangeData(change).elemID.typeName !== FIELD_TYPE_NAME)
-        .filter(change => getChangeData(change).elemID.typeName !== FIELD_CONTEXT_TYPE_NAME)
-        .filter(change => getChangeData(change).elemID.typeName !== FIELD_CONTEXT_OPTION_TYPE_NAME)
       removalChanges.forEach(change => {
         const instance = getChangeData(change)
         removalChanges


### PR DESCRIPTION
_Added getParentAsync to adapter utils and fixed Jira e2e_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* added getParentAsync to adapter utils and fixed Jira e2e

---
_User Notifications_: 
_None_
