### PR TITLE
SALTO-6735: (MS Security) Fix reference rule for Conditional Access Policy

### DIFF
--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -14,10 +14,10 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   testEnvironment: undefined,
   coverageThreshold: {
     global: {
-      statements: 98.57,
-      branches: 94.71,
-      functions: 93.95,
-      lines: 98.53,
+      statements: 98.10,
+      branches: 93.88,
+      functions: 93.60,
+      lines: 98.01,
     },
   },
 })

--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -14,10 +14,10 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   testEnvironment: undefined,
   coverageThreshold: {
     global: {
-      statements: 98.10,
+      statements: 97.94,
       branches: 93.88,
-      functions: 93.60,
-      lines: 98.01,
+      functions: 92.86,
+      lines: 97.83,
     },
   },
 })

--- a/packages/microsoft-security-adapter/src/definitions/references/entra_reference_rules.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/entra_reference_rules.ts
@@ -179,7 +179,7 @@ export const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<
       parentTypes: [CONDITIONAL_ACCESS_POLICY_CONDITION_APPLICATIONS_TYPE_NAME],
     },
     target: { type: SERVICE_PRINCIPAL_TYPE_NAME },
-    serializationStrategy: 'appId',
+    serializationStrategy: 'servicePrincipalAppId',
   },
   {
     src: {
@@ -187,7 +187,7 @@ export const REFERENCE_RULES: referenceUtils.FieldReferenceDefinition<
       parentTypes: [CONDITIONAL_ACCESS_POLICY_CONDITION_APPLICATIONS_TYPE_NAME],
     },
     target: { type: SERVICE_PRINCIPAL_TYPE_NAME },
-    serializationStrategy: 'appId',
+    serializationStrategy: 'servicePrincipalAppId',
   },
   {
     src: { field: 'includeRoles', parentTypes: [CONDITIONAL_ACCESS_POLICY_CONDITION_USERS_TYPE_NAME] },

--- a/packages/microsoft-security-adapter/src/definitions/references/references.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/references.ts
@@ -17,18 +17,21 @@ const REFERENCE_RULES = [...EntraReferenceRules, ...IntuneReferenceRules, ...Cro
 
 // We only use this record as a TS 'hack' to fail the build if we add a custom serialization strategy
 // and forget to add it to the fieldsToGroupBy.
-const fieldsToGroupBy: Record<referenceUtils.ReferenceIndexField | CustomReferenceSerializationStrategyName, null> = {
-  id: null,
-  name: null,
-  appId: null,
-  bundleId: null,
-  packageId: null,
-  servicePrincipalAppId: null,
-}
+const fieldsToGroupBy: Record<referenceUtils.ReferenceIndexField | CustomReferenceSerializationStrategyName, boolean> =
+  {
+    id: true,
+    name: true,
+    appId: true,
+    bundleId: true,
+    packageId: true,
+    servicePrincipalAppId: false,
+  }
 
 export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
   rules: REFERENCE_RULES,
-  fieldsToGroupBy: Object.keys(fieldsToGroupBy) as Array<keyof typeof fieldsToGroupBy>,
+  fieldsToGroupBy: Object.entries(fieldsToGroupBy)
+    .filter(([, shouldGroupBy]) => shouldGroupBy)
+    .map(([field]) => field) as Array<keyof typeof fieldsToGroupBy>,
   serializationStrategyLookup: {
     // Entra serialization strategies lookup
     appId: {

--- a/packages/microsoft-security-adapter/src/definitions/references/references.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/references.ts
@@ -15,23 +15,23 @@ import { REFERENCE_RULES as CrossReferenceRules } from './cross_reference_rules'
 
 const REFERENCE_RULES = [...EntraReferenceRules, ...IntuneReferenceRules, ...CrossReferenceRules]
 
+type FieldsToGroupBy =
+  | referenceUtils.ReferenceIndexField
+  | Exclude<CustomReferenceSerializationStrategyName, 'servicePrincipalAppId'>
+
 // We only use this record as a TS 'hack' to fail the build if we add a custom serialization strategy
 // and forget to add it to the fieldsToGroupBy.
-const fieldsToGroupBy: Record<referenceUtils.ReferenceIndexField | CustomReferenceSerializationStrategyName, boolean> =
-  {
-    id: true,
-    name: true,
-    appId: true,
-    bundleId: true,
-    packageId: true,
-    servicePrincipalAppId: false,
-  }
+const fieldsToGroupBy: Record<FieldsToGroupBy, null> = {
+  id: null,
+  name: null,
+  appId: null,
+  bundleId: null,
+  packageId: null,
+}
 
 export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
   rules: REFERENCE_RULES,
-  fieldsToGroupBy: Object.entries(fieldsToGroupBy)
-    .filter(([, shouldGroupBy]) => shouldGroupBy)
-    .map(([field]) => field) as Array<keyof typeof fieldsToGroupBy>,
+  fieldsToGroupBy: Object.keys(fieldsToGroupBy) as Array<keyof typeof fieldsToGroupBy>,
   serializationStrategyLookup: {
     // Entra serialization strategies lookup
     appId: {

--- a/packages/microsoft-security-adapter/src/definitions/references/references.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/references.ts
@@ -5,6 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import { logger } from '@salto-io/logging'
 import { definitions, references as referenceUtils, createChangeElementResolver } from '@salto-io/adapter-components'
 import { Change, InstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { ODATA_TYPE_FIELD_NACL_CASE, entraConstants } from '../../constants'
@@ -12,6 +13,8 @@ import { CustomReferenceSerializationStrategyName, Options } from '../types'
 import { REFERENCE_RULES as EntraReferenceRules } from './entra_reference_rules'
 import { REFERENCE_RULES as IntuneReferenceRules } from './intune_reference_rules'
 import { REFERENCE_RULES as CrossReferenceRules } from './cross_reference_rules'
+
+const log = logger(module)
 
 const REFERENCE_RULES = [...EntraReferenceRules, ...IntuneReferenceRules, ...CrossReferenceRules]
 
@@ -43,6 +46,9 @@ export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
       serialize: ({ ref }) => {
         const { appId } = ref.value.value
         if (isReferenceExpression(appId)) {
+          if (appId.elemID.typeName !== entraConstants.APPLICATION_TYPE_NAME) {
+            log.error('Unexpected reference type %s for appId', appId.elemID.typeName)
+          }
           return appId.value.value.appId
         }
         return appId

--- a/packages/microsoft-security-adapter/src/definitions/references/references.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/references.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { definitions, references as referenceUtils, createChangeElementResolver } from '@salto-io/adapter-components'
-import { Change, InstanceElement } from '@salto-io/adapter-api'
+import { Change, InstanceElement, isReferenceExpression } from '@salto-io/adapter-api'
 import { ODATA_TYPE_FIELD_NACL_CASE, entraConstants } from '../../constants'
 import { CustomReferenceSerializationStrategyName, Options } from '../types'
 import { REFERENCE_RULES as EntraReferenceRules } from './entra_reference_rules'
@@ -23,6 +23,7 @@ const fieldsToGroupBy: Record<referenceUtils.ReferenceIndexField | CustomReferen
   appId: null,
   bundleId: null,
   packageId: null,
+  servicePrincipalAppId: null,
 }
 
 export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
@@ -35,6 +36,18 @@ export const REFERENCES: definitions.ApiDefinitions<Options>['references'] = {
       lookup: referenceUtils.basicLookUp,
       lookupIndexName: 'appId',
     },
+    servicePrincipalAppId: {
+      serialize: ({ ref }) => {
+        const { appId } = ref.value.value
+        if (isReferenceExpression(appId)) {
+          return appId.value.value.appId
+        }
+        return appId
+      },
+      lookup: referenceUtils.basicLookUp,
+      lookupIndexName: 'appId',
+    },
+
     // Intune serialization strategies lookup
     bundleId: {
       serialize: ({ ref }) => ref.value.value.bundleId,

--- a/packages/microsoft-security-adapter/src/definitions/requests/clients.ts
+++ b/packages/microsoft-security-adapter/src/definitions/requests/clients.ts
@@ -55,6 +55,24 @@ export const createClientDefinitions = (
               },
             },
           },
+          '/beta/identity/conditionalAccess/policies': {
+            post: {
+              polling: {
+                interval: 5000,
+                retries: 3,
+                retryOnStatus: [400],
+                checkStatus: response => response.status === 201,
+              },
+            },
+            patch: {
+              polling: {
+                interval: 5000,
+                retries: 3,
+                retryOnStatus: [400],
+                checkStatus: response => response.status === 204,
+              },
+            },
+          },
         },
       },
     },

--- a/packages/microsoft-security-adapter/src/definitions/types.ts
+++ b/packages/microsoft-security-adapter/src/definitions/types.ts
@@ -12,7 +12,7 @@ export type AdditionalAction = never
 export type ClientOptions = 'main'
 type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = 'ODataType'
-export type CustomReferenceSerializationStrategyName = 'appId' | 'bundleId' | 'packageId'
+export type CustomReferenceSerializationStrategyName = 'appId' | 'bundleId' | 'packageId' | 'servicePrincipalAppId'
 export type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {


### PR DESCRIPTION
1. Add polling for creation/update of a Conditional Access Policy.
2. Fix reference rule for Conditional Access policies

---

1. When we deploy a conditional access policy and the service principal it references within the same request, the service might throw an error stating that the service principal does not exist. This issue resolved (i.e. the service principal is updated) after 5-15 seconds.

2. A Conditional access policy may contain the following structure for application references:
```
  conditions = {
    ...otherFields,
    applications = {
      includeApplications = [
        microsoft_security.EntraServicePrincipal.instance.someSPInstanceA,
        ...
      ]
      excludeApplications = [
        microsoft_security.EntraServicePrincipal.instance.someSPInstanceB,
        ...,
      ]
    }
  }
```

The current reference rule simply serialize the application reference by returning the `appId` field on the Service Principal.
However, this `appId` may (and in most cases _will_) be a reference itself - to the application instance.
In this case we should resolve this reference as well, and return the `appId` uuid.

Note that the reference here is to the Service Principal and not directly to the application. This is because that even if the application exists in the tenant - we still need its matching service principal to exist as well in order to reference it in the policy. 

---
_Release Notes_: 

---
_User Notifications_: 
