### PR TITLE
SALTO-2392 identify more ASVs

### DIFF
--- a/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/filters/workflow_account_specific_values.ts
@@ -133,6 +133,8 @@ const STANDARD_FIELDS_TO_RECORD_TYPE: Record<string, SuiteQLTableName | Addition
   STDBODYDEPARTMENT: 'department',
   STDBODYTOSUBSIDIARY: 'subsidiary',
   STDBODYLOCATION: 'location',
+  STDBODYDECISIONMAKER: 'contact',
+  STDBODYEMPLOYEE: 'employee',
   STDBODYNEXTAPPROVER: 'employee',
   STDBODYINCOTERM: 'incoterm',
   STDBODYENTITYEMPLOYEE: 'employee',
@@ -375,8 +377,10 @@ const getQueryRecordType = (path: ElemID): QueryRecordType | undefined => {
   return QUERY_RECORD_TYPES[path.createParentID().name as QueryRecordType]
 }
 
-const getTypesFromInternalId = (typeInternalId: string): string[] =>
-  INTERNAL_ID_TO_TYPES[typeInternalId] ?? ADDITIONAL_INTERNAL_ID_TO_TYPES[typeInternalId] ?? []
+const getTypesFromInternalId = (typeInternalId: string): string[] => [
+  ...(INTERNAL_ID_TO_TYPES[typeInternalId] ?? []),
+  ...(ADDITIONAL_INTERNAL_ID_TO_TYPES[typeInternalId] ?? []),
+]
 
 const getQueryRecordFieldType = (
   instance: InstanceElement,
@@ -621,7 +625,7 @@ const getParametersAccountSpecificValueToTransform = (
     // but only params that have selectrecordtype are represented with internalid in the formula.
     .filter(param => param?.[SELECT_RECORD_TYPE] !== undefined)
     // params that have a constant string `value` (e.g "INVOICE") aren't represented with internalid in the formula.
-    .filter(param => typeof param.value === 'string' && !/^[A-Z]+$/.test(param.value))
+    .filter(param => typeof param.value !== 'string' || !/^[A-Z]+$/.test(param.value))
     // each param can appear more than once in the condition formula.
     // in that case we're expecting to see it multiple times in formulaWithInternalIds.
     .flatMap(param => getParamLocations({ conditionFormula, param }))

--- a/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/workflow_account_specific_values.test.ts
@@ -86,6 +86,11 @@ describe('workflow account specific values filter', () => {
         },
       }),
       new InstanceElement('partner', suiteQLTableType),
+      new InstanceElement('entityStatus', suiteQLTableType, {
+        [INTERNAL_IDS_MAP]: {
+          1: { name: 'Entity Status 1' },
+        },
+      }),
     ]
     customRecordType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'customrecord123'),
@@ -181,7 +186,7 @@ describe('workflow account specific values filter', () => {
               Role1: {
                 name: 'Role1',
                 [SELECT_RECORD_TYPE]: '-118',
-                value: '[scriptid=customrole123]',
+                value: new ReferenceExpression(new ElemID(NETSUITE, 'role', 'instance', 'customrole123')),
               },
             },
           },
@@ -193,6 +198,11 @@ describe('workflow account specific values filter', () => {
               [SELECT_RECORD_TYPE]: new ReferenceExpression(
                 customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID),
               ),
+              defaultvalue: ACCOUNT_SPECIFIC_VALUE,
+            },
+            custworkflow2: {
+              [SCRIPT_ID]: 'custworkflow2',
+              [SELECT_RECORD_TYPE]: '-104',
               defaultvalue: ACCOUNT_SPECIFIC_VALUE,
             },
           },
@@ -371,6 +381,13 @@ describe('workflow account specific values filter', () => {
               },
               {
                 body: {
+                  [SCRIPT_ID]: 'custworkflow2',
+                  defaultvalue: '1',
+                },
+                sublists: [],
+              },
+              {
+                body: {
                   [SCRIPT_ID]: 'workflowstate118',
                 },
                 sublists: [
@@ -487,7 +504,7 @@ describe('workflow account specific values filter', () => {
               fields: ['scriptid', 'defaultvalue'],
               filter: {
                 fieldId: 'scriptid',
-                in: ['custworkflow1'],
+                in: ['custworkflow1', 'custworkflow2'],
               },
             },
           ],
@@ -553,7 +570,7 @@ describe('workflow account specific values filter', () => {
                 Role1: {
                   name: 'Role1',
                   [SELECT_RECORD_TYPE]: '-118',
-                  value: '[scriptid=customrole123]',
+                  value: new ReferenceExpression(new ElemID(NETSUITE, 'role', 'instance', 'customrole123')),
                 },
               },
             },
@@ -566,6 +583,11 @@ describe('workflow account specific values filter', () => {
                   customRecordType.elemID.createNestedID('field', 'custom_field', SCRIPT_ID),
                 ),
                 defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
+              },
+              custworkflow2: {
+                [SCRIPT_ID]: 'custworkflow2',
+                [SELECT_RECORD_TYPE]: '-104',
+                defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Entity Status 1)`,
               },
             },
           },
@@ -846,6 +868,11 @@ describe('workflow account specific values filter', () => {
               ),
               defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Account 5)`,
             },
+            custworkflow2: {
+              [SCRIPT_ID]: 'custworkflow2',
+              [SELECT_RECORD_TYPE]: '-104',
+              defaultvalue: `${ACCOUNT_SPECIFIC_VALUE} (Entity Status 1)`,
+            },
           },
         },
         workflowstates: {
@@ -1087,6 +1114,11 @@ describe('workflow account specific values filter', () => {
                 customRecordType,
               ),
               defaultvalue: '5',
+            },
+            custworkflow2: {
+              [SCRIPT_ID]: 'custworkflow2',
+              [SELECT_RECORD_TYPE]: '-104',
+              defaultvalue: '1',
             },
           },
         },


### PR DESCRIPTION
1. map `STDBODYDECISIONMAKER` & `STDBODYEMPLOYEE` to suiteql tables
2. fix `getTypesFromInternalId` to work when `typeInternalId` is in both `INTERNAL_ID_TO_TYPES` and `ADDITIONAL_INTERNAL_ID_TO_TYPES` 
3. fix `getParametersAccountSpecificValueToTransform` to consider param values that are referenes

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- identify more ASVs

---
_User Notifications_: 
Netsuite Adapter:
- unresolved `[ACCOUNT_SPECIFIC_VALUE]` values may be resolved