### PR TITLE
SALTO-6519: Add embeddedSignInSupport to classic engine exclude list

### DIFF
--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -48,6 +48,7 @@ export const PASSWORD_POLICY_PRIORITY_TYPE_NAME = 'PasswordPolicyPriority'
 export const AUTOMATION_TYPE_NAME = 'Automation'
 export const AUTOMATION_RULE_TYPE_NAME = 'AutomationRule'
 export const JWK_TYPE_NAME = 'JsonWebKey'
+export const EMBEDDED_SIGN_IN_SUPPORT_TYPE_NAME = 'EmbeddedSignInSuppport'
 export const ACTIVE_STATUS = 'ACTIVE'
 export const INACTIVE_STATUS = 'INACTIVE'
 export const POLICY_TYPE_NAMES = [

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -29,6 +29,7 @@ import {
   PROFILE_ENROLLMENT_RULE_TYPE_NAME,
   GROUP_MEMBERSHIP_TYPE_NAME,
   JWK_TYPE_NAME,
+  EMBEDDED_SIGN_IN_SUPPORT_TYPE_NAME,
 } from '../../constants'
 import { isGroupPushEntry } from '../../filters/group_push'
 import { extractSchemaIdFromUserType } from './types/user_type'
@@ -1295,6 +1296,7 @@ export const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [
   AUTHENTICATOR_TYPE_NAME,
   ACCESS_POLICY_TYPE_NAME,
   PROFILE_ENROLLMENT_POLICY_TYPE_NAME,
+  EMBEDDED_SIGN_IN_SUPPORT_TYPE_NAME,
 ]
 
 export const createFetchDefinitions = ({


### PR DESCRIPTION
The type shouldn't be fetched if the account is a classic engine

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
