### PR TITLE
SALTO-6712: (Salesforce) Add Targeted Fetch support for Profiles 

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
@@ -11,6 +11,8 @@ import {
   CUSTOM_OBJECT,
   FLOW_DEFINITION_METADATA_TYPE,
   FLOW_METADATA_TYPE,
+  PROFILE_METADATA_TYPE,
+  PROFILE_RELATED_METADATA_TYPES,
   TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../constants'
 
@@ -417,7 +419,6 @@ export const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
   'PrimaryTabComponents',
   'ProductAttributeSet',
   'ProductAttributeSetItem',
-  'Profile',
   'ProfileActionOverride',
   'ProfileApexClassAccess',
   'ProfileApexPageAccess',
@@ -580,6 +581,7 @@ export const METADATA_TYPES_WITH_DEPENDENCIES = [
   ...WORKFLOW_FIELDS,
   CUSTOM_OBJECT,
   FLOW_METADATA_TYPE,
+  PROFILE_METADATA_TYPE,
 ] as const
 
 export const EXCLUDED_METADATA_TYPES = [
@@ -630,6 +632,7 @@ export const METADATA_TYPE_TO_DEPENDENCIES: Record<MetadataTypeWithDependencies,
   WorkflowTask: ['Workflow'],
   CustomObject: [TOPICS_FOR_OBJECTS_METADATA_TYPE],
   Flow: [FLOW_DEFINITION_METADATA_TYPE],
+  Profile: [...PROFILE_RELATED_METADATA_TYPES],
 }
 
 export const isMetadataTypeWithoutDependencies = (

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
@@ -15,6 +15,7 @@ import {
   SALESFORCE_METADATA_TYPES,
   MetadataTypeWithoutDependencies,
 } from '../../src/fetch_profile/metadata_types'
+import { PROFILE_RELATED_METADATA_TYPES } from '../../src/constants'
 
 describe('Salesforce MetadataTypes', () => {
   const getDuplicates = (array: ReadonlyArray<string>): ReadonlyArray<string> =>
@@ -63,11 +64,11 @@ describe('Salesforce MetadataTypes', () => {
           'WorkflowKnowledgePublish',
           'WorkflowTask',
           'WorkflowRule',
-          'CustomObject',
           'Workflow',
           'TopicsForObjects',
           'Flow',
-          'FlowDefinition',
+          'Profile',
+          ...PROFILE_RELATED_METADATA_TYPES,
         ])
       })
     })


### PR DESCRIPTION
(Salesforce) Add Targeted Fetch support for Profiles

---

Profiles must be retrieved alongside all of their related types. This PR simply adds a dependency to the fetch targets for Profiles. 

---
_Release Notes_: 
_Salesforce Adapter_:
- Add Targeted Fetch support for Profiles.

---
_User Notifications_: 
_None_
