### PR TITLE
SALTO-6481 Allow controlling how full responses are logged

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -7,7 +7,7 @@
  */
 import _ from 'lodash'
 import { ResponseType } from 'axios'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -29,6 +29,7 @@ import {
 } from '../definitions/user/client_config'
 import { requiresLogin, logDecorator } from './decorators'
 import { throttle } from './rate_limit'
+import { createResponseLogFilter, FullResponseLogFilter } from './logging_utils'
 
 const log = logger(module)
 
@@ -121,6 +122,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
 {
   protected readonly conn: Connection<TCredentials>
   protected readonly credentials: TCredentials
+  protected responseLogFilter: FullResponseLogFilter
 
   constructor(
     clientName: string,
@@ -139,6 +141,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
       createConnection,
     })
     this.credentials = credentials
+    this.responseLogFilter = createResponseLogFilter(config?.logging)
   }
 
   protected async ensureLoggedIn(): Promise<void> {
@@ -228,6 +231,67 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
     return this.sendRequest('options', params)
   }
 
+  protected logResponse<T extends keyof HttpMethodToClientParams>({
+    response,
+    error,
+    method,
+    params,
+  }: {
+    response: Response<ResponseValue | ResponseValue[]>
+    error?: Error
+    method: T
+    params: HttpMethodToClientParams[T]
+  }): void {
+    const { url, queryParams, responseType } = params
+    const data = isMethodWithData(params) ? params.data : undefined
+    log.debug(
+      'Received response for %s on %s (%s) with status %d',
+      method.toUpperCase(),
+      url,
+      safeJsonStringify({ url, queryParams }),
+      response.status,
+    )
+
+    const responseObj = {
+      url,
+      method: method.toUpperCase(),
+      status: response.status,
+      queryParams,
+      response: Buffer.isBuffer(response.data)
+        ? `<omitted buffer of length ${response.data.length}>`
+        : this.clearValuesFromResponseData(response.data, url),
+      responseType,
+      headers: this.extractHeaders(response.headers),
+      data: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
+    }
+    const responseText = safeJsonStringify(responseObj)
+
+    if (error === undefined) {
+      const strategy = this.responseLogFilter({ responseText, url })
+      if (strategy === 'full') {
+        log.trace(
+          'Full HTTP response for %s on %s (size %d): %s',
+          method.toUpperCase(),
+          url,
+          responseText.length,
+          responseText,
+        )
+      } else if (strategy === 'truncate') {
+        const truncatedResponseText = inspectValue(responseObj, { maxArrayLength: 10, maxStringLength: 100, compact: true })
+        log.trace(
+          'Truncated HTTP response for %s on %s (original size %d, truncated dize %d): %s',
+          method.toUpperCase(),
+          url,
+          responseText.length,
+          truncatedResponseText.length,
+          truncatedResponseText,
+        )
+      }
+    } else {
+      log.warn(`failed to ${method} ${url} with error: ${error}, stack: ${error.stack}, ${responseText}`)
+    }
+  }
+
   protected async sendRequest<T extends keyof HttpMethodToClientParams>(
     method: T,
     params: HttpMethodToClientParams[T],
@@ -239,41 +303,6 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
 
     const { url, queryParams, headers, responseType, queryParamsSerializer: paramsSerializer } = params
     const data = isMethodWithData(params) ? params.data : undefined
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const logResponse = (res: Response<any>, error?: any): void => {
-      log.debug(
-        'Received response for %s on %s (%s) with status %d',
-        method.toUpperCase(),
-        url,
-        safeJsonStringify({ url, queryParams }),
-        res.status,
-      )
-
-      const responseText = safeJsonStringify({
-        url,
-        method: method.toUpperCase(),
-        status: res.status,
-        queryParams,
-        response: Buffer.isBuffer(res.data)
-          ? `<omitted buffer of length ${res.data.length}>`
-          : this.clearValuesFromResponseData(res.data, url),
-        headers: this.extractHeaders(res.headers),
-        data: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
-      })
-
-      if (error === undefined) {
-        log.trace(
-          'Full HTTP response for %s on %s (size %d): %s',
-          method.toUpperCase(),
-          url,
-          responseText.length,
-          responseText,
-        )
-      } else {
-        log.warn(`failed to ${method} ${url} with error: ${error}, stack: ${error.stack}, ${responseText}`)
-      }
-    }
 
     try {
       const requestConfig = [queryParams, headers, responseType, paramsSerializer].some(values.isDefined)
@@ -292,22 +321,24 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
             isMethodWithData(params) ? { ...requestConfig, data: params.data } : requestConfig,
           )
 
-      logResponse(res)
+      this.logResponse({ response: res, method, params })
       return {
         data: res.data,
         status: res.status,
         headers: this.extractHeaders(res.headers),
       }
     } catch (e) {
-      logResponse(
-        {
+      this.logResponse({
+        response: {
           data: e?.response?.data ?? data,
           status: e?.response?.status ?? 'undefined',
           headers: this.extractHeaders(e?.response?.headers ?? headers),
           requestPath: e?.response?.request?.path,
         },
-        e,
-      )
+        error: e,
+        method,
+        params,
+      })
       if (e.code === 'ETIMEDOUT') {
         throw new TimeoutError(`Failed to ${method} ${url} with error: ${e}`)
       }

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -7,7 +7,7 @@
  */
 import _ from 'lodash'
 import { ResponseType } from 'axios'
-import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
@@ -29,7 +29,7 @@ import {
 } from '../definitions/user/client_config'
 import { requiresLogin, logDecorator } from './decorators'
 import { throttle } from './rate_limit'
-import { createResponseLogFilter, FullResponseLogFilter } from './logging_utils'
+import { createResponseLogFilter, FullResponseLogFilter, truncateReplacer } from './logging_utils'
 
 const log = logger(module)
 
@@ -277,7 +277,7 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
           responseText,
         )
       } else if (strategy === 'truncate') {
-        const truncatedResponseText = inspectValue(responseObj, { maxArrayLength: 10, maxStringLength: 100, compact: true })
+        const truncatedResponseText = safeJsonStringify(responseObj, truncateReplacer)
         log.trace(
           'Truncated HTTP response for %s on %s (original size %d, truncated dize %d): %s',
           method.toUpperCase(),

--- a/packages/adapter-components/src/client/logging_utils.ts
+++ b/packages/adapter-components/src/client/logging_utils.ts
@@ -13,9 +13,9 @@ export type FullResponseLogFilter = (args: { responseText: string; url: string }
 
 const DEFAULT_LOGGING_CONFIG: ClientLoggingConfig = {
   responseStrategies: [
-    // by default, truncate logs larger than ~10K
+    // by default, truncate logs larger than ~80K
     {
-      size: 10 * 1000,
+      size: 80 * 1000,
       strategy: 'truncate',
     },
   ],

--- a/packages/adapter-components/src/client/logging_utils.ts
+++ b/packages/adapter-components/src/client/logging_utils.ts
@@ -5,6 +5,8 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import _ from 'lodash'
+import { Value } from '@salto-io/adapter-api'
 import { ClientLoggingConfig, ResponseLogStrategy } from '../definitions/user/client_config'
 
 export type FullResponseLogFilter = (args: { responseText: string; url: string }) => ResponseLogStrategy
@@ -44,4 +46,14 @@ export const createResponseLogFilter = (
 
     return strategy ?? 'full'
   }
+}
+
+export const truncateReplacer = (_key: string, value: Value): Value => {
+  if (Array.isArray(value)) {
+    return value.slice(0, 50)
+  }
+  if (_.isString(value) && value.length > 500) {
+    return value.slice(0, 500)
+  }
+  return value
 }

--- a/packages/adapter-components/src/client/logging_utils.ts
+++ b/packages/adapter-components/src/client/logging_utils.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ClientLoggingConfig, ResponseLogStrategy } from '../definitions/user/client_config'
+
+export type FullResponseLogFilter = (args: { responseText: string; url: string }) => ResponseLogStrategy
+
+const DEFAULT_LOGGING_CONFIG: ClientLoggingConfig = {
+  responseStrategies: [
+    // by default, truncate logs larger than ~10K
+    {
+      size: 10 * 1000,
+      strategy: 'truncate',
+    },
+  ],
+}
+
+export const createResponseLogFilter = (
+  clientLoggingConfig: ClientLoggingConfig = DEFAULT_LOGGING_CONFIG,
+): FullResponseLogFilter => {
+  if (clientLoggingConfig === undefined) {
+    return () => 'full'
+  }
+  let allRequests = 0
+  const counters = Object.fromEntries(
+    (clientLoggingConfig.responseStrategies ?? []).map(def => def.pattern ?? '').map(p => [p, 0]),
+  )
+  return ({ responseText, url }) => {
+    allRequests += 1
+    clientLoggingConfig.responseStrategies?.forEach(({ pattern }) => {
+      if (pattern !== undefined && new RegExp(pattern).test(url)) {
+        counters[pattern] += 1
+      }
+    })
+
+    const strategy = clientLoggingConfig.responseStrategies
+      ?.filter(({ pattern }) => pattern === undefined || new RegExp(pattern).test(url))
+      ?.filter(({ pattern, numItems }) => (pattern === undefined ? allRequests : counters[pattern]) > (numItems ?? 0))
+      ?.find(({ size }) => responseText.length >= (size ?? 0))?.strategy
+
+    return strategy ?? 'full'
+  }
+}

--- a/packages/adapter-components/src/definitions/user/client_config.ts
+++ b/packages/adapter-components/src/definitions/user/client_config.ts
@@ -46,12 +46,12 @@ export type ResponseLogStrategy = 'truncate' | 'omit' | 'full'
 // if an endpoint matching the pattern (or any endpoint if pattern is not provided) matches (all of) the following:
 // - logged more than "numItems" times (default: 0)
 // - the current response size is over "size" (default: 0)
-// then the strategy is used - if `omit`, the "Full http response" log is omitted completely, and if `truncate` the response is truncateed.
+// then the strategy is used - if `omit`, the "Full http response" log is omitted completely, and if `truncate` the response is truncated.
 // note: strategies are calculated in order and the first match wins.
 type ClientLoggingStrategyByEndpointConfig = {
   // when pattern is omitted, all endpoints match
   pattern?: string
-  // note: there is an OR between maxItems and maxSize
+  // note: there is an OR between numItems and size
   numItems?: number
   size?: number
   strategy: ResponseLogStrategy

--- a/packages/adapter-components/src/definitions/user/client_config.ts
+++ b/packages/adapter-components/src/definitions/user/client_config.ts
@@ -12,6 +12,7 @@ import {
   FieldDefinition,
   createRestriction,
   CORE_ANNOTATIONS,
+  ListType,
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 
@@ -40,6 +41,26 @@ export type ClientTimeoutConfig = Partial<{
   lastRetryNoTimeout: boolean
 }>
 
+export type ResponseLogStrategy = 'truncate' | 'omit' | 'full'
+// configuration for controlling logging of full http responses.
+// if an endpoint matching the pattern (or any endpoint if pattern is not provided) matches (all of) the following:
+// - logged more than "numItems" times (default: 0)
+// - the current response size is over "size" (default: 0)
+// then the strategy is used - if `omit`, the "Full http response" log is omitted completely, and if `truncate` the response is truncateed.
+// note: strategies are calculated in order and the first match wins.
+type ClientLoggingStrategyByEndpointConfig = {
+  // when pattern is omitted, all endpoints match
+  pattern?: string
+  // note: there is an OR between maxItems and maxSize
+  numItems?: number
+  size?: number
+  strategy: ResponseLogStrategy
+}
+
+export type ClientLoggingConfig = Partial<{
+  responseStrategies: ClientLoggingStrategyByEndpointConfig[]
+}>
+
 export type ClientBaseConfig<RateLimitConfig extends ClientRateLimitConfig> = Partial<{
   retry: ClientRetryConfig
   rateLimit: RateLimitConfig
@@ -48,6 +69,7 @@ export type ClientBaseConfig<RateLimitConfig extends ClientRateLimitConfig> = Pa
   useBottleneck: boolean
   pageSize: ClientPageSizeConfig
   timeout: ClientTimeoutConfig
+  logging: ClientLoggingConfig
 }>
 
 export const createClientConfigType = <RateLimitConfig extends ClientRateLimitConfig>({
@@ -117,6 +139,40 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
     },
   })
 
+  const clientLoggingStrategyByEndpointConfigType = createMatchingObjectType<ClientLoggingStrategyByEndpointConfig>({
+    elemID: new ElemID(adapter, 'clientLoggingResponseConfig'),
+    fields: {
+      pattern: {
+        refType: BuiltinTypes.STRING,
+      },
+      numItems: {
+        refType: BuiltinTypes.NUMBER,
+      },
+      size: {
+        refType: BuiltinTypes.NUMBER,
+      },
+      strategy: {
+        refType: BuiltinTypes.STRING,
+        annotations: {
+          _required: true,
+        },
+      },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
+  })
+
+  const clientLoggingConfigType = createMatchingObjectType<ClientLoggingConfig>({
+    elemID: new ElemID(adapter, 'clientLoggingConfig'),
+    fields: {
+      responseStrategies: { refType: new ListType(clientLoggingStrategyByEndpointConfigType) },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+    },
+  })
+
   const clientConfigType = new ObjectType({
     elemID: new ElemID(adapter, 'clientConfig'),
     fields: {
@@ -127,6 +183,7 @@ export const createClientConfigType = <RateLimitConfig extends ClientRateLimitCo
       useBottleneck: { refType: BuiltinTypes.BOOLEAN },
       pageSize: { refType: clientPageSizeConfigType },
       timeout: { refType: clientTimeoutConfigType },
+      logging: { refType: clientLoggingConfigType },
       ...additionalClientFields,
     },
     annotations: {

--- a/packages/adapter-components/test/client/logging_utils.test.ts
+++ b/packages/adapter-components/test/client/logging_utils.test.ts
@@ -16,7 +16,7 @@ describe('logging_utils', () => {
       expect(createResponseLogFilter({ responseStrategies: [] })({ responseText: 'aaa', url: 'aaa' })).toEqual('full')
     })
     it('should return "truncate" for large responses when no config is provided', async () => {
-      expect(createResponseLogFilter()({ responseText: _.repeat('a', 10 * 1000 + 1), url: '' })).toEqual('truncate')
+      expect(createResponseLogFilter()({ responseText: _.repeat('a', 80 * 1000 + 1), url: '' })).toEqual('truncate')
     })
 
     it('should choose matching strategy by url', async () => {

--- a/packages/adapter-components/test/client/logging_utils.test.ts
+++ b/packages/adapter-components/test/client/logging_utils.test.ts
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import { createResponseLogFilter } from '../../src/client/logging_utils'
+
+describe('logging_utils', () => {
+  describe('createResponseLogFilter', () => {
+    it('should return "full" for small responses when no config is provided', async () => {
+      expect(createResponseLogFilter()({ responseText: 'aaa', url: 'aaa' })).toEqual('full')
+      expect(createResponseLogFilter({ responseStrategies: [] })({ responseText: 'aaa', url: 'aaa' })).toEqual('full')
+    })
+    it('should return "truncate" for large responses when no config is provided', async () => {
+      expect(createResponseLogFilter()({ responseText: _.repeat('a', 10 * 1000 + 1), url: '' })).toEqual('truncate')
+    })
+
+    it('should choose matching strategy by url', async () => {
+      const filter = createResponseLogFilter({
+        responseStrategies: [
+          { pattern: 'permissions$', strategy: 'omit' },
+          { pattern: '\\/a\\/b', strategy: 'truncate' },
+        ],
+      })
+      expect(filter({ responseText: 'aaa', url: '/permissions/somethingelse' })).toEqual('full')
+      expect(filter({ responseText: 'aaa', url: '/x/permissions' })).toEqual('omit')
+      expect(filter({ responseText: 'aaa', url: '/a/b' })).toEqual('truncate')
+    })
+
+    it('should choose matching strategy by size', async () => {
+      const filter = createResponseLogFilter({
+        responseStrategies: [
+          { size: 5, strategy: 'truncate' },
+          { size: 2, strategy: 'omit' },
+        ],
+      })
+      expect(filter({ responseText: '1', url: '' })).toEqual('full')
+      expect(filter({ responseText: '123', url: '' })).toEqual('omit')
+      expect(filter({ responseText: '123456', url: '' })).toEqual('truncate')
+    })
+
+    it('should choose matching strategy by numItems and choose the first matching strategy', async () => {
+      const filter1 = createResponseLogFilter({
+        responseStrategies: [
+          { numItems: 1, strategy: 'omit' },
+          { numItems: 3, strategy: 'truncate' },
+        ],
+      })
+      expect(filter1({ responseText: 'aaa', url: '' })).toEqual('full')
+      expect(filter1({ responseText: 'aaa', url: '' })).toEqual('omit')
+      expect(filter1({ responseText: 'aaa', url: '' })).toEqual('omit')
+      expect(filter1({ responseText: 'aaa', url: '' })).toEqual('omit')
+
+      const filter2 = createResponseLogFilter({
+        responseStrategies: [
+          { numItems: 3, strategy: 'truncate' },
+          { numItems: 1, strategy: 'omit' },
+        ],
+      })
+      expect(filter2({ responseText: 'aaa', url: '' })).toEqual('full')
+      expect(filter2({ responseText: 'aaa', url: '' })).toEqual('omit')
+      expect(filter2({ responseText: 'aaa', url: '' })).toEqual('omit')
+      expect(filter2({ responseText: 'aaa', url: '' })).toEqual('truncate')
+    })
+
+    it('should count by pattern when provided and choose the first matching startegy', async () => {
+      const filter = createResponseLogFilter({
+        responseStrategies: [
+          { numItems: 3, strategy: 'truncate' },
+          { numItems: 1, pattern: 'permissions', strategy: 'omit' },
+        ],
+      })
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('full')
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('omit')
+      expect(filter({ responseText: 'aaa', url: '/somethingelse' })).toEqual('full')
+      expect(filter({ responseText: 'aaa', url: '/somethingelse' })).toEqual('truncate')
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('truncate')
+    })
+
+    it('should allow complex conditions', async () => {
+      const filter = createResponseLogFilter({
+        responseStrategies: [
+          { numItems: 5, strategy: 'omit' },
+          { size: 20, strategy: 'truncate' },
+          { pattern: 'permissions', size: 2, strategy: 'truncate' },
+          { numItems: 3, pattern: '\\/a\\/b', strategy: 'truncate' },
+        ],
+      })
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('truncate')
+      expect(filter({ responseText: 'aaa', url: '/a/b' })).toEqual('full')
+      expect(filter({ responseText: 'aaa', url: '/a/b' })).toEqual('full')
+      expect(filter({ responseText: _.repeat('a', 20), url: '/a/b' })).toEqual('truncate')
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('truncate')
+      expect(filter({ responseText: 'aaa', url: '/a/b' })).toEqual('omit')
+      expect(filter({ responseText: 'aaa', url: '/permissions' })).toEqual('omit')
+    })
+  })
+})

--- a/packages/adapter-components/test/definitions/user/client_config.test.ts
+++ b/packages/adapter-components/test/definitions/user/client_config.test.ts
@@ -12,11 +12,12 @@ describe('client_config', () => {
   describe('createClientConfigType', () => {
     it('should return default type when no custom buckets were added', async () => {
       const type = createClientConfigType({ adapter: 'myAdapter' })
-      expect(Object.keys(type.fields)).toHaveLength(7)
+      expect(Object.keys(type.fields)).toHaveLength(8)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()
       expect(type.fields.pageSize).toBeDefined()
       expect(type.fields.timeout).toBeDefined()
+      expect(type.fields.logging).toBeDefined()
       const rateLimitType = await type.fields.rateLimit.getType()
       expect(rateLimitType).toBeInstanceOf(ObjectType)
       expect(new Set(Object.keys((rateLimitType as ObjectType).fields))).toEqual(new Set(['get', 'total']))
@@ -28,11 +29,12 @@ describe('client_config', () => {
         a: number
         b: number
       }>({ adapter: 'myAdapter', bucketNames: ['a', 'b'] })
-      expect(Object.keys(type.fields)).toHaveLength(7)
+      expect(Object.keys(type.fields)).toHaveLength(8)
       expect(type.fields.rateLimit).toBeDefined()
       expect(type.fields.retry).toBeDefined()
       expect(type.fields.pageSize).toBeDefined()
       expect(type.fields.timeout).toBeDefined()
+      expect(type.fields.logging).toBeDefined()
       const rateLimitType = await type.fields.rateLimit.getType()
       expect(rateLimitType).toBeInstanceOf(ObjectType)
       expect(new Set(Object.keys((rateLimitType as ObjectType).fields))).toEqual(new Set(['get', 'total', 'a', 'b']))
@@ -55,7 +57,7 @@ describe('client_config', () => {
             },
           },
         })
-        expect(Object.keys(type.fields)).toHaveLength(9)
+        expect(Object.keys(type.fields)).toHaveLength(10)
         expect(type.fields.myField).toBeDefined()
         const myFields = type.fields.myField.getTypeSync()
         expect(myFields).toBe(BuiltinTypes.BOOLEAN)
@@ -75,7 +77,7 @@ describe('client_config', () => {
             myField: { refType: BuiltinTypes.BOOLEAN },
           },
         })
-        expect(Object.keys(type.fields)).toHaveLength(7)
+        expect(Object.keys(type.fields)).toHaveLength(8)
         const rateLimitType = (await type.fields.rateLimit.getType()) as ObjectType
         expect(rateLimitType.fields.myField).toBeDefined()
       })

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -924,7 +924,7 @@ export const elementExpressionStringifyReplacer: Replacer = (_key, value) =>
     : value
 
 // WARNING: using safeJsonStringify with a customizer is inefficient and should not be done at a large scale.
-// prefer inspect / safeStringifyWithInspect (which allow limiting depth / max array length / max string length)
+// prefer inspect / inspectValue (which allows limiting depth / max array length / max string length)
 // where applicable
 export const safeJsonStringify = (value: Value, replacer?: Replacer, space?: string | number): string =>
   safeStringify(value, replacer, space)

--- a/packages/okta-adapter/src/client/client.ts
+++ b/packages/okta-adapter/src/client/client.ts
@@ -10,7 +10,6 @@ import { client as clientUtils, definitions } from '@salto-io/adapter-components
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import axios from 'axios'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { promises } from '@salto-io/lowerdash'
 import { createConnection } from './connection'
 import { OKTA } from '../constants'
@@ -256,7 +255,6 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<Credential
       : undefined
   }
 
-  // eslint-disable-next-line class-methods-use-this
   @throttle<definitions.ClientRateLimitConfig>({ bucketName: 'get', keys: ['url'] })
   @logDecorator(['url'])
   // We use this function without client instance because we don't need it
@@ -269,17 +267,7 @@ export default class OktaClient extends clientUtils.AdapterHTTPClient<Credential
       const httpClient = axios.create({ url })
       const response = await httpClient.get(url, { responseType })
       const { data, status } = response
-      log.trace(
-        'Full HTTP response for GET on %s: %s',
-        url,
-        safeJsonStringify({
-          url,
-          method: 'GET',
-          status,
-          responseType,
-          response: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
-        }),
-      )
+      this.logResponse({ method: 'get', params: args, response })
       return {
         data,
         status,

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { createSchemeGuard, safeJsonStringify } from '@salto-io/adapter-utils'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { client as clientUtils, definitions } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { values } from '@salto-io/lowerdash'
@@ -211,17 +211,9 @@ export default class ZendeskClient extends clientUtils.AdapterHTTPClient<
             responseType,
           }
         : undefined
-      const { data, status } = await this.resourceClient.get(url, requestConfig)
-      log.trace(
-        'Full HTTP response for GET on %s: %s',
-        url,
-        safeJsonStringify({
-          url,
-          status,
-          requestConfig,
-          response: Buffer.isBuffer(data) ? `<omitted buffer of length ${data.length}>` : data,
-        }),
-      )
+      const response = await this.resourceClient.get(url, requestConfig)
+      const { data, status } = response
+      this.logResponse({ method: 'get', params: args, response })
       return {
         data,
         status,


### PR DESCRIPTION
Add some controls for truncating/omitting the full response logs (can extend later as needed, e.g. more granular control on truncating / better buckets by pattern).

This was added as part of the user-facing config for simplicity, but does not have a user-facing default.

Default behavior: responses over ~10kb will be truncated.

---

Also consolidated some code duplication (that missed past cleanups) from the zendesk and okta adapters.

---
_Release Notes_: 
None

---
_User Notifications_: 
None