### PR TITLE
SALTO-6710: Extract Entra AuthenticationMethodConfiguration from the Settings directory

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
@@ -769,7 +769,6 @@ const graphBetaCustomizations: FetchCustomizations = {
         [AUTHENTICATION_METHOD_CONFIGURATIONS_FIELD_NAME]: {
           standalone: {
             typeName: AUTHENTICATION_METHOD_CONFIGURATION_TYPE_NAME,
-            nestPathUnderParent: true,
             referenceFromParent: false,
             addParentAnnotation: false,
           },


### PR DESCRIPTION
AuthenticationMethodConfiguration can have multiple custom instances created by the user. It currently resides under the Settings directory since its parent is located there, and we've set it to nest under the parent directory. However, there's no real reason to keep it there. Therefore, it’s best to extract it outside of the Settings directory.

---
_Release Notes_: 

---
_User Notifications_: 
