### PR TITLE
Allow ignoring empty query args, fix precedence during recursion

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -53,6 +53,7 @@ export type ClientBaseParams = {
     // true: &arg[0]=val1&arg[1]=val2
     // null: &arg=val1&arg=val2
     indexes?: boolean | null
+    omitEmpty?: boolean
   }
 }
 
@@ -301,13 +302,15 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
       throw new Error(`uninitialized ${this.clientName} client`)
     }
 
-    const { url, queryParams, headers, responseType, queryParamsSerializer: paramsSerializer } = params
+    const { url, queryParams, headers, responseType, queryParamsSerializer } = params
     const data = isMethodWithData(params) ? params.data : undefined
+    const paramsSerializer = _.omit(queryParamsSerializer, 'omitEmpty')
+    const filteredQueryParams = queryParamsSerializer?.omitEmpty ? _.omitBy(queryParams, _.isEmpty) : queryParams
 
     try {
-      const requestConfig = [queryParams, headers, responseType, paramsSerializer].some(values.isDefined)
+      const requestConfig = [filteredQueryParams, headers, responseType, paramsSerializer].some(values.isDefined)
         ? {
-            params: queryParams,
+            params: filteredQueryParams,
             headers,
             responseType,
             paramsSerializer,

--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -304,7 +304,8 @@ export abstract class AdapterHTTPClient<TCredentials, TRateLimitConfig extends C
 
     const { url, queryParams, headers, responseType, queryParamsSerializer } = params
     const data = isMethodWithData(params) ? params.data : undefined
-    const paramsSerializer = _.omit(queryParamsSerializer, 'omitEmpty')
+    const paramsSerializerObj = _.omit(queryParamsSerializer, 'omitEmpty')
+    const paramsSerializer = _.isEmpty(paramsSerializerObj) ? undefined : paramsSerializerObj
     const filteredQueryParams = queryParamsSerializer?.omitEmpty ? _.omitBy(queryParams, _.isEmpty) : queryParams
 
     try {

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -30,6 +30,8 @@ export type RequestArgs = {
     // true: &arg[0]=val1&arg[1]=val2
     // null: &arg=val1&arg=val2
     indexes?: boolean | null
+    // when true, empty strings will be omitted from the query params
+    omitEmpty?: boolean
   }
   // TODO support x-www-form-urlencoded + URLSearchParams
   body?: unknown

--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -30,7 +30,7 @@ export type RequestArgs = {
     // true: &arg[0]=val1&arg[1]=val2
     // null: &arg=val1&arg=val2
     indexes?: boolean | null
-    // when true, empty strings will be omitted from the query params
+    // when true, empty values will be omitted from the query params
     omitEmpty?: boolean
   }
   // TODO support x-www-form-urlencoded + URLSearchParams

--- a/packages/adapter-components/src/fetch/resource/resource_manager.ts
+++ b/packages/adapter-components/src/fetch/resource/resource_manager.ts
@@ -70,7 +70,7 @@ export const createResourceManager = <ClientOptions extends string>({
             query,
             requester,
             handleError: elementGenerator.handleError,
-            initialRequestContext: _.defaults({}, initialRequestContext, context),
+            initialRequestContext: _.defaults({}, context, initialRequestContext),
             customItemFilter,
           })
         const directFetchResourceDefs = _.pickBy(resourceDefQuery.getAll(), def => def.directFetch)

--- a/packages/adapter-components/test/client/http_client.test.ts
+++ b/packages/adapter-components/test/client/http_client.test.ts
@@ -72,20 +72,27 @@ describe('client_http_client', () => {
         accountId: 'ACCOUNT_ID',
       })
       mockAxiosAdapter.onGet('/ep').replyOnce(200, { a: 'b' }, { h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' })
-      mockAxiosAdapter.onGet('/ep2', { a: ['AAA', 'BBB'] }).replyOnce(200, { c: 'd' }, { hh: 'header' })
+      mockAxiosAdapter.onGet('/ep2', { a: ['AAA', 'BBB'], c: '' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
+      mockAxiosAdapter.onGet('/ep3', { a: 'A' }).replyOnce(200, { c: 'd' }, { hh: 'header' })
 
       const getRes = await client.get({ url: '/ep' })
       const getRes2 = await client.get({
         url: '/ep2',
-        queryParams: { a: ['AAA', 'BBB'] },
+        queryParams: { a: ['AAA', 'BBB'], c: '' },
         queryParamsSerializer: { indexes: null },
+      })
+      const getRes3 = await client.get({
+        url: '/ep3',
+        queryParams: { a: 'A', b: '' },
+        queryParamsSerializer: { omitEmpty: true },
       })
       expect(getRes).toEqual({ data: { a: 'b' }, status: 200, headers: { 'X-Rate-Limit': '456', 'Retry-After': '93' } })
       expect(getRes2).toEqual({ data: { c: 'd' }, status: 200, headers: {} })
-      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(2)
+      expect(getRes3).toEqual({ data: { c: 'd' }, status: 200, headers: {} })
+      expect(clearValuesFromResponseDataFunc).toHaveBeenCalledTimes(3)
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(1, { a: 'b' }, '/ep')
       expect(clearValuesFromResponseDataFunc).toHaveBeenNthCalledWith(2, { c: 'd' }, '/ep2')
-      expect(extractHeadersFunc).toHaveBeenCalledTimes(4)
+      expect(extractHeadersFunc).toHaveBeenCalledTimes(6)
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(
         1,
         new AxiosHeaders({ h: '123', 'X-Rate-Limit': '456', 'Retry-After': '93' }),
@@ -96,6 +103,8 @@ describe('client_http_client', () => {
       )
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(3, new AxiosHeaders({ hh: 'header' }))
       expect(extractHeadersFunc).toHaveBeenNthCalledWith(4, new AxiosHeaders({ hh: 'header' }))
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(5, new AxiosHeaders({ hh: 'header' }))
+      expect(extractHeadersFunc).toHaveBeenNthCalledWith(6, new AxiosHeaders({ hh: 'header' }))
       const request = mockAxiosAdapter.history.get[2]
       expect(request.url).toEqual('/ep2')
       expect(request.paramsSerializer).toEqual({ indexes: null })


### PR DESCRIPTION
* Add an option to omit empty query args - which will allow unsetting values more easily when placeholders are defined (this still won't cover everything - we can later add conditions on fetch requests as well)
* Reverse order of precedence between initial context and overrides received from recurseInto args, to allow self-recursion

---
_Release Notes_: 
None

---
_User Notifications_: 
None