### PR TITLE
SALTO-6702: Remove unused revert function from remote map interface

### DIFF
--- a/packages/core/src/local-workspace/remote_map/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map/remote_map.ts
@@ -731,12 +731,6 @@ export const createRemoteMapCreator = (
         wasClearCalled = false
         return flushRes
       },
-      revert: async () => {
-        locationCache.reset()
-        delKeys.clear()
-        wasClearCalled = false
-        await clearImpl(tmpDB, tempKeyPrefix)
-      },
       clear: async () => {
         locationCache.reset()
         await clearImpl(tmpDB, tempKeyPrefix)
@@ -891,9 +885,6 @@ export const createReadOnlyRemoteMapCreator = (location: string): remoteMap.Read
       flush: async () => {
         notImplemented('flush')
         return false
-      },
-      revert: async () => {
-        notImplemented('revert')
       },
       clear: async () => {
         notImplemented('clear')

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -133,7 +133,6 @@ const persistentMockCreateRemoteMap = (): (<T, K extends string = string>(
       values: (): AsyncIterable<T> =>
         awu(Object.values(maps[opts.namespace])).map(async v => opts.deserialize(v as string)),
       flush: (): Promise<boolean> => Promise.resolve(false),
-      revert: (): Promise<void> => Promise.resolve(undefined),
       close: (): Promise<void> => Promise.resolve(undefined),
       isEmpty: (): Promise<boolean> => Promise.resolve(_.isEmpty(maps[opts.namespace])),
     }

--- a/packages/workspace/src/workspace/remote_map.ts
+++ b/packages/workspace/src/workspace/remote_map.ts
@@ -71,7 +71,7 @@ export type RemoteMap<T, K extends string = string> = {
   keys: RemoteMapIteratorCreator<K>
   values: RemoteMapIteratorCreator<T>
   flush: () => Promise<boolean>
-  revert: () => Promise<void>
+  revert?: () => Promise<void>
   clear(): Promise<void>
   close(): Promise<void>
   isEmpty(): Promise<boolean>
@@ -157,11 +157,6 @@ export class InMemoryRemoteMap<T, K extends string = string> implements RemoteMa
   // eslint-disable-next-line class-methods-use-this
   async flush(): Promise<boolean> {
     return Promise.resolve(false)
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async revert(): Promise<void> {
-    return Promise.resolve(undefined)
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -86,7 +86,6 @@ export const persistentMockCreateRemoteMap = (): RemoteMapCreator => {
       values: (): AsyncIterable<T> =>
         awu(Object.values(maps[opts.namespace])).map(async v => opts.deserialize(v as string)),
       flush: (): Promise<boolean> => Promise.resolve(false),
-      revert: (): Promise<void> => Promise.resolve(undefined),
       close: (): Promise<void> => Promise.resolve(undefined),
       isEmpty: (): Promise<boolean> => Promise.resolve(_.isEmpty(maps[opts.namespace])),
     }
@@ -142,7 +141,6 @@ export const createMockRemoteMap = <T>(): MockInterface<RemoteMap<T>> => ({
   keys: mockFunction<RemoteMap<T>['keys']>(),
   values: mockFunction<RemoteMap<T>['values']>(),
   flush: mockFunction<RemoteMap<T>['flush']>(),
-  revert: mockFunction<RemoteMap<T>['revert']>(),
   clear: mockFunction<RemoteMap<T>['clear']>(),
   close: mockFunction<RemoteMap<T>['close']>(),
   isEmpty: mockFunction<RemoteMap<T>['isEmpty']>(),


### PR DESCRIPTION

---

_Additional context for reviewer_
As a first step, removing all implementations but keeping the function optional in the interface to avoid breaking changes.
Will remove it from the interface in a follow up PR

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_