### PR TITLE
SALTO-6623: add perform side effect removals config option

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -47,6 +47,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   indexedEmailTemplateAttachments: false,
   skipParsingXmlNumbers: false,
   logDiffsFromParsingXmlNumbers: true,
+  performSideEffectDeletes: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -86,7 +86,14 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     .map(change => resolveChangeElement(change, getLookUpName))
     .toArray()
 
-  const fetchProfile = buildFetchProfile({ fetchParams: {} })
+  const fetchProfile = buildFetchProfile({
+    fetchParams: {
+      optionalFeatures: {
+        // Needed to remove related instances of custom objects (e.g - layouts, sharing rules, etc...)
+        performSideEffectDeletes: true,
+      },
+    },
+  })
   const filterRunner = filter.filtersRunner(
     {
       // TODO: This is a hack that we want to replace with something more type-safe in the near future

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -126,6 +126,7 @@ export type OptionalFeatures = {
   indexedEmailTemplateAttachments?: boolean
   skipParsingXmlNumbers?: boolean
   logDiffsFromParsingXmlNumbers?: boolean
+  performSideEffectDeletes?: boolean
 }
 
 export type ChangeValidatorName =
@@ -828,6 +829,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     indexedEmailTemplateAttachments: { refType: BuiltinTypes.BOOLEAN },
     skipParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
     logDiffsFromParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
+    performSideEffectDeletes: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
This is needed for SFDX dump code to actually delete side effects from the project

---

_Additional context for reviewer_

---
_Release Notes_: 
_Salesforce Adapter_:
- Added optional feature `performSideEffectDeletes` that allows explicitly deleting child instances of custom object when the custom object is removed (default: false)

---
_User Notifications_: 
_None_