### PR TITLE
SALTO-6512: fix Jira DC ruleScope bug

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_fetch.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_fetch.ts
@@ -157,6 +157,7 @@ const createInstance = (
   type: ObjectType,
   idToProject: Record<string, InstanceElement>,
   config: JiraConfig,
+  isDataCenter: boolean,
   getElemIdFunc?: ElemIdGetter,
 ): InstanceElement => {
   const serviceIds = elementUtils.createServiceIds({ entry: values, serviceIDFields: ['id'], typeID: type.elemID })
@@ -167,11 +168,12 @@ const createInstance = (
   )
   const idFields = TypeTransformationConfig.idFields ?? ['name']
   const idFieldsWithoutProjects = idFields.filter(field => field !== PROJECTS_FIELD)
+  const automationProjects = isDataCenter ? values.projects : convertRuleScopeValueToProjects(values)
   const defaultName = naclCase(
     [
       getInstanceName(values, idFieldsWithoutProjects, AUTOMATION_TYPE) ?? '',
       ...(idFields.includes(PROJECTS_FIELD)
-        ? (convertRuleScopeValueToProjects(values) ?? [])
+        ? (automationProjects ?? [])
             .map((project: Values) => idToProject[project.projectId]?.value.name)
             .filter(lowerdashValues.isDefined)
             .sort()
@@ -266,7 +268,9 @@ const filter: FilterCreator = ({ client, getElemIdFunc, config, fetchQuery }) =>
       const { automationType, subTypes } = createAutomationTypes()
 
       automations.forEach(automation =>
-        elements.push(createInstance(automation, automationType, idToProject, config, getElemIdFunc)),
+        elements.push(
+          createInstance(automation, automationType, idToProject, config, client.isDataCenter, getElemIdFunc),
+        ),
       )
       if (config.fetch.enableJSM && (config.fetch.enableJsmExperimental || config.fetch.enableJSMPremium)) {
         elements

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -281,6 +281,7 @@ const getScope = (resource: string): { projectId?: string; projectTypeKey?: stri
   return undefined
 }
 
+// should be used in Jira Cloud only since Automation structure is different in Jira DC
 export const convertRuleScopeValueToProjects = (
   values: Values,
 ):

--- a/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_fetch.test.ts
@@ -37,7 +37,7 @@ describe('automationFetchFilter', () => {
   let connection: MockInterface<clientUtils.APIConnection>
   let fetchQuery: MockInterface<elementUtils.query.ElementQuery>
 
-  const automationResponse = {
+  const automationResponseCloud = {
     status: 200,
     data: {
       total: 1,
@@ -64,9 +64,30 @@ describe('automationFetchFilter', () => {
       ],
     },
   }
+
+  const automationResponseDC = {
+    status: 200,
+    data: {
+      total: 1,
+      values: [
+        {
+          id: '1',
+          name: 'automationName',
+          projects: [
+            {
+              projectId: '2',
+            },
+            {
+              projectId: '3',
+            },
+          ],
+        },
+      ],
+    },
+  }
   const mockPostResponse = (url: string): Value => {
     if (url === DEFAULT_URL) {
-      return automationResponse
+      return automationResponseCloud
     }
 
     throw new Error(`Unexpected url ${url}`)
@@ -159,7 +180,7 @@ describe('automationFetchFilter', () => {
         if (url === '/rest/cb-automation/latest/project/GLOBAL/rule') {
           return {
             status: 200,
-            data: automationResponse.data.values,
+            data: automationResponseDC.data.values,
           }
         }
 
@@ -198,12 +219,6 @@ describe('automationFetchFilter', () => {
             projectId: '3',
           },
         ],
-        ruleScope: {
-          resources: [
-            'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/2',
-            'ari:cloud:jira:a35ab846-aa6a-41c1-b9ca-40eb4e260dd8:project/3',
-          ],
-        },
       })
 
       expect(connection.post).not.toHaveBeenCalled()
@@ -478,7 +493,7 @@ describe('automationFetchFilter', () => {
       if (url === '/rest/cb-automation/latest/project/GLOBAL/rule') {
         return {
           status: 200,
-          data: automationResponse.data.values,
+          data: automationResponseCloud.data.values,
         }
       }
 
@@ -509,7 +524,7 @@ describe('automationFetchFilter', () => {
       if (url === '/rest/cb-automation/latest/project/GLOBAL/rule') {
         return {
           status: 200,
-          data: automationResponse.data.values,
+          data: automationResponseCloud.data.values,
         }
       }
 


### PR DESCRIPTION
_fix Jira DC ruleScope bug_

---

_Additional context for reviewer_
* `convertRuleScopeValueToProjects` function was meant to be used in Cloud only but we were using it DC as well

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
