### PR TITLE
SALTO-6673: (Salesforce) Enable latestSupportedApiVersion feature by default

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/element_api_version.ts
+++ b/packages/salesforce-adapter/src/change_validators/element_api_version.ts
@@ -8,7 +8,7 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { ChangeValidator, ElemID, getChangeData, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { FLOW_METADATA_TYPE, ORGANIZATION_API_VERSION, ORGANIZATION_SETTINGS, SALESFORCE } from '../constants'
+import { FLOW_METADATA_TYPE, ORGANIZATION_SETTINGS, SALESFORCE } from '../constants'
 import { LATEST_SUPPORTED_API_VERSION_FIELD } from '../filters/organization_settings'
 import { isInstanceOfTypeSync } from '../filters/utils'
 
@@ -22,13 +22,7 @@ const getLatestSupportedApiVersion = async (elementsSource?: ReadOnlyElementsSou
   }
 
   const orgSettings = await elementsSource.get(new ElemID(SALESFORCE, ORGANIZATION_SETTINGS, 'instance'))
-  let latestApiVersion = orgSettings?.value[LATEST_SUPPORTED_API_VERSION_FIELD]
-  if (latestApiVersion === undefined) {
-    // TODO (SALTO-5978): Remove once we enable the optional feature.
-    const orgApiVersion = await elementsSource.get(new ElemID(SALESFORCE, ORGANIZATION_API_VERSION, 'instance'))
-    latestApiVersion = orgApiVersion?.value[LATEST_SUPPORTED_API_VERSION_FIELD]
-  }
-
+  const latestApiVersion = orgSettings?.value[LATEST_SUPPORTED_API_VERSION_FIELD]
   if (latestApiVersion === undefined) {
     log.debug('Latest API version not found.')
     return undefined

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -453,7 +453,6 @@ export const ArtificialTypes = {
 
 // Standard Object Types
 export const ORGANIZATION_SETTINGS = 'Organization'
-export const ORGANIZATION_API_VERSION = 'OrganizationApiVersion'
 
 // Retrieve constants
 export const RETRIEVE_LOAD_OF_METADATA_ERROR_REGEX =

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -35,7 +35,6 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   importantValues: true,
   hideTypesFolder: true,
   omitStandardFieldsNonDeployableValues: true,
-  latestSupportedApiVersion: false,
   metaTypes: false,
   cpqRulesAndConditionsRefs: true,
   flowCoordinates: false,

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -9,17 +9,10 @@
 import _ from 'lodash'
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { FilterContext, RemoteFilterCreator } from '../filter'
+import { RemoteFilterCreator } from '../filter'
 import { ensureSafeFilterFetch, queryClient, safeApiName } from './utils'
 import { getSObjectFieldElement, getTypePath } from '../transformers/transformer'
-import {
-  API_NAME,
-  ORGANIZATION_API_VERSION,
-  ORGANIZATION_SETTINGS,
-  RECORDS_PATH,
-  SALESFORCE,
-  SETTINGS_PATH,
-} from '../constants'
+import { API_NAME, ORGANIZATION_SETTINGS, RECORDS_PATH, SALESFORCE, SETTINGS_PATH } from '../constants'
 import SalesforceClient from '../client/client'
 import { FetchProfile } from '../types'
 
@@ -97,19 +90,17 @@ const enrichTypeWithFields = async (
   }
 }
 
-const createOrganizationType = (config: FilterContext): ObjectType =>
+const createOrganizationType = (): ObjectType =>
   new ObjectType({
     elemID: new ElemID(SALESFORCE, ORGANIZATION_SETTINGS),
-    fields: config.fetchProfile.isFeatureEnabled('latestSupportedApiVersion')
-      ? {
-          [LATEST_SUPPORTED_API_VERSION_FIELD]: {
-            refType: BuiltinTypes.NUMBER,
-            annotations: {
-              [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-            },
-          },
-        }
-      : {},
+    fields: {
+      [LATEST_SUPPORTED_API_VERSION_FIELD]: {
+        refType: BuiltinTypes.NUMBER,
+        annotations: {
+          [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
+        },
+      },
+    },
     annotations: {
       [CORE_ANNOTATIONS.UPDATABLE]: false,
       [CORE_ANNOTATIONS.CREATABLE]: false,
@@ -128,38 +119,12 @@ const createOrganizationInstance = (objectType: ObjectType, fieldValues: Values)
     ORGANIZATION_SETTINGS_INSTANCE_NAME,
   ])
 
-const createOrganizationApiVersionElements = (): [ObjectType, InstanceElement] => {
-  const objectType = new ObjectType({
-    elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
-    fields: {
-      [LATEST_SUPPORTED_API_VERSION_FIELD]: {
-        refType: BuiltinTypes.NUMBER,
-      },
-    },
-    annotations: {
-      [CORE_ANNOTATIONS.HIDDEN]: true,
-      [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-      [CORE_ANNOTATIONS.UPDATABLE]: false,
-      [CORE_ANNOTATIONS.CREATABLE]: false,
-      [CORE_ANNOTATIONS.DELETABLE]: false,
-    },
-    isSettings: true,
-    path: getTypePath(ORGANIZATION_API_VERSION),
-  })
-
-  const instance = new InstanceElement(ElemID.CONFIG_NAME, objectType)
-
-  return [objectType, instance]
-}
-
 type AddLatestSupportedAPIVersionParams = {
   client: SalesforceClient
-  apiVersionInstance: InstanceElement
-  organizationInstance?: InstanceElement
+  organizationInstance: InstanceElement
 }
 const addLatestSupportedAPIVersion = async ({
   client,
-  apiVersionInstance,
   organizationInstance,
 }: AddLatestSupportedAPIVersionParams): Promise<void> => {
   const versions = await client.request('/services/data/')
@@ -178,11 +143,7 @@ const addLatestSupportedAPIVersion = async ({
     log.error('Could not get the latest supported API version.')
     return
   }
-
-  apiVersionInstance.value[LATEST_SUPPORTED_API_VERSION_FIELD] = latestVersion
-  if (organizationInstance !== undefined) {
-    organizationInstance.value[LATEST_SUPPORTED_API_VERSION_FIELD] = latestVersion
-  }
+  organizationInstance.value[LATEST_SUPPORTED_API_VERSION_FIELD] = latestVersion
 }
 
 const FILTER_NAME = 'organizationSettings'
@@ -199,7 +160,7 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
       if (config.fetchProfile.metadataQuery.isFetchWithChangesDetection()) {
         return
       }
-      const objectType = createOrganizationType(config)
+      const objectType = createOrganizationType()
       const fieldsToIgnore = new Set(FIELDS_TO_IGNORE.concat(config.systemFields ?? []))
       await enrichTypeWithFields(client, objectType, fieldsToIgnore, config.fetchProfile)
 
@@ -210,20 +171,12 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
       }
 
       const organizationInstance = createOrganizationInstance(objectType, queryResult[0])
-
-      // TODO (SALTO-5978): Remove once we enable the optional feature.
-      const [apiVersionType, apiVersionInstance] = createOrganizationApiVersionElements()
-
-      const addLatestSupportedAPIVersionParams: AddLatestSupportedAPIVersionParams = {
+      await addLatestSupportedAPIVersion({
         client,
-        apiVersionInstance,
-      }
-      if (config.fetchProfile.isFeatureEnabled('latestSupportedApiVersion')) {
-        addLatestSupportedAPIVersionParams.organizationInstance = organizationInstance
-      }
-      await addLatestSupportedAPIVersion(addLatestSupportedAPIVersionParams)
+        organizationInstance,
+      })
 
-      elements.push(objectType, organizationInstance, apiVersionType, apiVersionInstance)
+      elements.push(objectType, organizationInstance)
     },
   }),
 })

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -114,7 +114,6 @@ export type OptionalFeatures = {
   importantValues?: boolean
   hideTypesFolder?: boolean
   omitStandardFieldsNonDeployableValues?: boolean
-  latestSupportedApiVersion?: boolean
   metaTypes?: boolean
   cpqRulesAndConditionsRefs?: boolean
   flowCoordinates?: boolean
@@ -816,7 +815,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     importantValues: { refType: BuiltinTypes.BOOLEAN },
     hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },
     omitStandardFieldsNonDeployableValues: { refType: BuiltinTypes.BOOLEAN },
-    latestSupportedApiVersion: { refType: BuiltinTypes.BOOLEAN },
     metaTypes: { refType: BuiltinTypes.BOOLEAN },
     cpqRulesAndConditionsRefs: { refType: BuiltinTypes.BOOLEAN },
     flowCoordinates: { refType: BuiltinTypes.BOOLEAN },

--- a/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/element_api_version.test.ts
@@ -8,7 +8,7 @@
 
 import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource, toChange } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { ORGANIZATION_API_VERSION, ORGANIZATION_SETTINGS, SALESFORCE } from '../../src/constants'
+import { ORGANIZATION_SETTINGS, SALESFORCE } from '../../src/constants'
 import { LATEST_SUPPORTED_API_VERSION_FIELD } from '../../src/filters/organization_settings'
 import { mockTypes } from '../mock_elements'
 import { createInstanceElement } from '../../src/transformers/transformer'
@@ -127,46 +127,6 @@ describe('Element API version Change Validator', () => {
       })
       const errors = await elementApiVersionValidator([change], elementsSource)
       expect(errors).toBeEmpty()
-    })
-  })
-
-  describe('with Organization API version with latest supported API version', () => {
-    beforeEach(() => {
-      elementsSource = buildElementsSourceFromElements([
-        new InstanceElement(
-          ElemID.CONFIG_NAME,
-          new ObjectType({
-            elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
-          }),
-          {
-            [LATEST_SUPPORTED_API_VERSION_FIELD]: 50,
-          },
-        ),
-      ])
-    })
-
-    it('should return no errors for valid elements', async () => {
-      const change = toChange({
-        before: flowWithApiVersion(40),
-        after: flowWithApiVersion(50),
-      })
-      const errors = await elementApiVersionValidator([change], elementsSource)
-      expect(errors).toBeEmpty()
-    })
-
-    it('should return an error with unsupported API version', async () => {
-      const flow = flowWithApiVersion(51)
-      const change = toChange({
-        after: flow,
-      })
-      const errors = await elementApiVersionValidator([change], elementsSource)
-      expect(errors).toEqual([
-        expect.objectContaining({
-          elemID: flow.elemID,
-          severity: 'Error',
-          detailedMessage: expect.stringContaining('50') && expect.stringContaining('51'),
-        }),
-      ])
     })
   })
 })

--- a/packages/salesforce-adapter/test/filters/organization_settings.test.ts
+++ b/packages/salesforce-adapter/test/filters/organization_settings.test.ts
@@ -9,14 +9,8 @@ import { CORE_ANNOTATIONS, Element, ElemID } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/organization_settings'
 import mockAdapter from '../adapter'
 import * as filterUtilsModule from '../../src/filters/utils'
-import {
-  API_NAME,
-  CUSTOM_OBJECT_ID_FIELD,
-  ORGANIZATION_API_VERSION,
-  ORGANIZATION_SETTINGS,
-  SALESFORCE,
-} from '../../src/constants'
-import { buildFilterContext } from '../utils'
+import { API_NAME, CUSTOM_OBJECT_ID_FIELD, ORGANIZATION_SETTINGS, SALESFORCE } from '../../src/constants'
+import { defaultFilterContext } from '../utils'
 
 jest.mock('../../src/filters/utils', () => ({
   ...jest.requireActual('../../src/filters/utils'),
@@ -27,11 +21,7 @@ describe('organization-wide defaults filter', () => {
   const mockedFilterUtils = jest.mocked(filterUtilsModule)
   const { client, connection } = mockAdapter({})
   const filter = filterCreator({
-    config: buildFilterContext({
-      optionalFeatures: {
-        latestSupportedApiVersion: true,
-      },
-    }),
+    config: defaultFilterContext,
     client,
   })
 
@@ -169,33 +159,12 @@ describe('organization-wide defaults filter', () => {
             LatestSupportedApiVersion: 60,
           },
         },
-        {
-          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
-          annotations: {
-            [CORE_ANNOTATIONS.HIDDEN]: true,
-            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-            [CORE_ANNOTATIONS.UPDATABLE]: false,
-            [CORE_ANNOTATIONS.CREATABLE]: false,
-            [CORE_ANNOTATIONS.DELETABLE]: false,
-          },
-          isSettings: true,
-        },
-        {
-          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION, 'instance', '_config'),
-          value: {
-            LatestSupportedApiVersion: 60,
-          },
-        },
       ])
     })
     it('should not add LatestSupportedApiVersion when latestSupportedApiVersion feature is disabled', async () => {
       const elements: Element[] = []
       const filterWithFeatureDisabled = filterCreator({
-        config: buildFilterContext({
-          optionalFeatures: {
-            latestSupportedApiVersion: false,
-          },
-        }),
+        config: defaultFilterContext,
         client,
       })
       await filterWithFeatureDisabled.onFetch?.(elements)
@@ -220,22 +189,6 @@ describe('organization-wide defaults filter', () => {
             DefaultContactAccess: 'ControlledByParent',
             DefaultLeadAccess: 'ReadEditTransfer',
             DefaultOpportunityAccess: 'None',
-          },
-        },
-        {
-          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION),
-          annotations: {
-            [CORE_ANNOTATIONS.HIDDEN]: true,
-            [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-            [CORE_ANNOTATIONS.UPDATABLE]: false,
-            [CORE_ANNOTATIONS.CREATABLE]: false,
-            [CORE_ANNOTATIONS.DELETABLE]: false,
-          },
-          isSettings: true,
-        },
-        {
-          elemID: new ElemID(SALESFORCE, ORGANIZATION_API_VERSION, 'instance', '_config'),
-          value: {
             LatestSupportedApiVersion: 60,
           },
         },


### PR DESCRIPTION
(Salesforce) Enable latestSupportedApiVersion feature by default

---

This is mainly a code clean-up that has no visible changes in existing workspaces.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
