### PR TITLE
SALTO-6753: Supporting workflows in SFDX

### DIFF
--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -236,7 +236,7 @@ const filterCreator: FilterCreator = ({ config, client }) => {
       originalWorkflowChanges = await groupByAsync(allWorkflowRelatedChanges, getWorkflowApiName)
 
       if (client === undefined) {
-        // In the SFDX flow we need to get the entire flow to avoid part of it being dropped.
+        // In the SFDX flow we need to get the entire workflow to avoid part of it being dropped.
         const workflowNames = new Set(Object.keys(originalWorkflowChanges))
 
         await awu(await config.elementsSource.list())

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -49,6 +49,7 @@ import {
   WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
   WORKFLOW_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE,
+  WORKFLOW_RULE_METADATA_TYPE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -333,6 +334,18 @@ export const mockTypes = {
       metadataType: WORKFLOW_FIELD_UPDATE_METADATA_TYPE,
       dirName: 'workflows',
       suffix: 'workflow',
+    },
+  }),
+  WorkflowRule: createMetadataObjectType({
+    annotations: {
+      metadataType: WORKFLOW_RULE_METADATA_TYPE,
+      dirName: 'workflows',
+      suffix: 'workflow',
+    },
+    fields: {
+      active: {
+        refType: BuiltinTypes.BOOLEAN,
+      },
     },
   }),
 

--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
@@ -23,9 +23,8 @@ import {
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { dumpElementsToFolder } from '../../src/sfdx_parser/sfdx_dump'
 import { mockTypes, mockDefaultValues } from '../mock_elements'
-import { createInstanceElement, createMetadataObjectType, Types } from '../../src/transformers/transformer'
+import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import { createCustomObjectType } from '../utils'
-import { WORKFLOW_RULE_METADATA_TYPE } from '../../src/constants'
 import { xmlToValues } from '../../src/transformers/xml_transformer'
 
 describe('dumpElementsToFolder', () => {
@@ -117,12 +116,9 @@ describe('dumpElementsToFolder', () => {
         // Here we use an example of a WorkflowRule that is dumped into a Workflow xml
         // Doing this makes us go through different code paths in SFDX, specifically, the flow that requires "readFileSync"
         // to be implemented in our SyncZipTreeContainer
-        const workflowRuleType = createMetadataObjectType({
-          annotations: { metadataType: WORKFLOW_RULE_METADATA_TYPE },
-        })
         const newWorkflowRule = createInstanceElement(
           { fullName: 'Test__c.Rule', actions: [], active: false },
-          workflowRuleType,
+          mockTypes.WorkflowRule,
           undefined,
           { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID('salesforce', 'Test__c'))] },
         )
@@ -134,7 +130,7 @@ describe('dumpElementsToFolder', () => {
               formula: 'One__c > 2',
               triggerType: 'onCreateOrTriggeringUpdate',
             },
-            workflowRuleType,
+            mockTypes.WorkflowRule,
             undefined,
             { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID('salesforce', 'Test__c'))] },
           ),
@@ -145,7 +141,7 @@ describe('dumpElementsToFolder', () => {
               formula: 'One__c < 10',
               triggerType: 'onCreateOrTriggeringUpdate',
             },
-            workflowRuleType,
+            mockTypes.WorkflowRule,
             undefined,
             { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(new ElemID('salesforce', 'Test__c'))] },
           ),
@@ -154,7 +150,7 @@ describe('dumpElementsToFolder', () => {
           baseDir: project.name(),
           changes: [toChange({ after: newWorkflowRule })],
           elementsSource: buildElementsSourceFromElements([
-            workflowRuleType,
+            mockTypes.WorkflowRule,
             newWorkflowRule,
             ...existingWorkflowRules,
           ]),


### PR DESCRIPTION
Since the SFDX code overrides entire workflows on any workflow change, we need to collect all workflow sub-instances on any workflow change.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
