### PR TITLE
SALTO-6750: Sort verification methods fields in Okta verify authenticator

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1388,6 +1388,16 @@ const createCustomizations = ({
       },
     },
   },
+  AuthenticatorSettings: {
+    element: {
+      fieldCustomizations: {
+        userVerificationMethods: {
+          fieldType: 'list<string>',
+          sort: { properties: [] }
+        }
+      },
+    },
+  }
 })
 
 export const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1393,11 +1393,11 @@ const createCustomizations = ({
       fieldCustomizations: {
         userVerificationMethods: {
           fieldType: 'list<string>',
-          sort: { properties: [] }
-        }
+          sort: { properties: [] },
+        },
       },
     },
-  }
+  },
 })
 
 export const CLASSIC_ENGINE_UNSUPPORTED_TYPES = [

--- a/packages/okta-adapter/src/filters/common.ts
+++ b/packages/okta-adapter/src/filters/common.ts
@@ -16,6 +16,7 @@ const filterCreators: Record<string, FilterCreator> = {
   referencedInstanceNames: filters.referencedInstanceNamesFilterCreator(),
   addAlias: filters.addAliasFilterCreator(),
   query: filters.queryFilterCreator({}),
+  sortLists: filters.sortListsFilterCreator(),
 }
 
 export default filterCreators


### PR DESCRIPTION
Sort a field causing noise between fetches

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
