### PR TITLE
SALTO-6736: Add Elapsed Time to Salesforce Metadata Deploy Progress Reporter

### DIFF
--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -44,6 +44,7 @@
     "@salto-io/salesforce-formula-parser": "0.1.5",
     "bottleneck": "^2.19.5",
     "fast-xml-parser": "^4.4.0",
+    "humanize-duration": "^3.22.0",
     "joi": "^17.4.0",
     "jszip": "^3.10.1",
     "lodash": "^4.17.21",

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -20,6 +20,7 @@ import { deployment } from '@salto-io/adapter-components'
 import { DeployResult } from '@salto-io/jsforce-types'
 import { values } from '@salto-io/lowerdash'
 import { inspectValue } from '@salto-io/adapter-utils'
+import humanizeDuration from 'humanize-duration'
 import SalesforceClient, { validateCredentials } from './client/client'
 import SalesforceAdapter from './adapter'
 import {
@@ -255,11 +256,11 @@ export const createDeployProgressReporter = async (
     if (deployResult) {
       const startTime = new Date(deployResult.createdDate).getTime()
       const currentTime = new Date().getTime()
-      const elapsedTimeMinutes = ((currentTime - startTime) / (1000 * 60)).toFixed(1)
+      const elapsedTimeMinutes = humanizeDuration(currentTime - startTime)
       metadataProgress =
         deployResult.status === METADATA_DEPLOY_PENDING_STATUS
-          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes} minutes`
-          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes} minutes.${linkToSalesforce(deployResult)}`
+          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes}`
+          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforce(deployResult)}`
     }
     if (deployedDataInstances > 0) {
       dataProgress = `${deployedDataInstances} Data Instances`

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -250,24 +250,17 @@ export const createDeployProgressReporter = async (
     return ` View ${deploymentOrValidation} status [in Salesforce](${deploymentUrl})`
   }
 
-  const linkToSalesforceDeploymentsPage = (): string => {
-    if (!baseUrl) {
-      return ''
-    }
-    return ` View deployments [in Salesforce](${baseUrl}lightning/setup/DeployStatus/home)`
-  }
-
   const reportProgress = (): void => {
     let metadataProgress: string | undefined
     let dataProgress: string | undefined
     if (deployResult) {
       const startTime = new Date(deployResult.createdDate).getTime()
       const currentTime = new Date().getTime()
-      const elapsedTimeMinutes = humanizeDuration(currentTime - startTime)
+      const elapsedTime = humanizeDuration(currentTime - startTime)
       metadataProgress =
         deployResult.status === METADATA_DEPLOY_PENDING_STATUS
-          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforceDeploymentsPage()}`
-          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforceDeployment(deployResult)}`
+          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTime}.${baseUrl ? ` View deployments [in Salesforce](${baseUrl}lightning/setup/DeployStatus/home)` : ''}`
+          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTime}.${linkToSalesforceDeployment(deployResult)}`
     }
     if (deployedDataInstances > 0) {
       dataProgress = `${deployedDataInstances} Data Instances`

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -253,10 +253,13 @@ export const createDeployProgressReporter = async (
     let metadataProgress: string | undefined
     let dataProgress: string | undefined
     if (deployResult) {
+      const startTime = new Date(deployResult.createdDate).getTime()
+      const currentTime = new Date().getTime()
+      const elapsedTimeMinutes = ((currentTime - startTime) / (1000 * 60)).toFixed(1)
       metadataProgress =
         deployResult.status === METADATA_DEPLOY_PENDING_STATUS
-          ? 'Metadata: Waiting on another deploy or automated process to finish in Salesforce'
-          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests.${linkToSalesforce(deployResult)}`
+          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes} minutes`
+          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes} minutes.${linkToSalesforce(deployResult)}`
     }
     if (deployedDataInstances > 0) {
       dataProgress = `${deployedDataInstances} Data Instances`

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -241,13 +241,20 @@ export const createDeployProgressReporter = async (
   let deployedDataInstances = 0
   const baseUrl = await client.getUrl()
 
-  const linkToSalesforce = ({ id, checkOnly }: DeployResult): string => {
+  const linkToSalesforceDeployment = ({ id, checkOnly }: DeployResult): string => {
     if (!baseUrl) {
       return ''
     }
     const deploymentUrl = `${baseUrl}lightning/setup/DeployStatus/page?address=%2Fchangemgmt%2FmonitorDeploymentsDetails.apexp%3FasyncId%3D${id}`
     const deploymentOrValidation = checkOnly ? 'validation' : 'deployment'
     return ` View ${deploymentOrValidation} status [in Salesforce](${deploymentUrl})`
+  }
+
+  const linkToSalesforceDeploymentsPage = (): string => {
+    if (!baseUrl) {
+      return ''
+    }
+    return ` View deployments [in Salesforce](${baseUrl}lightning/setup/DeployStatus/home)`
   }
 
   const reportProgress = (): void => {
@@ -259,8 +266,8 @@ export const createDeployProgressReporter = async (
       const elapsedTimeMinutes = humanizeDuration(currentTime - startTime)
       metadataProgress =
         deployResult.status === METADATA_DEPLOY_PENDING_STATUS
-          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes}`
-          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforce(deployResult)}`
+          ? `Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforceDeploymentsPage()}`
+          : `${deployResult.numberComponentsDeployed}/${deployResult.numberComponentsTotal} Metadata Components, ${deployResult.numberTestsCompleted}/${deployResult.numberTestsTotal} Tests. Elapsed Time: ${elapsedTimeMinutes}.${linkToSalesforceDeployment(deployResult)}`
     }
     if (deployedDataInstances > 0) {
       dataProgress = `${deployedDataInstances} Data Instances`

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -516,8 +516,12 @@ describe('SalesforceAdapter CRUD', () => {
           it('should deploy', () => {
             expect(result.errors).toBeEmpty()
             expect(result.appliedChanges).toHaveLength(1)
-            expect(progressReporter.getReportedMessages()).toSatisfyAny(message =>
-              message.endsWith(ProgressReporterSuffix.QuickDeploy),
+            expect(progressReporter.getReportedMessages()).toSatisfyAny(
+              message =>
+                message.endsWith(ProgressReporterSuffix.QuickDeploy) &&
+                message.includes('Waiting on another deploy') &&
+                message.includes('Elapsed Time:') &&
+                message.includes('View deployments [in Salesforce](https://url.com/lightning/setup/DeployStatus/home)'),
             )
           })
         })

--- a/yarn.lock
+++ b/yarn.lock
@@ -5274,6 +5274,7 @@ __metadata:
     eslint-plugin-react-hooks: ^1.7.0
     fast-xml-parser: ^4.4.0
     globals: ^15.8.0
+    humanize-duration: ^3.22.0
     jest: ^29.7.0
     jest-circus: ^29.7.0
     jest-extended: ^4.0.2


### PR DESCRIPTION
SALTO-6736: Add Elapsed Time to Salesforce Metadata Deploy Progress Reporter

---

Example for queued deployment: 
Metadata: Waiting on another deploy or automated process to finish in Salesforce. Elapsed Time: 3.344 seconds. View deployments [in Salesforce](https://salto-1a-dev-ed.develop.my.salesforce.com/lightning/setup/DeployStatus/home)

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved the Metadata Deploy progress to include the elapsed time since the deployment was created.

---
_User Notifications_: 
_None_
