### PR TITLE
SALTO-2061: Nest Recipe Code under Recipe instances in Workato

### DIFF
--- a/packages/workato-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/workato-adapter/src/definitions/fetch/fetch.ts
@@ -133,7 +133,7 @@ const createCustomizations = (): Record<string, definitions.fetch.InstanceFetchA
             typeName: RECIPE_CODE_TYPE,
             addParentAnnotation: true,
             referenceFromParent: true,
-            nestPathUnderParent: false,
+            nestPathUnderParent: true,
           },
         },
       },


### PR DESCRIPTION
Recipe code elements will now be nested under the parent recipe in the element tree

---

_Additional context for reviewer_

---
_Release Notes_: 

_Workato adapter_:
- Improve elements structure in Workato be nesting recipe code elements under their parent recipe.

---
_User Notifications_: 
None
