### PR TITLE
SALTO-6642 serialize ConflictingMetaTypeError

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -42,6 +42,7 @@ import {
   ConflictingFieldTypesError,
   ConflictingSettingError,
   DuplicateAnnotationTypeError,
+  ConflictingMetaTypeError,
 } from '../merger/internal/object_types'
 import { DuplicateVariableNameError } from '../merger/internal/variables'
 import { MultiplePrimitiveTypesError } from '../merger/internal/primitives'
@@ -108,6 +109,7 @@ const NameToType = {
   ConflictingFieldTypesError: ConflictingFieldTypesError,
   ConflictingSettingError: ConflictingSettingError,
   DuplicateAnnotationTypeError: DuplicateAnnotationTypeError,
+  ConflictingMetaTypeError: ConflictingMetaTypeError,
   DuplicateVariableNameError: DuplicateVariableNameError,
   MultiplePrimitiveTypesError: MultiplePrimitiveTypesError,
   InvalidValueValidationError: InvalidValueValidationError,
@@ -393,6 +395,10 @@ const generalDeserializeParsed = async <T>(parsed: unknown, staticFileReviver?: 
         new DuplicateAnnotationTypeError({
           elemID: reviveElemID(v.elemID),
           key: v.key,
+        }),
+      ConflictingMetaTypeError: v =>
+        new ConflictingMetaTypeError({
+          elemID: reviveElemID(v.elemID),
         }),
       DuplicateVariableNameError: v => new DuplicateVariableNameError({ elemID: reviveElemID(v.elemID) }),
       MultiplePrimitiveTypesError: v =>

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -49,6 +49,7 @@ import {
   DuplicateAnnotationFieldDefinitionError,
   DuplicateAnnotationTypeError,
   ConflictingSettingError,
+  ConflictingMetaTypeError,
 } from '../../src/merger/internal/object_types'
 import { DuplicateInstanceKeyError } from '../../src/merger/internal/instances'
 import { MultiplePrimitiveTypesError } from '../../src/merger/internal/primitives'
@@ -548,6 +549,7 @@ describe('State/cache serialization', () => {
     let duplicateInstanceKeyError: DuplicateInstanceKeyError
     let multiplePrimitiveTypesUnsupportedError: MultiplePrimitiveTypesError
     let duplicateVariableNameError: DuplicateVariableNameError
+    let conflictingMetaTypeError: ConflictingMetaTypeError
     beforeAll(async () => {
       duplicateAnnotationError = new DuplicateAnnotationError({
         elemID,
@@ -573,6 +575,7 @@ describe('State/cache serialization', () => {
         duplicates: [BuiltinTypes.BOOLEAN, BuiltinTypes.NUMBER],
       })
       duplicateVariableNameError = new DuplicateVariableNameError({ elemID })
+      conflictingMetaTypeError = new ConflictingMetaTypeError({ elemID })
       const mergeErrors: MergeError[] = [
         duplicateAnnotationError,
         conflictingFieldTypesError,
@@ -582,6 +585,7 @@ describe('State/cache serialization', () => {
         duplicateInstanceKeyError,
         multiplePrimitiveTypesUnsupportedError,
         duplicateVariableNameError,
+        conflictingMetaTypeError,
       ]
       serialized = await serialize(mergeErrors)
       deserialized = await deserializeMergeErrors(serialized)
@@ -613,6 +617,9 @@ describe('State/cache serialization', () => {
     })
     it('should serialize DuplicateVariableNameError correctly', () => {
       expect(deserialized[7]).toEqual(duplicateVariableNameError)
+    })
+    it('should serialize ConflictingMetaTypeError correctly', () => {
+      expect(deserialized[8]).toEqual(conflictingMetaTypeError)
     })
     it('should throw error if trying to deserialize a non merge error object', async () => {
       await expect(deserializeMergeErrors(safeJsonStringify([{ test }]))).rejects.toThrow()


### PR DESCRIPTION
We should serialize the `ConflictingMetaTypeError` merge error, to be able loading it back as a merge error (currently we fail with `Deserialization failed. At least one element did not deserialize to a MergeError`)

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None