### PR TITLE
SALTO-3464: Enhanced Search Noise reduction

### DIFF
--- a/packages/adapter-components/src/definitions/user/index.ts
+++ b/packages/adapter-components/src/definitions/user/index.ts
@@ -24,6 +24,7 @@ export {
 } from './fetch_config'
 export {
   UserDeployConfig,
+  createChangeValidatorConfigType,
   createUserDeployConfigType,
   validateDefaultMissingUserFallbackConfig,
   DefaultMissingUserFallbackConfig,

--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -202,6 +202,7 @@ import fieldContextOptionsDeploymentFilter from './filters/fields/context_option
 import fieldContextOptionsDeploymentOrderFilter from './filters/fields/context_options_order_deployment_filter'
 import contextDefaultValueDeploymentFilter from './filters/fields/context_default_value_deployment_filter'
 import statusPropertiesReferencesFilter from './filters/workflowV2/status_properties_references'
+import enhancedSearchNoiseReductionFilter from './filters/script_runner/enhanced_search/enhanced_search_noise_filter'
 
 const { getAllElements, addRemainingTypes } = elementUtils.ducktype
 const { findDataField } = elementUtils
@@ -321,6 +322,8 @@ export const DEFAULT_FILTERS = [
   fieldConfigurationSchemeFilter,
   userFilter,
   forbiddenPermissionSchemeFilter,
+  // Must run before jqlReferencesFilter
+  enhancedSearchNoiseReductionFilter,
   jqlReferencesFilter,
   removeEmptyValuesFilter,
   maskingFilter,

--- a/packages/jira-adapter/src/change_validators/board_culomn_config.ts
+++ b/packages/jira-adapter/src/change_validators/board_culomn_config.ts
@@ -16,11 +16,8 @@ import {
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { BOARD_TYPE_NAME } from '../constants'
-
-const { awu } = collections.asynciterable
 
 type BoardColumn = {
   name: string
@@ -55,17 +52,16 @@ const isInvalidColumnConfig = (boardInstance: InstanceElement): boolean => {
   return !hasNonEmptyStatuses
 }
 export const boardColumnConfigValidator: ChangeValidator = async changes =>
-  awu(changes)
+  changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
     .map(getChangeData)
     .filter(instance => instance.elemID.typeName === BOARD_TYPE_NAME)
     .filter(isInvalidColumnConfig)
-    .map(async instance => ({
+    .map(instance => ({
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'Unable to deploy Board without Columns and Statuses.',
       detailedMessage:
         'The board must have at least one column, and at least one of these columns must include a status. Please verify that these conditions are met before deploying it.',
     }))
-    .toArray()

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -72,6 +72,7 @@ import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME } from '../filt
 import { fieldContextDefaultValueValidator } from './field_contexts/field_context_default_value'
 import { fieldContextOrderRemovalValidator } from './field_contexts/order_removal'
 import { optionValueValidator } from './field_contexts/option_value'
+import { enhancedSearchDeploymentValidator } from './script_runner/enhanced_search_deployment'
 
 const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator, SCOPE } =
   deployment.changeValidators
@@ -152,6 +153,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     fieldContextDefaultValue: fieldContextDefaultValueValidator(config),
     fieldContextOrderRemoval: fieldContextOrderRemovalValidator(config),
     optionValue: optionValueValidator(config),
+    enhancedSearchDeployment: enhancedSearchDeploymentValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/script_runner/enhanced_search_deployment.ts
+++ b/packages/jira-adapter/src/change_validators/script_runner/enhanced_search_deployment.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ChangeError,
+  ChangeValidator,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { isEnhancedSearchInstance } from '../../common/script_runner'
+
+const createEnhancedSearchDeploymentErrors = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Error',
+  message: 'Filters created by Enhanced Search cannot be deployed',
+  detailedMessage: 'Salto does not support Enhanced Search, and cannot deploy filters created by it.',
+})
+
+export const enhancedSearchDeploymentValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(isEnhancedSearchInstance)
+    .map(createEnhancedSearchDeploymentErrors)

--- a/packages/jira-adapter/src/common/script_runner.ts
+++ b/packages/jira-adapter/src/common/script_runner.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { InstanceElement } from '@salto-io/adapter-api'
+import { FILTER_TYPE_NAME } from '../constants'
+
+export const isEnhancedSearchInstance = (instance: InstanceElement): boolean =>
+  instance.elemID.typeName === FILTER_TYPE_NAME &&
+  instance.value.description?.startsWith('Filter managed by Enhanced Search') === true

--- a/packages/jira-adapter/src/common/script_runner.ts
+++ b/packages/jira-adapter/src/common/script_runner.ts
@@ -10,4 +10,4 @@ import { FILTER_TYPE_NAME } from '../constants'
 
 export const isEnhancedSearchInstance = (instance: InstanceElement): boolean =>
   instance.elemID.typeName === FILTER_TYPE_NAME &&
-  instance.value.description?.startsWith('Filter managed by Enhanced Search') === true
+  instance.value.description?.startsWith('Filter managed by Enhanced Search')

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -208,7 +208,7 @@ const createClientConfigType = (): ObjectType => {
   return configType
 }
 
-const changeValidatorNames = [
+const CHANGE_VALIDATOR_NAMES = [
   'unresolvedReference',
   'brokenReferences',
   'deployTypesNotSupported',
@@ -275,11 +275,11 @@ const changeValidatorNames = [
   'enhancedSearchDeployment',
 ]
 
-export type ChangeValidatorName = (typeof changeValidatorNames)[number]
+export type ChangeValidatorName = (typeof CHANGE_VALIDATOR_NAMES)[number]
 
 const changeValidatorConfigType = definitions.createChangeValidatorConfigType({
   adapterName: JIRA,
-  changeValidatorNames,
+  changeValidatorNames: CHANGE_VALIDATOR_NAMES,
 })
 
 const jiraDeployConfigType = definitions.createUserDeployConfigType(JIRA, changeValidatorConfigType, {

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -272,6 +272,7 @@ const changeValidatorNames = [
   'fieldContextDefaultValue',
   'fieldContextOrderRemoval',
   'optionValue',
+  'enhancedSearchDeployment',
 ]
 
 export type ChangeValidatorName = (typeof changeValidatorNames)[number]

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -208,143 +208,77 @@ const createClientConfigType = (): ObjectType => {
   return configType
 }
 
-export type ChangeValidatorName =
-  | 'unresolvedReference'
-  | 'brokenReferences'
-  | 'deployTypesNotSupported'
-  | 'readOnlyProjectRoleChange'
-  | 'defaultFieldConfiguration'
-  | 'fieldConfigurationDescriptionLength'
-  | 'fieldConfigurationItemDescriptionLength'
-  | 'screen'
-  | 'issueTypeScheme'
-  | 'issueTypeSchemeDefaultType'
-  | 'teamManagedProject'
-  | 'projectDeletion'
-  | 'status'
-  | 'privateApi'
-  | 'emptyValidatorWorkflowChange'
-  | 'readOnlyWorkflow'
-  | 'dashboardGadgets'
-  | 'referencedWorkflowDeletion'
-  | 'dashboardLayout'
-  | 'issueLayouts'
-  | 'permissionType'
-  | 'automations'
-  | 'activeSchemeDeletion'
-  | 'statusMigrationChange'
-  | 'workflowSchemeMigration'
-  | 'workflowStatusMappings'
-  | 'inboundTransition'
-  | 'issueTypeSchemeMigration'
-  | 'missingExtensionsTransitionRules'
-  | 'activeSchemeChange'
-  | 'masking'
-  | 'issueTypeDeletion'
-  | 'lockedFields'
-  | 'fieldContext'
-  | 'fieldSecondGlobalContext'
-  | 'systemFields'
-  | 'workflowProperties'
-  | 'permissionScheme'
-  | 'screenSchemeDefault'
-  | 'wrongUserPermissionScheme'
-  | 'accountId'
-  | 'workflowSchemeDups'
-  | 'workflowTransitionDuplicateName'
-  | 'permissionSchemeDeployment'
-  | 'projectCategory'
-  | 'customFieldsWith10KOptions'
-  | 'issueTypeHierarchy'
-  | 'automationProjects'
-  | 'deleteLastQueueValidator'
-  | 'defaultAdditionQueueValidator'
-  | 'defaultAttributeValidator'
-  | 'boardColumnConfig'
-  | 'automationToAssets'
-  | 'addJsmProject'
-  | 'deleteLabelAtttribute'
-  | 'jsmPermissions'
-  | 'fieldContextOptions'
-  | 'uniqueFields'
-  | 'assetsObjectFieldConfigurationAql'
-  | 'projectAssigneeType'
-  | 'fieldContextDefaultValue'
-  | 'fieldContextOrderRemoval'
-  | 'optionValue'
+const changeValidatorNames = [
+  'unresolvedReference',
+  'brokenReferences',
+  'deployTypesNotSupported',
+  'readOnlyProjectRoleChange',
+  'defaultFieldConfiguration',
+  'fieldConfigurationDescriptionLength',
+  'fieldConfigurationItemDescriptionLength',
+  'screen',
+  'issueTypeScheme',
+  'issueTypeSchemeDefaultType',
+  'teamManagedProject',
+  'projectDeletion',
+  'status',
+  'privateApi',
+  'emptyValidatorWorkflowChange',
+  'readOnlyWorkflow',
+  'dashboardGadgets',
+  'referencedWorkflowDeletion',
+  'dashboardLayout',
+  'issueLayouts',
+  'permissionType',
+  'automations',
+  'activeSchemeDeletion',
+  'statusMigrationChange',
+  'workflowSchemeMigration',
+  'workflowStatusMappings',
+  'inboundTransition',
+  'issueTypeSchemeMigration',
+  'missingExtensionsTransitionRules',
+  'activeSchemeChange',
+  'masking',
+  'issueTypeDeletion',
+  'lockedFields',
+  'fieldContext',
+  'fieldSecondGlobalContext',
+  'systemFields',
+  'workflowProperties',
+  'permissionScheme',
+  'screenSchemeDefault',
+  'wrongUserPermissionScheme',
+  'accountId',
+  'workflowSchemeDups',
+  'workflowTransitionDuplicateName',
+  'permissionSchemeDeployment',
+  'projectCategory',
+  'customFieldsWith10KOptions',
+  'issueTypeHierarchy',
+  'automationProjects',
+  'deleteLastQueueValidator',
+  'defaultAdditionQueueValidator',
+  'defaultAttributeValidator',
+  'boardColumnConfig',
+  'automationToAssets',
+  'addJsmProject',
+  'deleteLabelAtttribute',
+  'jsmPermissions',
+  'fieldContextOptions',
+  'uniqueFields',
+  'assetsObjectFieldConfigurationAql',
+  'projectAssigneeType',
+  'fieldContextDefaultValue',
+  'fieldContextOrderRemoval',
+  'optionValue',
+]
 
-type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
+export type ChangeValidatorName = (typeof changeValidatorNames)[number]
 
-const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig>({
-  elemID: new ElemID(JIRA, 'changeValidatorConfig'),
-  fields: {
-    unresolvedReference: { refType: BuiltinTypes.BOOLEAN },
-    boardColumnConfig: { refType: BuiltinTypes.BOOLEAN },
-    brokenReferences: { refType: BuiltinTypes.BOOLEAN },
-    deployTypesNotSupported: { refType: BuiltinTypes.BOOLEAN },
-    readOnlyProjectRoleChange: { refType: BuiltinTypes.BOOLEAN },
-    defaultFieldConfiguration: { refType: BuiltinTypes.BOOLEAN },
-    fieldConfigurationDescriptionLength: { refType: BuiltinTypes.BOOLEAN },
-    fieldConfigurationItemDescriptionLength: { refType: BuiltinTypes.BOOLEAN },
-    screen: { refType: BuiltinTypes.BOOLEAN },
-    issueTypeScheme: { refType: BuiltinTypes.BOOLEAN },
-    issueTypeSchemeDefaultType: { refType: BuiltinTypes.BOOLEAN },
-    teamManagedProject: { refType: BuiltinTypes.BOOLEAN },
-    projectDeletion: { refType: BuiltinTypes.BOOLEAN },
-    status: { refType: BuiltinTypes.BOOLEAN },
-    privateApi: { refType: BuiltinTypes.BOOLEAN },
-    emptyValidatorWorkflowChange: { refType: BuiltinTypes.BOOLEAN },
-    referencedWorkflowDeletion: { refType: BuiltinTypes.BOOLEAN },
-    readOnlyWorkflow: { refType: BuiltinTypes.BOOLEAN },
-    dashboardGadgets: { refType: BuiltinTypes.BOOLEAN },
-    dashboardLayout: { refType: BuiltinTypes.BOOLEAN },
-    issueLayouts: { refType: BuiltinTypes.BOOLEAN },
-    permissionType: { refType: BuiltinTypes.BOOLEAN },
-    automations: { refType: BuiltinTypes.BOOLEAN },
-    activeSchemeDeletion: { refType: BuiltinTypes.BOOLEAN },
-    statusMigrationChange: { refType: BuiltinTypes.BOOLEAN },
-    workflowSchemeMigration: { refType: BuiltinTypes.BOOLEAN },
-    workflowStatusMappings: { refType: BuiltinTypes.BOOLEAN },
-    inboundTransition: { refType: BuiltinTypes.BOOLEAN },
-    issueTypeSchemeMigration: { refType: BuiltinTypes.BOOLEAN },
-    missingExtensionsTransitionRules: { refType: BuiltinTypes.BOOLEAN },
-    activeSchemeChange: { refType: BuiltinTypes.BOOLEAN },
-    masking: { refType: BuiltinTypes.BOOLEAN },
-    issueTypeDeletion: { refType: BuiltinTypes.BOOLEAN },
-    lockedFields: { refType: BuiltinTypes.BOOLEAN },
-    fieldContext: { refType: BuiltinTypes.BOOLEAN },
-    fieldSecondGlobalContext: { refType: BuiltinTypes.BOOLEAN },
-    systemFields: { refType: BuiltinTypes.BOOLEAN },
-    workflowProperties: { refType: BuiltinTypes.BOOLEAN },
-    permissionScheme: { refType: BuiltinTypes.BOOLEAN },
-    screenSchemeDefault: { refType: BuiltinTypes.BOOLEAN },
-    wrongUserPermissionScheme: { refType: BuiltinTypes.BOOLEAN },
-    accountId: { refType: BuiltinTypes.BOOLEAN },
-    workflowSchemeDups: { refType: BuiltinTypes.BOOLEAN },
-    workflowTransitionDuplicateName: { refType: BuiltinTypes.BOOLEAN },
-    permissionSchemeDeployment: { refType: BuiltinTypes.BOOLEAN },
-    projectCategory: { refType: BuiltinTypes.BOOLEAN },
-    customFieldsWith10KOptions: { refType: BuiltinTypes.BOOLEAN },
-    issueTypeHierarchy: { refType: BuiltinTypes.BOOLEAN },
-    automationProjects: { refType: BuiltinTypes.BOOLEAN },
-    deleteLastQueueValidator: { refType: BuiltinTypes.BOOLEAN },
-    defaultAdditionQueueValidator: { refType: BuiltinTypes.BOOLEAN },
-    defaultAttributeValidator: { refType: BuiltinTypes.BOOLEAN },
-    automationToAssets: { refType: BuiltinTypes.BOOLEAN },
-    addJsmProject: { refType: BuiltinTypes.BOOLEAN },
-    deleteLabelAtttribute: { refType: BuiltinTypes.BOOLEAN },
-    jsmPermissions: { refType: BuiltinTypes.BOOLEAN },
-    fieldContextOptions: { refType: BuiltinTypes.BOOLEAN },
-    uniqueFields: { refType: BuiltinTypes.BOOLEAN },
-    assetsObjectFieldConfigurationAql: { refType: BuiltinTypes.BOOLEAN },
-    projectAssigneeType: { refType: BuiltinTypes.BOOLEAN },
-    fieldContextDefaultValue: { refType: BuiltinTypes.BOOLEAN },
-    fieldContextOrderRemoval: { refType: BuiltinTypes.BOOLEAN },
-    optionValue: { refType: BuiltinTypes.BOOLEAN },
-  },
-  annotations: {
-    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
-  },
+const changeValidatorConfigType = definitions.createChangeValidatorConfigType({
+  adapterName: JIRA,
+  changeValidatorNames,
 })
 
 const jiraDeployConfigType = definitions.createUserDeployConfigType(JIRA, changeValidatorConfigType, {

--- a/packages/jira-adapter/src/filters/script_runner/enhanced_search/enhanced_search_noise_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/enhanced_search/enhanced_search_noise_filter.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { isInstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../../../filter'
+import { isEnhancedSearchInstance } from '../../../common/script_runner'
+
+const ENHANCED_SEARCH_REPLACE_TEXT = 'ENHANCED_SEARCH_ISSUE_TERMS'
+
+// This filter changes Enhanced Search jql to remove noise
+const filter: FilterCreator = () => ({
+  name: 'enhancedSearchNoiseReductionFilter',
+  onFetch: async elements => {
+    elements
+      .filter(isInstanceElement)
+      .filter(isEnhancedSearchInstance)
+      .filter(instance => instance.value.jql?.includes('issue in (') === true)
+      .forEach(instance => {
+        // replace 'issue in (' until the end of the bracket with 'ENHANCED_SEARCH_ISSUE_TERMS'
+        // the replace is lazy, so it will fail for things like 'issue in (a, (b,c))'
+        instance.value.jql = instance.value.jql.replace(/issue in \(.*?\)/, ENHANCED_SEARCH_REPLACE_TEXT)
+      })
+  },
+})
+export default filter

--- a/packages/jira-adapter/src/filters/script_runner/enhanced_search/enhanced_search_noise_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/enhanced_search/enhanced_search_noise_filter.ts
@@ -18,7 +18,7 @@ const filter: FilterCreator = () => ({
     elements
       .filter(isInstanceElement)
       .filter(isEnhancedSearchInstance)
-      .filter(instance => instance.value.jql?.includes('issue in (') === true)
+      .filter(instance => instance.value.jql?.includes('issue in ('))
       .forEach(instance => {
         // replace 'issue in (' until the end of the bracket with 'ENHANCED_SEARCH_ISSUE_TERMS'
         // the replace is lazy, so it will fail for things like 'issue in (a, (b,c))'

--- a/packages/jira-adapter/test/change_validators/script_runner/enhanced_search_deployment.test.ts
+++ b/packages/jira-adapter/test/change_validators/script_runner/enhanced_search_deployment.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { toChange, InstanceElement } from '@salto-io/adapter-api'
+import { enhancedSearchDeploymentValidator } from '../../../src/change_validators/script_runner/enhanced_search_deployment'
+import { createEmptyType } from '../../utils'
+import { FILTER_TYPE_NAME } from '../../../src/constants'
+
+describe('enhancedSearchDeploymentValidator', () => {
+  let instances: InstanceElement[] = []
+  const filterType = createEmptyType(FILTER_TYPE_NAME)
+  beforeEach(() => {
+    instances = [
+      new InstanceElement('instance1', filterType, {
+        description: 'Filter managed by Enhanced Search: issueFunction in linkedIssuesOf',
+        jql: 'ENHANCED_SEARCH_ISSUE_TERMS',
+      }),
+      new InstanceElement('instance2', filterType, {
+        description: 'description',
+        jql: 'ENHANCED_SEARCH_ISSUE_TERMS',
+      }),
+      new InstanceElement('instance3', filterType, {
+        description: 'Filter managed by Enhanced Search: ',
+        jql: 'ENHANCED_SEARCH_ISSUE_TERMS with more text',
+      }),
+    ]
+  })
+  it('should issue an error for an addition change', async () => {
+    expect(await enhancedSearchDeploymentValidator([toChange({ after: instances[0] })])).toEqual([
+      {
+        elemID: instances[0].elemID,
+        severity: 'Error',
+        message: 'Filters created by Enhanced Search cannot be deployed',
+        detailedMessage: 'Salto does not support Enhanced Search, and cannot deploy filters created by it.',
+      },
+    ])
+  })
+  it('should issue an error for a modification change', async () => {
+    expect(await enhancedSearchDeploymentValidator([toChange({ before: instances[0], after: instances[0] })])).toEqual([
+      {
+        elemID: instances[0].elemID,
+        severity: 'Error',
+        message: 'Filters created by Enhanced Search cannot be deployed',
+        detailedMessage: 'Salto does not support Enhanced Search, and cannot deploy filters created by it.',
+      },
+    ])
+  })
+  it('should not issue an error for a change that is not an enhanced search filter', async () => {
+    expect(await enhancedSearchDeploymentValidator([toChange({ after: instances[1] })])).toEqual([])
+  })
+  it('should not issue an error for a change that is not a filter', async () => {
+    const change = toChange({
+      after: new InstanceElement('instance3', createEmptyType('notFilter'), {
+        description: 'Filter managed by Enhanced Search: issueFunction in linkedIssuesOf',
+        jql: 'ENHANCED_SEARCH_ISSUE_TERMS',
+      }),
+    })
+    expect(await enhancedSearchDeploymentValidator([change])).toEqual([])
+  })
+  it('should not issue an error for a removal change', async () => {
+    expect(await enhancedSearchDeploymentValidator([toChange({ before: instances[0] })])).toEqual([])
+  })
+  it('should return the correct error messages for several changes', async () => {
+    expect(
+      await enhancedSearchDeploymentValidator([
+        toChange({ after: instances[0] }),
+        toChange({ after: instances[1] }),
+        toChange({ after: instances[2] }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instances[0].elemID,
+        severity: 'Error',
+        message: 'Filters created by Enhanced Search cannot be deployed',
+        detailedMessage: 'Salto does not support Enhanced Search, and cannot deploy filters created by it.',
+      },
+      {
+        elemID: instances[2].elemID,
+        severity: 'Error',
+        message: 'Filters created by Enhanced Search cannot be deployed',
+        detailedMessage: 'Salto does not support Enhanced Search, and cannot deploy filters created by it.',
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/filters/script_runner/enhanced_search/enhanced_search_noise_filter.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/enhanced_search/enhanced_search_noise_filter.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { filterUtils } from '@salto-io/adapter-components'
+import { InstanceElement } from '@salto-io/adapter-api'
+import { createEmptyType, getFilterParams } from '../../../utils'
+import { FILTER_TYPE_NAME } from '../../../../src/constants'
+import enhancedSearchNoiseFilter from '../../../../src/filters/script_runner/enhanced_search/enhanced_search_noise_filter'
+
+type FilterType = filterUtils.FilterWith<'onFetch'>
+
+describe('enhancedSearchNoiseFilter', () => {
+  let filter: FilterType
+  let instance: InstanceElement
+
+  beforeEach(() => {
+    instance = new InstanceElement('instance', createEmptyType(FILTER_TYPE_NAME), {
+      description: 'Filter managed by Enhanced Search: issueFunction in linkedIssuesOf',
+      jql: 'issue in (1, 2, 3)',
+    })
+    filter = enhancedSearchNoiseFilter(getFilterParams()) as FilterType
+  })
+  it('should replace noise in jql', async () => {
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('ENHANCED_SEARCH_ISSUE_TERMS')
+  })
+  it('should not replace noise in jql if there is no closing bracket', async () => {
+    instance.value.jql = 'issue in (1, 2, 3'
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('issue in (1, 2, 3')
+  })
+  it('should not replace noise in jql if there is no opening bracket', async () => {
+    instance.value.jql = 'issue in 1, 2, 3)'
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('issue in 1, 2, 3)')
+  })
+  it('should not replace noise in jql if there is no jql', async () => {
+    instance.value.jql = undefined
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toBeUndefined()
+  })
+  it('should not replace noise in jql if it is not an enhanced search filter', async () => {
+    instance.value.description = 'description'
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('issue in (1, 2, 3)')
+  })
+  it('should not replace noise in jql if it is there is no description', async () => {
+    instance.value.description = undefined
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('issue in (1, 2, 3)')
+  })
+})


### PR DESCRIPTION
Removed the variable part of Enhanced Search jql to reduce noise

---

Look at the jira thread [here](https://salto-io.atlassian.net/browse/SALTO-3464).
Enhanced Search is causing a lot of noise, as they change the jql almost every fetch. I have replaced the variable part with a constant string, and blocked the deployment.
Also, a minor clean-up, and a refactor of the CV config creation 
[Noise Reduction](https://github.com/salto-io/salto_private/pull/9272)

---
_Release Notes_: 
Jira Adapter:
* Enhanced Search will not create noise

---
_User Notifications_: 
Jira Adapter:
* The variable part of the jql in Enhanced Search will be replaced with a constant string
