### PR TITLE
SALTO-4990: Salesforce: Remodel picklist value lists to maps, to allow references to specific values (un-rollback)

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -16,7 +16,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     : undefined,
   coverageThreshold: {
     global: {
-      branches: 87.8,
+      branches: 87.75,
       functions: 94,
       lines: 95,
       statements: 95,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -198,9 +198,10 @@ export const allFilters: Array<FilterCreator> = [
   profilePermissionsFilter,
   // emailTemplateFilter should run before convertMapsFilter
   emailTemplateFilter,
+  // standardValueSetFilter should run before convertMapsFilter
+  standardValueSetFilter,
   // convertMapsFilter should run before profile fieldReferencesFilter
   convertMapsFilter,
-  standardValueSetFilter,
   flowFilter,
   customObjectInstanceReferencesFilter,
   cpqReferencableFieldReferencesFilter,

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -45,6 +45,7 @@ import elementApiVersionValidator from './change_validators/element_api_version'
 import cpqBillingStartDate from './change_validators/cpq_billing_start_date'
 import cpqBillingTriggers from './change_validators/cpq_billing_triggers'
 import managedApexComponent from './change_validators/managed_apex_component'
+import orderedMaps from './change_validators/ordered_maps'
 import SalesforceClient from './client/client'
 import { ChangeValidatorName, DEPLOY_CONFIG, FetchProfile, SalesforceConfig } from './types'
 import { buildFetchProfile } from './fetch_profile/fetch_profile'
@@ -104,6 +105,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   cpqBillingStartDate: () => cpqBillingStartDate,
   cpqBillingTriggers: () => cpqBillingTriggers,
   managedApexComponent: () => managedApexComponent,
+  orderedMaps: ({ fetchProfile }) => orderedMaps(fetchProfile),
   ..._.mapValues(getDefaultChangeValidators(), validator => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -74,7 +74,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   customObjectInstances: ({ getLookupNameFunc }) => customObjectInstancesValidator(getLookupNameFunc),
   customFieldType: () => customFieldTypeValidator,
   standardFieldLabel: () => standardFieldLabelValidator,
-  mapKeys: ({ getLookupNameFunc }) => mapKeysValidator(getLookupNameFunc),
+  mapKeys: ({ getLookupNameFunc, fetchProfile }) => mapKeysValidator(getLookupNameFunc, fetchProfile),
   multipleDefaults: () => multipleDefaultsValidator,
   picklistPromote: () => picklistPromoteValidator,
   cpqValidator: () => cpqValidator,

--- a/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
+++ b/packages/salesforce-adapter/src/change_validators/multiple_defaults.ts
@@ -21,6 +21,7 @@ import {
   Value,
   Values,
   isReferenceExpression,
+  getField,
 } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
@@ -38,8 +39,13 @@ type FieldDef = {
 const FIELD_NAME_TO_INNER_CONTEXT_FIELD: Record<string, FieldDef> = {
   applicationVisibilities: { name: 'application' },
   recordTypeVisibilities: { name: 'recordType', nested: true },
+
+  // TODO(SALTO-4990): Remove once picklistsAsMaps FF is deployed and removed.
   standardValue: { name: 'label' },
   customValue: { name: 'label' },
+
+  'standardValue.values': { name: 'label' },
+  'customValue.values': { name: 'label' },
 }
 
 type ValueSetInnerObject = {
@@ -47,14 +53,31 @@ type ValueSetInnerObject = {
   label: string
 } & Values[]
 
-type FieldWithValueSet = Field & {
+type FieldWithValueSetList = Field & {
   annotations: {
     valueSet: Array<ValueSetInnerObject>
   }
 }
 
-const isFieldWithValueSet = (field: Field): field is FieldWithValueSet =>
+// TODO(SALTO-4990): Remove once picklistsAsMaps FF is deployed and removed.
+type FieldWithValueSetOrderedMap = Field & {
+  annotations: {
+    valueSet: {
+      values: Array<ValueSetInnerObject>
+    }
+  }
+}
+
+type FieldWithValueSet = FieldWithValueSetList | FieldWithValueSetOrderedMap
+
+const isFieldWithValueSetList = (field: Field): field is FieldWithValueSetList =>
   _.isArray(field.annotations[FIELD_ANNOTATIONS.VALUE_SET])
+
+const isFieldWithOrderedMapValueSet = (field: Field): field is FieldWithValueSetOrderedMap =>
+  _.isArray(field.annotations[FIELD_ANNOTATIONS.VALUE_SET]?.order)
+
+const isFieldWithValueSet = (field: Field): field is FieldWithValueSet =>
+  isFieldWithValueSetList(field) || isFieldWithOrderedMapValueSet(field)
 
 const formatContext = (context: Value): string => {
   if (isReferenceExpression(context)) {
@@ -84,7 +107,9 @@ const createFieldChangeError = (field: Field, contexts: string[]): ChangeError =
 })
 
 const getPicklistMultipleDefaultsErrors = (field: FieldWithValueSet): ChangeError[] => {
-  const contexts = field.annotations.valueSet
+  const contexts = (
+    isFieldWithValueSetList(field) ? field.annotations.valueSet : Object.values(field.annotations.valueSet.values)
+  )
     .filter(obj => obj.default)
     .map(obj => obj[LABEL])
     .map(formatContext)
@@ -112,6 +137,9 @@ const getInstancesMultipleDefaultsErrors = async (after: InstanceElement): Promi
     valueName: string,
   ): Promise<string[] | undefined> => {
     const defaultObjects = await getDefaultObjectsList(value, fieldType)
+    if (!_.isArray(defaultObjects)) {
+      return undefined
+    }
     const contexts = defaultObjects
       .filter(val => val.default)
       .map(obj => obj[valueName])
@@ -130,17 +158,18 @@ const getInstancesMultipleDefaultsErrors = async (after: InstanceElement): Promi
     return []
   }
 
-  const errors: ChangeError[] = await awu(Object.entries(after.value))
-    .filter(([fieldName]) => Object.keys(FIELD_NAME_TO_INNER_CONTEXT_FIELD).includes(fieldName))
-    .flatMap(async ([fieldName, value]) => {
-      const field = (await after.getType()).fields[fieldName]
+  const errors: ChangeError[] = await awu(Object.keys(FIELD_NAME_TO_INNER_CONTEXT_FIELD))
+    .filter(fieldPath => _.has(after.value, fieldPath))
+    .flatMap(async fieldPath => {
+      const value = _.get(after.value, fieldPath)
+      const field = await getField(await after.getType(), fieldPath.split('.'))
       if (field === undefined) {
         // Can happen if the field exists in the instance but not in the type.
         return []
       }
       const fieldType = await field.getType()
-      const valueName = FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldName].name
-      if (_.isPlainObject(value) && FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldName].nested) {
+      const valueName = FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldPath].name
+      if (_.isPlainObject(value) && FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldPath].nested) {
         return awu(Object.entries(value)).flatMap(async ([_key, innerValue]) => {
           const startLevelType = isMapType(fieldType) ? await fieldType.getInnerType() : fieldType
           const defaultsContexts = await findMultipleDefaults(innerValue, startLevelType, valueName)

--- a/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
+++ b/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import {
+  ChangeError,
+  ChangeValidator,
+  Element,
+  ElemID,
+  getChangeData,
+  isFieldChange,
+  isInstanceChange,
+  isObjectTypeChange,
+  isReferenceExpression,
+  Value,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import {
+  metadataTypeToFieldToMapDef,
+  annotationDefsByType,
+  findInstancesToConvert,
+  getElementValueOrAnnotations,
+  getChangesWithFieldType,
+} from '../filters/convert_maps'
+import { FetchProfile } from '../types'
+
+const { awu } = collections.asynciterable
+
+export const getOrderedMapErrors = (element: Element, fieldName: string): ChangeError[] => {
+  const elementValues = getElementValueOrAnnotations(element)
+  const fieldValue = _.get(elementValues, fieldName)
+  if (fieldValue === undefined) {
+    return []
+  }
+  const { values, order } = fieldValue
+  if (order === undefined || values === undefined) {
+    return [
+      {
+        elemID: element.elemID,
+        severity: 'Error',
+        message: 'Missing field in ordered map',
+        detailedMessage: `Missing order or values fields in field ${fieldName}`,
+      },
+    ]
+  }
+  const valueElemIds: ElemID[] = Object.keys(values).map(key => element.elemID.createNestedID(fieldName, 'values', key))
+  const foundValueElemIds: ElemID[] = []
+  const errors: ChangeError[] = []
+  order.forEach((valueRef: Value) => {
+    if (
+      !isReferenceExpression(valueRef) ||
+      !valueElemIds.map(elemID => elemID.getFullName()).includes(valueRef.elemID.getFullName())
+    ) {
+      errors.push({
+        elemID: element.elemID,
+        severity: 'Error',
+        message: 'Invalid reference in ordered map',
+        detailedMessage: `Invalid reference in field ${fieldName}.order: ${valueRef.elemID?.getFullName() ?? valueRef}. Only reference to internal value keys are allowed.`,
+      })
+      return
+    }
+    if (foundValueElemIds.map(elemID => elemID.getFullName()).includes(valueRef.elemID.getFullName())) {
+      errors.push({
+        elemID: element.elemID,
+        severity: 'Error',
+        message: 'Duplicate reference in ordered map',
+        detailedMessage: `Duplicate reference in field ${fieldName}.order: ${valueRef.elemID.name}`,
+      })
+    }
+    foundValueElemIds.push(valueRef.elemID)
+  })
+  const missingElemIds = valueElemIds.filter(
+    valueElemId => !foundValueElemIds.map(elemID => elemID.getFullName()).includes(valueElemId.getFullName()),
+  )
+  if (!_.isEmpty(missingElemIds)) {
+    errors.push({
+      elemID: element.elemID,
+      severity: 'Error',
+      message: 'Missing reference in ordered map',
+      detailedMessage: `Missing reference in field ${fieldName}.order: ${missingElemIds.map(elemID => elemID.name).join(', ')}`,
+    })
+  }
+  return errors
+}
+
+const changeValidator: (fetchProfile: FetchProfile) => ChangeValidator = fetchProfile => {
+  if (!fetchProfile.isFeatureEnabled('picklistsAsMaps')) {
+    return async () => []
+  }
+  return async changes => {
+    const instanceErrors: ChangeError[] = await awu(Object.keys(metadataTypeToFieldToMapDef))
+      .flatMap(async targetMetadataType => {
+        const instances = await findInstancesToConvert(
+          changes.filter(isInstanceChange).map(getChangeData),
+          targetMetadataType,
+        )
+        if (_.isEmpty(instances)) {
+          return []
+        }
+        const fieldNames = Object.entries(metadataTypeToFieldToMapDef[targetMetadataType])
+          .filter(([_fieldName, mapDef]) => mapDef.maintainOrder)
+          .map(([fieldName, _mapDef]) => fieldName)
+
+        return fieldNames.flatMap(fieldName => instances.flatMap(instance => getOrderedMapErrors(instance, fieldName)))
+      })
+      .toArray()
+
+    const objectTypeErrors: ChangeError[] = await awu(Object.keys(annotationDefsByType))
+      .flatMap(async fieldType => {
+        const fieldNames = Object.entries(annotationDefsByType[fieldType])
+          .filter(([_fieldName, annotationDef]) => annotationDef.maintainOrder)
+          .map(([fieldName, _mapDef]) => fieldName)
+
+        const fieldChanges = getChangesWithFieldType(changes, fieldType)
+        return fieldChanges
+          .flatMap(change => {
+            if (isFieldChange(change)) {
+              return [getChangeData(change)]
+            }
+            if (isObjectTypeChange(change)) {
+              const objectType = getChangeData(change)
+              return Object.values(objectType.fields).filter(field => field.refType.elemID.typeName === fieldType)
+            }
+            return []
+          })
+          .flatMap(field => fieldNames.flatMap(fieldName => getOrderedMapErrors(field, fieldName)))
+      })
+      .toArray()
+    return instanceErrors.concat(objectTypeErrors)
+  }
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
+++ b/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
@@ -20,8 +20,8 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import {
-  metadataTypeToFieldToMapDef,
-  annotationDefsByType,
+  getMetadataTypeToFieldToMapDef,
+  getAnnotationDefsByType,
   findInstancesToConvert,
   getElementValueOrAnnotations,
   getChangesWithFieldType,
@@ -88,9 +88,9 @@ export const getOrderedMapErrors = (element: Element, fieldName: string): Change
 }
 
 const changeValidator: (fetchProfile: FetchProfile) => ChangeValidator = fetchProfile => {
-  if (!fetchProfile.isFeatureEnabled('picklistsAsMaps')) {
-    return async () => []
-  }
+  const metadataTypeToFieldToMapDef = getMetadataTypeToFieldToMapDef(fetchProfile)
+  const annotationDefsByType = getAnnotationDefsByType(fetchProfile)
+
   return async changes => {
     const instanceErrors: ChangeError[] = await awu(Object.keys(metadataTypeToFieldToMapDef))
       .flatMap(async targetMetadataType => {

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -51,6 +51,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   extendTriggersMetadata: false,
   removeReferenceFromFilterItemToRecordType: false,
   storeProfilesAndPermissionSetsBrokenPaths: true,
+  picklistsAsMaps: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -27,6 +27,12 @@ import {
   getDeepInnerType,
   isObjectType,
   getField,
+  isFieldChange,
+  ReferenceExpression,
+  TypeElement,
+  ElemID,
+  isObjectTypeChange,
+  BuiltinTypes,
 } from '@salto-io/adapter-api'
 import { collections, values as lowerdashValues } from '@salto-io/lowerdash'
 import { naclCase, applyFunctionToChangeData } from '@salto-io/adapter-utils'
@@ -45,6 +51,8 @@ import {
   INSTANCE_FULL_NAME_FIELD,
 } from '../constants'
 import { metadataType } from '../transformers/transformer'
+import { GLOBAL_VALUE_SET } from './global_value_sets'
+import { STANDARD_VALUE_SET } from './standard_value_sets'
 
 const { awu } = collections.asynciterable
 const { isDefined } = lowerdashValues
@@ -62,7 +70,32 @@ type MapDef = {
   mapToList?: boolean
   // with which mapper should we parse the key
   mapper?: (string: string) => string[]
+  // keep a separate list of references for each value to preserve the order
+  // Note: this is only supported for one-level maps (nested maps are not supported)
+  maintainOrder?: boolean
 }
+
+const ORDERED_MAP_VALUES_FIELD = 'values'
+const ORDERED_MAP_ORDER_FIELD = 'order'
+
+const createOrderedMapType = <T extends TypeElement>(innerType: T): ObjectType =>
+  new ObjectType({
+    elemID: new ElemID('salesforce', `OrderedMap<${innerType.elemID.name}>`),
+    fields: {
+      [ORDERED_MAP_VALUES_FIELD]: {
+        refType: new MapType(innerType),
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+      [ORDERED_MAP_ORDER_FIELD]: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: {
+          [CORE_ANNOTATIONS.REQUIRED]: true,
+        },
+      },
+    },
+  })
 
 /**
  * Convert a string value into the map index keys.
@@ -136,6 +169,20 @@ const SHARING_RULES_MAP_FIELD_DEF: Record<string, MapDef> = {
   sharingOwnerRules: { key: INSTANCE_FULL_NAME_FIELD },
 }
 
+const PICKLIST_MAP_FIELD_DEF: MapDef = {
+  key: 'fullName',
+  maintainOrder: true,
+  mapper: (val: string): string[] => [naclCase(val)],
+}
+
+const GLOBAL_VALUE_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
+  customValue: PICKLIST_MAP_FIELD_DEF,
+}
+
+const STANDARD_VALUE_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
+  standardValue: PICKLIST_MAP_FIELD_DEF,
+}
+
 export const metadataTypeToFieldToMapDef: Record<string, Record<string, MapDef>> = {
   [BUSINESS_HOURS_METADATA_TYPE]: BUSINESS_HOURS_MAP_FIELD_DEF,
   [EMAIL_TEMPLATE_METADATA_TYPE]: EMAIL_TEMPLATE_MAP_FIELD_DEF,
@@ -144,19 +191,33 @@ export const metadataTypeToFieldToMapDef: Record<string, Record<string, MapDef>>
   [MUTING_PERMISSION_SET_METADATA_TYPE]: PERMISSIONS_SET_MAP_FIELD_DEF,
   [LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE]: LIGHTNING_COMPONENT_BUNDLE_MAP,
   [SHARING_RULES_TYPE]: SHARING_RULES_MAP_FIELD_DEF,
+  [GLOBAL_VALUE_SET]: GLOBAL_VALUE_SET_MAP_FIELD_DEF,
+  [STANDARD_VALUE_SET]: STANDARD_VALUE_SET_MAP_FIELD_DEF,
 }
 
+export const annotationDefsByType: Record<string, Record<string, MapDef>> = {
+  Picklist: {
+    valueSet: PICKLIST_MAP_FIELD_DEF,
+  },
+  MultiselectPicklist: {
+    valueSet: PICKLIST_MAP_FIELD_DEF,
+  },
+}
+
+export const getElementValueOrAnnotations = (element: Element): Values =>
+  isInstanceElement(element) ? element.value : element.annotations
+
 /**
- * Convert the specified instance fields into maps.
+ * Convert the specified element fields into maps.
  * Choose between unique maps and lists based on each field's conversion definition. If a field
  * should use a unique map but fails due to conflicts, convert it to a list map, and include it
  * in the returned list so that it can be converted across the board.
  *
- * @param instance             The instance to modify
- * @param instanceMapFieldDef  The definitions of the fields to covert
+ * @param element             The instance to modify
+ * @param mapFieldDef         The definitions of the fields to covert
  * @returns                   The list of fields that were converted to non-unique due to duplicates
  */
-const convertArraysToMaps = (instance: InstanceElement, instanceMapFieldDef: Record<string, MapDef>): string[] => {
+const convertArraysToMaps = (element: Element, mapFieldDef: Record<string, MapDef>): string[] => {
   // fields that were intended to be unique, but have multiple values under to the same map key
   const nonUniqueMapFields: string[] = []
 
@@ -171,28 +232,44 @@ const convertArraysToMaps = (instance: InstanceElement, instanceMapFieldDef: Rec
     return _.groupBy(values, item => keyFunc(item))
   }
 
-  Object.entries(instanceMapFieldDef)
-    .filter(([fieldName]) => _.get(instance.value, fieldName) !== undefined)
+  Object.entries(mapFieldDef)
+    .filter(([fieldName]) => _.get(getElementValueOrAnnotations(element), fieldName) !== undefined)
     .forEach(([fieldName, mapDef]) => {
       const mapper = mapDef.mapper ?? defaultMapper
+      const elementValues = getElementValueOrAnnotations(element)
       if (mapDef.nested) {
         const firstLevelGroups = _.groupBy(
-          makeArray(_.get(instance.value, fieldName)),
+          makeArray(_.get(elementValues, fieldName)),
           item => mapper(item[mapDef.key])[0],
         )
         _.set(
-          instance.value,
+          elementValues,
           fieldName,
           _.mapValues(firstLevelGroups, firstLevelValues =>
             convertField(firstLevelValues, item => mapper(item[mapDef.key])[1], !!mapDef.mapToList, fieldName),
           ),
         )
+      } else if (mapDef.maintainOrder) {
+        const originalFieldValue = makeArray(_.get(elementValues, fieldName))
+        _.set(elementValues, fieldName, {
+          [ORDERED_MAP_VALUES_FIELD]: convertField(
+            originalFieldValue,
+            item => mapper(item[mapDef.key])[0],
+            !!mapDef.mapToList,
+            fieldName,
+          ),
+          [ORDERED_MAP_ORDER_FIELD]: originalFieldValue
+            .map(item => mapper(item[mapDef.key])[0])
+            .map(
+              name => new ReferenceExpression(element.elemID.createNestedID(fieldName, ORDERED_MAP_VALUES_FIELD, name)),
+            ),
+        })
       } else {
         _.set(
-          instance.value,
+          elementValues,
           fieldName,
           convertField(
-            makeArray(_.get(instance.value, fieldName)),
+            makeArray(_.get(elementValues, fieldName)),
             item => mapper(item[mapDef.key])[0],
             !!mapDef.mapToList,
             fieldName,
@@ -206,24 +283,28 @@ const convertArraysToMaps = (instance: InstanceElement, instanceMapFieldDef: Rec
 /**
  * Make sure all values in the specified non-unique fields are arrays.
  *
- * @param instance             The instance instance to update
+ * @param element             The element to update
  * @param nonUniqueMapFields  The list of fields to convert to arrays
- * @param instanceMapFieldDef  The original field mapping definition
+ * @param mapFieldDef         The original field mapping definition
  */
 const convertValuesToMapArrays = (
-  instance: InstanceElement,
+  element: Element,
   nonUniqueMapFields: string[],
-  instanceMapFieldDef: Record<string, MapDef>,
+  mapFieldDef: Record<string, MapDef>,
 ): void => {
   nonUniqueMapFields.forEach(fieldName => {
-    if (instanceMapFieldDef[fieldName]?.nested) {
+    if (mapFieldDef[fieldName]?.nested) {
       _.set(
-        instance.value,
+        getElementValueOrAnnotations(element),
         fieldName,
-        _.mapValues(_.get(instance.value, fieldName), val => _.mapValues(val, makeArray)),
+        _.mapValues(_.get(getElementValueOrAnnotations(element), fieldName), val => _.mapValues(val, makeArray)),
       )
     } else {
-      _.set(instance.value, fieldName, _.mapValues(_.get(instance.value, fieldName), makeArray))
+      _.set(
+        getElementValueOrAnnotations(element),
+        fieldName,
+        _.mapValues(_.get(getElementValueOrAnnotations(element), fieldName), makeArray),
+      )
     }
   })
 }
@@ -236,7 +317,7 @@ const convertValuesToMapArrays = (
  * @param instanceMapFieldDef  The original field mapping definition
  */
 const updateFieldTypes = async (
-  instanceType: ObjectType,
+  instanceType: ObjectType | TypeElement,
   nonUniqueMapFields: string[],
   instanceMapFieldDef: Record<string, MapDef>,
 ): Promise<void> => {
@@ -252,6 +333,8 @@ const updateFieldTypes = async (
         }
         if (mapDef.nested) {
           field.refType = createRefToElmWithValue(new MapType(new MapType(innerType)))
+        } else if (mapDef.maintainOrder) {
+          field.refType = createRefToElmWithValue(createOrderedMapType(innerType))
         } else {
           field.refType = createRefToElmWithValue(new MapType(innerType))
         }
@@ -271,74 +354,128 @@ const updateFieldTypes = async (
   })
 }
 
-const convertInstanceFieldsToMaps = async (
-  instancesToConvert: InstanceElement[],
-  instanceMapFieldDef: Record<string, MapDef>,
+const updateAnnotationRefTypes = async (
+  typeElement: TypeElement,
+  nonUniqueMapFields: string[],
+  mapFieldDef: Record<string, MapDef>,
+): Promise<void> => {
+  Object.entries(mapFieldDef).forEach(async ([fieldName, mapDef]) => {
+    const fieldType = _.get(typeElement.annotationRefTypes, fieldName).type
+    // navigate to the right field type
+    if (isDefined(fieldType) && !isMapType(fieldType)) {
+      let innerType = isContainerType(fieldType) ? await fieldType.getInnerType() : fieldType
+      if (mapDef.mapToList || nonUniqueMapFields.includes(fieldName)) {
+        innerType = new ListType(innerType)
+      }
+      if (mapDef.nested) {
+        typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(new MapType(new MapType(innerType)))
+      } else if (mapDef.maintainOrder) {
+        typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(createOrderedMapType(innerType))
+      } else {
+        typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(new MapType(innerType))
+      }
+
+      // make the key field required
+      const deepInnerType = await getDeepInnerType(innerType)
+      if (isObjectType(deepInnerType)) {
+        const keyFieldType = deepInnerType.fields[mapDef.key]
+        if (!keyFieldType) {
+          log.error('could not find key field %s for type %s', mapDef.key, fieldType.elemID.getFullName())
+          return
+        }
+        keyFieldType.annotations[CORE_ANNOTATIONS.REQUIRED] = true
+      }
+    }
+  })
+}
+
+const convertElementFieldsToMaps = async (
+  elementsToConvert: Element[],
+  mapFieldDef: Record<string, MapDef>,
 ): Promise<string[]> => {
   const nonUniqueMapFields = _.uniq(
-    instancesToConvert.flatMap(instance => {
-      const nonUniqueFields = convertArraysToMaps(instance, instanceMapFieldDef)
+    elementsToConvert.flatMap(element => {
+      const nonUniqueFields = convertArraysToMaps(element, mapFieldDef)
       if (nonUniqueFields.length > 0) {
-        log.info(`Instance ${instance.elemID.getFullName()} has non-unique map fields: ${nonUniqueFields}`)
+        log.info(`Instance ${element.elemID.getFullName()} has non-unique map fields: ${nonUniqueFields}`)
       }
       return nonUniqueFields
     }),
   )
   if (nonUniqueMapFields.length > 0) {
-    instancesToConvert.forEach(instance => {
-      convertValuesToMapArrays(instance, nonUniqueMapFields, instanceMapFieldDef)
+    elementsToConvert.forEach(element => {
+      convertValuesToMapArrays(element, nonUniqueMapFields, mapFieldDef)
     })
   }
   return nonUniqueMapFields
 }
 
 /**
- * Convert instance field values from maps back to arrays before deploy.
+ * Convert element field values from maps back to arrays before deploy.
  *
- * @param instanceChanges          The instance changes to deploy
- * @param instanceMapFieldDef      The definitions of the fields to covert
+ * @param changes          The changes to deploy
+ * @param mapFieldDef      The definitions of the fields to convert
+ * @param elementType      The type of the elements to convert
  */
 const convertFieldsBackToLists = async (
-  instanceChanges: ReadonlyArray<Change<InstanceElement>>,
-  instanceMapFieldDef: Record<string, MapDef>,
+  changes: ReadonlyArray<Change<Element>>,
+  mapFieldDef: Record<string, MapDef>,
+  elementType: string,
 ): Promise<void> => {
   const toVals = (values: Values): Values[] => Object.values(values).flat()
 
-  const backToArrays = (instance: InstanceElement): InstanceElement => {
-    Object.keys(instanceMapFieldDef)
-      .filter(fieldName => _.get(instance.value, fieldName) !== undefined)
-      .forEach(fieldName => {
-        if (Array.isArray(_.get(instance.value, fieldName))) {
-          // should not happen
-          return
-        }
+  const backToArrays = (baseElement: Element): Element => {
+    const elementsToConvert = []
+    if (isObjectType(baseElement)) {
+      Object.values(baseElement.fields)
+        .filter(field => field.refType.elemID.typeName === elementType)
+        .forEach(field => elementsToConvert.push(field))
+    } else {
+      elementsToConvert.push(baseElement)
+    }
+    elementsToConvert.forEach(element => {
+      Object.keys(mapFieldDef)
+        .filter(fieldName => getElementValueOrAnnotations(element)[fieldName] !== undefined)
+        .forEach(fieldName => {
+          const elementValues = getElementValueOrAnnotations(element)
+          if (Array.isArray(_.get(elementValues, fieldName))) {
+            // should not happen
+            return
+          }
 
-        if (instanceMapFieldDef[fieldName].nested) {
-          // first convert the inner levels to arrays, then merge into one array
-          _.set(instance.value, fieldName, _.mapValues(_.get(instance.value, fieldName), toVals))
-        }
-        _.set(instance.value, fieldName, toVals(_.get(instance.value, fieldName)))
-      })
-    return instance
+          if (mapFieldDef[fieldName].nested) {
+            // first convert the inner levels to arrays, then merge into one array
+            _.set(elementValues, fieldName, _.mapValues(elementValues[fieldName], toVals))
+          }
+          if (mapFieldDef[fieldName].maintainOrder) {
+            // OrderedMap keeps the order in a list of references, so we just need to override the top-level OrderedMap
+            // with this list.
+            _.set(elementValues, fieldName, elementValues[fieldName][ORDERED_MAP_ORDER_FIELD])
+          } else {
+            _.set(elementValues, fieldName, toVals(elementValues[fieldName]))
+          }
+        })
+    })
+    return baseElement
   }
 
-  await awu(instanceChanges).forEach(instanceChange => applyFunctionToChangeData(instanceChange, backToArrays))
+  await awu(changes).forEach(change => applyFunctionToChangeData(change, backToArrays))
 }
 
 /**
- * Convert instance's field values from arrays back to maps after deploy.
+ * Convert an element's field values from arrays back to maps after deploy.
  *
- * @param instanceChanges  The instance changes to deploy
- * @param instanceMapFieldDef      The definitions of the fields to covert
+ * @param changes          The changes to deploy
+ * @param mapFieldDef      The definitions of the fields to covert
  */
 const convertFieldsBackToMaps = (
-  instanceChanges: ReadonlyArray<Change<InstanceElement>>,
-  instanceMapFieldDef: Record<string, MapDef>,
+  changes: ReadonlyArray<Change<Element>>,
+  mapFieldDef: Record<string, MapDef>,
 ): void => {
-  instanceChanges.forEach(instanceChange =>
-    applyFunctionToChangeData(instanceChange, instance => {
-      convertArraysToMaps(instance, instanceMapFieldDef)
-      return instance
+  changes.forEach(change =>
+    applyFunctionToChangeData(change, element => {
+      convertArraysToMaps(element, mapFieldDef)
+      return element
     }),
   )
 }
@@ -379,6 +516,25 @@ export const getInstanceChanges = (
     .filter(async change => (await metadataType(getChangeData(change))) === targetMetadataType)
     .toArray()
 
+/** Get all changes that contain a specific field type.
+ *
+ * @return All changes that are either field changes of the specified type or object changes that contain fields of the
+ * specified type
+ */
+export const getChangesWithFieldType = (changes: ReadonlyArray<Change>, fieldType: string): Change[] => {
+  const fieldChanges: Change[] = changes
+    .filter(isFieldChange)
+    .filter(async change => getChangeData(change).getTypeSync().elemID.typeName === fieldType)
+
+  const objectTypeChanges = changes
+    .filter(isObjectTypeChange)
+    .filter(change =>
+      Object.values(getChangeData(change).fields).some(field => field.refType.elemID.typeName === fieldType),
+    )
+
+  return fieldChanges.concat(objectTypeChanges)
+}
+
 export const findInstancesToConvert = (elements: Element[], targetMetadataType: string): Promise<InstanceElement[]> => {
   const instances = elements.filter(isInstanceElement)
   return awu(instances)
@@ -399,14 +555,18 @@ export const findTypeToConvert = async (
 }
 
 /**
- * Convert certain instances' fields into maps, so that they are easier to view,
+ * Convert certain elements' fields into maps, so that they are easier to view,
  * could be referenced, and can be split across multiple files.
  */
 const filter: FilterCreator = ({ config }) => ({
   name: 'convertMapsFilter',
   onFetch: async (elements: Element[]) => {
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
-      if (targetMetadataType === SHARING_RULES_TYPE && !config.fetchProfile.isFeatureEnabled('sharingRulesMaps')) {
+      if (
+        (targetMetadataType === SHARING_RULES_TYPE && !config.fetchProfile.isFeatureEnabled('sharingRulesMaps')) ||
+        ([GLOBAL_VALUE_SET, STANDARD_VALUE_SET].includes(targetMetadataType) &&
+          !config.fetchProfile.isFeatureEnabled('picklistsAsMaps'))
+      ) {
         return
       }
       const instancesToConvert = await findInstancesToConvert(elements, targetMetadataType)
@@ -416,10 +576,26 @@ const filter: FilterCreator = ({ config }) => ({
         if (instancesToConvert.length === 0) {
           await updateFieldTypes(typeToConvert, [], mapFieldDef)
         } else {
-          const nonUniqueMapFields = await convertInstanceFieldsToMaps(instancesToConvert, mapFieldDef)
+          const nonUniqueMapFields = await convertElementFieldsToMaps(instancesToConvert, mapFieldDef)
           await updateFieldTypes(typeToConvert, nonUniqueMapFields, mapFieldDef)
         }
       }
+    })
+
+    const fields = elements.filter(isObjectType).flatMap(obj => Object.values(obj.fields))
+    await awu(Object.entries(annotationDefsByType)).forEach(async ([fieldType, annotationToMapDef]) => {
+      if (
+        ['Picklist', 'MultiselectPicklist'].includes(fieldType) &&
+        !config.fetchProfile.isFeatureEnabled('picklistsAsMaps')
+      ) {
+        return
+      }
+      const fieldsToConvert = fields.filter(field => field.refType.elemID.typeName === fieldType)
+      if (fieldsToConvert.length === 0) {
+        return
+      }
+      const nonUniqueMapFields = await convertElementFieldsToMaps(fieldsToConvert, annotationToMapDef)
+      await updateAnnotationRefTypes(await fieldsToConvert[0].getType(), nonUniqueMapFields, annotationToMapDef)
     })
   },
 
@@ -433,10 +609,19 @@ const filter: FilterCreator = ({ config }) => ({
       // since transformElement and salesforce do not require list fields to be defined as lists,
       // we only mark fields as lists of their map inner value is a list,
       // so that we can convert the object back correctly in onDeploy
-      await convertFieldsBackToLists(instanceChanges, mapFieldDef)
+      await convertFieldsBackToLists(instanceChanges, mapFieldDef, targetMetadataType)
 
       const instanceType = await getChangeData(instanceChanges[0]).getType()
       await convertFieldTypesBackToLists(instanceType, mapFieldDef)
+    })
+
+    await awu(Object.keys(annotationDefsByType)).forEach(async fieldType => {
+      const elementsWithFieldType = getChangesWithFieldType(changes, fieldType)
+      if (elementsWithFieldType.length === 0) {
+        return
+      }
+      const mapFieldDef = annotationDefsByType[fieldType]
+      await convertFieldsBackToLists(elementsWithFieldType, mapFieldDef, fieldType)
     })
   },
 
@@ -457,6 +642,15 @@ const filter: FilterCreator = ({ config }) => ({
         .filter(async fieldName => isListType(await instanceType.fields[fieldName].getType()))
         .toArray()
       await updateFieldTypes(instanceType, nonUniqueMapFields, mapFieldDef)
+    })
+
+    await awu(Object.keys(annotationDefsByType)).forEach(async fieldType => {
+      const fieldsChanges = getChangesWithFieldType(changes, fieldType)
+      if (fieldsChanges.length === 0) {
+        return
+      }
+      const mapFieldDef = annotationDefsByType[fieldType]
+      convertFieldsBackToMaps(fieldsChanges, mapFieldDef)
     })
   },
 })

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -128,6 +128,7 @@ export type OptionalFeatures = {
   extendTriggersMetadata?: boolean
   storeProfilesAndPermissionSetsBrokenPaths?: boolean
   removeReferenceFromFilterItemToRecordType?: boolean
+  picklistsAsMaps?: boolean
 }
 
 export type ChangeValidatorName =
@@ -167,6 +168,7 @@ export type ChangeValidatorName =
   | 'cpqBillingStartDate'
   | 'cpqBillingTriggers'
   | 'managedApexComponent'
+  | 'orderedMaps'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -840,6 +842,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     extendTriggersMetadata: { refType: BuiltinTypes.BOOLEAN },
     storeProfilesAndPermissionSetsBrokenPaths: { refType: BuiltinTypes.BOOLEAN },
     removeReferenceFromFilterItemToRecordType: { refType: BuiltinTypes.BOOLEAN },
+    picklistsAsMaps: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -887,6 +890,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     cpqBillingStartDate: { refType: BuiltinTypes.BOOLEAN },
     cpqBillingTriggers: { refType: BuiltinTypes.BOOLEAN },
     managedApexComponent: { refType: BuiltinTypes.BOOLEAN },
+    orderedMaps: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/change_validators/map_keys.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/map_keys.test.ts
@@ -111,7 +111,10 @@ describe('profile permission set map keys change validator', () => {
   let mapKeysValidator: ChangeValidator
 
   beforeEach(() => {
-    mapKeysValidator = changeValidatorCreator(getLookUpName(defaultFilterContext.fetchProfile))
+    mapKeysValidator = changeValidatorCreator(
+      getLookUpName(defaultFilterContext.fetchProfile),
+      defaultFilterContext.fetchProfile,
+    )
   })
   const runChangeValidator = (before?: InstanceElement, after?: InstanceElement): Promise<ReadonlyArray<ChangeError>> =>
     mapKeysValidator([toChange({ before, after })])

--- a/packages/salesforce-adapter/test/change_validators/ordered_maps.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/ordered_maps.test.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression, toChange } from '@salto-io/adapter-api'
+import changeValidatorCreator from '../../src/change_validators/ordered_maps'
+import { METADATA_TYPE, SALESFORCE } from '../../src/constants'
+import { GLOBAL_VALUE_SET } from '../../src/filters/global_value_sets'
+import { Types } from '../../src/transformers/transformer'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+
+describe('OrderedMap Change Validator', () => {
+  const changeValidator = changeValidatorCreator(
+    buildFetchProfile({ fetchParams: { optionalFeatures: { picklistsAsMaps: true } } }),
+  )
+  describe('InstanceElement with ordered map', () => {
+    const gvsType = new ObjectType({
+      elemID: new ElemID(SALESFORCE, GLOBAL_VALUE_SET),
+      annotations: { [METADATA_TYPE]: GLOBAL_VALUE_SET },
+    })
+    const gvs = new InstanceElement('MyGVS', gvsType, {
+      customValue: {
+        values: {
+          val1: 'value1',
+          val2: 'value2',
+        },
+      },
+    })
+
+    it('should return an error when the order field is missing', async () => {
+      const errors = await changeValidator([toChange({ after: gvs })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: gvs.elemID,
+        severity: 'Error',
+        message: 'Missing field in ordered map',
+        detailedMessage: 'Missing order or values fields in field customValue',
+      })
+    })
+
+    it('should return an error when a field ref is missing', async () => {
+      gvs.value.customValue.order = [
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val1')),
+      ]
+      const errors = await changeValidator([toChange({ after: gvs })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: gvs.elemID,
+        severity: 'Error',
+        message: 'Missing reference in ordered map',
+        detailedMessage: 'Missing reference in field customValue.order: val2',
+      })
+    })
+
+    it('should return an error when a ref is invalid', async () => {
+      gvs.value.customValue.order = [
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val1')),
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val2')),
+        'invalid',
+      ]
+      const errors = await changeValidator([toChange({ after: gvs })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: gvs.elemID,
+        severity: 'Error',
+        message: 'Invalid reference in ordered map',
+        detailedMessage:
+          'Invalid reference in field customValue.order: invalid. Only reference to internal value keys are allowed.',
+      })
+    })
+
+    it('should return an error for duplicate field refs', async () => {
+      gvs.value.customValue.order = [
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val1')),
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val1')),
+        new ReferenceExpression(gvs.elemID.createNestedID('customValue', 'values', 'val2')),
+      ]
+      const errors = await changeValidator([toChange({ after: gvs })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: gvs.elemID,
+        severity: 'Error',
+        message: 'Duplicate reference in ordered map',
+        detailedMessage: 'Duplicate reference in field customValue.order: val1',
+      })
+    })
+  })
+
+  describe('ObjectType with ordered map', () => {
+    const account = new ObjectType({
+      elemID: new ElemID(SALESFORCE, 'Account'),
+      fields: {
+        CustomerPriority__c: {
+          refType: Types.primitiveDataTypes.Picklist,
+          annotations: {
+            valueSet: {
+              values: {
+                High: 'High',
+                Low: 'Low',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    const fieldElemID = account.elemID.createNestedID('field', 'CustomerPriority__c')
+
+    it('should return an error when the order field is missing', async () => {
+      const errors = await changeValidator([toChange({ after: account })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: fieldElemID,
+        severity: 'Error',
+        message: 'Missing field in ordered map',
+        detailedMessage: 'Missing order or values fields in field valueSet',
+      })
+    })
+
+    it('should return an error when a field ref is missing', async () => {
+      account.fields.CustomerPriority__c.annotations.valueSet.order = [
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'High')),
+      ]
+      const errors = await changeValidator([toChange({ after: account })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: fieldElemID,
+        severity: 'Error',
+        message: 'Missing reference in ordered map',
+        detailedMessage: 'Missing reference in field valueSet.order: Low',
+      })
+    })
+
+    it('should return an error when a ref is invalid', async () => {
+      account.fields.CustomerPriority__c.annotations.valueSet.order = [
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'High')),
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'Low')),
+        'invalid',
+      ]
+      const errors = await changeValidator([toChange({ after: account })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: fieldElemID,
+        severity: 'Error',
+        message: 'Invalid reference in ordered map',
+        detailedMessage:
+          'Invalid reference in field valueSet.order: invalid. Only reference to internal value keys are allowed.',
+      })
+    })
+
+    it('should return an error for duplicate field refs', async () => {
+      account.fields.CustomerPriority__c.annotations.valueSet.order = [
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'High')),
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'High')),
+        new ReferenceExpression(fieldElemID.createNestedID('valueSet', 'values', 'Low')),
+      ]
+      const errors = await changeValidator([toChange({ after: account })])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toMatchObject({
+        elemID: fieldElemID,
+        severity: 'Error',
+        message: 'Duplicate reference in ordered map',
+        detailedMessage: 'Duplicate reference in field valueSet.order: High',
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -15,12 +15,16 @@ import {
   Change,
   toChange,
   isObjectType,
+  PrimitiveType,
+  TypeReference,
 } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/convert_maps'
-import { generateProfileType, generatePermissionSetType, defaultFilterContext } from '../utils'
-import { createInstanceElement } from '../../src/transformers/transformer'
+import { generateProfileType, generatePermissionSetType, defaultFilterContext, createCustomObjectType } from '../utils'
+import { createInstanceElement, Types } from '../../src/transformers/transformer'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import { FIELD_ANNOTATIONS } from '../../src/constants'
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 
@@ -589,6 +593,119 @@ describe('Convert maps filter', () => {
         const emailTemplateType = elements[0] as ObjectType
         const attachmentsType = await emailTemplateType.fields.attachments.getType()
         expect(isMapType(attachmentsType)).toBeTruthy()
+      })
+    })
+  })
+
+  describe('Maintain order', () => {
+    const gvsType = mockTypes.GlobalValueSet
+    const gvs = new InstanceElement('MyGVS', gvsType, {
+      customValue: [
+        { fullName: 'val1', default: true, label: 'value1' },
+        { fullName: 'val2', default: false, label: 'value2' },
+      ],
+    })
+    let elements: Element[]
+    type FilterType = FilterWith<'onFetch'>
+    let filter: FilterType
+    beforeAll(async () => {
+      elements = [gvs, gvsType]
+      filter = filterCreator({
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures: { picklistsAsMaps: true } } }),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+    })
+
+    it('should convert field type to ordered map', async () => {
+      const fieldType = await gvsType.fields.customValue.getType()
+      expect(fieldType.elemID.typeName).toEqual('OrderedMap<CustomValue>')
+    })
+
+    it('should convert instance value to map ', () => {
+      expect(gvs.value.customValue.values).toBeDefined()
+      expect(gvs.value.customValue.values).toEqual({
+        val1: { fullName: 'val1', default: true, label: 'value1' },
+        val2: { fullName: 'val2', default: false, label: 'value2' },
+      })
+    })
+  })
+
+  describe('Convert CustomObject field annotations by type', () => {
+    let picklistType: PrimitiveType
+    let multiselectPicklistType: PrimitiveType
+    let myCustomObj: ObjectType
+    let elements: Element[]
+    type FilterType = FilterWith<'onFetch'>
+    let filter: FilterType
+    beforeEach(async () => {
+      // Clone the types to avoid changing the original types and affecting other tests.
+      picklistType = Types.primitiveDataTypes.Picklist.clone()
+      multiselectPicklistType = Types.primitiveDataTypes.MultiselectPicklist.clone()
+      myCustomObj = createCustomObjectType('MyCustomObj', {
+        fields: {
+          myPicklist: {
+            refType: picklistType,
+            annotations: {
+              [FIELD_ANNOTATIONS.VALUE_SET]: [
+                { fullName: 'val1', default: true, label: 'value1' },
+                { fullName: 'val2', default: false, label: 'value2' },
+              ],
+            },
+          },
+          myMultiselectPicklist: {
+            refType: multiselectPicklistType,
+            annotations: {
+              [FIELD_ANNOTATIONS.VALUE_SET]: [
+                { fullName: 'val1', default: true, label: 'value1' },
+                { fullName: 'val2', default: false, label: 'value2' },
+              ],
+            },
+          },
+        },
+      })
+
+      elements = [myCustomObj]
+      filter = filterCreator({
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures: { picklistsAsMaps: true } } }),
+        },
+      }) as FilterType
+      await filter.onFetch(elements)
+    })
+
+    it('should convert Picklist valueSet type to ordered map', async () => {
+      expect(myCustomObj.fields.myPicklist.getTypeSync()).toEqual(picklistType)
+      const valueSetType = picklistType.annotationRefTypes.valueSet as TypeReference<ObjectType>
+      expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
+      expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
+      expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
+    })
+
+    it('should convert MultiselectPicklist valueSet type to ordered map', async () => {
+      expect(myCustomObj.fields.myMultiselectPicklist.getTypeSync()).toEqual(multiselectPicklistType)
+      const valueSetType = multiselectPicklistType.annotationRefTypes.valueSet as TypeReference<ObjectType>
+      expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
+      expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
+      expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
+    })
+
+    it('should convert annotation value to map (Picklist)', () => {
+      expect(myCustomObj.fields.myPicklist.annotations.valueSet.values).toBeDefined()
+      expect(myCustomObj.fields.myPicklist.annotations.valueSet.values).toEqual({
+        val1: { fullName: 'val1', default: true, label: 'value1' },
+        val2: { fullName: 'val2', default: false, label: 'value2' },
+      })
+    })
+
+    it('should convert annotation value to map (MultiselectPicklist)', () => {
+      expect(myCustomObj.fields.myMultiselectPicklist.annotations.valueSet.values).toBeDefined()
+      expect(myCustomObj.fields.myMultiselectPicklist.annotations.valueSet.values).toEqual({
+        val1: { fullName: 'val1', default: true, label: 'value1' },
+        val2: { fullName: 'val2', default: false, label: 'value2' },
       })
     })
   })


### PR DESCRIPTION
This is a redo of #6604 which was reverted in #6680.
There were a few issues, the main one was that I protected the filter behavior with a FF only on `onFetch` and not on `preDeploy` and `onDeploy`, but I also found more bugs and added some tests. Hopefully this looks better now.

Workspace diff: https://github.com/salto-io/amir-sf1/commit/1ff0e4d32556d0c661067317541b1e3769228c60

Original PR description below:

---

This PR remodels picklists (of various kinds) to "OrderedMap" which is a new type that has a Map and a separate list of references to all values in that map to maintain its order.

This behavior is protected by a `picklistsAsMaps` feature flag.

See SALTO-4990 for more details.

Workspace diff: https://github.com/salto-io/amir-sf1/commit/46f8c50dd0087d3baf3db3c00e9dbc9b3cc411d7

### Before

```
salesforce.GlobalValueSet Amir_s_Globalization {
  fullName = "Amir_s_Globalization"
  masterLabel = "Amir's Globalization"
  sorted = false
  customValue = [
    {
      fullName = "over"
      default = false
      label = "over"
    },
    {
      fullName = "take"
      default = true
      label = "take"
    },
    {
      fullName = "the world"
      default = false
      label = "the world"
    },
    {
      fullName = "_order"
      default = false
      label = "_order"
    },
    {
      fullName = "nice"
      default = false
      label = "nice"
    },
  ]
  _alias = "Amir_s_Globalization"
}
```

### After

```
salesforce.GlobalValueSet Amir_s_Globalization {
  fullName = "Amir_s_Globalization"
  masterLabel = "Amir's Globalization"
  sorted = false
  customValue = {
    values = {
      over = {
        fullName = "over"
        default = false
        label = "over"
      }
      take = {
        fullName = "take"
        default = true
        label = "take"
      }
      the_world@s = {
        fullName = "the world"
        default = false
        label = "the world"
      }
      _order = {
        fullName = "_order"
        default = false
        label = "_order"
      }
      nice = {
        fullName = "nice"
        default = false
        label = "nice"
      }
    }
    order = [
      salesforce.GlobalValueSet.instance.Amir_s_Globalization.customValue.values.over,
      salesforce.GlobalValueSet.instance.Amir_s_Globalization.customValue.values.take,
      salesforce.GlobalValueSet.instance.Amir_s_Globalization.customValue.values.the_world@s,
      salesforce.GlobalValueSet.instance.Amir_s_Globalization.customValue.values._order,
      salesforce.GlobalValueSet.instance.Amir_s_Globalization.customValue.values.nice,
    ]
  }
  _alias = "Amir_s_Globalization"
}

```

---

_Additional context for reviewer_:

Sent for a preliminary review - I still need to add:
- [x] A change validator to make sure the `order` field is exhaustive
- [x] Unit tests

But please do a quick pass to see that the general idea is okay.

---
_Release Notes_: 
None

---
_User Notifications_: 
None