### PR TITLE
SALTO-6573: Avoid redundant read of elements when rebuilding cache

### DIFF
--- a/packages/adapter-api/src/comparison.ts
+++ b/packages/adapter-api/src/comparison.ts
@@ -8,6 +8,7 @@
 import _ from 'lodash'
 import { CompareOptions, ReferenceExpression, Value, isReferenceExpression, isStaticFile } from './values'
 import { ReadOnlyElementsSource, isVariable } from './elements'
+import { ElemID } from './element_id'
 
 type ReferenceCompareReturnValue<T> =
   | {
@@ -199,3 +200,15 @@ export const compareSpecialValues = (first: Value, second: Value, options?: Comp
 
 export const isEqualValues = (first: Value, second: Value, options?: CompareOptions): boolean =>
   _.isEqualWith(first, second, (va1, va2) => compareSpecialValues(va1, va2, options))
+
+export const compareElementIDs = (id1: ElemID, id2: ElemID): number => {
+  const id1FullName = id1.getFullName()
+  const id2FullName = id2.getFullName()
+  if (id1FullName < id2FullName) {
+    return -1
+  }
+  if (id1FullName > id2FullName) {
+    return 1
+  }
+  return 0
+}

--- a/packages/core/src/core/plan/plan.ts
+++ b/packages/core/src/core/plan/plan.ts
@@ -33,6 +33,7 @@ import {
   isTemplateExpression,
   areReferencesEqual,
   CompareOptions,
+  compareElementIDs,
 } from '@salto-io/adapter-api'
 import { DataNodeMap, DiffNode, DiffGraph, GroupDAG } from '@salto-io/dag'
 import { logger } from '@salto-io/logging'
@@ -326,15 +327,7 @@ const addDifferentElements =
                 .filter(async id => _.every(await Promise.all(topLevelFilters.map(filter => filter(id)))))
                 .map(id => source.get(id))) as AsyncIterable<ChangeDataType>
 
-        const cmp = (e1: ChangeDataType, e2: ChangeDataType): number => {
-          if (e1.elemID.getFullName() < e2.elemID.getFullName()) {
-            return -1
-          }
-          if (e1.elemID.getFullName() > e2.elemID.getFullName()) {
-            return 1
-          }
-          return 0
-        }
+        const cmp = (e1: ChangeDataType, e2: ChangeDataType): number => compareElementIDs(e1.elemID, e2.elemID)
 
         await awu(iterateTogether(await getFilteredElements(before), await getFilteredElements(after), cmp))
           .map(handleSpecialIds)

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -71,7 +71,6 @@ export type RecoveryOverrideFunc = (
 export type CacheChangeSetUpdate = {
   src1Changes?: ChangeSet<Change<Element>>
   src2Changes?: ChangeSet<Change<Element>>
-  src1Overrides?: Record<string, Element | undefined>
   src2Overrides?: Record<string, Element | undefined>
   recoveryOverride?: RecoveryOverrideFunc
   src1Prefix: string
@@ -218,9 +217,7 @@ export const createMergeManager = async (
     noErrorMergeIds: string[]
   }> => {
     const { src1Changes: possibleSrc1Changes, src2Changes: possibleSrc2Changes } = cacheUpdate
-    const src1 = values.isDefined(cacheUpdate.src1Overrides)
-      ? createOverrideReadOnlyElementsSource(sources[cacheUpdate.src1Prefix], cacheUpdate.src1Overrides)
-      : sources[cacheUpdate.src1Prefix]
+    const src1 = sources[cacheUpdate.src1Prefix]
     const src2 = values.isDefined(cacheUpdate.src2Overrides)
       ? createOverrideReadOnlyElementsSource(sources[cacheUpdate.src2Prefix], cacheUpdate.src2Overrides)
       : sources[cacheUpdate.src2Prefix]

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -71,8 +71,8 @@ export type RecoveryOverrideFunc = (
 export type CacheChangeSetUpdate = {
   src1Changes?: ChangeSet<Change<Element>>
   src2Changes?: ChangeSet<Change<Element>>
-  src1Overrides?: Record<string, Element>
-  src2Overrides?: Record<string, Element>
+  src1Overrides?: Record<string, Element | undefined>
+  src2Overrides?: Record<string, Element | undefined>
   recoveryOverride?: RecoveryOverrideFunc
   src1Prefix: string
   src2Prefix: string
@@ -164,8 +164,11 @@ const createFreshChangeSet = async (
   noErrorMergeIds: [],
 })
 
-const getContainerTypeChanges = (changes: Change<Element>[]): Element[] =>
-  changes.map(change => getChangeData(change)).filter(element => isContainerType(element))
+const getContainerTypeChangeIDs = (changes: Change<Element>[]): ElemID[] =>
+  changes
+    .map(getChangeData)
+    .filter(isContainerType)
+    .map(elem => elem.elemID)
 
 export interface Flushable {
   flush: () => Promise<boolean | void>
@@ -271,7 +274,7 @@ export const createMergeManager = async (
         srcChanges: Change<Element>[],
       ): Promise<AsyncIterable<ElemID>> =>
         src && recoveryOperation === REBUILD_ON_RECOVERY
-          ? awu(await src.list()).concat(getContainerTypeChanges(srcChanges).map(elem => elem.elemID))
+          ? awu(await src.list()).concat(getContainerTypeChangeIDs(srcChanges))
           : awu([])
 
       const potentialDeletedIds = new Set<string>()

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -292,9 +292,22 @@ export const createMergeManager = async (
         ? await cacheUpdate.recoveryOverride(src1ElementsToMerge, src2ElementsToMerge, src2)
         : { src1ElementsToMerge, src2ElementsToMerge }
 
+      const src1AfterElements = _.keyBy(
+        src1Changes.changes.filter(isAdditionOrModificationChange).map(getChangeData),
+        elem => elem.elemID.getFullName(),
+      )
+      const src2AfterElements = _.keyBy(
+        src2Changes.changes.filter(isAdditionOrModificationChange).map(getChangeData),
+        elem => elem.elemID.getFullName(),
+      )
+
       return {
-        src1ElementsToMerge: awu(elementsToMerge.src1ElementsToMerge).map(elemID => src1.get(elemID)),
-        src2ElementsToMerge: awu(elementsToMerge.src2ElementsToMerge).map(elemID => src2.get(elemID)),
+        src1ElementsToMerge: awu(elementsToMerge.src1ElementsToMerge).map(
+          elemID => src1AfterElements[elemID.getFullName()] ?? src1.get(elemID),
+        ),
+        src2ElementsToMerge: awu(elementsToMerge.src2ElementsToMerge).map(
+          elemID => src2AfterElements[elemID.getFullName()] ?? src2.get(elemID),
+        ),
         potentialDeletedIds,
       }
     }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -824,12 +824,12 @@ export const loadWorkspace = async (
           .toArray(),
       )
 
-      const dropStateOnlyElementsRecovery: RecoveryOverrideFunc = async (src1RecElements, src2RecElements) => {
+      const dropStateOnlyElementsRecovery: RecoveryOverrideFunc = async (src1RecElements, src2RecElements, src2) => {
         const src1ElementsToMerge = await awu(src1RecElements).toArray()
-        const src1IDSet = new Set(src1ElementsToMerge.map(elem => elem.elemID.getFullName()))
+        const src1IDSet = new Set(src1ElementsToMerge.map(elemID => elemID.getFullName()))
 
-        const shouldIncludeStateElement = async (elem: Element): Promise<boolean> =>
-          src1IDSet.has(elem.elemID.getFullName()) || isHidden(elem, state(envName))
+        const shouldIncludeStateElement = async (elemID: ElemID): Promise<boolean> =>
+          src1IDSet.has(elemID.getFullName()) || isHidden(await src2.get(elemID), state(envName))
 
         const src2ElementsToMerge = awu(src2RecElements).filter(shouldIncludeStateElement)
 

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -31,6 +31,7 @@ import {
   isModificationChange,
   TypeReference,
   DEFAULT_SOURCE_SCOPE,
+  isElement,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import {
@@ -810,12 +811,13 @@ export const loadWorkspace = async (
 
       const workspaceChangedElements = Object.fromEntries(
         await awu(wsChanges[envName]?.changes ?? [])
-          .map(async change => {
+          .map(async (change: Change): Promise<[string, Element | undefined]> => {
             const workspaceElement = getChangeData(change)
+            const stateElement = await state(envName).get(workspaceElement.elemID)
             const hiddenOnlyElement = isRemovalChange(change)
               ? undefined
               : await getElementHiddenParts(
-                  (await state(envName).get(workspaceElement.elemID)) ?? workspaceElement,
+                  isElement(stateElement) ? stateElement : workspaceElement,
                   state(envName),
                   workspaceElement,
                 )

--- a/packages/workspace/test/workspace/elements_source.test.ts
+++ b/packages/workspace/test/workspace/elements_source.test.ts
@@ -5,8 +5,15 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { BuiltinTypes, ElemID } from '@salto-io/adapter-api'
-import { createInMemoryElementSource, RemoteElementSource } from '../../src/workspace/elements_source'
+import { BuiltinTypes, ElemID, ObjectType, Element, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import {
+  createInMemoryElementSource,
+  createOverrideReadOnlyElementsSource,
+  RemoteElementSource,
+} from '../../src/workspace/elements_source'
+
+const { awu } = collections.asynciterable
 
 describe('RemoteElementSource', () => {
   let elemSource: RemoteElementSource
@@ -32,6 +39,115 @@ describe('RemoteElementSource', () => {
     })
     it('should return true when there are no elements', async () => {
       expect(await createInMemoryElementSource([]).isEmpty()).toEqual(true)
+    })
+  })
+})
+
+describe('overrideReadOnlyElementsSource', () => {
+  let originalElem: ObjectType
+  let overriddenElem: ObjectType
+  let changedOverriddenElem: ObjectType
+  let removedElem: ObjectType
+  let newElem: ObjectType
+  let source: RemoteElementSource
+  let overrideSource: ReadOnlyElementsSource
+  beforeEach(() => {
+    originalElem = new ObjectType({ elemID: new ElemID('test', 'type') })
+    overriddenElem = new ObjectType({ elemID: new ElemID('test', 'override'), annotations: { value: 'orig' } })
+    removedElem = new ObjectType({ elemID: new ElemID('test', 'removed') })
+    source = createInMemoryElementSource([originalElem, overriddenElem])
+    changedOverriddenElem = overriddenElem.clone()
+    changedOverriddenElem.annotations.value = 'changed'
+    newElem = new ObjectType({ elemID: new ElemID('test', 'new') })
+    overrideSource = createOverrideReadOnlyElementsSource(source, {
+      [overriddenElem.elemID.getFullName()]: changedOverriddenElem,
+      [removedElem.elemID.getFullName()]: undefined,
+      [newElem.elemID.getFullName()]: newElem,
+    })
+  })
+  describe('list', () => {
+    let listResult: string[]
+    beforeEach(async () => {
+      listResult = await awu(await overrideSource.list())
+        .map(id => id.getFullName())
+        .toArray()
+    })
+    it('should return an ordered list of IDs', () => {
+      const sortedList = listResult.map(id => id).sort()
+      expect(listResult).toEqual(sortedList)
+    })
+    it('should omit ids that were removed by overrides', () => {
+      expect(listResult).not.toContainEqual(removedElem.elemID.getFullName())
+    })
+    it('should return ids from original source without override removals', () => {
+      expect(listResult).toContainValues([newElem, overriddenElem, originalElem].map(elem => elem.elemID.getFullName()))
+    })
+  })
+  describe('has', () => {
+    it('should return true for ids from the origin that were no removed', async () => {
+      await expect(overrideSource.has(overriddenElem.elemID)).resolves.toBeTrue()
+      await expect(overrideSource.has(originalElem.elemID)).resolves.toBeTrue()
+    })
+    it('should return true for ids that were added by overrides', async () => {
+      await expect(overrideSource.has(newElem.elemID)).resolves.toBeTrue()
+    })
+    it('should return false for ids that were removed by overrides', async () => {
+      await expect(overrideSource.has(removedElem.elemID)).resolves.toBeFalse()
+    })
+  })
+  describe('get', () => {
+    describe('with overridden element', () => {
+      let result: ObjectType
+      beforeEach(async () => {
+        result = await overrideSource.get(overriddenElem.elemID)
+      })
+      it('should return the value from the override', () => {
+        expect(result.annotations).toEqual(changedOverriddenElem.annotations)
+      })
+    })
+
+    describe('with removed element', () => {
+      let result: ObjectType
+      beforeEach(async () => {
+        result = await overrideSource.get(removedElem.elemID)
+      })
+      it('should return undefined', () => {
+        expect(result).toBeUndefined()
+      })
+    })
+    describe('with added element', () => {
+      let result: ObjectType
+      beforeEach(async () => {
+        result = await overrideSource.get(newElem.elemID)
+      })
+      it('should return the value from the override', () => {
+        expect(result.isEqual(newElem)).toBeTrue()
+      })
+    })
+    describe('with unchanged element', () => {
+      let result: ObjectType
+      beforeEach(async () => {
+        result = await overrideSource.get(originalElem.elemID)
+      })
+      it('should return the original element', () => {
+        expect(result.isEqual(originalElem)).toBeTrue()
+      })
+    })
+  })
+  describe('getAll', () => {
+    let result: Element[]
+    beforeEach(async () => {
+      result = await awu(await overrideSource.getAll()).toArray()
+    })
+    it('should return elements ordered by ID', () => {
+      const sortedList = result.map(elem => elem.elemID.getFullName()).sort()
+      expect(result.map(elem => elem.elemID.getFullName())).toEqual(sortedList)
+    })
+    it('should omit elements that were removed by overrides', () => {
+      expect(result).not.toContainEqual(removedElem)
+    })
+    it('should return elements from original source without override removals', () => {
+      expect(result).toContainValues([newElem, changedOverriddenElem, originalElem])
     })
   })
 })


### PR DESCRIPTION
This avoids loading another copy of the elements from the state
It also avoids re-calculating the hidden parts for each such element

---

_Additional context for reviewer_
The main point of the change here is this:
There is code that needs to decide which elements to merge (dropStateOnlyElementsRecovery)
before this change, that code gets two iterators of elements, it needs to filter the second iterator such that it only contains elements that exist in the first iterator (by element ID) or elements that are fully hidden.
to implement the first condition, it has to fully consume the first iterator just to get the element IDs, so essentially it loads all the elements into memory.

In this PR we change the interface such that it works with iterators of element IDs and not full elements, this mainly improves memory consumption since there is no need to hold all elements in memory in `dropStateOnlyElementsRecovery` anymore, it only holds the element IDs.

In the second commit we add a performance improvement such that if an element is overridden, the code will not try to read it from the original source.
This is significant because the original source in this case is a "map element source" ([here](https://github.com/salto-io/salto/blob/main/packages/workspace/src/workspace/workspace.ts/#L642)) that is heavy to calculate

---
_Release Notes_: 
Core:
- Slight performance improvement when loading workspaces without a valid workspace cache

---
_User Notifications_: 
_None_