### PR TITLE
SALTO-6734 Jira JSM Automation->projectId reference

### DIFF
--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -146,6 +146,14 @@ export const createAutomationTypes = (): {
     },
   })
 
+  const templateFormsConfigType = new ObjectType({
+    elemID: new ElemID(JIRA, 'TemplateFormsConfig'),
+    fields: {
+      projectId: { refType: BuiltinTypes.NUMBER },
+      templateFormIds: { refType: new ListType(BuiltinTypes.NUMBER) },
+    },
+  })
+
   const componentValueType = new ObjectType({
     elemID: new ElemID(JIRA, AUTOMATION_COMPONENT_VALUE_TYPE),
     fields: {
@@ -177,6 +185,7 @@ export const createAutomationTypes = (): {
       schemaId: { refType: BuiltinTypes.STRING },
       objectTypeLabel: { refType: BuiltinTypes.STRING },
       objectTypeId: { refType: BuiltinTypes.STRING },
+      templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
       serviceDesk: {
         refType: BuiltinTypes.STRING,

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -822,6 +822,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: PROJECT_TYPE },
   },
   {
+    src: { field: 'projectId', parentTypes: ['TemplateFormsConfig'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: PROJECT_TYPE },
+  },
+  {
     src: { field: 'groups', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'groupStrategyByOriginalName',
     target: { type: GROUP_TYPE_NAME },


### PR DESCRIPTION
Add projectId reference for JSM automation within components...children

---

_Additional context for reviewer_
https://github.com/salto-io/salto/pull/6634

---
_Release Notes_: 
None

---
_User Notifications_: 
None
