### PR TITLE
SALTO-6551: Fix - transforming removed values to null creates side effects in the workspace

### DIFF
--- a/packages/adapter-components/src/deployment/filtering.ts
+++ b/packages/adapter-components/src/deployment/filtering.ts
@@ -79,7 +79,8 @@ export const transformRemovedValuesToNull = ({
   applyToPath?: string[]
   skipSubFields?: boolean
 }): ModificationChange<InstanceElement> => {
-  const { before, after } = change.data
+  const { before, after: afterOriginal } = change.data
+  const after = afterOriginal.clone()
   const elemId = applyToPath
     ? getChangeData(change).elemID.createNestedID(...applyToPath)
     : getChangeData(change).elemID
@@ -103,5 +104,11 @@ export const transformRemovedValuesToNull = ({
       return WALK_NEXT_STEP.RECURSE
     },
   })
-  return change
+  return {
+    ...change,
+    data: {
+      before,
+      after,
+    },
+  }
 }

--- a/packages/adapter-components/test/deployment/filtering.test.ts
+++ b/packages/adapter-components/test/deployment/filtering.test.ts
@@ -128,6 +128,15 @@ describe('transformRemovedValuesToNull', () => {
     })
   })
 
+  it('should not modify the original change', () => {
+    const change = toChange({ before, after }) as ModificationChange<InstanceElement>
+    const result = transformRemovedValuesToNull({ change })
+    expect(change.data.before.value).toEqual(before.value)
+    expect(change.data.after.value).toEqual(after.value)
+    expect(result.data.before.value).toEqual(before.value)
+    expect(result.data.after.value).not.toEqual(after.value)
+  })
+
   it('should only transform the values in relevant path', () => {
     const change = toChange({ before, after }) as ModificationChange<InstanceElement>
     const result = transformRemovedValuesToNull({ change, applyToPath: ['nested1', 'nested2'] })


### PR DESCRIPTION
The existing utility `transformRemovedValuesToNull` sets the removed fields to null in-place. This means that once the deployment succeeds, these null changes will appear in the workspace, which is not supposed to happen.

---

_Additional context for reviewer_
To fix this, we simply modify a clone of the change, rather than the original one.

---
_Release Notes_: 

---
_User Notifications_: 
