### PR TITLE
SALTO-6522 Fix serializer for undefined

### DIFF
--- a/packages/lowerdash/src/serialize.ts
+++ b/packages/lowerdash/src/serialize.ts
@@ -7,7 +7,7 @@
  */
 import { EOL } from 'os'
 
-export type StreamSerializer = (items: (unknown[] | Record<string, unknown>)[]) => AsyncIterable<string>
+export type StreamSerializer = (items: unknown[]) => AsyncIterable<string>
 
 /**
  * avoid creating a single string for all items, which may exceed the max allowed string length.
@@ -28,7 +28,7 @@ export const createStreamSerializer = ({
 
   const initialLineLength = start.length + end.length
 
-  async function* serializer(items: (unknown[] | Record<string, unknown>)[]): AsyncIterable<string> {
+  async function* serializer(items: unknown[]): AsyncIterable<string> {
     let first = true
     let currentLineLength = initialLineLength
 
@@ -36,7 +36,7 @@ export const createStreamSerializer = ({
     for (const item of items) {
       // We don't use safeJsonStringify to save some time, because we know  we made sure there aren't circles
       // eslint-disable-next-line no-restricted-syntax
-      const serializedItem = JSON.stringify(item)
+      const serializedItem = JSON.stringify(item) ?? ''
       if (currentLineLength + serializedItem.length + 1 > maxLineLength) {
         yield end
         yield EOL

--- a/packages/lowerdash/test/serialize.test.ts
+++ b/packages/lowerdash/test/serialize.test.ts
@@ -15,6 +15,7 @@ describe('serialize', () => {
   const inputs = [
     [],
     [[]],
+    [undefined],
     [[''], ['']],
     [['abc'], ['def']],
     [[], ['def']],
@@ -24,8 +25,10 @@ describe('serialize', () => {
     [['a', 'b'], { c: 'd' }, { e: 'f' }],
   ]
 
-  const getSerializedStreamRes = async (items: (unknown[] | Record<string, unknown>)[]): Promise<string> =>
+  const getSerializedStreamRes = async (items: unknown[]): Promise<string> =>
     (await awu(streamSerialized(items)).toArray()).join('')
+
+  const fixUndefinedItem = (items: unknown[]): unknown[] => (items.length === 1 && items[0] === undefined ? [] : items)
 
   describe('getSerializedStream', () => {
     beforeEach(() => {
@@ -34,7 +37,7 @@ describe('serialize', () => {
     it('should match serialized strings', async () => {
       await awu(inputs).forEach(async items =>
         // eslint-disable-next-line no-restricted-syntax
-        expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify(items)),
+        expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify(fixUndefinedItem(items))),
       )
     })
   })
@@ -43,6 +46,7 @@ describe('serialize', () => {
     const chunkedLines = [
       [[]],
       [[[]]],
+      [[undefined]],
       [[[''], ['']]],
       [[['abc']], [['def']]],
       [[[], ['def']]],
@@ -60,7 +64,7 @@ describe('serialize', () => {
         await awu(inputs).forEach(async (items, index) =>
           expect(await getSerializedStreamRes(items)).toEqual(
             // eslint-disable-next-line no-restricted-syntax
-            chunkedLines[index].map(line => JSON.stringify(line)).join(EOL),
+            chunkedLines[index].map(line => JSON.stringify(fixUndefinedItem(line))).join(EOL),
           ),
         )
       })
@@ -73,7 +77,7 @@ describe('serialize', () => {
       it('should match serialized strings', async () => {
         await awu(inputs).forEach(async items =>
           // eslint-disable-next-line no-restricted-syntax
-          expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify({ elements: items })),
+          expect(await getSerializedStreamRes(items)).toEqual(JSON.stringify({ elements: fixUndefinedItem(items) })),
         )
       })
     })
@@ -86,7 +90,7 @@ describe('serialize', () => {
         await awu(inputs).forEach(async (items, index) =>
           expect(await getSerializedStreamRes(items)).toEqual(
             // eslint-disable-next-line no-restricted-syntax
-            chunkedLines[index].map(line => JSON.stringify({ elements: line })).join(EOL),
+            chunkedLines[index].map(line => JSON.stringify({ elements: fixUndefinedItem(line) })).join(EOL),
           ),
         )
       })


### PR DESCRIPTION
`JSON.stringify(undefined)` returns `undefined` and not `string`, which cause us to throw when accessing `serializedItem.length`

---

_Additional context for reviewer_

---
_Release Notes_: 
Lowerdash:
- Fix serializer for undefined

---
_User Notifications_: 
None