### PR TITLE
SAAS-12017: Add updateElementFolder

### DIFF
--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -253,7 +253,7 @@ export type UpdateElementFolderResult = {
   errors: ReadonlyArray<SaltoError>
 }
 
-export const updateElementFolder = async ({
+export const updateElementFolder = ({
   workspace,
   baseDir,
   changes,

--- a/packages/core/test/core/adapter_format.test.ts
+++ b/packages/core/test/core/adapter_format.test.ts
@@ -389,10 +389,10 @@ describe('updateElementFolder', () => {
     })
 
     const instance = new InstanceElement('instance', type, { f: 'v' })
-    changes = [toChange({ after: instance })]
+    changes = [toChange({ after: instance }), toChange({ after: type })]
     workspace = mockWorkspace({
       name: 'workspace',
-      elements: [],
+      elements: [instance, type],
       accountToServiceName: { [mockAdapterName]: mockAdapterName },
     })
   })


### PR DESCRIPTION
Add a new function `dumpElementsToFolder` which updates a “hybrid” folder - a folder containing a Salto workspace and an SFDX project.

It will get the changes to apply, it will call `dumpElementsToFolder` to update the SFDX part. And in the future, it should use the leftover changes to the Salto workspace


Additional context for the reviewer
No release notes

Release Notes:
None

User Notifications:
None