### PR TITLE
SALTO-5922 use provided type name for recurseInto types instead of generating default ducktype nested type name

### DIFF
--- a/packages/adapter-components/src/fetch/element/type_element.ts
+++ b/packages/adapter-components/src/fetch/element/type_element.ts
@@ -34,7 +34,7 @@ const log = logger(module)
 const generateNestedType = <Options extends FetchApiDefinitionsOptions>(
   args: lowerdashTypes.PickyRequired<GenerateTypeArgs<Options>, 'parentName'>,
 ): NestedTypeWithNestedTypes => {
-  const { typeName, parentName, entries, isUnknownEntry, isMapWithDynamicType } = args
+  const { typeName, parentName, entries, isUnknownEntry, isMapWithDynamicType, defQuery } = args
 
   const validEntries = entries.filter(entry => entry !== undefined && entry !== null)
 
@@ -78,10 +78,13 @@ const generateNestedType = <Options extends FetchApiDefinitionsOptions>(
   }
 
   if (validEntries.every(entry => _.isObjectLike(entry))) {
+    // if a specific type name was defined, use it instead of the default ducktype name
+    const nestedTypeName =
+      defQuery.query(parentName)?.resource?.recurseInto?.[typeName]?.typeName ?? toNestedTypeName(parentName, typeName)
     // eslint-disable-next-line no-use-before-define
     return generateType({
       ...args,
-      typeName: toNestedTypeName(parentName, typeName),
+      typeName: nestedTypeName,
       entries: validEntries,
       isSubType: true,
     })

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
-import { SaltoError, isInstanceElement } from '@salto-io/adapter-api'
+import { SaltoError, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
 import { HTTPReadClientInterface, HTTPWriteClientInterface } from '../../src/client'
 import { createMockQuery } from '../../src/fetch/query'
 import { noPagination } from '../../src/fetch/request/pagination'
@@ -89,6 +89,7 @@ describe('fetch', () => {
     it('should generate elements correctly', async () => {
       const customSaltoError: SaltoError = {
         message: 'error fetching default option',
+        detailedMessage: 'error fetching default option',
         severity: 'Warning',
       }
       const res = await getElements<{ customNameMappingOptions: 'custom' }>({
@@ -293,12 +294,12 @@ describe('fetch', () => {
         reason: 'error fetching options',
       })
       expect(res.elements.map(e => e.elemID.getFullName()).sort()).toEqual([
+        'myAdapter.default_option',
         'myAdapter.depending_option',
         'myAdapter.depending_option.instance.deps1Custom',
         'myAdapter.field',
         'myAdapter.field.instance.field1Custom',
         'myAdapter.field.instance.field2Custom',
-        'myAdapter.field__default',
         'myAdapter.group',
         'myAdapter.group.instance.group1Custom',
         'myAdapter.option',
@@ -310,6 +311,7 @@ describe('fetch', () => {
           .filter(isInstanceElement)
           .find(e => e.elemID.getFullName() === 'myAdapter.field.instance.field1Custom')?.value.default,
       ).toEqual({ name: 'opt1' })
+      expect(res.elements.filter(isObjectType).find(e => e.elemID.typeName === 'field')?.fields.default?.getTypeSync().elemID.typeName).toEqual('default_option')
       // TODO continue
     })
   })

--- a/packages/adapter-components/test/fetch/fetch.test.ts
+++ b/packages/adapter-components/test/fetch/fetch.test.ts
@@ -311,7 +311,12 @@ describe('fetch', () => {
           .filter(isInstanceElement)
           .find(e => e.elemID.getFullName() === 'myAdapter.field.instance.field1Custom')?.value.default,
       ).toEqual({ name: 'opt1' })
-      expect(res.elements.filter(isObjectType).find(e => e.elemID.typeName === 'field')?.fields.default?.getTypeSync().elemID.typeName).toEqual('default_option')
+      expect(
+        res.elements
+          .filter(isObjectType)
+          .find(e => e.elemID.typeName === 'field')
+          ?.fields.default?.getTypeSync().elemID.typeName,
+      ).toEqual('default_option')
       // TODO continue
     })
   })

--- a/packages/confluence-adapter/test/adapter.test.ts
+++ b/packages/confluence-adapter/test/adapter.test.ts
@@ -118,15 +118,15 @@ describe('adapter', () => {
           'confluence.page__authorId',
           'confluence.page__body',
           'confluence.page__ownerId',
-          'confluence.page__restriction',
-          'confluence.page__restriction__restrictions',
           'confluence.page__version',
+          'confluence.permission',
+          'confluence.restriction',
+          'confluence.restriction__restrictions',
           'confluence.space',
           'confluence.space.instance.My_first_space@s',
           'confluence.space.instance.Omri_Farkash@s',
           'confluence.space__authorId',
           'confluence.space__permissionInternalIdMap',
-          'confluence.space__permissions',
         ])
         expect(
           Object.fromEntries(


### PR DESCRIPTION
When adding a field with `resource.recurseInto`, the user provides the name of the type they are creating, and various downstream places rely on it. this was ignored when generating the ducktype type name, causing non-standalone types to not be defined correctly (and e.g. miss field customizations and not support defining nested references)

---
_Release Notes_: 
None

---
_User Notifications_: 
None