### PR TITLE
SALTO-6770: Add missing Intune oauth scope

### DIFF
--- a/packages/microsoft-security-adapter/src/auth.ts
+++ b/packages/microsoft-security-adapter/src/auth.ts
@@ -41,7 +41,12 @@ export const SCOPE_MAPPING: Record<AvailableMicrosoftSecurityServices, string[]>
     'RoleManagement.ReadWrite.Directory',
     'UserAuthenticationMethod.ReadWrite.All',
   ],
-  Intune: ['DeviceManagementApps.ReadWrite.All', 'DeviceManagementConfiguration.ReadWrite.All', 'User.Read'],
+  Intune: [
+    'DeviceManagementApps.ReadWrite.All',
+    'DeviceManagementConfiguration.ReadWrite.All',
+    'DeviceManagementRBAC.ReadWrite.All',
+    'User.Read',
+  ],
 }
 
 // Deprecated. This list should not be used as-is. Use getOAuthRequiredScopes instead.


### PR DESCRIPTION
The OAuth scope `DeviceManagementRBAC.ReadWrite.All` is missing in order to support `scope* tags` 
(*funny, isn't it? :)

---

_Additional context for reviewer_

---
_Release Notes_: 

---
_User Notifications_: 
