### PR TITLE
SALTO-6350 Add elemId hash to create uniqueness of static file paths

### DIFF
--- a/packages/zendesk-adapter/e2e_test/adapter.test.ts
+++ b/packages/zendesk-adapter/e2e_test/adapter.test.ts
@@ -93,6 +93,7 @@ import { getChangeGroupIds } from '../src/group_change'
 import { credsLease, realAdapter, Reals } from './adapter'
 import { mockDefaultValues } from './mock_elements'
 import { ThemeDirectory, unzipFolderToElements } from '../src/filters/guide_theme'
+import { shortElemIdHash } from '../src/filters/utils'
 
 const { awu } = collections.asynciterable
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
@@ -339,7 +340,7 @@ describe('Zendesk adapter E2E', () => {
       const root = await unzipFolderToElements({
         buffer,
         currentBrandName: brand.value.name,
-        name,
+        folderName: name,
         idsToElements: {},
         matchBrandSubdomain: (url: string) => (url === brand.value.brand_url ? brand : undefined),
         config: {
@@ -907,15 +908,15 @@ describe('Zendesk adapter E2E', () => {
         valuesOverride: {
           file_name: fileName,
           content_type: 'image/png',
-          content: new StaticFile({
-            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${fileName}/80f6f478ed_${fileName}`,
-            content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
-          }),
           inline: false,
           brand: new ReferenceExpression(brandInstanceE2eHelpCenter.elemID, brandInstanceE2eHelpCenter),
         },
         parent: articleInstance,
         name: `${articleName}_${sectionName}_${categoryName}_${HELP_CENTER_BRAND_NAME}__${fileName}_false`,
+      })
+      articleAttachment.value.content = new StaticFile({
+        filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${fileName}/${shortElemIdHash(articleAttachment.elemID)}_80f6f478ed_${fileName}`,
+        content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
       })
       const inlineFileName = `naclTwo${attachmentName}`
       const articleInlineAttachment = createInstanceElement({
@@ -923,17 +924,16 @@ describe('Zendesk adapter E2E', () => {
         valuesOverride: {
           file_name: inlineFileName,
           content_type: 'image/png',
-          content: new StaticFile({
-            filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${inlineFileName}/80f6f478ed_${inlineFileName}`,
-            content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
-          }),
           inline: true,
           brand: new ReferenceExpression(brandInstanceE2eHelpCenter.elemID, brandInstanceE2eHelpCenter),
         },
         parent: articleInstance,
         name: `${articleName}_${sectionName}_${categoryName}_${HELP_CENTER_BRAND_NAME}__${inlineFileName}_true`,
       })
-
+      articleInlineAttachment.value.content = new StaticFile({
+        filepath: `${ZENDESK}/${ARTICLE_ATTACHMENTS_FIELD}/${GUIDE}/brands/${HELP_CENTER_BRAND_NAME}/categories/${categoryName}/sections/${sectionName}/articles/${articleName}/article_attachment/${inlineFileName}/${shortElemIdHash(articleInlineAttachment.elemID)}_80f6f478ed_${inlineFileName}`,
+        content: fs.readFileSync(path.resolve(`${__dirname}/../e2e_test/images/nacl.png`)),
+      })
       articleInstance.value.attachments = [
         new ReferenceExpression(articleInlineAttachment.elemID, articleInlineAttachment),
         new ReferenceExpression(articleAttachment.elemID, articleAttachment),

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -44,6 +44,7 @@ import {
   GUIDE_THEME_TYPE_NAME,
   THEME_SETTINGS_TYPE_NAME,
 } from '../constants'
+import { shortElemIdHash } from './utils'
 
 const { RECORDS_PATH } = elementsUtils
 const log = logger(module)
@@ -344,7 +345,9 @@ const filterCreator: FilterCreator = () => ({
         ARTICLE_ATTACHMENTS_FIELD,
         ...path.slice(2, -1),
         normalizeFilePathPart(attachment.value.file_name.split('.')[0]), // file name
-        normalizeFilePathPart(`${staticFile.hash.slice(0, 10)}_${attachment.value.file_name}`), // <hash>_file_name
+        normalizeFilePathPart(
+          `${shortElemIdHash(attachment.elemID)}_${staticFile.hash.slice(0, 10)}_${attachment.value.file_name}`,
+        ), // <elemId-hash>_<file-hash>_file_name
       ]
       attachment.value.content = new StaticFile({
         filepath: staticFilePath.join('/'),

--- a/packages/zendesk-adapter/src/filters/guide_theme.ts
+++ b/packages/zendesk-adapter/src/filters/guide_theme.ts
@@ -59,7 +59,7 @@ import {
   createJavascriptTemplateExpression,
   TemplateEngineCreator,
 } from './template_engines/creator'
-import { getBrandsForGuideThemes, matchBrandSubdomainFunc } from './utils'
+import { getBrandsForGuideThemes, matchBrandSubdomainFunc, shortElemIdHash } from './utils'
 import { prepRef } from './article/utils'
 
 const READ_CONCURRENCY = 100
@@ -122,14 +122,14 @@ const createTemplateExpression = ({
 export const unzipFolderToElements = async ({
   buffer,
   currentBrandName,
-  name,
+  folderName,
   idsToElements,
   matchBrandSubdomain,
   config,
 }: {
   buffer: Buffer
   currentBrandName: string
-  name: string
+  folderName: string
   idsToElements: Record<string, InstanceElement>
   matchBrandSubdomain: (url: string) => InstanceElement | undefined
   config: Themes
@@ -153,7 +153,7 @@ export const unzipFolderToElements = async ({
 
     if (pathParts.length === 1) {
       // It's a file
-      const filepath = `${ZENDESK}/themes/brands/${currentBrandName}/${name}/${fullPath}`
+      const filepath = `${ZENDESK}/themes/brands/${currentBrandName}/${folderName}/${fullPath}`
       const content = await file.async('nodebuffer')
       const templateExpression = createTemplateExpression({
         filePath: fullPath,
@@ -396,7 +396,7 @@ const filterCreator: FilterCreator = ({ config, client, elementsSource }) => ({
           const themeElements = await unzipFolderToElements({
             buffer: themeZip,
             currentBrandName,
-            name: theme.value.name,
+            folderName: `${shortElemIdHash(theme.elemID)}_${theme.value.name}`, // This creates a unique folder name for each theme
             idsToElements,
             matchBrandSubdomain,
             config: config[FETCH_CONFIG].guide?.themes || {

--- a/packages/zendesk-adapter/src/filters/utils.ts
+++ b/packages/zendesk-adapter/src/filters/utils.ts
@@ -10,6 +10,7 @@ import Joi from 'joi'
 import {
   Change,
   ChangeDataType,
+  ElemID,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -21,7 +22,7 @@ import {
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData, createSchemeGuard, getParents, references } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { collections, values as lowerDashValues, hash as hashUtils } from '@salto-io/lowerdash'
 import wu from 'wu'
 import { references as referencesUtils, resolveChangeElement } from '@salto-io/adapter-components'
 import { lookupFunc } from './field_references'
@@ -301,3 +302,5 @@ export const transformReferenceUrls = ({
   // If nothing matched, return the original url
   return result ?? [urlPart]
 }
+
+export const shortElemIdHash = (elemID: ElemID): string => hashUtils.toMD5(elemID.getFullName()).slice(0, 10)

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -45,6 +45,7 @@ import {
 import { createEveryoneUserSegmentInstance } from '../src/filters/everyone_user_segment'
 import ZendeskAdapter from '../src/adapter'
 import { createFilterCreatorParams } from './utils'
+import { shortElemIdHash } from '../src/filters/utils'
 
 type MockReply = {
   url: string
@@ -2574,7 +2575,7 @@ describe('adapter', () => {
         ])
         expect(themeElements[0].value.root.files['hello_txt@v'].content).toEqual(
           new StaticFile({
-            filepath: 'zendesk/themes/brands/myBrand/Copenhagen/hello.txt',
+            filepath: `zendesk/themes/brands/myBrand/${shortElemIdHash(themeElements[0].elemID)}_Copenhagen/hello.txt`,
             content: Buffer.from('Hello World\n'),
           }),
         )

--- a/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_arrange_paths.test.ts
@@ -36,6 +36,7 @@ import {
 } from '../../src/constants'
 import filterCreator, { GUIDE_ELEMENT_DIRECTORY, GUIDE_PATH, UNSORTED } from '../../src/filters/guide_arrange_paths'
 import { createFilterCreatorParams } from '../utils'
+import { shortElemIdHash } from '../../src/filters/utils'
 
 describe('guide arrange paths', () => {
   let client: ZendeskClient
@@ -415,7 +416,7 @@ describe('guide arrange paths', () => {
           'article_name',
           GUIDE_ELEMENT_DIRECTORY[ARTICLE_ATTACHMENT_TYPE_NAME],
           'attachment',
-          `${staticFile.hash.slice(0, 10)}_attachment`,
+          `${shortElemIdHash(elements[3].elemID)}_${staticFile.hash.slice(0, 10)}_attachment`,
         ].join('/'),
       )
       expect(staticFile.isEqual(articleAttachmentInstance.value.content)).toBeTruthy()

--- a/packages/zendesk-adapter/test/filters/guide_theme.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_theme.test.ts
@@ -30,6 +30,7 @@ import * as CreateModule from '../../src/filters/guide_themes/create'
 import * as DeleteModule from '../../src/filters/guide_themes/delete'
 import * as PublishModule from '../../src/filters/guide_themes/publish'
 import { createFilterCreatorParams } from '../utils'
+import { shortElemIdHash } from '../../src/filters/utils'
 
 jest.mock('jszip', () =>
   jest.fn().mockImplementation(() => {
@@ -238,7 +239,7 @@ describe('filterCreator', () => {
           expect(liveThemeWithId.value.root.files['file1_txt@v'].filename).toEqual('file1.txt')
           expect(liveThemeWithId.value.root.files['file1_txt@v'].content).toEqual(
             new StaticFile({
-              filepath: `${ZENDESK}/themes/brands/oneTwo/SixFlags/file1.txt`,
+              filepath: `${ZENDESK}/themes/brands/oneTwo/${shortElemIdHash(liveThemeWithId.elemID)}_SixFlags/file1.txt`,
               content: Buffer.from('file1content'),
             }),
           )
@@ -247,7 +248,7 @@ describe('filterCreator', () => {
           )
           expect(liveThemeWithId.value.root.folders['subfolder_dot@v'].files['file2_txt@v'].content).toEqual(
             new StaticFile({
-              filepath: `${ZENDESK}/themes/brands/oneTwo/SixFlags/subfolder.dot/file2.txt`,
+              filepath: `${ZENDESK}/themes/brands/oneTwo/${shortElemIdHash(liveThemeWithId.elemID)}_SixFlags/subfolder.dot/file2.txt`,
               content: Buffer.from('file2content'),
             }),
           )
@@ -261,13 +262,13 @@ describe('filterCreator', () => {
           expect(Object.keys(nonLiveThemeWithId.value.root)).toHaveLength(2)
           expect(nonLiveThemeWithId.value.root.files['file1_txt@v'].content).toEqual(
             new StaticFile({
-              filepath: `${ZENDESK}/themes/brands/oneTwo/SixFlags/file1.txt`,
+              filepath: `${ZENDESK}/themes/brands/oneTwo/${shortElemIdHash(nonLiveThemeWithId.elemID)}_SixFlags/file1.txt`,
               content: Buffer.from('file1content'),
             }),
           )
           expect(nonLiveThemeWithId.value.root.folders['subfolder_dot@v'].files['file2_txt@v'].content).toEqual(
             new StaticFile({
-              filepath: `${ZENDESK}/themes/brands/oneTwo/SixFlags/subfolder.dot/file2.txt`,
+              filepath: `${ZENDESK}/themes/brands/oneTwo/${shortElemIdHash(nonLiveThemeWithId.elemID)}_SixFlags/subfolder.dot/file2.txt`,
               content: Buffer.from('file2content'),
             }),
           )

--- a/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
+++ b/packages/zendesk-adapter/test/filters/macro_attachments.test.ts
@@ -24,6 +24,7 @@ import { createFilterCreatorParams } from '../utils'
 import ZendeskClient from '../../src/client/client'
 import { ZENDESK, MACRO_TYPE_NAME } from '../../src/constants'
 import filterCreator, { ATTACHMENTS_FIELD_NAME, MACRO_ATTACHMENT_TYPE_NAME } from '../../src/filters/macro_attachments'
+import { shortElemIdHash } from '../../src/filters/utils'
 
 const mockDeployChange = jest.fn()
 jest.mock('@salto-io/adapter-components', () => {
@@ -123,7 +124,7 @@ describe('macro attachment filter', () => {
         filename,
         contentType: 'text/plain',
         content: new StaticFile({
-          filepath: 'zendesk/macro_attachment/test__test.txt',
+          filepath: `zendesk/macro_attachment/${attachment && shortElemIdHash(attachment.elemID)}_test__test.txt`,
           encoding: 'binary',
           content,
         }),


### PR DESCRIPTION
Currently in the relevant places in the Zendesk adapter

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 

_Zendesk Adapter:_
* Some static file paths will change in order to ensure uniqueness. Also the pointers to these static files will be updated to the correct path.

---
_User Notifications_: 

_Zendesk Adapter:_
* Some static file paths will change in order to ensure uniqueness. Also the pointers to these static files will be updated to the correct path.
