### PR TITLE
SALTO-6787 Return a detailed change on the whole primitive type when …

### DIFF
--- a/packages/adapter-utils/src/compare.ts
+++ b/packages/adapter-utils/src/compare.ts
@@ -269,9 +269,11 @@ export const detailedCompare = (
 
   // A special case to handle type changes.
   // In fields, we have to modify the whole field.
+  // For primitive types, we have to modify the entire type.
   // For object type meta types, we have to modify the entire object.
   if (
     (isField(before) && isField(after) && !before.refType.elemID.isEqual(after.refType.elemID)) ||
+    (isPrimitiveType(before) && isPrimitiveType(after) && before.primitive !== after.primitive) ||
     (isObjectType(before) && isObjectType(after) && !before.isMetaTypeEqual(after))
   ) {
     return [toDetailedChangeFromBaseChange(baseChange, { before: before.elemID, after: after.elemID })]

--- a/packages/adapter-utils/test/compare.test.ts
+++ b/packages/adapter-utils/test/compare.test.ts
@@ -519,6 +519,16 @@ describe('detailedCompare', () => {
       expect(hasChange(changes, 'modify', after.elemID.createNestedID('annotation', 'modify'))).toBeTruthy()
       expect(hasChange(changes, 'modify', after.elemID.createNestedID('attr', 'modify'))).toBeTruthy()
     })
+
+    describe("when the primitive type's primitive changed", () => {
+      it('should return a detailed change on the whole type', () => {
+        const afterWithDifferentPrimitive = after.clone()
+        afterWithDifferentPrimitive.primitive = PrimitiveTypes.NUMBER
+        const primitiveTypeChanges = detailedCompare(before, afterWithDifferentPrimitive)
+        expect(primitiveTypeChanges).toHaveLength(1)
+        expect(primitiveTypeChanges[0].id).toEqual(afterWithDifferentPrimitive.elemID)
+      })
+    })
   })
 
   describe('compare object types', () => {


### PR DESCRIPTION
…its primitive was changed

In detailedCompare of a primitive type, return a change on the whole type if the primitive was changed. This is similar to a change in field refType, or an objectType's metaType. I ran into this case in the tests, were we change a primitive type's primitive and expect validations to be calculated on an instance that have a field of that primitive.

---

_Additional context for reviewer_

---
_Release Notes_: 
Adapter Utils:
- Return a detailed change on the whole primitive type when its primitive was changed

---
_User Notifications_: 
None
