### PR TITLE
SALTO-6614: Create fetch warning on Brand Logo 403

### DIFF
--- a/packages/adapter-components/src/fetch/errors.ts
+++ b/packages/adapter-components/src/fetch/errors.ts
@@ -5,6 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import { SaltoError } from '@salto-io/adapter-api'
 import { FatalError } from '@salto-io/dag'
 import { HTTPError } from '../client'
 import { fetch } from '../definitions'
@@ -15,6 +16,11 @@ export class AbortFetchOnFailure extends FatalError {
   }
 }
 
+export const getInsufficientPermissionsError = (typeName: string): SaltoError => ({
+  message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
+  severity: 'Info',
+})
+
 export const createGetInsufficientPermissionsErrorFunction: (
   statuses: number[],
 ) => fetch.FetchResourceDefinition['onError'] = statuses => ({
@@ -24,10 +30,7 @@ export const createGetInsufficientPermissionsErrorFunction: (
       if (error instanceof HTTPError && statuses.includes(error.response.status)) {
         return {
           action: 'customSaltoError',
-          value: {
-            message: `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`,
-            severity: 'Info',
-          },
+          value: getInsufficientPermissionsError(typeName),
         }
       }
       return { action: 'failEntireFetch', value: false }

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -236,6 +236,7 @@ const filterCreator: FilterCreator = ({ client }) => ({
     } catch (error) {
       if (error instanceof clientUtils.HTTPError && error.response.status === 403) {
         log.error('failed to get brand logos due to insufficient permissions with error %s', error.message)
+        brandsWithLogos.forEach(brand => delete brand.value[LOGO_FIELD])
         return { errors: [fetchUtils.errors.getInsufficientPermissionsError(BRAND_LOGO_TYPE_NAME)] }
       }
       log.error('encountered an error while fetching brand logos %s', error.message)

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -24,7 +24,7 @@ import {
   SaltoError,
   StaticFile,
 } from '@salto-io/adapter-api'
-import { elements as elementsUtils, fetch as fetchUtils } from '@salto-io/adapter-components'
+import { elements as elementsUtils, fetch as fetchUtils, client as clientUtils } from '@salto-io/adapter-components'
 import {
   naclCase,
   safeJsonStringify,
@@ -227,10 +227,20 @@ const filterCreator: FilterCreator = ({ client }) => ({
       .filter(e => e.elemID.typeName === BRAND_TYPE_NAME)
       .filter(e => !_.isEmpty(e.value[LOGO_FIELD]))
     elements.push(BRAND_LOGO_TYPE)
-    const logoInstances = (
-      await Promise.all(brandsWithLogos.map(async brand => getBrandLogo({ client, brand })))
-    ).filter(isInstanceElement)
-    logoInstances.forEach(instance => elements.push(instance))
+    try {
+      const logoInstances = (
+        await Promise.all(brandsWithLogos.map(async brand => getBrandLogo({ client, brand })))
+      ).filter(isInstanceElement)
+      logoInstances.forEach(instance => elements.push(instance))
+      return { errors: [] }
+    } catch (error) {
+      if (error instanceof clientUtils.HTTPError && error.response.status === 403) {
+        log.error('failed to get brand logos due to insufficient permissions with error %s', error.message)
+        return { errors: [fetchUtils.errors.getInsufficientPermissionsError(BRAND_LOGO_TYPE_NAME)] }
+      }
+      log.error('encountered an error while fetching brand logos %s', error.message)
+      throw error
+    }
   },
   deploy: async (changes: Change<InstanceElement>[]) => {
     const [brandLogoChanges, leftoverChanges] = _.partition(

--- a/packages/zendesk-adapter/test/filters/brand_logo.test.ts
+++ b/packages/zendesk-adapter/test/filters/brand_logo.test.ts
@@ -117,7 +117,7 @@ describe('brand logo filter', () => {
         [LOGO_FIELD]: new ReferenceExpression(logo.elemID, logo),
       })
     })
-    it('should return fetch warning in case of 403 error', async () => {
+    it('should return fetch warning in case of 403 error and remove logo field from brand', async () => {
       mockGet.mockImplementation(_params => {
         throw new clientUtils.HTTPError('err', { data: 'err' as unknown as clientUtils.ResponseValue, status: 403 })
       })
@@ -131,6 +131,8 @@ describe('brand logo filter', () => {
           severity: 'Info',
         },
       ])
+      const brand = elements.filter(isInstanceElement).find(e => e.elemID.typeName === BRAND_TYPE_NAME)
+      expect(brand?.value[LOGO_FIELD]).toBeUndefined()
     })
     it('should throw error on any other error', async () => {
       mockGet.mockImplementation(_params => {


### PR DESCRIPTION
Until now, when we got 403 while trying to get brand logos, the entire fetch failed, we now convert it into a fetch warning, like we do to other types fetched with the infra.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Zendesk_adapter_:
- Create fetch warning when failing to get brand logos due to insufficient permissions, instead of failing the entire fetch

---
_User Notifications_: 
None