### PR TITLE
SALTO-6667 Zendesk trigger skill priority

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -120,6 +120,7 @@ import articleFilter from './filters/article/article'
 import articleBodyFilter from './filters/article/article_body'
 import { dependencyChanger } from './dependency_changers'
 import deployBrandedGuideTypesFilter from './filters/deploy_branded_guide_types'
+import deployTriggerSkills from './filters/deploy_trigger_skills'
 import { Credentials } from './auth'
 import guideSectionCategoryFilter from './filters/guide_section_and_category'
 import guideTranslationFilter from './filters/guide_translation'
@@ -268,6 +269,7 @@ export const DEFAULT_FILTERS = [
   handleIdenticalAttachmentConflicts,
   omitCollisionFilter, // needs to be after referencedIdFieldsFilter (which is part of the common filters)
   deployBrandedGuideTypesFilter,
+  deployTriggerSkills,
   guideThemeFilter, // fetches a lot of data, so should be after omitCollisionFilter to remove theme collisions
   guideThemeSettingFilter, // needs to be after guideThemeFilter as it depends on successful theme fetches
   addAliasFilter, // should run after fieldReferencesFilter and guideThemeSettingFilter

--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -10,7 +10,7 @@ import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import { ZendeskConfig } from '../../config'
 import { ZendeskFetchOptions } from '../types'
 import { BUSINESS_HOUR_SCHEDULE_HOLIDAY, EVERYONE_USER_TYPE } from '../../constants'
-import { transformGuideItem, transformQueueItem, transformSectionItem } from './transforms'
+import { transformGuideItem, transformQueueItem, transformSectionItem, transformTriggerItem } from './transforms'
 
 const NAME_ID_FIELD: definitions.fetch.FieldIDPart = { fieldName: 'name' }
 const DEFAULT_ID_PARTS = [NAME_ID_FIELD]
@@ -141,7 +141,7 @@ const createCustomizations = (): Record<
     requests: [
       {
         endpoint: { path: '/api/v2/triggers' },
-        transformation: { root: 'triggers' },
+        transformation: { root: 'triggers', adjust: transformTriggerItem },
       },
     ],
     resource: {

--- a/packages/zendesk-adapter/src/definitions/fetch/transforms/index.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/transforms/index.ts
@@ -9,3 +9,4 @@
 export { transform as transformGuideItem } from './guide_adjuster'
 export { transform as transformSectionItem } from './section_adjuster'
 export { transform as transformQueueItem } from './queue_adjuster'
+export { transform as transformTriggerItem } from './trigger_adjuster'

--- a/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
@@ -45,7 +45,7 @@ export const transform: definitions.AdjustFunctionSingle = async ({ value }) => 
         }
       }
     }
-    return action
+    return { ...action }
   })
 
   return {

--- a/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { definitions } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { values as lowerdashValues } from '@salto-io/lowerdash'
+import _ from 'lodash'
+
+const log = logger(module)
+
+export const TRIGGER_SKILL_FIELDS = ['add_skills', 'set_skills']
+const SKILL_WITH_PRIORITY_PATTERN = /^([a-zA-Z0-9-]+)#([01])$/ // the regex is a uuid followed by a priority number
+
+// This transformer parses skill priority in trigger actions.
+// See https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/
+export const transform: definitions.AdjustFunctionSingle = async ({ value }) => {
+  if (!lowerdashValues.isPlainObject(value)) {
+    throw new Error('unexpected value for trigger item, not transforming')
+  }
+
+  const actions = _.get(value, 'actions')
+  if (actions === undefined || !Array.isArray(actions)) {
+    return { value }
+  }
+  const updatedActions = actions.map(action => {
+    if (TRIGGER_SKILL_FIELDS.includes(_.get(action, 'field'))) {
+      const skillValue = _.get(action, 'value')
+      if (typeof skillValue === 'string') {
+        const skillWithPriority = skillValue.match(SKILL_WITH_PRIORITY_PATTERN)
+        if (skillWithPriority !== null) {
+          return {
+            ...action,
+            value: skillWithPriority[1],
+            priority: skillWithPriority[2] === '1' ? 'optional' : 'required',
+          }
+        }
+        if (!skillValue.match(/^[a-zA-Z0-9-]+$/)) {
+          const title = _.get(value, 'title', 'unknown')
+          log.warn(`For trigger ${title} - Failed to parse skill value with priority: %s`, skillValue)
+        }
+      }
+    }
+    return action
+  })
+
+  return {
+    value: {
+      ...value,
+      actions: updatedActions,
+    },
+  }
+}

--- a/packages/zendesk-adapter/src/filters/deploy_trigger_skills.ts
+++ b/packages/zendesk-adapter/src/filters/deploy_trigger_skills.ts
@@ -20,7 +20,7 @@ const restoreTriggerSkillToApi = async (
     .forEach((action: { value?: string; priority?: string }) => {
       if ('priority' in action && 'value' in action) {
         const { value, priority } = action as { value: string; priority: string }
-        action.value = `${value}#${priority === 'optional' ? '0' : '1'}`
+        action.value = `${value}#${priority === 'optional' ? '1' : '0'}`
         skillMapping[action.value] = { value, priority }
         delete action.priority
       }

--- a/packages/zendesk-adapter/src/filters/deploy_trigger_skills.ts
+++ b/packages/zendesk-adapter/src/filters/deploy_trigger_skills.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { TRIGGER_TYPE_NAME } from '../constants'
+import { TRIGGER_SKILL_FIELDS } from '../definitions/fetch/transforms/trigger_adjuster'
+import { FilterCreator } from '../filter'
+
+const restoreTriggerSkillToApi = async (
+  instance: InstanceElement,
+  skillMapping: Record<string, { value: string; priority: string }>,
+): Promise<void> => {
+  instance.value?.actions
+    .filter((action: unknown) => TRIGGER_SKILL_FIELDS.includes(_.get(action, 'field')))
+    .forEach((action: { value?: string; priority?: string }) => {
+      if ('priority' in action && 'value' in action) {
+        const { value, priority } = action as { value: string; priority: string }
+        action.value = `${value}#${priority === 'optional' ? '0' : '1'}`
+        skillMapping[action.value] = { value, priority }
+        delete action.priority
+      }
+    })
+}
+
+/**
+ * Restores trigger action skills to match the correct API calls.
+ * See https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/
+ */
+const filterCreator: FilterCreator = () => {
+  const skillMapping: Record<string, { value: string; priority: string }> = {}
+  return {
+    name: 'deployTriggerSkillsFilter',
+    preDeploy: async (changes: Change<InstanceElement>[]): Promise<void> => {
+      await Promise.all(
+        changes
+          .map(getChangeData)
+          .filter(instance => instance.elemID.typeName === TRIGGER_TYPE_NAME)
+          .map(instance => restoreTriggerSkillToApi(instance, skillMapping)),
+      )
+    },
+    onDeploy: async (changes: Change<InstanceElement>[]): Promise<void> =>
+      changes
+        .map(getChangeData)
+        .filter(instance => instance.elemID.typeName === TRIGGER_TYPE_NAME && Array.isArray(instance.value?.actions))
+        .forEach(async instance => {
+          instance.value.actions = instance.value.actions.map((action: { value: string }) => {
+            if (skillMapping[action.value]) {
+              return {
+                ...action,
+                value: skillMapping[action.value].value,
+                priority: skillMapping[action.value].priority,
+              }
+            }
+            return action
+          })
+        }),
+  }
+}
+
+export default filterCreator

--- a/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
+++ b/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { transformTriggerItem } from '../../../../src/definitions/fetch/transforms'
+
+describe('trigger_adjuster', () => {
+  describe('without priority', () => {
+    it('should not update trigger item with add_skills or set_skills field', async () => {
+      const value = {
+        actions: [
+          {
+            field: 'add_skills',
+            value: 'skillWithoutPriority',
+          },
+          {
+            field: 'set_skills',
+            value: 'skillWithoutPriority',
+          },
+        ],
+      }
+      const transformedItem = await transformTriggerItem({ value, context: {}, typeName: 'trigger' })
+      expect(transformedItem).toEqual({ value })
+    })
+  })
+
+  describe('with priority', () => {
+    it('should transform trigger item with skill priority', async () => {
+      const value = {
+        actions: [
+          {
+            field: 'add_skills',
+            value: 'requiredSkill#0',
+          },
+          {
+            field: 'set_skills',
+            value: 'optionalSkill#1',
+          },
+        ],
+      }
+      const transformedItem = await transformTriggerItem({ value, context: {}, typeName: 'trigger' })
+      expect(transformedItem).toEqual({
+        value: {
+          actions: [
+            {
+              field: 'add_skills',
+              value: 'requiredSkill',
+              priority: 'required',
+            },
+            {
+              field: 'set_skills',
+              value: 'optionalSkill',
+              priority: 'optional',
+            },
+          ],
+        },
+      })
+    })
+
+    it('should transform trigger item with mixed skill priority and non-priority skills', async () => {
+      const value = {
+        actions: [
+          {
+            field: 'add_skills',
+            value: 'requiredSkill#0',
+          },
+          {
+            field: 'set_skills',
+            value: 'skillWithoutPriority',
+          },
+        ],
+      }
+      const transformedItem = await transformTriggerItem({ value, context: {}, typeName: 'trigger' })
+      expect(transformedItem).toEqual({
+        value: {
+          actions: [
+            {
+              field: 'add_skills',
+              value: 'requiredSkill',
+              priority: 'required',
+            },
+            {
+              field: 'set_skills',
+              value: 'skillWithoutPriority',
+            },
+          ],
+        },
+      })
+    })
+  })
+
+  it('should not update trigger item without actions', async () => {
+    const value = { a: 1 }
+    const transformedItem = await transformTriggerItem({ value, context: {}, typeName: 'trigger' })
+    expect(transformedItem).toEqual({ value: { a: 1 } })
+  })
+})

--- a/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
+++ b/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { InstanceElement, ObjectType, ElemID, toChange } from '@salto-io/adapter-api'
+import { filterUtils } from '@salto-io/adapter-components'
+import { TRIGGER_TYPE_NAME, ZENDESK } from '../../src/constants'
+import filterCreator from '../../src/filters/deploy_trigger_skills'
+import { createFilterCreatorParams } from '../utils'
+
+type FilterType = filterUtils.FilterWith<'preDeploy' | 'onDeploy'>
+
+const triggerType = new ObjectType({ elemID: new ElemID(ZENDESK, TRIGGER_TYPE_NAME) })
+const triggerInstance = new InstanceElement('instance', triggerType, {
+  actions: [
+    { field: 'set_skills', value: 'wakeBoarding', priority: 'required' },
+    { field: 'no_skills_needed', value: 'breathing', priority: 'required' },
+    { field: 'add_skills', value: 'tyingShoes', priority: 'optional' },
+    { field: 'always_fun', value: 'livingWithoutPriority' },
+  ],
+})
+
+describe('deploy trigger skills filter', () => {
+  let instance: InstanceElement
+  let filter: FilterType
+  beforeEach(() => {
+    instance = triggerInstance.clone()
+    filter = filterCreator(createFilterCreatorParams({})) as FilterType
+  })
+  describe('preDeploy', () => {
+    it('should update the trigger actions to match the correct API calls', async () => {
+      await filter.preDeploy([toChange({ before: instance })])
+
+      expect(instance.value?.actions).toEqual([
+        { field: 'set_skills', value: 'wakeBoarding#0' },
+        { field: 'no_skills_needed', value: 'breathing', priority: 'required' },
+        { field: 'add_skills', value: 'tyingShoes#1' },
+        { field: 'always_fun', value: 'livingWithoutPriority' },
+      ])
+    })
+  })
+  describe('onDeploy', () => {
+    it('should restore the trigger actions to the original format', async () => {
+      await filter.preDeploy([toChange({ before: instance })])
+      await filter.onDeploy([toChange({ before: instance })])
+
+      expect(instance.value?.actions).toEqual(triggerInstance.value?.actions)
+    })
+  })
+})


### PR DESCRIPTION
Support a new API format of skills within Zendesk triggers.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Zendesk Adapter:_
* set_skills or add_skills under Trigger actions will now have a priority of required or optional as per https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/

---
_User Notifications_: 
_Zendesk Adapter:_
* Trigger nacls with set_skills or add_skills will now include a priority key if this is received from Zendesk.