### PR TITLE
SALTO-6677: (Salesforce) Simplify metadataQuery for targeted fetch

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -14,11 +14,8 @@ import { safeJsonStringify } from '@salto-io/adapter-utils'
 import {
   CUSTOM_OBJECT,
   DEFAULT_NAMESPACE,
-  FLOW_DEFINITION_METADATA_TYPE,
-  FLOW_METADATA_TYPE,
   MAX_TYPES_TO_SEPARATE_TO_FILE_PER_FIELD,
   SETTINGS_METADATA_TYPE,
-  TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../constants'
 import { ConfigValidationError, validateRegularExpressions } from '../config_validation'
 import {
@@ -98,27 +95,16 @@ export const buildMetadataQuery = ({ fetchParams }: BuildMetadataQueryParams): M
   const { include = [{}], exclude = [] } = metadata
   const fullExcludeList = [...exclude, ...PERMANENT_SKIP_LIST]
 
-  const isIncludedInPartialFetch = (type: string): boolean => {
+  const isIncludedInTargetedFetch = (type: string): boolean => {
     if (target === undefined) {
       return true
     }
-    if (target.includes(type)) {
-      return true
-    }
-    if (type === TOPICS_FOR_OBJECTS_METADATA_TYPE && target.includes(CUSTOM_OBJECT)) {
-      return true
-    }
-    // We should really do this only when config.preferActiveFlowVersions is true
-    // if you have another use-case to pass the config here also handle this please
-    if (type === FLOW_DEFINITION_METADATA_TYPE && target.includes(FLOW_METADATA_TYPE)) {
-      return true
-    }
-    return false
+    return target.includes(type)
   }
 
   const isTypeIncluded = (type: string): boolean =>
     include.some(({ metadataType = '.*' }) => new RegExp(`^${metadataType}$`).test(type)) &&
-    isIncludedInPartialFetch(type)
+    isIncludedInTargetedFetch(type)
   const isTypeExcluded = (type: string): boolean =>
     fullExcludeList.some(
       ({ metadataType = '.*', namespace = '.*', name = '.*' }) =>

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
@@ -7,6 +7,12 @@
  */
 
 import _ from 'lodash'
+import {
+  CUSTOM_OBJECT,
+  FLOW_DEFINITION_METADATA_TYPE,
+  FLOW_METADATA_TYPE,
+  TOPICS_FOR_OBJECTS_METADATA_TYPE,
+} from '../constants'
 
 export const FOLDER_METADATA_TYPES = ['ReportFolder', 'DashboardFolder', 'DocumentFolder', 'EmailFolder'] as const
 
@@ -139,7 +145,6 @@ export const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
   'CustomLabels',
   'CustomMetadataValue',
   'CustomNotificationType',
-  'CustomObject',
   'CustomObjectTranslation',
   'CustomPageWebLink',
   'CustomPermission',
@@ -223,7 +228,6 @@ export const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
   'FlexiPageEventSourceProperty',
   'FlexiPageEventTarget',
   'FlexiPageEventTargetProperty',
-  'Flow',
   'FlowActionCall',
   'FlowActionCallInputParameter',
   'FlowActionCallOutputParameter',
@@ -570,7 +574,13 @@ export const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
   'WorkspaceMapping',
 ] as const
 
-export const METADATA_TYPES_WITH_DEPENDENCIES = ['CustomMetadata', ...CUSTOM_OBJECT_FIELDS, ...WORKFLOW_FIELDS] as const
+export const METADATA_TYPES_WITH_DEPENDENCIES = [
+  'CustomMetadata',
+  ...CUSTOM_OBJECT_FIELDS,
+  ...WORKFLOW_FIELDS,
+  CUSTOM_OBJECT,
+  FLOW_METADATA_TYPE,
+] as const
 
 export const EXCLUDED_METADATA_TYPES = [
   'AssignmentRule', // Fetched through parent type
@@ -618,6 +628,8 @@ export const METADATA_TYPE_TO_DEPENDENCIES: Record<MetadataTypeWithDependencies,
   WorkflowOutboundMessage: ['Workflow'],
   WorkflowRule: ['Workflow'],
   WorkflowTask: ['Workflow'],
+  CustomObject: [TOPICS_FOR_OBJECTS_METADATA_TYPE],
+  Flow: [FLOW_DEFINITION_METADATA_TYPE],
 }
 
 export const isMetadataTypeWithoutDependencies = (

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
@@ -65,6 +65,9 @@ describe('Salesforce MetadataTypes', () => {
           'WorkflowRule',
           'CustomObject',
           'Workflow',
+          'TopicsForObjects',
+          'Flow',
+          'FlowDefinition',
         ])
       })
     })


### PR DESCRIPTION
(Salesforce) Simplify metadataQuery for targeted fetch.

---

Moved metadata targets dependencies from the metadataQuery implementation to the dependencies definitions.
Tested targeted fetch on both Flow and CustomObject.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_