### PR TITLE
SALTO-6707: Allow customizing prefix for element path

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/element.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/element.ts
@@ -55,6 +55,8 @@ export type ElemIDDefinition<TCustomNameMappingOptions extends string = never> =
 
 export type PathDefinition<TCustomNameMappingOptions extends string = never> = {
   pathParts?: IDPartsDefinition<TCustomNameMappingOptions>[]
+  // allow adding hard coded baseDir for path that will be added before the type name
+  baseDir?: string[]
 }
 
 type StandaloneFieldDefinition = {

--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -226,9 +226,9 @@ export const getElemPath =
     customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
   }): PartsCreator =>
   ({ entry, parent, defaultName }) => {
-    const pathPrefix = def?.prefix
+    const pathBaseDir = def?.baseDir ?? []
     if (singleton) {
-      return [typeID.adapter, RECORDS_PATH, ...(pathPrefix ? [pathPrefix] : []), SETTINGS_NESTED_PATH, pathNaclCase(typeID.typeName)]
+      return [typeID.adapter, RECORDS_PATH, ...pathBaseDir, SETTINGS_NESTED_PATH, pathNaclCase(typeID.typeName)]
     }
     const basicPathParts = def?.pathParts
       ?.map(part =>
@@ -245,7 +245,7 @@ export const getElemPath =
     return [
       adapterName,
       RECORDS_PATH,
-      ...(pathPrefix ? [pathPrefix] : []),
+      ...pathBaseDir,
       ...(nestUnderPath ?? [pathNaclCase(typeName)]),
       ...pathParts,
       ...(createSelfFolder && lastPart ? [lastPart] : []),

--- a/packages/adapter-components/src/fetch/element/id_utils.ts
+++ b/packages/adapter-components/src/fetch/element/id_utils.ts
@@ -226,8 +226,9 @@ export const getElemPath =
     customNameMappingFunctions?: NameMappingFunctionMap<TCustomNameMappingOptions>
   }): PartsCreator =>
   ({ entry, parent, defaultName }) => {
+    const pathPrefix = def?.prefix
     if (singleton) {
-      return [typeID.adapter, RECORDS_PATH, SETTINGS_NESTED_PATH, pathNaclCase(typeID.typeName)]
+      return [typeID.adapter, RECORDS_PATH, ...(pathPrefix ? [pathPrefix] : []), SETTINGS_NESTED_PATH, pathNaclCase(typeID.typeName)]
     }
     const basicPathParts = def?.pathParts
       ?.map(part =>
@@ -244,6 +245,7 @@ export const getElemPath =
     return [
       adapterName,
       RECORDS_PATH,
+      ...(pathPrefix ? [pathPrefix] : []),
       ...(nestUnderPath ?? [pathNaclCase(typeName)]),
       ...pathParts,
       ...(createSelfFolder && lastPart ? [lastPart] : []),

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -334,6 +334,43 @@ describe('id utils', () => {
         })({ entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }),
       ).toEqual(['myAdapter', 'Records', 'ParentType', 'FieldName', 'A', 'A'])
     })
+    describe('with baseDir provided', () => {
+      const args = { entry: { a: 'A', b: 'B', c: 'C' }, defaultName: 'unnamed' }
+      it('should nest instance path under baseDir', () => {
+        expect(
+          getElemPath({
+            def: {
+              pathParts: [{ parts: [{ fieldName: 'a' }] }],
+              baseDir: ['Base', 'Dir'],
+            },
+            typeID,
+            elemIDCreator: createElemIDFunc({
+              elemIDDef: {
+                parts: [{ fieldName: 'a' }],
+              },
+              typeID,
+            }),
+          })(args),
+        ).toEqual(['myAdapter', 'Records', 'Base', 'Dir', 'myType', 'A'])
+      })
+      it('should nest instance path under baseDir for singletons', () => {
+        expect(
+          getElemPath({
+            def: {
+              baseDir: ['Base', 'Dir'],
+            },
+            typeID,
+            elemIDCreator: createElemIDFunc({
+              elemIDDef: {
+                parts: [{ fieldName: 'a' }],
+              },
+              typeID,
+            }),
+            singleton: true,
+          })(args),
+        ).toEqual(['myAdapter', 'Records', 'Base', 'Dir', 'Settings', 'myType'])
+      })
+    })
   })
 
   describe('getNameMapping', () => {

--- a/packages/adapter-components/test/fetch/element/id_utils.test.ts
+++ b/packages/adapter-components/test/fetch/element/id_utils.test.ts
@@ -370,6 +370,24 @@ describe('id utils', () => {
           })(args),
         ).toEqual(['myAdapter', 'Records', 'Base', 'Dir', 'Settings', 'myType'])
       })
+      it('should ignore baseDir if provided with nestUnderPath, as types with nestUnderPath should already include the baseDir', () => {
+        expect(
+          getElemPath({
+            def: {
+              pathParts: [{ parts: [{ fieldName: 'a' }] }],
+              baseDir: ['Base', 'Dir'],
+            },
+            typeID,
+            elemIDCreator: createElemIDFunc({
+              elemIDDef: {
+                parts: [{ fieldName: 'a' }],
+              },
+              typeID,
+            }),
+            nestUnderPath: ['Base', 'Dir', 'ParentType', 'ParentName'],
+          })(args),
+        ).toEqual(['myAdapter', 'Records', 'Base', 'Dir', 'ParentType', 'ParentName', 'A'])
+      })
     })
   })
 


### PR DESCRIPTION
Allow customizing prefix for element path

---

_Additional context for reviewer_
hardcoded path added to the `topLevel`.`path` definition, allowing to consolidate few types under the same path.

example (not a real usecase):
<img width="288" alt="image" src="https://github.com/user-attachments/assets/e9d8e46b-8df6-4238-974d-855f92a66e59">


will add tests later

---
_Release Notes_: 
None

---
_User Notifications_: 
None
