### PR TITLE
SALTO-6674: fix scriptRunner workflow for old formats

### DIFF
--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_dc.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_dc.ts
@@ -24,13 +24,13 @@ const decodeBase64 = (base64: string): string => {
   try {
     const decoded = Buffer.from(base64, 'base64').toString('utf8')
     if (!decoded.startsWith(DC_ENCODE_PREFIX)) {
-      log.warn(`Could not decode DC ScriptRunner script, expected to start with ${DC_ENCODE_PREFIX}, got: ${decoded}`)
+      log.info(`Could not decode DC ScriptRunner script, expected to start with ${DC_ENCODE_PREFIX}, got: ${decoded}`)
       return base64
     }
     // all base64 strings of DC ScriptRunner scripts start with `!` (or YCFg in base 64)
     return decoded.substring(DC_ENCODE_PREFIX.length)
   } catch (e) {
-    log.warn(`Could not decode DC ScriptRunner script, expected base64, got: ${base64}`)
+    log.info(`Could not decode DC ScriptRunner script, expected base64, got: ${base64}`)
     return base64
   }
 }
@@ -39,9 +39,9 @@ const decodeBase64 = (base64: string): string => {
 const encodeBase64 = (script: string): string => Buffer.from(DC_ENCODE_PREFIX + script).toString('base64')
 
 const decodeScriptObject = (base64: string): unknown => {
-  const script = decodeBase64(base64)
+  const decoded = decodeBase64(base64)
   try {
-    const value = JSON.parse(script)
+    const value = JSON.parse(decoded)
     if (value.scriptPath === null) {
       delete value.scriptPath
     }
@@ -50,8 +50,10 @@ const decodeScriptObject = (base64: string): unknown => {
     }
     return value
   } catch (e) {
-    log.warn(`Could not decode DC ScriptRunner script, expected JSON, got: ${script}`)
-    return base64
+    log.info(`Could not decode DC ScriptRunner script, assuming an old format. Expected JSON, got: ${decoded}`)
+    return {
+      script: decoded,
+    }
   }
 }
 

--- a/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/workflow/workflow_dc.test.ts
@@ -160,13 +160,6 @@ describe('Scriptrunner DC Workflow', () => {
         await filterOff.onFetch([instance])
         expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
       })
-      it('should fail if script not in json format', async () => {
-        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = goodBase64
-        await filter.onFetch([instance])
-        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual(
-          goodBase64,
-        )
-      })
       it('should delete empty fields', async () => {
         instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = ''
         instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_SCRIPT_FILE_OR_SCRIPT = ''
@@ -218,6 +211,22 @@ describe('Scriptrunner DC Workflow', () => {
         instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES = goodBase64
         await filterOff.onDeploy([toChange({ after: instance })])
         expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_NOTES).toEqual(goodBase64)
+      })
+    })
+    describe('old format scripts', () => {
+      it('should format properly a script in plain text', async () => {
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = 'ABCD'
+        await filter.onFetch([instance])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual({
+          script: 'ABCD',
+        })
+      })
+      it('should format properly a script in base64 without json', async () => {
+        instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION = goodBase64
+        await filter.onFetch([instance])
+        expect(instance.value.transitions.tran1.rules.postFunctions[0].configuration.FIELD_CONDITION).toEqual({
+          script: 'demo string',
+        })
       })
     })
   })


### PR DESCRIPTION
Fixed a bug in ScriptRunner wokrflow for DC
---

_Additional context for reviewer_

The original implementation considered the following structure for some of the fields for scripts:
{
    script: "...."
}
The entire object is encoded.
We saw cases where there was not such structure, and others where the script was not encoded.
From now on all scripts will have the same structure (like the new format).
noise reduction: https://github.com/salto-io/salto_private/pull/9348

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug that prevented deployment of DC workflows with old format scriptRunner scripts

---
_User Notifications_: 
Jira Adapter:
* ScriptRunner scripts in old formats for DC will look like new format scripts inte NaCls
