### PR TITLE
SALTO-6544: Improve Data Instances References behavior

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -40,6 +40,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   metaTypes: false,
   cpqRulesAndConditionsRefs: true,
   flowCoordinates: false,
+  improvedDataBrokenReferences: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -36,6 +36,7 @@ import { FilterResult, RemoteFilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
 import {
+  apiNameSync,
   buildElementsSourceForFetch,
   instanceInternalId,
   isInstanceOfCustomObjectSync,
@@ -88,10 +89,6 @@ const createWarnings = async (
   dataManagement: DataManagement,
   baseUrl?: string,
 ): Promise<SaltoError[]> => {
-  log.trace('instancesWithCollidingElemID: %s', inspectValue(instancesWithCollidingElemID, { maxArrayLength: null }))
-  log.trace('instancesWithEmptyIds: %s', inspectValue(instancesWithEmptyIds, { maxArrayLength: null }))
-  log.trace('missingRefs: %s', inspectValue(missingRefs, { maxArrayLength: null }))
-  log.debug('illegalRefSources: %s', inspectValue(illegalRefSources))
   const createOmittedInstancesWarning = async (
     originTypeName: string,
     missingRefsFromOriginType: MissingRef[],
@@ -189,15 +186,27 @@ const createWarnings = async (
   return [...collisionWarnings, ...instanceWithEmptyIdWarnings, ...missingRefsWarnings, ...illegalOriginsWarnings]
 }
 
-const replaceLookupsWithRefsAndCreateRefMap = async (
-  referenceSources: InstanceElement[],
-  internalIdToReferenceTarget: Record<string, InstanceElement>,
-  internalToTypeName: (internalId: string) => string,
-  dataManagement: DataManagement,
-): Promise<{
+const replaceLookupsWithRefsAndCreateRefMap = async ({
+  referenceSources,
+  internalIdToReferenceTarget,
+  internalToTypeName,
+  dataManagement,
+  instancesWithCollidingElemID,
+  instancesWithEmptyId,
+}: {
+  referenceSources: InstanceElement[]
+  internalIdToReferenceTarget: Record<string, InstanceElement>
+  internalToTypeName: (internalId: string) => string
+  dataManagement: DataManagement
+  instancesWithCollidingElemID: InstanceElement[]
+  instancesWithEmptyId: InstanceElement[]
+}): Promise<{
   reverseReferencesMap: collections.map.DefaultMap<string, Set<string>>
   missingRefs: MissingRef[]
 }> => {
+  const invalidInstancesIds = new Set(
+    instancesWithCollidingElemID.concat(instancesWithEmptyId).map(instance => apiNameSync(instance)),
+  )
   const reverseReferencesMap = new DefaultMap<string, Set<string>>(() => new Set())
   const missingRefs: MissingRef[] = []
   const fieldsWithUnknownTargetType = new DefaultMap<string, Set<string>>(() => new Set())
@@ -213,21 +222,19 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
         .filter(isDefined)
         .pop()
 
-      if (refTarget === undefined) {
+      const targetTypeName = refTo.length === 1 ? refTo[0] : internalToTypeName(value)
+      const brokenRefBehavior = dataManagement.brokenReferenceBehaviorForTargetType(targetTypeName)
+      if (refTarget === undefined || invalidInstancesIds.has(apiNameSync(refTarget))) {
         if (_.isEmpty(value)) {
           return value
         }
         if (isReadOnlyField(field) || field?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true) {
           return value
         }
-
-        const targetTypeName = refTo.length === 1 ? refTo[0] : internalToTypeName(value)
-
         if (targetTypeName === undefined) {
           fieldsWithUnknownTargetType.get(field.elemID.getFullName()).add(value)
         }
 
-        const brokenRefBehavior = dataManagement.brokenReferenceBehaviorForTargetType(targetTypeName)
         switch (brokenRefBehavior) {
           case 'InternalId': {
             return value
@@ -252,9 +259,11 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
         }
       }
 
-      reverseReferencesMap
-        .get(await serializeInstanceInternalID(refTarget))
-        .add(await serializeInstanceInternalID(instance))
+      if (brokenRefBehavior === 'ExcludeInstance') {
+        reverseReferencesMap
+          .get(await serializeInstanceInternalID(refTarget))
+          .add(await serializeInstanceInternalID(instance))
+      }
       return new ReferenceExpression(refTarget.elemID)
     }
 
@@ -331,23 +340,26 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
       return {}
     }
     const fetchedInstances = elements.filter(isInstanceElement)
-    // In the partial fetch case, a fetched element may reference an element that was not fetched but exists in the workspace
-    const elementsSource = buildElementsSourceForFetch(elements, config)
-    const allElements = await awu(await elementsSource.getAll()).toArray()
     const fetchedCustomObjectInstances = fetchedInstances.filter(isInstanceOfCustomObjectSync)
-    const allInstances = allElements.filter(isInstanceElement)
-    const internalToInstance = await keyByAsync(allInstances, serializeInstanceInternalID)
-    const internalIdPrefixToType = await buildCustomObjectPrefixKeyMap(allElements)
-    const { reverseReferencesMap, missingRefs } = await replaceLookupsWithRefsAndCreateRefMap(
-      fetchedCustomObjectInstances,
-      internalToInstance,
-      (internalId: string): string => internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
-      dataManagement,
-    )
     const instancesWithCollidingElemID = getInstancesWithCollidingElemID(fetchedInstances)
     const instancesWithEmptyId = fetchedCustomObjectInstances.filter(
       instance => instance.elemID.name === ElemID.CONFIG_NAME,
     )
+    // In the partial fetch case, a fetched element may reference an element that was not fetched but exists in the workspace
+    const elementsSource = buildElementsSourceForFetch(elements, config)
+    const allElements = await awu(await elementsSource.getAll()).toArray()
+    const allInstances = allElements.filter(isInstanceElement)
+    const internalToInstance = await keyByAsync(allInstances, serializeInstanceInternalID)
+    const internalIdPrefixToType = await buildCustomObjectPrefixKeyMap(allElements)
+    const { reverseReferencesMap, missingRefs } = await replaceLookupsWithRefsAndCreateRefMap({
+      referenceSources: fetchedCustomObjectInstances,
+      internalIdToReferenceTarget: internalToInstance,
+      internalToTypeName: (internalId: string): string =>
+        internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
+      dataManagement,
+      instancesWithCollidingElemID,
+      instancesWithEmptyId,
+    })
     const missingRefOriginInternalIDs = new Set(
       missingRefs.map(missingRef => serializeInternalID(missingRef.origin.type, missingRef.origin.id)),
     )
@@ -364,7 +376,12 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     ])
     const illegalRefSources = getIllegalRefSources(illegalRefTargets, reverseReferencesMap)
     const invalidInstances = new Set([...illegalRefSources, ...illegalRefTargets])
-    log.trace('invalidInstances: %s', inspectValue(invalidInstances, { maxArrayLength: null }))
+    log.trace('invalidInstances: %s', inspectValue(invalidInstances))
+    log.trace('missingRefs: %s', inspectValue(missingRefOriginInternalIDs))
+    log.trace('instancesWithCollidingElemID: %s', inspectValue(instWithDupElemIDInterIDs))
+    log.trace('instancesWithEmptyId: %s', inspectValue(instancesWithEmptyIdInternalIDs))
+    log.trace('reverseReferencesMap: %s', inspectValue(reverseReferencesMap))
+
     await removeAsync(
       elements,
       async element =>

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -186,7 +186,108 @@ const createWarnings = async (
   return [...collisionWarnings, ...instanceWithEmptyIdWarnings, ...missingRefsWarnings, ...illegalOriginsWarnings]
 }
 
-const replaceLookupsWithRefsAndCreateRefMap = async ({
+const replaceLookupsWithRefsAndCreateRefMap = async (
+  referenceSources: InstanceElement[],
+  internalIdToReferenceTarget: Record<string, InstanceElement>,
+  internalToTypeName: (internalId: string) => string,
+  dataManagement: DataManagement,
+): Promise<{
+  reverseReferencesMap: collections.map.DefaultMap<string, Set<string>>
+  missingRefs: MissingRef[]
+}> => {
+  const reverseReferencesMap = new DefaultMap<string, Set<string>>(() => new Set())
+  const missingRefs: MissingRef[] = []
+  const fieldsWithUnknownTargetType = new DefaultMap<string, Set<string>>(() => new Set())
+  const replaceLookups = async (instance: InstanceElement): Promise<Values> => {
+    const transformFunc: TransformFunc = async ({ value, field }) => {
+      if (!isReferenceField(field)) {
+        return value
+      }
+      const refTo = referenceFieldTargetTypes(field)
+
+      const refTarget = refTo
+        .map(targetTypeName => internalIdToReferenceTarget[serializeInternalID(targetTypeName, value)])
+        .filter(isDefined)
+        .pop()
+
+      if (refTarget === undefined) {
+        if (_.isEmpty(value)) {
+          return value
+        }
+        if (isReadOnlyField(field) || field?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true) {
+          return value
+        }
+
+        const targetTypeName = refTo.length === 1 ? refTo[0] : internalToTypeName(value)
+
+        if (targetTypeName === undefined) {
+          fieldsWithUnknownTargetType.get(field.elemID.getFullName()).add(value)
+        }
+
+        const brokenRefBehavior = dataManagement.brokenReferenceBehaviorForTargetType(targetTypeName)
+        switch (brokenRefBehavior) {
+          case 'InternalId': {
+            return value
+          }
+          case 'BrokenReference': {
+            return createMissingValueReference(new ElemID(SALESFORCE, targetTypeName, 'instance'), value)
+          }
+          case 'ExcludeInstance': {
+            missingRefs.push({
+              origin: {
+                type: await apiName(await instance.getType(), true),
+                id: await apiName(instance),
+                field,
+              },
+              targetId: instance.value[field.name],
+            })
+            return value
+          }
+          default: {
+            throw new Error('Unrecognized broken refs behavior. Is the configuration valid?')
+          }
+        }
+      }
+
+      reverseReferencesMap
+        .get(await serializeInstanceInternalID(refTarget))
+        .add(await serializeInstanceInternalID(instance))
+      return new ReferenceExpression(refTarget.elemID)
+    }
+
+    return (
+      (await transformValues({
+        values: instance.value,
+        type: await instance.getType(),
+        transformFunc,
+        strict: false,
+        allowEmptyArrays: true,
+        allowEmptyObjects: true,
+      })) ?? instance.value
+    )
+  }
+
+  if (fieldsWithUnknownTargetType.size > 0) {
+    log.warn(
+      'The following fields have multiple %s annotations and contained internal IDs with an unknown key prefix. The default broken references behavior was used for them.',
+      FIELD_ANNOTATIONS.REFERENCE_TO,
+    )
+    fieldsWithUnknownTargetType.forEach((internalIds, fieldElemId) => {
+      log.warn('Field %s: %o', fieldElemId, internalIds)
+    })
+  }
+
+  await awu(referenceSources).forEach(async (instance, index) => {
+    instance.value = await replaceLookups(instance)
+    if (index > 0 && index % 500 === 0) {
+      log.debug(`Replaced lookup with references for ${index} instances`)
+    }
+  })
+
+  return { reverseReferencesMap, missingRefs }
+}
+
+const replaceLookupsWithRefsAndCreateRefMapV2 = async ({
   referenceSources,
   internalIdToReferenceTarget,
   internalToTypeName,
@@ -351,15 +452,22 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     const allInstances = allElements.filter(isInstanceElement)
     const internalToInstance = await keyByAsync(allInstances, serializeInstanceInternalID)
     const internalIdPrefixToType = await buildCustomObjectPrefixKeyMap(allElements)
-    const { reverseReferencesMap, missingRefs } = await replaceLookupsWithRefsAndCreateRefMap({
-      referenceSources: fetchedCustomObjectInstances,
-      internalIdToReferenceTarget: internalToInstance,
-      internalToTypeName: (internalId: string): string =>
-        internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
-      dataManagement,
-      instancesWithCollidingElemID,
-      instancesWithEmptyId,
-    })
+    const { reverseReferencesMap, missingRefs } = config.fetchProfile.isFeatureEnabled('improvedDataBrokenReferences')
+      ? await replaceLookupsWithRefsAndCreateRefMapV2({
+          referenceSources: fetchedCustomObjectInstances,
+          internalIdToReferenceTarget: internalToInstance,
+          internalToTypeName: (internalId: string): string =>
+            internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
+          dataManagement,
+          instancesWithCollidingElemID,
+          instancesWithEmptyId,
+        })
+      : await replaceLookupsWithRefsAndCreateRefMap(
+          fetchedCustomObjectInstances,
+          internalToInstance,
+          internalId => internalIdPrefixToType[internalId.slice(0, KEY_PREFIX_LENGTH)],
+          dataManagement,
+        )
     const missingRefOriginInternalIDs = new Set(
       missingRefs.map(missingRef => serializeInternalID(missingRef.origin.type, missingRef.origin.id)),
     )

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -119,6 +119,7 @@ export type OptionalFeatures = {
   metaTypes?: boolean
   cpqRulesAndConditionsRefs?: boolean
   flowCoordinates?: boolean
+  improvedDataBrokenReferences?: boolean
 }
 
 export type ChangeValidatorName =
@@ -814,6 +815,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     metaTypes: { refType: BuiltinTypes.BOOLEAN },
     cpqRulesAndConditionsRefs: { refType: BuiltinTypes.BOOLEAN },
     flowCoordinates: { refType: BuiltinTypes.BOOLEAN },
+    improvedDataBrokenReferences: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -18,6 +18,7 @@ import {
   ReferenceExpression,
   isInstanceElement,
   SaltoError,
+  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
@@ -46,6 +47,7 @@ import { mockInstances, mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 import { FetchProfile, OutgoingReferenceBehavior } from '../../src/types'
 import { buildMetadataQueryForFetchWithChangesDetection } from '../../src/fetch_profile/metadata_query'
+import { apiNameSync, isInstanceOfCustomObjectSync } from '../../src/filters/utils'
 
 const { MISSING_REF_PREFIX } = references
 
@@ -443,15 +445,18 @@ describe('Custom Object Instances References filter', () => {
       })
     })
   })
-
   describe('Broken refs behavior', () => {
     const testElements = [...objects, ...legalInstances, refFromEmptyRefsInstance]
     const buildTestFetchProfile = (
       defaultBehavior: OutgoingReferenceBehavior,
       overrides: Record<string, OutgoingReferenceBehavior>,
+      improvedDataBrokenReferences = false,
     ): FetchProfile =>
       buildFetchProfile({
         fetchParams: {
+          optionalFeatures: {
+            improvedDataBrokenReferences,
+          },
           data: {
             includeObjects: ['*'],
             saltoIDSettings: {
@@ -464,17 +469,76 @@ describe('Custom Object Instances References filter', () => {
           },
         },
       })
+    beforeEach(() => {
+      filter = filterCreator({
+        client,
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildTestFetchProfile('BrokenReference', {
+            User: 'InternalId',
+          }),
+        },
+      }) as FilterType
+    })
+    describe('ref lookups to illegal instances', () => {
+      beforeEach(() => {
+        elements = [...objects, firstDupInst, secondDupInst, refFromToDupInst].map(e => e.clone())
+      })
+      describe('when improvedDataBrokenReferences feature is disabled', () => {
+        beforeEach(() => {
+          filter = filterCreator({
+            client,
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildTestFetchProfile('BrokenReference', {
+                User: 'InternalId',
+              }),
+            },
+          }) as FilterType
+        })
+        it('should drop the illegal instances and instances that reference them', async () => {
+          await filter.onFetch(elements)
+          const remainingCustomObjectInstances = elements.filter(isInstanceOfCustomObjectSync)
+          expect(remainingCustomObjectInstances).toBeEmpty()
+        })
+      })
+      describe('when improvedDataBrokenReferences feature is enabled', () => {
+        beforeEach(() => {
+          filter = filterCreator({
+            client,
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildTestFetchProfile(
+                'BrokenReference',
+                {
+                  User: 'InternalId',
+                },
+                true,
+              ),
+            },
+          }) as FilterType
+        })
+        it('should drop the illegal instances and keep the instance that reference them with broken reference', async () => {
+          await filter.onFetch(elements)
+          const remainingCustomObjectInstances = elements.filter(isInstanceOfCustomObjectSync)
+          expect(remainingCustomObjectInstances).toHaveLength(1)
+          const [instanceWithBrokenRef] = remainingCustomObjectInstances
+          expect(apiNameSync(instanceWithBrokenRef)).toEqual(refFromToDupInst.value.Id)
+          expect(instanceWithBrokenRef.value.LookupExample).toSatisfy(
+            ref =>
+              isReferenceExpression(ref) &&
+              ref.elemID.getFullName() === 'salesforce.refToName.instance.missing_duplicateId_1@ub',
+          )
+          expect(instanceWithBrokenRef.value.MasterDetailExample).toSatisfy(
+            ref =>
+              isReferenceExpression(ref) &&
+              ref.elemID.getFullName() === 'salesforce.masterName.instance.missing_duplicateId_2@ub',
+          )
+        })
+      })
+    })
     describe('When default is BrokenReference and override is InternalId', () => {
       beforeEach(async () => {
-        filter = filterCreator({
-          client,
-          config: {
-            ...defaultFilterContext,
-            fetchProfile: buildTestFetchProfile('BrokenReference', {
-              User: 'InternalId',
-            }),
-          },
-        }) as FilterType
         elements = testElements.map(e => e.clone())
         const fetchResult = await filter.onFetch(elements)
         if (fetchResult) {


### PR DESCRIPTION
Improve Data Instances References behavior.

---

Implemented as optional feature for a gradual rollout. (`improvedDataBrokenReferences`)

Workspace Diff when feature is enabled: https://github.com/salto-io/tamir-sf/commit/806650b66b5c587cc64cf84cb09aa0f418b55bf7

When the `ReferenceBehavior` is not `ExcludeInstance`, instances that were referencing an invalid instance, would be omitted altogether, regardless to the defined reference behavior.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
