### PR TITLE
SALTO-6026: Update mappedReferenceRegex to not be greedy

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -60,7 +60,7 @@ const pathPrefixRegex = new RegExp(
   'm',
 )
 // matches key strings in format of 'key': value or key: value
-const mappedReferenceRegex = new RegExp(`['"]?(?<${OPTIONAL_REFS}>\\w+)['"]?\\s*:\\s*.+`, 'gm')
+const mappedReferenceRegex = new RegExp(`['"]?(?<${OPTIONAL_REFS}>\\w+)['"]?\\s*:\\s*\\S`, 'gm')
 // matches comments in js files
 // \\/\\*[\\s\\S]*?\\*\\/ - matches multiline comments by matching the first '/*' and the last '*/' and any character including newlines
 // ^\\s*\\/\\/.* - matches single line comments that start with '//'
@@ -224,31 +224,35 @@ const getSuiteScriptReferences = async (
     path => !path.startsWith(NETSUITE_MODULE_PREFIX),
   )
   if (config.fetch.calculateNewReferencesInSuiteScripts) {
-    const foundReferences = getReferencesWithRegex(content)
-    if (!hasValidExtension(element.value[PATH], config)) {
-      const referencesToBeRemoved = getServiceElemIDsFromPaths(
-        foundReferences,
+    try {
+      const foundReferences = getReferencesWithRegex(content)
+      if (!hasValidExtension(element.value[PATH], config)) {
+        const referencesToBeRemoved = getServiceElemIDsFromPaths(
+          foundReferences,
+          serviceIdToElemID,
+          customRecordFieldsToServiceIds,
+          element,
+        )
+        if (referencesToBeRemoved.length > 0) {
+          log.info(
+            'Ignoring file with unsupported extension %s and %d references will be removed: %o',
+            element.value[PATH],
+            referencesToBeRemoved.length,
+            referencesToBeRemoved,
+          )
+        }
+        skippedFileExtensions.add(osPath.extname(element.value[PATH]))
+      }
+      getAndLogReferencesDiff({
+        newReferences: foundReferences,
+        existingReferences: semanticReferences,
+        element,
         serviceIdToElemID,
         customRecordFieldsToServiceIds,
-        element,
-      )
-      if (referencesToBeRemoved.length > 0) {
-        log.info(
-          'Ignoring file with unsupported extension %s and %d references will be removed: %o',
-          element.value[PATH],
-          referencesToBeRemoved.length,
-          referencesToBeRemoved,
-        )
-      }
-      skippedFileExtensions.add(osPath.extname(element.value[PATH]))
+      })
+    } catch (e) {
+      log.error('Failed extracting references from file %s with error %s', element.value[PATH], e)
     }
-    getAndLogReferencesDiff({
-      newReferences: foundReferences,
-      existingReferences: semanticReferences,
-      element,
-      serviceIdToElemID,
-      customRecordFieldsToServiceIds,
-    })
   }
 
   return getServiceElemIDsFromPaths(

--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -251,7 +251,7 @@ const getSuiteScriptReferences = async (
         customRecordFieldsToServiceIds,
       })
     } catch (e) {
-      log.error('Failed extracting references from file %s with error %s', element.value[PATH], e)
+      log.error('Failed extracting references from file %s with error: %o', element.value[PATH], e)
     }
   }
 


### PR DESCRIPTION
_The existing version of the regex was greedy and caused parsing to misbehave, The regex now matches the key in key: value and verifies there something after the colon._

---

_None_

---
_Release Notes_: 
_Netsuite Adapter_:
* Failing to parse suitescripts for references logs error instead of failing fetch..

---
_User Notifications_: 
_None_
