### PR TITLE
SALTO-6056 Improve SuiteScripts object keys regex

### DIFF
--- a/packages/netsuite-adapter/src/filters/element_references.ts
+++ b/packages/netsuite-adapter/src/filters/element_references.ts
@@ -59,8 +59,8 @@ const pathPrefixRegex = new RegExp(
   `^${FILE_CABINET_PATH_SEPARATOR}|^\\.${FILE_CABINET_PATH_SEPARATOR}|^\\.\\.${FILE_CABINET_PATH_SEPARATOR}`,
   'm',
 )
-// matches key strings in format of 'key': value or key: value
-const mappedReferenceRegex = new RegExp(`\\b['"]?(?<${OPTIONAL_REFS}>\\w+)['"]?\\s*:\\s*\\S`, 'gm')
+// matches object keys (e.g `key: value`)
+const mappedReferenceRegex = new RegExp(`\\b(?<${OPTIONAL_REFS}>\\w+)\\s*:\\s*\\S`, 'gm')
 // matches comments in js files
 // \\/\\*[\\s\\S]*?\\*\\/ - matches multiline comments by matching the first '/*' and the last '*/' and any character including newlines
 // ^\\s*\\/\\/.* - matches single line comments that start with '//'


### PR DESCRIPTION
We don't need to extract object keys in the form of `{ "key": value }` / `{ 'key': value }`, because they are extracted from the general strings regex (`semanticReferenceRegex`)

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
