### PR TITLE
SALTO-6549: Output plan from test when it does not match expected plan

### DIFF
--- a/packages/cli/e2e_test/helpers/jest_matchers.ts
+++ b/packages/cli/e2e_test/helpers/jest_matchers.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import type { ChangeError } from '@salto-io/adapter-api'
+import type { Plan, PlanItem } from '@salto-io/core'
+
+expect.extend({
+  toBeEmptyPlan(plan?: Plan) {
+    const formatPlanItem = (item: PlanItem): string =>
+      Array.from(item.changes())
+        .flatMap(change => Array.from(change.detailedChanges()))
+        .map(change => `${change.action}: ${change.id.getFullName()}`)
+        .join('\n')
+
+    const formatChangeError = (error: ChangeError): string =>
+      `${error.elemID.getFullName()}: ${error.message} (${error.detailedMessage})`
+
+    const formatPlan = (): string => {
+      if (plan === undefined) {
+        return 'undefined'
+      }
+      if (plan.size === 0 && plan.changeErrors.length === 0) {
+        return 'empty plan'
+      }
+      return ['changes:']
+        .concat(Array.from(plan.itemsByEvalOrder()).map(formatPlanItem))
+        .concat(['errors:'])
+        .concat(plan.changeErrors.map(formatChangeError))
+        .join('\n')
+    }
+
+    const createMessage = (expected: string): string =>
+      [
+        this.utils.matcherHint('toBeEmptyPlan', undefined, ''),
+        '',
+        `Expected: ${this.utils.printExpected(expected)}`,
+        `Received: ${this.utils.printReceived(formatPlan())}`,
+      ].join('\n')
+
+    if (plan?.size === 0 && plan?.changeErrors.length === 0) {
+      return {
+        message: () => createMessage('non empty plan'),
+        pass: true,
+      }
+    }
+
+    return {
+      message: () => createMessage('empty plan'),
+      pass: false,
+    }
+  },
+})
+
+interface CustomMatchers<R = unknown> {
+  toBeEmptyPlan(): R
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace jest {
+    interface Expect extends CustomMatchers {}
+    interface Matchers<R> extends CustomMatchers<R> {}
+    interface InverseAsymmetricMatchers extends CustomMatchers {}
+  }
+}

--- a/packages/cli/e2e_test/multi_env.test.ts
+++ b/packages/cli/e2e_test/multi_env.test.ts
@@ -40,6 +40,7 @@ import {
   getCurrentEnv,
   loadValidWorkspace,
 } from './helpers/workspace'
+import './helpers/jest_matchers'
 import * as templates from './helpers/templates'
 
 const { awu } = collections.asynciterable
@@ -267,8 +268,8 @@ describe.each([
     })
 
     describe('have empty previews', () => {
-      let env1Plan: Plan | undefined
-      let env2Plan: Plan | undefined
+      let env1Plan: Plan
+      let env2Plan: Plan
       beforeAll(async () => {
         await runSetEnv(baseDir, ENV1_NAME)
         env1Plan = await runPreviewGetPlan(baseDir, accounts)
@@ -276,8 +277,8 @@ describe.each([
         env2Plan = await runPreviewGetPlan(baseDir, accounts)
       })
       it('should have empty previews for all envs', async () => {
-        expect(env1Plan?.size).toBe(0)
-        expect(env2Plan?.size).toBe(0)
+        expect(env1Plan).toBeEmptyPlan()
+        expect(env2Plan).toBeEmptyPlan()
       })
     })
 
@@ -355,7 +356,7 @@ describe.each([
       })
 
       it('should have empty preview for the env from which the element was fetched', () => {
-        expect(afterFetchPlan?.size).toBe(0)
+        expect(afterFetchPlan).toBeEmptyPlan()
       })
     })
 
@@ -372,8 +373,8 @@ describe.each([
         }
         await runDeploy({ workspacePath: baseDir })
       })
-      it('should have a non empty preview for the target enviornment', () => {
-        expect(afterOtherEnvFetchPlan?.size).toBeGreaterThan(0)
+      it('should have a non empty preview for the target environment', () => {
+        expect(afterOtherEnvFetchPlan).not.toBeEmptyPlan()
       })
 
       it('should create the element in the target env', async () => {
@@ -410,7 +411,7 @@ describe.each([
         expect(commonInstWithDiffEnv1FilePath()).not.toExist()
       })
       it('should have empty preview after fetching the delete changes', () => {
-        expect(afterDeleteFetchPlan?.size).toBe(0)
+        expect(afterDeleteFetchPlan).toBeEmptyPlan()
       })
     })
 
@@ -423,8 +424,8 @@ describe.each([
         await runDeploy({ workspacePath: baseDir, allowErrors: true })
       })
 
-      it('should have a non empty preview for the target enviornment', () => {
-        expect(afterDeleteOtherEnvFetchPlan?.size).toBeGreaterThan(0)
+      it('should have a non empty preview for the target environment', () => {
+        expect(afterDeleteOtherEnvFetchPlan).not.toBeEmptyPlan()
       })
 
       it('should delete the elements in the target env', async () => {
@@ -572,8 +573,8 @@ describe.each([
       })
 
       it('Should have non-empty deploy plans', () => {
-        expect(env1DeployPlan?.size).not.toEqual(0)
-        expect(env2DeployPlan?.size).not.toEqual(0)
+        expect(env1DeployPlan).not.toBeEmptyPlan()
+        expect(env2DeployPlan).not.toBeEmptyPlan()
       })
 
       it('should remove common elements from nacl change', async () => {


### PR DESCRIPTION
Before this change, when the test failed due to a plan that was not as expected we would only know the size was wrong and we would not get the actual changes

Added toBeEmptyPlan custom matcher to allow tests to verify if a plan is empty in a way that will print the plan if it is not as expected

---

_Additional context for reviewer_
example output from a failed run on this PR can be found [here](https://app.circleci.com/pipelines/github/salto-io/salto/28870/workflows/3bd88849-dd32-43fe-9194-3a8626e89c06/jobs/293152/parallel-runs/0/steps/0-106) (search for "empty plan" in the output)

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_