### PR TITLE
SALTO-6428: Change Microsoft Security type names to PascalCase

### DIFF
--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -105,31 +105,3 @@ export type RecursivePartial<T> = {
       ? RecursivePartial<T[P]>
       : T[P]
 }
-
-export type UPPER_CASE_LETTERS =
-  | 'A'
-  | 'B'
-  | 'C'
-  | 'D'
-  | 'E'
-  | 'F'
-  | 'G'
-  | 'H'
-  | 'I'
-  | 'J'
-  | 'K'
-  | 'L'
-  | 'M'
-  | 'N'
-  | 'O'
-  | 'P'
-  | 'Q'
-  | 'R'
-  | 'S'
-  | 'T'
-  | 'U'
-  | 'V'
-  | 'W'
-  | 'X'
-  | 'Y'
-  | 'Z'

--- a/packages/lowerdash/src/types.ts
+++ b/packages/lowerdash/src/types.ts
@@ -105,3 +105,31 @@ export type RecursivePartial<T> = {
       ? RecursivePartial<T[P]>
       : T[P]
 }
+
+export type UPPER_CASE_LETTERS =
+  | 'A'
+  | 'B'
+  | 'C'
+  | 'D'
+  | 'E'
+  | 'F'
+  | 'G'
+  | 'H'
+  | 'I'
+  | 'J'
+  | 'K'
+  | 'L'
+  | 'M'
+  | 'N'
+  | 'O'
+  | 'P'
+  | 'Q'
+  | 'R'
+  | 'S'
+  | 'T'
+  | 'U'
+  | 'V'
+  | 'W'
+  | 'X'
+  | 'Y'
+  | 'Z'

--- a/packages/microsoft-security-adapter/src/constants/entra.ts
+++ b/packages/microsoft-security-adapter/src/constants/entra.ts
@@ -6,11 +6,12 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { fetch as fetchUtils } from '@salto-io/adapter-components'
+import { types } from '@salto-io/lowerdash'
 import { ODATA_PREFIX } from './shared'
 
 const { recursiveNestedTypeName } = fetchUtils.element
 
-const toEntraTypeName = (typeName: string): string => `entra_${typeName}`
+const toEntraTypeName = (typeName: `${types.UPPER_CASE_LETTERS}${string}`): string => `Entra${typeName}`
 
 /* Fields */
 export const APP_ROLE_ASSIGNMENT_FIELD_NAME = 'appRoleAssignments'
@@ -27,30 +28,30 @@ export const PRE_AUTHORIZED_APPLICATIONS_FIELD_NAME = 'preAuthorizedApplications
 
 /* Type names */
 // Top level
-export const ADMINISTRATIVE_UNIT_TYPE_NAME = toEntraTypeName('administrativeUnit')
-export const APPLICATION_TYPE_NAME = toEntraTypeName('application')
-export const APP_ROLE_TYPE_NAME = toEntraTypeName('appRole')
-export const AUTHENTICATION_STRENGTH_POLICY_TYPE_NAME = toEntraTypeName('authenticationStrengthPolicy')
-export const AUTHENTICATION_METHOD_POLICY_TYPE_NAME = toEntraTypeName('authenticationMethodPolicy')
-export const CLAIM_MAPPING_POLICY_TYPE_NAME = toEntraTypeName('claimMappingPolicy')
-export const CONDITIONAL_ACCESS_POLICY_TYPE_NAME = toEntraTypeName('conditionalAccessPolicy')
+export const ADMINISTRATIVE_UNIT_TYPE_NAME = toEntraTypeName('AdministrativeUnit')
+export const APPLICATION_TYPE_NAME = toEntraTypeName('Application')
+export const APP_ROLE_TYPE_NAME = toEntraTypeName('AppRole')
+export const AUTHENTICATION_STRENGTH_POLICY_TYPE_NAME = toEntraTypeName('AuthenticationStrengthPolicy')
+export const AUTHENTICATION_METHOD_POLICY_TYPE_NAME = toEntraTypeName('AuthenticationMethodPolicy')
+export const CLAIM_MAPPING_POLICY_TYPE_NAME = toEntraTypeName('ClaimMappingPolicy')
+export const CONDITIONAL_ACCESS_POLICY_TYPE_NAME = toEntraTypeName('ConditionalAccessPolicy')
 export const CONDITIONAL_ACCESS_POLICY_NAMED_LOCATION_TYPE_NAME = toEntraTypeName(
-  'conditionalAccessPolicyNamedLocation',
+  'ConditionalAccessPolicyNamedLocation',
 )
-export const CROSS_TENANT_ACCESS_POLICY_TYPE_NAME = toEntraTypeName('crossTenantAccessPolicy')
-export const CUSTOM_SECURITY_ATTRIBUTE_DEFINITION_TYPE_NAME = toEntraTypeName('customSecurityAttributeDefinition')
-export const CUSTOM_SECURITY_ATTRIBUTE_SET_TYPE_NAME = toEntraTypeName('customSecurityAttributeSet')
-export const DOMAIN_TYPE_NAME = toEntraTypeName('domain')
-export const DIRECTORY_ROLE_TYPE_NAME = toEntraTypeName('directoryRole')
-export const DIRECTORY_ROLE_TEMPLATE_TYPE_NAME = toEntraTypeName('directoryRoleTemplate')
-export const GROUP_TYPE_NAME = toEntraTypeName('group')
-export const HOME_REALM_DISCOVERY_POLICY_TYPE_NAME = toEntraTypeName('homeRealmDiscoveryPolicy')
-export const LIFE_CYCLE_POLICY_TYPE_NAME = toEntraTypeName('groupLifeCyclePolicy')
-export const OAUTH2_PERMISSION_GRANT_TYPE_NAME = toEntraTypeName('oauth2PermissionGrant')
-export const PERMISSION_GRANT_POLICY_TYPE_NAME = toEntraTypeName('permissionGrantPolicy')
-export const ROLE_DEFINITION_TYPE_NAME = toEntraTypeName('roleDefinition')
-export const SERVICE_PRINCIPAL_TYPE_NAME = toEntraTypeName('servicePrincipal')
-export const TOKEN_LIFETIME_POLICY_TYPE_NAME = toEntraTypeName('tokenLifetimePolicy')
+export const CROSS_TENANT_ACCESS_POLICY_TYPE_NAME = toEntraTypeName('CrossTenantAccessPolicy')
+export const CUSTOM_SECURITY_ATTRIBUTE_DEFINITION_TYPE_NAME = toEntraTypeName('CustomSecurityAttributeDefinition')
+export const CUSTOM_SECURITY_ATTRIBUTE_SET_TYPE_NAME = toEntraTypeName('CustomSecurityAttributeSet')
+export const DOMAIN_TYPE_NAME = toEntraTypeName('Domain')
+export const DIRECTORY_ROLE_TYPE_NAME = toEntraTypeName('DirectoryRole')
+export const DIRECTORY_ROLE_TEMPLATE_TYPE_NAME = toEntraTypeName('DirectoryRoleTemplate')
+export const GROUP_TYPE_NAME = toEntraTypeName('Group')
+export const HOME_REALM_DISCOVERY_POLICY_TYPE_NAME = toEntraTypeName('HomeRealmDiscoveryPolicy')
+export const LIFE_CYCLE_POLICY_TYPE_NAME = toEntraTypeName('GroupLifeCyclePolicy')
+export const OAUTH2_PERMISSION_GRANT_TYPE_NAME = toEntraTypeName('Oauth2PermissionGrant')
+export const PERMISSION_GRANT_POLICY_TYPE_NAME = toEntraTypeName('PermissionGrantPolicy')
+export const ROLE_DEFINITION_TYPE_NAME = toEntraTypeName('RoleDefinition')
+export const SERVICE_PRINCIPAL_TYPE_NAME = toEntraTypeName('ServicePrincipal')
+export const TOKEN_LIFETIME_POLICY_TYPE_NAME = toEntraTypeName('TokenLifetimePolicy')
 
 // Nested types
 export const ADMINISTRATIVE_UNIT_MEMBERS_TYPE_NAME = recursiveNestedTypeName(

--- a/packages/microsoft-security-adapter/src/constants/entra.ts
+++ b/packages/microsoft-security-adapter/src/constants/entra.ts
@@ -6,12 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { fetch as fetchUtils } from '@salto-io/adapter-components'
-import { types } from '@salto-io/lowerdash'
 import { ODATA_PREFIX } from './shared'
 
 const { recursiveNestedTypeName } = fetchUtils.element
 
-const toEntraTypeName = (typeName: `${types.UPPER_CASE_LETTERS}${string}`): string => `Entra${typeName}`
+const toEntraTypeName = (typeName: string): string => `Entra${typeName}`
 
 /* Fields */
 export const APP_ROLE_ASSIGNMENT_FIELD_NAME = 'appRoleAssignments'

--- a/packages/microsoft-security-adapter/src/constants/intune.ts
+++ b/packages/microsoft-security-adapter/src/constants/intune.ts
@@ -6,11 +6,12 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
+import { types } from '@salto-io/lowerdash'
 import { fetch as fetchUtils } from '@salto-io/adapter-components'
 
 const { recursiveNestedTypeName } = fetchUtils.element
 
-const toIntuneTypeName = (typeName: string): string => `intune_${typeName}`
+const toIntuneTypeName = (typeName: `${types.UPPER_CASE_LETTERS}${string}`): string => `Intune${typeName}`
 
 /* Field names */
 // Application fields
@@ -34,14 +35,14 @@ export const SCHEDULED_ACTION_CONFIGURATIONS_FIELD_NAME = 'scheduledActionConfig
 
 /* Type names */
 // Top level
-export const APPLICATION_TYPE_NAME = toIntuneTypeName('application')
-export const APPLICATION_CONFIGURATION_MANAGED_APP_TYPE_NAME = toIntuneTypeName('applicationConfigurationManagedApp')
+export const APPLICATION_TYPE_NAME = toIntuneTypeName('Application')
+export const APPLICATION_CONFIGURATION_MANAGED_APP_TYPE_NAME = toIntuneTypeName('ApplicationConfigurationManagedApp')
 export const APPLICATION_CONFIGURATION_MANAGED_DEVICE_TYPE_NAME = toIntuneTypeName(
-  'applicationConfigurationManagedDevice',
+  'ApplicationConfigurationManagedDevice',
 )
-export const DEVICE_CONFIGURATION_TYPE_NAME = toIntuneTypeName('deviceConfiguration')
-export const DEVICE_CONFIGURATION_SETTING_CATALOG_TYPE_NAME = toIntuneTypeName('deviceConfigurationSettingCatalog')
-export const DEVICE_COMPLIANCE_TYPE_NAME = toIntuneTypeName('deviceCompliance')
+export const DEVICE_CONFIGURATION_TYPE_NAME = toIntuneTypeName('DeviceConfiguration')
+export const DEVICE_CONFIGURATION_SETTING_CATALOG_TYPE_NAME = toIntuneTypeName('DeviceConfigurationSettingCatalog')
+export const DEVICE_COMPLIANCE_TYPE_NAME = toIntuneTypeName('DeviceCompliance')
 
 // Nested types
 export const APPLICATION_CONFIGURATION_MANAGED_APP_APPS_TYPE_NAME = recursiveNestedTypeName(

--- a/packages/microsoft-security-adapter/src/constants/intune.ts
+++ b/packages/microsoft-security-adapter/src/constants/intune.ts
@@ -6,12 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { types } from '@salto-io/lowerdash'
 import { fetch as fetchUtils } from '@salto-io/adapter-components'
 
 const { recursiveNestedTypeName } = fetchUtils.element
 
-const toIntuneTypeName = (typeName: `${types.UPPER_CASE_LETTERS}${string}`): string => `Intune${typeName}`
+const toIntuneTypeName = (typeName: string): string => `Intune${typeName}`
 
 /* Field names */
 // Application fields

--- a/packages/microsoft-security-adapter/test/adapter.test.ts
+++ b/packages/microsoft-security-adapter/test/adapter.test.ts
@@ -65,33 +65,33 @@ describe('Microsoft Security adapter', () => {
 
       it('should generate the right elements on fetch', async () => {
         expect([...new Set(elements.filter(isInstanceElement).map(e => e.elemID.typeName))].sort()).toEqual([
-          'entra_administrativeUnit',
-          'entra_appRole',
-          'entra_application',
-          'entra_authenticationMethodPolicy',
-          'entra_authenticationMethodPolicy__authenticationMethodConfigurations',
-          'entra_authenticationStrengthPolicy',
-          'entra_conditionalAccessPolicy',
-          'entra_conditionalAccessPolicyNamedLocation',
-          'entra_crossTenantAccessPolicy',
-          'entra_customSecurityAttributeDefinition',
-          'entra_customSecurityAttributeDefinition__allowedValues',
-          'entra_customSecurityAttributeSet',
-          'entra_directoryRoleTemplate',
-          'entra_domain',
-          'entra_group',
-          'entra_groupLifeCyclePolicy',
-          'entra_group__appRoleAssignments',
-          'entra_oauth2PermissionGrant',
-          'entra_permissionGrantPolicy',
-          'entra_roleDefinition',
-          'entra_servicePrincipal',
-          'intune_application',
-          'intune_applicationConfigurationManagedApp',
-          'intune_applicationConfigurationManagedDevice',
-          'intune_deviceCompliance',
-          'intune_deviceConfiguration',
-          'intune_deviceConfigurationSettingCatalog',
+          'EntraAdministrativeUnit',
+          'EntraAppRole',
+          'EntraApplication',
+          'EntraAuthenticationMethodPolicy',
+          'EntraAuthenticationMethodPolicy__authenticationMethodConfigurations',
+          'EntraAuthenticationStrengthPolicy',
+          'EntraConditionalAccessPolicy',
+          'EntraConditionalAccessPolicyNamedLocation',
+          'EntraCrossTenantAccessPolicy',
+          'EntraCustomSecurityAttributeDefinition',
+          'EntraCustomSecurityAttributeDefinition__allowedValues',
+          'EntraCustomSecurityAttributeSet',
+          'EntraDirectoryRoleTemplate',
+          'EntraDomain',
+          'EntraGroup',
+          'EntraGroupLifeCyclePolicy',
+          'EntraGroup__appRoleAssignments',
+          'EntraOauth2PermissionGrant',
+          'EntraPermissionGrantPolicy',
+          'EntraRoleDefinition',
+          'EntraServicePrincipal',
+          'IntuneApplication',
+          'IntuneApplicationConfigurationManagedApp',
+          'IntuneApplicationConfigurationManagedDevice',
+          'IntuneDeviceCompliance',
+          'IntuneDeviceConfiguration',
+          'IntuneDeviceConfigurationSettingCatalog',
         ])
         // TODO: Validate Entra sub-types and structure of the elements
       })
@@ -103,7 +103,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneApplications = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_application')
+                .filter(e => e.elemID.typeName === 'IntuneApplication')
             })
 
             it('should create the correct instances for Intune applications', async () => {
@@ -126,12 +126,12 @@ describe('Microsoft Security adapter', () => {
               const intuneApplicationParts = intuneApplications.map(e => e.path)
               expect(intuneApplicationParts).toEqual(
                 expect.arrayContaining([
-                  ['microsoft_security', 'Records', 'intune_application', 'iosStoreApp', 'test'],
-                  ['microsoft_security', 'Records', 'intune_application', 'androidStoreApp', 'com_test'],
-                  ['microsoft_security', 'Records', 'intune_application', 'androidManagedStoreApp', 'com_test'],
-                  ['microsoft_security', 'Records', 'intune_application', 'managedIOSStoreApp', 'test'],
-                  ['microsoft_security', 'Records', 'intune_application', 'managedAndroidStoreApp', 'com_test2'],
-                  ['microsoft_security', 'Records', 'intune_application', 'managedAndroidStoreApp', 'com_test'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'iosStoreApp', 'test'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'androidStoreApp', 'com_test'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'androidManagedStoreApp', 'com_test'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'managedIOSStoreApp', 'test'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'managedAndroidStoreApp', 'com_test2'],
+                  ['microsoft_security', 'Records', 'IntuneApplication', 'managedAndroidStoreApp', 'com_test'],
                 ]),
               )
             })
@@ -142,7 +142,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneApplicationConfigurations = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_applicationConfigurationManagedApp')
+                .filter(e => e.elemID.typeName === 'IntuneApplicationConfigurationManagedApp')
             })
 
             it('should create the correct instances for Intune application configurations', async () => {
@@ -156,7 +156,7 @@ describe('Microsoft Security adapter', () => {
               const intuneApplicationConfigurationParts = intuneApplicationConfigurations.map(e => e.path)
               expect(intuneApplicationConfigurationParts).toEqual(
                 expect.arrayContaining([
-                  ['microsoft_security', 'Records', 'intune_applicationConfigurationManagedApp', 'test_configuration'],
+                  ['microsoft_security', 'Records', 'IntuneApplicationConfigurationManagedApp', 'test_configuration'],
                 ]),
               )
             })
@@ -172,7 +172,7 @@ describe('Microsoft Security adapter', () => {
                 },
               })
               expect(targetApps[0].mobileAppIdentifier.packageId.elemID.getFullName()).toEqual(
-                'microsoft_security.intune_application.instance.managedAndroidStoreApp_com_test2@uv',
+                'microsoft_security.IntuneApplication.instance.managedAndroidStoreApp_com_test2@uv',
               )
             })
           })
@@ -182,7 +182,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneApplicationConfigurations = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_applicationConfigurationManagedDevice')
+                .filter(e => e.elemID.typeName === 'IntuneApplicationConfigurationManagedDevice')
             })
 
             it('should create the correct instances for Intune application configurations', async () => {
@@ -198,8 +198,8 @@ describe('Microsoft Security adapter', () => {
               const intuneApplicationConfigurationParts = intuneApplicationConfigurations.map(e => e.path)
               expect(intuneApplicationConfigurationParts).toEqual(
                 expect.arrayContaining([
-                  ['microsoft_security', 'Records', 'intune_applicationConfigurationManagedDevice', 'test_android'],
-                  ['microsoft_security', 'Records', 'intune_applicationConfigurationManagedDevice', 'test_ios'],
+                  ['microsoft_security', 'Records', 'IntuneApplicationConfigurationManagedDevice', 'test_android'],
+                  ['microsoft_security', 'Records', 'IntuneApplicationConfigurationManagedDevice', 'test_ios'],
                 ]),
               )
             })
@@ -211,7 +211,7 @@ describe('Microsoft Security adapter', () => {
               expect(targetMobileAppsIos).toHaveLength(1)
               expect(targetMobileAppsIos[0]).toBeInstanceOf(ReferenceExpression)
               expect(targetMobileAppsIos[0].elemID.getFullName()).toEqual(
-                'microsoft_security.intune_application.instance.managedIOSStoreApp_test',
+                'microsoft_security.IntuneApplication.instance.managedIOSStoreApp_test',
               )
 
               const androidIdx = intuneApplicationConfigurations.findIndex(e => e.elemID.name === 'test_android@s')
@@ -220,7 +220,7 @@ describe('Microsoft Security adapter', () => {
               expect(targetMobileAppsAndroid).toHaveLength(1)
               expect(targetMobileAppsAndroid[0]).toBeInstanceOf(ReferenceExpression)
               expect(targetMobileAppsAndroid[0].elemID.getFullName()).toEqual(
-                'microsoft_security.intune_application.instance.managedAndroidStoreApp_com_test@uv',
+                'microsoft_security.IntuneApplication.instance.managedAndroidStoreApp_com_test@uv',
               )
             })
 
@@ -260,7 +260,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneDeviceConfigurations = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_deviceConfiguration')
+                .filter(e => e.elemID.typeName === 'IntuneDeviceConfiguration')
             })
 
             it('should create the correct instances for Intune device configurations', async () => {
@@ -283,7 +283,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneDeviceConfigurationSettingCatalogs = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_deviceConfigurationSettingCatalog')
+                .filter(e => e.elemID.typeName === 'IntuneDeviceConfigurationSettingCatalog')
             })
 
             it('should create the correct instances for Intune device configuration setting catalogs', async () => {
@@ -311,7 +311,7 @@ describe('Microsoft Security adapter', () => {
             beforeEach(async () => {
               intuneDeviceCompliances = elements
                 .filter(isInstanceElement)
-                .filter(e => e.elemID.typeName === 'intune_deviceCompliance')
+                .filter(e => e.elemID.typeName === 'IntuneDeviceCompliance')
             })
 
             it('should create the correct instances for Intune device compliances', async () => {
@@ -326,7 +326,7 @@ describe('Microsoft Security adapter', () => {
               const groupRef = intuneDeviceCompliance.value.restrictedApps[0]?.appId
               expect(groupRef).toBeInstanceOf(ReferenceExpression)
               expect(groupRef.elemID.getFullName()).toEqual(
-                'microsoft_security.intune_application.instance.managedIOSStoreApp_test',
+                'microsoft_security.IntuneApplication.instance.managedIOSStoreApp_test',
               )
             })
 


### PR DESCRIPTION
Change all Microsoft Security type names to PascalCase, following the discussion here

---
This was done following the discussion [here](https://github.com/salto-io/salto/pull/6456#discussion_r1727124764).

---
_Release Notes_: 

---
_User Notifications_: 
