### PR TITLE
SALTO-6531: Add logs on omitted instances warnings in Salesforce Data Fetch

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -364,6 +364,7 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     ])
     const illegalRefSources = getIllegalRefSources(illegalRefTargets, reverseReferencesMap)
     const invalidInstances = new Set([...illegalRefSources, ...illegalRefTargets])
+    log.trace('invalidInstances: %s', inspectValue(invalidInstances, { maxArrayLength: null }))
     await removeAsync(
       elements,
       async element =>

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -15,6 +15,7 @@ import {
   createWarningFromMsg,
   getInstancesWithCollidingElemID,
   safeJsonStringify,
+  inspectValue,
 } from '@salto-io/adapter-utils'
 import { references } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
@@ -87,6 +88,10 @@ const createWarnings = async (
   dataManagement: DataManagement,
   baseUrl?: string,
 ): Promise<SaltoError[]> => {
+  log.trace('instancesWithCollidingElemID: %s', inspectValue(instancesWithCollidingElemID, { maxArrayLength: null }))
+  log.trace('instancesWithEmptyIds: %s', inspectValue(instancesWithEmptyIds, { maxArrayLength: null }))
+  log.trace('missingRefs: %s', inspectValue(missingRefs, { maxArrayLength: null }))
+  log.debug('illegalRefSources: %s', inspectValue(illegalRefSources))
   const createOmittedInstancesWarning = async (
     originTypeName: string,
     missingRefsFromOriginType: MissingRef[],


### PR DESCRIPTION
Add logs on omitted instances warnings in Salesforce Data Fetch

---

This should help us troubleshoot issues.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
