### PR TITLE
SALTO-6611: Targeted CBF fetches modified Flow instances even though the Flow MetadataType is not in the fetch targets

### DIFF
--- a/packages/salesforce-adapter/src/filters/flows_filter.ts
+++ b/packages/salesforce-adapter/src/filters/flows_filter.ts
@@ -124,7 +124,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     const flowType = findObjectType(elements, FLOW_METADATA_TYPE_ID)
-    if (flowType === undefined) {
+    if (!config.fetchProfile.metadataQuery.isTypeMatch(FLOW_METADATA_TYPE) || flowType === undefined) {
       return {}
     }
     const flowDefinitionType = findObjectType(elements, FLOW_DEFINITION_METADATA_TYPE_ID)

--- a/packages/salesforce-adapter/test/filters/flows_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/flows_filter.test.ts
@@ -94,7 +94,7 @@ describe('flows filter', () => {
             ...defaultFilterContext,
             fetchProfile: buildFetchProfile({
               fetchParams: {
-                target: ['Flow'],
+                target: [FLOW_METADATA_TYPE],
               },
             }),
           },

--- a/packages/salesforce-adapter/test/filters/flows_filter.test.ts
+++ b/packages/salesforce-adapter/test/filters/flows_filter.test.ts
@@ -65,6 +65,47 @@ describe('flows filter', () => {
   describe('onFetch', () => {
     let elements: (InstanceElement | ObjectType)[]
     let flowDefinitionInstance: InstanceElement
+
+    describe('when Flow MetadataType is not in the fetch targets', () => {
+      beforeEach(async () => {
+        elements = [flowType, flowDefinitionType, flowDefinitionInstance]
+        filter = filterCreator({
+          config: {
+            ...defaultFilterContext,
+            fetchProfile: buildFetchProfile({
+              fetchParams: {
+                target: ['ApexClass'],
+              },
+            }),
+          },
+          client,
+        }) as typeof filter
+        await filter.onFetch(elements)
+      })
+      it('should not fetch the Flow instances', async () => {
+        expect(fetchMetadataInstancesSpy).not.toHaveBeenCalled()
+      })
+    })
+    describe('when Flow MetadataType is in the fetch targets', () => {
+      beforeEach(async () => {
+        elements = [flowType, flowDefinitionType, flowDefinitionInstance]
+        filter = filterCreator({
+          config: {
+            ...defaultFilterContext,
+            fetchProfile: buildFetchProfile({
+              fetchParams: {
+                target: ['Flow'],
+              },
+            }),
+          },
+          client,
+        }) as typeof filter
+        await filter.onFetch(elements)
+      })
+      it('should fetch the Flow instances', async () => {
+        expect(fetchMetadataInstancesSpy).toHaveBeenCalled()
+      })
+    })
     describe('with preferActiveFlowVersions true', () => {
       beforeEach(async () => {
         flowDefinitionInstance = createInstanceElement(


### PR DESCRIPTION
Targeted CBF fetches modified Flow instances even though the Flow MetadataType is not in the fetch targets

---

The filter implementation relied on the existence of the Flow MetadataType to understand if the Flow type should be retrieved or not. This caused a weird behavior in Change-Based Fetches where we get the types from the Elements Source and not filter them. This will be fixed in the major changes from the way we handle types in CBF here: https://github.com/salto-io/salto/pull/6389.

---

_Release Notes_: 
_Salesforce Adapter_:
- Bug-fix: Targeted Change-based fetch fetches modified Flow instances even though the Flow MetadataType is not in the fetch targets.

---
_User Notifications_: 
_None_
