### PR TITLE
SALTO-6730: (Microsoft Security) Fix inconsistent order of array fields

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
@@ -341,6 +341,11 @@ const graphV1Customizations: FetchCustomizations = {
             referenceFromParent: false,
           },
         },
+        tags: {
+          sort: {
+            properties: [],
+          },
+        },
       },
     },
   },

--- a/packages/microsoft-security-adapter/src/definitions/fetch/intune/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/intune/fetch.ts
@@ -17,6 +17,7 @@ import { odataType } from '../../../utils'
 import { applicationConfiguration } from '../../../utils/intune'
 import { createCustomizationsWithBasePathForFetch } from '../shared/utils'
 import { application, deviceConfigurationSettings, platformScript } from './utils'
+import { ASSIGNMENT_FIELD_CUSTOMIZATION } from './utils/group_assignments'
 
 const {
   // Top level types
@@ -87,6 +88,7 @@ const graphBetaCustomizations: FetchCustomizations = {
       fieldCustomizations: {
         ...ID_FIELD_TO_HIDE,
         ...application.APPLICATION_FIELDS_TO_OMIT,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
       },
     },
   },
@@ -118,7 +120,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   [APPLICATION_PROTECTION_WINDOWS_INFORMATION_PROTECTION_TYPE_NAME]: {
@@ -148,7 +153,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   [DEVICE_CONFIGURATION_TYPE_NAME]: {
@@ -178,7 +186,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   ...deviceConfigurationSettings.createDeviceConfigurationSettingsFetchDefinition({
@@ -217,7 +228,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   [DEVICE_COMPLIANCE_SCHEDULED_ACTIONS_TYPE_NAME]: {
@@ -339,7 +353,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   ..._.mapValues(TYPES_WITH_TARGET_APPS_PATH_MAP, ({ resourcePath, serviceUrlPath }) => ({

--- a/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/device_configuration_settings.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/device_configuration_settings.ts
@@ -10,8 +10,15 @@ import { DEFAULT_TRANSFORMATION, ID_FIELD_TO_HIDE } from '../../shared/defaults'
 import { AdjustFunctionMergeAndTransform, FetchCustomizations } from '../../shared/types'
 import { intuneConstants } from '../../../../constants'
 import { EndpointPath } from '../../../types'
+import { ASSIGNMENT_FIELD_CUSTOMIZATION } from './group_assignments'
 
-const { SETTINGS_FIELD_NAME, SETTING_COUNT_FIELD_NAME, ASSIGNMENTS_ODATA_CONTEXT, SERVICE_BASE_URL } = intuneConstants
+const {
+  SETTINGS_FIELD_NAME,
+  SETTING_COUNT_FIELD_NAME,
+  ASSIGNMENTS_ODATA_CONTEXT,
+  SERVICE_BASE_URL,
+  ASSIGNMENTS_FIELD_NAME,
+} = intuneConstants
 
 // In the Intune admin center, some of the device configurations (setting catalog) are located in the Device Configuration settings tab
 // and some are located in the Platform Scripts tab. We align with the UI view by separating them to two different types.
@@ -74,7 +81,10 @@ export const createDeviceConfigurationSettingsFetchDefinition = ({
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   [settingsTypeName]: {

--- a/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/group_assignments.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/group_assignments.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ODATA_TYPE_FIELD_NACL_CASE } from '../../../../constants'
+import { ElementFieldCustomization } from '../../shared/types'
+
+export const ASSIGNMENT_FIELD_CUSTOMIZATION: ElementFieldCustomization = {
+  sort: {
+    properties: [
+      { path: `target.${ODATA_TYPE_FIELD_NACL_CASE}` },
+      { path: 'target.groupId.displayName' },
+      { path: 'target.deviceAndAppManagementAssignmentFilterId.displayName' },
+      { path: 'target.deviceAndAppManagementAssignmentFilterId.platform' },
+    ],
+  },
+}

--- a/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/platform_script.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/intune/utils/platform_script.ts
@@ -16,6 +16,7 @@ import { AdjustFunctionMergeAndTransform, FetchCustomizations } from '../../shar
 import { ADAPTER_NAME, intuneConstants } from '../../../../constants'
 import { EndpointPath } from '../../../types'
 import { SERVICE_BASE_URL } from '../../../../constants/intune'
+import { ASSIGNMENT_FIELD_CUSTOMIZATION } from './group_assignments'
 
 const log = logger(module)
 const { recursiveNestedTypeName } = fetchUtils.element
@@ -31,6 +32,7 @@ const {
   SETTINGS_FIELD_NAME,
   SIMPLE_SETTING_VALUE_FIELD_NAME,
   ASSIGNMENTS_ODATA_CONTEXT,
+  ASSIGNMENTS_FIELD_NAME,
 } = intuneConstants
 
 const createStaticFileFromScript = ({
@@ -180,7 +182,10 @@ export const createPlatformScriptFetchDefinition = ({
         },
         allowEmptyArrays: true,
       },
-      fieldCustomizations: ID_FIELD_TO_HIDE,
+      fieldCustomizations: {
+        ...ID_FIELD_TO_HIDE,
+        [ASSIGNMENTS_FIELD_NAME]: ASSIGNMENT_FIELD_CUSTOMIZATION,
+      },
     },
   },
   [recursiveNestedTypeName(typeName, SCRIPT_CONTENT_RECURSE_INTO_FIELD_NAME)]: {

--- a/packages/microsoft-security-adapter/test/definitions/fetch/intune/utils/platform_script.test.ts
+++ b/packages/microsoft-security-adapter/test/definitions/fetch/intune/utils/platform_script.test.ts
@@ -11,6 +11,7 @@ import { StaticFile } from '@salto-io/adapter-api'
 import { platformScript } from '../../../../../src/definitions/fetch/intune/utils'
 import { contextMock } from '../../../../mocks'
 import { intuneConstants } from '../../../../../src/constants'
+import { ASSIGNMENT_FIELD_CUSTOMIZATION } from '../../../../../src/definitions/fetch/intune/utils/group_assignments'
 
 const { SCRIPT_CONTENT_RECURSE_INTO_FIELD_NAME } = intuneConstants
 
@@ -262,6 +263,7 @@ describe('Intune platform script fetch utils', () => {
               id: {
                 hide: true,
               },
+              assignments: ASSIGNMENT_FIELD_CUSTOMIZATION,
             },
           },
         },


### PR DESCRIPTION
MS Graph doesn’t return the following fields in a specific order (between different tenants), so we sort them to maintain consistency:
* Assignments: Found in various Intune types.
* Application Tags: Found in Entra Service Principals.

---
_Release Notes_: 

---
_User Notifications_: 
