### PR TITLE
SALTO-6535 change log level in google-workspace E2E

### DIFF
--- a/packages/google-workspace-adapter/e2e_test/adapter.test.ts
+++ b/packages/google-workspace-adapter/e2e_test/adapter.test.ts
@@ -154,10 +154,10 @@ const getChangesForInitialCleanup = (elements: InstanceElement[]): Change<Instan
   elements.filter(checkNameField).map(instance => toChange({ before: instance }))
 
 const deployCleanup = async (adapterAttr: Reals, elements: InstanceElement[]): Promise<void> => {
-  log.debug('Cleaning up the environment before starting e2e test')
+  log.info('Cleaning up the environment before starting e2e test')
   const cleanupChanges = getChangesForInitialCleanup(elements)
   await deployChanges(adapterAttr, cleanupChanges)
-  log.debug('Environment cleanup successful')
+  log.info('Environment cleanup successful')
 }
 
 describe('Google Workspace adapter E2E', () => {
@@ -176,7 +176,7 @@ describe('Google Workspace adapter E2E', () => {
       const fetchResult = await adapterAttr.adapter.fetch({
         progressReporter: { reportProgress: () => null },
       })
-      log.debug(
+      log.info(
         'Google WS fetch result instance elements: %o',
         fetchResult.elements.filter(isInstanceElement).map(e => e.elemID.getFullName()),
       )
@@ -263,7 +263,7 @@ describe('Google Workspace adapter E2E', () => {
         .flat()
         .map(change => getChangeData(change)) as InstanceElement[]
 
-      log.debug('Deployed instances length: %d', deployInstances.length)
+      log.info('Deployed instances length: %d', deployInstances.length)
       // TODO SALTO-6535 there is a flakiness in the fetch of the group type that we need to fix
       deployInstances
         .filter(deployInstance => deployInstance.elemID.typeName !== GROUP_TYPE_NAME)


### PR DESCRIPTION
SALTO-6535 change log level in google-workspace E2E
---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
