### PR TITLE
SALTO-6539 regenerate auth header inside the axios request

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/types.ts
@@ -102,8 +102,6 @@ export type RestletResults = RestletSuccessResults | RestletErrorResults
 
 export const isError = (results: RestletResults): results is RestletErrorResults => results.status === 'error'
 
-export type HttpMethod = 'POST' | 'GET'
-
 export type SuiteAppClientParameters = {
   credentials: SuiteAppCredentials
   config?: SuiteAppClientConfig

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -203,6 +203,12 @@ describe('SuiteAppClient', () => {
 
           expect(await client.runSuiteQL({ select: 'field', from: 'table' })).toEqual([{ a: 1 }, { a: 2 }])
           expect(mockAxiosAdapter.history.post.length).toBe(3)
+          const uniqAuthHeaders = _.uniq(
+            mockAxiosAdapter.history.post
+              .map(request => request.headers?.['Authorization'])
+              .filter(header => header !== undefined),
+          )
+          expect(uniqAuthHeaders.length).toBe(3)
         })
         it('with server error retry', async () => {
           jest
@@ -226,6 +232,12 @@ describe('SuiteAppClient', () => {
 
           expect(await client.runSuiteQL({ select: 'field', from: 'table' })).toEqual([{ a: 1 }, { a: 2 }])
           expect(mockAxiosAdapter.history.post.length).toBe(4)
+          const uniqAuthHeaders = _.uniq(
+            mockAxiosAdapter.history.post
+              .map(request => request.headers?.['Authorization'])
+              .filter(header => header !== undefined),
+          )
+          expect(uniqAuthHeaders.length).toBe(4)
         })
         it('invalid results', async () => {
           mockAxiosAdapter.onPost().reply(200, {})

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_client.test.ts
@@ -205,7 +205,7 @@ describe('SuiteAppClient', () => {
           expect(mockAxiosAdapter.history.post.length).toBe(3)
           const uniqAuthHeaders = _.uniq(
             mockAxiosAdapter.history.post
-              .map(request => request.headers?.['Authorization'])
+              .map(request => request.headers?.Authorization)
               .filter(header => header !== undefined),
           )
           expect(uniqAuthHeaders.length).toBe(3)
@@ -234,7 +234,7 @@ describe('SuiteAppClient', () => {
           expect(mockAxiosAdapter.history.post.length).toBe(4)
           const uniqAuthHeaders = _.uniq(
             mockAxiosAdapter.history.post
-              .map(request => request.headers?.['Authorization'])
+              .map(request => request.headers?.Authorization)
               .filter(header => header !== undefined),
           )
           expect(uniqAuthHeaders.length).toBe(4)


### PR DESCRIPTION
regenerate the auth header on each axios request in a way that we’ll regenerate it also when the axios-retry mechanism makes the next request (and we’re not getting to call `axiosClient.post` again).
this should prevent us from getting `401 unauthorized` on a second request after the first request failed with `429 concurrency limit reached`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Prevent getting  "Invalid login attempt" after a delayed request (e.g. due to concurrency limit)

---
_User Notifications_: 
None
