### PR TITLE
SALTO-6530: add file type to the static file path for article attachment

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -343,7 +343,7 @@ const filterCreator: FilterCreator = () => ({
         ZENDESK,
         ARTICLE_ATTACHMENTS_FIELD,
         ...path.slice(2, -1),
-        normalizeFilePathPart(attachment.value.file_name.split('.')[0]), // file name
+        `${normalizeFilePathPart(attachment.value.file_name.split('.')[0])}_${attachment.value.inline ?? 'no_inline_info'}`, // file name
         normalizeFilePathPart(`${staticFile.hash.slice(0, 10)}_${attachment.value.file_name}`), // <hash>_file_name
       ]
       attachment.value.content = new StaticFile({

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -146,6 +146,7 @@ describe('guide arrange paths', () => {
     brand: new ReferenceExpression(brandInstance.elemID, brandInstance),
     content: new StaticFile({ filepath: 'something', content }),
     file_name: 'attachment',
+    inline: 'true',
   })
   articleAttachmentInstance.annotations[CORE_ANNOTATIONS.PARENT] = [
     new ReferenceExpression(articleInstance.elemID, articleInstance),
@@ -414,7 +415,7 @@ describe('guide arrange paths', () => {
           GUIDE_ELEMENT_DIRECTORY[ARTICLE_TYPE_NAME],
           'article_name',
           GUIDE_ELEMENT_DIRECTORY[ARTICLE_ATTACHMENT_TYPE_NAME],
-          'attachment',
+          'attachment_true',
           `${staticFile.hash.slice(0, 10)}_attachment`,
         ].join('/'),
       )


### PR DESCRIPTION
add file type to the static file path for article attachment

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
