### PR TITLE
SALTO-6549: Fix fetch isolated mode omitting field annotations

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -110,6 +110,10 @@ const separateChangeByFiles = async (change: DetailedChange, source: NaclFilesSo
   if (_.isEmpty(elementNaclFiles)) {
     return [change]
   }
+  if (elementNaclFiles.length === 1) {
+    // Optimization - no need to parse files and go over all the values if there is only one possible location
+    return [{ ...change, path: toPathHint(elementNaclFiles[0]) }]
+  }
   const sortedChanges = (
     await Promise.all(
       elementNaclFiles.map(async filename => {
@@ -129,6 +133,19 @@ const separateChangeByFiles = async (change: DetailedChange, source: NaclFilesSo
       }),
     )
   ).filter(values.isDefined)
+
+  if (sortedChanges.length <= 1) {
+    // The code in "filterByFile" can omit information if it did not exist in the source.
+    // There can be information that does not exist in the source if, for example, the change is a field type modification.
+    // in that case, the change would contain the whole field, but when we filter the annotation values of the field
+    // we would only know where to put the ones that existed before the type change, so the code above would omit
+    // all the new annotation values.
+    // Also, if all the annotation values are new, the entire change would be omitted because of "isEmptyChangeElement".
+    // The hacky bug fix here - assuming there is no case where we actually split the field to multiple files (a wrong assumption)
+    // we will get here with either 1 change that potentially is missing some values, or 0 changes (which is missing everything)
+    // either way, since there is no need to split anything, we can return the original change that contains all the values for sure
+    return [{ ...change, path: sortedChanges[0]?.path ?? change.path }]
+  }
 
   return sortedChanges
 }

--- a/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/routers.ts
@@ -144,7 +144,11 @@ const separateChangeByFiles = async (change: DetailedChange, source: NaclFilesSo
     // The hacky bug fix here - assuming there is no case where we actually split the field to multiple files (a wrong assumption)
     // we will get here with either 1 change that potentially is missing some values, or 0 changes (which is missing everything)
     // either way, since there is no need to split anything, we can return the original change that contains all the values for sure
-    return [{ ...change, path: sortedChanges[0]?.path ?? change.path }]
+    if (sortedChanges.length === 0) {
+      log.warn('separateChangeByFiles resulted in 0 sorted changes for change id %s', change.id.getFullName())
+      return [change]
+    }
+    return [{ ...change, path: sortedChanges[0].path }]
   }
 
   return sortedChanges

--- a/packages/workspace/test/workspace/multi_env/routers.test.ts
+++ b/packages/workspace/test/workspace/multi_env/routers.test.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { detailedCompare } from '@salto-io/adapter-utils'
+import { detailedCompare, toDetailedChangeFromBaseChange } from '@salto-io/adapter-utils'
 import {
   ElemID,
   Field,
@@ -23,6 +23,7 @@ import {
   ReferenceExpression,
   INSTANCE_ANNOTATIONS,
   toChange,
+  isAdditionChange,
 } from '@salto-io/adapter-api'
 import { ModificationDiff, RemovalDiff, AdditionDiff } from '@salto-io/dag'
 import { createMockNaclFileSource } from '../../common/nacl_file_source'
@@ -33,6 +34,7 @@ import {
   routeCopyTo,
   getMergeableParentID,
   routeRemoveFrom,
+  RoutedChanges,
 } from '../../../src/workspace/nacl_files/multi_env/routers'
 
 const hasChanges = (changes: DetailedChange[], lookup: { action: string; id: ElemID }[]): boolean =>
@@ -41,7 +43,7 @@ const hasChanges = (changes: DetailedChange[], lookup: { action: string; id: Ele
   )
 
 const objectElemID = new ElemID('salto', 'object')
-const commonField = { name: 'commonField', refType: BuiltinTypes.STRING }
+const commonField = { name: 'commonField', refType: BuiltinTypes.STRING, annotations: { before: 'before' } }
 const envField = { name: 'envField', refType: BuiltinTypes.STRING }
 const simpleObjID = new ElemID('salto', 'simple')
 const simpleObj = new ObjectType({
@@ -1043,6 +1045,100 @@ describe('isolated routing', () => {
       expect(secChangeData.data.after.annotations).toEqual(beforeField.annotations)
     },
   )
+  describe('with field type change for a field that exists in common', () => {
+    let routedChanges: RoutedChanges
+    let beforeField: Field
+    let afterField: Field
+    let fieldModification: DetailedChange
+    beforeEach(() => {
+      beforeField = splitObjJoined.fields.commonField
+      const afterObj = splitObjJoined.clone()
+      afterField = new Field(afterObj, beforeField.name, BuiltinTypes.NUMBER, { value: 'value' })
+      afterObj.fields.commonField = afterField
+      fieldModification = toDetailedChangeFromBaseChange(toChange({ before: beforeField, after: afterField }))
+    })
+    describe('when object type already exists in env', () => {
+      beforeEach(async () => {
+        const objInEnvs = new ObjectType({ elemID: splitObjJoined.elemID })
+        const testEnvSources = {
+          [primarySrcName]: createMockNaclFileSource([objInEnvs], { 'obj.nacl': [objInEnvs] }),
+          [secSrcName]: createMockNaclFileSource([objInEnvs], { 'obj.nacl': [objInEnvs] }),
+        }
+        routedChanges = await routeChanges(
+          [fieldModification],
+          primarySrcName,
+          commonSource,
+          testEnvSources,
+          'isolated',
+        )
+      })
+      it('should remove the field from common', () => {
+        expect(routedChanges.commonSource).toContainEqual(
+          expect.objectContaining({
+            action: 'remove',
+            id: beforeField.elemID,
+          }),
+        )
+      })
+      it('should add the original field value to secondary envs', () => {
+        const secondaryChanges = routedChanges.envSources?.[secSrcName] as DetailedChange[]
+        expect(secondaryChanges).toHaveLength(1)
+        const [change] = secondaryChanges
+        expect(change).toHaveProperty('action', 'add')
+        const afterValue = isAdditionChange(change) ? change.data.after : undefined
+        expect(afterValue).toBeDefined()
+        expect(afterValue).toBeInstanceOf(Field)
+        expect(afterValue).toHaveProperty('annotations', beforeField.annotations)
+        expect(afterValue.refType).toEqual(beforeField.refType)
+      })
+      it('should add the new field with all annotations to the primary env', () => {
+        const primaryChanges = routedChanges.envSources?.[primarySrcName] as DetailedChange[]
+        expect(primaryChanges).toHaveLength(1)
+        const [change] = primaryChanges
+        expect(change).toHaveProperty('action', 'add')
+        const afterValue = isAdditionChange(change) ? change.data.after : undefined
+        expect(afterValue).toBeDefined()
+        expect(afterValue).toBeInstanceOf(Field)
+        expect(afterValue).toHaveProperty('annotations', afterField.annotations)
+        expect(afterValue.refType).toEqual(afterField.refType)
+      })
+    })
+    describe('when object type does not exist in env', () => {
+      beforeEach(async () => {
+        routedChanges = await routeChanges([fieldModification], primarySrcName, commonSource, envSources, 'isolated')
+      })
+      it('should remove the field from common', () => {
+        expect(routedChanges.commonSource).toContainEqual(
+          expect.objectContaining({
+            action: 'remove',
+            id: beforeField.elemID,
+          }),
+        )
+      })
+      it('should add the original field value to secondary envs, wrapped in an object type', () => {
+        const secondaryChanges = routedChanges.envSources?.[secSrcName] as DetailedChange[]
+        expect(secondaryChanges).toHaveLength(1)
+        const [change] = secondaryChanges
+        expect(change).toHaveProperty('action', 'add')
+        const afterValue = isAdditionChange(change) ? change.data.after : undefined
+        expect(afterValue).toBeDefined()
+        expect(afterValue).toBeInstanceOf(ObjectType)
+        expect(afterValue.fields[beforeField.name]).toHaveProperty('annotations', beforeField.annotations)
+        expect(afterValue.fields[beforeField.name].refType).toEqual(beforeField.refType)
+      })
+      it('should add the new field with all annotations to the primary env, wrapped in an object type', () => {
+        const primaryChanges = routedChanges.envSources?.[primarySrcName] as DetailedChange[]
+        expect(primaryChanges).toHaveLength(1)
+        const [change] = primaryChanges
+        expect(change).toHaveProperty('action', 'add')
+        const afterValue = isAdditionChange(change) ? change.data.after : undefined
+        expect(afterValue).toBeDefined()
+        expect(afterValue).toBeInstanceOf(ObjectType)
+        expect(afterValue.fields[afterField.name]).toHaveProperty('annotations', afterField.annotations)
+        expect(afterValue.fields[afterField.name].refType).toEqual(afterField.refType)
+      })
+    })
+  })
   it('name', async () => {
     const annotationID = commonObjWithList.elemID.createNestedID('attr', 'list')
     const specificChange: DetailedChange = {


### PR DESCRIPTION
The change routing code would omit annotation values from fields when the field type changed. This is a hacky fix that does not really cover all cases, but should solve the most obvious ones at least

---

_Additional context for reviewer_
This issue was caught by the cli e2e, see ticket for more details on the scenario

---
_Release Notes_: 
Core:
- Fixed issue where fetch in "isolated" mode could potentially drop field attributes in some cases

---
_User Notifications_: 
_None_