### PR TITLE
Improve memory usage of custom references calculation in Jira

### DIFF
--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -6,7 +6,6 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import Joi from 'joi'
 import {
   CORE_ANNOTATIONS,
   ElemID,
@@ -18,8 +17,9 @@ import {
   Values,
   ReadOnlyElementsSource,
   ReferenceExpression,
+  Value,
 } from '@salto-io/adapter-api'
-import { createSchemeGuard, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { isResolvedReferenceExpression } from '@salto-io/adapter-utils'
 import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { findObject } from '../../utils'
@@ -31,36 +31,16 @@ const log = logger(module)
 
 const { awu } = collections.asynciterable
 
-type FieldItem = {
-  description?: string
-  isHidden?: boolean
-  isRequired?: boolean
-  renderer?: string
-}
-
-type EnrichedFieldItem = FieldItem & { id: ReferenceExpression }
-
-type FieldConfigurationItems = {
-  [key: string]: FieldItem
-}
-
-const FIELD_CONFIGURATION_ITEM_SCHEME = Joi.object({
-  description: Joi.optional(),
-  isHidden: Joi.boolean().optional(),
-  isRequired: Joi.boolean().optional(),
-  renderer: Joi.optional(),
-})
-
-const FIELD_CONFIGURATION_ITEMS_SCHEME = Joi.object().pattern(/.*/, FIELD_CONFIGURATION_ITEM_SCHEME)
-
-const isFieldConfigurationItems = createSchemeGuard<FieldConfigurationItems>(FIELD_CONFIGURATION_ITEMS_SCHEME)
-
 const enrichFieldItem = async (
   fieldName: string,
-  fieldItem: FieldItem,
+  fieldItem: Value,
   elementSource: ReadOnlyElementsSource,
   instanceName: string,
-): Promise<EnrichedFieldItem | undefined> => {
+): Promise<Exclude<Value, undefined> | undefined> => {
+  if (!_.isPlainObject(fieldItem)) {
+    log.warn('field item is not plain object - ignoring it')
+    return undefined
+  }
   const elemId = new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', fieldName)
   const fieldInstance = await elementSource.get(elemId)
   if (fieldInstance === undefined) {
@@ -86,7 +66,7 @@ const replaceToMap = (instance: InstanceElement): void => {
 
 const replaceFromMap = async (instance: InstanceElement, elementSource: ReadOnlyElementsSource): Promise<void> => {
   const fieldConfigurationItems = instance.value.fields
-  if (fieldConfigurationItems === undefined || !isFieldConfigurationItems(fieldConfigurationItems)) {
+  if (!_.isPlainObject(fieldConfigurationItems)) {
     log.warn(`fields value is corrupted in instance ${instance.elemID.getFullName()}, hence not changing fields format`)
     return
   }

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -36,9 +36,9 @@ const enrichFieldItem = async (
   fieldItem: Value,
   elementSource: ReadOnlyElementsSource,
   instanceName: string,
-): Promise<Exclude<Value, undefined> | undefined> => {
+): Promise<Value> => {
   if (!_.isPlainObject(fieldItem)) {
-    log.warn('field item is not plain object - ignoring it')
+    log.warn('ignoring field item %s in instance %s that is not plain object: %o', fieldName, instanceName, fieldItem)
     return undefined
   }
   const elemId = new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', fieldName)
@@ -66,8 +66,15 @@ const replaceToMap = (instance: InstanceElement): void => {
 
 const replaceFromMap = async (instance: InstanceElement, elementSource: ReadOnlyElementsSource): Promise<void> => {
   const fieldConfigurationItems = instance.value.fields
+  if (fieldConfigurationItems === undefined) {
+    return
+  }
   if (!_.isPlainObject(fieldConfigurationItems)) {
-    log.warn(`fields value is corrupted in instance ${instance.elemID.getFullName()}, hence not changing fields format`)
+    log.warn(
+      'fields value is corrupted in instance %s, hence not changing fields format: %o',
+      instance.elemID.getFullName(),
+      fieldConfigurationItems,
+    )
     return
   }
   instance.value.fields = await awu(Object.entries(fieldConfigurationItems))

--- a/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/field_configuration/replace_field_configuration_references.ts
@@ -67,6 +67,7 @@ const replaceToMap = (instance: InstanceElement): void => {
 const replaceFromMap = async (instance: InstanceElement, elementSource: ReadOnlyElementsSource): Promise<void> => {
   const fieldConfigurationItems = instance.value.fields
   if (fieldConfigurationItems === undefined) {
+    log.warn('fields value is missing in instance %s, hence not changing fields format', instance.elemID.getFullName())
     return
   }
   if (!_.isPlainObject(fieldConfigurationItems)) {

--- a/packages/jira-adapter/src/weak_references/field_configuration_items.ts
+++ b/packages/jira-adapter/src/weak_references/field_configuration_items.ts
@@ -28,6 +28,10 @@ const log = logger(module)
 const getFieldReferences = (instance: InstanceElement, fieldElemIdsMap: Record<string, ElemID>): ReferenceInfo[] => {
   const fieldConfigurationItems = instance.value.fields
   if (fieldConfigurationItems === undefined) {
+    log.warn(
+      'fields value is missing in instance %s, hence not calculating fields weak references',
+      instance.elemID.getFullName(),
+    )
     return []
   }
   if (!_.isPlainObject(fieldConfigurationItems)) {
@@ -86,6 +90,10 @@ const removeMissingFields: WeakReferencesHandler['removeWeakReferences'] =
         .map(async instance => {
           const fieldConfigurationItems = instance.value.fields
           if (fieldConfigurationItems === undefined) {
+            log.warn(
+              'fields value is missing in instance %s, hence not omitting missing fields',
+              instance.elemID.getFullName(),
+            )
             return undefined
           }
           if (!_.isPlainObject(fieldConfigurationItems)) {

--- a/packages/jira-adapter/src/weak_references/field_configuration_items.ts
+++ b/packages/jira-adapter/src/weak_references/field_configuration_items.ts
@@ -51,18 +51,17 @@ const getFieldReferences = (instance: InstanceElement, fieldToElemId: Record<str
 /**
  * Marks each field reference in field configuration as a weak reference.
  */
-const getFieldConfigurationItemsReferences: GetCustomReferencesFunc = async elements =>
-  log.timeDebug(
-    () => {
-      const fieldToElemId: Record<string, ElemID> = {}
-      return elements
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
-        .flatMap(instance => getFieldReferences(instance, fieldToElemId))
-    },
-    'getFieldConfigurationItemsReferences for %d elements',
-    elements.length,
+const getFieldConfigurationItemsReferences: GetCustomReferencesFunc = async elements => {
+  const fieldConfigurationInstances = elements
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
+  const fieldToElemId: Record<string, ElemID> = {}
+  return log.timeDebug(
+    () => fieldConfigurationInstances.flatMap(instance => getFieldReferences(instance, fieldToElemId)),
+    'getFieldConfigurationItemsReferences for %d FieldConfiguration instances',
+    fieldConfigurationInstances.length,
   )
+}
 
 const fieldExists = async (fieldName: string, elementSource: ReadOnlyElementsSource): Promise<boolean> => {
   const elemId = new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', fieldName)

--- a/packages/jira-adapter/src/weak_references/field_configuration_items.ts
+++ b/packages/jira-adapter/src/weak_references/field_configuration_items.ts
@@ -35,7 +35,9 @@ const getFieldReferences = (instance: InstanceElement, fieldElemIdsMap: FieldEle
   }
   if (!_.isPlainObject(fieldConfigurationItems)) {
     log.warn(
-      `fields value is corrupted in instance ${instance.elemID.getFullName()}, hence not calculating fields weak references`,
+      'fields value is corrupted in instance %s, hence not calculating fields weak references: %o',
+      instance.elemID.getFullName(),
+      fieldConfigurationItems,
     )
     return []
   }
@@ -87,9 +89,14 @@ const removeMissingFields: WeakReferencesHandler['removeWeakReferences'] =
         .filter(instance => instance.elemID.typeName === FIELD_CONFIGURATION_TYPE_NAME)
         .map(async instance => {
           const fieldConfigurationItems = instance.value.fields
+          if (fieldConfigurationItems === undefined) {
+            return undefined
+          }
           if (!_.isPlainObject(fieldConfigurationItems)) {
             log.warn(
-              `fields value is corrupted in instance ${instance.elemID.getFullName()}, hence not omitting missing fields`,
+              'fields value is corrupted in instance %s, hence not omitting missing fields: %o',
+              instance.elemID.getFullName(),
+              fieldConfigurationItems,
             )
             return undefined
           }

--- a/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
+++ b/packages/jira-adapter/test/filters/field_configuration/replace_field_configuration_references.test.ts
@@ -109,6 +109,18 @@ describe('replaceFieldConfigurationReferencesFilter', () => {
       })
     })
 
+    it('should do nothing if fields is corrupted', async () => {
+      instance.value.fields = 'invalid'
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toEqual('invalid')
+    })
+
+    it('should omit corrupted fields', async () => {
+      instance.value.fields.anotherField = 'invalid'
+      await filter.preDeploy?.([toChange({ after: instance })])
+      expect(instance.value.fields).toBeArrayOfSize(1)
+    })
+
     it('should do nothing if splitFieldConfiguration is true', async () => {
       config.fetch.splitFieldConfiguration = true
       await filter.preDeploy?.([toChange({ after: instance })])


### PR DESCRIPTION
In `getFieldConfigurationItemsReferences`:
1. I removed the usage of `joi` schema for `fields` in `FieldConfiguration` instances, because I suspected that it has memory/runtime implications, and we actually only care about the key of each field in `fields`
2. I reused the `elemIDs` of the `Field` instances, because there's no reason to create a new `ElemID` object in memory for each field in each fieldConfiguration instance, as all fieldConfiguration instances reference the same field instances (`ElemID` objects are immutable, so there's no problem sharing them).

Those improvements made it possible to run `salto workspace cache update` on a really large Jira environment - with more that 1M references of `Field` instances in `FieldConfiguration` instances.

---

_Additional context for reviewer_

---
_Release Notes_: 
Jira Adapter:
- Improve memory usage of custom references calculation

---
_User Notifications_: 
None
