### PR TITLE
SALTO-5887 JSM - support Field RequestType name change

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -75,6 +75,7 @@ type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFil
   enableAssetsObjectFieldConfiguration?: boolean
   automationPageSize?: number
   splitFieldContextOptions?: boolean
+  enableRequestTypeFieldNameAlignment?: boolean
 }
 
 export type MaskingConfig = {
@@ -328,6 +329,7 @@ const fetchConfigType = definitions.createUserFetchConfigType({
     enableAssetsObjectFieldConfiguration: { refType: BuiltinTypes.BOOLEAN },
     automationPageSize: { refType: BuiltinTypes.NUMBER },
     splitFieldContextOptions: { refType: BuiltinTypes.BOOLEAN },
+    enableRequestTypeFieldNameAlignment: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchCriteriaType: fetchFiltersType,
   omitElemID: true,

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -385,6 +385,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'fetch.enableAssetsObjectFieldConfiguration',
       'fetch.automationPageSize',
       'fetch.parseAdditionalAutomationExpressions',
+      'fetch.enableRequestTypeFieldNameAlignment',
       'deploy.taskMaxRetries',
       'deploy.taskRetryDelay',
       'deploy.ignoreMissingExtensions',

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -29,15 +29,16 @@ const getFieldType = (instance: InstanceElement): string | undefined =>
 
 const isCustomField = (instance: InstanceElement): boolean => instance.value.schema?.custom !== undefined
 
-const nameNaclCase = (baseName: string, instance: InstanceElement, config: JiraConfig): string => naclCase(
-  [
-    baseName,
-    config.fetch.addTypeToFieldName ?? true ? getFieldType(instance) : undefined,
-    isCustomField(instance) ? CUSTOM_FIELDS_SUFFIX : undefined,
-  ]
-    .filter(values.isDefined)
-    .join('__'),
-)
+const nameNaclCase = (baseName: string, instance: InstanceElement, config: JiraConfig): string =>
+  naclCase(
+    [
+      baseName,
+      config.fetch.addTypeToFieldName ?? true ? getFieldType(instance) : undefined,
+      isCustomField(instance) ? CUSTOM_FIELDS_SUFFIX : undefined,
+    ]
+      .filter(values.isDefined)
+      .join('__'),
+  )
 
 const getInstanceName = (instance: InstanceElement, config: JiraConfig, getElemIdFunc?: ElemIdGetter): string => {
   const baseName = generateInstanceNameFromConfig(instance.value, instance.elemID.typeName, config.apiDefinitions)

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -49,7 +49,11 @@ const getInstanceName = (instance: InstanceElement, config: JiraConfig, getElemI
 
   // SALTO-5887: JSM CustomerRequestType was changed to RequestType - support same id for both
   // we do not support id stickiness (through get element from state) in this case
-  if (config.fetch.enableRequestTypeFieldNameAlignment && baseName === 'Customer Request Type' && instance.value.isLocked) {
+  if (
+    config.fetch.enableRequestTypeFieldNameAlignment &&
+    baseName === 'Customer Request Type' &&
+    instance.value.isLocked
+  ) {
     const newName = getFieldElementName('Request Type', instance, config)
     log.trace(`'Customer Request Type' field was found. changing id to be based on 'Request Type': ${newName}`)
     return newName

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -9,11 +9,14 @@ import { Element, ElemIdGetter, InstanceElement, isInstanceElement } from '@salt
 import { elements as elementUtils, config as configUtils } from '@salto-io/adapter-components'
 import { naclCase } from '@salto-io/adapter-utils'
 import { values } from '@salto-io/lowerdash'
+import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { JiraConfig } from '../../config/config'
 import { JIRA } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { FIELD_TYPE_NAME } from './constants'
+
+const log = logger(module)
 
 const { generateInstanceNameFromConfig } = elementUtils
 
@@ -26,6 +29,16 @@ const getFieldType = (instance: InstanceElement): string | undefined =>
 
 const isCustomField = (instance: InstanceElement): boolean => instance.value.schema?.custom !== undefined
 
+const nameNaclCase = (baseName: string, instance: InstanceElement, config: JiraConfig): string => naclCase(
+  [
+    baseName,
+    config.fetch.addTypeToFieldName ?? true ? getFieldType(instance) : undefined,
+    isCustomField(instance) ? CUSTOM_FIELDS_SUFFIX : undefined,
+  ]
+    .filter(values.isDefined)
+    .join('__'),
+)
+
 const getInstanceName = (instance: InstanceElement, config: JiraConfig, getElemIdFunc?: ElemIdGetter): string => {
   const baseName = generateInstanceNameFromConfig(instance.value, instance.elemID.typeName, config.apiDefinitions)
 
@@ -33,15 +46,15 @@ const getInstanceName = (instance: InstanceElement, config: JiraConfig, getElemI
     return instance.elemID.name
   }
 
-  const defaultName = naclCase(
-    [
-      baseName,
-      config.fetch.addTypeToFieldName ?? true ? getFieldType(instance) : undefined,
-      isCustomField(instance) ? CUSTOM_FIELDS_SUFFIX : undefined,
-    ]
-      .filter(values.isDefined)
-      .join('__'),
-  )
+  // SALTO-5887: JSM CustomerRequestType was changed to RequestType - support same id for both
+  // we do not support id stickiness (through get element from state) in this case
+  if (baseName === 'Customer Request Type' && instance.value.isLocked) {
+    const newName = nameNaclCase('Request Type', instance, config)
+    log.trace(`'Customer Request Type' field was found. changing id to be based on 'Request Type': ${newName}`)
+    return newName
+  }
+
+  const defaultName = nameNaclCase(baseName, instance, config)
 
   const { serviceIdField } = configUtils.getConfigWithDefault(
     config.apiDefinitions.types[instance.elemID.typeName].transformation,

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -29,7 +29,7 @@ const getFieldType = (instance: InstanceElement): string | undefined =>
 
 const isCustomField = (instance: InstanceElement): boolean => instance.value.schema?.custom !== undefined
 
-const nameNaclCase = (baseName: string, instance: InstanceElement, config: JiraConfig): string =>
+const getFieldElementName = (baseName: string, instance: InstanceElement, config: JiraConfig): string =>
   naclCase(
     [
       baseName,
@@ -49,13 +49,13 @@ const getInstanceName = (instance: InstanceElement, config: JiraConfig, getElemI
 
   // SALTO-5887: JSM CustomerRequestType was changed to RequestType - support same id for both
   // we do not support id stickiness (through get element from state) in this case
-  if (baseName === 'Customer Request Type' && instance.value.isLocked) {
-    const newName = nameNaclCase('Request Type', instance, config)
+  if (config.fetch.enableRequestTypeFieldNameAlignment && baseName === 'Customer Request Type' && instance.value.isLocked) {
+    const newName = getFieldElementName('Request Type', instance, config)
     log.trace(`'Customer Request Type' field was found. changing id to be based on 'Request Type': ${newName}`)
     return newName
   }
 
-  const defaultName = nameNaclCase(baseName, instance, config)
+  const defaultName = getFieldElementName(baseName, instance, config)
 
   const { serviceIdField } = configUtils.getConfigWithDefault(
     config.apiDefinitions.types[instance.elemID.typeName].transformation,

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -156,4 +156,69 @@ describe('field_name_filter', () => {
     await filter.onFetch(elements)
     expect(elements.map(e => e.elemID.name)).toEqual(['custom2'])
   })
+
+  describe('SALTO-5887: JSM CustomerRequestType was changed to RequestType - support same id for both', () => {
+    it.only('change field name', async () => {
+      const custom = new InstanceElement('Customer Request Type', fieldType, {
+        name: 'Customer Request Type',
+        schema: {
+          custom: 'someType',
+        },
+        isLocked: true,
+      })
+      config.fetch.enableRequestTypeFieldNameAlignment = true
+
+      const elements = [custom]
+      await filter.onFetch(elements)
+      expect(elemIdGetter).not.toHaveBeenCalled()
+      expect(elements.map(e => e.elemID.name)).toEqual(['Request_Type__c@suu'])
+    })
+
+    it.only('do nothing when FF off', async () => {
+      const custom = new InstanceElement('Customer Request Type', fieldType, {
+        name: 'Customer Request Type',
+        schema: {
+          custom: 'someType',
+        },
+        isLocked: true,
+      })
+
+      const elements = [custom]
+      await filter.onFetch(elements)
+      expect(elemIdGetter).toHaveBeenCalled()
+      expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type__c@ssuu'])
+    })
+
+    it.only('do nothing for non locked fields', async () => {
+      const custom = new InstanceElement('Customer Request Type', fieldType, {
+        name: 'Customer Request Type',
+        schema: {
+          custom: 'someType',
+        },
+        isLocked: false,
+      })
+      config.fetch.enableRequestTypeFieldNameAlignment = true
+
+      const elements = [custom]
+      await filter.onFetch(elements)
+      expect(elemIdGetter).toHaveBeenCalled()
+      expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type__c@ssuu'])
+    })
+
+    it.only('do nothing for irrelevant an field name', async () => {
+      const custom = new InstanceElement('Customer Request Type', fieldType, {
+        name: 'Customer Request Type la la la',
+        schema: {
+          custom: 'someType',
+        },
+        isLocked: true,
+      })
+      config.fetch.enableRequestTypeFieldNameAlignment = true
+
+      const elements = [custom]
+      await filter.onFetch(elements)
+      expect(elemIdGetter).toHaveBeenCalled()
+      expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type_la_la_la__c@sssssuu'])
+    })
+  })
 })

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -158,7 +158,7 @@ describe('field_name_filter', () => {
   })
 
   describe('SALTO-5887: JSM CustomerRequestType was changed to RequestType - support same id for both', () => {
-    it.only('change field name', async () => {
+    it('change field name', async () => {
       const custom = new InstanceElement('Customer Request Type', fieldType, {
         name: 'Customer Request Type',
         schema: {
@@ -174,7 +174,7 @@ describe('field_name_filter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['Request_Type__c@suu'])
     })
 
-    it.only('do nothing when FF off', async () => {
+    it('do nothing when FF off', async () => {
       const custom = new InstanceElement('Customer Request Type', fieldType, {
         name: 'Customer Request Type',
         schema: {
@@ -189,7 +189,7 @@ describe('field_name_filter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type__c@ssuu'])
     })
 
-    it.only('do nothing for non locked fields', async () => {
+    it('do nothing for non locked fields', async () => {
       const custom = new InstanceElement('Customer Request Type', fieldType, {
         name: 'Customer Request Type',
         schema: {
@@ -205,7 +205,7 @@ describe('field_name_filter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type__c@ssuu'])
     })
 
-    it.only('do nothing for irrelevant an field name', async () => {
+    it('do nothing for irrelevant an field name', async () => {
       const custom = new InstanceElement('Customer Request Type', fieldType, {
         name: 'Customer Request Type la la la',
         schema: {

--- a/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_name_filter.test.ts
@@ -205,7 +205,7 @@ describe('field_name_filter', () => {
       expect(elements.map(e => e.elemID.name)).toEqual(['Customer_Request_Type__c@ssuu'])
     })
 
-    it('do nothing for irrelevant an field name', async () => {
+    it('do nothing for an irrelevant field name', async () => {
       const custom = new InstanceElement('Customer Request Type', fieldType, {
         name: 'Customer Request Type la la la',
         schema: {


### PR DESCRIPTION
Temp solution till we handle id-alignment generally

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira Adapter_:
- SALTO-5887: Fix a bug where RequestType field name in JSM is different for some old envs

---
_User Notifications_: 
None
