### PR TITLE
SALTO-6605 SOAP WSDL version config

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -58,6 +58,7 @@ netsuite {
   suiteAppClient = {
    suiteAppConcurrencyLimit = 4
    httpTimeoutLimitInMinutes = 20
+   wsdlVersion = "2024_1"
   }
 }
 ```
@@ -143,6 +144,7 @@ netsuite {
 | ------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
 | suiteAppConcurrencyLimit  | 4                      | Limits the max number of concurrent Salto SuiteApp API calls. The number should not exceed the concurrency limit enforced by the upstream service. |
 | httpTimeoutLimitInMinutes | 20                     | Set a timeout, in minutes, for HTTP calls. Restricted to a value greater than 1.                                                                   |
+| wsdlVersion               | "2020_2"               | SOAP WSDL version to use. Should be a valid WSDL version (e.g 2023_2, 2024_1)                                                                      |
 
 ### Skip list configuration options
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/types.ts
@@ -5,6 +5,11 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+
+export const SUPPORTED_WSDL_VERSIONS = ['2020_2', '2023_1', '2023_2', '2024_1'] as const
+
+export type WSDLVersion = (typeof SUPPORTED_WSDL_VERSIONS)[number]
+
 type StatusSuccess = {
   attributes: {
     isSuccess: 'true'

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -158,7 +158,13 @@ export default class SuiteAppClient {
 
     this.ajv = new Ajv({ allErrors: true, strict: false })
     const timeout = (params.config?.httpTimeoutLimitInMinutes ?? DEFAULT_AXIOS_TIMEOUT_IN_MINUTES) * 60 * 1000
-    this.soapClient = new SoapClient(this.credentials, this.callsLimiter, params.instanceLimiter, timeout)
+    this.soapClient = new SoapClient(
+      this.credentials,
+      params.config,
+      this.callsLimiter,
+      params.instanceLimiter,
+      timeout,
+    )
     this.axiosClient = this.createAxiosClient({ timeout })
     this.versionFeatures = undefined
     this.setVersionFeaturesLock = new AsyncLock()

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -30,6 +30,7 @@ import {
 } from '../constants'
 import { netsuiteSupportedTypes } from '../types'
 import { ITEM_TYPE_TO_SEARCH_STRING } from '../data_elements/types'
+import { SUPPORTED_WSDL_VERSIONS, WSDLVersion } from '../client/suiteapp_client/soap_client/types'
 import {
   ALL_TYPES_REGEX,
   GROUPS_TO_DATA_FILE_TYPES,
@@ -196,11 +197,13 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
   httpTimeoutLimitInMinutes?: number
+  wsdlVersion?: WSDLVersion
 }
 
 export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
   suiteAppConcurrencyLimit: 'suiteAppConcurrencyLimit',
   httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
+  wsdlVersion: 'wsdlVersion',
 }
 
 export type NetsuiteConfig = {
@@ -380,6 +383,14 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
         [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_AXIOS_TIMEOUT_IN_MINUTES,
         [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
           min: 1,
+        }),
+      },
+    },
+    wsdlVersion: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({
+          values: SUPPORTED_WSDL_VERSIONS,
         }),
       },
     },

--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -58,15 +58,15 @@ function validateDefined(value: unknown, configPath: string | string[]): asserts
 }
 
 function validateBoolean(value: unknown, configPath: string | string[]): asserts value is boolean {
-  if (value !== undefined && typeof value !== 'boolean') {
+  if (typeof value !== 'boolean') {
     throw new Error(
       `Expected "${makeArray(configPath).join('.')}" to be a boolean, but received:\n ${JSON.stringify(value, undefined, 4)}`,
     )
   }
 }
 
-function validateNumber(value: unknown, configPath: string | string[]): asserts value is boolean | undefined {
-  if (value !== undefined && typeof value !== 'number') {
+function validateNumber(value: unknown, configPath: string | string[]): asserts value is number {
+  if (typeof value !== 'number') {
     throw new Error(
       `Expected "${makeArray(configPath).join('.')}" to be a number, but received:\n ${JSON.stringify(value, undefined, 4)}`,
     )
@@ -77,10 +77,7 @@ function validateEnumValue(
   value: unknown,
   enumValues: ReadonlyArray<string>,
   configPath: string | string[],
-): asserts value is string | undefined {
-  if (value === undefined) {
-    return
-  }
+): asserts value is string {
   if (typeof value !== 'string') {
     throw new Error(
       `Expected "${makeArray(configPath).join('.')}" to be a string, but received:\n ${JSON.stringify(value, undefined, 4)}`,

--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -11,6 +11,7 @@ import { regex, strings, collections } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { isCustomRecordTypeName, netsuiteSupportedTypes } from '../types'
 import { isRequiredFeature, removeRequiredFeatureSuffix } from '../client/utils'
+import { SUPPORTED_WSDL_VERSIONS } from '../client/suiteapp_client/soap_client/types'
 import { ALL_TYPES_REGEX, ERROR_MESSAGE_PREFIX, SUITEAPP_ID_FORMAT_REGEX } from './constants'
 import {
   AdditionalDependencies,
@@ -68,6 +69,26 @@ function validateNumber(value: unknown, configPath: string | string[]): asserts 
   if (value !== undefined && typeof value !== 'number') {
     throw new Error(
       `Expected "${makeArray(configPath).join('.')}" to be a number, but received:\n ${JSON.stringify(value, undefined, 4)}`,
+    )
+  }
+}
+
+function validateEnumValue(
+  value: unknown,
+  enumValues: ReadonlyArray<string>,
+  configPath: string | string[],
+): asserts value is string | undefined {
+  if (value === undefined) {
+    return
+  }
+  if (typeof value !== 'string') {
+    throw new Error(
+      `Expected "${makeArray(configPath).join('.')}" to be a string, but received:\n ${JSON.stringify(value, undefined, 4)}`,
+    )
+  }
+  if (!enumValues.includes(value)) {
+    throw new Error(
+      `Expected "${makeArray(configPath).join('.')}" to be one of: ${enumValues.map(enumValue => JSON.stringify(enumValue, undefined, 4)).join(', ')}, but received:\n ${JSON.stringify(value, undefined, 4)}`,
     )
   }
 }
@@ -399,12 +420,16 @@ const validateDeployParams = ({
 const validateSuiteAppClientParams = ({
   suiteAppConcurrencyLimit,
   httpTimeoutLimitInMinutes,
+  wsdlVersion,
 }: Record<keyof SuiteAppClientConfig, unknown>): void => {
   if (suiteAppConcurrencyLimit !== undefined) {
     validateNumber(suiteAppConcurrencyLimit, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.suiteAppConcurrencyLimit])
   }
   if (httpTimeoutLimitInMinutes !== undefined) {
     validateNumber(httpTimeoutLimitInMinutes, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.httpTimeoutLimitInMinutes])
+  }
+  if (wsdlVersion !== undefined) {
+    validateEnumValue(wsdlVersion, SUPPORTED_WSDL_VERSIONS, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.wsdlVersion])
   }
 }
 

--- a/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/soap_client/soap_client.test.ts
@@ -83,6 +83,7 @@ describe('soap_client', () => {
         suiteAppTokenId: 'tokenId',
         suiteAppTokenSecret: 'tokenSecret',
       },
+      {},
       fn => fn(),
       (_t: string, _c: number) => false,
       defaultSoapTimeOut,
@@ -625,7 +626,22 @@ describe('soap_client', () => {
     })
   })
 
-  describe('getAllRecords', () => {
+  describe.each(['default', '2023_1', '2024_1'] as const)('getAllRecords with version %s', inputWsdlVersion => {
+    const wsdlVersion = inputWsdlVersion === 'default' ? undefined : inputWsdlVersion
+    beforeEach(() => {
+      client = new SoapClient(
+        {
+          accountId: 'ACCOUNT_ID',
+          suiteAppTokenId: 'tokenId',
+          suiteAppTokenSecret: 'tokenSecret',
+        },
+        { wsdlVersion },
+        fn => fn(),
+        (_t: string, _c: number) => false,
+        defaultSoapTimeOut,
+      )
+    })
+
     it('Should return record using search', async () => {
       searchAsyncMock.mockResolvedValue([
         {
@@ -695,6 +711,7 @@ describe('soap_client', () => {
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
         },
+        {},
         fn => fn(),
         (_type: string, count: number) => count > 1,
         defaultSoapTimeOut,
@@ -779,8 +796,8 @@ describe('soap_client', () => {
           },
           'q1:basic': {
             attributes: {
-              'xmlns:platformCommon': 'urn:common_2020_2.platform.webservices.netsuite.com',
-              'xmlns:platformCore': 'urn:core_2020_2.platform.webservices.netsuite.com',
+              'xmlns:platformCommon': `urn:common_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+              'xmlns:platformCore': `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
             },
             'platformCommon:type': {
               attributes: {
@@ -1100,6 +1117,7 @@ describe('soap_client', () => {
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
         },
+        {},
         fn => fn(),
         (_type: string, count: number) => count > 1,
         defaultSoapTimeOut,
@@ -1413,7 +1431,23 @@ describe('soap_client', () => {
     })
   })
 
-  describe('getSelectValue', () => {
+  describe.each(['default', '2023_1', '2024_1'] as const)('getSelectValuewith version %s', inputWsdlVersion => {
+    const wsdlVersion = inputWsdlVersion === 'default' ? undefined : inputWsdlVersion
+
+    beforeEach(() => {
+      client = new SoapClient(
+        {
+          accountId: 'ACCOUNT_ID',
+          suiteAppTokenId: 'tokenId',
+          suiteAppTokenSecret: 'tokenSecret',
+        },
+        { wsdlVersion },
+        fn => fn(),
+        (_t: string, _c: number) => false,
+        defaultSoapTimeOut,
+      )
+    })
+
     it('should make one request and return result', async () => {
       getSelectValueAsyncMock.mockResolvedValue([
         {
@@ -1459,11 +1493,15 @@ describe('soap_client', () => {
         pageIndex: 1,
         fieldDescription: {
           recordType: {
-            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            attributes: {
+              xmlns: `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+            },
             $value: 'account',
           },
           field: {
-            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            attributes: {
+              xmlns: `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+            },
             $value: 'unitstype',
           },
         },
@@ -1609,15 +1647,21 @@ describe('soap_client', () => {
         pageIndex: 1,
         fieldDescription: {
           recordType: {
-            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            attributes: {
+              xmlns: `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+            },
             $value: 'account',
           },
           field: {
-            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            attributes: {
+              xmlns: `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+            },
             $value: 'unit',
           },
           filterByValueList: {
-            attributes: { xmlns: 'urn:core_2020_2.platform.webservices.netsuite.com' },
+            attributes: {
+              xmlns: `urn:core_${wsdlVersion ?? soapClientUtils.DEFAULT_WSDL_VERSION}.platform.webservices.netsuite.com`,
+            },
             filterBy: [
               {
                 field: 'unitstype',
@@ -1842,6 +1886,7 @@ describe('soap_client', () => {
           suiteAppTokenId: 'tokenId',
           suiteAppTokenSecret: 'tokenSecret',
         },
+        {},
         fn => fn(),
         (_type: string, count: number) => count > 1,
         timeout,

--- a/packages/netsuite-adapter/test/config/validations.test.ts
+++ b/packages/netsuite-adapter/test/config/validations.test.ts
@@ -396,4 +396,47 @@ describe('netsuite config validations', () => {
       })
     })
   })
+
+  describe('suiteAppClient config', () => {
+    describe('validate suiteAppConcurrencyLimit', () => {
+      it('should validate that suiteAppConcurrencyLimit is a number', () => {
+        config.suiteAppClient = { suiteAppConcurrencyLimit: 5 }
+        expect(() => validateConfig(config)).not.toThrow()
+      })
+      it('should throw when suiteAppConcurrencyLimit is not a number', () => {
+        config.suiteAppClient = { suiteAppConcurrencyLimit: '5' }
+        expect(() => validateConfig(config)).toThrow(
+          'Expected "suiteAppClient.suiteAppConcurrencyLimit" to be a number',
+        )
+      })
+    })
+    describe('validate httpTimeoutLimitInMinutes', () => {
+      it('should validate that httpTimeoutLimitInMinutes is a number', () => {
+        config.suiteAppClient = { httpTimeoutLimitInMinutes: 5 }
+        expect(() => validateConfig(config)).not.toThrow()
+      })
+      it('should throw when httpTimeoutLimitInMinutes is not a number', () => {
+        config.suiteAppClient = { httpTimeoutLimitInMinutes: '5' }
+        expect(() => validateConfig(config)).toThrow(
+          'Expected "suiteAppClient.httpTimeoutLimitInMinutes" to be a number',
+        )
+      })
+    })
+    describe('validate wsdlVersion', () => {
+      it('should validate that wsdlVersion is a valid enum value', () => {
+        config.suiteAppClient = { wsdlVersion: '2024_1' }
+        expect(() => validateConfig(config)).not.toThrow()
+      })
+      it('should throw when wsdlVersion is not a string', () => {
+        config.suiteAppClient = { wsdlVersion: true }
+        expect(() => validateConfig(config)).toThrow('Expected "suiteAppClient.wsdlVersion" to be a string')
+      })
+      it('should throw when wsdlVersion is not a valid enum value', () => {
+        config.suiteAppClient = { wsdlVersion: 'invalid' }
+        expect(() => validateConfig(config)).toThrow(
+          'Expected "suiteAppClient.wsdlVersion" to be one of: "2020_2", "2023_1", "2023_2", "2024_1"',
+        )
+      })
+    })
+  })
 })


### PR DESCRIPTION
Allow users to config the SOAP WSDL version used by `SoapClient` - using the `suiteAppClient.wsdlVersion` adapter config.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Allow users to config the SOAP WSDL version used by `SoapClient` - using the `suiteAppClient.wsdlVersion` adapter config

---
_User Notifications_: 
None
