### PR TITLE
SALTO-6645: Fix IdP check in Okta's E2E

### DIFF
--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -277,6 +277,7 @@ export const mockDefaultValues: Record<string, Values> = {
         matchAttribute: '',
       },
       maxClockSkew: 0,
+      transformedUsernameMatchingEnabled: false,
     },
     type: 'OIDC',
   },


### PR DESCRIPTION
Added the new field added by Okta

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
