### PR TITLE
SALTO-6505 stop fetching templates for archived spaces

### DIFF
--- a/packages/confluence-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/confluence-adapter/src/definitions/fetch/fetch.ts
@@ -117,6 +117,7 @@ const createCustomizations = (
           },
         },
         templates: {
+          conditions: [{ fromField: 'status', match: ['current'] }],
           typeName: TEMPLATE_TYPE_NAME,
           context: {
             args: {


### PR DESCRIPTION


---



---
_Release Notes_: 
_Confluence Adapter_:
- stop fetching templates for archived spaces

---
_User Notifications_: 
None
