### PR TITLE
SALTO-5884: Fix Entra Directory Role modification definition

### DIFF
--- a/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/deploy.ts
@@ -441,7 +441,7 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
             },
             condition: {
               transformForCheck: {
-                pick: [MEMBERS_FIELD_NAME],
+                omit: [MEMBERS_FIELD_NAME],
               },
             },
           },

--- a/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
@@ -441,7 +441,7 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
             },
             condition: {
               transformForCheck: {
-                pick: [MEMBERS_FIELD_NAME],
+                omit: [MEMBERS_FIELD_NAME],
               },
             },
           },


### PR DESCRIPTION
The members of the `Directory Role` are deployed using a dedicated filter, so we omit the members field from the modification request. We also have a condition property that should check for changes other than in the members field, but we accidentally used `pick` instead of `omit`.
Thanks @netama for this catch :)

---
_Release Notes_: 

---
_User Notifications_: 