### PR TITLE
SALTO-6679: add timeout only for safe requests

### DIFF
--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -204,8 +204,15 @@ export const axiosConnection = <TCredentials>({
       baseURL: await baseURLFunc(credentials),
       ...(await authParamsFunc(credentials)),
       maxBodyLength: Infinity,
-      timeout,
     })
+    httpClient.interceptors.request.use(
+      config => {
+        config.timeout = timeout
+        return config
+      },
+      null,
+      { runWhen: config => ['get', 'head', 'options'].includes(config.method ?? '') },
+    )
     axiosRetry(httpClient, retryOptions)
 
     try {

--- a/packages/adapter-components/test/client/http_connection.test.ts
+++ b/packages/adapter-components/test/client/http_connection.test.ts
@@ -134,7 +134,7 @@ describe('client_http_connection', () => {
 
       const httpClient = await connection.login(mockCredentials)
 
-      // Mock a POST request
+      // Mock a GET request
       mockAxiosAdapter.onGet('/test').reply(200, { data: 'success' })
 
       // Make a POST request


### PR DESCRIPTION
add timeout only for safe requests

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
