### PR TITLE
SALTO-6625: Parse additional smart values in automations

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -60,6 +60,7 @@ type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFil
   addTypeToFieldName?: boolean
   convertUsersIds?: boolean
   parseTemplateExpressions?: boolean
+  parseAdditionalAutomationExpressions?: boolean
   enableScriptRunnerAddon?: boolean
   enableJSM?: boolean
   enableJsmExperimental?: boolean
@@ -381,6 +382,7 @@ const fetchConfigType = definitions.createUserFetchConfigType({
     allowUserCallFailure: { refType: BuiltinTypes.BOOLEAN },
     // Default is true
     parseTemplateExpressions: { refType: BuiltinTypes.BOOLEAN },
+    parseAdditionalAutomationExpressions: { refType: BuiltinTypes.BOOLEAN },
     addAlias: { refType: BuiltinTypes.BOOLEAN },
     splitFieldConfiguration: { refType: BuiltinTypes.BOOLEAN },
     enableMissingReferences: { refType: BuiltinTypes.BOOLEAN },
@@ -443,6 +445,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'fetch.allowUserCallFailure',
       'fetch.enableAssetsObjectFieldConfiguration',
       'fetch.automationPageSize',
+      'fetch.parseAdditionalAutomationExpressions',
       'deploy.taskMaxRetries',
       'deploy.taskRetryDelay',
       'deploy.ignoreMissingExtensions',

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -102,9 +102,7 @@ const getPossibleSmartValues = (
     }
   }
 
-  ;(automation.value.components ?? []).concat(automation.value.trigger).forEach(component => {
-    findSmartValues(component)
-  })
+  ;(automation.value.components ?? []).concat(automation.value.trigger).forEach(component => findSmartValues(component))
   return containers
 }
 

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -38,6 +38,7 @@ const log = logger(module)
 type Component = {
   value?: Values | boolean
   rawValue?: unknown
+  children?: Component[]
 }
 
 type AutomationInstance = InstanceElement & {
@@ -50,6 +51,7 @@ type AutomationInstance = InstanceElement & {
 const COMPONENT_SCHEME = Joi.object({
   value: Joi.alternatives(Joi.object(), Joi.boolean()).optional(),
   rawValue: Joi.optional(),
+  children: Joi.array().optional(),
 }).unknown(true)
 
 const AUTOMATION_INSTANCE_SCHEME = Joi.object({
@@ -69,31 +71,47 @@ const filterAutomations = (instances: InstanceElement[]): AutomationInstance[] =
 
 type SmartValueContainer = { obj: Values; key: string }
 
-const getPossibleSmartValues = (automation: AutomationInstance): SmartValueContainer[] =>
-  _(automation.value.components ?? [])
-    .concat(automation.value.trigger)
-    .flatMap(component => {
-      const containers: SmartValueContainer[] = []
+const getPossibleSmartValues = (
+  automation: AutomationInstance,
+  parseAdditionalAutomationExpressions?: boolean,
+): SmartValueContainer[] => {
+  const containers: SmartValueContainer[] = []
 
-      if (component.value !== undefined && !_.isBoolean(component.value)) {
-        const { value } = component
-        Object.keys(component.value)
-          .filter(key => _.isString(value[key]) || isTemplateExpression(value[key]))
-          .map(key => ({
-            key,
-            obj: value,
-          }))
-          .forEach(container => containers.push(container))
+  const findSmartValues = (component: Component): void => {
+    if (component.value !== undefined && !_.isBoolean(component.value)) {
+      const { value } = component
+      if (parseAdditionalAutomationExpressions === true && Array.isArray(value?.operations)) {
+        value.operations.forEach(findSmartValues)
       }
+      Object.keys(value)
+        .filter(key => _.isString(value[key]) || isTemplateExpression(value[key]))
+        .map(key => ({ key, obj: value }))
+        .forEach(container => containers.push(container))
+    }
 
-      if (_.isString(component.rawValue) || isTemplateExpression(component.rawValue)) {
-        containers.push({ key: 'rawValue', obj: component })
-      }
-      return containers
-    })
-    .value()
+    if (_.isString(component.rawValue) || isTemplateExpression(component.rawValue)) {
+      containers.push({ key: 'rawValue', obj: component })
+    }
 
-const replaceFormulasWithTemplates = async (instances: InstanceElement[]): Promise<SaltoError[]> => {
+    if (
+      parseAdditionalAutomationExpressions === true &&
+      Array.isArray(component.children) &&
+      component.children.length > 0
+    ) {
+      component.children.forEach(findSmartValues)
+    }
+  }
+
+  ;(automation.value.components ?? []).concat(automation.value.trigger).forEach(component => {
+    findSmartValues(component)
+  })
+  return containers
+}
+
+const replaceFormulasWithTemplates = async (
+  instances: InstanceElement[],
+  parseAdditionalAutomationExpressions?: boolean,
+): Promise<SaltoError[]> => {
   const fieldInstances = instances.filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
   const fieldInstancesByName = _(fieldInstances)
     .filter(instance => _.isString(instance.value.name))
@@ -108,7 +126,7 @@ const replaceFormulasWithTemplates = async (instances: InstanceElement[]): Promi
   const ambiguousTokensWarnings = filterAutomations(instances)
     .map(instance => {
       const allAmbiguousTokens = new Set<string>()
-      getPossibleSmartValues(instance)
+      getPossibleSmartValues(instance, parseAdditionalAutomationExpressions)
         .filter(({ obj, key }) => {
           if (!_.isString(obj[key])) {
             log.debug(`'${key}' in ${instance.elemID.getFullName()} key is not a string`)
@@ -164,11 +182,15 @@ const filterCreator: FilterCreator = ({ config }) => {
   return {
     name: 'smartValueReferenceFilter',
     onFetch: async (elements: Element[]) => {
-      if (config.fetch.parseTemplateExpressions === false) {
+      const { parseTemplateExpressions, parseAdditionalAutomationExpressions } = config.fetch
+      if (parseTemplateExpressions === false) {
         log.debug('Parsing smart values template expressions was disabled')
         return {}
       }
-      const warnings = await replaceFormulasWithTemplates(elements.filter(isInstanceElement))
+      const warnings = await replaceFormulasWithTemplates(
+        elements.filter(isInstanceElement),
+        parseAdditionalAutomationExpressions,
+      )
       return {
         errors: warnings,
       }


### PR DESCRIPTION
Added additional smart values parsing, under a flag so we can open it gradually.

---

_Additional context for reviewer_

- Added support for smart values under `operations` field
- Added support for nested smart values in `BRANCH` components

---
_Release Notes_: 

_Jira Adapter_:
- Parse additional smart values in automations. To enable this feature add `parseAdditionalAutomationExpressions` config flag under the `fetch` section.

---
_User Notifications_: 
None