### PR TITLE
SALTO-6643 add calculatePendingChanges param to calcFetchChanges

### DIFF
--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -383,14 +383,15 @@ export const calculatePatchFromChanges = async ({
     .forEach(id => {
       partialFetchData.get(id.adapter)?.deletedElements.add(id.getFullName())
     })
-  const result = await calcFetchChanges(
-    unmergedAfterElements,
-    afterElements,
-    elementSource.createInMemoryElementSource(beforeElements),
-    await workspace.elements(false),
-    partialFetchData,
-    new Set(accounts),
-  )
+  const result = await calcFetchChanges({
+    accountElements: unmergedAfterElements,
+    mergedAccountElements: afterElements,
+    stateElements: elementSource.createInMemoryElementSource(beforeElements),
+    workspaceElements: await workspace.elements(false),
+    partiallyFetchedAccounts: partialFetchData,
+    allFetchedAccounts: new Set(accounts),
+    calculatePendingChanges: true,
+  })
   return result.changes
 }
 

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -390,7 +390,6 @@ export const calculatePatchFromChanges = async ({
     workspaceElements: await workspace.elements(false),
     partiallyFetchedAccounts: partialFetchData,
     allFetchedAccounts: new Set(accounts),
-    calculatePendingChanges: true,
   })
   return result.changes
 }

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -138,14 +138,15 @@ export const calculatePatch = async ({
       updatedConfig: {},
     }
   }
-  const { changes } = await calcFetchChanges(
-    afterElements,
-    mergedAfterElements,
-    elementSource.createInMemoryElementSource(mergedBeforeElements),
-    await workspace.elements(false),
-    new Map([[accountName, {}]]),
-    new Set([accountName]),
-  )
+  const { changes } = await calcFetchChanges({
+    accountElements: afterElements,
+    mergedAccountElements: mergedAfterElements,
+    stateElements: elementSource.createInMemoryElementSource(mergedBeforeElements),
+    workspaceElements: await workspace.elements(false),
+    partiallyFetchedAccounts: new Map([[accountName, {}]]),
+    allFetchedAccounts: new Set([accountName]),
+    calculatePendingChanges: true,
+  })
   return {
     changes,
     mergeErrors: [],

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -145,7 +145,6 @@ export const calculatePatch = async ({
     workspaceElements: await workspace.elements(false),
     partiallyFetchedAccounts: new Map([[accountName, {}]]),
     allFetchedAccounts: new Set([accountName]),
-    calculatePendingChanges: true,
   })
   return {
     changes,

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -786,14 +786,23 @@ type DetailedChangeTreesResults = {
 
 // Calculate the fetch changes - calculation should be done only if workspace has data,
 // o/w all account elements should be consider as "add" changes.
-export const calcFetchChanges = async (
-  accountElements: ReadonlyArray<Element>,
-  mergedAccountElements: ReadonlyArray<Element>,
-  stateElements: elementSource.ElementsSource,
-  workspaceElements: ReadOnlyElementsSource,
-  partiallyFetchedAccounts: Map<string, PartiallyFetchedAccountData>,
-  allFetchedAccounts: Set<string>,
-): Promise<CalcFetchChangesResult> => {
+export const calcFetchChanges = async ({
+  accountElements,
+  mergedAccountElements,
+  stateElements,
+  workspaceElements,
+  partiallyFetchedAccounts,
+  allFetchedAccounts,
+  calculatePendingChanges,
+}: {
+  accountElements: ReadonlyArray<Element>
+  mergedAccountElements: ReadonlyArray<Element>
+  stateElements: elementSource.ElementsSource
+  workspaceElements: ReadOnlyElementsSource
+  partiallyFetchedAccounts: Map<string, PartiallyFetchedAccountData>
+  allFetchedAccounts: Set<string>
+  calculatePendingChanges: boolean
+}): Promise<CalcFetchChangesResult> => {
   const mergedAccountElementsSource = elementSource.createInMemoryElementSource(mergedAccountElements)
 
   const partialFetchFilter: IDFilter = id =>
@@ -892,13 +901,9 @@ export const calcFetchChanges = async (
     }
   }
 
-  // When we init a new env, state will be empty. We fallback to the workspace
-  // elements since they should be considered a part of the env and the diff
-  // should be calculated with them in mind.
-  const isStateEmpty = await stateElements.isEmpty()
-  const { serviceChanges, pendingChanges, workspaceToServiceChanges, serviceToStateChanges } = isStateEmpty
-    ? await calculateChangesWithEmptyState()
-    : await calculateChangesWithState()
+  const { serviceChanges, pendingChanges, workspaceToServiceChanges, serviceToStateChanges } = calculatePendingChanges
+    ? await calculateChangesWithState()
+    : await calculateChangesWithEmptyState()
 
   // Merge pending changes and service changes into one tree so we can find conflicts between them
   serviceChanges.merge(pendingChanges)
@@ -958,16 +963,19 @@ const createFetchChanges = async ({
     .filter(e => !e.isConfigType())
     .isEmpty()
 
+  const isStateEmpty = await stateElements.isEmpty()
+
   const { changes, serviceToStateChanges } = isFirstFetch
     ? await createFirstFetchChanges(unmergedElements, processErrorsResult.keptElements)
-    : await calcFetchChanges(
-        unmergedElements,
-        processErrorsResult.keptElements,
+    : await calcFetchChanges({
+        accountElements: unmergedElements,
+        mergedAccountElements: processErrorsResult.keptElements,
         stateElements,
         workspaceElements,
-        partiallyFetchedAccountData,
-        new Set(adapterNames),
-      )
+        partiallyFetchedAccounts: partiallyFetchedAccountData,
+        allFetchedAccounts: new Set(adapterNames),
+        calculatePendingChanges: !isStateEmpty,
+      })
   log.debug('finished to calculate fetch changes')
   if (progressEmitter) {
     calculateDiffEmitter.emit('completed')

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2322,14 +2322,15 @@ describe('calc fetch changes', () => {
   const instanceA = new InstanceElement('instanceA', existingElement)
   const instanceB = new InstanceElement('instanceB', existingElement)
   it('should calculate a remove change when instanceA was deleted in service', async () => {
-    const { changes, serviceToStateChanges } = await calcFetchChanges(
-      [existingElement],
-      [existingElement],
-      createInMemoryElementSource([existingElement, instanceA, instanceB]),
-      createInMemoryElementSource([existingElement, instanceA, instanceB]),
-      new Map([['salto', { deletedElements: new Set([instanceA.elemID.getFullName()]) }]]),
-      new Set(['salto']),
-    )
+    const { changes, serviceToStateChanges } = await calcFetchChanges({
+      accountElements: [existingElement],
+      mergedAccountElements: [existingElement],
+      stateElements: createInMemoryElementSource([existingElement, instanceA, instanceB]),
+      workspaceElements: createInMemoryElementSource([existingElement, instanceA, instanceB]),
+      partiallyFetchedAccounts: new Map([['salto', { deletedElements: new Set([instanceA.elemID.getFullName()]) }]]),
+      allFetchedAccounts: new Set(['salto']),
+      calculatePendingChanges: true,
+    })
 
     expect(changes).toHaveLength(1)
     expect(changes[0].change.action).toEqual('remove')

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2348,8 +2348,9 @@ describe('calc fetch changes', () => {
     })
   })
 
-  describe('calculating pending changes', () => {
+  describe('calculatePendingChanges parameter', () => {
     let params: Parameters<typeof calcFetchChanges>[0]
+    let changes: FetchChange[]
     const accountName = 'salto'
     const elemID = new ElemID(accountName, 'type')
     beforeEach(() => {
@@ -2364,51 +2365,91 @@ describe('calc fetch changes', () => {
         allFetchedAccounts: new Set([accountName]),
       }
     })
-    it('should calculate pending changes', async () => {
-      const { changes } = await calcFetchChanges(params)
-      expect(changes).toEqual([
-        {
-          change: expect.objectContaining({
-            id: elemID.createNestedID('attr', 'test'),
-            action: 'modify',
-            data: { before: false, after: true },
-          }),
-          serviceChanges: [
-            expect.objectContaining({
-              id: elemID,
-              action: 'add',
-            }),
-          ],
-          pendingChanges: [
-            expect.objectContaining({
-              id: elemID,
-              action: 'add',
-            }),
-          ],
-          metadata: {},
-        },
-      ])
-    })
-    it('should not calculate pending changes', async () => {
-      const { changes } = await calcFetchChanges({ ...params, calculatePendingChanges: false })
-      expect(changes).toEqual([
-        {
-          change: expect.objectContaining({
-            id: elemID.createNestedID('attr', 'test'),
-            action: 'modify',
-            data: { before: false, after: true },
-          }),
-          serviceChanges: [
-            expect.objectContaining({
+    describe('when not passing the calculatePendingChanges parameter', () => {
+      beforeEach(async () => {
+        const result = await calcFetchChanges(params)
+        changes = result.changes
+      })
+      it('should calculate pending changes', async () => {
+        expect(changes).toEqual([
+          {
+            change: expect.objectContaining({
               id: elemID.createNestedID('attr', 'test'),
               action: 'modify',
               data: { before: false, after: true },
             }),
-          ],
-          pendingChanges: [],
-          metadata: {},
-        },
-      ])
+            serviceChanges: [
+              expect.objectContaining({
+                id: elemID,
+                action: 'add',
+              }),
+            ],
+            pendingChanges: [
+              expect.objectContaining({
+                id: elemID,
+                action: 'add',
+              }),
+            ],
+            metadata: {},
+          },
+        ])
+      })
+    })
+    describe('when calculatePendingChanges is true', () => {
+      beforeEach(async () => {
+        const result = await calcFetchChanges({ ...params, calculatePendingChanges: true })
+        changes = result.changes
+      })
+      it('should calculate pending changes', async () => {
+        expect(changes).toEqual([
+          {
+            change: expect.objectContaining({
+              id: elemID.createNestedID('attr', 'test'),
+              action: 'modify',
+              data: { before: false, after: true },
+            }),
+            serviceChanges: [
+              expect.objectContaining({
+                id: elemID,
+                action: 'add',
+              }),
+            ],
+            pendingChanges: [
+              expect.objectContaining({
+                id: elemID,
+                action: 'add',
+              }),
+            ],
+            metadata: {},
+          },
+        ])
+      })
+    })
+    describe('when calculatePendingChanges is false', () => {
+      beforeEach(async () => {
+        const result = await calcFetchChanges({ ...params, calculatePendingChanges: false })
+        changes = result.changes
+      })
+      it('should not calculate pending changes', async () => {
+        expect(changes).toEqual([
+          {
+            change: expect.objectContaining({
+              id: elemID.createNestedID('attr', 'test'),
+              action: 'modify',
+              data: { before: false, after: true },
+            }),
+            serviceChanges: [
+              expect.objectContaining({
+                id: elemID.createNestedID('attr', 'test'),
+                action: 'modify',
+                data: { before: false, after: true },
+              }),
+            ],
+            pendingChanges: [],
+            metadata: {},
+          },
+        ])
+      })
     })
   })
 })


### PR DESCRIPTION
We can have conflicts even when there are no before elements. We currently don’t calculate the pending changes in this case (because we treat it as "empty state"), which makes us accept all the service changes even if there are already nacls with elements that conflict that.

In fetch we shouldn't do that, because we can fetch an environment for the first time (so there's no state) and already have elements in common - we don't want pending changes in that case.

In `calculatePatch` it can happen, if there are no elements in the `fromDir`, which we use as the state when calculating the pending changes.

In `calculatePatchFromChanges` it can happen, when we have only addition changes, because then there won’t be any `before` elements to use as the state when calculating the pending changes - this is a bug.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Calculate pending changes when patch has only addition changes

---
_User Notifications_: 
None