### PR TITLE
SALTO-6632 Remove API response restriction

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_themes/types.ts
+++ b/packages/zendesk-adapter/src/filters/guide_themes/types.ts
@@ -19,7 +19,7 @@ const JOB_ERROR_SCHEMA = Joi.object({
   title: Joi.string(),
   code: Joi.string().required(),
   message: Joi.string(),
-  meta: Joi.object(),
+  meta: Joi.object().allow(null),
 })
 
 export type UploadJobData = {

--- a/packages/zendesk-adapter/src/filters/guide_themes/types.ts
+++ b/packages/zendesk-adapter/src/filters/guide_themes/types.ts
@@ -19,7 +19,7 @@ const JOB_ERROR_SCHEMA = Joi.object({
   title: Joi.string(),
   code: Joi.string().required(),
   message: Joi.string(),
-  meta: Joi.object().required(),
+  meta: Joi.object(),
 })
 
 export type UploadJobData = {

--- a/packages/zendesk-adapter/test/filters/guide_themes/api/pollJobStatus.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_themes/api/pollJobStatus.test.ts
@@ -48,6 +48,23 @@ describe('pollJobStatus', () => {
         success: false,
         errors: ['code1 - message1'],
       })
+
+      // Also if the error meta is null
+      mockGet.mockResolvedValue({
+        status: 202,
+        data: {
+          job: {
+            id: '1',
+            status: 'failed',
+            errors: [{ message: 'message2', code: 'code2', meta: null }],
+            data: null,
+          },
+        },
+      })
+      expect(await pollJobStatus('11', client, 200, 1)).toEqual({
+        success: false,
+        errors: ['code2 - message2'],
+      })
     })
 
     it('returns false on wrong response structure', async () => {


### PR DESCRIPTION
Remove restriction on API response, as we've seen a `null` value instead of an object.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
