### PR TITLE
SALTO-6543: Remove dependencies between objectTypeOrder and objectSchema in removal

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -19,6 +19,7 @@ import { fieldConfigurationDependencyChanger } from './field_configuration'
 import { rootObjectTypeToObjectSchemaDependencyChanger } from './root_object_type_to_schema'
 import { issueLayoutDependencyChanger } from './issue_layout_dependency'
 import { objectTypeParentDependencyChanger } from './object_type_parent'
+import { objectTypeOrderToSchemaDependencyChanger } from './object_type_order_to_schema'
 
 const { awu } = collections.asynciterable
 
@@ -35,6 +36,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   fieldContextDependencyChanger,
   fieldConfigurationDependencyChanger,
   issueLayoutDependencyChanger,
+  objectTypeOrderToSchemaDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (changes, deps) =>

--- a/packages/jira-adapter/src/dependency_changers/object_type_order_to_schema.ts
+++ b/packages/jira-adapter/src/dependency_changers/object_type_order_to_schema.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  DependencyChange,
+  DependencyChanger,
+  InstanceElement,
+  RemovalChange,
+  dependencyChange,
+  getChangeData,
+  isInstanceChange,
+  isRemovalChange,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { deployment } from '@salto-io/adapter-components'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_ORDER_TYPE } from '../constants'
+
+const createDependencyChange = (
+  objectTypeChange: deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>,
+  objectSchemaChange: deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>,
+): DependencyChange[] => [dependencyChange('remove', objectTypeChange.key, objectSchemaChange.key)]
+
+/*
+ * This dependency changer is used to remove a dependency from root object type to it's schema
+ * upon removal because we added the reference for Salto's internal use. but no real dependency exists
+ * In this direction. We also have parent annotation that is used for the real dependency.
+ */
+export const objectTypeOrderToSchemaDependencyChanger: DependencyChanger = async changes => {
+  const instanceChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(({ change }) => isRemovalChange(change))
+    .filter((change): change is deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>> =>
+      isInstanceChange(change.change),
+    )
+  const relevantChanges = instanceChanges.filter(change => {
+    const instance = getChangeData(change.change)
+    return instance.elemID.typeName === OBJECT_TYPE_ORDER_TYPE || instance.elemID.typeName === OBJECT_SCHEMA_TYPE
+  })
+
+  const [objectTypeOrderChanges, objectSchemaChanges] = _.partition(
+    relevantChanges,
+    change => getChangeData(change.change).elemID.typeName === OBJECT_TYPE_ORDER_TYPE,
+  )
+
+  if (_.isEmpty(objectTypeOrderChanges) || _.isEmpty(objectSchemaChanges)) {
+    return []
+  }
+  return objectTypeOrderChanges.flatMap(change => {
+    const objectTypeChange = change as deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>
+    return objectSchemaChanges
+      .map(objectSchemaChange => createDependencyChange(objectTypeChange, objectSchemaChange))
+      .flat()
+  })
+}

--- a/packages/jira-adapter/test/dependency_changers/object_type_order_to_schema.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/object_type_order_to_schema.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  InstanceElement,
+  toChange,
+  DependencyChange,
+  CORE_ANNOTATIONS,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { createEmptyType } from '../utils'
+import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_ORDER_TYPE, OBJECT_TYPE_TYPE } from '../../src/constants'
+import { objectTypeOrderToSchemaDependencyChanger } from '../../src/dependency_changers/object_type_order_to_schema'
+
+describe('objectTypeOrderToSchemaDependencyChanger', () => {
+  let dependencyChanges: DependencyChange[]
+  let objectTypeInstance: InstanceElement
+  let objectSchemaInstance: InstanceElement
+  let objectTypeOrderInstance: InstanceElement
+  describe('objectTypeOrderToSchemaDependencyChanger with expected changes', () => {
+    beforeEach(async () => {
+      objectSchemaInstance = new InstanceElement('objectSchemaInstance', createEmptyType(OBJECT_SCHEMA_TYPE), {
+        id: '0',
+        name: 'objectSchemaInstanceName',
+      })
+      objectTypeInstance = new InstanceElement(
+        'objectTypeInstance',
+        createEmptyType(OBJECT_TYPE_TYPE),
+        {
+          id: '1',
+          name: 'objectTypeInstanceName',
+          parentObjectTypeId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)],
+        },
+      )
+      objectTypeOrderInstance = new InstanceElement(
+        'objectTypeOrderInstance',
+        createEmptyType(OBJECT_TYPE_ORDER_TYPE),
+        {
+          objectTypes: [new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance)],
+        },
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance)],
+        },
+      )
+    })
+    it('should remove dependencies from objectTypeOrderInstance to objectSchema when they are both removal change', async () => {
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeOrderInstance })],
+        [1, toChange({ before: objectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await objectTypeOrderToSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(1)
+      expect(dependencyChanges[0].action).toEqual('remove')
+      expect(dependencyChanges[0].dependency.source).toEqual(0)
+      expect(dependencyChanges[0].dependency.target).toEqual(1)
+    })
+    it('should not remove dependencies from objectTypeOrderInstance to objectSchema when objectTypeOrderInstance is modification change', async () => {
+      const objectTypeOrderInstanceAfter = objectTypeOrderInstance.clone()
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeOrderInstance, after: objectTypeOrderInstanceAfter })],
+        [1, toChange({ before: objectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await objectTypeOrderToSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+    it('should not remove dependencies from objectTypeOrderInstance to objectSchema when objectSchema is modification change', async () => {
+      const objectSchemaInstanceAfter = objectSchemaInstance.clone()
+      objectSchemaInstanceAfter.value.name = 'objectSchemaInstanceName2'
+      const inputChanges = new Map([
+        [0, toChange({ before: objectSchemaInstance, after: objectSchemaInstanceAfter })],
+        [1, toChange({ after: objectTypeOrderInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await objectTypeOrderToSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
+  })
+})

--- a/packages/jira-adapter/test/dependency_changers/object_type_order_to_schema.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/object_type_order_to_schema.test.ts
@@ -87,5 +87,22 @@ describe('objectTypeOrderToSchemaDependencyChanger', () => {
       dependencyChanges = [...(await objectTypeOrderToSchemaDependencyChanger(inputChanges, inputDeps))]
       expect(dependencyChanges).toHaveLength(0)
     })
+    it('should not remove dependencies from objectTypeOrderInstance to objectSchema when objectSchema is not the parent', async () => {
+      const otherObjectSchemaInstance = new InstanceElement(
+        'otherObjectSchemaInstance',
+        createEmptyType(OBJECT_SCHEMA_TYPE),
+        {
+          id: '2',
+          name: 'objectSchemaInstanceName2',
+        },
+      )
+      const inputChanges = new Map([
+        [0, toChange({ before: objectTypeOrderInstance })],
+        [1, toChange({ before: otherObjectSchemaInstance })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+      dependencyChanges = [...(await objectTypeOrderToSchemaDependencyChanger(inputChanges, inputDeps))]
+      expect(dependencyChanges).toHaveLength(0)
+    })
   })
 })


### PR DESCRIPTION
In this PR I removed the dependencies between objectTypeOrder and objectSchema in removal

---

_Additional context for reviewer_
Context can be found in [SALTO-6543](https://salto-io.atlassian.net/browse/SALTO-6543).

---
_Release Notes_: 
_Jira Adapter:_
* Fixed a bug caused by circular dependency between root `ObjectType`, `ObjectTypeOrder` and `ObjectSchema`.

---
_User Notifications_: 
None


[SALTO-6543]: https://salto-io.atlassian.net/browse/SALTO-6543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ