### PR TITLE
SALTO-6503: Add logs for visibility to `validateElementsAndDependents`

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -725,7 +725,7 @@ export const loadWorkspace = async (
         const elementsToValidate = elements.concat(dependents)
         return {
           errors: await validateElements(elementsToValidate, elementSource),
-          validatedElementsIDs: _.uniqBy([...elementsToValidate.map(elem => elem.elemID), ...relevantElementIDs], e =>
+          validatedElementsIDs: _.uniqBy(elementsToValidate.map(elem => elem.elemID).concat(relevantElementIDs), e =>
             e.getFullName(),
           ),
         }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -688,10 +688,15 @@ export const loadWorkspace = async (
         log.timeDebug(
           async () => {
             elemIDs.forEach(id => addedIDs.add(id.getFullName()))
-            const filesWithDependencies = _.uniq(
-              await awu(elemIDs)
-                .flatMap(id => source.getElementReferencedFiles(envName, id))
-                .toArray(),
+            const filesWithDependencies = await log.timeDebug(
+              async () =>
+                _.uniq(
+                  await awu(elemIDs)
+                    .flatMap(id => source.getElementReferencedFiles(envName, id))
+                    .toArray(),
+                ),
+              'running getElementReferencedFiles for %s elemIDs',
+              elemIDs.length,
             )
             const dependentsIDs = await log.timeDebug(
               async () =>


### PR DESCRIPTION
Added some logs for visibility to understand why we get out of memory error

---

_Additional context for reviewer_

Also replaced `...` with concat as a first attempt to resolve the issue

---
_Release Notes_: 
None

---
_User Notifications_: 
None
