### PR TITLE
Throw the right error on InvalidSuiteAppCredentialsError

### DIFF
--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_client.ts
@@ -534,13 +534,16 @@ export default class SuiteAppClient {
       const result = await this.sendRestletRequest(operation)
       if (!this.ajv.validate<T[]>(schema, result)) {
         log.error(`${operation} failed. Got invalid results - %s: %o`, this.ajv.errorsText(), result)
-        throw Error(this.ajv.errorsText())
+        throw new Error(this.ajv.errorsText())
       }
       return result
-    } catch (e) {
-      const errorMessage = `${operation} operation failed. Received the following error: ${e.message}`
+    } catch (error) {
+      if (error instanceof InvalidSuiteAppCredentialsError) {
+        throw error
+      }
+      const errorMessage = `${operation} operation failed. Received the following error: ${error.message}`
       log.error(errorMessage)
-      throw Error(errorMessage)
+      throw new Error(errorMessage)
     }
   }
 


### PR DESCRIPTION
When we receive an invalid creds error inside the `listBundles` query we throw this error:
`listBundles operation failed. Received the following error: Invalid SuiteApp credentials`
We should instead throw the `InvalidSuiteAppCredentialsError` itself.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Throw a right error on InvalidSuiteAppCredentialsError

---
_User Notifications_: 
None
