### PR TITLE
SALTO-6350 remove --immutable flag from yarn in version script

### DIFF
--- a/build_utils/create_version_pr.sh
+++ b/build_utils/create_version_pr.sh
@@ -41,7 +41,7 @@ fi
 BUMP=${1:-patch}
 
 yarn lerna-version -y $BUMP
-yarn --immutable
+yarn
 
 DIRTY_FILES=$(git diff-index --name-only HEAD)
 


### PR DESCRIPTION
fix for https://github.com/salto-io/salto/pull/6302 since the yarn lockfile is mutated as part of version bumps

---
_Release Notes_: 
None

---
_User Notifications_: 
None