### PR TITLE
SALTO-6480 make sure there are no dups before cloning fields parent

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -262,8 +262,10 @@ const getClonedElements = (elements: Element[]): Element[] => {
     clonedRestOfElements.filter(isObjectType).map(type => [type.elemID.getFullName(), type]),
   )
   const clonedMissingParentsMap = new Map(
-    fields
-      .map(field => field.parent)
+    _.uniqBy(
+      fields.map(field => field.parent),
+      parent => parent.elemID.getFullName(),
+    )
       .filter(parent => !clonedTypesMap.has(parent.elemID.getFullName()))
       .map(parent => [parent.elemID.getFullName(), parent.clone()]),
   )


### PR DESCRIPTION
On `getClonedElements` in `workspace` package, we are cloning the parent of each Field. This might cause an OOM error, we should first filter out duplications before cloning

---



---

_Release Notes_: 
_Core_:
- fix OOM error when cloning large amount of Fields

---

_User Notifications_: 
None
