### PR TITLE
SALTO-5922 fix confluence reference rule

### DIFF
--- a/packages/confluence-adapter/src/definitions/references.ts
+++ b/packages/confluence-adapter/src/definitions/references.ts
@@ -6,7 +6,14 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { definitions, references as referenceUtils } from '@salto-io/adapter-components'
-import { GROUP_TYPE_NAME, LABEL_TYPE_NAME, PAGE_TYPE_NAME, PERMISSION_TYPE_NAME, SPACE_TYPE_NAME, TEMPLATE_TYPE_NAMES } from '../constants'
+import {
+  GROUP_TYPE_NAME,
+  LABEL_TYPE_NAME,
+  PAGE_TYPE_NAME,
+  PERMISSION_TYPE_NAME,
+  SPACE_TYPE_NAME,
+  TEMPLATE_TYPE_NAMES,
+} from '../constants'
 
 const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
   {

--- a/packages/confluence-adapter/src/definitions/references.ts
+++ b/packages/confluence-adapter/src/definitions/references.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { definitions, references as referenceUtils } from '@salto-io/adapter-components'
-import { GROUP_TYPE_NAME, LABEL_TYPE_NAME, PAGE_TYPE_NAME, SPACE_TYPE_NAME, TEMPLATE_TYPE_NAMES } from '../constants'
+import { GROUP_TYPE_NAME, LABEL_TYPE_NAME, PAGE_TYPE_NAME, PERMISSION_TYPE_NAME, SPACE_TYPE_NAME, TEMPLATE_TYPE_NAMES } from '../constants'
 
 const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
   {
@@ -37,7 +37,7 @@ const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<never>[] = [
     target: { type: PAGE_TYPE_NAME },
   },
   {
-    src: { field: 'principalId', parentTypes: ['space__permissions'] },
+    src: { field: 'principalId', parentTypes: [PERMISSION_TYPE_NAME] },
     serializationStrategy: 'id',
     target: { type: GROUP_TYPE_NAME },
   },


### PR DESCRIPTION
after the fix in https://github.com/salto-io/salto/pull/6558, the reference rule should use the correct type name from the definitions


---
_Release Notes_: 
None

---
_User Notifications_: 
None