### PR TITLE
SALTO-6531: Change custom name logic in Okta to be less strict

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -386,11 +386,13 @@ const getHiddenFieldsToOmit = (
 ): string[] => {
   const customizations = definitionsUtils.queryWithDefault(fetchDefinitions.instances).query(typeName)
     ?.element?.fieldCustomizations
-  return Object.entries(customizations ?? {})
-    .filter(([, customization]) => customization.hide === true)
-    .map(([fieldName]) => fieldName)
-    // ignore fields that are written to nacl after deployment
-    .filter(fieldName => !['id', CUSTOM_NAME_FIELD].includes(fieldName))
+  return (
+    Object.entries(customizations ?? {})
+      .filter(([, customization]) => customization.hide === true)
+      .map(([fieldName]) => fieldName)
+      // ignore fields that are written to nacl after deployment
+      .filter(fieldName => !['id', CUSTOM_NAME_FIELD].includes(fieldName))
+  )
 }
 
 describe('Okta adapter E2E', () => {

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -50,6 +50,7 @@ import {
   AUTHENTICATOR_TYPE_NAME,
   BRAND_THEME_TYPE_NAME,
   BRAND_TYPE_NAME,
+  CUSTOM_NAME_FIELD,
   DOMAIN_TYPE_NAME,
   GROUP_RULE_TYPE_NAME,
   GROUP_TYPE_NAME,
@@ -388,7 +389,8 @@ const getHiddenFieldsToOmit = (
   return Object.entries(customizations ?? {})
     .filter(([, customization]) => customization.hide === true)
     .map(([fieldName]) => fieldName)
-    .filter(fieldName => fieldName !== 'id')
+    // ignore fields that are written to nacl after deployment
+    .filter(fieldName => !['id', CUSTOM_NAME_FIELD].includes(fieldName))
 }
 
 describe('Okta adapter E2E', () => {

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -335,7 +335,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 additional: {
                   adjust: async ({ value, context }) => {
                     const subdomain = await getSubdomainFromElementsSource(context.elementSource)
-                    if (subdomain !== undefined && isCustomApp(value as Values, subdomain)) {
+                    if (isCustomApp(value as Values, subdomain)) {
                       const createdAppName = _.get(value, NAME_FIELD)
                       return {
                         value: {

--- a/packages/okta-adapter/src/definitions/fetch/types/application.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/application.ts
@@ -88,7 +88,7 @@ export const isCustomApp = (value: Values, subdomain?: string): boolean => {
     )
   }
 
-  // when subdomain was replaced in the tenant, existing apps will include the prevoius subdomain in their name, so we rely on the regex as a fallback
+  // when subdomain was replaced in the tenant, existing apps will include the previous subdomain in their name, so we rely on the regex as a fallback
   const isCustomAppName = subdomainMatch || customAppNamePatternMatch
   return [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) && isCustomAppName
 }

--- a/packages/okta-adapter/src/definitions/fetch/types/application.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/application.ts
@@ -57,34 +57,38 @@ export const assignPolicyIdsToApplication = (value: unknown): Value => {
   }
 }
 
-const endsWithNumberRegex = new RegExp(/_\d+$/)
+// custom app name pattern is: subdomain_appName_number
+const customAppNamePattern = new RegExp(/^[\w-]+_[\w-]+_\d+$/)
 
-export const isCustomApp = (value: Values, subdomain: string): boolean => {
+export const isCustomApp = (value: Values, subdomain?: string): boolean => {
   const subdomainMatch =
+    _.isString(subdomain) &&
     value.name !== undefined &&
     // custom app names starts with subdomain and '_'
     _.startsWith(value.name, `${subdomain}_`)
 
-  const endsWithNumberMatch =
+  const customAppNamePatternMatch =
     value.name !== undefined &&
     // custom app names ends with a number
-    endsWithNumberRegex.test(value.name)
+    customAppNamePattern.test(value.name)
 
-  if (subdomainMatch !== endsWithNumberMatch) {
-    log.warn(
-      'isCustomApp matching methods disagree for %s: subdomainMatch=%s, endsWithNumberMatch=%s',
+  if (subdomainMatch !== customAppNamePatternMatch) {
+    log.debug(
+      'isCustomApp matching methods disagree for %s: subdomainMatch=%s, customAppNamePatternMatch=%s',
       value.name,
       subdomainMatch,
-      endsWithNumberMatch,
+      customAppNamePatternMatch,
     )
   } else {
-    log.info(
-      'isCustomApp matching methods agree for %s: subdomainMatch=%s, endsWithNumberMatch=%s',
+    log.trace(
+      'isCustomApp matching methods agree for %s: subdomainMatch=%s, customAppNamePatternMatch=%s',
       value.name,
       subdomainMatch,
-      endsWithNumberMatch,
+      customAppNamePatternMatch,
     )
   }
 
-  return [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) && subdomainMatch
+  // when subdomain was replaced in the tenant, existing apps will include the prevoius subdomain in their name, so we rely on the regex as a fallback
+  const isCustomAppName = subdomainMatch || customAppNamePatternMatch
+  return [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) && isCustomAppName
 }

--- a/packages/okta-adapter/src/filters/app_fetch.ts
+++ b/packages/okta-adapter/src/filters/app_fetch.ts
@@ -45,11 +45,11 @@ const filterCreator: FilterCreator = () => ({
     const orgInstance = instances.find(instance => instance.elemID.typeName === ORG_SETTING_TYPE_NAME)
     const subdomain = orgInstance?.value?.subdomain
     if (!_.isString(subdomain)) {
-      log.error('Could not create customName field for custom apps because subdomain was missing')
+      log.error('subdomain field is missing and will not be used to determined if the app is custom')
     }
     appInstances.forEach(app => {
       // create customName field for non-custom apps and delete name field as its value is not multienv
-      if (_.isString(subdomain) && isCustomApp(app.value, subdomain)) {
+      if (isCustomApp(app.value, subdomain)) {
         app.value.customName = app.value.name
         delete app.value.name
       }

--- a/packages/okta-adapter/test/definitions/fetch/types/application.test.ts
+++ b/packages/okta-adapter/test/definitions/fetch/types/application.test.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { assignPolicyIdsToApplication } from '../../../../src/definitions/fetch/types/application'
+import { assignPolicyIdsToApplication, isCustomApp } from '../../../../src/definitions/fetch/types/application'
 
 describe('application', () => {
   it('should replace create new fields from urls with ids', () => {
@@ -68,5 +68,43 @@ describe('application', () => {
     const res = assignPolicyIdsToApplication(appValue)
     expect(res.profileEnrollment).toBeUndefined()
     expect(res.accessPolicy).toBeUndefined()
+  })
+
+  describe('isCustomApp', () => {
+    const appValue = {
+      name: 'oie-123_myAppName_2',
+      signOnMode: 'AUTO_LOGIN',
+      settings: {
+        url: 'https://test.salto.com/acme',
+      },
+    }
+    describe('with subdomain', () => {
+      const subdomain = 'oie-123'
+      it('should return true when name match subdomain', () => {
+        expect(isCustomApp(appValue, subdomain)).toEqual(true)
+      })
+      it('should return false when name does not match subdomain and does not match custom app name pattern', () => {
+        const app = { ...appValue }
+        app.name = 'jira_cloud2'
+        expect(isCustomApp(app, subdomain)).toEqual(false)
+      })
+    })
+    describe('without subdomain', () => {
+      it('should return true when name match custom app pattern and application signOnMode is AUTO_LOGIN', () => {
+        expect(isCustomApp(appValue)).toEqual(true)
+      })
+      it('should return true when name match custom app pattern and application signOnMode is SAML_2_0', () => {
+        appValue.signOnMode = 'SAML_2_0'
+        expect(isCustomApp(appValue)).toEqual(true)
+      })
+      it('should return false when name does not match custom app pattern', () => {
+        appValue.name = 'myAppName_2'
+        expect(isCustomApp(appValue)).toEqual(false)
+      })
+      it('should return false when name match custom app pattern but application signOnMode is not AUTO_LOGIN or SAML_2_0', () => {
+        appValue.signOnMode = 'BROWSER_PLUGIN'
+        expect(isCustomApp(appValue)).toEqual(false)
+      })
+    })
   })
 })


### PR DESCRIPTION
Our current custom app logic didn't take into account domain changes, this PR fixes this

---

_Additional context for reviewer_
When the subdomain of the tenant changes, apps created before the changes will keep the name of the original domain and will not get updated. This leads to cases when we false detect certain apps as non custom, though they actually are.

This PR introduces a new logic to determine if an app is custom - 
1. If the OrgSetting type exist, we will use the domain
2. If there's no match, we will use the tenant_appName_number pattern to detect it

---
_Release Notes_: 

_Okta_adapter_:
- Fix a bug in the deployment of custom apps when subdomain has changed.

---
_User Notifications_: 

_Okta_adapter_:
- Name field will be removed for custom SAML and AUTO_LOGIN applications.

