### PR TITLE
SALTO-6779: add workflow transition links

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -43,7 +43,7 @@ export type ClientOpts<TCredentials, TRateLimitConfig extends ClientRateLimitCon
 
 export type ClientBaseParams = {
   url: string
-  queryParams?: Record<string, string | string[]>
+  queryParams?: Record<string, string | string[] | boolean>
   headers?: Record<string, string>
   responseType?: ResponseType
   params?: Record<string, Values>

--- a/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/workflow.ts
@@ -26,10 +26,7 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     [naclCase('Build Broken::From: any status::Global')]: {
       name: 'Build Broken',
       description: '',
-      to: {
-        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-        port: 7,
-      },
+      toStatusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
       type: 'GLOBAL',
       triggers: [
         {
@@ -80,10 +77,12 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     [naclCase('Create::From: none::Initial')]: {
       name: 'Create',
       description: '',
-      to: {
-        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-        port: 7,
-      },
+      toStatusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+      links: [
+        {
+          toPort: 7,
+        },
+      ],
       type: 'INITIAL',
       validators: [
         {
@@ -151,16 +150,14 @@ export const createWorkflowValues = (name: string, allElements: Element[]): Valu
     [naclCase('TransitionToShared::From: Done::Directed')]: {
       name: 'TransitionToShared',
       description: '',
-      from: [
+      toStatusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
+      links: [
         {
-          statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
-          port: 1,
+          toPort: 7,
+          fromPort: 1,
+          fromStatusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'done'), allElements),
         },
       ],
-      to: {
-        statusReference: createReference(new ElemID(JIRA, STATUS_TYPE_NAME, 'instance', 'backlog'), allElements),
-        port: 7,
-      },
       type: 'DIRECTED',
       validators: [
         {

--- a/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
+++ b/packages/jira-adapter/src/change_validators/workflowsV2/inbound_transition.ts
@@ -23,7 +23,7 @@ const { awu } = collections.asynciterable
 
 const getStatusesWithoutInboundTransitions = (instance: WorkflowV2Instance): ReferenceExpression[] => {
   const statusesRefsWithInboundTransitions = Object.values(instance.value.transitions)
-    .map(transition => transition.to?.statusReference)
+    .map(transition => transition.toStatusReference)
     .filter(isDefined)
     .filter(isResolvedReferenceExpression)
   const statusesRefs = instance.value.statuses

--- a/packages/jira-adapter/src/filters/workflow/transition_structure.ts
+++ b/packages/jira-adapter/src/filters/workflow/transition_structure.ts
@@ -7,12 +7,12 @@
  */
 
 import { invertNaclCase, naclCase } from '@salto-io/adapter-utils'
-import { SaltoError, Value } from '@salto-io/adapter-api'
+import { ReferenceExpression, SaltoError, Value } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { Status, Transition as WorkflowTransitionV1, WorkflowV1Instance } from './types'
+import { isWorkflowV1Transition, Status, Transition as WorkflowTransitionV1, WorkflowV1Instance } from './types'
 import { SCRIPT_RUNNER_POST_FUNCTION_TYPE } from '../script_runner/workflow/workflow_cloud'
-import { isWorkflowV2Transition, WorkflowV2Transition } from '../workflowV2/types'
+import { isWorkflowV2Transition, WorkflowV2Transition, WorkflowVersionType } from '../workflowV2/types'
 
 const { makeArray } = collections.array
 
@@ -31,18 +31,22 @@ const getTransitionTypeFromKey = (key: string): string => {
   return type === 'Circular' ? 'Global' : type
 }
 
-const getTransitionType = (transition: WorkflowTransitionV1 | WorkflowV2Transition): TransitionType => {
+const getTransitionType = (
+  transition: WorkflowTransitionV1 | WorkflowV2Transition,
+  workflowVersion: WorkflowVersionType,
+): TransitionType => {
   if (transition.type?.toLowerCase() === 'initial') {
     return 'Initial'
   }
-  if (isWorkflowV2Transition(transition)) {
+  if (workflowVersion === WorkflowVersionType.V2 && isWorkflowV2Transition(transition)) {
     if (transition.links !== undefined && transition.links.length !== 0) {
       return 'Directed'
     }
     if (transition.toStatusReference === undefined) {
       return 'Circular'
     }
-  } else {
+  }
+  if (workflowVersion === WorkflowVersionType.V1 && isWorkflowV1Transition(transition)) {
     if (transition.from !== undefined && transition.from.length !== 0) {
       return 'Directed'
     }
@@ -82,17 +86,26 @@ export const createStatusMap = (statuses: Status[]): Map<string, string> =>
       .map(status => [status.id, status.name]),
   )
 
-export const getTransitionKey = (
-  transition: WorkflowTransitionV1 | WorkflowV2Transition,
-  statusesMap: Map<string, string>,
-): string => {
-  const type = getTransitionType(transition)
+export const getTransitionKey = ({
+  transition,
+  statusesMap,
+  workflowVersion,
+}: {
+  transition: WorkflowTransitionV1 | WorkflowV2Transition
+  statusesMap: Map<string, string>
+  workflowVersion: WorkflowVersionType
+}): string => {
+  const type = getTransitionType(transition, workflowVersion)
+  let fromIds: (string | ReferenceExpression | undefined)[] = []
+  if (workflowVersion === WorkflowVersionType.V2 && isWorkflowV2Transition(transition)) {
+    fromIds = makeArray(transition.links).map(link => link.fromStatusReference)
+  }
+  if (workflowVersion === WorkflowVersionType.V1 && isWorkflowV1Transition(transition)) {
+    fromIds = makeArray(transition.from).map(from => (_.isString(from) ? from : from.id ?? ''))
+  }
   const fromSorted =
     type === 'Directed'
-      ? (isWorkflowV2Transition(transition)
-          ? makeArray(transition.links).map(link => link.fromStatusReference)
-          : makeArray(transition.from).map(from => (_.isString(from) ? from : from.id ?? ''))
-        )
+      ? fromIds
           .map(from => (_.isString(from) && statusesMap.get(from) !== undefined ? statusesMap.get(from) : from))
           .sort()
           .join(',')
@@ -101,10 +114,18 @@ export const getTransitionKey = (
   return naclCase([transition.name, `From: ${fromSorted}`, type].join(TRANSITION_PARTS_SEPARATOR))
 }
 
-export const transformTransitions = (value: Value, statuses?: Pick<Status, 'id' | 'name'>[]): SaltoError[] => {
+export const transformTransitions = ({
+  value,
+  workflowVersion,
+  statuses,
+}: {
+  value: Value
+  workflowVersion: WorkflowVersionType
+  statuses?: Pick<Status, 'id' | 'name'>[]
+}): SaltoError[] => {
   const statusesMap = createStatusMap(statuses ?? value.statuses ?? [])
   const maxCounts = _(value.transitions)
-    .map(transition => getTransitionKey(transition, statusesMap))
+    .map(transition => getTransitionKey({ transition, statusesMap, workflowVersion }))
     .countBy()
     .value()
 
@@ -114,7 +135,7 @@ export const transformTransitions = (value: Value, statuses?: Pick<Status, 'id' 
     value.transitions
       // This is Value and not the actual type as we change types
       .map((transition: Value) => {
-        const key = getTransitionKey(transition, statusesMap)
+        const key = getTransitionKey({ transition, statusesMap, workflowVersion })
         counts[key] = (counts[key] ?? 0) + 1
         if (maxCounts[key] > 1) {
           return [naclCase(`${invertNaclCase(key)}${TRANSITION_PARTS_SEPARATOR}${counts[key]}`), transition]
@@ -168,20 +189,22 @@ export const expectedToActualTransitionIds = ({
   transitions,
   expectedTransitionIds,
   statusesMap,
+  workflowVersion,
 }: {
   transitions: WorkflowTransitionV1[]
   expectedTransitionIds: Map<string, string>
   statusesMap: Map<string, string>
+  workflowVersion: WorkflowVersionType
 }): Record<string, string> =>
   Object.fromEntries(
     transitions
       // create a map of [expectedId, actualId]
       .map(
         transition =>
-          [expectedTransitionIds.get(getTransitionKey(transition, statusesMap)), transition.id] as [
-            string | undefined,
-            string | undefined,
-          ],
+          [
+            expectedTransitionIds.get(getTransitionKey({ transition, statusesMap, workflowVersion })),
+            transition.id,
+          ] as [string | undefined, string | undefined],
       )
       .filter(([expectedId, actualId]) => expectedId !== undefined && actualId !== undefined)
       .filter(([expectedId, actualId]) => expectedId !== actualId),

--- a/packages/jira-adapter/src/filters/workflow/types.ts
+++ b/packages/jira-adapter/src/filters/workflow/types.ts
@@ -204,6 +204,11 @@ const isWorkflowResponseValues = createSchemeGuard<WorkflowResponse>(
   'Received unexpected workflow response from service',
 )
 
+export const isWorkflowV1Transition = createSchemeGuard<Transition>(
+  transitionsSchema,
+  'Received an invalid workflowV1 transition',
+)
+
 export const isWorkflowValues = (values: unknown): values is Workflow => {
   const { error } = workflowSchema.validate(values)
   if (error !== undefined) {

--- a/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_deploy_filter.ts
@@ -48,6 +48,7 @@ import {
   getTransitionKey,
 } from './transition_structure'
 import { decodeCloudFields, encodeCloudFields } from '../script_runner/workflow/workflow_cloud'
+import { WorkflowVersionType } from '../workflowV2/types'
 
 const log = logger(module)
 
@@ -97,10 +98,16 @@ const sameTransitionIds = (
   statusesMap: Map<string, string>,
 ): boolean => {
   const transitionIds = Object.fromEntries(
-    transitions.map(transition => [transition.id, getTransitionKey(transition, statusesMap)]),
+    transitions.map(transition => [
+      transition.id,
+      getTransitionKey({ transition, statusesMap, workflowVersion: WorkflowVersionType.V1 }),
+    ]),
   )
   const otherTransitionIds = Object.fromEntries(
-    otherTransitions.map(transition => [transition.id, getTransitionKey(transition, statusesMap)]),
+    otherTransitions.map(transition => [
+      transition.id,
+      getTransitionKey({ transition, statusesMap, workflowVersion: WorkflowVersionType.V1 }),
+    ]),
   )
   return _.isEqual(transitionIds, otherTransitionIds)
 }
@@ -146,7 +153,10 @@ const addTransitionIdsToInstance = (
   statusesMap: Map<string, string>,
 ): void => {
   const transitionIds = Object.fromEntries(
-    transitions.map(transition => [getTransitionKey(transition, statusesMap), transition.id]),
+    transitions.map(transition => [
+      getTransitionKey({ transition, statusesMap, workflowVersion: WorkflowVersionType.V1 }),
+      transition.id,
+    ]),
   )
   Object.entries(workflowInstance.value.transitions).forEach(([key, transition]) => {
     transition.id = transitionIds[key]
@@ -285,6 +295,7 @@ const verifyAndFixTransitionReferences = async ({
     transitions,
     expectedTransitionIds,
     statusesMap,
+    workflowVersion: WorkflowVersionType.V1,
   })
   if (Object.keys(transitionIdsMap).length === 0) {
     return transitions

--- a/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_structure_filter.ts
@@ -26,6 +26,7 @@ import { Condition, isWorkflowResponseInstance, Rules, WorkflowResponse, Status,
 import { validatorType, types as validatorTypes } from './validators_types'
 import { JIRA, WORKFLOW_RULES_TYPE_NAME, WORKFLOW_TRANSITION_TYPE_NAME, WORKFLOW_TYPE_NAME } from '../../constants'
 import { transformTransitions } from './transition_structure'
+import { WorkflowVersionType } from '../workflowV2/types'
 
 const NOT_FETCHED_POST_FUNCTION_TYPES = ['GenerateChangeHistoryFunction', 'IssueReindexFunction', 'IssueCreateFunction']
 
@@ -147,7 +148,7 @@ const transformWorkflowInstance = (workflowValues: WorkflowResponse): SaltoError
     })
 
   // The type is changed after transform Transitions, so should be last
-  return transformTransitions(workflowValues)
+  return transformTransitions({ value: workflowValues, workflowVersion: WorkflowVersionType.V1 })
 }
 
 // This filter transforms the workflow values structure so it will fit its deployment endpoint

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -34,6 +34,7 @@ export const ID_TO_UUID_PATH_NAME_TO_RECURSE = new Set([
   'transitions',
   'statusMappings',
   'statusMigrations',
+  'links',
 ])
 export const CONDITION_GROUPS_PATH_NAME_TO_RECURSE = new Set(['transitions', 'conditions', 'conditionGroups'])
 export const EMPTY_STRINGS_PATH_NAME_TO_RECURSE = new Set([
@@ -75,6 +76,12 @@ export type WorkflowStatusAndPort = {
   port?: number
 }
 
+export type WorkflowTransitionLinks = {
+  fromPort?: number
+  fromStatusReference?: string | ReferenceExpression
+  toPort?: number
+}
+
 export type WorkflowV2TransitionRuleParameters = {
   appKey?: string
   key?: string
@@ -95,8 +102,8 @@ export type WorkflowV2Transition = {
   id?: string
   type: string
   name: string
-  from?: WorkflowStatusAndPort[]
-  to?: WorkflowStatusAndPort
+  links?: WorkflowTransitionLinks[]
+  toStatusReference?: string | ReferenceExpression
   actions?: WorkflowV2TransitionRule[]
   conditions?: WorkflowV2TransitionConditionGroup
   validators?: WorkflowV2TransitionRule[]
@@ -150,16 +157,16 @@ const TRANSITION_SCHEME = Joi.object({
   actions: Joi.array().items(TRANSITION_RULE_SCHEME).optional(),
   type: Joi.string().required(),
   name: Joi.string().required(),
-  from: Joi.array().items(
-    Joi.object({
-      statusReference: Joi.alternatives(Joi.object(), Joi.string()).required(),
-      port: Joi.number(),
-    }),
-  ),
-  to: Joi.object({
-    statusReference: Joi.alternatives(Joi.object(), Joi.string()).required(),
-    port: Joi.number(),
-  }),
+  links: Joi.array()
+    .items(
+      Joi.object({
+        fromPort: Joi.number(),
+        fromStatusReference: Joi.alternatives(Joi.object(), Joi.string()),
+        toPort: Joi.number(),
+      }),
+    )
+    .optional(),
+  toStatusReference: Joi.alternatives(Joi.object(), Joi.string()).optional(),
   conditions: TRANSITION_CONDITION_GROUP_SCHEME.optional(),
   validators: Joi.array().items(TRANSITION_RULE_SCHEME).optional(),
   properties: Joi.alternatives(Joi.array().items(Joi.object()), Joi.object()).optional(),
@@ -331,3 +338,5 @@ export const isWorkflowResponse = createSchemeGuard<WorkflowResponse>(
 )
 
 export const isTaskResponse = createSchemeGuard<TaskResponse>(TASK_RESPONSE_SCHEMA, 'Received an invalid task response')
+
+export const isWorkflowV2Transition = createSchemeGuard<WorkflowV2Transition>(TRANSITION_SCHEME)

--- a/packages/jira-adapter/src/filters/workflowV2/types.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/types.ts
@@ -339,4 +339,12 @@ export const isWorkflowResponse = createSchemeGuard<WorkflowResponse>(
 
 export const isTaskResponse = createSchemeGuard<TaskResponse>(TASK_RESPONSE_SCHEMA, 'Received an invalid task response')
 
-export const isWorkflowV2Transition = createSchemeGuard<WorkflowV2Transition>(TRANSITION_SCHEME)
+export const isWorkflowV2Transition = createSchemeGuard<WorkflowV2Transition>(
+  TRANSITION_SCHEME,
+  'Received an invalid workflowV2 transition',
+)
+
+export enum WorkflowVersionType {
+  V1 = 'V1',
+  V2 = 'V2',
+}

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -71,6 +71,7 @@ import {
   EMPTY_STRINGS_PATH_NAME_TO_RECURSE,
   TRANSITION_LIST_FIELDS,
   WorkflowV2Transition,
+  WorkflowVersionType,
 } from './types'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
 import { JIRA, PROJECT_TYPE, WORKFLOW_CONFIGURATION_TYPE, WORKFLOW_RETRY_PERIODS } from '../../constants'
@@ -252,7 +253,11 @@ const createWorkflowInstances = async ({
             return undefined
           }
           // convert transition list to map
-          const [error] = transformTransitions(workflow, workflowIdToStatuses[workflow.id])
+          const [error] = transformTransitions({
+            value: workflow,
+            statuses: workflowIdToStatuses[workflow.id],
+            workflowVersion: WorkflowVersionType.V2,
+          })
           if (error) {
             errors.push(error)
           }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -263,6 +263,18 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: STATUS_TYPE_NAME },
   },
   {
+    src: { field: 'fromStatusReference', parentTypes: ['WorkflowTransitionLinks'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: STATUS_TYPE_NAME },
+  },
+  {
+    src: { field: 'toStatusReference', parentTypes: ['WorkflowTransitions'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: STATUS_TYPE_NAME },
+  },
+  {
     src: { field: 'issueTypeId', parentTypes: ['StatusMappingDTO'] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -257,12 +257,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: STATUS_TYPE_NAME },
   },
   {
-    src: { field: 'statusReference', parentTypes: ['WorkflowStatusAndPort'] },
-    serializationStrategy: 'id',
-    missingRefStrategy: 'typeAndValue',
-    target: { type: STATUS_TYPE_NAME },
-  },
-  {
     src: { field: 'fromStatusReference', parentTypes: ['WorkflowTransitionLinks'] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',

--- a/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
+++ b/packages/jira-adapter/test/change_validators/workflowsV2/inbound_transition.test.ts
@@ -69,9 +69,7 @@ describe('inboundTransitionChangeValidator', () => {
           name: 'tran1',
           id: 'id',
           type: 'DIRECTED',
-          to: {
-            statusReference: status1Ref,
-          },
+          toStatusReference: status1Ref,
         },
         tran2: {
           name: 'tran1',
@@ -82,9 +80,7 @@ describe('inboundTransitionChangeValidator', () => {
           name: 'tran3',
           id: 'id',
           type: 'DIRECTED',
-          to: {
-            statusReference: status3Ref,
-          },
+          toStatusReference: status3Ref,
         },
       },
     })
@@ -109,9 +105,7 @@ describe('inboundTransitionChangeValidator', () => {
       name: 'tran4',
       id: 'id',
       type: 'DIRECTED',
-      to: {
-        statusReference: status2Ref,
-      },
+      toStatusReference: status2Ref,
     }
     expect(await inboundTransitionChangeValidator(changes)).toEqual([])
   })

--- a/packages/jira-adapter/test/filters/workflow/transition_structure.test.ts
+++ b/packages/jira-adapter/test/filters/workflow/transition_structure.test.ts
@@ -11,6 +11,7 @@ import { naclCase } from '@salto-io/adapter-utils'
 import { Transition, TransitionFrom, WorkflowV1Instance } from '../../../src/filters/workflow/types'
 import { createEmptyType } from '../../utils'
 import { getTransitionKey, transitionKeysToExpectedIds } from '../../../src/filters/workflow/transition_structure'
+import { WorkflowVersionType } from '../../../src/filters/workflowV2/types'
 
 const keys = {
   t1: naclCase('transition1::From: Open::Directed'),
@@ -68,7 +69,7 @@ describe('transitionKeysToExpectedIds', () => {
       from: [{} as TransitionFrom],
       name: 'transition1',
     }
-    getTransitionKey(transition1, new Map())
-    getTransitionKey(transition2, new Map())
+    getTransitionKey({ transition: transition1, statusesMap: new Map(), workflowVersion: WorkflowVersionType.V1 })
+    getTransitionKey({ transition: transition2, statusesMap: new Map(), workflowVersion: WorkflowVersionType.V1 })
   })
 })

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -583,9 +583,6 @@ It is strongly recommended to rename these transitions so they are unique in Jir
                     id: '1',
                     name: 'Create',
                     toStatusReference: 'uuid1',
-                    // to: {
-                    //   statusReference: 'uuid1',
-                    // },
                     type: 'INITIAL',
                     conditions: {
                       operation: 'ALL',

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -130,21 +130,22 @@ describe('workflow filter', () => {
                   properties: {
                     'jira.issue.editable': 'true',
                   },
-                  to: {
-                    statusReference: '11',
-                  },
+                  toStatusReference: '11',
+                  links: [
+                    {
+                      toPort: 7,
+                    },
+                  ],
                 },
                 {
                   type: 'DIRECTED',
                   name: 'ToStatus2',
-                  from: [
+                  links: [
                     {
-                      statusReference: '11',
+                      fromStatusReference: '11',
                     },
                   ],
-                  to: {
-                    statusReference: '2',
-                  },
+                  toStatusReference: '2',
                 },
               ],
               statuses: [
@@ -181,9 +182,7 @@ describe('workflow filter', () => {
                 {
                   type: 'GLOBAL',
                   name: 'Done',
-                  to: {
-                    statusReference: '22',
-                  },
+                  toStatusReference: '22',
                 },
               ],
             },
@@ -233,21 +232,22 @@ describe('workflow filter', () => {
                 value: 'true',
               },
             ],
-            to: {
-              statusReference: '11',
-            },
+            toStatusReference: '11',
+            links: [
+              {
+                toPort: 7,
+              },
+            ],
           },
           [TRANSITION_NAME_TO_KEY.ToStatus2]: {
             type: 'DIRECTED',
             name: 'ToStatus2',
-            from: [
+            links: [
               {
-                statusReference: '11',
+                fromStatusReference: '11',
               },
             ],
-            to: {
-              statusReference: '2',
-            },
+            toStatusReference: '2',
           },
         },
         statuses: [
@@ -283,9 +283,7 @@ describe('workflow filter', () => {
           [TRANSITION_NAME_TO_KEY.Done]: {
             type: 'GLOBAL',
             name: 'Done',
-            to: {
-              statusReference: '22',
-            },
+            toStatusReference: '22',
           },
         },
         statuses: [
@@ -339,7 +337,11 @@ describe('workflow filter', () => {
         {
           workflowIds: ['1', '2'],
         },
-        undefined,
+        {
+          params: {
+            useTransitionLinksFormat: true,
+          },
+        },
       )
     })
     it('should not add workflow instances if new workflow api is disabled', async () => {
@@ -432,17 +434,13 @@ describe('workflow filter', () => {
                 {
                   id: '1',
                   name: 'Create',
-                  to: {
-                    statusReference: 'uuid1',
-                  },
+                  toStatusReference: 'uuid1',
                   type: 'INITIAL',
                 },
                 {
                   id: '2',
                   name: 'Create',
-                  to: {
-                    statusReference: 'uuid2',
-                  },
+                  toStatusReference: 'uuid2',
                   type: 'INITIAL',
                 },
               ],
@@ -504,21 +502,17 @@ It is strongly recommended to rename these transitions so they are unique in Jir
                     properties: {
                       'jira.issue.editable': 'true',
                     },
-                    to: {
-                      statusReference: '11',
-                    },
+                    toStatusReference: '11',
                   },
                   {
                     type: 'DIRECTED',
                     name: 'ToStatus2',
-                    from: [
+                    links: [
                       {
-                        statusReference: '11',
+                        fromStatusReference: '11',
                       },
                     ],
-                    to: {
-                      statusReference: '2',
-                    },
+                    toStatusReference: '2',
                     properties: {
                       'jira.field.resolution.exclude': '10000,10001',
                       'jira.field.resolution.include': '10002',
@@ -587,9 +581,10 @@ It is strongly recommended to rename these transitions so they are unique in Jir
                   {
                     id: '1',
                     name: 'Create',
-                    to: {
-                      statusReference: 'uuid1',
-                    },
+                    toStatusReference: 'uuid1',
+                    // to: {
+                    //   statusReference: 'uuid1',
+                    // },
                     type: 'INITIAL',
                     conditions: {
                       operation: 'ALL',
@@ -836,9 +831,12 @@ It is strongly recommended to rename these transitions so they are unique in Jir
             {
               id: '1',
               name: 'Create',
-              to: {
-                statusReference: 'uuid1',
-              },
+              toStatusReference: 'uuid1',
+              links: [
+                {
+                  toPort: 7,
+                },
+              ],
               type: 'INITIAL',
               conditions: {
                 operation: 'ALL',
@@ -852,16 +850,14 @@ It is strongly recommended to rename these transitions so they are unique in Jir
             {
               id: '2',
               name: 'toStatus2',
-              from: [
+              links: [
                 {
-                  port: 3,
-                  statusReference: 'uuid1',
+                  fromPort: 3,
+                  fromStatusReference: 'uuid1',
+                  toPort: 7,
                 },
               ],
-              to: {
-                port: 7,
-                statusReference: 'uuid2',
-              },
+              toStatusReference: 'uuid2',
               type: 'DIRECTED',
               conditions: {
                 operation: 'ALL',
@@ -912,7 +908,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
     }
 
     let workflowReferenceStatusType: ObjectType
-    let WorkflowStatusAndPortType: ObjectType
+    let WorkflowTransitionLinks: ObjectType
     let transitionType: ObjectType
     let statusMappingType: ObjectType
     let statusMigrationType: ObjectType
@@ -961,11 +957,12 @@ It is strongly recommended to rename these transitions so they are unique in Jir
       // types
       statusCategoryType = createEmptyType(STATUS_CATEGORY_TYPE_NAME)
       statusType = createEmptyType(STATUS_TYPE_NAME)
-      WorkflowStatusAndPortType = new ObjectType({
-        elemID: new ElemID(JIRA, 'WorkflowStatusAndPort'),
+      WorkflowTransitionLinks = new ObjectType({
+        elemID: new ElemID(JIRA, 'WorkflowTransitionLinks'),
         fields: {
-          statusReference: { refType: BuiltinTypes.STRING },
-          port: { refType: BuiltinTypes.NUMBER },
+          fromPort: { refType: BuiltinTypes.NUMBER },
+          fromStatusReference: { refType: BuiltinTypes.STRING },
+          toPort: { refType: BuiltinTypes.NUMBER },
         },
       })
       transitionParametersType = new ObjectType({
@@ -1003,8 +1000,8 @@ It is strongly recommended to rename these transitions so they are unique in Jir
           conditions: { refType: conditionGroupConfigurationType },
           name: { refType: BuiltinTypes.STRING },
           type: { refType: BuiltinTypes.STRING },
-          from: { refType: new ListType(WorkflowStatusAndPortType) },
-          to: { refType: WorkflowStatusAndPortType },
+          links: { refType: new ListType(WorkflowTransitionLinks) },
+          toStatusReference: { refType: BuiltinTypes.STRING },
         },
       })
 
@@ -1089,9 +1086,12 @@ It is strongly recommended to rename these transitions so they are unique in Jir
             id: '1',
             type: 'INITIAL',
             name: 'Create',
-            to: {
-              statusReference: new ReferenceExpression(status1.elemID, status1),
-            },
+            toStatusReference: new ReferenceExpression(status1.elemID, status1),
+            links: [
+              {
+                toPort: 7,
+              },
+            ],
             conditions: {
               operation: 'ALL',
               conditions: [],
@@ -1107,16 +1107,14 @@ It is strongly recommended to rename these transitions so they are unique in Jir
             id: '2',
             type: 'DIRECTED',
             name: 'toStatus2',
-            from: [
+            links: [
               {
-                statusReference: new ReferenceExpression(status1.elemID, status1),
-                port: 3,
+                fromPort: 3,
+                fromStatusReference: new ReferenceExpression(status1.elemID, status1),
+                toPort: 7,
               },
             ],
-            to: {
-              statusReference: new ReferenceExpression(status2.elemID, status2),
-              port: 7,
-            },
+            toStatusReference: new ReferenceExpression(status2.elemID, status2),
             conditions: {
               operation: 'ALL',
               conditionGroups: [
@@ -1189,9 +1187,8 @@ It is strongly recommended to rename these transitions so they are unique in Jir
               {
                 id: '1',
                 name: 'Create',
-                to: {
-                  statusReference: 'uuid1',
-                },
+                toStatusReference: 'uuid1',
+                links: [{ toPort: 7 }],
                 type: 'INITIAL',
                 conditions: {
                   operation: 'ALL',
@@ -1208,16 +1205,14 @@ It is strongly recommended to rename these transitions so they are unique in Jir
               {
                 id: '2',
                 name: 'toStatus2',
-                from: [
+                links: [
                   {
-                    port: 3,
-                    statusReference: 'uuid1',
+                    fromPort: 3,
+                    fromStatusReference: 'uuid1',
+                    toPort: 7,
                   },
                 ],
-                to: {
-                  port: 7,
-                  statusReference: 'uuid2',
-                },
+                toStatusReference: 'uuid2',
                 type: 'DIRECTED',
                 conditions: {
                   operation: 'ALL',

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -73,6 +73,7 @@ describe('workflow filter', () => {
     Create: naclCase('Create::From: none::Initial'),
     Done: naclCase('Done::From: any status::Global'),
     ToStatus2: naclCase('ToStatus2::From: Create::Directed'),
+    GlobalTransition: naclCase('globalTransition::From: any status::Global'),
   }
 
   beforeEach(async () => {
@@ -871,6 +872,13 @@ It is strongly recommended to rename these transitions so they are unique in Jir
                 ],
               },
             },
+            {
+              id: '3',
+              name: 'globalTransition',
+              links: [],
+              toStatusReference: 'uuid2',
+              type: 'GLOBAL',
+            },
           ],
         },
       ],
@@ -952,6 +960,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
       workflowInstance.value.statusMappings = statusMapping
       workflowInstance.value.statuses.pop()
       delete workflowInstance.value.transitions[TRANSITION_NAME_TO_KEY.ToStatus2]
+      delete workflowInstance.value.transitions[TRANSITION_NAME_TO_KEY.GlobalTransition]
     }
     beforeEach(() => {
       // types
@@ -1126,6 +1135,12 @@ It is strongly recommended to rename these transitions so they are unique in Jir
               conditions: [],
             },
           },
+          [TRANSITION_NAME_TO_KEY.GlobalTransition]: {
+            id: '3',
+            type: 'GLOBAL',
+            name: 'globalTransition',
+            toStatusReference: new ReferenceExpression(status2.elemID, status2),
+          },
         },
       })
       issueTypeInstance = new InstanceElement('issueType', createEmptyType(ISSUE_TYPE_NAME))
@@ -1224,6 +1239,13 @@ It is strongly recommended to rename these transitions so they are unique in Jir
                     },
                   ],
                 },
+              },
+              {
+                id: '3',
+                name: 'globalTransition',
+                links: [],
+                toStatusReference: 'uuid2',
+                type: 'GLOBAL',
               },
             ],
             scope: {
@@ -1886,6 +1908,7 @@ It is strongly recommended to rename these transitions so they are unique in Jir
       it('should undo the preDeploy changes', async () => {
         workflowInstanceBefore.value.statuses.pop()
         delete workflowInstanceBefore.value.transitions[TRANSITION_NAME_TO_KEY.ToStatus2]
+        delete workflowInstanceBefore.value.transitions[TRANSITION_NAME_TO_KEY.GlobalTransition]
         const { statuses: statusesBefore, transitions: transitionsBefore } = workflowInstanceBefore.value
         const { statuses: statusesAfter, transitions: transitionsAfter } = workflowInstance.value
         expect(statusesAfter).toEqual(statusesBefore)


### PR DESCRIPTION
_add workflow transition links_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira adapter_:
* Workflow transitions will no longer have the `to` and `from` fields, instead we will use `links` and `toStatusReference` due to an Atlassian API change (Jira Cloud only).

---
_User Notifications_: 
_Jira adapter_:
* Workflow transitions will no longer have the `to` and `from` fields, instead we will use `links` and `toStatusReference` due to an Atlassian API change (Jira Cloud only).
