### PR TITLE
SALTO-6646: use detailedMessage instead of message in saltoError

### DIFF
--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -66,7 +66,7 @@ const applyPatchToWorkspace = async (
   if (fetchErrors.length > 0) {
     // We currently assume all fetchErrors are warnings
     log.debug(`apply-patch had ${fetchErrors.length} warnings`)
-    outputLine(formatFetchWarnings(fetchErrors.map(fetchError => fetchError.message)), output)
+    outputLine(formatFetchWarnings(fetchErrors.map(fetchError => fetchError.detailedMessage)), output)
   }
   if (updateState) {
     outputLine(`Updating state for environment ${workspace.currentEnv()}`, output)

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -175,7 +175,7 @@ const deployPlan = async (
   )
   outputLine(deployErrorsOutput(result.errors), output)
   outputLine(deployPhaseEpilogue(nonErroredActions.length, result.errors.length, checkOnly), output)
-  log.debug(`${result.errors.length} errors occurred:\n${result.errors.map(err => err.message).join('\n')}`)
+  log.debug(`${result.errors.length} errors occurred:\n${result.errors.map(err => err.detailedMessage).join('\n')}`)
 
   if (executingDeploy) {
     cliTelemetry.actionsSuccess(nonErroredActions.length)

--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -247,7 +247,7 @@ export const fetchCommand = async ({
   if (!_.isEmpty(fetchResult.fetchErrors)) {
     // We currently assume all fetchErrors are warnings
     log.debug(`fetch had ${fetchResult.fetchErrors.length} warnings`)
-    bindedOutputline(formatFetchWarnings(fetchResult.fetchErrors.map(fetchError => fetchError.message)))
+    bindedOutputline(formatFetchWarnings(fetchResult.fetchErrors.map(fetchError => fetchError.detailedMessage)))
   }
   if (updatingWsSucceeded) {
     bindedOutputline(formatFetchFinish())

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -370,7 +370,7 @@ export const cancelDeployOutput = (checkOnly: boolean): string =>
 
 export const deployErrorsOutput = (allErrors: DeployError[]): string => {
   const getErrorMessage = (err: DeployError): string =>
-    formatListRecord(`${isSaltoElementError(err) ? `${err.elemID.getFullName()}: ` : ''}${err.message}`, 1)
+    formatListRecord(`${isSaltoElementError(err) ? `${err.elemID.getFullName()}: ` : ''}${err.detailedMessage}`, 1)
   const errorOutputLines = [emptyLine()]
   if (allErrors.length > 0) {
     const warnings = allErrors.filter(warning => warning.severity === 'Warning')
@@ -495,7 +495,7 @@ export const formatFetchWarnings = (warnings: string[]): string =>
 export const formatSyncToWorkspaceErrors = (syncErrors: ReadonlyArray<SaltoError | SaltoElementError>): string =>
   [
     emptyLine(),
-    `${Prompts.SYNC_TO_WORKSPACE_ERRORS}\n${syncErrors.map(err => `${err.severity} ${err.message}${isSaltoElementError(err) ? ` (${err.elemID.getFullName()})` : ''}`).join('\n')}`,
+    `${Prompts.SYNC_TO_WORKSPACE_ERRORS}\n${syncErrors.map(err => `${err.severity} ${err.detailedMessage}${isSaltoElementError(err) ? ` (${err.elemID.getFullName()})` : ''}`).join('\n')}`,
   ].join('\n')
 
 export const formatWorkspaceLoadFailed = (numErrors: number): string =>

--- a/packages/cli/test/commands/adapter_format.test.ts
+++ b/packages/cli/test/commands/adapter_format.test.ts
@@ -259,7 +259,9 @@ describe('sync-to-workspace command', () => {
   describe('when core sync returns with errors', () => {
     let result: CliExitCode
     beforeEach(async () => {
-      mockSyncWorkspaceToFolder.mockResolvedValueOnce({ errors: [{ severity: 'Error', message: 'Not supported' }] })
+      mockSyncWorkspaceToFolder.mockResolvedValueOnce({
+        errors: [{ severity: 'Error', message: 'Not supported', detailedMessage: 'detailed Not Supported' }],
+      })
       result = await syncWorkspaceToFolderAction({
         ...cliCommandArgs,
         workspace,

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -68,7 +68,9 @@ describe('fetch command', () => {
     describe('with errored workspace', () => {
       beforeEach(async () => {
         const workspace = mocks.mockWorkspace({})
-        workspace.errors.mockResolvedValue(mocks.mockErrors([{ severity: 'Error', message: 'some error' }]))
+        workspace.errors.mockResolvedValue(
+          mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some detailed error' }]),
+        )
         result = await action({
           ...cliCommandArgs,
           input: {
@@ -572,7 +574,11 @@ describe('fetch command', () => {
               const workspace = mocks.mockWorkspace({})
               workspace.updateNaclFiles.mockImplementation(async () => {
                 // Make the workspace errored after updateNaclFiles is called
-                workspace.errors.mockResolvedValue(mocks.mockErrors([{ severity: 'Error', message: 'BLA Error' }]))
+                workspace.errors.mockResolvedValue(
+                  mocks.mockErrors([
+                    { severity: 'Error', message: 'BLA Error', detailedMessage: 'detailed BLA Error' },
+                  ]),
+                )
                 return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
 
@@ -600,7 +606,11 @@ describe('fetch command', () => {
               const workspace = mocks.mockWorkspace({})
               workspace.updateNaclFiles.mockImplementation(async () => {
                 // Make the workspace errored after updateNaclFiles is called
-                workspace.errors.mockResolvedValue(mocks.mockErrors([{ severity: 'Warning', message: 'BLA Error' }]))
+                workspace.errors.mockResolvedValue(
+                  mocks.mockErrors([
+                    { severity: 'Warning', message: 'BLA Error', detailedMessage: 'detailed BLA Error' },
+                  ]),
+                )
                 return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
 
@@ -636,6 +646,7 @@ describe('fetch command', () => {
                 elemID: mocks.elements()[0].elemID,
                 error: 'test',
                 message: 'test merge error',
+                detailedMessage: 'detailed test merge error',
                 severity: 'Warning',
               },
             },

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -58,10 +58,12 @@ describe('formatter', () => {
       },
     ],
     message: 'This is my error',
+    detailedMessage: 'This is my error detailed message',
     severity: 'Error',
   }
   const workspaceErrorWithoutSourceFragments: wsErrors.WorkspaceError<SaltoError> = {
     message: 'This is my error',
+    detailedMessage: 'This is my error detailed message',
     sourceLocations: [],
     severity: 'Error',
   }
@@ -87,24 +89,28 @@ describe('formatter', () => {
     {
       elemID: new ElemID('salesforce', 'TestType1'),
       message: 'my error message 1',
+      detailedMessage: 'my error detailed message 1',
       severity: 'Error',
       groupId: 'test group',
     },
     {
       elemID: new ElemID('salesforce', 'TestType2'),
       message: 'my error message 2',
+      detailedMessage: 'my error detailed message 2',
       severity: 'Error',
       groupId: 'test group',
     },
     {
       elemID: new ElemID('salesforce', 'TestType3'),
       message: 'my warning message',
+      detailedMessage: 'my warning detailed message',
       severity: 'Warning',
       groupId: 'test group',
     },
     {
       elemID: new ElemID('salesforce', 'TestType4'),
       message: 'my info message',
+      detailedMessage: 'my info detailed message',
       severity: 'Info',
       groupId: 'test group',
     },
@@ -596,10 +602,10 @@ describe('formatter', () => {
       formattedErrors = deployErrorsOutput(workspaceDeployProblems)
     })
     it('should have both error messages', () => {
-      expect(formattedErrors).toContain('my error message 1')
-      expect(formattedErrors).toContain('my error message 2')
-      expect(formattedErrors).toContain('my warning message')
-      expect(formattedErrors).toContain('my info message')
+      expect(formattedErrors).toContain('my error detailed message 1')
+      expect(formattedErrors).toContain('my error detailed message 2')
+      expect(formattedErrors).toContain('my warning detailed message')
+      expect(formattedErrors).toContain('my info detailed message')
     })
     it('should contain element ID for salto element errors', () => {
       expect(formattedErrors).toContain('salesforce.TestType1')

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -161,12 +161,16 @@ export const deployActions = async (
           log.warn(
             'Deploy of %s encountered non-fatal issues: %s',
             item.groupKey,
-            nonFatalErrors.map(err => err.message).join('\n\n'),
+            nonFatalErrors.map(err => err.detailedMessage).join('\n\n'),
           )
           accumulatedNonFatalErrors.push(...nonFatalErrors.map(err => ({ ...err, groupId: item.groupKey })))
         }
         if (fatalErrors.length > 0) {
-          log.warn('Failed to deploy %s, errors: %s', item.groupKey, fatalErrors.map(err => err.message).join('\n\n'))
+          log.warn(
+            'Failed to deploy %s, errors: %s',
+            item.groupKey,
+            fatalErrors.map(err => err.detailedMessage).join('\n\n'),
+          )
           throw new WalkDeployError(fatalErrors)
         }
         reportProgress(item, 'finished')

--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -137,11 +137,11 @@ export const deployChanges = async <T extends Change<ChangeDataType>>(
           log.error(
             'An error occurred during deployment of %s: %o',
             getChangeData(change).elemID.getFullName(),
-            err.message,
+            err.detailedMessage,
           )
           errors.push({
             message: err.message,
-            detailedMessage: err.message,
+            detailedMessage: err.detailedMessage,
             severity: err.severity,
             elemID: getChangeData(change).elemID,
           })

--- a/packages/jira-adapter/test/deployment/standard_deployment.test.ts
+++ b/packages/jira-adapter/test/deployment/standard_deployment.test.ts
@@ -37,7 +37,7 @@ describe('deployChanges', () => {
   it('should return the applied change and an error when the error severity is not Error', async () => {
     const warningError: SaltoError = {
       message: 'warning message',
-      detailedMessage: 'warning message',
+      detailedMessage: 'warning detailed message',
       severity: 'Warning',
     }
     const res = await deployChanges([toChange({ after: instance })], () => {
@@ -48,7 +48,7 @@ describe('deployChanges', () => {
     expect(res.errors).toEqual([
       {
         message: 'warning message',
-        detailedMessage: 'warning message',
+        detailedMessage: 'warning detailed message',
         severity: 'Warning',
         elemID: instance.elemID,
       },

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -621,13 +621,13 @@ export default class NetsuiteAdapter implements AdapterOperations {
     const errorsOnCustomFieldsByParents = _(originalChangesErrors)
       .filter(error => error.elemID.idType === 'field')
       .groupBy(error => error.elemID.createTopLevelParentID().parent.getFullName())
-      .mapValues(errors => new Set(errors.map(error => error.message)))
+      .mapValues(errors => new Set(errors.map(error => error.detailedMessage)))
       .value()
 
     additionalChangesErrors.forEach(error => {
       const errorsOnFields = errorsOnCustomFieldsByParents[error.elemID.createBaseID().parent.getFullName()]
-      if (!errorsOnFields?.has(error.message)) {
-        saltoErrors.push({ message: error.message, detailedMessage: error.message, severity: error.severity })
+      if (!errorsOnFields?.has(error.detailedMessage)) {
+        saltoErrors.push({ message: error.message, detailedMessage: error.detailedMessage, severity: error.severity })
       }
     })
 

--- a/packages/netsuite-adapter/src/change_validators/client_validation.ts
+++ b/packages/netsuite-adapter/src/change_validators/client_validation.ts
@@ -32,7 +32,7 @@ const toChangeErrors = (errors: SaltoElementError[]): ChangeError[] => {
     regexes => regexes.manifestErrorDetailsRegex,
   )
   const [missingDependenciesErrors, nonMissingDependenciesErrors] = _.partition(errors, error =>
-    missingDependenciesRegexes.some(regex => getGroupItemFromRegex(error.message, regex, OBJECT_ID).length > 0),
+    missingDependenciesRegexes.some(regex => getGroupItemFromRegex(error.detailedMessage, regex, OBJECT_ID).length > 0),
   )
 
   const missingDependenciesChangeErrors = Object.values(
@@ -40,7 +40,7 @@ const toChangeErrors = (errors: SaltoElementError[]): ChangeError[] => {
   ).map(elementErrors => {
     const missingDependencies = _.uniq(
       elementErrors.flatMap(error =>
-        missingDependenciesRegexes.flatMap(regex => getGroupItemFromRegex(error.message, regex, OBJECT_ID)),
+        missingDependenciesRegexes.flatMap(regex => getGroupItemFromRegex(error.detailedMessage, regex, OBJECT_ID)),
       ),
     )
 
@@ -60,7 +60,9 @@ const toChangeErrors = (errors: SaltoElementError[]): ChangeError[] => {
     regexes => regexes.missingFeatureInAccountErrorRegex,
   )
   const [missingFeatureErrors, unclassifiedErrors] = _.partition(nonMissingDependenciesErrors, error =>
-    missingFeatureInAccountRegexes.some(regex => getGroupItemFromRegex(error.message, regex, FEATURE_NAME).length > 0),
+    missingFeatureInAccountRegexes.some(
+      regex => getGroupItemFromRegex(error.detailedMessage, regex, FEATURE_NAME).length > 0,
+    ),
   )
 
   const missingFeatureChangeErrors = Object.values(
@@ -68,7 +70,9 @@ const toChangeErrors = (errors: SaltoElementError[]): ChangeError[] => {
   ).map(elementErrors => {
     const missingFeatures = _.uniq(
       elementErrors.flatMap(error =>
-        missingFeatureInAccountRegexes.flatMap(regex => getGroupItemFromRegex(error.message, regex, FEATURE_NAME)),
+        missingFeatureInAccountRegexes.flatMap(regex =>
+          getGroupItemFromRegex(error.detailedMessage, regex, FEATURE_NAME),
+        ),
       ),
     )
 
@@ -87,7 +91,7 @@ const toChangeErrors = (errors: SaltoElementError[]): ChangeError[] => {
       elemID: error.elemID,
       severity: error.severity,
       message: 'SDF validation error',
-      detailedMessage: error.message,
+      detailedMessage: error.detailedMessage,
     }))
     .concat(missingDependenciesChangeErrors)
     .concat(missingFeatureChangeErrors)
@@ -143,7 +147,7 @@ const changeValidator: ClientChangeValidator = async (changes, client, additiona
         realGroupChanges.map(change => ({
           elemID: getChangeData(change).elemID,
           message: error.message,
-          detailedMessage: error.message,
+          detailedMessage: error.detailedMessage,
           severity: error.severity,
         })),
       )

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -127,20 +127,20 @@ describe('client validation', () => {
     mockValidate.mockResolvedValue([
       {
         elemID: getChangeData(changes[0]).elemID,
-        message: 'Details: The manifest contains a dependency on customlist1',
-        detailedMessage: 'detailed Details: The manifest contains a dependency on customlist1',
+        message: 'SDF Error',
+        detailedMessage: 'Details: The manifest contains a dependency on customlist1',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[0]).elemID,
-        message: 'Details: The manifest contains a dependency on customworkflow2.workflowstate1',
-        detailedMessage: 'detailed Details: The manifest contains a dependency on customworkflow2.workflowstate1',
+        message: 'SDF Error',
+        detailedMessage: 'Details: The manifest contains a dependency on customworkflow2.workflowstate1',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[1]).elemID,
-        message: "D.tails: Le manifeste comporte une d.pendance sur l'objet customlist1",
-        detailedMessage: "detailed D.tails: Le manifeste comporte une d.pendance sur l'objet customlist1",
+        message: 'SDF Error',
+        detailedMessage: "D.tails: Le manifeste comporte une d.pendance sur l'objet customlist1",
         severity: 'Error',
       },
     ])

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -176,26 +176,23 @@ describe('client validation', () => {
     mockValidate.mockResolvedValue([
       {
         elemID: getChangeData(changes[0]).elemID,
-        message:
-          'Details: To install this SuiteCloud project, the ADVANCEDREVENUERECOGNITION(Advanced Revenue Management (Essentials)) feature must be enabled in the account.',
+        message: 'SDF Error',
         detailedMessage:
-          'detailed Details: To install this SuiteCloud project, the ADVANCEDREVENUERECOGNITION(Advanced Revenue Management (Essentials)) feature must be enabled in the account.',
+          'Details: To install this SuiteCloud project, the ADVANCEDREVENUERECOGNITION(Advanced Revenue Management (Essentials)) feature must be enabled in the account.',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[0]).elemID,
-        message:
-          'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+        message: 'SDF Error',
         detailedMessage:
-          'detailed Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+          'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[1]).elemID,
-        message:
-          'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+        message: 'SDF Error',
         detailedMessage:
-          'detailed Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+          'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
         severity: 'Error',
       },
     ])

--- a/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/client_validation.test.ts
@@ -62,6 +62,7 @@ describe('client validation', () => {
       {
         elemID: getChangeData(changes[0]).elemID,
         message: 'Some Error',
+        detailedMessage: 'Some detailed Error',
         severity: 'Error',
       },
     ])
@@ -75,7 +76,7 @@ describe('client validation', () => {
       {
         elemID: getChangeData(changes[0]).elemID,
         message: 'SDF validation error',
-        detailedMessage: 'Some Error',
+        detailedMessage: 'Some detailed Error',
         severity: 'Error',
       },
     ])
@@ -84,6 +85,7 @@ describe('client validation', () => {
     mockValidate.mockResolvedValue([
       {
         message: 'Some Error',
+        detailedMessage: 'Some detailed Error',
         severity: 'Error',
       },
     ])
@@ -99,7 +101,7 @@ describe('client validation', () => {
         changes.map(change => ({
           elemID: getChangeData(change).elemID,
           message: 'SDF validation error',
-          detailedMessage: 'Some Error',
+          detailedMessage: 'Some detailed Error',
           severity: 'Error',
         })),
       ),
@@ -126,16 +128,19 @@ describe('client validation', () => {
       {
         elemID: getChangeData(changes[0]).elemID,
         message: 'Details: The manifest contains a dependency on customlist1',
+        detailedMessage: 'detailed Details: The manifest contains a dependency on customlist1',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[0]).elemID,
         message: 'Details: The manifest contains a dependency on customworkflow2.workflowstate1',
+        detailedMessage: 'detailed Details: The manifest contains a dependency on customworkflow2.workflowstate1',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[1]).elemID,
         message: "D.tails: Le manifeste comporte une d.pendance sur l'objet customlist1",
+        detailedMessage: "detailed D.tails: Le manifeste comporte une d.pendance sur l'objet customlist1",
         severity: 'Error',
       },
     ])
@@ -173,18 +178,24 @@ describe('client validation', () => {
         elemID: getChangeData(changes[0]).elemID,
         message:
           'Details: To install this SuiteCloud project, the ADVANCEDREVENUERECOGNITION(Advanced Revenue Management (Essentials)) feature must be enabled in the account.',
+        detailedMessage:
+          'detailed Details: To install this SuiteCloud project, the ADVANCEDREVENUERECOGNITION(Advanced Revenue Management (Essentials)) feature must be enabled in the account.',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[0]).elemID,
         message:
           'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+        detailedMessage:
+          'detailed Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
         severity: 'Error',
       },
       {
         elemID: getChangeData(changes[1]).elemID,
         message:
           'Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
+        detailedMessage:
+          'detailed Details: To install this SuiteCloud project, the MULTIBOOK(Adjustment Only Books) feature must be enabled in the account.',
         severity: 'Error',
       },
     ])
@@ -256,15 +267,18 @@ describe('client validation', () => {
         {
           elemID: getChangeData(fileChange).elemID,
           message: 'File Error',
+          detailedMessage: 'detailed File Error',
           severity: 'Error',
         },
         {
           elemID: getChangeData(changes[0]).elemID,
           message: 'SDF Change Error',
+          detailedMessage: 'detailed SDF Change Error',
           severity: 'Error',
         },
         {
           message: 'General Error',
+          detailedMessage: 'detailed General Error',
           severity: 'Error',
         },
       ])
@@ -282,13 +296,13 @@ describe('client validation', () => {
             .map(change => ({
               elemID: getChangeData(change).elemID,
               message: 'SDF validation error',
-              detailedMessage: 'General Error',
+              detailedMessage: 'detailed General Error',
               severity: 'Error',
             }))
             .concat({
               elemID: getChangeData(changes[0]).elemID,
               message: 'SDF validation error',
-              detailedMessage: 'SDF Change Error',
+              detailedMessage: 'detailed SDF Change Error',
               severity: 'Error',
             }),
         ),

--- a/packages/parser/src/utils/template_static_file.ts
+++ b/packages/parser/src/utils/template_static_file.ts
@@ -26,7 +26,7 @@ const parseBufferToTemplateExpression = (
   const tokens = stringLexerFromString(buffer.toString())
   const context = { errors: [] as ParseError[], filename: '' }
   const value = createStringValue(context, tokens, createSimpleStringValue)
-  const errors = context.errors.map(err => err.message)
+  const errors = context.errors.map(err => err.detailedMessage)
   if (typeof value === 'string') {
     log.trace('Template static file is a string. Creating a TemplateExpression from it')
     return {

--- a/packages/workspace/src/workspace/errors.ts
+++ b/packages/workspace/src/workspace/errors.ts
@@ -32,7 +32,7 @@ export class Errors extends types.Bean<
 
   strings(): ReadonlyArray<string> {
     return [
-      ...this.parse.map(error => error.message),
+      ...this.parse.map(error => error.detailedMessage),
       ...this.merge.map(error => error.error),
       ...this.validation.map(error => error.error),
     ]

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1096,6 +1096,8 @@ export const loadWorkspace = async (
 
     return {
       ...saltoElemErr,
+      message: saltoElemErr.message,
+      detailedMessage: saltoElemErr.detailedMessage,
       sourceLocations,
     }
   }

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1096,7 +1096,6 @@ export const loadWorkspace = async (
 
     return {
       ...saltoElemErr,
-      message: saltoElemErr.message,
       sourceLocations,
     }
   }

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -518,6 +518,7 @@ describe('workspace', () => {
       const wsErrors = workspaceErrors[0]
       expect(wsErrors.sourceLocations).toHaveLength(2)
       expect(wsErrors.message).toMatch(mergeError)
+      expect(wsErrors.detailedMessage).toMatch(mergeError)
       expect(wsErrors.severity).toBe('Error')
       const firstSourceLocation = wsErrors.sourceLocations[0]
       expect(firstSourceLocation.sourceRange.filename).toBe('file.nacl')
@@ -562,7 +563,7 @@ describe('workspace', () => {
     describe('when no source is available', () => {
       it('should return empty source fragments', async () => {
         const ws = await createWorkspace()
-        const wsError = await ws.transformError({ severity: 'Warning', message: '' })
+        const wsError = await ws.transformError({ severity: 'Warning', message: '', detailedMessage: '' })
         expect(wsError.sourceLocations).toHaveLength(0)
       })
     })


### PR DESCRIPTION
_use detailedMessage instead of message in saltoError_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
