### PR TITLE
SALTO-6592: fix elementsSource has implementation

### DIFF
--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -67,14 +67,14 @@ export const buildElementsSourceFromElements = (
     }
   }
 
-  const getElement = (id: ElemID): Value => {
+  const retrieveValueByID = (id: ElemID): Value => {
     const { parent } = id.createTopLevelParentID()
     const topLevelElement = elementsMap[parent.getFullName()]
     return elementsMap[id.getFullName()] ?? (topLevelElement && resolvePath(topLevelElement, id))
   }
 
   const get = async (id: ElemID): Promise<Value> => {
-    const element = getElement(id)
+    const element = retrieveValueByID(id)
     if (element !== undefined) {
       return element
     }
@@ -85,7 +85,7 @@ export const buildElementsSourceFromElements = (
   }
 
   const has = async (id: ElemID): Promise<boolean> =>
-    getElement(id) !== undefined || awu(fallbackSources).some(async source => source.has(id))
+    retrieveValueByID(id) !== undefined || awu(fallbackSources).some(source => source.has(id))
 
   self = {
     getAll: async () => getElements(),

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -67,10 +67,14 @@ export const buildElementsSourceFromElements = (
     }
   }
 
-  const get = async (id: ElemID): Promise<Value> => {
+  const getElement = (id: ElemID): Value => {
     const { parent } = id.createTopLevelParentID()
     const topLevelElement = elementsMap[parent.getFullName()]
-    const element = elementsMap[id.getFullName()] ?? (topLevelElement && resolvePath(topLevelElement, id))
+    return elementsMap[id.getFullName()] ?? (topLevelElement && resolvePath(topLevelElement, id))
+  }
+
+  const get = async (id: ElemID): Promise<Value> => {
+    const element = getElement(id)
     if (element !== undefined) {
       return element
     }
@@ -80,7 +84,8 @@ export const buildElementsSourceFromElements = (
       .find(values.isDefined)
   }
 
-  const has = async (id: ElemID): Promise<boolean> => (await get(id)) !== undefined
+  const has = async (id: ElemID): Promise<boolean> =>
+    getElement(id) !== undefined || awu(fallbackSources).some(async source => source.has(id))
 
   self = {
     getAll: async () => getElements(),

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -75,9 +75,9 @@ export const buildElementsSourceFromElements = (
   }
 
   const get = async (id: ElemID): Promise<Value> => {
-    const element = getValueByID(id)
-    if (element !== undefined) {
-      return element
+    const value = getValueByID(id)
+    if (value !== undefined) {
+      return value
     }
 
     return awu(fallbackSources)

--- a/packages/adapter-utils/src/element_source.ts
+++ b/packages/adapter-utils/src/element_source.ts
@@ -67,14 +67,15 @@ export const buildElementsSourceFromElements = (
     }
   }
 
-  const retrieveValueByID = (id: ElemID): Value => {
-    const { parent } = id.createTopLevelParentID()
-    const topLevelElement = elementsMap[parent.getFullName()]
-    return elementsMap[id.getFullName()] ?? (topLevelElement && resolvePath(topLevelElement, id))
+  const getValueByID = (id: ElemID): Value => {
+    const baseId = id.createBaseID().parent
+    const topLevelParentId = id.createTopLevelParentID().parent
+    const element = elementsMap[baseId.getFullName()] ?? elementsMap[topLevelParentId.getFullName()]
+    return element && resolvePath(element, id)
   }
 
   const get = async (id: ElemID): Promise<Value> => {
-    const element = retrieveValueByID(id)
+    const element = getValueByID(id)
     if (element !== undefined) {
       return element
     }
@@ -85,7 +86,7 @@ export const buildElementsSourceFromElements = (
   }
 
   const has = async (id: ElemID): Promise<boolean> =>
-    retrieveValueByID(id) !== undefined || awu(fallbackSources).some(source => source.has(id))
+    getValueByID(id) !== undefined || awu(fallbackSources).some(source => source.has(id))
 
   self = {
     getAll: async () => getElements(),


### PR DESCRIPTION
_fix elementsSource has implementation_

---

_Additional context for reviewer_
* it is a fix for the change from this [pr](https://github.com/salto-io/salto/pull/6505). I changed `elementsSource.has` implementation to use `elementsSource.get` inside, which may cause performance issues.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
