### PR TITLE
SALTO-6688: (Bugfix) Change-Based fetch deletes sub-instances that their type is not included explicitly in the adapter config

### DIFF
--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -398,6 +398,42 @@ describe('buildMetadataQuery', () => {
     })
   })
 
+  describe('isTypeMatch on nested types', () => {
+    let metadataQuery: MetadataQuery
+    describe('when parent type is included', () => {
+      beforeEach(() => {
+        metadataQuery = buildMetadataQuery({
+          fetchParams: {
+            metadata: {
+              include: [{ metadataType: CUSTOM_OBJECT }],
+            },
+          },
+        })
+      })
+      it('should return true for nested types', () => {
+        expect(metadataQuery.isTypeMatch('ValidationRule')).toBeTrue()
+        expect(metadataQuery.isTypeMatch('CustomField')).toBeTrue()
+        expect(metadataQuery.isTypeMatch('FieldSet')).toBeTrue()
+      })
+    })
+    describe('when parent type is excluded', () => {
+      beforeEach(() => {
+        metadataQuery = buildMetadataQuery({
+          fetchParams: {
+            metadata: {
+              exclude: [{ metadataType: CUSTOM_OBJECT }],
+            },
+          },
+        })
+      })
+      it('should return false for nested types', () => {
+        expect(metadataQuery.isTypeMatch('ValidationRule')).toBeFalse()
+        expect(metadataQuery.isTypeMatch('CustomField')).toBeFalse()
+        expect(metadataQuery.isTypeMatch('FieldSet')).toBeFalse()
+      })
+    })
+  })
+
   it('isTypeMatch should return correct results', () => {
     const query = buildMetadataQuery({
       fetchParams: {

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -432,6 +432,36 @@ describe('buildMetadataQuery', () => {
         expect(metadataQuery.isTypeMatch('FieldSet')).toBeFalse()
       })
     })
+    describe('when parent type is included and type is excluded', () => {
+      beforeEach(() => {
+        metadataQuery = buildMetadataQuery({
+          fetchParams: {
+            metadata: {
+              include: [{ metadataType: CUSTOM_OBJECT }],
+              exclude: [{ metadataType: 'ValidationRule' }],
+            },
+          },
+        })
+      })
+      it('should return true for the nested type', () => {
+        expect(metadataQuery.isTypeMatch('ValidationRule')).toBeTrue()
+      })
+    })
+    describe('when parent type is excluded and type is included', () => {
+      beforeEach(() => {
+        metadataQuery = buildMetadataQuery({
+          fetchParams: {
+            metadata: {
+              include: [{ metadataType: 'ValidationRule' }],
+              exclude: [{ metadataType: CUSTOM_OBJECT }],
+            },
+          },
+        })
+      })
+      it('should return false for the nested type', () => {
+        expect(metadataQuery.isTypeMatch('ValidationRule')).toBeFalse()
+      })
+    })
   })
 
   it('isTypeMatch should return correct results', () => {


### PR DESCRIPTION
 (Bugfix) Change-Based fetch deletes sub-instances that their type is not included explicitly in the adapter config
 
---

Made the implementation of `metadataQuery.isTypeMatch` more correct and take into consideration the relationship between the nested instances and their parent.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
