### PR TITLE
SALTO-6793: Fix SFDX broken UT

### DIFF
--- a/packages/salesforce-adapter/src/sfdx_parser/project.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/project.ts
@@ -7,6 +7,7 @@
  */
 
 import path from 'path'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { AdapterFormat } from '@salto-io/adapter-api'
 import { API_VERSION } from '../client/client'
@@ -62,7 +63,7 @@ export const createProject: InitFolderFunc = async ({ baseDir }) => {
     await templateService.create(TemplateType.Project, opts)
     return { errors: [] }
   } catch (error) {
-    log.error(error)
+    log.error('Error occurred when creating SFDX project: %s', inspectValue(error))
     return {
       errors: [
         {


### PR DESCRIPTION
Wrong invocation of `log.error`. Was called with `Error` object and not string as expected.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_