### PR TITLE
SALTO-6657-Fix fetch requestType with empty content in the new format

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/layout_types.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_types.ts
@@ -103,9 +103,7 @@ const CONTAINER_ISSUE_LAYOUT_RESPONSE_SCHEME = Joi.object({
               Joi.object({
                 fieldItemId: Joi.string(),
                 panelItemId: Joi.string(),
-              })
-                .unknown(true)
-                .required(),
+              }).unknown(true),
             ),
           }).unknown(true),
         }).unknown(true),


### PR DESCRIPTION
In this PR I fixed the fetching of reqesutType with empty content in the new requestType format

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter:_
* Fixed the fetching of `reqesutType` with empty content in the new requestType format

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
