### PR TITLE
SALTO-2601: Nest folders under their parent folder (Workato)

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -36,6 +36,7 @@ import fieldReferencesFilter from './filters/field_references'
 import jiraProjectIssueTypeFilter from './filters/cross_service/jira/project_issuetypes'
 import recipeCrossServiceReferencesFilter from './filters/cross_service/recipe_references'
 import serviceUrlFilter from './filters/service_url'
+import customPathFilter from './filters/custom_paths'
 import commonFilters from './filters/common'
 import { DEPLOY_USING_RLM_GROUP, RECIPE_CODE_TYPE, WORKATO } from './constants'
 import changeValidator from './change_validator'
@@ -60,6 +61,8 @@ export const DEFAULT_FILTERS = [
   serviceUrlFilter,
   // referencedIdFieldsFilter and queryFilter should run after element references are resolved
   ...Object.values(commonFilters),
+  // must run after commonFilters and fieldReferencesFilter
+  customPathFilter,
 ]
 
 export interface WorkatoAdapterParams {

--- a/packages/workato-adapter/src/filters/custom_paths.ts
+++ b/packages/workato-adapter/src/filters/custom_paths.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import { isInstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
+import { filters, filterUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { FOLDER_TYPE } from '../constants'
+
+const log = logger(module)
+
+const pathMapper: filters.PathMapperFunc = inst => {
+  const { typeName } = inst.elemID
+  if (typeName !== FOLDER_TYPE) {
+    return undefined
+  }
+  const { parent_id: parentID } = inst.value
+  if (!isReferenceExpression(parentID) || !isInstanceElement(parentID.value)) {
+    log.warn('folder %s does not reference a valid parent, not updating path', inst.elemID.getFullName())
+    return undefined
+  }
+  const pathSuffix = [_.last(parentID.value.path), _.last(inst.path)].filter(_.isString)
+  if (pathSuffix?.length !== 2) {
+    log.warn('instance %s does not have the expected path, not updating', inst.elemID.getFullName())
+    return undefined
+  }
+  return {
+    nestUnder: parentID.elemID,
+    pathSuffix,
+  }
+}
+
+const filter: filterUtils.NoOptionsFilterCreator<filterUtils.FilterResult> =
+  filters.customPathsFilterCreator(pathMapper)
+
+export default filter

--- a/packages/workato-adapter/test/filters/custom_paths.test.ts
+++ b/packages/workato-adapter/test/filters/custom_paths.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
+import { FOLDER_TYPE, WORKATO } from '../../src/constants'
+import { getFilterParams } from '../utils'
+import customPathsFilter from '../../src/filters/custom_paths'
+
+describe('customPathsFilter', () => {
+  type FilterType = filterUtils.FilterWith<'onFetch'>
+  let filter: FilterType
+
+  const folderType = new ObjectType({
+    elemID: new ElemID(WORKATO, FOLDER_TYPE),
+  })
+  const rootFolder = new InstanceElement('Root', folderType, { name: 'Root' }, [
+    WORKATO,
+    elementUtils.RECORDS_PATH,
+    FOLDER_TYPE,
+    'Root',
+  ]) // root folder
+  const underRootFolderA = new InstanceElement(
+    'folderA',
+    folderType,
+    {
+      name: 'folderA',
+      id: 1,
+      parent_id: new ReferenceExpression(rootFolder.elemID, rootFolder),
+    },
+    [WORKATO, elementUtils.RECORDS_PATH, FOLDER_TYPE, 'folderA'],
+  )
+  const underRootFolderB = new InstanceElement(
+    'folderB',
+    folderType,
+    {
+      name: 'folderB',
+      id: 2,
+      parent_id: new ReferenceExpression(rootFolder.elemID, rootFolder),
+    },
+    [WORKATO, elementUtils.RECORDS_PATH, FOLDER_TYPE, 'folderB'],
+  )
+  const underFolderA = new InstanceElement(
+    'folderAA',
+    folderType,
+    {
+      name: 'folderAA',
+      id: 3,
+      parent_id: new ReferenceExpression(underRootFolderA.elemID, underRootFolderA),
+    },
+    [WORKATO, elementUtils.RECORDS_PATH, FOLDER_TYPE, 'folderAA'],
+  )
+
+  const fetchParams = getFilterParams()
+
+  it('should nest folders under their parent folder', async () => {
+    filter = customPathsFilter(fetchParams) as FilterType
+    await filter.onFetch([rootFolder, underRootFolderA, underRootFolderB, underFolderA])
+    expect(rootFolder.path).toEqual([WORKATO, elementUtils.RECORDS_PATH, 'folder', 'Root'])
+    expect(underRootFolderA.path).toEqual([WORKATO, elementUtils.RECORDS_PATH, 'folder', 'Root', 'folderA'])
+    expect(underRootFolderB.path).toEqual([WORKATO, elementUtils.RECORDS_PATH, 'folder', 'Root', 'folderB'])
+    expect(underFolderA.path).toEqual([WORKATO, elementUtils.RECORDS_PATH, 'folder', 'Root', 'folderA', 'folderAA'])
+  })
+})


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

Tried to align folder structure with the one from Workato's UI

updated structure: 
<img width="399" alt="image" src="https://github.com/user-attachments/assets/2f3bb320-b795-4b25-b9f5-bddfa7a04d24">

---
_Release Notes_: 

_Workato adapter_:
- Enhancements to Workato Folder directory structure

---
_User Notifications_: 
None
