### PR TITLE
SALTO-6658: Fix Automation Type

### DIFF
--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -194,6 +194,7 @@ export const createAutomationTypes = (): {
       type: { refType: BuiltinTypes.STRING },
       value: { refType: componentValueType },
       hasAttachmentsValue: { refType: BuiltinTypes.BOOLEAN },
+      rawValue: { refType: BuiltinTypes.UNKNOWN },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_TYPE],
   })


### PR DESCRIPTION
Fixed automation type to support the deployment of new automation references

---

None

---
_Release Notes_: 
Jira Adapter:
* Fix a bug that prevented deployment of automation references with circular references error

---
_User Notifications_: 
None
