### PR TITLE
SALTO-6680: Add reference from authorization servers to client ids

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -267,8 +267,8 @@ export const addReferences = async <
   fieldsToGroupBy.forEach(fieldName =>
     indexer.addIndex({
       name: fieldName,
-      filter: e => isInstanceElement(e) && e.value[fieldName] !== undefined,
-      key: (inst: InstanceElement) => [inst.refType.elemID.name, inst.value[fieldName]],
+      filter: e => isInstanceElement(e) && _.get(e.value, fieldName) !== undefined,
+      key: (inst: InstanceElement) => [inst.refType.elemID.name, _.get(inst.value, fieldName)],
     }),
   )
   const { elemByElemID, ...fieldLookups } = await indexer.process(awu(contextElements))

--- a/packages/okta-adapter/src/filters/field_references.ts
+++ b/packages/okta-adapter/src/filters/field_references.ts
@@ -20,7 +20,7 @@ const filter: FilterCreator = ({ config, fetchQuery }) => ({
   onFetch: async (elements: Element[]) => {
     await referenceUtils.addReferences({
       elements,
-      fieldsToGroupBy: ['id', 'name', 'key', 'mappingRuleId', 'kid'],
+      fieldsToGroupBy: ['id', 'name', 'key', 'mappingRuleId', 'kid', 'credentials.oauthClient.client_id'],
       defs: getReferenceDefs({
         enableMissingReferences: config[FETCH_CONFIG].enableMissingReferences,
         isUserTypeIncluded: fetchQuery.isTypeMatch(USER_TYPE_NAME),

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -34,7 +34,7 @@ import { resolveUserSchemaRef } from './filters/expression_language'
 
 const { awu } = collections.asynciterable
 
-type OktaReferenceSerializationStrategyName = 'key' | 'mappingRuleId' | 'kid'
+type OktaReferenceSerializationStrategyName = 'key' | 'mappingRuleId' | 'kid' | 'credentials.oauthClient.client_id'
 type OktaReferenceIndexName = OktaReferenceSerializationStrategyName
 const OktaReferenceSerializationStrategyLookup: Record<
   OktaReferenceSerializationStrategyName | referenceUtils.ReferenceSerializationStrategyName,
@@ -55,6 +55,11 @@ const OktaReferenceSerializationStrategyLookup: Record<
     serialize: ({ ref }) => ref.value.value.kid,
     lookup: val => val,
     lookupIndexName: 'kid',
+  },
+  'credentials.oauthClient.client_id': {
+    lookup: val => val,
+    lookupIndexName: 'credentials.oauthClient.client_id',
+    getReferenceId: topLevelId => topLevelId.createNestedID('credentials', 'oauthClient', 'client_id'),
   },
 }
 
@@ -288,6 +293,11 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     src: { field: 'include', parentTypes: ['OAuth2ScopesMediationPolicyRuleCondition'] },
     serializationStrategy: 'name',
     target: { type: 'OAuth2Scope' },
+  },
+  {
+    src: { field: 'include', parentTypes: ['ClientPolicyCondition'] },
+    serializationStrategy: 'credentials.oauthClient.client_id',
+    target: { type: APPLICATION_TYPE_NAME },
   },
 ]
 

--- a/packages/okta-adapter/test/filters/field_references.test.ts
+++ b/packages/okta-adapter/test/filters/field_references.test.ts
@@ -208,7 +208,9 @@ describe('fieldReferencesFilter', () => {
         'okta.Authenticator.instance.authenticator',
       )
 
-      const authorizationServerPolicy = elements.filter(e => isInstanceElement(e) && e.elemID.name === 'authServerPolicy')[0] as InstanceElement
+      const authorizationServerPolicy = elements.filter(
+        e => isInstanceElement(e) && e.elemID.name === 'authServerPolicy',
+      )[0] as InstanceElement
       expect(authorizationServerPolicy.value.conditions.clients.include[0]).toBeInstanceOf(ReferenceExpression)
       expect(authorizationServerPolicy.value.conditions.clients.include[0].elemID.getFullName()).toEqual(
         'okta.Application.instance.app1.credentials.oauthClient.client_id',


### PR DESCRIPTION
I created a reference to the `client_id` field of the application

---

_Additional context for reviewer_
had to make a tiny change in the reference filter to work with `_.get` to allow fields that are not top level.


---
_Release Notes_: 

_Okta adapter_
- Fix a bug causing Authorization Server Policies that apply to specific clients to fail, due to missing reference

---
_User Notifications_: 

_Okta adapter_:
- Authorization server policies that applies to specific clients, will have reference added to this client.