### PR TITLE
SALTO-6556: Salesforce customObjectInstanceReferencesFilter fails on Cannot read properties of null (reading 'slice')

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -200,7 +200,7 @@ const replaceLookupsWithRefsAndCreateRefMap = async (
   const fieldsWithUnknownTargetType = new DefaultMap<string, Set<string>>(() => new Set())
   const replaceLookups = async (instance: InstanceElement): Promise<Values> => {
     const transformFunc: TransformFunc = async ({ value, field }) => {
-      if (!isReferenceField(field)) {
+      if (!isReferenceField(field) || !_.isString(value)) {
         return value
       }
       const refTo = referenceFieldTargetTypes(field)
@@ -313,7 +313,7 @@ const replaceLookupsWithRefsAndCreateRefMapV2 = async ({
   const fieldsWithUnknownTargetType = new DefaultMap<string, Set<string>>(() => new Set())
   const replaceLookups = async (instance: InstanceElement): Promise<Values> => {
     const transformFunc: TransformFunc = async ({ value, field }) => {
-      if (!isReferenceField(field)) {
+      if (!isReferenceField(field) || !_.isString(value)) {
         return value
       }
       const refTo = referenceFieldTargetTypes(field)

--- a/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_object_instances_references.test.ts
@@ -164,6 +164,16 @@ describe('Custom Object Instances References filter', () => {
           [FIELD_ANNOTATIONS.UPDATEABLE]: true,
         },
       },
+      LookupNoRefTo: {
+        refType: Types.primitiveDataTypes.Lookup,
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+          [LABEL]: 'lookupNoRefTo',
+          [API_NAME]: 'LookupNoRefTo',
+          [FIELD_ANNOTATIONS.CREATABLE]: true,
+          [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        },
+      },
       HiddenValueField: {
         refType: Types.primitiveDataTypes.MasterDetail,
         annotations: {
@@ -236,6 +246,7 @@ describe('Custom Object Instances References filter', () => {
     Id: 'toDuplicate',
     LookupExample: 'duplicateId-1',
     MasterDetailExample: 'duplicateId-2',
+    LookupNoRefTo: null,
   })
   const refFromToRefToDupName = 'refFromToRefToDupInstance'
   const refFromToRefToDupInst = new InstanceElement(refFromToRefToDupName, refFromObj, {


### PR DESCRIPTION
Salesforce customObjectInstanceReferencesFilter fails on Cannot read properties of null (reading 'slice')

---

This is an edge-case where the Lookup field has either no `referenceTo` annotation or multiple `referenceTo` annotations, but the value of the Lookup is not a string. (null is possible for optional Lookup Field).
I simply validate the value of the reference field is a string as part of the transform function.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
