### PR TITLE
SALTO-6618: Avoid using persistent workspace for read only commands

### DIFF
--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -70,6 +70,7 @@ export type WorkspaceCommandAction<T> = (args: WorkspaceCommandArgs<T>) => Promi
 export type WorkspaceCommandDef<T> = {
   properties: CommandOptions<T>
   action: WorkspaceCommandAction<T>
+  loadWorkspaceArgs?: { persistent?: false }
   extraTelemetryTags?: (args: { workspace: Workspace; input: T }) => Tags
 }
 
@@ -211,6 +212,7 @@ export const createWorkspaceCommand = <T>(def: WorkspaceCommandDef<T>): CommandD
     const workspace = await loadLocalWorkspace({
       path: args.workspacePath,
       configOverrides: getConfigOverrideChanges(args.input),
+      ...(def.loadWorkspaceArgs ?? {}),
     })
 
     args.cliTelemetry.setTags({

--- a/packages/cli/src/commands/account.ts
+++ b/packages/cli/src/commands/account.ts
@@ -313,6 +313,7 @@ const accountListCommandDef: WorkspaceCommandDef<AccountListArgs> = {
     keyedOptions: [ENVIRONMENT_OPTION],
   },
   action: listAction,
+  loadWorkspaceArgs: { persistent: false },
 }
 
 const accountListDef = createWorkspaceCommand(accountListCommandDef)

--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -202,6 +202,7 @@ const syncToWorkspaceCmd = createWorkspaceCommand({
     ],
   },
   action: syncWorkspaceToFolderAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 export const adapterFormatGroupDef = createCommandGroupDef({

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -496,6 +496,7 @@ const listUnresolvedDef = createWorkspaceCommand({
     ],
   },
   action: listUnresolvedAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 // Open
@@ -553,6 +554,7 @@ const elementOpenDef = createWorkspaceCommand({
     ],
   },
   action: openAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 type ElementListArgs = {
@@ -625,6 +627,7 @@ const listElementsDef = createWorkspaceCommand({
     ],
   },
   action: listAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 type ElementRenameArgs = {
@@ -764,6 +767,7 @@ const printElementDef = createWorkspaceCommand({
     ],
   },
   action: printElementAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 type FixElementsArgs = {

--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -168,6 +168,7 @@ const envDiffDef = createWorkspaceCommand({
     ],
   },
   action: diffAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 // Rename
@@ -294,6 +295,7 @@ const envCurrentDef = createWorkspaceCommand({
     description: 'Print the name of the current workspace environment',
   },
   action: currentAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 // List
@@ -311,6 +313,7 @@ const envListDef = createWorkspaceCommand({
     description: 'List all workspace environments',
   },
   action: listAction,
+  loadWorkspaceArgs: { persistent: false },
 })
 
 // Create


### PR DESCRIPTION


---

_Additional context for reviewer_
This was mildly annoying that I couldn't run `salto element print` when I tried to debug something...

---
_Release Notes_: 
Cli:
- Enable running commands that do not change the workspace while other commands are running

---
_User Notifications_: 
_None_