### PR TITLE
SALTO-6734 Revert Jira JSM Automation->projectId reference #6634

### DIFF
--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -146,14 +146,6 @@ export const createAutomationTypes = (): {
     },
   })
 
-  const templateFormsConfigType = new ObjectType({
-    elemID: new ElemID(JIRA, 'TemplateFormsConfig'),
-    fields: {
-      projectId: { refType: BuiltinTypes.NUMBER },
-      templateFormIds: { refType: new ListType(BuiltinTypes.NUMBER) },
-    },
-  })
-
   const componentValueType = new ObjectType({
     elemID: new ElemID(JIRA, AUTOMATION_COMPONENT_VALUE_TYPE),
     fields: {
@@ -185,7 +177,6 @@ export const createAutomationTypes = (): {
       schemaId: { refType: BuiltinTypes.STRING },
       objectTypeLabel: { refType: BuiltinTypes.STRING },
       objectTypeId: { refType: BuiltinTypes.STRING },
-      templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
       serviceDesk: {
         refType: BuiltinTypes.STRING,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -822,11 +822,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: PROJECT_TYPE },
   },
   {
-    src: { field: 'projectId', parentTypes: ['TemplateFormsConfig'] },
-    serializationStrategy: 'id',
-    target: { type: PROJECT_TYPE },
-  },
-  {
     src: { field: 'groups', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'groupStrategyByOriginalName',
     target: { type: GROUP_TYPE_NAME },


### PR DESCRIPTION
Revert adding projectId reference for JSM automation within components...children

---

_Additional context for reviewer_
https://github.com/salto-io/salto/pull/6634

---
_Release Notes_: 
None

---
_User Notifications_: 
None
