### PR TITLE
SALTO-6536: Avoid fetching Group stats when not necessary

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -235,12 +235,13 @@ const createCustomizations = ({
       {
         endpoint: {
           path: '/api/v1/groups',
-          queryArgs: { expand: 'stats' },
+          queryArgs: includeGroupMemberships ? { expand: 'stats' } : {},
         },
         transformation: {
           adjust: async ({ value }) => ({
             value: {
               ...(_.isObject(value) ? { ..._.omit(value, '_embedded') } : {}),
+              // we set hasUsersAssigned to true when usersCount is undefined, cause in this case we don't know if there are users assigned
               hasUsersAssigned: _.get(value, ['_embedded', 'stats', 'usersCount']) === 0 ? 'false' : 'true',
             },
           }),


### PR DESCRIPTION
We added the `stats` query param to all `/api/v1/groups` requests, but we only use it when `includeGroupMemberships` is enabled.

---

_Additional context for reviewer_
In some cases, we suspect that adding the `stats` causes a time out in Okta while querying the groups. so I changes this behavior to only get it when needed.


---
_Release Notes_: 

_Okta_adapter_:
None

---
_User Notifications_: 
None
