### PR TITLE
SALTO-6779: remove boolean query param from adapter component client interface

### DIFF
--- a/packages/adapter-components/src/client/http_client.ts
+++ b/packages/adapter-components/src/client/http_client.ts
@@ -43,7 +43,7 @@ export type ClientOpts<TCredentials, TRateLimitConfig extends ClientRateLimitCon
 
 export type ClientBaseParams = {
   url: string
-  queryParams?: Record<string, string | string[] | boolean>
+  queryParams?: Record<string, string | string[]>
   headers?: Record<string, string>
   responseType?: ResponseType
   params?: Record<string, Values>

--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -232,7 +232,7 @@ const createWorkflowInstances = async ({
         workflowIds,
       },
       queryParams: {
-        useTransitionLinksFormat: true,
+        useTransitionLinksFormat: 'true',
       },
     })
     if (!isWorkflowResponse(response.data)) {

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -340,7 +340,7 @@ describe('workflow filter', () => {
         },
         {
           params: {
-            useTransitionLinksFormat: true,
+            useTransitionLinksFormat: 'true',
           },
         },
       )


### PR DESCRIPTION
_remove boolean query param from adapter component client interface_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
