### PR TITLE
SALTO-6621: Sort profiles

### DIFF
--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -7,11 +7,19 @@
  */
 import _ from 'lodash'
 import { strings, collections, promises } from '@salto-io/lowerdash'
-import { Element, ObjectType, isMapType, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import {
+  Element,
+  ObjectType,
+  isMapType,
+  InstanceElement,
+  Change,
+  isInstanceChange,
+  isAdditionOrModificationChange,
+} from '@salto-io/adapter-api'
 
 import { FilterCreator } from '../filter'
-import { metadataType } from '../transformers/transformer'
 import { PROFILE_METADATA_TYPE } from '../constants'
+import { isInstanceOfTypeChangeSync, isInstanceOfTypeSync } from './utils'
 
 const { groupByAsync, awu } = collections.asynciterable
 const { removeAsync } = promises.array
@@ -46,23 +54,48 @@ const splitProfile = async (profile: InstanceElement): Promise<InstanceElement[]
   return profileInstances
 }
 
-const isProfileInstance = async (elem: Element): Promise<boolean> =>
-  isInstanceElement(elem) && (await metadataType(elem)) === PROFILE_METADATA_TYPE
+const sortInstance = (instance: InstanceElement): void => {
+  instance.value = Object.keys(instance.value)
+    .sort()
+    .reduce(
+      (sorted, key) => {
+        sorted[key] = instance.value[key]
+        return sorted
+      },
+      {} as typeof instance.value,
+    )
+}
 
 /**
  * Split profile instances, each assigned to its own nacl path.
  * Each map field is assigned to a separate file, and the other fields and annotations
  * to Attributes.nacl.
  */
-const filterCreator: FilterCreator = () => ({
+const filterCreator: FilterCreator = ({ client }) => ({
   name: 'profileInstanceSplitFilter',
   onFetch: async (elements: Element[]) => {
-    const profileInstances = (await removeAsync(elements, isProfileInstance)) as InstanceElement[]
+    const profileInstances = (await removeAsync(
+      elements,
+      isInstanceOfTypeSync(PROFILE_METADATA_TYPE),
+    )) as InstanceElement[]
     if (profileInstances.length === 0) {
       return
     }
     const newProfileInstances = await awu(profileInstances).flatMap(splitProfile).toArray()
     elements.push(...newProfileInstances)
+  },
+  preDeploy: async (changes: Change[]) => {
+    // Splitting into files can cause the internal order of the profile to be affected by which files are changed.
+    // In order to maintain the order in SFDX we sort the value.
+    if (client !== undefined) {
+      return
+    }
+
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceOfTypeChangeSync(PROFILE_METADATA_TYPE))
+      .forEach(change => sortInstance(change.data.after))
   },
 })
 

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -36,8 +36,7 @@ export const UNSUPPORTED_TYPES = new Set([
   // Salto uses non-standard type names here (SFDX names them all "Settings", we have a separate type for each one)
   // This causes us to always think the settings in the project need to be deleted
   'Settings',
-  // SFDX convert does not preserve the order of values on its own, so currently every time we dump a profile
-  // the file changes because of random order changes
+  // We need to disable the profile permissions filter in the SFDX flow
   'Profile',
   // For documents with a file extension (e.g. bla.txt) the SF API returns their fullName with the extension (so "bla.txt")
   // but the SFDX convert code loads them as a component with a fullName without the extension (so "bla").


### PR DESCRIPTION
Reordering profiles pre deploy to maintain order in SFDX.
This is the last issue for profiles so enabling them.

---

_Additional context for reviewer_:
For elements split between files, the NaCl source loads only the files that have been changed and then merges them with the element in the state. This means that the order of the value depends on which files have been changed.
In order to avoid fundementally changing the way the NaCl source works I instead opted for just fixing the issue for Profiles which as far as I can tell is the only type affected in this way which is merged back into a single file in SFDX.

---
_Release Notes_: 
* None.

---
_User Notifications_: 
* None.
