### PR TITLE
SALTO-6691: Hide priority field from policies to be used in modification changes

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -32,6 +32,7 @@ import {
   EMBEDDED_SIGN_IN_SUPPORT_TYPE_NAME,
   EMAIL_CUSTOMIZATION_TYPE_NAME,
   EMAIL_TEMPLATE_TYPE_NAME,
+  AUTOMATION_RULE_TYPE_NAME,
 } from '../../constants'
 import { isGroupPushEntry } from '../../filters/group_push'
 import { extractSchemaIdFromUserType } from './types/user_type'
@@ -142,8 +143,13 @@ const accessPolicyRuleCustomizer: definitions.fetch.FetchTopLevelElementDefiniti
 }
 
 const getPolicyCustomizations = (): Record<string, definitions.fetch.InstanceFetchApiDefinitions<OktaOptions>> => {
-  const policiesToOmitPriorities = [ACCESS_POLICY_TYPE_NAME, PROFILE_ENROLLMENT_POLICY_TYPE_NAME, IDP_POLICY_TYPE_NAME]
-  const policyRulesToOmitPriorities = [PROFILE_ENROLLMENT_RULE_TYPE_NAME]
+  const policiesToOmitPriorities = [
+    ACCESS_POLICY_TYPE_NAME,
+    PROFILE_ENROLLMENT_POLICY_TYPE_NAME,
+    IDP_POLICY_TYPE_NAME,
+    AUTOMATION_TYPE_NAME,
+  ]
+  const policyRulesToOmitPriorities = [PROFILE_ENROLLMENT_RULE_TYPE_NAME, AUTOMATION_RULE_TYPE_NAME]
   const rulesWithFieldsCustomizations = [MFA_RULE_TYPE_NAME, IDP_RULE_TYPE_NAME]
   const defs = Object.entries(POLICY_TYPE_NAME_TO_PARAMS).map(([typeName, details]) => ({
     [typeName]: {
@@ -182,7 +188,7 @@ const getPolicyCustomizations = (): Record<string, definitions.fetch.InstanceFet
         fieldCustomizations: {
           id: { hide: true },
           _links: { omit: true },
-          ...(policiesToOmitPriorities.includes(typeName) ? { priority: { omit: true } } : {}),
+          priority: policiesToOmitPriorities.includes(typeName) ? { omit: true } : { hide: true },
           policyRules: {
             standalone: {
               typeName: details.ruleName,
@@ -212,7 +218,7 @@ const getPolicyCustomizations = (): Record<string, definitions.fetch.InstanceFet
           ...(rulesWithFieldsCustomizations.includes(details.ruleName)
             ? { actions: { fieldType: 'PolicyRuleActions' }, conditions: { fieldType: 'PolicyRuleConditions' } }
             : {}),
-          ...(policyRulesToOmitPriorities.includes(details.ruleName) ? { priority: { omit: true } } : {}),
+          priority: policyRulesToOmitPriorities.includes(details.ruleName) ? { omit: true } : { hide: true },
         },
       },
     },
@@ -1146,6 +1152,7 @@ const createCustomizations = ({
       fieldCustomizations: {
         id: { hide: true },
         _links: { omit: true },
+        priority: { hide: true },
       },
     },
   },

--- a/packages/okta-adapter/src/filters/policy_priority.ts
+++ b/packages/okta-adapter/src/filters/policy_priority.ts
@@ -308,10 +308,6 @@ const filter: FilterCreator = ({ definitions }) => ({
       })
       elements.push(priorityInstance)
     })
-    // Remove priority field from the instances
-    policiesRules.concat(Object.values(policyTypeNameToPolicies).flat()).forEach(rule => {
-      delete rule.value.priority
-    })
   },
   deploy: async changes => {
     const [relevantChanges, leftoverChanges] = _.partition(changes, change =>


### PR DESCRIPTION
This should fix a bug causing the policy / policy rule to be "pushed" as the latest policy upon modifications.

---

_Additional context for reviewer_
Until now, for policies / rules with a dedicated order instance, we completely removed the `priority` field from the element. This caused modification changes to send the payload without the `priority`, and have Okta to fallback to the lowest priority available (so the policies were "push" down the queue)

To solve this, I made the field hidden (when relevant), this should give us the following - 
1. Addition changes - the priority field will not exist, and the policy priority will be inclusively determined by the order instance
2. Removal changes - this doesn't matter
3. Modification changes -
    - If policy changed its position, we first modify the policy (sending the previous priority), and then update the priority when deploying the order change
    - If the policy didn't change it's position, we should the hidden priority from state, as it's reflects the current policy priorty.
  By doing the modification changes of policies / rules before updating order changes, we promise we always send the policy with its correct priority. 


In addition, I removed Automation and AutomationRule priority field, as priorities doesn't have a meaning in those so we should omit it as we do for other policies.

---
_Release Notes_: 

_Okta_adapter_:
- Fix a bug causing policies and policy rules to have the lowest priority when modifying policy settings.

---
_User Notifications_: 

_Okta_adapter_:
- `priority` field will be omitted from `Automation` policy.