### PR TITLE
SALTO-6701: Do not omit objectPermissions of standard objects in the Profiles & PS Elements fixer

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
@@ -260,7 +260,10 @@ const instanceEntriesTargets = (instance: InstanceElement, metadataQuery?: Metad
     .value()
 
 const isStandardFieldPermissionsPath = (path: string): boolean =>
-  path.startsWith('fieldPermissions') && !ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(path)
+  path.startsWith(section.FIELD_PERMISSIONS) && !ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(path)
+
+const isStandardObjectPermissionsPath = (path: string): boolean =>
+  path.startsWith(section.OBJECT) && !ENDS_WITH_CUSTOM_SUFFIX_REGEX.test(path)
 
 type TopLevelElemID = Omit<ElemID, 'idType'> & {
   idType: 'type' | 'instance'
@@ -308,7 +311,10 @@ const removeWeakReferences: WeakReferencesHandler['removeWeakReferences'] =
     const brokenReferenceFields = Object.keys(
       await pickAsync(entriesTargets, async target => !elementNames.has(target.getFullName())),
       // fieldPermissions may contain standard values that are not referring to any field, we shouldn't omit these
-    ).filter(path => !isStandardFieldPermissionsPath(path))
+    )
+      .filter(path => !isStandardFieldPermissionsPath(path))
+      // Some standard objects are not managed in the metadata API and won't exist in the workspace.
+      .filter(path => !isStandardObjectPermissionsPath(path))
     const instancesWithBrokenReferences = instances.filter(instance =>
       brokenReferenceFields.some(field => _(instance.value).has(field)),
     )

--- a/packages/salesforce-adapter/test/custom_references/profiles_and_permission_sets.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/profiles_and_permission_sets.test.ts
@@ -776,6 +776,7 @@ describe('Profiles And Permission Sets Custom References', () => {
         ],
       },
       objectPermissions: {
+        // Make sure we don't omit values of standard objects with broken reference
         Account: {
           allowCreate: true,
           allowDelete: true,
@@ -783,6 +784,15 @@ describe('Profiles And Permission Sets Custom References', () => {
           allowRead: true,
           modifyAllRecords: false,
           object: 'Account',
+          viewAllRecords: false,
+        },
+        TestObj__c: {
+          allowCreate: true,
+          allowDelete: true,
+          allowEdit: true,
+          allowRead: true,
+          modifyAllRecords: false,
+          object: 'TestObj__c',
           viewAllRecords: false,
         },
       },
@@ -843,7 +853,17 @@ describe('Profiles And Permission Sets Custom References', () => {
             },
             flowAccesses: {},
             layoutAssignments: {},
-            objectPermissions: {},
+            objectPermissions: {
+              Account: {
+                allowCreate: true,
+                allowDelete: true,
+                allowEdit: true,
+                allowRead: true,
+                modifyAllRecords: false,
+                object: 'Account',
+                viewAllRecords: false,
+              },
+            },
             pageAccesses: {},
             recordTypeVisibilities: {
               Case: {},
@@ -874,6 +894,7 @@ describe('Profiles And Permission Sets Custom References', () => {
               [API_NAME]: 'Account',
             },
           }),
+          createCustomObjectType('TestObj__c', {}),
           new InstanceElement('SomeApplication', mockTypes.CustomApplication, {}),
           new InstanceElement('SomeApexClass', mockTypes.ApexClass, {}),
           new InstanceElement('SomeFlow', mockTypes.Flow, {}),
@@ -911,6 +932,7 @@ describe('Profiles And Permission Sets Custom References', () => {
         const elementsSource = buildElementsSourceFromElements([
           new InstanceElement('Account_Account_Layout@bs', mockTypes.Layout, {}),
           mockTypes.Account,
+          createCustomObjectType('TestObj__c', {}),
           new InstanceElement('SomeApexPage', mockTypes.ApexPage, {}),
           new InstanceElement('Case_SomeCaseRecordType', mockTypes.RecordType, {}),
         ])
@@ -947,6 +969,15 @@ describe('Profiles And Permission Sets Custom References', () => {
                 allowRead: true,
                 modifyAllRecords: false,
                 object: 'Account',
+                viewAllRecords: false,
+              },
+              TestObj__c: {
+                allowCreate: true,
+                allowDelete: true,
+                allowEdit: true,
+                allowRead: true,
+                modifyAllRecords: false,
+                object: 'TestObj__c',
                 viewAllRecords: false,
               },
             },


### PR DESCRIPTION
Do not omit objectPermissions of standard objects in the Profiles & PS Elements fixer

---

Some Standard Objects are not in the workspace and are being omitted from the PermissionSet. This is most likely due to the fact they are not managed in the Metadata API. See this for example as a result of running the fixer on Weave’s environment:

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
