### PR TITLE
SALTO-6747: Change InitFolder params

### DIFF
--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -171,7 +171,7 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
 }) => {
   const { accountName, toDir, force } = input
 
-  const initializedResult = await isInitializedFolder({ workspace, accountName, baseDir: toDir })
+  const initializedResult = await isInitializedFolder({ adapterName: accountName, baseDir: toDir })
   if (initializedResult.errors.length > 0) {
     outputLine(formatSyncToWorkspaceErrors(initializedResult.errors), output)
     return CliExitCode.AppError
@@ -180,7 +180,7 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
   if (!initializedResult.result) {
     if (force || (await getUserBooleanInput('The folder is no initialized for the adapter format, initialize?'))) {
       outputLine(`Initializing adapter format folder at ${toDir}`, output)
-      const initResult = await initFolder({ workspace, accountName, baseDir: toDir })
+      const initResult = await initFolder({ adapterName: accountName, baseDir: toDir })
       if (initResult.errors.length > 0) {
         outputLine(formatSyncToWorkspaceErrors(initResult.errors), output)
         return CliExitCode.AppError

--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -170,8 +170,8 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
   output,
 }) => {
   const { accountName, toDir, force } = input
-
-  const initializedResult = await isInitializedFolder({ adapterName: accountName, baseDir: toDir })
+  const adapterName = workspace.getServiceFromAccountName(accountName)
+  const initializedResult = await isInitializedFolder({ adapterName, baseDir: toDir })
   if (initializedResult.errors.length > 0) {
     outputLine(formatSyncToWorkspaceErrors(initializedResult.errors), output)
     return CliExitCode.AppError
@@ -180,7 +180,7 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
   if (!initializedResult.result) {
     if (force || (await getUserBooleanInput('The folder is no initialized for the adapter format, initialize?'))) {
       outputLine(`Initializing adapter format folder at ${toDir}`, output)
-      const initResult = await initFolder({ adapterName: accountName, baseDir: toDir })
+      const initResult = await initFolder({ adapterName, baseDir: toDir })
       if (initResult.errors.length > 0) {
         outputLine(formatSyncToWorkspaceErrors(initResult.errors), output)
         return CliExitCode.AppError

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -87,7 +87,8 @@ const getAdapterAndContext = async ({
 
 type IsInitializedFolderArgs = {
   baseDir: string
-} & GetAdapterArgs
+  adapterName: string
+}
 
 export type IsInitializedFolderResult = {
   result: boolean
@@ -96,17 +97,9 @@ export type IsInitializedFolderResult = {
 
 export const isInitializedFolder = async ({
   baseDir,
-  workspace,
-  accountName,
+  adapterName,
 }: IsInitializedFolderArgs): Promise<IsInitializedFolderResult> => {
-  const { adapter, error } = getAdapter({ workspace, accountName })
-  if (error !== undefined) {
-    return {
-      result: false,
-      errors: [error],
-    }
-  }
-
+  const adapter = adapterCreators[adapterName]
   if (adapter.adapterFormat?.isInitializedFolder === undefined) {
     return {
       result: false,
@@ -114,7 +107,7 @@ export const isInitializedFolder = async ({
         {
           severity: 'Error' as const,
           message: 'Format not supported',
-          detailedMessage: `Account ${accountName}'s adapter does not support checking a non-nacl format folder`,
+          detailedMessage: `Adapter ${adapterName} does not support checking a non-nacl format folder`,
         },
       ],
     }
@@ -125,18 +118,15 @@ export const isInitializedFolder = async ({
 
 type InitFolderArgs = {
   baseDir: string
-} & GetAdapterArgs
+  adapterName: string
+}
 
 export type InitFolderResult = {
   errors: ReadonlyArray<SaltoError>
 }
 
-export const initFolder = async ({ baseDir, workspace, accountName }: InitFolderArgs): Promise<InitFolderResult> => {
-  const { adapter, error } = getAdapter({ workspace, accountName })
-  if (error !== undefined) {
-    return { errors: [error] }
-  }
-
+export const initFolder = async ({ baseDir, adapterName }: InitFolderArgs): Promise<InitFolderResult> => {
+  const adapter = adapterCreators[adapterName]
   const adapterInitFolder = adapter.adapterFormat?.initFolder
   if (adapterInitFolder === undefined) {
     return {
@@ -144,7 +134,7 @@ export const initFolder = async ({ baseDir, workspace, accountName }: InitFolder
         {
           severity: 'Error' as const,
           message: 'Format not supported',
-          detailedMessage: `Account ${accountName}'s adapter does not support initializing a non-nacl format folder`,
+          detailedMessage: `Adapter ${adapterName} does not support initializing a non-nacl format folder`,
         },
       ],
     }

--- a/packages/core/test/core/adapter_format.test.ts
+++ b/packages/core/test/core/adapter_format.test.ts
@@ -37,16 +37,9 @@ describe('isInitializedFolder', () => {
   const mockAdapterName = 'mock'
 
   let mockAdapter: ReturnType<typeof createMockAdapter>
-  let workspace: Workspace
   beforeEach(() => {
     mockAdapter = createMockAdapter(mockAdapterName)
     adapterCreators[mockAdapterName] = mockAdapter
-
-    workspace = mockWorkspace({
-      name: 'workspace',
-      accounts: [mockAdapterName],
-      accountToServiceName: { [mockAdapterName]: mockAdapterName },
-    })
   })
   afterEach(() => {
     delete adapterCreators[mockAdapterName]
@@ -58,7 +51,7 @@ describe('isInitializedFolder', () => {
     })
 
     it('should return false', async () => {
-      const res = await isInitializedFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await isInitializedFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.result).toBeFalse()
       expect(res.errors).toBeEmpty()
     })
@@ -70,7 +63,7 @@ describe('isInitializedFolder', () => {
     })
 
     it('should return true', async () => {
-      const res = await isInitializedFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await isInitializedFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.result).toBeTrue()
       expect(res.errors).toBeEmpty()
     })
@@ -91,7 +84,7 @@ describe('isInitializedFolder', () => {
     })
 
     it('should return an error', async () => {
-      const res = await isInitializedFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await isInitializedFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.result).toBeFalse()
       expect(res.errors).toEqual([
         {
@@ -109,12 +102,12 @@ describe('isInitializedFolder', () => {
     })
 
     it('should return an error', async () => {
-      const res = await isInitializedFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await isInitializedFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.errors).toEqual([
         {
           severity: 'Error',
           message: 'Format not supported',
-          detailedMessage: `Account ${mockAdapterName}'s adapter does not support checking a non-nacl format folder`,
+          detailedMessage: `Adapter ${mockAdapterName} does not support checking a non-nacl format folder`,
         },
       ])
     })
@@ -125,16 +118,9 @@ describe('initFolder', () => {
   const mockAdapterName = 'mock'
 
   let mockAdapter: ReturnType<typeof createMockAdapter>
-  let workspace: Workspace
   beforeEach(() => {
     mockAdapter = createMockAdapter(mockAdapterName)
     adapterCreators[mockAdapterName] = mockAdapter
-
-    workspace = mockWorkspace({
-      name: 'workspace',
-      accounts: [mockAdapterName],
-      accountToServiceName: { [mockAdapterName]: mockAdapterName },
-    })
   })
   afterEach(() => {
     delete adapterCreators[mockAdapterName]
@@ -146,7 +132,7 @@ describe('initFolder', () => {
     })
 
     it('should return no errors', async () => {
-      const res = await initFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await initFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.errors).toBeEmpty()
     })
   })
@@ -165,7 +151,7 @@ describe('initFolder', () => {
     })
 
     it('should return errors', async () => {
-      const res = await initFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await initFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.errors).toEqual([
         {
           severity: 'Error',
@@ -182,12 +168,12 @@ describe('initFolder', () => {
     })
 
     it('should return an error', async () => {
-      const res = await initFolder({ workspace, accountName: mockAdapterName, baseDir: 'dir' })
+      const res = await initFolder({ adapterName: mockAdapterName, baseDir: 'dir' })
       expect(res.errors).toEqual([
         {
           severity: 'Error',
           message: 'Format not supported',
-          detailedMessage: `Account ${mockAdapterName}'s adapter does not support initializing a non-nacl format folder`,
+          detailedMessage: `Adapter ${mockAdapterName} does not support initializing a non-nacl format folder`,
         },
       ])
     })


### PR DESCRIPTION

---

_Release Notes_: 
Core: Change the parameters of `isInitializedFolder` and `initFolder` not to include `workspace`

---

_User Notifications_: 
