### PR TITLE
Refactor SuiteApp FileCabinet

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -35,6 +35,7 @@ import SuiteAppClient from './suiteapp_client'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from './types'
 import { ImportFileCabinetResult } from '../types'
 import { FILE_CABINET_PATH_SEPARATOR, INTERNAL_ID, PARENT, PATH } from '../../constants'
+import { FileCabinetDeployGroup } from '../../group_changes'
 import { NetsuiteQuery } from '../../config/query'
 import { isFileCabinetType, isFileInstance } from '../../types'
 import { filterFilePathsInFolders, filterFolderPathsInFolders, largeFoldersToExclude } from '../file_cabinet_utils'
@@ -43,7 +44,13 @@ import { SoapDeployResult } from './soap_client/types'
 
 const log = logger(module)
 
-export type DeployType = 'add' | 'update' | 'delete'
+type DeployType = 'add' | 'update' | 'delete'
+
+const FILE_CABINET_DEPLOY_GROUPS: Record<FileCabinetDeployGroup, DeployType> = {
+  'Salto SuiteApp - File Cabinet - Creating Files': 'add',
+  'Salto SuiteApp - File Cabinet - Updating Files': 'update',
+  'Salto SuiteApp - File Cabinet - Deleting Files': 'delete',
+}
 
 type WithPath = Record<typeof PATH, string>
 type WithInternalId = Record<typeof INTERNAL_ID, string>
@@ -69,7 +76,10 @@ type FileCabinetDeployResult = {
   errors: SaltoElementError[]
   elemIdToInternalId: Record<string, string>
 }
-type DeployFunction = (changes: ReadonlyArray<Change<FileCabinetInstance>>) => Promise<FileCabinetDeployResult>
+type DeployFunction = (
+  suiteAppClient: SuiteAppClient,
+  changes: ReadonlyArray<Change<FileCabinetInstance>>,
+) => Promise<FileCabinetDeployResult>
 
 const FOLDERS_SCHEMA = {
   type: 'array',
@@ -156,16 +166,6 @@ export const THROW_ON_MISSING_FEATURE_ERROR: Record<string, string> = {
   "Unknown identifier 'bundleable'": SUITEBUNDLES_DISABLED_ERROR,
 }
 
-export type SuiteAppFileCabinetOperations = {
-  importFileCabinet: (
-    query: NetsuiteQuery,
-    maxFileCabinetSizeInGB: number,
-    extensionsToExclude: string[],
-    forceFileCabinetExclude: boolean,
-  ) => Promise<ImportFileCabinetResult>
-  deploy: (changes: ReadonlyArray<Change<InstanceElement>>, type: DeployType) => Promise<FileCabinetDeployResult>
-}
-
 export const getContent = async (content: unknown): Promise<Buffer> => {
   if (isStaticFile(content)) {
     return (await content.getContent()) ?? Buffer.from('')
@@ -221,537 +221,545 @@ const groupChangesByDepth = (
     .sortBy(([depth]) => depth)
     .value()
 
-export const createSuiteAppFileCabinetOperations = (suiteAppClient: SuiteAppClient): SuiteAppFileCabinetOperations => {
-  let fileCabinetResults: FileCabinetResults
-
-  const validateFoldersResults = (foldersResults: Record<string, unknown>[] | undefined): FolderResult[] => {
-    if (foldersResults === undefined) {
-      throw new RetryableError(new Error('Failed to list folders'))
-    }
-
-    const ajv = new Ajv({ allErrors: true, strict: false })
-    if (!ajv.validate<FolderResult[]>(FOLDERS_SCHEMA, foldersResults)) {
-      log.error('Got invalid results from listing folders - %s: %o', ajv.errorsText(), foldersResults)
-      throw new RetryableError(new Error('Failed to list folders'))
-    }
-
-    return foldersResults
+function assertFoldersResults(
+  foldersResults: Record<string, unknown>[] | undefined,
+): asserts foldersResults is FolderResult[] {
+  if (foldersResults === undefined) {
+    throw new RetryableError(new Error('Failed to list folders'))
   }
 
-  const queryFolders = (
-    whereQuery: string,
-    isSuiteBundlesEnabled = true,
-  ): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
-    retryOnRetryableError(async () => {
-      const foldersQuery = {
-        select: `id, name${isSuiteBundlesEnabled ? BUNDLEABLE : ''}, isinactive, isprivate, description, parent`,
-        from: 'mediaitemfolder',
-        where: whereQuery,
-        orderBy: 'id',
+  const ajv = new Ajv({ allErrors: true, strict: false })
+  if (!ajv.validate<FolderResult[]>(FOLDERS_SCHEMA, foldersResults)) {
+    log.error('Got invalid results from listing folders - %s: %o', ajv.errorsText(), foldersResults)
+    throw new RetryableError(new Error('Failed to list folders'))
+  }
+}
+
+const queryFolders = (
+  suiteAppClient: SuiteAppClient,
+  whereQuery: string,
+  isSuiteBundlesEnabled = true,
+): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
+  retryOnRetryableError(async () => {
+    const foldersQuery = {
+      select: `id, name${isSuiteBundlesEnabled ? BUNDLEABLE : ''}, isinactive, isprivate, description, parent`,
+      from: 'mediaitemfolder',
+      where: whereQuery,
+      orderBy: 'id',
+    }
+    try {
+      const folderResults = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
+      assertFoldersResults(folderResults)
+      return { folderResults, isSuiteBundlesEnabled: true }
+    } catch (e) {
+      if (toError(e).message === SUITEBUNDLES_DISABLED_ERROR && isSuiteBundlesEnabled) {
+        log.debug("SuiteBundles not enabled in the account, removing 'bundleable' from query")
+        const noBundleableQuery = { ...foldersQuery, select: foldersQuery.select.replace(BUNDLEABLE, '') }
+        const folderResults = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)
+        assertFoldersResults(folderResults)
+        return { folderResults, isSuiteBundlesEnabled: false }
       }
-      try {
-        const foldersResults = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
-        return { folderResults: validateFoldersResults(foldersResults), isSuiteBundlesEnabled: true }
-      } catch (e) {
-        if (toError(e).message === SUITEBUNDLES_DISABLED_ERROR && isSuiteBundlesEnabled) {
-          log.debug("SuiteBundles not enabled in the account, removing 'bundleable' from query")
-          const noBundleableQuery = { ...foldersQuery, select: foldersQuery.select.replace(BUNDLEABLE, '') }
-          const queryResult = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)
-          return { folderResults: validateFoldersResults(queryResult), isSuiteBundlesEnabled: false }
+      throw e
+    }
+  })
+
+const queryTopLevelFolders = async (
+  suiteAppClient: SuiteAppClient,
+): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
+  queryFolders(suiteAppClient, "istoplevel = 'T'")
+
+const querySubFolders = async (
+  suiteAppClient: SuiteAppClient,
+  topLevelFolders: FolderResult[],
+  isSuiteBundlesEnabled: boolean,
+): Promise<FolderResult[]> => {
+  const subFolderCriteria = "istoplevel = 'F'"
+  const whereQuery =
+    topLevelFolders.length > 0
+      ? `${subFolderCriteria} AND (${topLevelFolders.map(folder => `appfolder LIKE '${folder.name}%'`).join(' OR ')})`
+      : subFolderCriteria
+  return (await queryFolders(suiteAppClient, whereQuery, isSuiteBundlesEnabled)).folderResults
+}
+
+const queryFiles = (
+  suiteAppClient: SuiteAppClient,
+  folderIdsToQuery: string[],
+  isSuiteBundlesEnabled: boolean,
+  extensionsToExclude: string[],
+): Promise<FileResult[]> =>
+  retryOnRetryableError(async () => {
+    const whereNotHideInBundle = isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''
+    const whereNotExtension = extensionsToExclude.map(reg => `NOT REGEXP_LIKE(name, '${reg}') AND `).join('')
+    const whereQueries = _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(
+      foldersToQueryChunk => `${whereNotExtension}${whereNotHideInBundle}folder IN (${foldersToQueryChunk.join(', ')})`,
+    )
+    const results = await Promise.all(
+      whereQueries.map(async whereQuery => {
+        const filesResults = await suiteAppClient.runSuiteQL({
+          select: `id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url${isSuiteBundlesEnabled ? ', bundleable, hideinbundle' : ''}`,
+          from: 'file',
+          where: whereQuery,
+          orderBy: 'id',
+        })
+
+        if (filesResults === undefined) {
+          throw new RetryableError(new Error('Failed to list files'))
         }
-        throw e
-      }
-    })
 
-  const queryTopLevelFolders = async (): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
-    queryFolders("istoplevel = 'T'")
-
-  const querySubFolders = async (
-    topLevelFolders: FolderResult[],
-    isSuiteBundlesEnabled: boolean,
-  ): Promise<FolderResult[]> => {
-    const subFolderCriteria = "istoplevel = 'F'"
-    const whereQuery =
-      topLevelFolders.length > 0
-        ? `${subFolderCriteria} AND (${topLevelFolders.map(folder => `appfolder LIKE '${folder.name}%'`).join(' OR ')})`
-        : subFolderCriteria
-    return (await queryFolders(whereQuery, isSuiteBundlesEnabled)).folderResults
-  }
-
-  const queryFiles = (
-    folderIdsToQuery: string[],
-    isSuiteBundlesEnabled: boolean,
-    extensionsToExclude: string[],
-  ): Promise<FileResult[]> =>
-    retryOnRetryableError(async () => {
-      const whereNotHideInBundle = isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''
-      const whereNotExtension = extensionsToExclude.map(reg => `NOT REGEXP_LIKE(name, '${reg}') AND `).join('')
-      const whereQueries = _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(
-        foldersToQueryChunk =>
-          `${whereNotExtension}${whereNotHideInBundle}folder IN (${foldersToQueryChunk.join(', ')})`,
-      )
-      const results = await Promise.all(
-        whereQueries.map(async whereQuery => {
-          const filesResults = await suiteAppClient.runSuiteQL({
-            select: `id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url${isSuiteBundlesEnabled ? ', bundleable, hideinbundle' : ''}`,
-            from: 'file',
-            where: whereQuery,
-            orderBy: 'id',
-          })
-
-          if (filesResults === undefined) {
-            throw new RetryableError(new Error('Failed to list files'))
-          }
-
-          const ajv = new Ajv({ allErrors: true, strict: false })
-          if (!ajv.validate<FileResult[]>(FILES_SCHEMA, filesResults)) {
-            log.error('Got invalid results from listing files - %s: %o', ajv.errorsText(), filesResults)
-            throw new RetryableError(new Error('Failed to list files'))
-          }
-          return filesResults
-        }),
-      )
-
-      return results.flat()
-    })
-
-  const removeResultsWithoutParentFolder = (foldersResults: FolderResult[]): FolderResult[] => {
-    const folderIdsSet = new Set(foldersResults.map(folder => folder.id))
-    const removeFoldersWithoutParentFolder = (folders: FolderResult[]): FolderResult[] => {
-      const filteredFolders = folders.filter(folder => {
-        if (folder.parent !== undefined && !folderIdsSet.has(folder.parent)) {
-          log.warn("folder's parent does not exist: %o", folder)
-          folderIdsSet.delete(folder.id)
-          return false
+        const ajv = new Ajv({ allErrors: true, strict: false })
+        if (!ajv.validate<FileResult[]>(FILES_SCHEMA, filesResults)) {
+          log.error('Got invalid results from listing files - %s: %o', ajv.errorsText(), filesResults)
+          throw new RetryableError(new Error('Failed to list files'))
         }
-        return true
-      })
-      if (folders.length === filteredFolders.length) {
-        return folders
-      }
-      return removeFoldersWithoutParentFolder(filteredFolders)
-    }
-    return removeFoldersWithoutParentFolder(foldersResults)
-  }
+        return filesResults
+      }),
+    )
 
-  const removeFilesWithoutParentFolder = (
-    filesResults: FileResult[],
-    filteredFolderResults: ExtendedFolderResult[],
-  ): FileResult[] => {
-    const folderIdsSet = new Set(filteredFolderResults.map(folder => folder.id))
-    return filesResults.filter(file => {
-      if (!folderIdsSet.has(file.folder)) {
-        log.warn("file's folder does not exist: %o", file)
+    return results.flat()
+  })
+
+const removeResultsWithoutParentFolder = (foldersResults: FolderResult[]): FolderResult[] => {
+  const folderIdsSet = new Set(foldersResults.map(folder => folder.id))
+  const removeFoldersWithoutParentFolder = (folders: FolderResult[]): FolderResult[] => {
+    const filteredFolders = folders.filter(folder => {
+      if (folder.parent !== undefined && !folderIdsSet.has(folder.parent)) {
+        log.warn("folder's parent does not exist: %o", folder)
+        folderIdsSet.delete(folder.id)
         return false
       }
       return true
     })
+    if (folders.length === filteredFolders.length) {
+      return folders
+    }
+    return removeFoldersWithoutParentFolder(filteredFolders)
+  }
+  return removeFoldersWithoutParentFolder(foldersResults)
+}
+
+const removeFilesWithoutParentFolder = (
+  filesResults: FileResult[],
+  filteredFolderResults: ExtendedFolderResult[],
+): FileResult[] => {
+  const folderIdsSet = new Set(filteredFolderResults.map(folder => folder.id))
+  return filesResults.filter(file => {
+    if (!folderIdsSet.has(file.folder)) {
+      log.warn("file's folder does not exist: %o", file)
+      return false
+    }
+    return true
+  })
+}
+
+const fullPathParts = (folder: FolderResult, idToFolder: Record<string, FolderResult>): string[] => {
+  if (folder.parent === undefined) {
+    return [folder.name]
+  }
+  if (idToFolder[folder.parent] === undefined) {
+    log.error("folder's parent is unknown\nfolder: %o\nidToFolder: %o", folder, idToFolder)
+    throw new Error(`Failed to get absolute folder path of ${folder.name}`)
+  }
+  return [...fullPathParts(idToFolder[folder.parent], idToFolder), folder.name]
+}
+
+const fullPath = (fileParts: string[]): string =>
+  `${FILE_CABINET_PATH_SEPARATOR}${fileParts.join(FILE_CABINET_PATH_SEPARATOR)}`
+
+const queryFileCabinet = async (
+  suiteAppClient: SuiteAppClient,
+  query: NetsuiteQuery,
+  extensionsToExclude: string[],
+  forceFileCabinetExclude: boolean,
+): Promise<FileCabinetResults> => {
+  const { folderResults, isSuiteBundlesEnabled } = await queryTopLevelFolders(suiteAppClient)
+  const topLevelFoldersResults = folderResults.filter(folder => query.isParentFolderMatch(`/${folder.name}`))
+
+  if (topLevelFoldersResults.length === 0) {
+    log.warn("No top level folder matched the adapter's query. returning empty result")
+    return { foldersResults: [], filesResults: [] }
+  }
+  log.debug(
+    'the following top level folders have been queried: %o',
+    topLevelFoldersResults.map(folder => folder.name),
+  )
+
+  const subFoldersResults = await querySubFolders(suiteAppClient, topLevelFoldersResults, isSuiteBundlesEnabled)
+  const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
+  const idToFolder = _.keyBy(foldersResults, folder => folder.id)
+  const [filteredFolderResults, removedFolders] = _.partition(
+    removeResultsWithoutParentFolder(foldersResults).map(folder => ({
+      path: fullPathParts(folder, idToFolder),
+      ...folder,
+    })),
+    // remove excluded folders before creating the files query
+    folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
+  )
+  log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
+
+  // SALTO-6145: remove this to exclude relevant folders
+  const foldersThatShouldBeRemoved = removedFolders.filter(folder =>
+    query.isParentFolderMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
+  )
+  if (!forceFileCabinetExclude && foldersThatShouldBeRemoved.length > 0) {
+    log.warn(
+      'the following %d folders should be removed too: %o',
+      foldersThatShouldBeRemoved.length,
+      foldersThatShouldBeRemoved,
+    )
+    foldersThatShouldBeRemoved.forEach(folder => filteredFolderResults.push(folder))
   }
 
-  const fullPathParts = (folder: FolderResult, idToFolder: Record<string, FolderResult>): string[] => {
-    if (folder.parent === undefined) {
-      return [folder.name]
-    }
-    if (idToFolder[folder.parent] === undefined) {
-      log.error("folder's parent is unknown\nfolder: %o\nidToFolder: %o", folder, idToFolder)
-      throw new Error(`Failed to get absolute folder path of ${folder.name}`)
-    }
-    return [...fullPathParts(idToFolder[folder.parent], idToFolder), folder.name]
-  }
-
-  const fullPath = (fileParts: string[]): string =>
-    `${FILE_CABINET_PATH_SEPARATOR}${fileParts.join(FILE_CABINET_PATH_SEPARATOR)}`
-
-  const queryFileCabinet = async (
-    query: NetsuiteQuery,
-    extensionsToExclude: string[],
-    forceFileCabinetExclude: boolean,
-  ): Promise<FileCabinetResults> => {
-    if (fileCabinetResults === undefined) {
-      const { folderResults, isSuiteBundlesEnabled } = await queryTopLevelFolders()
-      const topLevelFoldersResults = folderResults.filter(folder => query.isParentFolderMatch(`/${folder.name}`))
-
-      if (topLevelFoldersResults.length === 0) {
-        log.warn("No top level folder matched the adapter's query. returning empty result")
-        fileCabinetResults = { foldersResults: [], filesResults: [] }
-        return fileCabinetResults
-      }
-      log.debug(
-        'the following top level folders have been queried: %o',
-        topLevelFoldersResults.map(folder => folder.name),
-      )
-
-      const subFoldersResults = await querySubFolders(topLevelFoldersResults, isSuiteBundlesEnabled)
-      const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
-      const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-      const [filteredFolderResults, removedFolders] = _.partition(
-        removeResultsWithoutParentFolder(foldersResults).map(folder => ({
-          path: fullPathParts(folder, idToFolder),
-          ...folder,
-        })),
-        // remove excluded folders before creating the files query
-        folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
-      )
-      log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
-
-      // SALTO-6145: remove this to exclude relevant folders
-      const foldersThatShouldBeRemoved = removedFolders.filter(folder =>
-        query.isParentFolderMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
-      )
-      if (!forceFileCabinetExclude && foldersThatShouldBeRemoved.length > 0) {
-        log.warn(
-          'the following %d folders should be removed too: %o',
-          foldersThatShouldBeRemoved.length,
-          foldersThatShouldBeRemoved,
+  const filesResults =
+    filteredFolderResults.length > 0
+      ? await queryFiles(
+          suiteAppClient,
+          filteredFolderResults.map(folder => folder.id),
+          isSuiteBundlesEnabled,
+          extensionsToExclude,
         )
-        foldersThatShouldBeRemoved.forEach(folder => filteredFolderResults.push(folder))
-      }
+      : []
+  const filteredFilesResults = removeFilesWithoutParentFolder(filesResults, filteredFolderResults)
+    .map(file => ({ path: [...fullPathParts(idToFolder[file.folder], idToFolder), file.name], ...file }))
+    .filter(file => query.isFileMatch(fullPath(file.path)))
+  return { filesResults: filteredFilesResults, foldersResults: filteredFolderResults }
+}
 
-      const filesResults =
-        filteredFolderResults.length > 0
-          ? await queryFiles(
-              filteredFolderResults.map(folder => folder.id),
-              isSuiteBundlesEnabled,
-              extensionsToExclude,
-            )
-          : []
-      const filteredFilesResults = removeFilesWithoutParentFolder(filesResults, filteredFolderResults)
-        .map(file => ({ path: [...fullPathParts(idToFolder[file.folder], idToFolder), file.name], ...file }))
-        .filter(file => query.isFileMatch(fullPath(file.path)))
-      fileCabinetResults = { filesResults: filteredFilesResults, foldersResults: filteredFolderResults }
-    }
-    return fileCabinetResults
+export const importFileCabinet = async (
+  suiteAppClient: SuiteAppClient,
+  query: NetsuiteQuery,
+  maxFileCabinetSizeInGB: number,
+  extensionsToExclude: string[],
+  forceFileCabinetExclude: boolean,
+): Promise<ImportFileCabinetResult> => {
+  if (!query.areSomeFilesMatch()) {
+    return { elements: [], failedPaths: { lockedError: [], otherError: [], largeFolderError: [] } }
   }
 
-  const importFileCabinet = async (
-    query: NetsuiteQuery,
-    maxFileCabinetSizeInGB: number,
-    extensionsToExclude: string[],
-    forceFileCabinetExclude: boolean,
-  ): Promise<ImportFileCabinetResult> => {
-    if (!query.areSomeFilesMatch()) {
-      return { elements: [], failedPaths: { lockedError: [], otherError: [], largeFolderError: [] } }
-    }
+  const { foldersResults, filesResults } = await queryFileCabinet(
+    suiteAppClient,
+    query,
+    extensionsToExclude,
+    forceFileCabinetExclude,
+  )
+  const unfilteredFoldersCustomizationInfo = foldersResults.map(folder => ({
+    path: folder.path,
+    typeName: 'folder',
+    values: {
+      description: folder.description ?? '',
+      bundleable: folder.bundleable ?? 'F',
+      isinactive: folder.isinactive,
+      isprivate: folder.isprivate,
+      internalId: folder.id,
+    },
+  }))
 
-    const { foldersResults, filesResults } = await queryFileCabinet(query, extensionsToExclude, forceFileCabinetExclude)
-    const unfilteredFoldersCustomizationInfo = foldersResults.map(folder => ({
-      path: folder.path,
-      typeName: 'folder',
-      values: {
-        description: folder.description ?? '',
-        bundleable: folder.bundleable ?? 'F',
-        isinactive: folder.isinactive,
-        isprivate: folder.isprivate,
-        internalId: folder.id,
-      },
-    }))
+  const filesCustomizations = filesResults.map(file => ({
+    path: file.path,
+    typeName: 'file',
+    values: {
+      description: file.description ?? '',
+      bundleable: file.bundleable ?? 'F',
+      isinactive: file.isinactive,
+      availablewithoutlogin: file.isonline,
+      generateurltimestamp: file.addtimestamptourl,
+      hideinbundle: file.hideinbundle ?? 'F',
+      internalId: file.id,
+      ...(file.islink === 'T' ? { link: file.url } : {}),
+    },
+    id: file.id,
+    size: parseInt(file.filesize, 10),
+  }))
 
-    const filesCustomizations = filesResults.map(file => ({
-      path: file.path,
-      typeName: 'file',
-      values: {
-        description: file.description ?? '',
-        bundleable: file.bundleable ?? 'F',
-        isinactive: file.isinactive,
-        availablewithoutlogin: file.isonline,
-        generateurltimestamp: file.addtimestamptourl,
-        hideinbundle: file.hideinbundle ?? 'F',
-        internalId: file.id,
-        ...(file.islink === 'T' ? { link: file.url } : {}),
-      },
-      id: file.id,
-      size: parseInt(file.filesize, 10),
-    }))
+  const [unfilteredFilesCustomizationWithoutContent, filesCustomizationsLinks] = _.partition(
+    filesCustomizations,
+    file => file.values.link === undefined,
+  )
 
-    const [unfilteredFilesCustomizationWithoutContent, filesCustomizationsLinks] = _.partition(
-      filesCustomizations,
-      file => file.values.link === undefined,
-    )
+  const filesSize = unfilteredFilesCustomizationWithoutContent.map(file => ({
+    path: fullPath(file.path),
+    size: file.size,
+  }))
+  const largeFolders = largeFoldersToExclude(filesSize, maxFileCabinetSizeInGB)
+  const filesCustomizationWithoutContent = filterFilePathsInFolders(
+    unfilteredFilesCustomizationWithoutContent,
+    largeFolders,
+  )
+  const foldersCustomizationInfo = filterFolderPathsInFolders(unfilteredFoldersCustomizationInfo, largeFolders)
 
-    const filesSize = unfilteredFilesCustomizationWithoutContent.map(file => ({
-      path: fullPath(file.path),
-      size: file.size,
-    }))
-    const largeFolders = largeFoldersToExclude(filesSize, maxFileCabinetSizeInGB)
-    const filesCustomizationWithoutContent = filterFilePathsInFolders(
-      unfilteredFilesCustomizationWithoutContent,
-      largeFolders,
-    )
-    const foldersCustomizationInfo = filterFolderPathsInFolders(unfilteredFoldersCustomizationInfo, largeFolders)
+  const fileChunks = chunks.weightedChunks(
+    filesCustomizationWithoutContent,
+    FILES_CHUNK_SIZE,
+    file => file.size,
+    MAX_FILES_IN_READ_REQUEST,
+  )
 
-    const fileChunks = chunks.weightedChunks(
-      filesCustomizationWithoutContent,
-      FILES_CHUNK_SIZE,
-      file => file.size,
-      MAX_FILES_IN_READ_REQUEST,
-    )
+  const filesContent = (
+    await Promise.all(
+      fileChunks.map(async (fileChunk, i) => {
+        if (fileChunk[0].size > FILES_CHUNK_SIZE) {
+          const id = parseInt(fileChunk[0].id, 10)
+          log.debug(`File with id ${id} is too big to fetch via Restlet (${fileChunk[0].size}), using SOAP API`)
+          return suiteAppClient.readLargeFile(id)
+        }
 
-    const filesContent = (
-      await Promise.all(
-        fileChunks.map(async (fileChunk, i) => {
-          if (fileChunk[0].size > FILES_CHUNK_SIZE) {
-            const id = parseInt(fileChunk[0].id, 10)
-            log.debug(`File with id ${id} is too big to fetch via Restlet (${fileChunk[0].size}), using SOAP API`)
-            return suiteAppClient.readLargeFile(id)
+        const results = await retryOnRetryableError(async () => {
+          const res = await suiteAppClient.readFiles(fileChunk.map(f => parseInt(f.id, 10)))
+          if (res === undefined) {
+            throw new RetryableError(new Error('Request for reading files from the file cabinet failed'))
           }
+          return res
+        })
+        log.debug(`Finished Reading files chunk ${i + 1}/${fileChunks.length} with ${fileChunk.length} files`)
 
-          const results = await retryOnRetryableError(async () => {
-            const res = await suiteAppClient.readFiles(fileChunk.map(f => parseInt(f.id, 10)))
-            if (res === undefined) {
-              throw new RetryableError(new Error('Request for reading files from the file cabinet failed'))
-            }
-            return res
-          })
-          log.debug(`Finished Reading files chunk ${i + 1}/${fileChunks.length} with ${fileChunk.length} files`)
+        return (
+          results &&
+          Promise.all(
+            results.map(async (content, index) => {
+              if (!(content instanceof ReadFileEncodingError)) {
+                return content
+              }
 
-          return (
-            results &&
-            Promise.all(
-              results.map(async (content, index) => {
-                if (!(content instanceof ReadFileEncodingError)) {
-                  return content
-                }
-
-                const id = parseInt(fileChunk[index].id, 10)
-                log.debug(`Received file encoding error for id ${id}. Fallback to SOAP request`)
-                return suiteAppClient.readLargeFile(id)
-              }),
-            )
+              const id = parseInt(fileChunk[index].id, 10)
+              log.debug(`Received file encoding error for id ${id}. Fallback to SOAP request`)
+              return suiteAppClient.readLargeFile(id)
+            }),
           )
-        }),
-      )
-    ).flat()
+        )
+      }),
+    )
+  ).flat()
 
-    const failedPaths: string[][] = []
-    const lockedPaths: string[][] = []
-    const filesCustomizationWithContent = filesCustomizationWithoutContent
-      .map((file, index) => {
-        if (!(filesContent[index] instanceof Buffer)) {
-          log.warn(`Failed reading file ${fullPath(file.path)} with id ${file.id}`)
-          if (filesContent[index] instanceof ReadFileInsufficientPermissionError) {
-            lockedPaths.push(file.path)
-          } else {
-            failedPaths.push(file.path)
-          }
-          return undefined
+  const failedPaths: string[][] = []
+  const lockedPaths: string[][] = []
+  const filesCustomizationWithContent = filesCustomizationWithoutContent
+    .map((file, index) => {
+      if (!(filesContent[index] instanceof Buffer)) {
+        log.warn(`Failed reading file ${fullPath(file.path)} with id ${file.id}`)
+        if (filesContent[index] instanceof ReadFileInsufficientPermissionError) {
+          lockedPaths.push(file.path)
+        } else {
+          failedPaths.push(file.path)
         }
-        return {
-          path: file.path,
-          typeName: 'file',
-          fileContent: filesContent[index],
-          values: file.values,
-        }
-      })
-      .filter(values.isDefined)
-
-    return {
-      elements: [
-        ...foldersCustomizationInfo,
-        ...filesCustomizationWithContent,
-        ...filesCustomizationsLinks.map(file => ({
-          path: file.path,
-          typeName: 'file',
-          values: file.values,
-        })),
-      ],
-      failedPaths: {
-        otherError: failedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
-        lockedError: lockedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
-        largeFolderError: largeFolders,
-      },
-    }
-  }
-
-  const convertToFileCabinetDetails = async (
-    change: Change<FileCabinetInstance>,
-    type: DeployType,
-  ): Promise<FileCabinetInstanceDetails> => {
-    const instance = getChangeData(change)
-
-    const { parent, id } =
-      type === 'add'
-        ? { parent: instance.value.parent, id: undefined }
-        : { id: parseInt(getChangeData(change).value.internalId, 10), parent: undefined }
-
-    const base = {
-      id,
-      path: instance.value.path,
-      bundleable: instance.value.bundleable ?? false,
-      isInactive: instance.value.isinactive ?? false,
-      description: instance.value.description ?? '',
-    }
-
-    return isFileInstance(instance)
-      ? {
-          ...base,
-          type: 'file',
-          folder: parent,
-          isOnline: instance.value.availablewithoutlogin ?? false,
-          hideInBundle: instance.value.hideinbundle ?? false,
-          ...(instance.value.link === undefined
-            ? { content: await getContent(instance.value.content) }
-            : { url: instance.value.link }),
-        }
-      : {
-          ...base,
-          type: 'folder',
-          parent,
-          isPrivate: instance.value.isprivate ?? false,
-        }
-  }
-
-  const deployInstances = async (
-    instances: FileCabinetInstanceDetails[],
-    type: DeployType,
-  ): Promise<SoapDeployResult[]> => {
-    if (type === 'add') {
-      return suiteAppClient.addFileCabinetInstances(instances)
-    }
-    if (type === 'delete') {
-      return suiteAppClient.deleteFileCabinetInstances(instances as ExistingFileCabinetInstanceDetails[])
-    }
-    return suiteAppClient.updateFileCabinetInstances(instances as ExistingFileCabinetInstanceDetails[])
-  }
-
-  const deployChunk = async (
-    changes: Change<FileCabinetInstance>[],
-    type: DeployType,
-  ): Promise<FileCabinetDeployResult> => {
-    log.debug(`Deploying chunk of ${changes.length} file changes`)
-    const fileCabinetDetails = await Promise.all(changes.map(change => convertToFileCabinetDetails(change, type)))
-
-    try {
-      const deployResults = await deployInstances(fileCabinetDetails, type)
-      log.debug(`Deployed chunk of ${changes.length} file changes`)
-      return getDeployResultFromSuiteAppResult(changes, deployResults)
-    } catch (e) {
-      const { message } = toError(e)
+        return undefined
+      }
       return {
-        errors: changes.map(change =>
-          toElementError({ elemID: getChangeData(change).elemID, message, detailedMessage: message }),
-        ),
-        appliedChanges: [],
-        elemIdToInternalId: {},
+        path: file.path,
+        typeName: 'file',
+        fileContent: filesContent[index],
+        values: file.values,
       }
-    }
-  }
-
-  const deployChanges = async (
-    changes: ReadonlyArray<Change<FileCabinetInstance>>,
-    type: DeployType,
-  ): Promise<FileCabinetDeployResult> => {
-    const deployChunkResults = await Promise.all(
-      _.chunk(changes, DEPLOY_CHUNK_SIZE).map(chunk => deployChunk(chunk, type)),
-    )
-    return {
-      appliedChanges: deployChunkResults.flatMap(res => res.appliedChanges),
-      errors: deployChunkResults.flatMap(res => res.errors),
-      elemIdToInternalId: deployChunkResults.reduce(
-        (acc, { elemIdToInternalId }) => Object.assign(acc, elemIdToInternalId),
-        {},
-      ),
-    }
-  }
-
-  const deployAdditions: DeployFunction = async allChanges => {
-    const changesByParentDirectory = _.groupBy(allChanges, change => path.dirname(getChangeData(change).value.path))
-    const elemIdToPath = Object.fromEntries(
-      allChanges.map(change => {
-        const instance = getChangeData(change)
-        return [instance.elemID.getFullName(), instance.value.path]
-      }),
-    )
-    const changesToSkip = new Set<string>()
-
-    const deployGroup = async (changes: Change<FileCabinetInstance>[]): Promise<FileCabinetDeployResult> => {
-      const changesToDeploy = changes.filter(change => !changesToSkip.has(getChangeData(change).elemID.getFullName()))
-      const deployResult = await deployChanges(changesToDeploy, 'add')
-
-      deployResult.appliedChanges.forEach(appliedChange => {
-        const appliedInstance = getChangeData(appliedChange)
-        const children = changesByParentDirectory[appliedInstance.value.path] ?? []
-        if (children.length > 0) {
-          log.debug(
-            'adding %s internal id as parent for %d childern files/folders',
-            appliedInstance.value.path,
-            children.length,
-          )
-        }
-        children.forEach(change => {
-          getChangeData(change).value.parent = deployResult.elemIdToInternalId[appliedInstance.elemID.getFullName()]
-        })
-      })
-
-      deployResult.errors.forEach(error => {
-        const failedPath = elemIdToPath[error.elemID.getFullName()]
-        const children = changesByParentDirectory[failedPath] ?? []
-        if (children.length > 0) {
-          log.debug('skipping %d childern files/folders of %s that failed the deploy', children.length, failedPath)
-        }
-        children.forEach(change => {
-          changesToSkip.add(getChangeData(change).elemID.getFullName())
-        })
-      })
-
-      return deployResult
-    }
-
-    const orderedChangesGroups = groupChangesByDepth(allChanges)
-    const deployResults = await promises.array.series(
-      orderedChangesGroups.map(([depth, group]) => async () => {
-        log.debug(`Deploying ${group.length} new files with depth of ${depth}`)
-        return deployGroup(group)
-      }),
-    )
-
-    const dependencyErrors = [...changesToSkip].map(id => {
-      const elemID = ElemID.fromFullName(id)
-      const message = `Cannot deploy this ${elemID.typeName} because its parent folder deploy failed`
-      return toElementError({ elemID, message, detailedMessage: message })
     })
+    .filter(values.isDefined)
 
-    return {
-      appliedChanges: deployResults.flatMap(res => res.appliedChanges),
-      errors: deployResults.flatMap(res => res.errors).concat(dependencyErrors),
-      elemIdToInternalId: deployResults.reduce(
-        (acc, { elemIdToInternalId }) => Object.assign(acc, elemIdToInternalId),
-        {},
-      ),
-    }
+  return {
+    elements: [
+      ...foldersCustomizationInfo,
+      ...filesCustomizationWithContent,
+      ...filesCustomizationsLinks.map(file => ({
+        path: file.path,
+        typeName: 'file',
+        values: file.values,
+      })),
+    ],
+    failedPaths: {
+      otherError: failedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
+      lockedError: lockedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
+      largeFolderError: largeFolders,
+    },
+  }
+}
+
+const convertToFileCabinetDetails = async (
+  change: Change<FileCabinetInstance>,
+  type: DeployType,
+): Promise<FileCabinetInstanceDetails> => {
+  const instance = getChangeData(change)
+
+  const { parent, id } =
+    type === 'add'
+      ? { parent: instance.value.parent, id: undefined }
+      : { id: parseInt(getChangeData(change).value.internalId, 10), parent: undefined }
+
+  const base = {
+    id,
+    path: instance.value.path,
+    bundleable: instance.value.bundleable ?? false,
+    isInactive: instance.value.isinactive ?? false,
+    description: instance.value.description ?? '',
   }
 
-  const deployDeletions: DeployFunction = async changes => {
-    const orderedChangesGroups = groupChangesByDepth(changes).reverse()
-    const deployResults = await promises.array.series(
-      orderedChangesGroups.map(([depth, group]) => async () => {
-        log.debug(`Deleting ${group.length} files with depth of ${depth}`)
-        return deployChanges(group, 'delete')
-      }),
-    )
+  return isFileInstance(instance)
+    ? {
+        ...base,
+        type: 'file',
+        folder: parent,
+        isOnline: instance.value.availablewithoutlogin ?? false,
+        hideInBundle: instance.value.hideinbundle ?? false,
+        ...(instance.value.link === undefined
+          ? { content: await getContent(instance.value.content) }
+          : { url: instance.value.link }),
+      }
+    : {
+        ...base,
+        type: 'folder',
+        parent,
+        isPrivate: instance.value.isprivate ?? false,
+      }
+}
 
+const deployInstances = async (
+  suiteAppClient: SuiteAppClient,
+  instances: FileCabinetInstanceDetails[],
+  type: DeployType,
+): Promise<SoapDeployResult[]> => {
+  if (type === 'add') {
+    return suiteAppClient.addFileCabinetInstances(instances)
+  }
+  if (type === 'delete') {
+    return suiteAppClient.deleteFileCabinetInstances(instances as ExistingFileCabinetInstanceDetails[])
+  }
+  return suiteAppClient.updateFileCabinetInstances(instances as ExistingFileCabinetInstanceDetails[])
+}
+
+const deployChunk = async (
+  suiteAppClient: SuiteAppClient,
+  changes: Change<FileCabinetInstance>[],
+  type: DeployType,
+): Promise<FileCabinetDeployResult> => {
+  log.debug(`Deploying chunk of ${changes.length} file changes`)
+  const fileCabinetDetails = await Promise.all(changes.map(change => convertToFileCabinetDetails(change, type)))
+
+  try {
+    const deployResults = await deployInstances(suiteAppClient, fileCabinetDetails, type)
+    log.debug(`Deployed chunk of ${changes.length} file changes`)
+    return getDeployResultFromSuiteAppResult(changes, deployResults)
+  } catch (e) {
+    const { message } = toError(e)
     return {
-      appliedChanges: deployResults.flatMap(res => res.appliedChanges),
-      errors: deployResults.flatMap(res => res.errors),
+      errors: changes.map(change =>
+        toElementError({ elemID: getChangeData(change).elemID, message, detailedMessage: message }),
+      ),
+      appliedChanges: [],
       elemIdToInternalId: {},
     }
   }
+}
 
-  const deployUpdates: DeployFunction = changes => deployChanges(changes, 'update')
-
-  const typeToDeployFunction: Record<DeployType, DeployFunction> = {
-    add: deployAdditions,
-    delete: deployDeletions,
-    update: deployUpdates,
-  }
-
-  const deploy = async (
-    changes: ReadonlyArray<Change<InstanceElement>>,
-    type: DeployType,
-  ): Promise<FileCabinetDeployResult> =>
-    typeToDeployFunction[type](changes as ReadonlyArray<Change<FileCabinetInstance>>)
-
+const deployChanges = async (
+  suiteAppClient: SuiteAppClient,
+  changes: ReadonlyArray<Change<FileCabinetInstance>>,
+  type: DeployType,
+): Promise<FileCabinetDeployResult> => {
+  const deployChunkResults = await Promise.all(
+    _.chunk(changes, DEPLOY_CHUNK_SIZE).map(chunk => deployChunk(suiteAppClient, chunk, type)),
+  )
   return {
-    importFileCabinet,
-    deploy,
+    appliedChanges: deployChunkResults.flatMap(res => res.appliedChanges),
+    errors: deployChunkResults.flatMap(res => res.errors),
+    elemIdToInternalId: deployChunkResults.reduce(
+      (acc, { elemIdToInternalId }) => Object.assign(acc, elemIdToInternalId),
+      {},
+    ),
   }
 }
+
+const deployAdditions: DeployFunction = async (suiteAppClient, allChanges) => {
+  const changesByParentDirectory = _.groupBy(allChanges, change => path.dirname(getChangeData(change).value.path))
+  const elemIdToPath = Object.fromEntries(
+    allChanges.map(change => {
+      const instance = getChangeData(change)
+      return [instance.elemID.getFullName(), instance.value.path]
+    }),
+  )
+  const changesToSkip = new Set<string>()
+
+  const deployGroup = async (changes: Change<FileCabinetInstance>[]): Promise<FileCabinetDeployResult> => {
+    const changesToDeploy = changes.filter(change => !changesToSkip.has(getChangeData(change).elemID.getFullName()))
+    const deployResult = await deployChanges(suiteAppClient, changesToDeploy, 'add')
+
+    deployResult.appliedChanges.forEach(appliedChange => {
+      const appliedInstance = getChangeData(appliedChange)
+      const children = changesByParentDirectory[appliedInstance.value.path] ?? []
+      if (children.length > 0) {
+        log.debug(
+          'adding %s internal id as parent for %d childern files/folders',
+          appliedInstance.value.path,
+          children.length,
+        )
+      }
+      children.forEach(change => {
+        getChangeData(change).value.parent = deployResult.elemIdToInternalId[appliedInstance.elemID.getFullName()]
+      })
+    })
+
+    deployResult.errors.forEach(error => {
+      const failedPath = elemIdToPath[error.elemID.getFullName()]
+      const children = changesByParentDirectory[failedPath] ?? []
+      if (children.length > 0) {
+        log.debug('skipping %d childern files/folders of %s that failed the deploy', children.length, failedPath)
+      }
+      children.forEach(change => {
+        changesToSkip.add(getChangeData(change).elemID.getFullName())
+      })
+    })
+
+    return deployResult
+  }
+
+  const orderedChangesGroups = groupChangesByDepth(allChanges)
+  const deployResults = await promises.array.series(
+    orderedChangesGroups.map(([depth, group]) => async () => {
+      log.debug(`Deploying ${group.length} new files with depth of ${depth}`)
+      return deployGroup(group)
+    }),
+  )
+
+  const dependencyErrors = [...changesToSkip].map(id => {
+    const elemID = ElemID.fromFullName(id)
+    const message = `Cannot deploy this ${elemID.typeName} because its parent folder deploy failed`
+    return toElementError({ elemID, message, detailedMessage: message })
+  })
+
+  return {
+    appliedChanges: deployResults.flatMap(res => res.appliedChanges),
+    errors: deployResults.flatMap(res => res.errors).concat(dependencyErrors),
+    elemIdToInternalId: deployResults.reduce(
+      (acc, { elemIdToInternalId }) => Object.assign(acc, elemIdToInternalId),
+      {},
+    ),
+  }
+}
+
+const deployDeletions: DeployFunction = async (suiteAppClient, changes) => {
+  const orderedChangesGroups = groupChangesByDepth(changes).reverse()
+  const deployResults = await promises.array.series(
+    orderedChangesGroups.map(([depth, group]) => async () => {
+      log.debug(`Deleting ${group.length} files with depth of ${depth}`)
+      return deployChanges(suiteAppClient, group, 'delete')
+    }),
+  )
+
+  return {
+    appliedChanges: deployResults.flatMap(res => res.appliedChanges),
+    errors: deployResults.flatMap(res => res.errors),
+    elemIdToInternalId: {},
+  }
+}
+
+const deployUpdates: DeployFunction = (suiteAppClient, changes) => deployChanges(suiteAppClient, changes, 'update')
+
+const typeToDeployFunction: Record<DeployType, DeployFunction> = {
+  add: deployAdditions,
+  delete: deployDeletions,
+  update: deployUpdates,
+}
+
+export const deployFileCabinetInstances = async (
+  suiteAppClient: SuiteAppClient,
+  changes: ReadonlyArray<Change<InstanceElement>>,
+  groupId: FileCabinetDeployGroup,
+): Promise<FileCabinetDeployResult> =>
+  typeToDeployFunction[FILE_CABINET_DEPLOY_GROUPS[groupId]](
+    suiteAppClient,
+    changes as ReadonlyArray<Change<FileCabinetInstance>>,
+  )

--- a/packages/netsuite-adapter/src/group_changes.ts
+++ b/packages/netsuite-adapter/src/group_changes.ts
@@ -66,11 +66,16 @@ export const isSuiteAppDeleteRecordsGroupId = (groupId: string): boolean =>
 export const isSuiteAppUpdateConfigGroupId = (groupId: string): boolean =>
   groupId.startsWith(SUITEAPP_UPDATING_CONFIG_GROUP_ID)
 
-export const SUITEAPP_FILE_CABINET_GROUPS = [
+const SUITEAPP_FILE_CABINET_GROUPS = [
   SUITEAPP_CREATING_FILES_GROUP_ID,
   SUITEAPP_UPDATING_FILES_GROUP_ID,
   SUITEAPP_DELETING_FILES_GROUP_ID,
-]
+] as const
+
+export type FileCabinetDeployGroup = (typeof SUITEAPP_FILE_CABINET_GROUPS)[number]
+
+export const isFileCabinetDeployGroup = (groupId: string): groupId is FileCabinetDeployGroup =>
+  SUITEAPP_FILE_CABINET_GROUPS.includes(groupId as FileCabinetDeployGroup)
 
 const getSdfWithSuiteAppGroupName = (change: Change): string => {
   const element = getChangeData(change)

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -1431,8 +1431,6 @@ describe('Adapter', () => {
     })
 
     describe('getChangedObjects', () => {
-      let suiteAppClient: SuiteAppClient
-
       beforeEach(() => {
         getElementMock.mockResolvedValue(
           new InstanceElement(

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -69,9 +69,7 @@ import * as deletionCalculator from '../src/deletion_calculator'
 import SdfClient from '../src/client/sdf_client'
 import SuiteAppClient from '../src/client/suiteapp_client/suiteapp_client'
 import { SERVER_TIME_TYPE_NAME } from '../src/server_time'
-import * as suiteAppFileCabinet from '../src/client/suiteapp_client/suiteapp_file_cabinet'
 import { SDF_CREATE_OR_UPDATE_GROUP_ID } from '../src/group_changes'
-import { SuiteAppFileCabinetOperations } from '../src/client/suiteapp_client/suiteapp_file_cabinet'
 import getChangeValidator from '../src/change_validator'
 import { getStandardTypesNames } from '../src/autogen/types'
 import { createCustomRecordTypes } from '../src/custom_records/custom_record_type'
@@ -103,6 +101,12 @@ jest.mock('../src/config/suggestions', () => ({
 jest.mock('../src/data_elements/data_elements', () => ({
   ...jest.requireActual<{}>('../src/data_elements/data_elements'),
   getDataElements: jest.fn(() => ({ elements: [], largeTypesError: [] })),
+}))
+
+const suiteAppImportFileCabinetMock = jest.fn()
+jest.mock('../src/client/suiteapp_client/suiteapp_file_cabinet', () => ({
+  ...jest.requireActual<{}>('../src/client/suiteapp_client/suiteapp_file_cabinet'),
+  importFileCabinet: jest.fn((...args) => suiteAppImportFileCabinetMock(...args)),
 }))
 
 jest.mock('../src/change_validator')
@@ -159,12 +163,6 @@ describe('Adapter', () => {
     },
     withPartialDeletion: true,
   }
-
-  const suiteAppImportFileCabinetMock = jest.fn()
-
-  jest.spyOn(suiteAppFileCabinet, 'createSuiteAppFileCabinetOperations').mockReturnValue({
-    importFileCabinet: suiteAppImportFileCabinetMock,
-  } as unknown as SuiteAppFileCabinetOperations)
 
   const netsuiteAdapter = new NetsuiteAdapter({
     client: new NetsuiteClient(client),
@@ -1340,6 +1338,7 @@ describe('Adapter', () => {
 
   describe('SuiteAppClient', () => {
     let adapter: NetsuiteAdapter
+    let suiteAppClient: SuiteAppClient
 
     const dummyElement = new ObjectType({ elemID: new ElemID('dum', 'test') })
     const elementsSource = buildElementsSourceFromElements([dummyElement])
@@ -1383,7 +1382,7 @@ describe('Adapter', () => {
         largeTypesError: [],
       })
 
-      const suiteAppClient = {
+      suiteAppClient = {
         getSystemInformation: getSystemInformationMock,
         getNetsuiteWsdl: () => undefined,
         getConfigRecords: () => [],
@@ -1404,7 +1403,13 @@ describe('Adapter', () => {
 
     it('should use suiteAppFileCabinet importFileCabinet and pass it the right params', async () => {
       await adapter.fetch(mockFetchOpts)
-      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(expect.anything(), 3, ['.*\\.(csv|pdf|png)'], false)
+      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(
+        suiteAppClient,
+        expect.anything(),
+        3,
+        ['.*\\.(csv|pdf|png)'],
+        false,
+      )
     })
 
     it('should not create serverTime elements when getSystemInformation returns undefined', async () => {


### PR DESCRIPTION
delete `SuiteAppFileCabinetOperations` and export `importFileCabinet` & `deployFileCabinetInstances` directly.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
