### PR TITLE
SALTO-4821: (Salesforce) Fetch OrganizationSettings in Change-Based Fetch 

### DIFF
--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -195,10 +195,6 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     warningMessage: WARNING_MESSAGE,
     config,
     fetchFilterFunc: async elements => {
-      // SALTO-4821
-      if (config.fetchProfile.metadataQuery.isFetchWithChangesDetection()) {
-        return
-      }
       const objectType = createOrganizationType(config)
       const fieldsToIgnore = new Set(FIELDS_TO_IGNORE.concat(config.systemFields ?? []))
       await enrichTypeWithFields(client, objectType, fieldsToIgnore, config.fetchProfile)


### PR DESCRIPTION
(Salesforce) Fetch OrganizationSettings in Change-Based Fetch 

---

_Release Notes_: 
_Salesforce Adapter_:
- The OrganizationSettings instance will now be fetched in Change-Based fetch.

---
_User Notifications_: 
_None_
