### PR TITLE
Add additionalSuiteQLTables NS adapter config

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -66,6 +66,7 @@ import { Filter } from './filter'
 import { NetsuiteChangeValidator } from './change_validators/types'
 import { FetchByQueryFunc } from './config/query'
 import { getUpdatedSuiteQLNameToInternalIdsMap } from './account_specific_values_resolver'
+import { getTypesToInternalId } from './data_elements/types'
 
 const { createChangeValidator } = deployment.changeValidators
 
@@ -185,7 +186,17 @@ const getChangeValidator: ({
       ? { ...netsuiteChangeValidators, ...onlySuiteAppValidators }
       : { ...netsuiteChangeValidators, ...nonSuiteAppValidators }
 
-    const suiteQLNameToInternalIdsMap = await getUpdatedSuiteQLNameToInternalIdsMap(client, elementsSource, changes)
+    const { internalIdToTypes, typeToInternalId } = getTypesToInternalId(
+      config.suiteAppClient?.additionalSuiteQLTables ?? [],
+    )
+
+    const suiteQLNameToInternalIdsMap = await getUpdatedSuiteQLNameToInternalIdsMap(
+      client,
+      config,
+      elementsSource,
+      changes,
+      internalIdToTypes,
+    )
 
     // Converts NetsuiteChangeValidator to ChangeValidator
     const validators: Record<string, ChangeValidator> = _.mapValues(
@@ -197,6 +208,8 @@ const getChangeValidator: ({
           config,
           client,
           suiteQLNameToInternalIdsMap,
+          internalIdToTypes,
+          typeToInternalId,
         }),
     )
     const safeDeploy = warnStaleData

--- a/packages/netsuite-adapter/src/change_validators/types.ts
+++ b/packages/netsuite-adapter/src/change_validators/types.ts
@@ -17,5 +17,7 @@ export type NetsuiteChangeValidator = (
     config: NetsuiteConfig
     client: NetsuiteClient
     suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
+    internalIdToTypes: Record<string, string[]>
+    typeToInternalId: Record<string, string>
   },
 ) => Promise<ReadonlyArray<ChangeError>>

--- a/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
+++ b/packages/netsuite-adapter/src/change_validators/workflow_account_specific_values.ts
@@ -123,7 +123,10 @@ const getChangeErrorsOnAccountSpecificValues = (
     .concat(returnGenericAccountSpecificValuesWarning ? toAccountSpecificValuesWarning(instance) : [])
 }
 
-const changeValidator: NetsuiteChangeValidator = async (changes, { suiteQLNameToInternalIdsMap }) => {
+const changeValidator: NetsuiteChangeValidator = async (
+  changes,
+  { suiteQLNameToInternalIdsMap, internalIdToTypes },
+) => {
   const workflowChanges = changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
@@ -145,6 +148,7 @@ const changeValidator: NetsuiteChangeValidator = async (changes, { suiteQLNameTo
     const { resolvedAccountSpecificValues, resolveWarnings } = getResolvedAccountSpecificValues(
       instance,
       suiteQLNameToInternalIdsMap,
+      internalIdToTypes,
     )
     resolvedAccountSpecificValues.forEach(({ path, value }) => setPath(instance, path, value))
     return resolveWarnings

--- a/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/soap_client/soap_client.ts
@@ -67,7 +67,7 @@ import {
 } from './schemas'
 import { InvalidSuiteAppCredentialsError } from '../../types'
 import { isCustomRecordType } from '../../../types'
-import { isItemType, ITEM_TYPE_TO_SEARCH_STRING, TYPES_TO_INTERNAL_ID } from '../../../data_elements/types'
+import { getTypesToInternalId, isItemType, ITEM_TYPE_TO_SEARCH_STRING } from '../../../data_elements/types'
 import { XSI_TYPE } from '../../constants'
 import { InstanceLimiterFunc, SuiteAppClientConfig } from '../../../config/types'
 import { toError } from '../../utils'
@@ -724,10 +724,12 @@ export default class SoapClient {
   }
 
   public async deleteSdfInstances(instances: InstanceElement[]): Promise<SoapDeployResult[]> {
+    // getting the hardcoded sdf types in SOAP format
+    const { typeToInternalId } = getTypesToInternalId([])
     const body = {
       baseRef: await awu(instances)
         .map(async instance => {
-          const instanceTypeFromMap = Object.keys(TYPES_TO_INTERNAL_ID).find(
+          const instanceTypeFromMap = Object.keys(typeToInternalId).find(
             key => key.toLowerCase() === instance.elemID.typeName.toLowerCase(),
           )
           return this.convertToDeletionRecord({

--- a/packages/netsuite-adapter/src/config/query.ts
+++ b/packages/netsuite-adapter/src/config/query.ts
@@ -9,11 +9,11 @@ import _ from 'lodash'
 import { regex, strings } from '@salto-io/lowerdash'
 import { ChangeDataType, ElemID, ProgressReporter, SaltoError } from '@salto-io/adapter-api'
 import { FailedFiles, FailedTypes } from '../client/types'
-import { TYPES_TO_INTERNAL_ID } from '../data_elements/types'
 import { CUSTOM_RECORD_TYPE, CUSTOM_SEGMENT } from '../constants'
 import { addCustomRecordTypePrefix } from '../types'
 import { CriteriaQuery, FetchTypeQueryParams, IdsQuery, NetsuiteQueryParameters, ObjectID, QueryParams } from './types'
 import { ALL_TYPES_REGEX } from './constants'
+import { getTypesToInternalId } from '../data_elements/types'
 
 export type TypesQuery = {
   isTypeMatch: (typeName: string) => boolean
@@ -111,14 +111,13 @@ export const buildNetsuiteQuery = ({
   fileCabinet = [],
   customRecords = [],
 }: Partial<QueryParams>): NetsuiteQuery => {
+  const { typeToInternalId } = getTypesToInternalId([])
   // This is to support the adapter configuration before the migration of
   // the SuiteApp type names from PascalCase to camelCase
   const fixedTypes = types.map(type => ({
     ...type,
     name:
-      strings.lowerCaseFirstLetter(type.name) in TYPES_TO_INTERNAL_ID
-        ? strings.lowerCaseFirstLetter(type.name)
-        : type.name,
+      strings.lowerCaseFirstLetter(type.name) in typeToInternalId ? strings.lowerCaseFirstLetter(type.name) : type.name,
   }))
 
   const { isTypeMatch, areAllObjectsMatch, isObjectMatch } = buildTypesQuery(fixedTypes)

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -194,16 +194,29 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
   maxFileCabinetSizeInGB: 'maxFileCabinetSizeInGB',
 }
 
+export type SuiteQLTableQueryParams = {
+  internalIdField: string
+  nameField: string
+}
+
+export type AdditionalSuiteQLTable = {
+  name: string
+  typeId: string
+  queryParams?: SuiteQLTableQueryParams
+}
+
 export type SuiteAppClientConfig = {
   suiteAppConcurrencyLimit?: number
   httpTimeoutLimitInMinutes?: number
   wsdlVersion?: WSDLVersion
+  additionalSuiteQLTables?: AdditionalSuiteQLTable[]
 }
 
 export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
   suiteAppConcurrencyLimit: 'suiteAppConcurrencyLimit',
   httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
   wsdlVersion: 'wsdlVersion',
+  additionalSuiteQLTables: 'additionalSuiteQLTables',
 }
 
 export type NetsuiteConfig = {
@@ -364,6 +377,43 @@ const clientConfigType = createMatchingObjectType<ClientConfig>({
   },
 })
 
+const suiteQLTableQueryParamsType = createMatchingObjectType<SuiteQLTableQueryParams>({
+  elemID: new ElemID(NETSUITE, 'suiteQLTableQueryParams'),
+  fields: {
+    internalIdField: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    nameField: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
+const additionalSuiteQLTableType = createMatchingObjectType<AdditionalSuiteQLTable>({
+  elemID: new ElemID(NETSUITE, 'additionalSuiteQLTable'),
+  fields: {
+    name: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    typeId: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    queryParams: {
+      refType: suiteQLTableQueryParamsType,
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>({
   elemID: new ElemID(NETSUITE, 'suiteAppClientConfig'),
   fields: {
@@ -393,6 +443,9 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
           values: SUPPORTED_WSDL_VERSIONS,
         }),
       },
+    },
+    additionalSuiteQLTables: {
+      refType: new ListType(additionalSuiteQLTableType),
     },
   },
   annotations: {

--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -414,10 +414,40 @@ const validateDeployParams = ({
   }
 }
 
+const validateAdditionalSuiteQLTables = (additionalSuiteQLTables: unknown): void => {
+  if (!Array.isArray(additionalSuiteQLTables)) {
+    throw new Error(
+      `Expected ${CONFIG.suiteAppClient}.${SUITEAPP_CLIENT_CONFIG.additionalSuiteQLTables} to be a list but found:\n${safeJsonStringify(additionalSuiteQLTables, undefined, 4)}.`,
+    )
+  }
+  const invalidAdditionalSuiteQLTables = additionalSuiteQLTables.filter(
+    params => !_.isPlainObject(params) || typeof params.name !== 'string' || typeof params.typeId !== 'string',
+  )
+  if (invalidAdditionalSuiteQLTables.length > 0) {
+    throw new Error(
+      `Expected each item in ${CONFIG.suiteAppClient}.${SUITEAPP_CLIENT_CONFIG.additionalSuiteQLTables} to be { name: string; typeId: string }, but found:\n${JSON.stringify(invalidAdditionalSuiteQLTables, null, 4)}}.`,
+    )
+  }
+  const invalidQueryParams = additionalSuiteQLTables
+    .filter(params => params.queryParams !== undefined)
+    .filter(
+      params =>
+        !_.isPlainObject(params.queryParams) ||
+        typeof params.queryParams.internalIdField !== 'string' ||
+        typeof params.queryParams.nameField !== 'string',
+    )
+  if (invalidQueryParams.length > 0) {
+    throw new Error(
+      `Expected each 'queryParams' in ${CONFIG.suiteAppClient}.${SUITEAPP_CLIENT_CONFIG.additionalSuiteQLTables} to be { internalIdField: string; nameField: string }, but found:\n${JSON.stringify(invalidQueryParams, null, 4)}}.`,
+    )
+  }
+}
+
 const validateSuiteAppClientParams = ({
   suiteAppConcurrencyLimit,
   httpTimeoutLimitInMinutes,
   wsdlVersion,
+  additionalSuiteQLTables,
 }: Record<keyof SuiteAppClientConfig, unknown>): void => {
   if (suiteAppConcurrencyLimit !== undefined) {
     validateNumber(suiteAppConcurrencyLimit, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.suiteAppConcurrencyLimit])
@@ -427,6 +457,9 @@ const validateSuiteAppClientParams = ({
   }
   if (wsdlVersion !== undefined) {
     validateEnumValue(wsdlVersion, SUPPORTED_WSDL_VERSIONS, [CONFIG.suiteAppClient, SUITEAPP_CLIENT_CONFIG.wsdlVersion])
+  }
+  if (additionalSuiteQLTables !== undefined) {
+    validateAdditionalSuiteQLTables(additionalSuiteQLTables)
   }
 }
 

--- a/packages/netsuite-adapter/src/data_elements/custom_fields.ts
+++ b/packages/netsuite-adapter/src/data_elements/custom_fields.ts
@@ -9,7 +9,6 @@
 import { BuiltinTypes, Field, InstanceElement } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { SOAP_FIELDS_TYPES } from '../client/suiteapp_client/soap_client/types'
-import { INTERNAL_ID_TO_TYPES } from './types'
 import { EMPLOYEE, OTHER_CUSTOM_FIELD } from '../constants'
 
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})?$/
@@ -44,15 +43,18 @@ const CUSTOM_FIELD_TO_TYPE: Record<string, Record<string, string[]>> = {
  * @param instance an instance of a field type (e.g., entitycustomfield, crmcustomfield, etc...)
  * @returns All the names of types a certain field instance applies to
  */
-export const getFieldInstanceTypes = (instance: InstanceElement): string[] => {
+export const getFieldInstanceTypes = (
+  instance: InstanceElement,
+  internalIdToTypes: Record<string, string[]>,
+): string[] => {
   if (instance.elemID.typeName in CUSTOM_FIELD_TO_TYPE) {
     return Object.entries(CUSTOM_FIELD_TO_TYPE[instance.elemID.typeName])
       .filter(([fieldName]) => instance.value[fieldName])
       .flatMap(([_fieldName, typeNames]) => typeNames)
   }
 
-  if (instance.elemID.typeName === OTHER_CUSTOM_FIELD && instance.value.rectype in INTERNAL_ID_TO_TYPES) {
-    return INTERNAL_ID_TO_TYPES[instance.value.rectype]
+  if (instance.elemID.typeName === OTHER_CUSTOM_FIELD && instance.value.rectype in internalIdToTypes) {
+    return internalIdToTypes[instance.value.rectype]
   }
   return []
 }

--- a/packages/netsuite-adapter/src/data_elements/types.ts
+++ b/packages/netsuite-adapter/src/data_elements/types.ts
@@ -7,6 +7,7 @@
  */
 import { ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
+import { AdditionalSuiteQLTable } from '../config/types'
 
 const ITEM_TYPES = [
   'assemblyItem',
@@ -256,19 +257,24 @@ const SCRIPT_TYPES = [
   'sdfinstallationscript',
 ]
 
-export const TYPES_TO_INTERNAL_ID: Record<string, string> = {
-  ...ALL_TABLE_TO_INTERNAL_ID,
-  ...Object.fromEntries(TRANSACTION_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.transaction])),
-  ...Object.fromEntries(FIELD_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.customfield])),
-  ...Object.fromEntries(SCRIPT_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.script])),
-  ...Object.fromEntries(ITEM_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.item])),
+export const getTypesToInternalId = (
+  additionalSuiteQLTables: AdditionalSuiteQLTable[],
+): { internalIdToTypes: Record<string, string[]>; typeToInternalId: Record<string, string> } => {
+  const typeToInternalId = {
+    ...ALL_TABLE_TO_INTERNAL_ID,
+    ...Object.fromEntries(TRANSACTION_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.transaction])),
+    ...Object.fromEntries(FIELD_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.customfield])),
+    ...Object.fromEntries(SCRIPT_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.script])),
+    ...Object.fromEntries(ITEM_TYPES.map(type => [type, TABLE_TO_INTERNAL_ID.item])),
+    ...Object.fromEntries(additionalSuiteQLTables.map(table => [table.name, table.typeId])),
+  }
+  const internalIdToTypes = _(typeToInternalId)
+    .entries()
+    .groupBy(([_type, internalId]) => internalId)
+    .mapValues(values => values.map(([type]) => type))
+    .value()
+  return { internalIdToTypes, typeToInternalId }
 }
-
-export const INTERNAL_ID_TO_TYPES: Record<string, string[]> = _(TYPES_TO_INTERNAL_ID)
-  .entries()
-  .groupBy(([_type, internalId]) => internalId)
-  .mapValues(values => values.map(([type]) => type))
-  .value()
 
 export const ITEM_TYPE_TO_SEARCH_STRING: Record<ItemType, string> = {
   assemblyItem: '_assembly',

--- a/packages/netsuite-adapter/src/filter.ts
+++ b/packages/netsuite-adapter/src/filter.ts
@@ -20,6 +20,8 @@ export type LocalFilterOpts = {
   elementsSource: ReadOnlyElementsSource
   isPartial: boolean
   config: NetsuiteConfig
+  internalIdToTypes: Record<string, string[]>
+  typeToInternalId: Record<string, string>
   timeZoneAndFormat?: TimeZoneAndFormat
   changesGroupId?: string
   fetchTime?: Date

--- a/packages/netsuite-adapter/src/filters/custom_record_types.ts
+++ b/packages/netsuite-adapter/src/filters/custom_record_types.ts
@@ -32,6 +32,7 @@ const addFieldsToType = (
   type: ObjectType,
   nameToType: Record<string, ObjectType>,
   customRecordTypes: Record<string, ObjectType>,
+  internalIdToTypes: Record<string, string[]>,
 ): void => {
   makeArray(type.annotations[CUSTOM_FIELDS]?.[CUSTOM_FIELDS_LIST]).forEach((customField, index) => {
     const field = getCustomField({
@@ -39,6 +40,7 @@ const addFieldsToType = (
       customField,
       nameToType,
       customRecordTypes,
+      internalIdToTypes,
     })
     field.annotations = { ...customField, [INDEX]: index }
     type.fields[field.name] = field
@@ -94,7 +96,13 @@ const getElementsSourceTypes = async (
         .toArray()
     : []
 
-const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, elementsSource, isPartial, config }) => ({
+const filterCreator: LocalFilterCreator = ({
+  elementsSourceIndex,
+  elementsSource,
+  isPartial,
+  config,
+  internalIdToTypes,
+}) => ({
   name: 'customRecordTypesType',
   onFetch: async elements => {
     const types = elements.filter(isObjectType)
@@ -119,7 +127,7 @@ const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, elementsSource
     )
 
     customRecordTypes.forEach(type => {
-      addFieldsToType(type, nameToType, customRecordTypesMap)
+      addFieldsToType(type, nameToType, customRecordTypesMap, internalIdToTypes)
       removeCustomFieldsAnnotation(type)
       if (fetchQuery.isCustomRecordTypeMatch(type.elemID.name)) {
         removeInstancesAnnotation(type)

--- a/packages/netsuite-adapter/src/filters/data_instances_references.ts
+++ b/packages/netsuite-adapter/src/filters/data_instances_references.ts
@@ -89,7 +89,7 @@ const replaceReference =
 const getReferenceInternalId = (reference: ReferenceExpression): Value =>
   (isElement(reference.value) ? getElementValueOrAnnotations(reference.value) : reference.value ?? {}).internalId
 
-const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, isPartial }) => ({
+const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, isPartial, typeToInternalId }) => ({
   name: 'dataInstancesReferences',
   onFetch: async elements => {
     const elementsMap: Record<string, ElemID> = isPartial
@@ -97,7 +97,7 @@ const filterCreator: LocalFilterCreator = ({ elementsSourceIndex, isPartial }) =
       : {}
 
     await awu(elements).forEach(async element => {
-      await assignToInternalIdsIndex(element, elementsMap)
+      await assignToInternalIdsIndex(element, elementsMap, typeToInternalId)
     })
 
     await awu(elements)

--- a/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
+++ b/packages/netsuite-adapter/src/filters/remove_unsupported_types.ts
@@ -11,16 +11,16 @@ import { isObjectType } from '@salto-io/adapter-api'
 import { NETSUITE } from '../constants'
 import { LocalFilterCreator } from '../filter'
 import { getMetadataTypes, isCustomRecordType, isDataObjectType, metadataTypesToList } from '../types'
-import { SUPPORTED_TYPES, TYPES_TO_INTERNAL_ID } from '../data_elements/types'
+import { SUPPORTED_TYPES } from '../data_elements/types'
 
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: LocalFilterCreator = ({ typeToInternalId }) => ({
   name: 'removeUnsupportedTypes',
   onFetch: async elements => {
     const sdfTypeNames = new Set(metadataTypesToList(getMetadataTypes()).map(e => e.elemID.getFullName().toLowerCase()))
     const dataTypes = elements.filter(isObjectType).filter(isDataObjectType)
     const supportedFetchedInstancesTypeNames = SUPPORTED_TYPES
     // types we fetch without their instances
-    const additionalFetchedTypes = Object.keys(TYPES_TO_INTERNAL_ID)
+    const additionalFetchedTypes = Object.keys(typeToInternalId)
     const customRecordTypeNames = dataTypes.filter(isCustomRecordType).map(({ elemID }) => elemID.name)
 
     const supportedTypeNames = _.uniq(

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -11,22 +11,34 @@ import { allFilters } from './adapter'
 import { createElementsSourceIndex } from './elements_source_index/elements_source_index'
 import { parseSdfProjectDir } from './client/sdf_parser'
 import { createElements } from './transformer'
+import { getTypesToInternalId } from './data_elements/types'
 import { netsuiteConfigFromConfig } from './config/config_creator'
 import { TYPES_TO_SKIP } from './types'
 
 const localFilters = allFilters.filter(filter.isLocalFilterCreator).map(({ creator }) => creator)
 
 const loadElementsFromFolder = async (
-  { baseDir, elementsSource, config, getElemIdFunc }: LoadElementsFromFolderArgs,
+  { baseDir, elementsSource, config: configInstance, getElemIdFunc }: LoadElementsFromFolderArgs,
   filters = localFilters,
 ): Promise<FetchResult> => {
   const isPartial = true
+  const config = netsuiteConfigFromConfig(configInstance)
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId(
+    config.suiteAppClient?.additionalSuiteQLTables ?? [],
+  )
   const filtersRunner = filter.filtersRunner(
     {
-      elementsSourceIndex: createElementsSourceIndex(elementsSource, isPartial),
+      elementsSourceIndex: createElementsSourceIndex({
+        elementsSource,
+        isPartial,
+        typeToInternalId,
+        internalIdToTypes,
+      }),
       elementsSource,
       isPartial,
-      config: netsuiteConfigFromConfig(config),
+      config,
+      typeToInternalId,
+      internalIdToTypes,
     },
     filters,
   )

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -79,6 +79,7 @@ import * as elementsSourceIndexModule from '../src/elements_source_index/element
 import { fullQueryParams, fullFetchConfig } from '../src/config/config_creator'
 import { FetchByQueryFunc } from '../src/config/query'
 import { createObjectIdListElements, OBJECT_ID_LIST_TYPE_NAME, OBJECT_ID_LIST_FIELD_NAME } from '../src/scriptid_list'
+import { getTypesToInternalId } from '../src/data_elements/types'
 
 const DEFAULT_SDF_DEPLOY_PARAMS = {
   manifestDependencies: {
@@ -1607,7 +1608,14 @@ describe('Adapter', () => {
         const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
         expect(getDeletedElementsMock).toHaveBeenCalled()
         expect(partialFetchData?.deletedElements).toEqual([elemId])
-        expect(spy).toHaveBeenCalledWith(expect.anything(), true, [elemId])
+        const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
+        expect(spy).toHaveBeenCalledWith({
+          elementsSource: expect.anything(),
+          isPartial: true,
+          typeToInternalId,
+          internalIdToTypes,
+          deletedElements: [elemId],
+        })
       })
     })
 
@@ -1624,7 +1632,14 @@ describe('Adapter', () => {
         const { partialFetchData } = await adapter.fetch({ ...mockFetchOpts })
         expect(getDeletedElementsMock).not.toHaveBeenCalled()
         expect(partialFetchData?.deletedElements).toEqual(undefined)
-        expect(spy).toHaveBeenCalledWith(expect.anything(), false, [])
+        const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
+        expect(spy).toHaveBeenCalledWith({
+          elementsSource: expect.anything(),
+          isPartial: false,
+          typeToInternalId,
+          internalIdToTypes,
+          deletedElements: [],
+        })
       })
     })
   })

--- a/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/workflow_account_specific_values.test.ts
@@ -13,11 +13,13 @@ import { EMPLOYEE, SCRIPT_ID } from '../../src/constants'
 import { fullFetchConfig } from '../../src/config/config_creator'
 import NetsuiteClient from '../../src/client/client'
 import mockSdfClient from '../client/sdf_client'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 describe('workflow account specific values', () => {
   let instance: InstanceElement
   let suiteQLNameToInternalIdsMap: Record<string, Record<string, string[]>>
 
+  const { internalIdToTypes, typeToInternalId } = getTypesToInternalId([])
   const baseParams = {
     deployReferencedElements: false,
     elementsSource: buildElementsSourceFromElements([]),
@@ -26,6 +28,8 @@ describe('workflow account specific values', () => {
     },
     client: new NetsuiteClient(mockSdfClient()),
     suiteQLNameToInternalIdsMap: {},
+    internalIdToTypes,
+    typeToInternalId,
   }
 
   beforeEach(() => {

--- a/packages/netsuite-adapter/test/data_elements/custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/data_elements/custom_fields.test.ts
@@ -16,7 +16,7 @@ describe('getFieldInstanceTypes', () => {
   it('Should return matching types for other custom field', () => {
     const otherCustomFieldInstance = new InstanceElement('test', othercustomfieldType().type, { rectype: '-112' })
 
-    const relevantTypes = getFieldInstanceTypes(otherCustomFieldInstance)
+    const relevantTypes = getFieldInstanceTypes(otherCustomFieldInstance, { '-112': ['account'] })
     expect(relevantTypes).toEqual(['account'])
   })
 
@@ -29,7 +29,7 @@ describe('getFieldInstanceTypes', () => {
       appliestovendor: false,
       appliestopricelist: false,
     })
-    const relevantTypes = getFieldInstanceTypes(entityCustomFieldInstance)
+    const relevantTypes = getFieldInstanceTypes(entityCustomFieldInstance, {})
     expect(relevantTypes).toEqual(['contact', 'customer', 'partner'])
   })
 
@@ -42,7 +42,7 @@ describe('getFieldInstanceTypes', () => {
       appliestononinventory: true,
       appliestoothercharge: true,
     })
-    const relevantTypes = getFieldInstanceTypes(itemCustomFieldInstance)
+    const relevantTypes = getFieldInstanceTypes(itemCustomFieldInstance, {})
     expect(relevantTypes).toEqual([
       'inventoryItem',
       'assemblyItem',
@@ -63,7 +63,7 @@ describe('getFieldInstanceTypes', () => {
       appliestosolution: true,
       appliestotask: false,
     })
-    const relevantTypes = getFieldInstanceTypes(crmCustomFieldInstance)
+    const relevantTypes = getFieldInstanceTypes(crmCustomFieldInstance, {})
     expect(relevantTypes).toEqual(['campaign', 'projectTask', 'phoneCall', 'solution'])
   })
 })

--- a/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
+++ b/packages/netsuite-adapter/test/filters/author_information/system_note.test.ts
@@ -21,6 +21,7 @@ import { EMPLOYEE_NAME_QUERY } from '../../../src/filters/author_information/con
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../../utils'
 import { toSuiteQLSelectDateString, toSuiteQLWhereDateString } from '../../../src/changes_detector/date_formats'
 import { INTERNAL_IDS_MAP, SUITEQL_TABLE } from '../../../src/data_elements/suiteql_table_elements'
+import { getTypesToInternalId } from '../../../src/data_elements/types'
 
 describe('netsuite system note author information', () => {
   let filterOpts: RemoteFilterOpts
@@ -43,6 +44,7 @@ describe('netsuite system note author information', () => {
 
   const client = new NetsuiteClient(SDFClient, suiteAppClient)
   const [serverTimeType, serverTimeInstance] = createServerTimeElements(new Date('2022-01-01'))
+  const { internalIdToTypes, typeToInternalId } = getTypesToInternalId([])
 
   beforeEach(async () => {
     runSuiteQLMock.mockReset()
@@ -99,6 +101,8 @@ describe('netsuite system note author information', () => {
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
       config: await getDefaultAdapterConfig(),
+      internalIdToTypes,
+      typeToInternalId,
     }
   })
 
@@ -240,6 +244,8 @@ describe('netsuite system note author information', () => {
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
       config: await getDefaultAdapterConfig(),
+      internalIdToTypes,
+      typeToInternalId,
     }
     await filterCreator(opts).onFetch?.(elements)
     expect(missingInstance.annotations[CORE_ANNOTATIONS.CHANGED_BY] === 'another user name').toBeTruthy()
@@ -264,6 +270,8 @@ describe('netsuite system note author information', () => {
       elementsSource: buildElementsSourceFromElements([serverTimeType, serverTimeInstance]),
       isPartial: false,
       config: await getDefaultAdapterConfig(),
+      internalIdToTypes,
+      typeToInternalId,
     }
     await filterCreator(opts).onFetch?.(elements)
     expect(missingInstance.annotations[CORE_ANNOTATIONS.CHANGED_AT]).toEqual('8/19/2022')
@@ -331,6 +339,8 @@ describe('netsuite system note author information', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        internalIdToTypes,
+        typeToInternalId,
       }
     })
     it('should not change any elements in fetch', async () => {
@@ -355,6 +365,8 @@ describe('netsuite system note author information', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        internalIdToTypes,
+        typeToInternalId,
       }
     })
     it('should not change any elements in fetch', async () => {
@@ -387,6 +399,8 @@ describe('netsuite system note author information', () => {
             },
           },
         },
+        internalIdToTypes,
+        typeToInternalId,
       }
     })
     it('should not change any elements in fetch', async () => {

--- a/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
@@ -28,8 +28,9 @@ describe('custom record types filter', () => {
   let customRecordFieldRefType: ObjectType
   let lockedCustomRecordFieldRefType: ObjectType
   let dataType: ObjectType
+  let anotherDataType: ObjectType
 
-  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([{ name: 'data_type', typeId: '1234' }])
   const filterOpts = {
     config: { fetch: { include: { types: [{ name: '.*' }], fileCabinet: ['.*'] }, exclude: emptyQueryParams() } },
     isPartial: false,
@@ -73,6 +74,11 @@ describe('custom record types filter', () => {
               fieldtype: 'SELECT',
               selectrecordtype: '-112',
             },
+            {
+              scriptid: 'custrecord_data_type',
+              fieldtype: 'SELECT',
+              selectrecordtype: '1234',
+            },
           ],
         },
         instances: [1, 2, 3],
@@ -97,6 +103,9 @@ describe('custom record types filter', () => {
     dataType = new ObjectType({
       elemID: new ElemID(NETSUITE, 'account'),
     })
+    anotherDataType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'data_type'),
+    })
   })
   it('should add fields to type', async () => {
     await filterCreator(filterOpts).onFetch?.([
@@ -104,12 +113,14 @@ describe('custom record types filter', () => {
       customRecordFieldRefType,
       lockedCustomRecordFieldRefType,
       dataType,
+      anotherDataType,
     ])
     expect(Object.keys(customRecordType.fields)).toEqual([
       'custom_custrecord_newfield',
       'custom_custrecord_ref',
       'custom_custrecord_ref_locked',
       'custom_custrecord_account',
+      'custom_custrecord_data_type',
     ])
     expect(customRecordType.fields.custom_custrecord_newfield.refType.elemID.name).toEqual(
       BuiltinTypes.STRING.elemID.name,
@@ -141,6 +152,13 @@ describe('custom record types filter', () => {
       fieldtype: 'SELECT',
       selectrecordtype: '-112',
       index: 3,
+    })
+    expect(customRecordType.fields.custom_custrecord_data_type.refType.elemID.name).toEqual('data_type')
+    expect(customRecordType.fields.custom_custrecord_data_type.annotations).toEqual({
+      scriptid: 'custrecord_data_type',
+      fieldtype: 'SELECT',
+      selectrecordtype: '1234',
+      index: 4,
     })
   })
   it('should add fields correctly on partial fetch', async () => {

--- a/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/custom_record_types.test.ts
@@ -19,6 +19,7 @@ import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE, SCRIPT_ID } from '../../sr
 import filterCreator from '../../src/filters/custom_record_types'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { emptyQueryParams } from '../../src/config/config_creator'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 const { awu } = collections.asynciterable
 
@@ -28,6 +29,7 @@ describe('custom record types filter', () => {
   let lockedCustomRecordFieldRefType: ObjectType
   let dataType: ObjectType
 
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
   const filterOpts = {
     config: { fetch: { include: { types: [{ name: '.*' }], fileCabinet: ['.*'] }, exclude: emptyQueryParams() } },
     isPartial: false,
@@ -41,6 +43,8 @@ describe('custom record types filter', () => {
         throw new Error('should not call elementsSource.list')
       },
     },
+    typeToInternalId,
+    internalIdToTypes,
   } as unknown as LocalFilterOpts
 
   beforeEach(() => {

--- a/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
@@ -28,6 +28,7 @@ import filterCreator, {
   UNKNOWN_TYPE_REFERENCES_ELEM_ID,
   UNKNOWN_TYPE_REFERENCES_TYPE_NAME,
 } from '../../src/filters/data_account_specific_values'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 const runSuiteQLMock = jest.fn()
 const runSavedSearchQueryMock = jest.fn()
@@ -79,6 +80,7 @@ describe('data account specific values filter', () => {
         789: 'Value 789',
       },
     })
+    const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
     filterOpts = {
       client,
       elementsSourceIndex: {} as LazyElementsSourceIndexes,
@@ -93,6 +95,8 @@ describe('data account specific values filter', () => {
           resolveAccountSpecificValues: true,
         },
       },
+      typeToInternalId,
+      internalIdToTypes,
     }
   })
 

--- a/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_account_specific_values.test.ts
@@ -45,6 +45,7 @@ describe('data account specific values filter', () => {
   let recordRefType: ObjectType
   let suiteQLTableType: ObjectType
   let suiteQLTableInstance: InstanceElement
+  let anotherSuiteQLTableInstance: InstanceElement
   let taxScheduleSuiteQLTableInstance: InstanceElement
   let unknownTypeReferencesType: ObjectType
   let existingUnknownTypeReferencesInstance: InstanceElement
@@ -69,6 +70,11 @@ describe('data account specific values filter', () => {
         1: { name: 'Account 1' },
       },
     })
+    anotherSuiteQLTableInstance = new InstanceElement('data_type', suiteQLTableType, {
+      [INTERNAL_IDS_MAP]: {
+        2: { name: 'Some Name' },
+      },
+    })
     taxScheduleSuiteQLTableInstance = new InstanceElement('taxSchedule', suiteQLTableType, {
       [INTERNAL_IDS_MAP]: {
         1: { name: 'Tax Schedule 1' },
@@ -80,7 +86,7 @@ describe('data account specific values filter', () => {
         789: 'Value 789',
       },
     })
-    const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
+    const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([{ name: 'data_type', typeId: '1234' }])
     filterOpts = {
       client,
       elementsSourceIndex: {} as LazyElementsSourceIndexes,
@@ -119,6 +125,11 @@ describe('data account specific values filter', () => {
           internalId: '2',
           typeId: '-112',
         },
+        anotherCustomField: {
+          name: 'Some Name',
+          internalId: '2',
+          typeId: '1234',
+        },
         someField: {
           inner: {
             name: 'Value 123',
@@ -135,7 +146,14 @@ describe('data account specific values filter', () => {
           internalId: '1',
         },
       })
-      elements = [dataType, dataInstance, suiteQLTableType, suiteQLTableInstance, taxScheduleSuiteQLTableInstance]
+      elements = [
+        dataType,
+        dataInstance,
+        suiteQLTableType,
+        suiteQLTableInstance,
+        anotherSuiteQLTableInstance,
+        taxScheduleSuiteQLTableInstance,
+      ]
     })
 
     it('should transform references to ACCOUNT_SPECIFIC_VALUE', async () => {
@@ -150,6 +168,9 @@ describe('data account specific values filter', () => {
         },
         customField: {
           id: '[ACCOUNT_SPECIFIC_VALUE] (account) (Account 2)',
+        },
+        anotherCustomField: {
+          id: '[ACCOUNT_SPECIFIC_VALUE] (data_type) (Some Name)',
         },
         someField: {
           inner: {
@@ -274,6 +295,11 @@ describe('data account specific values filter', () => {
           name: 'Account 2',
           internalId: '2',
           typeId: '-112',
+        },
+        anotherCustomField: {
+          name: 'Some Name',
+          internalId: '2',
+          typeId: '1234',
         },
         someField: {
           inner: {

--- a/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_instances_references.test.ts
@@ -20,8 +20,10 @@ import filterCreator from '../../src/filters/data_instances_references'
 import NetsuiteClient from '../../src/client/client'
 import { NETSUITE } from '../../src/constants'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 describe('data_instances_references', () => {
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
   const firstType = new ObjectType({
     elemID: new ElemID(NETSUITE, 'firstType'),
     fields: {
@@ -54,6 +56,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(filterOpts).onFetch?.([instance, referencedInstance])
       expect((instance.value.field as ReferenceExpression).elemID.getFullName()).toBe(
@@ -73,6 +77,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(fetchOpts).onFetch?.([instance])
       expect(instance.value.field.internalId).toBe('1')
@@ -97,6 +103,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(fetchOpts).onFetch?.([instance])
       expect((instance.value.field as ReferenceExpression).elemID.getFullName()).toBe(
@@ -119,6 +127,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(fetchOpts).onFetch?.([instance, referencedInstance])
       expect((instance.value.recordRefList[0] as ReferenceExpression).elemID.getFullName()).toBe(
@@ -143,6 +153,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(fetchOpts).preDeploy?.([toChange({ before: instance, after: instance })])
       expect(instance.value).toEqual({
@@ -167,6 +179,8 @@ describe('data_instances_references', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: false,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(fetchOpts).preDeploy?.([
         toChange({ before: instance, after: instance }),

--- a/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
+++ b/packages/netsuite-adapter/test/filters/data_types_custom_fields.test.ts
@@ -12,6 +12,7 @@ import { NETSUITE } from '../../src/constants'
 import { entitycustomfieldType } from '../../src/autogen/types/standard_types/entitycustomfield'
 import { LocalFilterOpts } from '../../src/filter'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 describe('data_types_custom_fields', () => {
   let filterOpts: LocalFilterOpts
@@ -19,6 +20,7 @@ describe('data_types_custom_fields', () => {
   let instance: InstanceElement
 
   const Account = new ObjectType({ elemID: new ElemID(NETSUITE, 'account'), annotations: { source: 'soap' } })
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
 
   beforeEach(async () => {
     type = new ObjectType({ elemID: new ElemID(NETSUITE, 'customer'), fields: {}, annotations: { source: 'soap' } })
@@ -34,6 +36,8 @@ describe('data_types_custom_fields', () => {
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
       config: await getDefaultAdapterConfig(),
+      typeToInternalId,
+      internalIdToTypes,
     }
   })
   it('should add integer field', async () => {
@@ -91,6 +95,8 @@ describe('data_types_custom_fields', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(filterOpts).onFetch?.([type, Account])
       expect((await type.fields.custom_someid.getType()).elemID.getFullName()).toBe(
@@ -115,6 +121,8 @@ describe('data_types_custom_fields', () => {
         elementsSource: buildElementsSourceFromElements([]),
         isPartial: true,
         config: await getDefaultAdapterConfig(),
+        typeToInternalId,
+        internalIdToTypes,
       }
       await filterCreator(filterOpts).onFetch?.([type, fetchedInstance, Account])
       expect(type.fields.custom_someid).toBeUndefined()

--- a/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
+++ b/packages/netsuite-adapter/test/filters/remove_unsupported_types.test.ts
@@ -12,6 +12,7 @@ import { NETSUITE } from '../../src/constants'
 import { LocalFilterOpts } from '../../src/filter'
 import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
 import { createEmptyElementsSourceIndexes, getDefaultAdapterConfig } from '../utils'
+import { getTypesToInternalId } from '../../src/data_elements/types'
 
 describe('remove_unsupported_types', () => {
   let filterOpts: LocalFilterOpts
@@ -40,6 +41,7 @@ describe('remove_unsupported_types', () => {
       metadataType: 'customrecordtype',
     },
   })
+  const { typeToInternalId, internalIdToTypes } = getTypesToInternalId([])
 
   beforeEach(async () => {
     elements = [
@@ -57,6 +59,8 @@ describe('remove_unsupported_types', () => {
       elementsSource: buildElementsSourceFromElements([]),
       isPartial: false,
       config: await getDefaultAdapterConfig(),
+      typeToInternalId,
+      internalIdToTypes,
     }
   })
 

--- a/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
+++ b/packages/netsuite-adapter/test/sdf_folder_loader.test.ts
@@ -30,6 +30,7 @@ import { LocalFilterCreator } from '../src/filter'
 import { addApplicationIdToType, addBundleFieldToType } from '../src/transformer'
 import { createEmptyElementsSourceIndexes } from './utils'
 import { fullFetchConfig } from '../src/config/config_creator'
+import { getTypesToInternalId } from '../src/data_elements/types'
 
 const parseSdfProjectDirMock = jest.fn()
 jest.mock('../src/client/sdf_parser', () => ({
@@ -114,13 +115,20 @@ describe('sdf folder loader', () => {
       },
       [filterMock],
     )
-
-    expect(createElementsSourceIndexMock).toHaveBeenCalledWith(elementsSource, true)
+    const { internalIdToTypes, typeToInternalId } = getTypesToInternalId([])
+    expect(createElementsSourceIndexMock).toHaveBeenCalledWith({
+      elementsSource,
+      isPartial: true,
+      internalIdToTypes,
+      typeToInternalId,
+    })
     expect(filterMock).toHaveBeenCalledWith({
       elementsSourceIndex,
       elementsSource,
       isPartial: true,
       config: { fetch: fullFetchConfig() },
+      internalIdToTypes,
+      typeToInternalId,
     })
     expect(parseSdfProjectDirMock).toHaveBeenCalledWith('projectDir')
 


### PR DESCRIPTION
Add the ability to configure additional SuiteQL table queries, and map between a type and its `typeId`.
For example:
```
netsuite {
  suiteAppClient = {
      additionalSuiteQLTables = [
       // only typeId mapping, without SuiteQL table query
        {
          name = "emailtemplate"
          typeId = "-120"
        },
       // with SuiteQL table query
        {
          name = "othertype"
          typeId = "1111"
          queryParams = {
            internalIdField = "id"
            nameField = "name"
          }
        },
     ]
  }
  ...
}
```

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Add the ability to configure additional SuiteQL table queries, and map between a type and its `typeId` - using the `additionalSuiteQLTables` adapter config.

---
_User Notifications_: 
None