### PR TITLE
SALTO-6685: Deploy Authorization Server Claims

### DIFF
--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -895,6 +895,42 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
+    OAuth2Claim: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{parent_id}/claims',
+                  method: 'post',
+                },
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{parent_id}/claims/{id}',
+                  method: 'put',
+                },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{parent_id}/claims/{id}',
+                  method: 'delete',
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
     [EMAIL_TEMPLATE_TYPE_NAME]: {
       requestsByAction: {
         customizations: {

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -290,6 +290,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     target: { type: JWK_TYPE_NAME },
   },
   {
+    src: { field: 'scopes', parentTypes: ['OAuth2ClaimConditions'] },
+    serializationStrategy: 'name',
+    target: { type: 'OAuth2Scope' },
+  },
+  {
     src: { field: 'include', parentTypes: ['OAuth2ScopesMediationPolicyRuleCondition'] },
     serializationStrategy: 'name',
     target: { type: 'OAuth2Scope' },

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -3035,7 +3035,7 @@ describe('adapter', () => {
           },
         })
         scopeType = new ObjectType({
-          elemID: new ElemID(OKTA, 'OAuth2Claim'),
+          elemID: new ElemID(OKTA, 'OAuth2Scope'),
           fields: {
             id: { refType: BuiltinTypes.SERVICE_ID },
             name: { refType: BuiltinTypes.STRING },
@@ -3085,7 +3085,7 @@ describe('adapter', () => {
         claimInstance.value.id = 'claim-fakeid'
         const updatedClaimInstance = claimInstance.clone()
         updatedClaimInstance.value.status = 'INACTIVE'
-        updatedClaimInstance.value.value = "isMemberOf('oag21341241')"
+        updatedClaimInstance.value.value = "isMemberOf('oag2134124222')"
         const result = await operations.deploy({
           changeGroup: {
             groupID: claimInstance.elemID.getFullName(),

--- a/packages/okta-adapter/test/mock_replies/authorization_server_claim_add.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_claim_add.json
@@ -1,0 +1,47 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/claims",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "claim-fakeid",
+      "name": "access_custom",
+      "status": "ACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "isMemberOf('oag21341241')",
+      "conditions": {
+        "scopes": ["address"]
+      },
+      "system": false,
+      "alwaysIncludeInToken": true,
+      "apiResourceId": null,
+      "_links": {
+        "self": {
+          "href": "https://test.okta.com/api/v1/authorizationServers/default/claims/claim-fakeid",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {
+      "name": "access_custom",
+      "status": "ACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "isMemberOf('oag21341241')",
+      "conditions": {
+        "scopes": ["address"]
+      },
+      "system": false,
+      "alwaysIncludeInToken": true
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1726651475"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_claim_modify.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_claim_modify.json
@@ -1,0 +1,48 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/claims/claim-fakeid",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "claim-fakeid",
+      "name": "access_custom",
+      "status": "INACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "isMemberOf('oag2134124222')",
+      "conditions": {
+        "scopes": ["address"]
+      },
+      "system": false,
+      "alwaysIncludeInToken": true,
+      "apiResourceId": null,
+      "_links": {
+        "self": {
+          "href": "https://test.okta.com/api/v1/authorizationServers/authorizationserver-fakeid1/claims/claim-fakeid",
+          "hints": {
+            "allow": ["GET", "PUT", "DELETE"]
+          }
+        }
+      }
+    },
+    "body": {
+      "id": "claim-fakeid",
+      "name": "access_custom",
+      "status": "INACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "isMemberOf('oag2134124222')",
+      "conditions": {
+        "scopes": ["address"]
+      },
+      "system": false,
+      "alwaysIncludeInToken": true
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1726651562"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_claim_remove.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_claim_remove.json
@@ -1,0 +1,14 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/claims/claim-fakeid",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1726651388"
+    }
+  }
+]


### PR DESCRIPTION
Added support for authorization server claims + reference from auth server claims to scopes.

---

_Additional context for reviewer_
status field can be changed with the regular `PUT`, `POST` requests

---
_Release Notes_: 

_Okta adapter_:
- Support deployment of Authorization Server Claims

---
_User Notifications_: 

_Okta adapter_:
- Authorization Server Claims will now have reference to Authorization Server Scopes