### PR TITLE
SALTO-6656: Remove fixRetrieveFilePaths FF in Salesforce Adapter

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -459,13 +459,7 @@ export const retrieveMetadataInstances = async ({
       )
     }
 
-    const allValues = await fromRetrieveResult(
-      result,
-      allFileProps,
-      typesWithMetaFile,
-      typesWithContent,
-      fetchProfile.isFeatureEnabled('fixRetrieveFilePaths'),
-    )
+    const allValues = await fromRetrieveResult(result, allFileProps, typesWithMetaFile, typesWithContent)
     // Exclude Profile related instances we fail to retrieve for envs that manage Profiles to improve performance
     // in subsequent fetches and avoid broken references in Profiles.
     if (

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -30,7 +30,6 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   generateRefsInProfiles: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
-  fixRetrieveFilePaths: true,
   extraDependenciesV2: true,
   extendedCustomFieldInformation: false,
   importantValues: true,

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -314,7 +314,6 @@ type ExtractFileNameToDataParams = {
   withMetadataSuffix: boolean
   complexType: boolean
   namespacePrefix?: string
-  fixRetrieveFilePaths: boolean
 }
 
 const fixPath = (path: string): string =>
@@ -328,12 +327,11 @@ const extractFileNameToData = async ({
   withMetadataSuffix,
   complexType,
   namespacePrefix,
-  fixRetrieveFilePaths,
 }: ExtractFileNameToDataParams): Promise<Record<string, Buffer>> => {
   if (!complexType) {
     // this is a single file
     const path = `${PACKAGE}/${fileName}${withMetadataSuffix ? METADATA_XML_SUFFIX : ''}`
-    const fixedFilePath = fixRetrieveFilePaths ? fixPath(path) : path
+    const fixedFilePath = fixPath(path)
     const zipFile = zip.file(fixedFilePath)
     if (zipFile === null) {
       log.warn('Could not find file %s in zip', fixedFilePath)
@@ -359,7 +357,6 @@ export const fromRetrieveResult = async (
   fileProps: ReadonlyArray<FileProperties>,
   typesWithMetaFile: Set<string>,
   typesWithContent: Set<string>,
-  fixRetrieveFilePaths: boolean,
 ): Promise<{ file: FileProperties; values: MetadataValues }[]> => {
   const fromZip = async (zip: JSZip, file: FileProperties): Promise<MetadataValues | undefined> => {
     // extract metadata values
@@ -369,7 +366,6 @@ export const fromRetrieveResult = async (
       withMetadataSuffix: typesWithMetaFile.has(file.type) || isComplexType(file.type),
       complexType: isComplexType(file.type),
       namespacePrefix: file.namespacePrefix,
-      fixRetrieveFilePaths,
     })
     if (Object.values(fileNameToValuesBuffer).length !== 1) {
       if (file.fullName !== UNFILED_PUBLIC_FOLDER) {
@@ -392,7 +388,6 @@ export const fromRetrieveResult = async (
         withMetadataSuffix: false,
         complexType: isComplexType(file.type),
         namespacePrefix: file.namespacePrefix,
-        fixRetrieveFilePaths,
       })
       if (_.isEmpty(fileNameToContent)) {
         log.warn(`Could not find content files for instance (type:${file.type}, fullName:${file.fullName})`)

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -110,7 +110,6 @@ export type OptionalFeatures = {
   fetchProfilesUsingReadApi?: boolean
   toolingDepsOfCurrentNamespace?: boolean
   useLabelAsAlias?: boolean
-  fixRetrieveFilePaths?: boolean
   extendedCustomFieldInformation?: boolean
   importantValues?: boolean
   hideTypesFolder?: boolean
@@ -809,7 +808,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
     toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
-    fixRetrieveFilePaths: { refType: BuiltinTypes.BOOLEAN },
     extendedCustomFieldInformation: { refType: BuiltinTypes.BOOLEAN },
     importantValues: { refType: BuiltinTypes.BOOLEAN },
     hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -697,9 +697,6 @@ describe('SalesforceAdapter fetch', () => {
             getElemIdFunc: mockGetElemIdFunc,
             config: {
               fetch: {
-                optionalFeatures: {
-                  fixRetrieveFilePaths: true,
-                },
                 metadata: {
                   include: [
                     { metadataType: '.*' },
@@ -1381,7 +1378,6 @@ describe('SalesforceAdapter fetch', () => {
           ]),
           expect.anything(),
           expect.anything(),
-          true,
         )
       })
     })
@@ -2184,9 +2180,6 @@ public class LargeClass${index} {
             getElemIdFunc: mockGetElemIdFunc,
             config: {
               fetch: {
-                optionalFeatures: {
-                  fixRetrieveFilePaths: true,
-                },
                 metadata: {
                   include: [
                     { metadataType: '.*' },
@@ -2301,9 +2294,6 @@ public class LargeClass${index} {
             getElemIdFunc: mockGetElemIdFunc,
             config: {
               fetch: {
-                optionalFeatures: {
-                  fixRetrieveFilePaths: true,
-                },
                 metadata: {
                   include: [{ metadataType: '.*' }],
                 },
@@ -2544,7 +2534,6 @@ public class LargeClass${index} {
           ]),
           expect.anything(),
           expect.anything(),
-          true,
         )
       })
     })


### PR DESCRIPTION
Remove fixRetrieveFilePaths FF in Salesforce Adapter

---

_Release Notes_: 
Salesforce Adapter:
- Removed the `fixRetrieveFilePaths` optional feature.
---
_User Notifications_: 
_None_
