### PR TITLE
SALTO-6666 Add explicit reference to custom_status_id in views

### DIFF
--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -69,6 +69,7 @@ const NEIGHBOR_FIELD_TO_TYPE_NAMES: Record<string, string> = {
   add_skills: 'routing_attribute_value',
   set_skills: 'routing_attribute_value',
   remove_skills: 'routing_attribute_value',
+  custom_status_id: CUSTOM_STATUS_TYPE_NAME,
 }
 
 const SPECIAL_CONTEXT_NAMES: Record<string, string> = {


### PR DESCRIPTION
Add explicit reference to custom_status_id in views

---

_Additional context for reviewer_

---
_Release Notes_: 
__Zendesk:__
* Fix a bug with missing references to a `custom_status` from a `view`.

---
_User Notifications_: 
__Zendesk:__
* Instead of unresolved ids, `view` nacls will have a missing reference for `custom_status`es.
