### PR TITLE
SALTO-6742: Fix auto response rule field name

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -372,7 +372,7 @@ export const NESTED_METADATA_TYPES = {
     isNestedApiNameRelative: true,
   },
   AutoResponseRules: {
-    nestedInstanceFields: ['autoresponseRule'],
+    nestedInstanceFields: ['autoResponseRule'],
     isNestedApiNameRelative: true,
   },
   EscalationRules: {


### PR DESCRIPTION


---

_Additional context for reviewer_
Unclear why this didn't prevent the deployment from working until now, I did check that deploying auto response rule changes works before and after this change.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_