### PR TITLE
SALTO-6550: Allow transforming removed object fields to null

### DIFF
--- a/packages/adapter-components/src/deployment/filtering.ts
+++ b/packages/adapter-components/src/deployment/filtering.ts
@@ -70,10 +70,15 @@ export const filterIgnoredValues = async (
 /**
  * Transform removed change values to null, for APIs that require explicit null values
  */
-export const transformRemovedValuesToNull = (
-  change: ModificationChange<InstanceElement>,
-  applyToPath?: string[],
-): ModificationChange<InstanceElement> => {
+export const transformRemovedValuesToNull = ({
+  change,
+  applyToPath,
+  skipSubFields = false,
+}: {
+  change: ModificationChange<InstanceElement>
+  applyToPath?: string[]
+  skipSubFields?: boolean
+}): ModificationChange<InstanceElement> => {
   const { before, after } = change.data
   const elemId = applyToPath
     ? getChangeData(change).elemID.createNestedID(...applyToPath)
@@ -84,7 +89,7 @@ export const transformRemovedValuesToNull = (
     func: ({ value, path }) => {
       const valueInAfter = resolvePath(after, path)
       if (valueInAfter === undefined) {
-        if (!_.isPlainObject(value)) {
+        if (!_.isPlainObject(value) || skipSubFields) {
           setPath(after, path, null)
           return WALK_NEXT_STEP.SKIP
         }

--- a/packages/adapter-components/test/deployment/filtering.test.ts
+++ b/packages/adapter-components/test/deployment/filtering.test.ts
@@ -108,7 +108,7 @@ describe('transformRemovedValuesToNull', () => {
   })
   it('should transform removed values to null', () => {
     const change = toChange({ before, after }) as ModificationChange<InstanceElement>
-    const result = transformRemovedValuesToNull(change)
+    const result = transformRemovedValuesToNull({ change })
     expect(result.data.before.value).toEqual(before.value)
     expect(result.data.after.value).toEqual({
       name: 'inst',
@@ -130,7 +130,7 @@ describe('transformRemovedValuesToNull', () => {
 
   it('should only transform the values in relevant path', () => {
     const change = toChange({ before, after }) as ModificationChange<InstanceElement>
-    const result = transformRemovedValuesToNull(change, ['nested1', 'nested2'])
+    const result = transformRemovedValuesToNull({ change, applyToPath: ['nested1', 'nested2'] })
     expect(result.data.before.value).toEqual(before.value)
     expect(result.data.after.value).toEqual({
       name: 'inst',
@@ -144,6 +144,28 @@ describe('transformRemovedValuesToNull', () => {
       },
       settings: {
         url: 'http://example.com',
+      },
+    })
+  })
+
+  it('should not transform sub fields when skipSubFields is true', () => {
+    const change = toChange({ before, after }) as ModificationChange<InstanceElement>
+    const result = transformRemovedValuesToNull({ change, skipSubFields: true })
+    expect(result.data.before.value).toEqual(before.value)
+    expect(result.data.after.value).toEqual({
+      name: 'inst',
+      status: 'active',
+      nested1: {
+        field: [1, 2],
+        nested2: {
+          some: 'value',
+          another: null,
+        },
+        removedArray: null,
+      },
+      settings: {
+        url: 'http://example.com',
+        url2: null,
       },
     })
   })

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -373,7 +373,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                       throw new Error('Change is not a modification change')
                     }
                     const transformed = getChangeData(
-                      deployment.transformRemovedValuesToNull(context.change, ['settings']),
+                      deployment.transformRemovedValuesToNull({ change: context.change, applyToPath: ['settings'] }),
                     ).value
                     return {
                       value: {


### PR DESCRIPTION
The current implementation of transformRemovedValuesToNull recurses into subfields when a deleted field is an object, and it only transforms the lowest-level fields to null. In some cases, we want to allow the top-level deleted field to be set to null without including its subfields.

---
_Release Notes_: 

---
_User Notifications_: 
