### PR TITLE
SALTO-6056 add word boundaries to regex

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -60,7 +60,7 @@ const pathPrefixRegex = new RegExp(
   'm',
 )
 // matches key strings in format of 'key': value or key: value
-const mappedReferenceRegex = new RegExp(`['"]?(?<${OPTIONAL_REFS}>\\w+)['"]?\\s*:\\s*\\S`, 'gm')
+const mappedReferenceRegex = new RegExp(`\\b['"]?(?<${OPTIONAL_REFS}>\\w+)['"]?\\s*:\\s*\\S`, 'gm')
 // matches comments in js files
 // \\/\\*[\\s\\S]*?\\*\\/ - matches multiline comments by matching the first '/*' and the last '*/' and any character including newlines
 // ^\\s*\\/\\/.* - matches single line comments that start with '//'


### PR DESCRIPTION
add word boundaries to regex to improve its performance by to preventing partial matches that could lead to more backtracking.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None