### PR TITLE
SALTO-6699: Cache whether a remote map is empty

### DIFF
--- a/packages/core/src/local-workspace/remote_map/counters.ts
+++ b/packages/core/src/local-workspace/remote_map/counters.ts
@@ -23,6 +23,7 @@ const COUNTER_TYPES = [
   'PersistentDbConnectionCreated',
   'PersistentDbConnectionReuse',
   'TmpDbConnectionReuse',
+  'DBIteratorCreated',
 ] as const
 type CounterType = (typeof COUNTER_TYPES)[number]
 

--- a/packages/core/src/local-workspace/remote_map/remote_map.ts
+++ b/packages/core/src/local-workspace/remote_map/remote_map.ts
@@ -637,12 +637,10 @@ export const createRemoteMapCreator = (
                 resolve(undefined)
                 return
               }
-              isNamespaceEmpty = false
               await resolveRet(innerValue)
               statCounters.RemoteMapHit.inc()
             })
           } else {
-            isNamespaceEmpty = false
             await resolveRet(value)
             statCounters.RemoteMapHit.inc()
           }


### PR DESCRIPTION
Checking if a remote map is empty requires creating a DB iterator with a prefix. If we know that a namespace is empty, we can avoid doing that and hopefully reduce the amount of DB iterators we create. This in turn will hopefully reduce the chances that we trigger the crazy memory consumption issue in rocksdb

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Improve performance when reading many elements with static files for a workspace

---
_User Notifications_: 
_None_