### PR TITLE
SALTO-6633: Everyone group assignment validator

### DIFF
--- a/packages/okta-adapter/src/change_validators/everyone_group_assignments.ts
+++ b/packages/okta-adapter/src/change_validators/everyone_group_assignments.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ChangeValidator, getChangeData, isInstanceChange, isModificationChange } from '@salto-io/adapter-api'
+import { GROUP_MEMBERSHIP_TYPE_NAME } from '../constants'
+
+/**
+ * Assignments to the "Everyone" group are managed by Okta and cannot be modified.
+ */
+export const everyoneGroupAssignments: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === GROUP_MEMBERSHIP_TYPE_NAME)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.name === 'Everyone')
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error',
+      message: 'Assignment to the "Everyone" group are managed by Okta.',
+      detailedMessage:
+        'Group assignments to the "Everyone" group are managed by Okta. Any users added in this deployment will be auto assigned to this group.',
+    }))

--- a/packages/okta-adapter/src/change_validators/everyone_group_assignments.ts
+++ b/packages/okta-adapter/src/change_validators/everyone_group_assignments.ts
@@ -15,8 +15,8 @@ export const everyoneGroupAssignments: ChangeValidator = async changes =>
   changes
     .filter(isInstanceChange)
     .filter(isModificationChange)
-    .filter(change => getChangeData(change).elemID.typeName === GROUP_MEMBERSHIP_TYPE_NAME)
     .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === GROUP_MEMBERSHIP_TYPE_NAME)
     .filter(instance => instance.elemID.name === 'Everyone')
     .map(instance => ({
       elemID: instance.elemID,

--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -34,6 +34,7 @@ import { brandThemeRemovalValidator } from './brand_theme_removal'
 import { userStatusValidator } from './user_status'
 import { disabledAuthenticatorsInMfaPolicyValidator } from './disabled_authenticators_in_mfa'
 import { oidcIdentityProviderValidator } from './oidc_idp'
+import { everyoneGroupAssignments } from './everyone_group_assignments'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -110,6 +111,7 @@ export default ({
     userStatusChanges: userStatusValidator,
     disabledAuthenticatorsInMfaPolicy: disabledAuthenticatorsInMfaPolicyValidator,
     oidcIdentityProvider: oidcIdentityProviderValidator,
+    everyoneGroupAssignments,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/filters/group_members.ts
+++ b/packages/okta-adapter/src/filters/group_members.ts
@@ -152,13 +152,25 @@ const deployGroupMembershipChange = async (
     additions.map(member => deployGroupAssignment({ groupId: parentGroupId, userId: member, action: 'add', client })),
   )
   const failedAdditions = additionsResult.filter(({ result }) => result === 'failure').map(({ userId }) => userId)
-  log.error('failed to add the following group assignments: %s', failedAdditions.join(', '))
+  if (failedAdditions.length > 0) {
+    log.error(
+      'failed to add the following group assignments for group %s: %s',
+      getChangeData(change).elemID.getFullName(),
+      failedAdditions.join(', '),
+    )
+  }
 
   const removalResult = await Promise.all(
     removals.map(member => deployGroupAssignment({ groupId: parentGroupId, userId: member, action: 'remove', client })),
   )
   const failedRemovals = removalResult.filter(({ result }) => result === 'failure').map(({ userId }) => userId)
-  log.error('failed to remove the following group assignments: %s', failedRemovals.join(', '))
+  if (failedRemovals.length > 0) {
+    log.error(
+      'failed to remove the following group assignments for group %s: %s',
+      getChangeData(change).elemID.getFullName(),
+      failedRemovals.join(', '),
+    )
+  }
 
   return { appliedChange: await updateChangeWithFailedAssignments(change, failedAdditions, failedRemovals) }
 }

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -66,6 +66,7 @@ const changeValidatorNames = [
   'userStatusChanges',
   'disabledAuthenticatorsInMfaPolicy',
   'oidcIdentityProvider',
+  'everyoneGroupAssignments',
 ] as const
 
 export type ChangeValidatorName = (typeof changeValidatorNames)[number]

--- a/packages/okta-adapter/test/change_validators/everyone_group_assignments.test.ts
+++ b/packages/okta-adapter/test/change_validators/everyone_group_assignments.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { everyoneGroupAssignments } from '../../src/change_validators/everyone_group_assignments'
+import { OKTA, GROUP_MEMBERSHIP_TYPE_NAME } from '../../src/constants'
+
+describe('everyoneGroupAssignments', () => {
+  const groupMembersType = new ObjectType({ elemID: new ElemID(OKTA, GROUP_MEMBERSHIP_TYPE_NAME) })
+  const everyoneGroup = new InstanceElement('Everyone', groupMembersType, { members: ['a', 'b', 'c'] })
+  const otherGroup = new InstanceElement('Other', groupMembersType, { members: ['a'] })
+
+  it('should return an error when modifying the Everyone group members instance', async () => {
+    expect(await everyoneGroupAssignments([toChange({ before: everyoneGroup, after: everyoneGroup })])).toEqual([
+      {
+        elemID: everyoneGroup.elemID,
+        severity: 'Error',
+        message: 'Assignment to the "Everyone" group are managed by Okta.',
+        detailedMessage:
+          'Group assignments to the "Everyone" group are managed by Okta. Any users added in this deployment will be auto assigned to this group.',
+      },
+    ])
+  })
+  it('should not return an error when modifying a different group members instance', async () => {
+    expect(await everyoneGroupAssignments([toChange({ before: otherGroup, after: otherGroup })])).toEqual([])
+  })
+})


### PR DESCRIPTION
Added a validator to block assignments to the "Everyone" Group in Okta as it is auto managed by Okta

---

_Additional context for reviewer_
- Added a validator
- Also fixed some logs as we were logging an error also when all assignments succeeded 


---
_Release Notes_: 

_Okta_adapter_:
- Add a validator to block assignments to "Everyone" group in Okta

---
_User Notifications_: 
None