### PR TITLE
SALTO-6621: Skipping additional profile permissions in SFDX flow

### DIFF
--- a/packages/salesforce-adapter/src/filters/profile_instance_split.ts
+++ b/packages/salesforce-adapter/src/filters/profile_instance_split.ts
@@ -84,9 +84,10 @@ const filterCreator: FilterCreator = ({ client }) => ({
     const newProfileInstances = await awu(profileInstances).flatMap(splitProfile).toArray()
     elements.push(...newProfileInstances)
   },
+  // Splitting into files can cause the internal order of the profile to be affected by which files are changed.
+  // In order to maintain the order in SFDX we sort the value.
   preDeploy: async (changes: Change[]) => {
-    // Splitting into files can cause the internal order of the profile to be affected by which files are changed.
-    // In order to maintain the order in SFDX we sort the value.
+    // Skipping in the deploy flow since the service is indifferent to the order.
     if (client !== undefined) {
       return
     }

--- a/packages/salesforce-adapter/src/filters/profile_permissions.ts
+++ b/packages/salesforce-adapter/src/filters/profile_permissions.ts
@@ -118,7 +118,7 @@ const addMissingPermissions = (
  * Do the same with added fields and fieldPermissions.
  * No reason to handle deleted Profiles.
  */
-const filterCreator: FilterCreator = ({ config }) => {
+const filterCreator: FilterCreator = ({ config, client }) => {
   let originalProfileChangesByName: Record<
     string,
     AdditionChange<InstanceElement> | ModificationChange<InstanceElement>
@@ -127,6 +127,11 @@ const filterCreator: FilterCreator = ({ config }) => {
   return {
     name: 'profilePermissionsFilter',
     preDeploy: async changes => {
+      if (client === undefined) {
+        // We don't want to add extra permissions in the SFDX flow.
+        return
+      }
+
       const allAdditions = changes.filter(isAdditionChange)
 
       const newCustomObjects = (await awu(allAdditions)

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -36,8 +36,6 @@ export const UNSUPPORTED_TYPES = new Set([
   // Salto uses non-standard type names here (SFDX names them all "Settings", we have a separate type for each one)
   // This causes us to always think the settings in the project need to be deleted
   'Settings',
-  // We need to disable the profile permissions filter in the SFDX flow
-  'Profile',
   // For documents with a file extension (e.g. bla.txt) the SF API returns their fullName with the extension (so "bla.txt")
   // but the SFDX convert code loads them as a component with a fullName without the extension (so "bla").
   // This causes us to always think documents with an extension in the project need to be deleted


### PR DESCRIPTION
We add some extra permissions to profiles when deploying to make sure users have access, but we don't want to do this in the SFDX dump flow.

---

_Additional context for reviewer_:
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
