### PR TITLE
SALTO-6504: Fix memory leak in remote map cache

### DIFF
--- a/packages/core/src/local-workspace/remote_map/location_pool.ts
+++ b/packages/core/src/local-workspace/remote_map/location_pool.ts
@@ -17,7 +17,7 @@ type RemoteMapLocation = {
 
 type RemoteMapLocationPool = {
   get: (location: string) => RemoteMapLocation
-  return: (location: RemoteMapLocation) => void
+  return: (location: string) => void
 }
 const createRemoteMapLocationPool = (): RemoteMapLocationPool => ({
   get: location => ({
@@ -26,8 +26,8 @@ const createRemoteMapLocationPool = (): RemoteMapLocationPool => ({
     cache: locationCaches.get(location),
   }),
   return: location => {
-    locationCaches.return(location.cache)
-    counters.return(location.name)
+    locationCaches.return(location)
+    counters.return(location)
   },
 })
 

--- a/packages/core/test/workspace/local/adapters_config.test.ts
+++ b/packages/core/test/workspace/local/adapters_config.test.ts
@@ -48,7 +48,6 @@ describe('adapters local config', () => {
       keys: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['keys']>(),
       values: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['values']>(),
       flush: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['flush']>(),
-      revert: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['revert']>(),
       clear: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['clear']>(),
       close: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['close']>(),
       isEmpty: mockFunction<remoteMap.RemoteMap<validator.ValidationError[]>['isEmpty']>(),

--- a/packages/core/test/workspace/local/remote_map/location_cache.test.ts
+++ b/packages/core/test/workspace/local/remote_map/location_cache.test.ts
@@ -21,7 +21,7 @@ describe('remote map location cache pool', () => {
   const LOCATION2 = 'SomeOtherLocation'
 
   beforeEach(() => {
-    poolContents = new Map<string, { cache: LocationCache; refcnt: number }>()
+    poolContents = new Map<string, LocationCache>()
     pool = createLocationCachePool(poolContents)
   })
 
@@ -46,8 +46,8 @@ describe('remote map location cache pool', () => {
   })
 
   it('should destroy cache when the last reference to it is returned', () => {
-    const cache = pool.get(LOCATION1)
-    pool.return(cache)
+    pool.get(LOCATION1)
+    pool.return(LOCATION1)
     expect(poolContents.size).toEqual(0)
     pool.get(LOCATION1)
     expect(poolContents.size).toEqual(1)

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -133,7 +133,6 @@ const persistentMockCreateRemoteMap = (): (<T, K extends string = string>(
       values: (): AsyncIterable<T> =>
         awu(Object.values(maps[opts.namespace])).map(async v => opts.deserialize(v as string)),
       flush: (): Promise<boolean> => Promise.resolve(false),
-      revert: (): Promise<void> => Promise.resolve(undefined),
       close: (): Promise<void> => Promise.resolve(undefined),
       isEmpty: (): Promise<boolean> => Promise.resolve(_.isEmpty(maps[opts.namespace])),
     }

--- a/packages/workspace/src/workspace/remote_map.ts
+++ b/packages/workspace/src/workspace/remote_map.ts
@@ -71,7 +71,9 @@ export type RemoteMap<T, K extends string = string> = {
   keys: RemoteMapIteratorCreator<K>
   values: RemoteMapIteratorCreator<T>
   flush: () => Promise<boolean>
-  revert: () => Promise<void>
+  // DEPRECATED - this function should not be used or implemented by remote map implementations
+  // it should be removed once all implementations are aligned
+  revert?: () => Promise<void>
   clear(): Promise<void>
   close(): Promise<void>
   isEmpty(): Promise<boolean>
@@ -157,11 +159,6 @@ export class InMemoryRemoteMap<T, K extends string = string> implements RemoteMa
   // eslint-disable-next-line class-methods-use-this
   async flush(): Promise<boolean> {
     return Promise.resolve(false)
-  }
-
-  // eslint-disable-next-line class-methods-use-this
-  async revert(): Promise<void> {
-    return Promise.resolve(undefined)
   }
 
   // eslint-disable-next-line class-methods-use-this

--- a/packages/workspace/test/utils.ts
+++ b/packages/workspace/test/utils.ts
@@ -86,7 +86,6 @@ export const persistentMockCreateRemoteMap = (): RemoteMapCreator => {
       values: (): AsyncIterable<T> =>
         awu(Object.values(maps[opts.namespace])).map(async v => opts.deserialize(v as string)),
       flush: (): Promise<boolean> => Promise.resolve(false),
-      revert: (): Promise<void> => Promise.resolve(undefined),
       close: (): Promise<void> => Promise.resolve(undefined),
       isEmpty: (): Promise<boolean> => Promise.resolve(_.isEmpty(maps[opts.namespace])),
     }
@@ -142,7 +141,6 @@ export const createMockRemoteMap = <T>(): MockInterface<RemoteMap<T>> => ({
   keys: mockFunction<RemoteMap<T>['keys']>(),
   values: mockFunction<RemoteMap<T>['values']>(),
   flush: mockFunction<RemoteMap<T>['flush']>(),
-  revert: mockFunction<RemoteMap<T>['revert']>(),
   clear: mockFunction<RemoteMap<T>['clear']>(),
   close: mockFunction<RemoteMap<T>['close']>(),
   isEmpty: mockFunction<RemoteMap<T>['isEmpty']>(),

--- a/packages/workspace/test/workspace/adapters_config.test.ts
+++ b/packages/workspace/test/workspace/adapters_config.test.ts
@@ -92,7 +92,6 @@ describe('adapters config', () => {
       keys: mockFunction<RemoteMap<ValidationError[]>['keys']>(),
       values: mockFunction<RemoteMap<ValidationError[]>['values']>(),
       flush: mockFunction<RemoteMap<ValidationError[]>['flush']>(),
-      revert: mockFunction<RemoteMap<ValidationError[]>['revert']>(),
       clear: mockFunction<RemoteMap<ValidationError[]>['clear']>(),
       close: mockFunction<RemoteMap<ValidationError[]>['close']>(),
       isEmpty: mockFunction<RemoteMap<ValidationError[]>['isEmpty']>(),

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -126,7 +126,6 @@ describe('Nacl Files Source', () => {
         keys: mockFunction<RemoteMap<Value>['keys']>().mockImplementation(realMap.keys.bind(realMap)),
         values: mockFunction<RemoteMap<Value>['values']>().mockImplementation(realMap.values.bind(realMap)),
         flush: mockFunction<RemoteMap<Value>['flush']>().mockImplementation(realMap.flush.bind(realMap)),
-        revert: mockFunction<RemoteMap<Value>['revert']>().mockImplementation(realMap.revert.bind(realMap)),
         clear: mockFunction<RemoteMap<Value>['clear']>().mockImplementation(realMap.clear.bind(realMap)),
         close: mockFunction<RemoteMap<Value>['close']>().mockImplementation(realMap.close.bind(realMap)),
         isEmpty: mockFunction<RemoteMap<Value>['isEmpty']>().mockImplementation(realMap.isEmpty.bind(realMap)),

--- a/packages/workspace/test/workspace/remote_map.test.ts
+++ b/packages/workspace/test/workspace/remote_map.test.ts
@@ -102,11 +102,6 @@ describe('remote map', () => {
         await inMemRemoteMap.flush()
       })
     })
-    describe('revert', () => {
-      it('should do nothing', async () => {
-        await inMemRemoteMap.revert()
-      })
-    })
     describe('close', () => {
       it('should do nothing', async () => {
         await inMemRemoteMap.close()


### PR DESCRIPTION
Remove reference counting logic from remote map cache. Unfortunately, we can't really count references because the interface for closing remote maps is not symmetric with the interface for creating them. Currently when we close remote maps, we just close them, no matter how many references they had, so the cache has to have the same behavior.

Also, removed the unused "revert" function from the remote map interface (will need another PR to fully remove it)

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fix potential memory leak in long running processes using workspaces

---
_User Notifications_: 
_None_