### PR TITLE
SALTO-6398: add sync-to-folder command

### DIFF
--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import fetchDef from './fetch'
-import applyPatchDef from './apply_patch'
+import { adapterFormatGroupDef } from './adapter_format'
 import envGroupDef from './env'
 import { accountGroupDef, serviceGroupDef } from './account'
 import deployDef from './deploy'
@@ -22,7 +22,7 @@ export default [
   accountGroupDef,
   serviceGroupDef, // Deprecated. Maintained for backward compatibility.
   fetchDef,
-  applyPatchDef,
+  adapterFormatGroupDef,
   deployDef,
   restoreDef,
   elementGroupDef,

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -32,6 +32,7 @@ import {
   ChangeDataType,
   isStaticFile,
   isSaltoElementError,
+  SaltoElementError,
 } from '@salto-io/adapter-api'
 import {
   Plan,
@@ -490,6 +491,12 @@ export const formatMergeErrors = (mergeErrors: FetchResult['mergeErrors']): stri
 
 export const formatFetchWarnings = (warnings: string[]): string =>
   [emptyLine(), `${Prompts.FETCH_WARNINGS}\n${warnings.join('\n\n')}`].join('\n')
+
+export const formatSyncToWorkspaceErrors = (syncErrors: ReadonlyArray<SaltoError | SaltoElementError>): string =>
+  [
+    emptyLine(),
+    `${Prompts.SYNC_TO_WORKSPACE_ERRORS}\n${syncErrors.map(err => `${err.severity} ${err.message}${isSaltoElementError(err) ? ` (${err.elemID.getFullName()})` : ''}`).join('\n')}`,
+  ].join('\n')
 
 export const formatWorkspaceLoadFailed = (numErrors: number): string =>
   formatSimpleError(`${Prompts.WORKSPACE_LOAD_FAILED(numErrors)}`)

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -128,6 +128,9 @@ The steps are: I. Fetching configs, II. Calculating difference and III. Applying
 
   public static readonly FETCH_MERGE_ERRORS = 'These errors occurred as part of the fetch:'
   public static readonly FETCH_WARNINGS = 'The fetch concluded with the following warnings:'
+  public static readonly SYNC_TO_WORKSPACE_ERRORS =
+    'Encountered the following issues when synchronizing the workspace with a folder:'
+
   public static readonly FETCH_CHANGES_APPLIED = (appliedChanges: number): string =>
     `${appliedChanges} changes were applied to the local workspace`
 

--- a/packages/cli/test/commands/adapter_format.test.ts
+++ b/packages/cli/test/commands/adapter_format.test.ts
@@ -270,7 +270,7 @@ describe('sync-to-workspace command', () => {
       })
     })
     it('should return non-success exit code', () => {
-      expect(result).not.toEqual(CliExitCode.Success)
+      expect(result).toEqual(CliExitCode.AppError)
     })
   })
 })

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -6,13 +6,14 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { Adapter, AdapterOperationsContext, ChangeDataType, Element, SaltoError, toChange } from '@salto-io/adapter-api'
+import { Adapter, AdapterOperationsContext, Element, SaltoError } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { merger, Workspace, ElementSelector, expressions, elementSource } from '@salto-io/workspace'
 import { FetchResult } from '../types'
 import { adapterCreators } from './adapters'
 import { MergeErrorWithElements, getFetchAdapterAndServicesSetup, calcFetchChanges } from './fetch'
+import { getPlan } from './plan'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -170,7 +171,11 @@ export const syncWorkspaceToFolder = ({
 }: SyncWorkspaceToFolderArgs): Promise<SyncWorkspaceToFolderResult> =>
   log.time(
     async () => {
-      const { resolvedElements, adapter, adapterContext } = await getAdapterAndContext({
+      const {
+        resolvedElements: workspaceElements,
+        adapter,
+        adapterContext,
+      } = await getAdapterAndContext({
         workspace,
         accountName,
         ignoreStateElemIdMapping,
@@ -178,45 +183,56 @@ export const syncWorkspaceToFolder = ({
       })
       const { loadElementsFromFolder, dumpElementsToFolder } = adapter
       if (loadElementsFromFolder === undefined) {
-        throw new Error(`Account ${accountName}'s adapter does not support loading a non-nacl format`)
+        return {
+          errors: [
+            {
+              severity: 'Error' as const,
+              message: `Account ${accountName}'s adapter does not support loading a non-nacl format`,
+            },
+          ],
+        }
       }
       if (dumpElementsToFolder === undefined) {
-        throw new Error(`Account ${accountName}'s adapter does not support writing a non-nacl format`)
-      }
-
-      const loadResult = await loadElementsAndMerge(baseDir, loadElementsFromFolder, adapterContext)
-      if (!_.isEmpty(loadResult.loadErrors) || !_.isEmpty(loadResult.mergeErrors)) {
         return {
-          errors: makeArray(loadResult.loadErrors).concat(loadResult.mergeErrors.map(mergeError => mergeError.error)),
+          errors: [
+            {
+              severity: 'Error' as const,
+              message: `Account ${accountName}'s adapter does not support writing a non-nacl format`,
+            },
+          ],
         }
       }
 
-      const workspaceElementIDs = new Set(resolvedElements.map(elem => elem.elemID.getFullName()))
+      const {
+        mergedElements: folderElements,
+        mergeErrors,
+        loadErrors,
+      } = await loadElementsAndMerge(baseDir, loadElementsFromFolder, adapterContext)
+      if (!_.isEmpty(loadErrors) || !_.isEmpty(mergeErrors)) {
+        return {
+          errors: makeArray(loadErrors).concat(mergeErrors.map(mergeError => mergeError.error)),
+        }
+      }
 
-      const deleteChanges = loadResult.elements
-        .filter(elem => !workspaceElementIDs.has(elem.elemID.getFullName()))
-        .map(elem => toChange({ before: elem as ChangeDataType }))
-
-      const folderElementsByID = _.keyBy(loadResult.elements, elem => elem.elemID.getFullName())
-
-      const changes = deleteChanges.concat(
-        resolvedElements.map(elem =>
-          toChange({
-            before: folderElementsByID[elem.elemID.getFullName()] as ChangeDataType,
-            after: elem as ChangeDataType,
-          }),
-        ),
-      )
+      // We know this is not accurate - we will get false modify changes here because we are directly comparing
+      // salto elements to folder elements and we know salto elements have more information in them.
+      // This should hopefully be ok because the effect of this incorrect comparison is that we will potentially
+      // re-dump elements that are equal, so even though we do redundant work, the end result should be correct
+      const plan = await getPlan({
+        before: elementSource.createInMemoryElementSource(folderElements),
+        after: elementSource.createInMemoryElementSource(workspaceElements),
+        dependencyChangers: [],
+      })
+      const changes = Array.from(plan.itemsByEvalOrder()).flatMap(item => Array.from(item.changes()))
+      const changeCounts = _.countBy(changes, change => change.action)
 
       log.debug(
-        'Loaded %d elements from folder %s and %d elements from workspace, applying %d changes (%d delete, %d modify, %d add) to folder',
-        loadResult.elements.length,
+        'Loaded %d elements from folder %s and %d elements from workspace, applying %d changes (%o) to folder',
+        folderElements.length,
         baseDir,
-        resolvedElements.length,
+        workspaceElements.length,
         changes.length,
-        deleteChanges.length,
-        loadResult.elements.length - deleteChanges.length,
-        resolvedElements.length - (loadResult.elements.length - deleteChanges.length),
+        changeCounts,
       )
       return dumpElementsToFolder({ baseDir, changes, elementsSource: adapterContext.elementsSource })
     },


### PR DESCRIPTION
Add cli command to sync a salto workspace to an adapter format folder

---

_Additional context for reviewer_

---
_Release Notes_: 
Cli:
- Added cli command to sync a salto workspace to an adapter format folder

---
_User Notifications_: 
_None_