### PR TITLE
SALTO-6577: support OAuth server scopes

### DIFF
--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -804,6 +804,51 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
+    OAuth2Scope: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{authServerId}/scopes',
+                  method: 'post',
+                },
+                context: {
+                  authServerId: '{_parent.0.id}',
+                },
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{authServerId}/scopes/{id}',
+                  method: 'put',
+                },
+                context: {
+                  authServerId: '{_parent.0.id}',
+                },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{authServerId}/scopes/{id}',
+                  method: 'delete',
+                },
+                context: {
+                  authServerId: '{_parent.0.id}',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
   }
 
   return _.merge(standardRequestDefinitions, customDefinitions)

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -811,11 +811,8 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: {
-                  path: '/api/v1/authorizationServers/{authServerId}/scopes',
+                  path: '/api/v1/authorizationServers/{parent_id}/scopes',
                   method: 'post',
-                },
-                context: {
-                  authServerId: '{_parent.0.id}',
                 },
               },
             },
@@ -824,11 +821,8 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: {
-                  path: '/api/v1/authorizationServers/{authServerId}/scopes/{id}',
+                  path: '/api/v1/authorizationServers/{parent_id}/scopes/{id}',
                   method: 'put',
-                },
-                context: {
-                  authServerId: '{_parent.0.id}',
                 },
               },
             },
@@ -837,11 +831,8 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: {
-                  path: '/api/v1/authorizationServers/{authServerId}/scopes/{id}',
+                  path: '/api/v1/authorizationServers/{parent_id}/scopes/{id}',
                   method: 'delete',
-                },
-                context: {
-                  authServerId: '{_parent.0.id}',
                 },
               },
             },

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -284,6 +284,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'kid',
     target: { type: JWK_TYPE_NAME },
   },
+  {
+    src: { field: 'include', parentTypes: ['OAuth2ScopesMediationPolicyRuleCondition'] },
+    serializationStrategy: 'name',
+    target: { type: 'OAuth2Scope' },
+  },
 ]
 
 const userReferenceRules: OktaFieldReferenceDefinition[] = [


### PR DESCRIPTION

Adde deploy support for `OAuth2Scope` type, and a missing ref from ` AuthorizationServerPolicyRule` to `OAuth2Scope`

---

_Additional context for reviewer_

will add tests & noise reduction later

---
_Release Notes_: 
_Okta_adapter_:
- Support deployment of Authorization Server scopes 
- Fix a bug in deployment of Authorization Server Policy Rules that references scopes

---
_User Notifications_: 

_Okta_adapter_:
- Reference will be added in Authorization Server Policy Rule that references Auth Scopes