### PR TITLE
SALTO-6737: Limit the number of users fetched in Okta

### DIFF
--- a/packages/adapter-components/src/definitions/system/fetch/resource.ts
+++ b/packages/adapter-components/src/definitions/system/fetch/resource.ts
@@ -33,7 +33,7 @@ type IgnoreError = {
   action: 'ignoreError'
 }
 
-export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion | IgnoreError
+export type OnErrorHandlerAction = FailEntireFetch | CustomSaltoError | ConfigSuggestion | IgnoreError | undefined
 
 type OnErrorHandler = ArgsWithCustomizer<OnErrorHandlerAction, OnErrorHandlerAction, { error: Error; typeName: string }>
 

--- a/packages/adapter-components/src/fetch/errors.ts
+++ b/packages/adapter-components/src/fetch/errors.ts
@@ -16,6 +16,14 @@ export class AbortFetchOnFailure extends FatalError {
   }
 }
 
+export class MaxResultsExceeded extends Error {
+  maxResults: number
+  constructor({ endpoint, maxResults }: { endpoint: string; maxResults: number }) {
+    super(`Reached max results for endpoint ${endpoint} (${maxResults})`)
+    this.maxResults = maxResults
+  }
+}
+
 export const getInsufficientPermissionsError = (typeName: string): SaltoError => {
   const message = `Salto could not access the ${typeName} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`
   return {

--- a/packages/adapter-components/src/fetch/request/pagination/index.ts
+++ b/packages/adapter-components/src/fetch/request/pagination/index.ts
@@ -17,5 +17,6 @@ export {
   PathCheckerFunc,
   tokenPagination,
   offsetAndLimitPagination,
+  getPaginationWithLimitedResults,
 } from './pagination_functions'
 export { traversePages } from './pagination'

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -445,6 +445,37 @@ describe('element', () => {
           expect(() => generator.handleError({ typeName: 'myType', error: fetchError })).toThrow(AbortFetchOnFailure)
           expect(customErrorHandler).toHaveBeenCalledWith({ error: fetchError, typeName: 'myType' })
         })
+        it('should fallback to default behavior if custom error handler returns undefined', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                  },
+                },
+              },
+              default: {
+                resource: {
+                  onError: {
+                    custom: () => () => undefined,
+                  },
+                },
+              },
+            }),
+          })
+          generator.handleError({ typeName: 'myType', error: fetchError })
+          generator.generate()
+          expect(logErrorSpy).toHaveBeenCalledWith(
+            'unexpectedly failed to fetch type %s:%s: %s',
+            expect.any(String),
+            expect.any(String),
+            fetchError.message,
+            { adapterName: 'myAdapter', typeName: 'myType' },
+          )
+        })
       })
 
       describe('when onError is not provided', () => {

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -87,7 +87,7 @@ import { isClassicEngineOrg, logUsersCount } from './utils'
 import { createFixElementFunctions } from './fix_elements'
 import { CLASSIC_ENGINE_UNSUPPORTED_TYPES, createFetchDefinitions } from './definitions/fetch'
 import { createDeployDefinitions } from './definitions/deploy/deploy'
-import { PAGINATION } from './definitions/requests/pagination'
+import { createPaginationDefinitions } from './definitions/requests/pagination'
 import { createClientDefinitions, shouldAccessPrivateAPIs } from './definitions/requests/clients'
 import { OktaOptions } from './definitions/types'
 import { OPEN_API_DEFINITIONS } from './definitions/sources'
@@ -214,7 +214,7 @@ export default class OktaAdapter implements AdapterOperations {
     const definitions = {
       // TODO - SALTO-5746 - only provide adminClient when it is defined
       clients: createClientDefinitions({ main: this.client, private: this.adminClient ?? this.client }),
-      pagination: PAGINATION,
+      pagination: createPaginationDefinitions(this.userConfig),
       fetch: createFetchDefinitions({
         userConfig: this.userConfig,
         fetchQuery: this.fetchQuery,

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1256,7 +1256,7 @@ const createCustomizations = ({
           () =>
           ({ error }) => {
             if (error instanceof fetchUtils.errors.MaxResultsExceeded) {
-              const message = `The number of users fetched exceeded the maximum allowed: ${error.maxResults}. Consider excluding this type or filtering users by specific status.`
+              const message = `The number of users fetched exceeded the maximum allowed: ${error.maxResults}. Consider excluding this type or filtering users by a specific status.`
               return {
                 action: 'customSaltoError',
                 value: {
@@ -1266,7 +1266,7 @@ const createCustomizations = ({
                 },
               }
             }
-            return { action: 'failEntireFetch', value: false }
+            return undefined
           },
         action: 'failEntireFetch',
         value: false,

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1249,7 +1249,29 @@ const createCustomizations = ({
         },
       },
     ],
-    resource: { directFetch: true },
+    resource: {
+      directFetch: true,
+      onError: {
+        custom:
+          () =>
+          ({ error }) => {
+            if (error instanceof fetchUtils.errors.MaxResultsExceeded) {
+              const message = `The number of users fetched exceeded the maximum allowed: ${error.maxResults}. Consider excluding this type or filtering users by specific status.`
+              return {
+                action: 'customSaltoError',
+                value: {
+                  message,
+                  detailedMessage: message,
+                  severity: 'Warning',
+                },
+              }
+            }
+            return { action: 'failEntireFetch', value: false }
+          },
+        action: 'failEntireFetch',
+        value: false,
+      },
+    },
     element: {
       topLevel: {
         isTopLevel: true,

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -70,7 +70,7 @@ export const createClientDefinitions = (
                 limit: '200', // maximum page size allowed
                 search: 'id pr', // The search query is needed to fetch deprovisioned users
               },
-              pagination: 'limitedCursorHeader',
+              pagination: 'usersCursorHeader',
             },
           },
           '/api/v1/apps/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -70,6 +70,7 @@ export const createClientDefinitions = (
                 limit: '200', // maximum page size allowed
                 search: 'id pr', // The search query is needed to fetch deprovisioned users
               },
+              pagination: 'limitedCursorHeader',
             },
           },
           '/api/v1/apps/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,

--- a/packages/okta-adapter/src/definitions/requests/pagination.ts
+++ b/packages/okta-adapter/src/definitions/requests/pagination.ts
@@ -23,7 +23,7 @@ export const createPaginationDefinitions = (
   cursor: {
     funcCreator: () => cursorPagination({ paginationField: 'nextMappingsPageUrl', pathChecker: defaultPathChecker }),
   },
-  limitedCursorHeader: {
+  usersCursorHeader: {
     funcCreator: () =>
       getPaginationWithLimitedResults({
         maxResultsNumber: config.fetch.maxUsersResults ?? DEFAULT_MAX_ALLOWED_RESULTS,

--- a/packages/okta-adapter/src/definitions/requests/pagination.ts
+++ b/packages/okta-adapter/src/definitions/requests/pagination.ts
@@ -7,14 +7,27 @@
  */
 import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import { OktaOptions } from '../types'
+import { OktaUserConfig } from '../../user_config'
 
-const { cursorPagination, defaultPathChecker, cursorHeaderPagination } = fetchUtils.request.pagination
+const { cursorPagination, defaultPathChecker, cursorHeaderPagination, getPaginationWithLimitedResults } =
+  fetchUtils.request.pagination
 
-export const PAGINATION: definitions.ApiDefinitions<OktaOptions>['pagination'] = {
+const DEFAULT_MAX_ALLOWED_RESULTS = 200000
+
+export const createPaginationDefinitions = (
+  config: OktaUserConfig,
+): definitions.ApiDefinitions<OktaOptions>['pagination'] => ({
   cursorHeader: {
     funcCreator: () => cursorHeaderPagination({ pathChecker: defaultPathChecker }),
   },
   cursor: {
     funcCreator: () => cursorPagination({ paginationField: 'nextMappingsPageUrl', pathChecker: defaultPathChecker }),
   },
-}
+  limitedCursorHeader: {
+    funcCreator: () =>
+      getPaginationWithLimitedResults({
+        maxResultsNumber: config.fetch.maxUsersResults ?? DEFAULT_MAX_ALLOWED_RESULTS,
+        paginationFunc: cursorHeaderPagination({ pathChecker: defaultPathChecker }),
+      }),
+  },
+})

--- a/packages/okta-adapter/src/definitions/types.ts
+++ b/packages/okta-adapter/src/definitions/types.ts
@@ -8,7 +8,7 @@
 export type StatusActionName = 'activate' | 'deactivate'
 export type AdditionalAction = StatusActionName
 export type ClientOptions = 'main' | 'private'
-type PaginationOptions = 'cursorHeader' | 'cursor'
+type PaginationOptions = 'cursorHeader' | 'cursor' | 'limitedCursorHeader'
 export type OktaOptions = {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions

--- a/packages/okta-adapter/src/definitions/types.ts
+++ b/packages/okta-adapter/src/definitions/types.ts
@@ -8,7 +8,7 @@
 export type StatusActionName = 'activate' | 'deactivate'
 export type AdditionalAction = StatusActionName
 export type ClientOptions = 'main' | 'private'
-type PaginationOptions = 'cursorHeader' | 'cursor' | 'limitedCursorHeader'
+type PaginationOptions = 'cursorHeader' | 'cursor' | 'usersCursorHeader'
 export type OktaOptions = {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -25,6 +25,7 @@ export type OktaUserFetchConfig = definitions.UserFetchConfig<{
   includeGroupMemberships?: boolean
   includeProfileMappingProperties?: boolean
   getUsersStrategy?: GetUsersStrategy
+  maxUsersResults?: number
 }
 
 export type OktaClientRateLimitConfig = definitions.ClientRateLimitConfig & { rateLimitBuffer?: number }
@@ -111,6 +112,7 @@ const additionalFetchConfigFields = {
     },
   },
   isClassicOrg: { refType: BuiltinTypes.BOOLEAN },
+  maxUsersResults: { refType: BuiltinTypes.NUMBER },
 }
 
 export const configType = definitions.createUserConfigType({

--- a/packages/okta-adapter/test/utils.ts
+++ b/packages/okta-adapter/test/utils.ts
@@ -22,7 +22,7 @@ import { DEFAULT_CONFIG, OktaUserConfig } from '../src/user_config'
 import { OLD_API_DEFINITIONS_CONFIG } from '../src/config'
 import { OktaOptions } from '../src/definitions/types'
 import { createClientDefinitions } from '../src/definitions/requests/clients'
-import { PAGINATION } from '../src/definitions/requests/pagination'
+import { createPaginationDefinitions } from '../src/definitions/requests/pagination'
 import { createFetchDefinitions } from '../src/definitions/fetch/fetch'
 import { getAdminUrl } from '../src/client/admin'
 import fetchCriteria from '../src/fetch_criteria'
@@ -83,7 +83,7 @@ export const createDefinitions = ({
   const cli = client ?? mockClient().client
   return {
     clients: createClientDefinitions({ main: cli, private: cli }),
-    pagination: PAGINATION,
+    pagination: createPaginationDefinitions(DEFAULT_CONFIG),
     fetch: createFetchDefinitions({
       userConfig: DEFAULT_CONFIG,
       fetchQuery,


### PR DESCRIPTION
We want to limit the number of users fetched to 200,000

---

_Additional context for reviewer_
Set the default max users number to 200,000, when exceeding this, the pagination func will throw and this error will be caught by the custom error handler that will convert the error into fetch warning.
The max number is configurable through the adapter config, and can also be set to `-1` to cancel this limitation.

---
_Release Notes_: 

_Okta adapter_:
- Add safety to avoid fetching users in account with more than 200,000 users

---
_User Notifications_: 
None
