### PR TITLE
SALTO-6344 delay after creation or deletion on Jamf

### DIFF
--- a/packages/jamf-adapter/src/adapter_creator.ts
+++ b/packages/jamf-adapter/src/adapter_creator.ts
@@ -30,7 +30,7 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
     clients: createClientDefinitions(clients),
     pagination: PAGINATION,
     fetch: createFetchDefinitions(userConfig.fetch),
-    deploy: createDeployDefinitions(),
+    deploy: createDeployDefinitions(userConfig),
     references: REFERENCES,
   }),
   operationsCustomizations: {

--- a/packages/jamf-adapter/src/config.ts
+++ b/packages/jamf-adapter/src/config.ts
@@ -12,11 +12,15 @@ export type UserFetchConfig = definitions.UserFetchConfig<{
   fetchCriteria: definitions.DefaultFetchCriteria
 }>
 
+export type UserDeployConfig = definitions.UserDeployConfig & {
+  delayAfterDeploy: number
+}
+
 export type UserConfig = definitions.UserConfig<
   never,
   definitions.ClientBaseConfig<definitions.ClientRateLimitConfig>,
   UserFetchConfig,
-  definitions.UserDeployConfig
+  UserDeployConfig
 >
 
 export const DEFAULT_CONFIG: UserConfig = {

--- a/packages/jamf-adapter/src/config.ts
+++ b/packages/jamf-adapter/src/config.ts
@@ -13,7 +13,7 @@ export type UserFetchConfig = definitions.UserFetchConfig<{
 }>
 
 export type UserDeployConfig = definitions.UserDeployConfig & {
-  delayAfterDeploy: number
+  delayAfterDeploy?: number
 }
 
 export type UserConfig = definitions.UserConfig<

--- a/packages/jamf-adapter/src/constants.ts
+++ b/packages/jamf-adapter/src/constants.ts
@@ -19,3 +19,4 @@ export const RESULTS = 'results'
 export const OS_X_CONFIGURATION_PROFILE_TYPE_NAME = 'os_x_configuration_profile'
 export const MOBILE_DEVICE_CONFIGURATION_PROFILE_TYPE_NAME = 'mobile_device_configuration_profile'
 export const MAC_APPLICATION_TYPE_NAME = 'mac_application'
+export const DUMMY_DELAY_TIMEOUT = 50 * 1000 // 50 seconds in ms

--- a/packages/jamf-adapter/src/constants.ts
+++ b/packages/jamf-adapter/src/constants.ts
@@ -19,4 +19,4 @@ export const RESULTS = 'results'
 export const OS_X_CONFIGURATION_PROFILE_TYPE_NAME = 'os_x_configuration_profile'
 export const MOBILE_DEVICE_CONFIGURATION_PROFILE_TYPE_NAME = 'mobile_device_configuration_profile'
 export const MAC_APPLICATION_TYPE_NAME = 'mac_application'
-export const DUMMY_DELAY_TIMEOUT = 50 * 1000 // 50 seconds in ms
+export const DEFAULT_POST_DEPLOY_DELAY = 50 * 1000 // 50 seconds in ms

--- a/packages/jamf-adapter/src/constants.ts
+++ b/packages/jamf-adapter/src/constants.ts
@@ -19,4 +19,3 @@ export const RESULTS = 'results'
 export const OS_X_CONFIGURATION_PROFILE_TYPE_NAME = 'os_x_configuration_profile'
 export const MOBILE_DEVICE_CONFIGURATION_PROFILE_TYPE_NAME = 'mobile_device_configuration_profile'
 export const MAC_APPLICATION_TYPE_NAME = 'mac_application'
-export const DEFAULT_POST_DEPLOY_DELAY = 50 * 1000 // 50 seconds in ms

--- a/packages/jamf-adapter/src/definitions/deploy/classic_api_utils.ts
+++ b/packages/jamf-adapter/src/definitions/deploy/classic_api_utils.ts
@@ -12,10 +12,11 @@ import { values, promises } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import xmljs from 'xml-js'
 import { UserConfig } from '../../config'
-import { DEFAULT_POST_DEPLOY_DELAY } from '../../constants'
 import { AdditionalAction, ClientOptions } from '../types'
 
 const { timeout } = promises
+const DEFAULT_POST_DEPLOY_DELAY = 50 * 1000 // 50 seconds in ms
+
 // we use a delay to handle the delay of the service to be updated after addition and deletion
 // https://community.jamf.com/t5/jamf-pro/delay-time-after-post-or-delete-api-calls/m-p/323383/emcs_t/S2h8ZW1haWx8dG9waWNfc3Vic2NyaXB0aW9ufE0wM1dLNk4xNU4yMlBFfDMyMzM4M3xTVUJTQ1JJUFRJT05TfGhL#M278490
 const postDeployDelay = (delay = DEFAULT_POST_DEPLOY_DELAY): Promise<void> => timeout.sleep(delay)

--- a/packages/jamf-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/jamf-adapter/src/definitions/deploy/deploy.ts
@@ -24,10 +24,11 @@ import {
 } from '../../constants'
 import { createClassicApiDefinitionsForType } from './classic_api_utils'
 import { adjustPolicyOnDeploy } from './policy'
+import { UserConfig } from '../../config'
 
 type InstanceDeployApiDefinitions = definitions.deploy.InstanceDeployApiDefinitions<AdditionalAction, ClientOptions>
 
-const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> => {
+const createCustomizations = (userConfig: UserConfig): Record<string, InstanceDeployApiDefinitions> => {
   const standardRequestDefinitions = deployment.helpers.createStandardDeployDefinitions<
     AdditionalAction,
     ClientOptions
@@ -39,16 +40,18 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
     [PACKAGE_TYPE_NAME]: { bulkPath: '/api/v1/packages' },
   })
   const customDefinitions: Record<string, Partial<InstanceDeployApiDefinitions>> = {
-    [CLASS_TYPE_NAME]: createClassicApiDefinitionsForType(CLASS_TYPE_NAME, `${CLASS_TYPE_NAME}es`),
-    [POLICY_TYPE_NAME]: createClassicApiDefinitionsForType(POLICY_TYPE_NAME, 'policies', {
+    [CLASS_TYPE_NAME]: createClassicApiDefinitionsForType(userConfig, CLASS_TYPE_NAME, `${CLASS_TYPE_NAME}es`),
+    [POLICY_TYPE_NAME]: createClassicApiDefinitionsForType(userConfig, POLICY_TYPE_NAME, 'policies', {
       add: adjustPolicyOnDeploy,
       modify: adjustPolicyOnDeploy,
     }),
     [OS_X_CONFIGURATION_PROFILE_TYPE_NAME]: createClassicApiDefinitionsForType(
+      userConfig,
       OS_X_CONFIGURATION_PROFILE_TYPE_NAME,
       'osxconfigurationprofiles',
     ),
     [MOBILE_DEVICE_CONFIGURATION_PROFILE_TYPE_NAME]: createClassicApiDefinitionsForType(
+      userConfig,
       'configuration_profile',
       'mobiledeviceconfigurationprofiles',
     ),
@@ -91,13 +94,19 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
-    [SITE_TYPE_NAME]: createClassicApiDefinitionsForType(SITE_TYPE_NAME, `${SITE_TYPE_NAME}s`),
-    [MAC_APPLICATION_TYPE_NAME]: createClassicApiDefinitionsForType(MAC_APPLICATION_TYPE_NAME, 'macapplications'),
+    [SITE_TYPE_NAME]: createClassicApiDefinitionsForType(userConfig, SITE_TYPE_NAME, `${SITE_TYPE_NAME}s`),
+    [MAC_APPLICATION_TYPE_NAME]: createClassicApiDefinitionsForType(
+      userConfig,
+      MAC_APPLICATION_TYPE_NAME,
+      'macapplications',
+    ),
   }
   return _.merge(standardRequestDefinitions, customDefinitions)
 }
 
-export const createDeployDefinitions = (): definitions.deploy.DeployApiDefinitions<never, ClientOptions> => ({
+export const createDeployDefinitions = (
+  userConfig: UserConfig,
+): definitions.deploy.DeployApiDefinitions<never, ClientOptions> => ({
   instances: {
     default: {
       requestsByAction: {
@@ -110,6 +119,6 @@ export const createDeployDefinitions = (): definitions.deploy.DeployApiDefinitio
       },
       changeGroupId: deployment.grouping.selfGroup,
     },
-    customizations: createCustomizations(),
+    customizations: createCustomizations(userConfig),
   },
 })


### PR DESCRIPTION
We need to add some busy waiting after POST or DELETE api calls on Jamf classicAPI
Please see https://community.jamf.com/t5/jamf-pro/delay-time-after-post-or-delete-api-calls/m-p/323383/emcs_t/S2h8ZW1haWx8dG9waWNfc3Vic2NyaXB0aW9ufE0wM1dLNk4xNU4yMlBFfDMyMzM4M3xTVUJTQ1JJUFRJT05TfGhL#M278490


---

_Additional context for reviewer_

---

_Release Notes_: 
_Jamf Adapter_:
- Fix deployment fails when there are dependencies on creation or deletion

---

_User Notifications_: 
_Jamf Adapter_:
- Fix deployment fails when there are dependencies on creation or deletion
