### PR TITLE
SALTO-6716: (Bug-fix) Salesforce Standard Layouts are being removed and added randomly

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -367,8 +367,8 @@ export const retrieveMetadataInstances = async ({
       log.trace('Layout file properties are %s', inspectValue(res, { maxArrayLength: null }))
     }
     return _(res)
-      .uniqBy(file => file.fullName)
       .map(file => getPropsWithFullName(file, fetchProfile.addNamespacePrefixToFullName, client.orgNamespace))
+      .uniqBy(file => file.fullName)
       .value()
   }
 

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -239,6 +239,50 @@ describe('SalesforceAdapter fetch', () => {
       }
     }
 
+    describe('When a managed Instance with no namespace prefix has the same fullName as another Instance', () => {
+      const NAMESPACE1 = 'namespace1'
+      const NAMESPACE2 = 'namespace2'
+      beforeEach(() => {
+        mockMetadataType({ xmlName: 'Layout' }, { valueTypeFields: [] }, [
+          {
+            props: {
+              fullName: 'Account-Account Layout',
+              namespacePrefix: NAMESPACE1,
+            },
+            values: {
+              fullName: 'Account-Account Layout',
+            },
+          },
+          {
+            props: {
+              fullName: 'Account-Account Layout',
+              namespacePrefix: NAMESPACE2,
+            },
+            values: {
+              fullName: 'Account-Account Layout',
+            },
+          },
+          {
+            props: {
+              fullName: 'Account-Account Layout',
+            },
+            values: {
+              fullName: 'Account-Account Layout',
+            },
+          },
+        ])
+      })
+      it('should attempt to retrieve all the Instances', async () => {
+        await adapter.fetch(mockFetchOpts)
+        const request = connection.metadata.retrieve.mock.calls[0][0]
+        expect(request?.unpackaged?.types?.find(v => v.name === 'Layout')?.members).toIncludeSameMembers([
+          'Account-Account Layout',
+          `Account-${NAMESPACE1}__Account Layout`,
+          `Account-${NAMESPACE2}__Account Layout`,
+        ])
+      })
+    })
+
     describe('profiles fetch with changes detection', () => {
       const DATE = '2023-01-12T00:00:00.000Z'
       const GREATER_DATE = '2023-02-12T00:00:00.000Z'


### PR DESCRIPTION
(Bug-fix) Salesforce Standard Layouts are being removed and added randomly

---

The bug occurred since we've uniqued the **fileProperties** before fixing properties of managed Elements that don't have the namespace prefix as part of their fullName. See added UT for a clear example. It happened sporadically since the order of the `list` result is inconsistent.

---
_Release Notes_: 
_Salesforce Adapter_:
- (Bug-fix) Standard Layouts are being removed and added randomly

---
_User Notifications_: 
_Salesforce_:
- You may notice new Elements that were omitted previously due to the bug.
