### PR TITLE
Salto-6621: Skip minifying profiles when dumping SFDX

### DIFF
--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -278,6 +278,6 @@ export const runFiltersOnFetch = async (
   client: SalesforceClient,
   context: Partial<FilterContext>,
   elements: Element[],
-  filterCreators = allFilters.map(({ creator }) => creator),
+  filterCreators = allFilters,
 ): Promise<void | FilterResult> =>
   filter.filtersRunner({ client, config: { ...defaultFilterContext, ...context } }, filterCreators).onFetch(elements)

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -263,9 +263,6 @@ export const allFilters: Array<FilterCreator> = [
   changedAtSingletonFilter,
 ]
 
-// By default we run all filters and provide a client
-const defaultFilters = allFilters
-
 export interface SalesforceAdapterParams {
   // Max items to fetch in one retrieve request
   maxItemsInRetrieveRequest?: number
@@ -450,7 +447,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
     maxItemsInRetrieveRequest = constants.DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST,
     metadataToRetrieve = METADATA_TO_RETRIEVE,
     nestedMetadataTypes = NESTED_METADATA_TYPES,
-    filterCreators = defaultFilters,
+    filterCreators = allFilters,
     client,
     getElemIdFunc,
     elementsSource,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -111,15 +111,7 @@ import mergeProfilesWithSourceValuesFilter from './filters/merge_profiles_with_s
 import flowCoordinatesFilter from './filters/flow_coordinates'
 import taskAndEventCustomFields from './filters/task_and_event_custom_fields'
 import { getConfigFromConfigChanges } from './config_change'
-import {
-  LocalFilterCreator,
-  Filter,
-  FilterResult,
-  RemoteFilterCreator,
-  LocalFilterCreatorDefinition,
-  RemoteFilterCreatorDefinition,
-  FilterContext,
-} from './filter'
+import { Filter, FilterResult, FilterContext, FilterCreator } from './filter'
 import {
   addDefaults,
   apiNameSync,
@@ -176,106 +168,103 @@ const { isDefined } = values
 
 const log = logger(module)
 
-export const allFilters: Array<LocalFilterCreatorDefinition | RemoteFilterCreatorDefinition> = [
-  { creator: waveStaticFilesFilter },
-  {
-    creator: createMissingInstalledPackagesInstancesFilter,
-    addsNewInformation: true,
-  },
-  { creator: settingsFilter, addsNewInformation: true },
+export const allFilters: Array<FilterCreator> = [
+  waveStaticFilesFilter,
+  createMissingInstalledPackagesInstancesFilter,
+  settingsFilter,
   // should run before customObjectsFilter
-  { creator: workflowFilter },
+  workflowFilter,
   // fetchFlowsFilter should run before flowFilter
-  { creator: flowsFilter, addsNewInformation: true },
+  flowsFilter,
   // customMetadataToObjectTypeFilter should run before customObjectsFromDescribeFilter
-  { creator: customMetadataToObjectTypeFilter },
+  customMetadataToObjectTypeFilter,
   // customObjectsFilter depends on missingFieldsFilter and settingsFilter
-  { creator: customObjectsFromDescribeFilter, addsNewInformation: true },
-  { creator: organizationWideDefaults, addsNewInformation: true },
+  customObjectsFromDescribeFilter,
+  organizationWideDefaults,
   // customSettingsFilter depends on customObjectsFilter
-  { creator: customSettingsFilter, addsNewInformation: true },
-  { creator: customObjectsToObjectTypeFilter },
+  customSettingsFilter,
+  customObjectsToObjectTypeFilter,
   // customObjectsInstancesFilter depends on customObjectsToObjectTypeFilter
-  { creator: customObjectsInstancesFilter, addsNewInformation: true },
-  { creator: removeFieldsAndValuesFilter },
-  { creator: removeRestrictionAnnotationsFilter },
+  customObjectsInstancesFilter,
+  removeFieldsAndValuesFilter,
+  removeRestrictionAnnotationsFilter,
   // addMissingIdsFilter should run after customObjectsFilter
-  { creator: addMissingIdsFilter, addsNewInformation: true },
-  { creator: customMetadataRecordsFilter },
-  { creator: layoutFilter },
+  addMissingIdsFilter,
+  customMetadataRecordsFilter,
+  layoutFilter,
   // profilePermissionsFilter depends on layoutFilter because layoutFilter
   // changes ElemIDs that the profile references
-  { creator: profilePermissionsFilter },
+  profilePermissionsFilter,
   // emailTemplateFilter should run before convertMapsFilter
-  { creator: emailTemplateFilter },
+  emailTemplateFilter,
   // convertMapsFilter should run before profile fieldReferencesFilter
-  { creator: convertMapsFilter },
-  { creator: standardValueSetFilter, addsNewInformation: true },
-  { creator: flowFilter },
-  { creator: customObjectInstanceReferencesFilter, addsNewInformation: true },
-  { creator: cpqReferencableFieldReferencesFilter },
-  { creator: cpqCustomScriptFilter },
-  { creator: cpqLookupFieldsFilter },
+  convertMapsFilter,
+  standardValueSetFilter,
+  flowFilter,
+  customObjectInstanceReferencesFilter,
+  cpqReferencableFieldReferencesFilter,
+  cpqCustomScriptFilter,
+  cpqLookupFieldsFilter,
   // cpqRulesAndConditionsFilter depends on cpqReferencableFieldReferencesFilter
-  { creator: cpqRulesAndConditionsRefsFilter },
-  { creator: animationRulesFilter },
-  { creator: samlInitMethodFilter },
-  { creator: topicsForObjectsFilter },
-  { creator: globalValueSetFilter },
-  { creator: staticResourceFileExtFilter },
-  { creator: extendTriggersMetadataFilter, addsNewInformation: true },
-  { creator: profilePathsFilter, addsNewInformation: true },
-  { creator: territoryFilter },
-  { creator: elementsUrlFilter, addsNewInformation: true },
-  { creator: nestedInstancesAuthorInformation, addsNewInformation: true },
-  { creator: customObjectAuthorFilter, addsNewInformation: true },
-  { creator: dataInstancesAuthorFilter, addsNewInformation: true },
-  { creator: sharingRulesAuthorFilter, addsNewInformation: true },
-  { creator: hideReadOnlyValuesFilter },
-  { creator: currencyIsoCodeFilter },
-  { creator: splitCustomLabels },
-  { creator: xmlAttributesFilter },
-  { creator: minifyDeployFilter },
-  { creator: formulaDepsFilter },
+  cpqRulesAndConditionsRefsFilter,
+  animationRulesFilter,
+  samlInitMethodFilter,
+  topicsForObjectsFilter,
+  globalValueSetFilter,
+  staticResourceFileExtFilter,
+  extendTriggersMetadataFilter,
+  profilePathsFilter,
+  territoryFilter,
+  elementsUrlFilter,
+  nestedInstancesAuthorInformation,
+  customObjectAuthorFilter,
+  dataInstancesAuthorFilter,
+  sharingRulesAuthorFilter,
+  hideReadOnlyValuesFilter,
+  currencyIsoCodeFilter,
+  splitCustomLabels,
+  xmlAttributesFilter,
+  minifyDeployFilter,
+  formulaDepsFilter,
   // centralizeTrackingInfoFilter depends on customObjectsToObjectTypeFilter and must run before customTypeSplit
-  { creator: centralizeTrackingInfoFilter },
+  centralizeTrackingInfoFilter,
   // The following filters should remain last in order to make sure they fix all elements
-  { creator: convertListsFilter },
-  { creator: convertTypeFilter },
+  convertListsFilter,
+  convertTypeFilter,
   // should be after convertTypeFilter & convertMapsFilter and before profileInstanceSplitFilter
-  { creator: enumFieldPermissionsFilter },
+  enumFieldPermissionsFilter,
   // should run after convertListsFilter
-  { creator: replaceFieldValuesFilter },
-  { creator: valueToStaticFileFilter },
-  { creator: fieldReferencesFilter },
+  replaceFieldValuesFilter,
+  valueToStaticFileFilter,
+  fieldReferencesFilter,
   // should run after customObjectsInstancesFilter for now
-  { creator: referenceAnnotationsFilter },
+  referenceAnnotationsFilter,
   // foreignLeyReferences should come after referenceAnnotationsFilter
-  { creator: foreignKeyReferencesFilter },
+  foreignKeyReferencesFilter,
   // extraDependenciesFilter should run after addMissingIdsFilter
-  { creator: extraDependenciesFilter, addsNewInformation: true },
-  { creator: installedPackageGeneratedDependencies },
-  { creator: omitStandardFieldsNonDeployableValuesFilter },
+  extraDependenciesFilter,
+  installedPackageGeneratedDependencies,
+  omitStandardFieldsNonDeployableValuesFilter,
   // taskAndEventCustomFields should run before customTypeSplit
-  { creator: taskAndEventCustomFields },
+  taskAndEventCustomFields,
   // customTypeSplit should run after omitStandardFieldsNonDeployableValuesFilter
-  { creator: customTypeSplit },
-  { creator: mergeProfilesWithSourceValuesFilter },
+  customTypeSplit,
+  mergeProfilesWithSourceValuesFilter,
   // profileInstanceSplitFilter should run after mergeProfilesWithSourceValuesFilter
-  { creator: profileInstanceSplitFilter },
+  profileInstanceSplitFilter,
   // Any filter that relies on _created_at or _changed_at should run after removeUnixTimeZero
-  { creator: removeUnixTimeZeroFilter },
-  { creator: metadataInstancesAliasesFilter },
-  { creator: importantValuesFilter },
-  { creator: hideTypesFolder },
-  { creator: generatedDependenciesFilter },
-  { creator: flowCoordinatesFilter },
+  removeUnixTimeZeroFilter,
+  metadataInstancesAliasesFilter,
+  importantValuesFilter,
+  hideTypesFolder,
+  generatedDependenciesFilter,
+  flowCoordinatesFilter,
   // createChangedAtSingletonInstanceFilter should run last
-  { creator: changedAtSingletonFilter },
+  changedAtSingletonFilter,
 ]
 
 // By default we run all filters and provide a client
-const defaultFilters = allFilters.map(({ creator }) => creator)
+const defaultFilters = allFilters
 
 export interface SalesforceAdapterParams {
   // Max items to fetch in one retrieve request
@@ -294,7 +283,7 @@ export interface SalesforceAdapterParams {
   nestedMetadataTypes?: Record<string, NestedMetadataTypeInfo>
 
   // Filters to deploy to all adapter operations
-  filterCreators?: Array<LocalFilterCreator | RemoteFilterCreator>
+  filterCreators?: Array<FilterCreator>
 
   // client to use
   client: SalesforceClient

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -48,7 +48,6 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   indexedEmailTemplateAttachments: false,
   skipParsingXmlNumbers: false,
   logDiffsFromParsingXmlNumbers: true,
-  performSideEffectDeletes: false,
   extendTriggersMetadata: false,
   removeReferenceFromFilterItemToRecordType: false,
 }

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -22,16 +22,9 @@ export type FilterContext = {
   lastChangeDateOfTypesWithNestedInstances?: LastChangeDateOfTypesWithNestedInstances
 }
 
-type FilterFilesContext = {
-  baseDirName: string
-  sourceFileNames: string[]
-  staticFileNames: string[]
-}
-
 export type FilterOpts = {
-  client: SalesforceClient
+  client?: SalesforceClient
   config: FilterContext
-  files: FilterFilesContext
 }
 
 export type FilterResult = filterUtils.FilterResult & {
@@ -40,20 +33,4 @@ export type FilterResult = filterUtils.FilterResult & {
 
 export type Filter = filter.Filter<FilterResult>
 
-// Local filters only use information in existing elements
-// They can change the format of elements, but cannot use external sources of information
-type LocalFilterOpts = Pick<FilterOpts, 'config'>
-export type LocalFilterCreator = filter.FilterCreator<FilterResult, LocalFilterOpts>
-
-// Remote filters can add more information to existing elements
-// They should not change the format of existing elements, they should focus only on adding
-// the new information
-type RemoteFilterOpts = Pick<FilterOpts, 'config' | 'client'>
-export type RemoteFilterCreator = filter.RemoteFilterCreator<FilterResult, RemoteFilterOpts>
-
-// Files filters can run on folders and get additional context from the list of available files
-type FilesFilterOpts = Pick<FilterOpts, 'config' | 'files'>
-export type FilesFilterCreator = filter.FilterCreator<FilterResult, FilesFilterOpts>
-
-export type LocalFilterCreatorDefinition = filter.LocalFilterCreatorDefinition<FilterResult, LocalFilterOpts>
-export type RemoteFilterCreatorDefinition = filter.RemoteFilterCreatorDefinition<FilterResult, RemoteFilterOpts>
+export type FilterCreator = filter.FilterCreator<FilterResult, FilterOpts>

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -9,7 +9,7 @@ import { Element, isObjectType, isField, isInstanceElement } from '@salto-io/ada
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName, metadataType } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import {
@@ -86,7 +86,7 @@ export const WARNING_MESSAGE =
 /**
  * Add missing env-specific ids using listMetadataObjects.
  */
-const filter: RemoteFilterCreator = ({ client, config }) => ({
+const filter: FilterCreator = ({ client, config }) => ({
   name: 'addMissingIdsFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -94,6 +94,9 @@ const filter: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'addMissingIds',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
       const groupedElements = await groupByAsync(await elementsWithMissingIds(elements), metadataType)
       log.debug(`Getting missing ids for the following types: ${Object.keys(groupedElements)}`)
       const errorElements = (

--- a/packages/salesforce-adapter/src/filters/animation_rules.ts
+++ b/packages/salesforce-adapter/src/filters/animation_rules.ts
@@ -8,7 +8,7 @@
 import wu from 'wu'
 import { Element, ElemID, ObjectType, InstanceElement, getRestriction } from '@salto-io/adapter-api'
 import { findObjectType, findInstances } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 
 export const ANIMATION_RULE_TYPE_ID = new ElemID(SALESFORCE, 'AnimationRule')
@@ -21,7 +21,7 @@ export const RECORD_TYPE_CONTEXT = 'recordTypeContext'
  * returns only the first letter of the picklist value
  *
  */
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'animationRulesFilter',
   /**
    * Upon fetch, transforms ANIMATION_FREQUENCY & RECORD_TYPE_CONTEXT values of animation rule

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -13,7 +13,7 @@ import { collections, values } from '@salto-io/lowerdash'
 import { inspectValue } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELD, CUSTOM_OBJECT, INTERNAL_ID_ANNOTATION } from '../../constants'
 import { getAuthorAnnotations, MetadataInstanceElement } from '../../transformers/transformer'
-import { RemoteFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import {
   apiNameSync,
@@ -132,7 +132,7 @@ export const WARNING_MESSAGE =
 /*
  * add author information to object types and fields.
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectAuthorFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -140,6 +140,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'authorInformation',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const customTypeFilePropertiesMap = await getCustomObjectFileProperties(client)
       const customFieldsFilePropertiesMap = await getCustomFieldFileProperties(client)
       const instancesByParent = _.groupBy(

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -8,7 +8,7 @@
 import { CORE_ANNOTATIONS, Element, InstanceElement } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { isInstanceOfCustomObject } from '../../transformers/transformer'
-import { RemoteFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { conditionQueries, ensureSafeFilterFetch, queryClient } from '../utils'
 
@@ -50,7 +50,7 @@ export const WARNING_MESSAGE =
 /*
  * add author information to data instance elements.
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'dataInstancesAuthorFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -58,6 +58,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'authorInformation',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const customObjectInstances = (await awu(elements)
         .filter(isInstanceOfCustomObject)
         .toArray()) as InstanceElement[]

--- a/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
@@ -8,7 +8,7 @@
 import { Element } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
-import { RemoteFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import { apiNameSync, ensureSafeFilterFetch, isMetadataInstanceElementSync } from '../utils'
 import { WORKFLOW_FIELD_TO_TYPE } from '../workflow'
 import { NESTED_INSTANCE_VALUE_TO_TYPE_NAME } from '../custom_objects_to_object_type'
@@ -68,7 +68,7 @@ const setAuthorInformationForInstancesOfType = async ({
 /*
  * add author information on nested instances
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'nestedInstancesAuthorFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -76,6 +76,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'authorInformation',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const nestedInstancesByType = _.pick(
         _.groupBy(elements.filter(isMetadataInstanceElementSync), e => apiNameSync(e.getTypeSync())),
         NESTED_INSTANCES_METADATA_TYPES,

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -13,7 +13,7 @@ import { collections, values } from '@salto-io/lowerdash'
 import { inspectValue } from '@salto-io/adapter-utils'
 import { SHARING_RULES_TYPE } from '../../constants'
 import { getAuthorAnnotations } from '../../transformers/transformer'
-import { RemoteFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import SalesforceClient from '../../client/client'
 import { ensureSafeFilterFetch, isInstanceOfType } from '../utils'
 
@@ -56,7 +56,7 @@ export const WARNING_MESSAGE =
 /*
  * add author information to sharing rules instances.
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'sharingRulesAuthorFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -64,6 +64,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'authorInformation',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const sharingRulesMap = await fetchAllSharingRules(client)
       const sharingRulesInstances = await awu(elements)
         .filter(isInstanceElement)

--- a/packages/salesforce-adapter/src/filters/centralize_tracking_info.ts
+++ b/packages/salesforce-adapter/src/filters/centralize_tracking_info.ts
@@ -25,7 +25,7 @@ import {
   ReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { isCustomObject, isFieldOfCustomObject } from '../transformers/transformer'
 import {
   FIELD_ANNOTATIONS,
@@ -202,7 +202,7 @@ const createHistoryTrackingFieldChange = (
  * Note: we assume this filter runs *after* custom objects are turned into types (custom_object_to_object_type) but
  * *before* these types are split up into different elements (custom_type_split)
  * */
-const filter: LocalFilterCreator = () => {
+const filter: FilterCreator = () => {
   let fieldsWithSyntheticChanges: Set<string> = new Set()
   return {
     name: 'centralizeTrackingInfo',

--- a/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
+++ b/packages/salesforce-adapter/src/filters/changed_at_singleton.ts
@@ -7,7 +7,7 @@
  */
 import { CORE_ANNOTATIONS, Element, ElemID, InstanceElement, Values } from '@salto-io/adapter-api'
 import _ from 'lodash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ArtificialTypes, DATA_INSTANCES_CHANGED_AT_MAGIC } from '../constants'
 import {
   apiNameSync,
@@ -42,7 +42,7 @@ const dateStringOfMostRecentlyChangedInstance = (instances: InstanceElement[]): 
     .filter(_.isString)
     .maxBy(changedAt => new Date(changedAt).getTime())
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'changedAtSingletonFilter',
   onFetch: async (elements: Element[]) => {
     const { lastChangeDateOfTypesWithNestedInstances = {} } = config

--- a/packages/salesforce-adapter/src/filters/convert_lists.ts
+++ b/packages/salesforce-adapter/src/filters/convert_lists.ts
@@ -23,7 +23,7 @@ import {
 } from '@salto-io/adapter-api'
 import { applyRecursive, resolvePath } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 import hardcodedListsData from './hardcoded_lists.json'
 import { metadataType } from '../transformers/transformer'
@@ -185,7 +185,7 @@ export const makeFilter =
     unorderedListFields: ReadonlyArray<UnorderedList>,
     unorderedListAnnotations: ReadonlyArray<UnorderedList>,
     hardcodedLists: ReadonlyArray<string>,
-  ): LocalFilterCreator =>
+  ): FilterCreator =>
   () => ({
     name: 'convertListsFilter',
     /**

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -32,7 +32,7 @@ import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { naclCase, applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   API_NAME_SEPARATOR,
   PROFILE_METADATA_TYPE,
@@ -402,7 +402,7 @@ export const findTypeToConvert = async (
  * Convert certain instances' fields into maps, so that they are easier to view,
  * could be referenced, and can be split across multiple files.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'convertMapsFilter',
   onFetch: async (elements: Element[]) => {
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -8,14 +8,14 @@
 import { Element, isObjectType, isInstanceElement } from '@salto-io/adapter-api'
 import { transformValuesSync } from '@salto-io/adapter-utils'
 import wu from 'wu'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { transformPrimitive } from '../transformers/transformer'
 
 /**
  * Convert types of values in instance elements to match the expected types according to the
  * instance type definition.
  */
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'convertTypeFilter',
   /**
    * Upon fetch, convert all instance values to their correct type according to the

--- a/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/custom_script.ts
@@ -28,7 +28,7 @@ import {
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import { isInstanceOfTypeChange } from '../utils'
 import {
   CPQ_CUSTOM_SCRIPT,
@@ -163,7 +163,7 @@ const applyFuncOnCustomScriptFieldChange = async (
     .forEach(change => applyFunctionToChangeData(change, fn))
 }
 
-const filter: LocalFilterCreator = () => ({
+const filter: FilterCreator = () => ({
   name: 'cpqCustomScriptFilter',
   onFetch: async (elements: Element[]) => {
     const customObjects = (await awu(elements).filter(isCustomObject).toArray()) as ObjectType[]

--- a/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/hide_read_only_values.ts
@@ -7,13 +7,13 @@
  */
 import { Element, CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import { isCustomObject } from '../../transformers/transformer'
 import { FIELD_ANNOTATIONS } from '../../constants'
 
 const { awu } = collections.asynciterable
 
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'hideReadOnlyValuesFilter',
   onFetch: async (elements: Element[]) => {
     if (config.fetchProfile.dataManagement?.showReadOnlyValues === true) {

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -23,7 +23,7 @@ import {
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import { apiName, isCustomObject, relativeApiName } from '../../transformers/transformer'
 import {
   FIELD_ANNOTATIONS,
@@ -259,7 +259,7 @@ const applyFuncOnCustomObjectWithMappingLookupChange = async (
   await awu(customObjectWithMappingLookupChanges).forEach(async change => applyFunctionToChangeData(change, fn))
 }
 
-const filter: LocalFilterCreator = () => ({
+const filter: FilterCreator = () => ({
   name: 'cpqLookupFieldsFilter',
   onFetch: async (elements: Element[]) => {
     log.debug('Started replacing lookupObject values with references')

--- a/packages/salesforce-adapter/src/filters/cpq/referencable_field_references.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/referencable_field_references.ts
@@ -21,7 +21,7 @@ import { collections, types } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import {
   CPQ_FILTER_SOURCE_FIELD,
   CPQ_FILTER_SOURCE_OBJECT,
@@ -131,7 +131,7 @@ const createDeployableInstance = (instance: InstanceElement): InstanceElement =>
   return deployableInstance
 }
 
-const filter: LocalFilterCreator = () => {
+const filter: FilterCreator = () => {
   let originalChangesByFullName: Record<string, Change<InstanceElement>>
   return {
     name: 'cpqReferencableFieldReferencesFilter',

--- a/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/rules_and_conditions_refs.ts
@@ -43,7 +43,7 @@ import {
   SBAA_APPROVAL_RULE,
   SBAA_INDEX_FIELD,
 } from '../../constants'
-import { LocalFilterCreator } from '../../filter'
+import { FilterCreator } from '../../filter'
 import {
   apiNameSync,
   buildElementsSourceForFetch,
@@ -231,7 +231,7 @@ const isCPQRuleChange = (change: Change): change is Change<InstanceElement> =>
   isInstanceOfCustomObjectChangeSync(change) &&
   ruleTypeNames.includes(apiNameSync(getChangeData(change).getTypeSync()) ?? '')
 
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   const templateMappingByRuleType: Partial<Record<string, Record<string, TemplateExpression>>> = {}
   return {
     name: 'cpqRulesAndConditionsFilter',

--- a/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
+++ b/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
@@ -9,7 +9,7 @@ import { Element, isInstanceElement, isObjectType, ObjectType } from '@salto-io/
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { FileProperties } from '@salto-io/jsforce-types'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import { isInstanceOfType, listMetadataObjects } from './utils'
 import { INSTALLED_PACKAGE_METADATA, INSTANCE_FULL_NAME_FIELD } from '../constants'
 import { notInSkipList } from '../fetch'
@@ -25,10 +25,13 @@ const createMissingInstalledPackageInstance = (file: FileProperties, installedPa
     getAuthorAnnotations(file),
   )
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'createMissingInstalledPackagesInstancesFilter',
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult | undefined> => {
+    if (client === undefined) {
+      return
+    }
     const installedPackageType = await awu(elements)
       .filter(isObjectType)
       .find(async objectType => (await apiName(objectType)) === INSTALLED_PACKAGE_METADATA)

--- a/packages/salesforce-adapter/src/filters/currency_iso_code.ts
+++ b/packages/salesforce-adapter/src/filters/currency_iso_code.ts
@@ -18,7 +18,7 @@ import {
   getChangeData,
 } from '@salto-io/adapter-api'
 import Joi from 'joi'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   SALESFORCE,
   FIELD_ANNOTATIONS,
@@ -94,7 +94,7 @@ const createCurrencyCodesInstance = (supportedCurrencies?: ValueSet): InstanceEl
  * Build a global list of available currency code, and a replace all the explicit ValueSets
  * with ValueSetName which points to it
  */
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'currencyIsoCodeFilter',
   onFetch: async (elements: Element[]) => {
     const affectedElements = elements.filter(isObjectType).filter(isTypeWithCurrencyIsoCode)

--- a/packages/salesforce-adapter/src/filters/custom_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata.ts
@@ -25,7 +25,7 @@ import {
   Field,
 } from '@salto-io/adapter-api'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   buildElementsSourceForFetch,
   isCustomMetadataRecordInstance,
@@ -246,7 +246,7 @@ const toDeployableChange = async (
     : toChange({ after: deployableAfter })
 }
 
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   let originalChangesByApiName: Record<string, Change>
   return {
     name: 'customMetadataRecordsFilter',

--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -20,7 +20,7 @@ import {
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { FilterContext, LocalFilterCreator } from '../filter'
+import { FilterContext, FilterCreator } from '../filter'
 import { CUSTOM_METADATA, CUSTOM_METADATA_META_TYPE, CUSTOM_METADATA_SUFFIX, CUSTOM_OBJECT } from '../constants'
 import { createCustomObjectChange, createCustomTypeFromCustomObjectInstance } from './custom_objects_to_object_type'
 import { apiName, createMetaType, isMetadataObjectType } from '../transformers/transformer'
@@ -70,7 +70,7 @@ const getApiNameOfRelatedChange = async (change: Change<ObjectType | Field>): Pr
   return isField(element) ? apiName(element.parent) : apiName(element)
 }
 
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   let groupedOriginalChangesByApiName: Record<string, Change[]>
   return {
     name: 'customMetadataToObjectTypeFilter',

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -32,7 +32,7 @@ import {
   ObjectType,
   isInstanceElement,
 } from '@salto-io/adapter-api'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import { apiName, isInstanceOfCustomObject } from '../transformers/transformer'
 import { FIELD_ANNOTATIONS, KEY_PREFIX, KEY_PREFIX_LENGTH, SALESFORCE } from '../constants'
 import {
@@ -432,10 +432,13 @@ const buildCustomObjectPrefixKeyMap = async (elements: Element[]): Promise<Recor
   return mapValuesAsync(typeMap, async (objectType: ObjectType) => apiName(objectType))
 }
 
-const filter: RemoteFilterCreator = ({ client, config }) => ({
+const filter: FilterCreator = ({ client, config }) => ({
   name: 'customObjectInstanceReferencesFilter',
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
+    if (client === undefined) {
+      return {}
+    }
     const { dataManagement } = config.fetchProfile
     if (dataManagement === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
@@ -11,7 +11,7 @@ import { collections, values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { ObjectType, isInstanceElement, ElemID, InstanceElement, Element } from '@salto-io/adapter-api'
 import { CUSTOM_OBJECT, COMPOUND_FIELD_TYPE_NAMES, NAME_FIELDS } from '../constants'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import { getSObjectFieldElement, apiName, isSubfieldOfCompound } from '../transformers/transformer'
 import { isInstanceOfType, ensureSafeFilterFetch, toCustomField } from './utils'
 import { CustomField } from '../client/types'
@@ -130,7 +130,7 @@ const WARNING_MESSAGE = 'Encountered an error while trying to fetch additional i
  * Custom objects filter.
  * Fetches the custom objects via the soap api and adds them to the elements
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectsFromDescribeFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -138,6 +138,9 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     warningMessage: WARNING_MESSAGE,
     config,
     fetchFilterFunc: async (elements: Element[]): Promise<FilterResult> => {
+      if (client === undefined) {
+        return {}
+      }
       const customObjectInstances = await keyByAsync(
         awu(elements).filter(isInstanceElement).filter(isInstanceOfType(CUSTOM_OBJECT)),
         instance => apiName(instance),

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -40,7 +40,7 @@ import {
   API_NAME_SEPARATOR,
   DATA_INSTANCES_CHANGED_AT_MAGIC,
 } from '../constants'
-import { FilterContext, FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterContext, FilterResult, FilterCreator } from '../filter'
 import { apiName, Types, createInstanceServiceIds, isNameField, toRecord } from '../transformers/transformer'
 import {
   getNamespace,
@@ -693,10 +693,13 @@ const createInaccessibleFieldsFetchWarning = (objectType: ObjectType, inaccessib
   }
 }
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectsInstancesFilter',
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
+    if (client === undefined) {
+      return {}
+    }
     const getAllCustomObjects = async (elementsSource: ReadOnlyElementsSource): Promise<ObjectType[]> => {
       const customObjects = await awu(await elementsSource.getAll())
         .filter(isCustomObjectSync)

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -912,7 +912,7 @@ const removeDuplicateElements = <T extends Element>(elements: T[]): T[] => {
 /**
  * Convert custom object instance elements into object types
  */
-const filterCreator: FilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config, client }) => {
   let originalChanges: Record<string, Change[]> = {}
   return {
     name: 'customObjectsToObjectTypeFilter',
@@ -967,7 +967,8 @@ const filterCreator: FilterCreator = ({ config }) => {
         originalChangeMapping[name].filter(isObjectTypeChange).some(isRemovalChange),
       )
 
-      if (!config.fetchProfile.isFeatureEnabled('performSideEffectDeletes')) {
+      // We only want to perform side effect removals when deploying to the service.
+      if (client !== undefined) {
         const sideEffectRemovalsByObject = await groupByAsync(
           (await awu(changes).filter(isSideEffectRemoval(removedCustomObjectNames)).toArray()) as Change[],
           async c => (await getParentCustomObjectName(c)) ?? '',

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -82,7 +82,7 @@ import {
   CUSTOM_SETTINGS_META_TYPE,
   CUSTOM_FIELD_DEPLOYABLE_TYPES,
 } from '../constants'
-import { FilterContext, LocalFilterCreator } from '../filter'
+import { FilterContext, FilterCreator } from '../filter'
 import {
   Types,
   isCustomObject,
@@ -912,7 +912,7 @@ const removeDuplicateElements = <T extends Element>(elements: T[]): T[] => {
 /**
  * Convert custom object instance elements into object types
  */
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   let originalChanges: Record<string, Change[]> = {}
   return {
     name: 'customObjectsToObjectTypeFilter',

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -9,7 +9,7 @@ import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import { isCustomSettingsObject, apiName } from '../transformers/transformer'
 import { getAllInstances, getCustomObjectsFetchSettings, CustomObjectFetchSetting } from './custom_objects_instances'
 import { CUSTOM_SETTINGS_TYPE, LIST_CUSTOM_SETTINGS_TYPE } from '../constants'
@@ -28,10 +28,14 @@ const logInvalidCustomSettings = async (invalidCustomSettings: CustomObjectFetch
     ),
   )
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customSettingsFilter',
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
+    if (client === undefined) {
+      return {}
+    }
+
     if (!config.fetchProfile.shouldFetchAllCustomSettings()) {
       return {}
     }

--- a/packages/salesforce-adapter/src/filters/custom_type_split.ts
+++ b/packages/salesforce-adapter/src/filters/custom_type_split.ts
@@ -10,7 +10,7 @@ import { Element, isObjectType, ObjectType } from '@salto-io/adapter-api'
 import { pathNaclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import { isCustom, isCustomObject, apiName } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { getObjectDirectoryPath } from './custom_objects_to_object_type'
 import { OBJECT_FIELDS_PATH } from '../constants'
 import { isCustomMetadataRecordType } from './utils'
@@ -72,7 +72,7 @@ const customObjectToSplitElements = async (
   return _.concat(fieldObjects, annotationsObject)
 }
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'customTypeSplit',
   onFetch: async (elements: Element[]) => {
     const customObjects = await awu(elements)

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -8,7 +8,7 @@
 import { logger } from '@salto-io/logging'
 import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { lightningElementsUrlRetriever } from '../elements_url_retriever/elements_url_retriever'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields, ensureSafeFilterFetch } from './utils'
 
@@ -22,7 +22,7 @@ const getRelevantElements = (elements: Element[]): AsyncIterable<Element> =>
 export const WARNING_MESSAGE =
   'Encountered an error while trying to populate URLs for some of your salesforce configuration elements. This might affect the availability of the ‘go to service’ functionality in your workspace.'
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'elementsUrlFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -30,6 +30,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'elementsUrls',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const url = await client.getUrl()
       if (url === undefined) {
         log.error('Failed to get salesforce URL')

--- a/packages/salesforce-adapter/src/filters/email_template_static_files.ts
+++ b/packages/salesforce-adapter/src/filters/email_template_static_files.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import path from 'path'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName } from '../transformers/transformer'
 import { EMAIL_TEMPLATE_METADATA_TYPE, RECORDS_PATH, SALESFORCE } from '../constants'
 import { isInstanceOfType, isInstanceOfTypeChange } from './utils'
@@ -114,7 +114,7 @@ const getAttachmentsFromChanges = async (changes: Change[]): Promise<Attachment[
 /**
  * Extract emailTemplate with attachments and save their content in a static file.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'emailTemplateFilter',
   onFetch: async (elements: Element[]) => {
     await awu(elements)

--- a/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
@@ -21,7 +21,7 @@ import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { inspectValue } from '@salto-io/adapter-utils'
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   apiNameSync,
   buildElementsSourceForFetch,
@@ -116,7 +116,7 @@ type ValuesToRestoreOnDeploy = {
   parent?: unknown
 }
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => {
+const filterCreator: FilterCreator = ({ client, config }) => {
   const valuesToRestoreByElemId: Record<string, ValuesToRestoreOnDeploy> = {}
   return {
     name: 'extendTriggersMetadata',
@@ -126,6 +126,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => {
       filterName: 'extendTriggersMetadata',
       warningMessage: 'Failed to extend the Metadata on Apex Triggers',
       fetchFilterFunc: async elements => {
+        if (client === undefined) {
+          return
+        }
+
         const apexTriggerMetadataType = elements
           .filter(isObjectType)
           .find(type => apiNameSync(type) === APEX_TRIGGER_METADATA_TYPE)

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -16,7 +16,7 @@ import {
   safeJsonStringify,
 } from '@salto-io/adapter-utils'
 import { getAllReferencedIds } from '@salto-io/adapter-components'
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { metadataType, apiName, isCustomObject } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import {
@@ -330,7 +330,7 @@ export const WARNING_MESSAGE =
 /**
  * Add references using the tooling API.
  */
-const creator: RemoteFilterCreator = ({ client, config }) => ({
+const creator: FilterCreator = ({ client, config }) => ({
   name: 'extraDependenciesFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -338,6 +338,10 @@ const creator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'extraDependencies',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const groupedDeps = config.fetchProfile.isFeatureEnabled('extraDependenciesV2')
         ? await getDependenciesV2({
             client,

--- a/packages/salesforce-adapter/src/filters/field_permissions_enum.ts
+++ b/packages/salesforce-adapter/src/filters/field_permissions_enum.ts
@@ -32,7 +32,7 @@ import {
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeData } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName, isCustomObject } from '../transformers/transformer'
 import {
   SALESFORCE,
@@ -233,7 +233,7 @@ const removeUnfethcedCustomObjects = (instance: InstanceElement, customObjects: 
   }
 }
 
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'enumFieldPermissionsFilter',
   onFetch: async elements => {
     log.info('Running fieldPermissionsEnum onFetch - reducing fieldPermissions size')

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -17,7 +17,7 @@ import { getParents } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, multiIndex } from '@salto-io/lowerdash'
 import { apiName, metadataType } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   generateReferenceResolverFinder,
   ReferenceContextStrategyName,
@@ -202,7 +202,7 @@ export const addReferences = async (
  * Convert field values into references, based on predefined rules.
  *
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async elements => {
     const typesToIgnore = config.fetchProfile.isCustomReferencesHandlerEnabled('profilesAndPermissionSets')

--- a/packages/salesforce-adapter/src/filters/flow.ts
+++ b/packages/salesforce-adapter/src/filters/flow.ts
@@ -7,7 +7,7 @@
  */
 import { Element, ElemID, getRestriction } from '@salto-io/adapter-api'
 import { findObjectType } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 
 export const FLOW_METADATA_TYPE_ID = new ElemID(SALESFORCE, 'FlowMetadataValue')
@@ -15,7 +15,7 @@ export const FLOW_METADATA_TYPE_ID = new ElemID(SALESFORCE, 'FlowMetadataValue')
 /**
  * Create filter that handles flow type/instances corner case.
  */
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'flowFilter',
   /**
    * Upon fetch remove restriction values from flowMetadataValue.name.

--- a/packages/salesforce-adapter/src/filters/flow_coordinates.ts
+++ b/packages/salesforce-adapter/src/filters/flow_coordinates.ts
@@ -8,7 +8,7 @@
 import { getChangeData, InstanceElement, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiNameSync, ensureSafeFilterFetch, isInstanceOfTypeChangeSync, isInstanceOfTypeSync } from './utils'
 import { FLOW_METADATA_TYPE } from '../constants'
 
@@ -80,7 +80,7 @@ const addZeroCoordinatesToAllSections: TransformFuncSync = ({ value, field }) =>
 
 const FILTER_NAME = 'flowCoordinates'
 
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: FILTER_NAME,
   onFetch: ensureSafeFilterFetch({
     warningMessage: '',

--- a/packages/salesforce-adapter/src/filters/flows_filter.ts
+++ b/packages/salesforce-adapter/src/filters/flows_filter.ts
@@ -21,7 +21,7 @@ import {
 } from '@salto-io/adapter-api'
 import { findObjectType, inspectValue, resolveTypeShallow } from '@salto-io/adapter-utils'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import {
   ACTIVE_VERSION_NUMBER,
   FLOW_DEFINITION_METADATA_TYPE,
@@ -185,10 +185,14 @@ const getFlowInstances = async (
   }
 }
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'flowsFilter',
   remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
+    if (client === undefined) {
+      return {}
+    }
+
     const flowType = findObjectType(elements, FLOW_METADATA_TYPE_ID)
     if (!config.fetchProfile.metadataQuery.isTypeMatch(FLOW_METADATA_TYPE) || flowType === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -16,7 +16,7 @@ import {
 import _ from 'lodash'
 import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import { values, collections, multiIndex } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { FOREIGN_KEY_DOMAIN } from '../constants'
 import { metadataType, apiName } from '../transformers/transformer'
 import { buildElementsSourceForFetch, extractFlatCustomObjectFields, hasApiName } from './utils'
@@ -64,7 +64,7 @@ const resolveReferences = async (
  * Use annotations generated from the DescribeValueType API foreignKeyDomain data to resolve
  * names into reference expressions.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'foreignKeyReferencesFilter',
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)

--- a/packages/salesforce-adapter/src/filters/formula_deps.ts
+++ b/packages/salesforce-adapter/src/filters/formula_deps.ts
@@ -11,7 +11,7 @@ import { collections } from '@salto-io/lowerdash'
 import { Element, Field, isObjectType, ReferenceExpression } from '@salto-io/adapter-api'
 import { extendGeneratedDependencies } from '@salto-io/adapter-utils'
 import { parseFormulaIdentifier, extractFormulaIdentifiers } from '@salto-io/salesforce-formula-parser'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { isFormulaField } from '../transformers/transformer'
 import { FORMULA } from '../constants'
 import { buildElementsSourceForFetch, ensureSafeFilterFetch, extractFlatCustomObjectFields } from './utils'
@@ -85,7 +85,7 @@ const FILTER_NAME = 'formulaDeps'
  * formula field.
  * Note: Currently (pending a fix to SALTO-3176) we only look at formula fields in custom objects.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: FILTER_NAME,
   onFetch: ensureSafeFilterFetch({
     warningMessage: 'Error while parsing formulas',

--- a/packages/salesforce-adapter/src/filters/generated_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/generated_dependencies.ts
@@ -7,7 +7,7 @@
  */
 import { ChangeDataType, CORE_ANNOTATIONS, getChangeData, isAdditionOrModificationChange } from '@salto-io/adapter-api'
 import { DetailedDependency } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 
 type ElementWithGeneratedDependencies = ChangeDataType & {
   annotations: ChangeDataType['annotations'] & {
@@ -18,7 +18,7 @@ type ElementWithGeneratedDependencies = ChangeDataType & {
 /**
  * Remove generated dependencies before deploy.
  */
-const filterCreator: LocalFilterCreator = () => {
+const filterCreator: FilterCreator = () => {
   let generatedDependencies: Record<string, DetailedDependency[]>
 
   return {

--- a/packages/salesforce-adapter/src/filters/global_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/global_value_sets.ts
@@ -7,7 +7,7 @@
  */
 import { Element, ObjectType, Field, ReferenceExpression, ElemID, isObjectType } from '@salto-io/adapter-api'
 import { multiIndex } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { VALUE_SET_FIELDS } from '../constants'
 import { isCustomObject, apiName } from '../transformers/transformer'
 import { isInstanceOfType, buildElementsSourceForFetch } from './utils'
@@ -34,7 +34,7 @@ const addGlobalValueSetRefToObject = (object: ObjectType, gvsToRef: multiIndex.I
 /**
  * Create filter that adds global value set references where needed
  */
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'globalValueSetFilter',
   /**
    * @param elements the already fetched elements

--- a/packages/salesforce-adapter/src/filters/hide_types_folder.ts
+++ b/packages/salesforce-adapter/src/filters/hide_types_folder.ts
@@ -7,13 +7,13 @@
  */
 import { Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { SALESFORCE, TYPES_PATH } from '../constants'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ensureSafeFilterFetch } from './utils'
 
 const isElementWithinTypesFolder = ({ path = [] }: Element): boolean =>
   path?.[0] === SALESFORCE && path?.[1] === TYPES_PATH
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'hideTypesFolder',
   onFetch: ensureSafeFilterFetch({
     config,

--- a/packages/salesforce-adapter/src/filters/important_values_filter.ts
+++ b/packages/salesforce-adapter/src/filters/important_values_filter.ts
@@ -7,9 +7,9 @@
  */
 import { CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { isMetadataObjectType, MetadataObjectType } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'salesforceImportantValuesFilter',
   onFetch: async elements => {
     if (!config.fetchProfile.isFeatureEnabled('importantValues')) {

--- a/packages/salesforce-adapter/src/filters/installed_package_generated_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/installed_package_generated_dependencies.ts
@@ -10,7 +10,7 @@ import { collections, multiIndex, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { extendGeneratedDependencies, safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { INSTALLED_PACKAGE_METADATA, INSTALLED_PACKAGES_PATH } from '../constants'
 import {
   buildElementsSourceForFetch,
@@ -40,7 +40,7 @@ const installedPackageReference = (
   return new ReferenceExpression(installedPackageElemID)
 }
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'installedPackageGeneratedDependencies',
   onFetch: async (elements: Element[]) => {
     const knownInstancesNamespaces = _.uniq(elements.map(getNamespaceSync).filter(isDefined))

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -10,7 +10,7 @@ import { Element, InstanceElement, ObjectType, ElemID, isInstanceElement } from 
 import { naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { multiIndex, collections } from '@salto-io/lowerdash'
 import { apiName, isCustomObject } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { addElementParentReference, isInstanceOfType, buildElementsSourceForFetch, layoutObjAndName } from './utils'
 import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, WEBLINK_METADATA_TYPE } from '../constants'
 import { getObjectDirectoryPath } from './custom_objects_to_object_type'
@@ -34,7 +34,7 @@ const fixLayoutPath = async (layout: InstanceElement, customObject: ObjectType, 
  * Declare the layout filter, this filter adds reference from the sobject to it's layouts.
  * Fixes references in layout items.
  */
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'layoutFilter',
   /**
    * Upon fetch, shorten layout ID and add reference to layout sobjects.

--- a/packages/salesforce-adapter/src/filters/merge_profiles_with_source_values.ts
+++ b/packages/salesforce-adapter/src/filters/merge_profiles_with_source_values.ts
@@ -10,7 +10,7 @@ import _ from 'lodash'
 import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiNameSync, isInstanceOfTypeSync } from './utils'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
@@ -23,7 +23,7 @@ const log = logger(module)
  * This is required in fetch with changes detection where we retrieve partial profile instances
  * with the modified related props only.
  */
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'mergeProfilesWithSourceValues',
   onFetch: async elements => {
     const profileInstances = elements.filter(isInstanceOfTypeSync(PROFILE_METADATA_TYPE))

--- a/packages/salesforce-adapter/src/filters/metadata_instances_aliases.ts
+++ b/packages/salesforce-adapter/src/filters/metadata_instances_aliases.ts
@@ -8,14 +8,14 @@
 import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { getInstanceAlias } from './utils'
 import { isMetadataInstanceElement, MetadataInstanceElement } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
 const log = logger(module)
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'metadataInstancesAliases',
   onFetch: async (elements: Element[]): Promise<void> => {
     if (config.fetchProfile.isFeatureEnabled('skipAliases')) {

--- a/packages/salesforce-adapter/src/filters/minify_deploy.ts
+++ b/packages/salesforce-adapter/src/filters/minify_deploy.ts
@@ -123,7 +123,7 @@ const filterCreator: FilterCreator = ({ client }) => {
     },
     onDeploy: async changes => {
       if (client === undefined) {
-        // We don't want to run this filter when the results aren't being sent to the service.
+        // We don't want to minify profiles in the SFDX flow.
         return
       }
 

--- a/packages/salesforce-adapter/src/filters/omit_standard_fields_non_deployable_values.ts
+++ b/packages/salesforce-adapter/src/filters/omit_standard_fields_non_deployable_values.ts
@@ -7,10 +7,10 @@
  */
 
 import { FIELD_ANNOTATIONS } from '../constants'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ensureSafeFilterFetch, isCustomObjectSync, isStandardField } from './utils'
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'omitStandardFieldsNonDeployableValues',
   onFetch: ensureSafeFilterFetch({
     config,

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -9,7 +9,7 @@
 import _ from 'lodash'
 import { BuiltinTypes, CORE_ANNOTATIONS, ElemID, InstanceElement, ObjectType, Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ensureSafeFilterFetch, queryClient, safeApiName } from './utils'
 import { getSObjectFieldElement, getTypePath } from '../transformers/transformer'
 import { API_NAME, ORGANIZATION_SETTINGS, RECORDS_PATH, SALESFORCE, SETTINGS_PATH } from '../constants'
@@ -149,13 +149,17 @@ const addLatestSupportedAPIVersion = async ({
 const FILTER_NAME = 'organizationSettings'
 export const WARNING_MESSAGE = 'Failed to fetch OrganizationSettings.'
 
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: FILTER_NAME,
   remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,
     fetchFilterFunc: async elements => {
+      if (client === undefined) {
+        return
+      }
+
       const objectType = createOrganizationType()
       const fieldsToIgnore = new Set(FIELDS_TO_IGNORE.concat(config.systemFields ?? []))
       await enrichTypeWithFields(client, objectType, fieldsToIgnore, config.fetchProfile)

--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -9,7 +9,7 @@ import _ from 'lodash'
 import { strings, collections, promises } from '@salto-io/lowerdash'
 import { Element, ObjectType, isMapType, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 import { PROFILE_METADATA_TYPE } from '../constants'
 
@@ -54,7 +54,7 @@ const isProfileInstance = async (elem: Element): Promise<boolean> =>
  * Each map field is assigned to a separate file, and the other fields and annotations
  * to Attributes.nacl.
  */
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'profileInstanceSplitFilter',
   onFetch: async (elements: Element[]) => {
     const profileInstances = (await removeAsync(elements, isProfileInstance)) as InstanceElement[]

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -9,7 +9,7 @@ import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-a
 import { pathNaclCase, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 
-import { RemoteFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
 import { getInternalId, isInstanceOfType, ensureSafeFilterFetch } from './utils'
@@ -44,7 +44,7 @@ export const WARNING_MESSAGE =
 /**
  * replace paths for profile instances upon fetch
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'profilePathsFilter',
   remote: true,
   onFetch: ensureSafeFilterFetch({
@@ -52,6 +52,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
     config,
     filterName: 'profilePaths',
     fetchFilterFunc: async (elements: Element[]) => {
+      if (client === undefined) {
+        return
+      }
+
       const profiles = await awu(elements)
         .filter(async e => isInstanceOfType(PROFILE_METADATA_TYPE)(e))
         .toArray()

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -31,7 +31,7 @@ import {
   metadataAnnotationTypes,
   MetadataTypeAnnotations,
 } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ProfileInfo, FieldPermissions, ObjectPermissions } from '../client/types'
 import { apiNameSync, isInstanceOfTypeChangeSync, isMasterDetailField } from './utils'
 
@@ -118,7 +118,7 @@ const addMissingPermissions = (
  * Do the same with added fields and fieldPermissions.
  * No reason to handle deleted Profiles.
  */
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   let originalProfileChangesByName: Record<
     string,
     AdditionChange<InstanceElement> | ModificationChange<InstanceElement>

--- a/packages/salesforce-adapter/src/filters/reference_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/reference_annotations.ts
@@ -8,7 +8,7 @@
 import { Element, Field, ReferenceExpression, ObjectType, isObjectType } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { collections, multiIndex } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { FIELD_ANNOTATIONS, FOREIGN_KEY_DOMAIN, CUSTOM_OBJECT, CUSTOM_OBJECT_TYPE_NAME } from '../constants'
 import { apiName, metadataType, isMetadataObjectType, isCustomObject } from '../transformers/transformer'
 import { apiNameSync, buildElementsSourceForFetch } from './utils'
@@ -64,7 +64,7 @@ const convertAnnotationsToReferences = async (
 /**
  * Convert referenceTo and foreignKeyDomain annotations into reference expressions.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'referenceAnnotationsFilter',
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -7,7 +7,7 @@
  */
 import { isObjectType, Element, isInstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { TransformFunc, transformValuesSync } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiNameSync } from './utils'
 
 const TYPE_NAME_TO_FIELD_REMOVALS: Map<string, string[]> = new Map([['Profile', ['tabVisibilities']]])
@@ -60,7 +60,7 @@ const removeValuesFromInstances = (elements: Element[], typeNameToFieldRemovals:
  * their corresponding instances upon fetch.
  * */
 export const makeFilter =
-  (typeNameToFieldRemovals: Map<string, string[]>): LocalFilterCreator =>
+  (typeNameToFieldRemovals: Map<string, string[]>): FilterCreator =>
   () => ({
     name: 'removeFieldsAndValuesFilter',
     onFetch: async (elements: Element[]) => {

--- a/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
+++ b/packages/salesforce-adapter/src/filters/remove_restriction_annotations.ts
@@ -7,7 +7,7 @@
  */
 import { isObjectType, Element, ObjectType, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
@@ -30,7 +30,7 @@ const FIELDS_TO_REMOVE_RESTRICTION_FROM_BY_TYPE: Record<string, string[]> = {
  * and hide all the values on upgrade.
  */
 export const makeFilter =
-  (typeNameToFieldMapping: Record<string, string[]>): LocalFilterCreator =>
+  (typeNameToFieldMapping: Record<string, string[]>): FilterCreator =>
   () => ({
     name: 'removeRestrictionAnnotationsFilter',
     onFetch: async (elements: Element[]) => {

--- a/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
+++ b/packages/salesforce-adapter/src/filters/remove_unix_time_zero.ts
@@ -8,7 +8,7 @@
 import { CORE_ANNOTATIONS, Element, isElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName } from '../transformers/transformer'
 import { UNIX_TIME_ZERO_STRING } from '../constants'
 
@@ -34,7 +34,7 @@ const removeUnixTimeZero = async (elements: Element[]): Promise<void> => {
 /**
  * Replace specific field values that are fetched as ids, to their names.
  */
-const filter: LocalFilterCreator = () => ({
+const filter: FilterCreator = () => ({
   name: 'removeUnixTimeZero',
   onFetch: async (elements: Element[]) => {
     await removeUnixTimeZero(elements)

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -19,7 +19,7 @@ import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections, multiIndex } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName, metadataType, isCustomObject } from '../transformers/transformer'
 import { generateReferenceResolverFinder } from '../transformers/reference_mapping'
 import { getInternalId, hasInternalId, buildElementsSourceForFetch } from './utils'
@@ -125,7 +125,7 @@ const replaceInstancesValues = async (
 /**
  * Replace specific field values that are fetched as ids, to their names.
  */
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'replaceFieldValuesFilter',
   onFetch: async (elements: Element[]) => {
     const referenceElements = buildElementsSourceForFetch(elements, config)

--- a/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
+++ b/packages/salesforce-adapter/src/filters/saml_initiation_method.ts
@@ -8,7 +8,7 @@
 import wu from 'wu'
 import { Element, ElemID, getRestriction } from '@salto-io/adapter-api'
 import { findObjectType, findInstances } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { SALESFORCE } from '../constants'
 
 export const CANVAS_METADATA_TYPE_ID = new ElemID(SALESFORCE, 'CanvasMetadata')
@@ -18,7 +18,7 @@ export const SAML_INIT_METHOD_FIELD_NAME = 'samlInitiationMethod'
  * Declare the assignment rules filter, this filter renames assignment rules instances to match
  * the names in the Salesforce UI
  */
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'samlInitMethodFilter',
   /**
    * Upon discover, rename assignment rules instances

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -8,7 +8,7 @@
 import { Element, isObjectType, ObjectType, TypeElement } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import {
   createMetadataTypeElements,
   apiName,
@@ -59,7 +59,7 @@ const getSettingsTypeName = (typeName: string): string => typeName.concat(SETTIN
 /**
  * Add settings type
  */
-const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
+const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'settingsFilter',
   remote: true,
   /**
@@ -68,6 +68,10 @@ const filterCreator: RemoteFilterCreator = ({ client, config }) => ({
    * @param elements
    */
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
+    if (client === undefined) {
+      return {}
+    }
+
     // Fetch list of all settings types
     const { elements: settingsList, configChanges: listObjectsConfigChanges } = await listMetadataObjects(
       client,

--- a/packages/salesforce-adapter/src/filters/split_custom_labels.ts
+++ b/packages/salesforce-adapter/src/filters/split_custom_labels.ts
@@ -21,7 +21,7 @@ import _ from 'lodash'
 import Joi from 'joi'
 import { collections } from '@salto-io/lowerdash'
 import { createSchemeGuard, pathNaclCase } from '@salto-io/adapter-utils'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiName, createInstanceElement, metadataAnnotationTypes } from '../transformers/transformer'
 import { getDataFromChanges, isInstanceOfType } from './utils'
 import {
@@ -129,7 +129,7 @@ const createCustomLabelsChange = async (customLabelChanges: Change[]): Promise<C
 /**
  * Split custom labels into individual instances
  */
-const filterCreator: LocalFilterCreator = () => {
+const filterCreator: FilterCreator = () => {
   let customLabelChanges: Change[]
   return {
     name: 'splitCustomLabels',

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -24,7 +24,7 @@ import {
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { collections, types } from '@salto-io/lowerdash'
 
-import { FilterResult, RemoteFilterCreator } from '../filter'
+import { FilterResult, FilterCreator } from '../filter'
 import { FIELD_ANNOTATIONS, VALUE_SET_FIELDS } from '../constants'
 import { metadataType, isCustomObject, Types, isCustom } from '../transformers/transformer'
 import { apiNameSync, extractFullNamesFromValueList, isInstanceOfTypeSync } from './utils'
@@ -194,7 +194,7 @@ const getAllStandardPicklistFields = (changes: Change[]): Field[] =>
  * and modify reference in fetched elements that uses them.
  */
 export const makeFilter =
-  (standardValueSetNames: StandardValuesSets): RemoteFilterCreator =>
+  (standardValueSetNames: StandardValuesSets): FilterCreator =>
   ({ client, config }) => {
     const fieldToRemovedValueSetName = new Map<string, string>()
     return {
@@ -207,6 +207,10 @@ export const makeFilter =
        * @param elements the already fetched elements
        */
       onFetch: async (elements: Element[]): Promise<FilterResult> => {
+        if (client === undefined) {
+          return {}
+        }
+
         const svsMetadataType: ObjectType | undefined = await findStandardValueSetType(elements)
         let configChanges: ConfigChangeSuggestion[] = []
         let fetchedSVSInstances: InstanceElement[] = []

--- a/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_file_ext.ts
@@ -11,7 +11,7 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import mime from 'mime-types'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { SALESFORCE, METADATA_CONTENT_FIELD } from '../constants'
 
 const { awu } = collections.asynciterable
@@ -62,7 +62,7 @@ const modifyFileExtension = async (staticResourceInstance: InstanceElement): Pro
   })
 }
 
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'staticResourceFileExtFilter',
   /**
    * Upon fetch modify the extension of the StaticResource's static file CONTENT field

--- a/packages/salesforce-adapter/src/filters/task_and_event_custom_fields.ts
+++ b/packages/salesforce-adapter/src/filters/task_and_event_custom_fields.ts
@@ -17,7 +17,7 @@ import {
   isFieldChange,
   ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { ACTIVITY_CUSTOM_OBJECT, EVENT_CUSTOM_OBJECT, SALESFORCE, TASK_CUSTOM_OBJECT } from '../constants'
 import {
   apiNameSync,
@@ -32,7 +32,7 @@ import { findMatchingActivityChange } from '../change_validators/task_or_event_f
 const log = logger(module)
 const { isDefined } = values
 
-const filterCreator: LocalFilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config }) => {
   let taskOrEventFieldChanges: Change[]
 
   return {

--- a/packages/salesforce-adapter/src/filters/territory.ts
+++ b/packages/salesforce-adapter/src/filters/territory.ts
@@ -15,7 +15,7 @@ import {
   isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { isMetadataObjectType, metadataType, apiName } from '../transformers/transformer'
 import { CONTENT_FILENAME_OVERRIDE } from '../transformers/xml_transformer'
 import { TERRITORY2_TYPE, TERRITORY2_MODEL_TYPE, TERRITORY2_RULE_TYPE } from '../constants'
@@ -60,7 +60,7 @@ const setTerritoryDeployPkgStructure = async (element: InstanceElement): Promise
   element.annotate({ [CONTENT_FILENAME_OVERRIDE]: contentPath })
 }
 
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'territoryFilter',
   onFetch: async elements => {
     // Territory2 and Territory2Model support custom fields - these are returned

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -37,7 +37,7 @@ import {
   MetadataTypeAnnotations,
   isMetadataObjectType,
 } from '../transformers/transformer'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { TopicsForObjectsInfo } from '../client/types'
 import { apiNameSync, boolValue, getInstancesOfMetadataType, isCustomObjectSync, isInstanceOfTypeChange } from './utils'
 
@@ -130,7 +130,7 @@ const setTopicsForObjectsForFetchWithChangesDetection = async ({
   })
 }
 
-const filterCreator: LocalFilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = ({ config }) => ({
   name: 'topicsForObjectsFilter',
   onFetch: async (elements: Element[]): Promise<void> => {
     if (!config.fetchProfile.metadataQuery.isTypeMatch(TOPICS_FOR_OBJECTS_METADATA_TYPE)) {

--- a/packages/salesforce-adapter/src/filters/trim_keys.ts
+++ b/packages/salesforce-adapter/src/filters/trim_keys.ts
@@ -9,7 +9,7 @@ import { Element, isInstanceElement } from '@salto-io/adapter-api'
 import { MapKeyFunc, mapKeysRecursive } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { metadataType } from '../transformers/transformer'
 import { LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE } from '../constants'
 
@@ -25,7 +25,7 @@ const trimKeys: MapKeyFunc = ({ key }) => {
   return trimmedKey
 }
 
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'trimKeysFilter',
   /**
    * Remove the leading and trailing whitespaces and new line chars from the

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -11,7 +11,7 @@ import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { WEBLINK_METADATA_TYPE } from '../constants'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { generateReferenceResolverFinder } from '../transformers/reference_mapping'
 import { apiName, metadataType } from '../transformers/transformer'
 
@@ -67,7 +67,7 @@ const extractToStaticFile = async (instance: InstanceElement): Promise<void> => 
 /**
  * Extract field value to static-resources for chosen instances.
  */
-const filter: LocalFilterCreator = () => ({
+const filter: FilterCreator = () => ({
   name: 'valueToStaticFileFilter',
   onFetch: async (elements: Element[]) => {
     await awu(elements)

--- a/packages/salesforce-adapter/src/filters/wave_static_files.ts
+++ b/packages/salesforce-adapter/src/filters/wave_static_files.ts
@@ -7,7 +7,7 @@
  */
 import _ from 'lodash'
 import { InstanceElement, StaticFile } from '@salto-io/adapter-api'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { apiNameSync, ensureSafeFilterFetch, isInstanceOfTypeSync, metadataTypeSync } from './utils'
 import {
   RECORDS_PATH,
@@ -42,7 +42,7 @@ const convertContentToStaticFile = (instance: InstanceElement): void => {
 // Oddly enough, the API expects the decoded Base64 content as input for deploy, so no transformation
 // is need before deploying back to the service. The transformation in fetch
 // should allow deploying these instances successfully.
-const filter: LocalFilterCreator = ({ config }) => ({
+const filter: FilterCreator = ({ config }) => ({
   name: 'waveStaticFiles',
   onFetch: ensureSafeFilterFetch({
     warningMessage: 'Error occurred while attempting to convert Wave Metadata content to static files',

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -31,7 +31,7 @@ import {
   WORKFLOW_TASK_METADATA_TYPE,
   SALESFORCE,
 } from '../constants'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   apiName,
   metadataType,
@@ -164,7 +164,7 @@ const getWorkflowApiName = async (change: Change<InstanceElement>): Promise<stri
   return (await isWorkflowInstance(inst)) ? apiName(inst) : parentApiName(inst)
 }
 
-const filterCreator: LocalFilterCreator = () => {
+const filterCreator: FilterCreator = () => {
   let originalWorkflowChanges: Record<string, Change<InstanceElement>[]> = {}
   return {
     name: 'workflowFilter',

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -17,7 +17,7 @@ import {
 } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
-import { LocalFilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { IS_ATTRIBUTE, XML_ATTRIBUTE_PREFIX } from '../constants'
 import { metadataType } from '../transformers/transformer'
 import { metadataTypesWithAttributes } from '../transformers/xml_transformer'
@@ -56,7 +56,7 @@ const removeAttributePrefix = async (instance: InstanceElement): Promise<void> =
     })) ?? instance.value
 }
 
-const filterCreator: LocalFilterCreator = () => ({
+const filterCreator: FilterCreator = () => ({
   name: 'xmlAttributesFilter',
   /**
    * Upon fetch remove the XML_ATTRIBUTE_PREFIX from the instance.value keys so it'll match the type

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -112,12 +112,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
   const unappliedChanges = typeChanges.concat(customObjectInstanceChanges)
 
   const fetchProfile = buildFetchProfile({
-    fetchParams: {
-      optionalFeatures: {
-        // Needed to remove related instances of custom objects (e.g - layouts, sharing rules, etc...)
-        performSideEffectDeletes: true,
-      },
-    },
+    fetchParams: {},
   })
 
   const resolvedChanges = await awu(metadataChanges)
@@ -136,7 +131,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
         flsProfiles: [],
       },
     },
-    allFilters.map(({ creator }) => creator),
+    allFilters,
   )
   await filterRunner.preDeploy(resolvedChanges)
 

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -17,7 +17,6 @@ import { allFilters, NESTED_METADATA_TYPES } from '../adapter'
 import { CUSTOM_METADATA, SYSTEM_FIELDS, UNSUPPORTED_SYSTEM_FIELDS, API_NAME } from '../constants'
 import { getLookUpName } from '../transformers/reference_mapping'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
-import SalesforceClient from '../client/client'
 import { createDeployPackage, DeployPackage, PACKAGE } from '../transformers/xml_transformer'
 import { addChangeToPackage, validateChanges } from '../metadata_deploy'
 import {
@@ -59,6 +58,10 @@ const getComponentsToDelete = async (
   pkg: DeployPackage,
   currentComponents: SourceComponent[],
 ): Promise<{ fullDelete: SourceComponent[]; partialDelete: SourceComponent[] }> => {
+  if (currentComponents.length === 0) {
+    return { fullDelete: [], partialDelete: [] }
+  }
+
   const manifestDeletions = await getManifestComponentsToDelete(tree, pkg)
   const isInDeleteManifest = (comp: SourceComponent): boolean =>
     manifestDeletions.has(`${comp.type.id}.${comp.fullName}`)
@@ -120,9 +123,6 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     .toArray()
   const filterRunner = filter.filtersRunner(
     {
-      // TODO: This is a hack that we want to replace with something more type-safe in the near future
-      // for now this works because non of the remote filters actually uses the client on preDeploy
-      client: {} as unknown as SalesforceClient,
       config: {
         unsupportedSystemFields: UNSUPPORTED_SYSTEM_FIELDS,
         systemFields: SYSTEM_FIELDS,

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -202,7 +202,6 @@ export const loadElementsFromFolder = async ({
       createInstanceElement(values, typesByName[file.type]),
     )
 
-    const localFilters = allFilters.filter(filter.isLocalFilterCreator).map(({ creator }) => creator)
     const filterRunner = filter.filtersRunner(
       {
         config: {
@@ -213,7 +212,7 @@ export const loadElementsFromFolder = async ({
           flsProfiles: [],
         },
       },
-      localFilters,
+      allFilters,
       results => ({ errors: results.flatMap(res => collections.array.makeArray(res.errors)) }),
     )
     // Some filters assume the types have to come from the elements list

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -38,7 +38,6 @@ export const UNSUPPORTED_TYPES = new Set([
   'Settings',
   // SFDX convert does not preserve the order of values on its own, so currently every time we dump a profile
   // the file changes because of random order changes
-  // The SFDX code also does not know how to handle "partial" information, so when we "minify" the profile it removes information
   'Profile',
   // For documents with a file extension (e.g. bla.txt) the SF API returns their fullName with the extension (so "bla.txt")
   // but the SFDX convert code loads them as a component with a fullName without the extension (so "bla").

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -125,7 +125,6 @@ export type OptionalFeatures = {
   indexedEmailTemplateAttachments?: boolean
   skipParsingXmlNumbers?: boolean
   logDiffsFromParsingXmlNumbers?: boolean
-  performSideEffectDeletes?: boolean
   extendTriggersMetadata?: boolean
   removeReferenceFromFilterItemToRecordType?: boolean
 }
@@ -837,7 +836,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     indexedEmailTemplateAttachments: { refType: BuiltinTypes.BOOLEAN },
     skipParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
     logDiffsFromParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
-    performSideEffectDeletes: { refType: BuiltinTypes.BOOLEAN },
     extendTriggersMetadata: { refType: BuiltinTypes.BOOLEAN },
     removeReferenceFromFilterItemToRecordType: { refType: BuiltinTypes.BOOLEAN },
   },

--- a/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
@@ -58,7 +58,7 @@ import {
   LOOKUP_FILTER_FIELDS,
   FILTER_ITEM_FIELDS,
 } from '../../src/constants'
-import { findElements, createValueSetEntry, defaultFilterContext, buildFilterContext } from '../utils'
+import { findElements, createValueSetEntry, defaultFilterContext } from '../utils'
 import { mockTypes } from '../mock_elements'
 import filterCreator, {
   INSTANCE_REQUIRED_FIELD,
@@ -79,6 +79,7 @@ import { DEPLOY_WRAPPER_INSTANCE_MARKER } from '../../src/metadata_deploy'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { FilterWith } from './mocks'
 import { CustomField } from '../../src/client/types'
+import mockClient from '../client'
 
 export const generateCustomObjectType = (): ObjectType => {
   const generateInnerMetadataTypeFields = (name: string): Record<string, FieldDefinition> => {
@@ -1051,10 +1052,11 @@ describe('Custom Objects to Object Type filter', () => {
         )
         changes = [toChange({ before: testObject }), toChange({ before: sideEffectInst })]
       })
-      describe('when performSideEffectDeletes is false', () => {
+      describe('when a client is passed', () => {
         beforeAll(() => {
           filter = filterCreator({
             config: defaultFilterContext,
+            client: mockClient().client,
           }) as typeof filter
         })
         describe('preDeploy', () => {
@@ -1080,10 +1082,10 @@ describe('Custom Objects to Object Type filter', () => {
           })
         })
       })
-      describe('when performSideEffectDeletes is true', () => {
+      describe('when no client is passed', () => {
         beforeAll(() => {
           filter = filterCreator({
-            config: buildFilterContext({ optionalFeatures: { performSideEffectDeletes: true } }),
+            config: defaultFilterContext,
           }) as typeof filter
         })
         describe('preDeploy', () => {

--- a/packages/salesforce-adapter/test/filters/filters.test.ts
+++ b/packages/salesforce-adapter/test/filters/filters.test.ts
@@ -8,7 +8,7 @@
 import { toChange, Change, FetchOptions } from '@salto-io/adapter-api'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import SalesforceAdapter from '../../src/adapter'
-import { LocalFilterCreator } from '../../src/filter'
+import { FilterCreator } from '../../src/filter'
 import mockAdapter from '../adapter'
 import { mockDeployResult, mockDeployMessage } from '../connection'
 import { apiName, createInstanceElement, metadataType } from '../../src/transformers/transformer'
@@ -20,7 +20,7 @@ describe('SalesforceAdapter filters', () => {
   describe('when filter methods are implemented', () => {
     let adapter: SalesforceAdapter
     let filter: MockInterface<FilterWith<'onFetch' | 'onDeploy' | 'deploy' | 'preDeploy' | 'onPostFetch'>>
-    let filterCreator: jest.MockedFunction<LocalFilterCreator>
+    let filterCreator: jest.MockedFunction<FilterCreator>
     let connection: ReturnType<typeof mockAdapter>['connection']
     const mockFetchOpts: MockInterface<FetchOptions> = {
       progressReporter: { reportProgress: jest.fn() },
@@ -36,7 +36,7 @@ describe('SalesforceAdapter filters', () => {
         onPostFetch: mockFunction<(typeof filter)['onPostFetch']>().mockResolvedValue(),
       }
 
-      filterCreator = mockFunction<LocalFilterCreator>().mockReturnValue(filter)
+      filterCreator = mockFunction<FilterCreator>().mockReturnValue(filter)
       const mocks = mockAdapter({
         adapterParams: { filterCreators: [filterCreator] },
       })


### PR DESCRIPTION
When dumping SFDX we need to pass entire profiles and not minified.

---

_Additional context for reviewer_:
This required changing the interface for SF filters so that we can selectively skip them in the SFDX flow (Local/Remote doesn't really cover all the bases here).

---
_Release Notes_: 
* None.

---
_User Notifications_: 
* None.
