### PR TITLE
Improve dangling static files removal

### DIFF
--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -16,12 +16,13 @@ import {
   BuiltinTypes,
   createRefToElmWithValue,
   InstanceElement,
+  isStaticFile,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { MockInterface, mockFunction } from '@salto-io/test-utils'
 import { parser } from '@salto-io/parser'
-import { detailedCompare } from '@salto-io/adapter-utils'
+import { detailedCompare, transformElement } from '@salto-io/adapter-utils'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
 import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
@@ -821,6 +822,29 @@ describe('Nacl Files Source', () => {
     })
     it('should not return removed static file if it is still referenced in another field', () => {
       expect(result).not.toContain(staticFile7)
+    })
+
+    describe('when there are no static files in the changes before', () => {
+      let mockStaticFilesIndex: Pick<RemoteMap<string[]>, 'get'>
+
+      beforeAll(async () => {
+        const beforeElemWithoutStaticFiles = await transformElement({
+          element: beforeElem,
+          strict: false,
+          transformFunc: ({ value }) => (isStaticFile(value) ? undefined : value),
+        })
+        mockStaticFilesIndex = { get: jest.fn() }
+        result = await getDanglingStaticFiles(
+          detailedCompare(beforeElemWithoutStaticFiles, afterElem),
+          mockStaticFilesIndex,
+        )
+      })
+      it('should return empty list', () => {
+        expect(result).toBeEmpty()
+      })
+      it('should not query staticFilesIndex', () => {
+        expect(mockStaticFilesIndex.get).not.toHaveBeenCalled()
+      })
     })
   })
 })


### PR DESCRIPTION
this is an improvement for fetches with mainly additions (like first fetch), or when no static file was removed - we can then avoid going over all of the changes' after and return an empty result.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Improve dangling static files removal

---
_User Notifications_: 
None
