### PR TITLE
SALTO-6522 Extend stream serializer

### DIFF
--- a/packages/lowerdash/src/serialize.ts
+++ b/packages/lowerdash/src/serialize.ts
@@ -5,24 +5,58 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import { EOL } from 'os'
+
+export type StreamSerializer = (items: (unknown[] | Record<string, unknown>)[]) => AsyncIterable<string>
 
 /**
  * avoid creating a single string for all items, which may exceed the max allowed string length.
  * currently only supports JSON.stringify - if cycles are possible, safeJsonStringify should be used instead.
  */
-export async function* getSerializedStream(items: (unknown[] | Record<string, unknown>)[]): AsyncIterable<string> {
-  let first = true
-  yield '['
-  for (const item of items) {
-    if (first) {
-      first = false
-    } else {
-      yield ','
+export const createStreamSerializer = ({
+  maxLineLength = Infinity,
+  wrapWithKey,
+}: {
+  maxLineLength?: number
+  wrapWithKey?: string
+} = {}): StreamSerializer => {
+  const [start, end] =
+    wrapWithKey === undefined
+      ? ['[', ']']
+      : // eslint-disable-next-line no-restricted-syntax
+        [`{${JSON.stringify(wrapWithKey)}:[`, ']}']
+
+  const initialLineLength = start.length + end.length
+
+  async function* serializer(items: (unknown[] | Record<string, unknown>)[]): AsyncIterable<string> {
+    let first = true
+    let currentLineLength = initialLineLength
+
+    yield start
+    for (const item of items) {
+      // We don't use safeJsonStringify to save some time, because we know  we made sure there aren't circles
+      // eslint-disable-next-line no-restricted-syntax
+      const serializedItem = JSON.stringify(item)
+      if (currentLineLength + serializedItem.length + 1 > maxLineLength) {
+        yield end
+        yield EOL
+        yield start
+        first = true
+        currentLineLength = initialLineLength
+      }
+      if (first) {
+        first = false
+      } else {
+        yield ','
+        currentLineLength += 1
+      }
+      yield serializedItem
+      currentLineLength += serializedItem.length
     }
-    // We don't use safeJsonStringify to save some time, because we know  we made sure there aren't
-    // circles
-    // eslint-disable-next-line no-restricted-syntax
-    yield JSON.stringify(item)
+    yield end
   }
-  yield ']'
+
+  return serializer
 }
+
+export const getSerializedStream = createStreamSerializer()

--- a/packages/lowerdash/test/serialize.test.ts
+++ b/packages/lowerdash/test/serialize.test.ts
@@ -33,6 +33,7 @@ describe('serialize', () => {
     })
     it('should match serialized strings', async () => {
       await awu(inputs).forEach(async items =>
+        // eslint-disable-next-line no-restricted-syntax
         expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify(items)),
       )
     })
@@ -58,6 +59,7 @@ describe('serialize', () => {
       it('should match serialized strings', async () => {
         await awu(inputs).forEach(async (items, index) =>
           expect(await getSerializedStreamRes(items)).toEqual(
+            // eslint-disable-next-line no-restricted-syntax
             chunkedLines[index].map(line => JSON.stringify(line)).join(EOL),
           ),
         )
@@ -70,6 +72,7 @@ describe('serialize', () => {
       })
       it('should match serialized strings', async () => {
         await awu(inputs).forEach(async items =>
+          // eslint-disable-next-line no-restricted-syntax
           expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify({ elements: items })),
         )
       })
@@ -82,6 +85,7 @@ describe('serialize', () => {
       it('should match serialized strings', async () => {
         await awu(inputs).forEach(async (items, index) =>
           expect(await getSerializedStreamRes(items)).toEqual(
+            // eslint-disable-next-line no-restricted-syntax
             chunkedLines[index].map(line => JSON.stringify({ elements: line })).join(EOL),
           ),
         )


### PR DESCRIPTION
Allow creating serialized stream with the following options:
- `maxLineLength`: writes the result in multiple lines, each line with length <= `maxLineLength`. for example:
```
createStreamSerializer({ maxLineLength: 5 })([1,2,3,4,5]) will result:
[1,2]
[3,4]
[5]
```
- `wrapWithKey`: wraps the output list with `{wrapWithKey:[]}`. for example:
```
createStreamSerializer({ wrapWithKey: 'elements' })([1,2,3,4,5]) will result:
{"elements":[1,2,3,4,5]}
```

---

_Additional context for reviewer_

---
_Release Notes_: 
Lowerdash:
- Extend stream serializer

---
_User Notifications_: 
None