### PR TITLE
Identify email template references in data instances

### DIFF
--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -450,6 +450,7 @@ export const QUERIES_BY_TABLE_NAME: Record<SuiteQLTableName, QueryParams | undef
   role: undefined,
   workflow: undefined,
   customrecordtype: undefined,
+  emailtemplate: undefined,
 }
 
 export const getSuiteQLTableInternalIdsMap = (instance: InstanceElement): InternalIdsMap => {

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -162,6 +162,7 @@ const MANUALLY_TABLE_TO_INTERNAL_ID = {
   vendor: '-9',
   customrecordtype: TABLE_TO_INTERNAL_ID.customRecordType,
   priceLevel: TABLE_TO_INTERNAL_ID.item,
+  emailtemplate: '-120',
 } as const
 
 const ALL_TABLE_TO_INTERNAL_ID = {


### PR DESCRIPTION
`customrecordtype = "-120"` means that the field reference an email template instance, and we can use a reference (e.g. `netsuite.emailtemplate.instance.custtemailtmpl123`) instead of ASV (e.g `[ACCOUNT_SPECIFIC_VALUE] (object) (email template name)`).

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Identify email template references in data instances

---
_User Notifications_: 
Netsuite Adapter:
- Fields in custom record types that reference email template will replace their field type:
```diff
-  unknown custom_custrecord_email_template {
+  netsuite.emailtemplateReference custom_custrecord_email_template {
     scriptid = "custrecord_email_template"
```
- References to email templates in data instances will replace ASVs:
```diff
-  custom_custrecord_email_template = {
-    id = "[ACCOUNT_SPECIFIC_VALUE] (object) (email template name)
-  }
+  custom_custrecord_email_template = netsuite.emailtemplate.instance.custtemailtmpl123
```