### PR TITLE
SALTO-6552: add elementsSource to assetObjectFieldConfiguration deployment

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_field_configuration.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_field_configuration.ts
@@ -25,6 +25,7 @@ import {
   ReferenceExpression,
   isRemovalChange,
   isAdditionChange,
+  ReadOnlyElementsSource,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
@@ -103,6 +104,7 @@ export const deployAssetObjectContext = async (
   change: Change<InstanceElement>,
   client: JiraClient,
   config: JiraConfig,
+  elementsSource?: ReadOnlyElementsSource,
 ): Promise<void> => {
   if (!config.fetch.enableAssetsObjectFieldConfiguration) {
     return
@@ -120,7 +122,9 @@ export const deployAssetObjectContext = async (
     )
   }
 
-  const resolvedInstance = await resolveValues(instance, getLookUpName)
+  // we need the elementsSource when the change was added from contexts_projects_filter because the change can not be resolved without it
+  // we can remove the elementsSource when SALTO-6322 is done
+  const resolvedInstance = await resolveValues(instance, getLookUpName, elementsSource)
   try {
     const configId = await getFieldConfigId(client, change)
     await client.putPrivate({

--- a/packages/jira-adapter/src/filters/assets/assets_object_field_configuration.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_field_configuration.ts
@@ -170,9 +170,11 @@ export const deployAssetObjectContext = async (
       data: _.omit(resolvedInstance.value.assetsObjectFieldConfiguration, 'id'),
     })
   } catch (e) {
-    const errorMessages = isCMBDErrorResponse(e) && e.response.data.errors.map(error => error.errorMessage)
+    const errorMessages = isCMBDErrorResponse(e)
+      ? e.response.data.errors.map(error => error.errorMessage).join(', ')
+      : e.message
     throw new Error(
-      `Failed to deploy asset object field configuration for instance ${instance.elemID.getFullName()} with error: ${errorMessages ? errorMessages.join(', ') : e.message}. The context might be deployed partially.`,
+      `Failed to deploy asset object field configuration for instance ${instance.elemID.getFullName()} with error: ${errorMessages}. The context might be deployed partially.`,
     )
   }
 }

--- a/packages/jira-adapter/src/filters/fields/contexts.ts
+++ b/packages/jira-adapter/src/filters/fields/contexts.ts
@@ -95,7 +95,7 @@ export const deployContextChange = async ({
     await setContextOptions(change, client, elementsSource, paginator)
     await updateDefaultValues(change, client, config, elementsSource)
   }
-  await deployAssetObjectContext(change, client, config)
+  await deployAssetObjectContext(change, client, config, elementsSource)
 }
 
 export const getContexts = async (

--- a/packages/jira-adapter/test/filters/fields/assets_object_field_configuration.test.ts
+++ b/packages/jira-adapter/test/filters/fields/assets_object_field_configuration.test.ts
@@ -490,7 +490,7 @@ describe('assetsObjectFieldConfiguration', () => {
         deployAssetObjectContext(toChange({ after: contextInstance1 }), client, config),
       ).rejects.toThrowWithMessage(
         Error,
-        'Failed to deploy asset object field configuration for instance jira.CustomFieldContext.instance.context1 with error: Failed to put rest/servicedesk/cmdb/latest/fieldconfig/55555 with error: Error: error. The context might be deployed partially.',
+        'Failed to deploy asset object field configuration for instance jira.CustomFieldContext.instance.context1 with error: Failed to put rest/servicedesk/cmdb/latest/fieldconfig/55555 with error: error. The context might be deployed partially.',
       )
     })
   })


### PR DESCRIPTION
_add elementsSource to assetObjectFieldConfiguration deployment_

---

_Additional context for reviewer_
* while working I found a bug in the jql filter - unresolved references were not resolved.
* fix a bug in the elementsSource that would not resolve references of not top-level instances.
---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
