### PR TITLE
SAAS-5602: Dummy: Support loadElementsFromFolder

### DIFF
--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -15,12 +15,21 @@ import {
   GetCustomReferencesFunc,
   ConfigCreator,
   createRestriction,
+  FetchResult,
+  LoadElementsFromFolderArgs,
 } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
-import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType, fetchErrorType } from './generator'
+import {
+  GeneratorParams,
+  DUMMY_ADAPTER,
+  defaultParams,
+  changeErrorType,
+  fetchErrorType,
+  generateExtraElements,
+} from './generator'
 
 const log = logger(module)
 
@@ -56,6 +65,10 @@ const getCustomReferences: GetCustomReferencesFunc = async elements =>
         },
       ]
     : []
+
+const loadElementsFromFolder = async ({ baseDir }: LoadElementsFromFolderArgs): Promise<FetchResult> => ({
+  elements: await generateExtraElements([baseDir]),
+})
 
 const objectFieldType = new ObjectType({
   elemID: new ElemID(DUMMY_ADAPTER, 'objectFieldType'),
@@ -198,4 +211,5 @@ export const adapter: Adapter = {
   configType,
   getCustomReferences,
   configCreator,
+  loadElementsFromFolder,
 }

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -15,8 +15,6 @@ import {
   GetCustomReferencesFunc,
   ConfigCreator,
   createRestriction,
-  FetchResult,
-  LoadElementsFromFolderArgs,
 } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
@@ -28,7 +26,7 @@ import {
   defaultParams,
   changeErrorType,
   fetchErrorType,
-  generateExtraElements,
+  generateExtraElementsFromPaths,
 } from './generator'
 
 const log = logger(module)
@@ -66,8 +64,8 @@ const getCustomReferences: GetCustomReferencesFunc = async elements =>
       ]
     : []
 
-const loadElementsFromFolder = async ({ baseDir }: LoadElementsFromFolderArgs): Promise<FetchResult> => ({
-  elements: await generateExtraElements([baseDir]),
+const loadElementsFromFolder: Adapter['loadElementsFromFolder'] = async ({ baseDir }) => ({
+  elements: await generateExtraElementsFromPaths([baseDir]),
 })
 
 const objectFieldType = new ObjectType({

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -284,6 +284,55 @@ const defaultObj = new ObjectType({
   path: [DUMMY_ADAPTER, 'Default', 'Default'],
 })
 
+export const generateExtraElements = async (naclDirs: string[]): Promise<Element[]> => {
+  const allNaclMocks = (
+    await Promise.all(
+      naclDirs.map(naclDir =>
+        readdirp.promise(naclDir, {
+          fileFilter: [`*.${MOCK_NACL_SUFFIX}`],
+        }),
+      ),
+    )
+  ).flatMap(list => list)
+  log.debug('the list of files read in generateExtraElements is: %s', allNaclMocks.map(mock => mock.path).join(' , '))
+  const elements = await awu(
+    allNaclMocks.map(async file => {
+      const content = fs.readFileSync(file.fullPath, 'utf8')
+      log.debug('content of file %s is %s', file.path, content)
+      const parsedNaclFile = await parser.parse(Buffer.from(content), file.basename, {
+        file: {
+          parse: async funcParams => {
+            const [filepath] = funcParams
+            let fileContent: Buffer
+            try {
+              fileContent = fs.readFileSync(`${file.fullPath.replace(file.basename, '')}${filepath}`)
+            } catch {
+              fileContent = Buffer.from('THIS IS STATIC FILE')
+            }
+            return new StaticFile({
+              content: fileContent,
+              filepath,
+            })
+          },
+          dump: async () => ({ funcName: 'file', parameters: [] }),
+          isSerializedAsFunction: () => true,
+        },
+      })
+      log.debug(`parsedNaclFile of file ${file.fullPath} is equal ${inspectValue(parsedNaclFile)}`)
+      await awu(parsedNaclFile.elements).forEach(elem => {
+        elem.path = [DUMMY_ADAPTER, 'extra', file.basename.replace(new RegExp(`.${MOCK_NACL_SUFFIX}$`), '')]
+      })
+      return parsedNaclFile.elements
+    }),
+  )
+    .flat()
+    .toArray()
+  const mergedElements = await merger.mergeElements(awu(elements))
+  log.debug(`mergedElements is equal ${inspectValue(mergedElements)}`)
+  const inMemElemSource = elementSource.createInMemoryElementSource(await awu(mergedElements.merged.values()).toArray())
+  return (await Promise.all(elements.map(async elem => expressions.resolve([elem], inMemElemSource)))).flat()
+}
+
 const permissionsType = new ObjectType({
   elemID: new ElemID(DUMMY_ADAPTER, 'Permissions'),
   fields: {
@@ -787,56 +836,6 @@ export const generateElements = async (
         ),
       ]
     }).flat()
-  }
-  const generateExtraElements = async (naclDirs: string[]): Promise<Element[]> => {
-    const allNaclMocks = (
-      await Promise.all(
-        naclDirs.map(naclDir =>
-          readdirp.promise(naclDir, {
-            fileFilter: [`*.${MOCK_NACL_SUFFIX}`],
-          }),
-        ),
-      )
-    ).flatMap(list => list)
-    log.debug('the list of files read in generateExtraElements is: %s', allNaclMocks.map(mock => mock.path).join(' , '))
-    const elements = await awu(
-      allNaclMocks.map(async file => {
-        const content = fs.readFileSync(file.fullPath, 'utf8')
-        log.debug('content of file %s is %s', file.path, content)
-        const parsedNaclFile = await parser.parse(Buffer.from(content), file.basename, {
-          file: {
-            parse: async funcParams => {
-              const [filepath] = funcParams
-              let fileContent: Buffer
-              try {
-                fileContent = fs.readFileSync(`${file.fullPath.replace(file.basename, '')}${filepath}`)
-              } catch {
-                fileContent = Buffer.from('THIS IS STATIC FILE')
-              }
-              return new StaticFile({
-                content: fileContent,
-                filepath,
-              })
-            },
-            dump: async () => ({ funcName: 'file', parameters: [] }),
-            isSerializedAsFunction: () => true,
-          },
-        })
-        log.debug(`parsedNaclFile of file ${file.fullPath} is equal ${inspectValue(parsedNaclFile)}`)
-        await awu(parsedNaclFile.elements).forEach(elem => {
-          elem.path = [DUMMY_ADAPTER, 'extra', file.basename.replace(new RegExp(`.${MOCK_NACL_SUFFIX}$`), '')]
-        })
-        return parsedNaclFile.elements
-      }),
-    )
-      .flat()
-      .toArray()
-    const mergedElements = await merger.mergeElements(awu(elements))
-    log.debug(`mergedElements is equal ${inspectValue(mergedElements)}`)
-    const inMemElemSource = elementSource.createInMemoryElementSource(
-      await awu(mergedElements.merged.values()).toArray(),
-    )
-    return (await Promise.all(elements.map(async elem => expressions.resolve([elem], inMemElemSource)))).flat()
   }
 
   const generateEnvElements = (): Element[] => {

--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -284,7 +284,7 @@ const defaultObj = new ObjectType({
   path: [DUMMY_ADAPTER, 'Default', 'Default'],
 })
 
-export const generateExtraElements = async (naclDirs: string[]): Promise<Element[]> => {
+export const generateExtraElementsFromPaths = async (naclDirs: string[]): Promise<Element[]> => {
   const allNaclMocks = (
     await Promise.all(
       naclDirs.map(naclDir =>
@@ -294,7 +294,10 @@ export const generateExtraElements = async (naclDirs: string[]): Promise<Element
       ),
     )
   ).flatMap(list => list)
-  log.debug('the list of files read in generateExtraElements is: %s', allNaclMocks.map(mock => mock.path).join(' , '))
+  log.debug(
+    'the list of files read in generateExtraElementsFromPaths is: %s',
+    allNaclMocks.map(mock => mock.path).join(' , '),
+  )
   const elements = await awu(
     allNaclMocks.map(async file => {
       const content = fs.readFileSync(file.fullPath, 'utf8')
@@ -1012,8 +1015,8 @@ export const generateElements = async (
   progressReporter.reportProgress({ message: 'Generating profile likes' })
   const profiles = generateProfileLike()
   progressReporter.reportProgress({ message: 'Generating extra elements' })
-  const extraElements = params.extraNaclPaths ? await generateExtraElements(params.extraNaclPaths) : []
-  const defaultExtraElements = await generateExtraElements([path.join(dataPath, 'fixtures')])
+  const extraElements = params.extraNaclPaths ? await generateExtraElementsFromPaths(params.extraNaclPaths) : []
+  const defaultExtraElements = await generateExtraElementsFromPaths([path.join(dataPath, 'fixtures')])
   log.debug('default fixture element are: %s', defaultExtraElements.map(elem => elem.elemID.getFullName()).join(' , '))
   progressReporter.reportProgress({ message: 'Generating conflicted elements' })
   const envObjects = generateEnvElements()

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -5,11 +5,26 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ObjectType, InstanceElement, ConfigCreator, ElemID } from '@salto-io/adapter-api'
+import fs from 'fs'
+import readdirp from 'readdirp'
+import { ObjectType, InstanceElement, ConfigCreator, ElemID, FetchResult } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, createDefaultInstanceFromType } from '@salto-io/adapter-utils'
 import { adapter } from '../src/adapter_creator'
 import { defaultParams, DUMMY_ADAPTER } from '../src/generator'
 import DummyAdapter from '../src/adapter'
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  readFileSync: jest.fn(),
+}))
+
+jest.mock('readdirp', () => ({
+  ...jest.requireActual('readdirp'),
+  promise: jest.fn(),
+}))
+
+const mockedFs = fs as jest.Mocked<typeof fs>
+const mockedReaddirp = readdirp as jest.Mocked<typeof readdirp>
 
 describe('adapter creator', () => {
   it('should return a config containing all of the generator params', () => {
@@ -42,6 +57,52 @@ describe('adapter creator', () => {
         elementsSource: buildElementsSourceFromElements([]),
       }),
     ).toBeInstanceOf(DummyAdapter)
+  })
+  describe('loadElementsFromFolder', () => {
+    let loadedElements: FetchResult | undefined
+    describe('When the path exists and contains a valid NaCl file', () => {
+      let remoteNaclDir: string
+      const naclFileContents = `
+      type dummy.SomeType {
+        annotations {
+        }        
+      }
+      `
+      beforeEach(async () => {
+        const originalReadFileSync = jest.requireActual('fs').readFileSync
+        mockedFs.readFileSync
+          .mockImplementationOnce((path): string => {
+            remoteNaclDir = path as string
+            return naclFileContents
+          })
+          .mockImplementation((path, encoding) => originalReadFileSync(path, encoding))
+        mockedReaddirp.promise.mockImplementation(
+          async (dir): Promise<readdirp.EntryInfo[]> =>
+            Promise.resolve([
+              {
+                path: 'some_type.nacl',
+                fullPath: `${dir}/some_type.nacl`,
+                basename: 'some_type.nacl',
+              },
+            ]),
+        )
+        loadedElements = await adapter.loadElementsFromFolder?.({
+          baseDir: 'some_path',
+          elementsSource: buildElementsSourceFromElements([]),
+        })
+      })
+      afterEach(() => {
+        jest.clearAllMocks()
+        jest.resetAllMocks()
+      })
+      it('should fetch elements from the correct dir', () => {
+        expect(remoteNaclDir).toEqual('some_path/some_type.nacl')
+      })
+      it('should load the NaCl file from the provided dir', () => {
+        expect(loadedElements?.elements).toHaveLength(1)
+        expect(loadedElements?.elements[0]).toHaveProperty('elemID', new ElemID(DUMMY_ADAPTER, 'SomeType'))
+      })
+    })
   })
 
   describe('configCreator', () => {


### PR DESCRIPTION
Support loadElementsFromFolder in dummy adapter as a first step towards running "Deploy from PR" tests using the dummy adapter instead of using Netsuite.

---

Per the requirements specified in the ticket, the adapter will look for a dummy.nacl file in the provided directory and use it as a configuration file to generate elements.

---
_Release Notes_: 

- Dummy adapter supports loadElementsFromFolder function

---
_User Notifications_: 

