### PR TITLE
SALTO-6687: Omit ORN field from Okta applications

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -435,6 +435,7 @@ const createCustomizations = ({
       fieldCustomizations: {
         name: { fieldType: 'string' },
         id: { hide: true },
+        orn: { omit: true },
         [CUSTOM_NAME_FIELD]: { fieldType: 'string', hide: true },
         _links: { hide: true },
         _embedded: { omit: true },


### PR DESCRIPTION
Okta added ORN (=Okta resource name) to all apps

---

_Additional context for reviewer_

deploy works without this field so it should be safe to remove

---
_Release Notes_: 
None

---
_User Notifications_: 

_Okta_adapter_:
- `orn` field will be deleted from all applications