### PR TITLE
SALTO-6559: Improve Salesforce warning logs that print [object Object]

### DIFF
--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -10,6 +10,7 @@ import { FileProperties } from '@salto-io/jsforce-types'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELD, CUSTOM_OBJECT, INTERNAL_ID_ANNOTATION } from '../../constants'
 import { getAuthorAnnotations, MetadataInstanceElement } from '../../transformers/transformer'
 import { RemoteFilterCreator } from '../../filter'
@@ -54,7 +55,7 @@ const getCustomObjectFileProperties = async (client: SalesforceClient): Promise<
     type: CUSTOM_OBJECT,
   })
   if (errors && errors.length > 0) {
-    log.warn(`Encountered errors while listing file properties for CustomObjects: ${errors}`)
+    log.warn('Encountered errors while listing file properties for CustomObjects: %s', inspectValue(errors))
   }
   return _.keyBy(result, fileProp => fileProp.fullName)
 }
@@ -64,7 +65,7 @@ const getCustomFieldFileProperties = async (client: SalesforceClient): Promise<R
     type: CUSTOM_FIELD,
   })
   if (errors && errors.length > 0) {
-    log.warn(`Encountered errors while listing file properties for CustomFields: ${errors}`)
+    log.warn('Encountered errors while listing file properties for CustomFields: %s', inspectValue(errors))
   }
   return _(result)
     .groupBy((fileProps: FileProperties) => getFieldNameParts(fileProps).objectName)

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -10,6 +10,7 @@ import { FileProperties } from '@salto-io/jsforce-types'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { collections, values } from '@salto-io/lowerdash'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { SHARING_RULES_TYPE } from '../../constants'
 import { getAuthorAnnotations } from '../../transformers/transformer'
 import { RemoteFilterCreator } from '../../filter'
@@ -29,7 +30,7 @@ const getSharingRulesFileProperties = async (client: SalesforceClient): Promise<
     SHARING_RULES_API_NAMES.map(ruleType => ({ type: ruleType })),
   )
   if (errors && errors.length > 0) {
-    log.warn(`Encountered errors while listing file properties for SharingRules: ${errors}`)
+    log.warn('Encountered errors while listing file properties for SharingRules: %s', inspectValue(errors))
   }
   return result
 }


### PR DESCRIPTION
Improve Salesforce warning logs that print [object Object]

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
