### PR TITLE
SALTO-6755: Salesforce Adapter Log fixes

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -363,7 +363,7 @@ export const retrieveMetadataInstances = async ({
       : await listMetadataObjects(client, typeName)
     configChanges.push(...listObjectsConfigChanges)
     if (typeName === LAYOUT_TYPE_ID_METADATA_TYPE) {
-      log.trace('Layout file properties are %s', inspectValue(res, {maxArrayLength: null}))
+      log.trace('Layout file properties are %s', inspectValue(res, { maxArrayLength: null }))
     }
     return _(res)
       .uniqBy(file => file.fullName)

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -363,7 +363,7 @@ export const retrieveMetadataInstances = async ({
       : await listMetadataObjects(client, typeName)
     configChanges.push(...listObjectsConfigChanges)
     if (typeName === LAYOUT_TYPE_ID_METADATA_TYPE) {
-      log.trace('Layout file properties are %s', inspectValue(res))
+      log.trace('Layout file properties are %s', inspectValue(res, {maxArrayLength: null}))
     }
     return _(res)
       .uniqBy(file => file.fullName)

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -410,7 +410,7 @@ export const fromRetrieveResult = async (
         typesWithDiff.add(file.type)
         log.trace(
           'Found differences in the xml parsing of instance of type %s: %s',
-          file.fullName,
+          file.type,
           inspectValue(detailedChanges),
         )
       }
@@ -462,6 +462,7 @@ export const fromRetrieveResult = async (
       return values === undefined ? undefined : { file, values }
     }),
   )
+  log.debug('xml parsing types  with diffs: [%s]', Array.from(typesWithDiff).join(', '))
   return instances.filter(isDefined)
 }
 


### PR DESCRIPTION
Salesforce Adapter Log fixes

---

- Changed the trace log to be explicit about the array length of the Layout FileProperties, to avoid the values being truncated.
- Fixed a printed value in the xml parsing numbers diff log. Added explicit log on affected types.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
