### PR TITLE
SALTO-4757 remove the autoMergeDisable core flag

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -244,7 +244,7 @@ const toMergedChange = (change: FetchChange, after: Value): FetchChange => ({
 })
 
 const autoMergeChange: ChangeTransformFunction = async change => {
-  if (getCoreFlagBool(CORE_FLAGS.autoMergeDisabled) || !isMergeableDiffChange(change)) {
+  if (!isMergeableDiffChange(change)) {
     return [change]
   }
 

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -11,7 +11,6 @@ export const CORE_FLAG_PREFIX = 'SALTO_'
 
 export const CORE_FLAGS = {
   skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
-  autoMergeDisabled: 'AUTO_MERGE_DISABLE',
   autoMergeListsDisabled: 'AUTO_MERGE_LISTS_DISABLE',
 } as const
 

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -32,7 +32,6 @@ import {
   StaticFile,
   isStaticFile,
   toChange,
-  isModificationChange,
   toServiceIdsString,
   ElemIdGetter,
   ServiceIds,

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -1010,35 +1010,7 @@ describe('fetch', () => {
             unmergeableAddedContent: allValues.unmergeableValue,
             mismatchValue: allValues.mismatchValue,
           })
-          describe('when auto merge is disabled', () => {
-            beforeEach(async () => {
-              process.env.SALTO_AUTO_MERGE_DISABLE = '1'
-              mockAdapters[testID.adapter].fetch.mockResolvedValueOnce(Promise.resolve({ elements: [serviceInstance] }))
-              const result = await fetchChanges(
-                mockAdapters,
-                createElementSource([workspaceInstance]),
-                createElementSource([stateInstance]),
-                { [testID.adapter]: 'dummy' },
-                [],
-              )
-              changes = [...result.changes]
-            })
-            afterEach(() => {
-              delete process.env.SALTO_AUTO_MERGE_DISABLE
-            })
-            it('should calculate fetch changes', () => {
-              expect(changes).toHaveLength(5)
-            })
-            it('should not merge any change', () => {
-              expect(
-                changes.every(
-                  change =>
-                    isModificationChange(change.change) && _.isEqual(change.change.data.after, allValues.serviceValue),
-                ),
-              ).toBeTrue()
-            })
-          })
-          describe('when auto merge is enabled', () => {
+          describe('merge content', () => {
             beforeEach(async () => {
               mockAdapters[testID.adapter].fetch.mockResolvedValueOnce(Promise.resolve({ elements: [serviceInstance] }))
               const result = await fetchChanges(


### PR DESCRIPTION
after seeing that the merge-content code is stable, the `autoMergeDisable` core flag (the SALTO_AUTO_MERGE_DISABLE env var) can be removed.

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Remove the ability to disable auto merge

---
_User Notifications_: 
None