### PR TITLE
SALTO-6811: Adding try/catch on calls to SF library

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -214,7 +214,7 @@ export type DumpElementsToFolderArgs = {
 }
 
 export type DumpElementsResult = {
-  unappliedChanges: Change[]
+  unappliedChanges: ReadonlyArray<Change>
   errors: ReadonlyArray<SaltoError | SaltoElementError>
 }
 

--- a/packages/salesforce-adapter/src/sfdx_parser/errors.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/errors.ts
@@ -23,5 +23,5 @@ export const detailedMessageFromSfError = (error: unknown): string => {
     return error.message
   }
 
-  return 'Internal error in Salesforce library'
+  return `Internal error in Salesforce library: ${error}`
 }

--- a/packages/salesforce-adapter/src/sfdx_parser/errors.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/errors.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { inspectValue } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
+import { SfError } from './salesforce_imports'
+
+const log = logger(module)
+
+export const detailedMessageFromSfError = (error: unknown): string => {
+  if (error instanceof SfError) {
+    log.warn('Got an SfError: %s', inspectValue(error.toObject()))
+    const actionsBullets = error.actions?.map(action => `* ${action}`).join('\n')
+    const actionsBlock = actionsBullets ? `\nSuggested actions:\n${actionsBullets}` : ''
+    return `${error.name}: ${error.message}${actionsBlock}`
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message
+  }
+
+  return 'Internal error in Salesforce library'
+}

--- a/packages/salesforce-adapter/src/sfdx_parser/project.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/project.ts
@@ -38,7 +38,7 @@ export const isProjectFolder: IsInitializedFolderFunc = async ({ baseDir }) => {
         {
           severity: 'Error',
           message: 'Failed checking if folder contains an SFDX project',
-          detailedMessage: error.message,
+          detailedMessage: error.message ?? 'Internal error in Salesforce library',
         },
       ],
     }
@@ -69,7 +69,7 @@ export const createProject: InitFolderFunc = async ({ baseDir }) => {
         {
           severity: 'Error',
           message: 'Failed initializing SFDX project',
-          detailedMessage: error.message,
+          detailedMessage: error.message ?? 'Internal error in Salesforce library',
         },
       ],
     }

--- a/packages/salesforce-adapter/src/sfdx_parser/project.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/project.ts
@@ -12,6 +12,7 @@ import { logger } from '@salto-io/logging'
 import { AdapterFormat } from '@salto-io/adapter-api'
 import { API_VERSION } from '../client/client'
 import { SfProject, SfError, TemplateService, TemplateType, ProjectOptions } from './salesforce_imports'
+import { detailedMessageFromSfError } from './errors'
 
 const log = logger(module)
 
@@ -38,7 +39,7 @@ export const isProjectFolder: IsInitializedFolderFunc = async ({ baseDir }) => {
         {
           severity: 'Error',
           message: 'Failed checking if folder contains an SFDX project',
-          detailedMessage: error.message ?? 'Internal error in Salesforce library',
+          detailedMessage: detailedMessageFromSfError(error),
         },
       ],
     }
@@ -69,7 +70,7 @@ export const createProject: InitFolderFunc = async ({ baseDir }) => {
         {
           severity: 'Error',
           message: 'Failed initializing SFDX project',
-          detailedMessage: error.message ?? 'Internal error in Salesforce library',
+          detailedMessage: detailedMessageFromSfError(error),
         },
       ],
     }

--- a/packages/salesforce-adapter/src/sfdx_parser/salesforce_imports.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/salesforce_imports.ts
@@ -12,6 +12,7 @@ import './salesforce_imports_fix'
 export { SfProject, SfError } from '@salesforce/core'
 export {
   ComponentSet,
+  ConvertResult,
   ZipTreeContainer,
   MetadataConverter,
   TreeContainer,

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -35,6 +35,7 @@ import {
   SfProject,
 } from './salesforce_imports'
 import { SyncZipTreeContainer } from './tree_container'
+import { detailedMessageFromSfError } from './errors'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -224,8 +225,8 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
       unappliedChanges: changes,
       errors: errors.concat({
         severity: 'Error',
-        message: 'Failed merging changes',
-        detailedMessage: error.message ?? 'Internal error in Salesforce library',
+        message: 'Failed persisting changes to SFDX project',
+        detailedMessage: detailedMessageFromSfError(error),
       }),
     }
   }

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -222,7 +222,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     )
   } catch (error) {
     return {
-      unappliedChanges: changes,
+      unappliedChanges,
       errors: errors.concat({
         severity: 'Error',
         message: 'Failed persisting changes to SFDX project',

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -29,6 +29,7 @@ import { allFilters } from '../adapter'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
 import { metadataTypeSync } from '../filters/utils'
 import { getTypesWithContent, getTypesWithMetaFile } from '../fetch'
+import { detailedMessageFromSfError } from './errors'
 
 const log = logger(module)
 const { awu, keyByAsync } = collections.asynciterable
@@ -97,7 +98,7 @@ export const loadElementsFromFolder: LoadElementsFromFolderFunc = async ({ baseD
           {
             severity: 'Error',
             message: 'Failed to load project',
-            detailedMessage: error.message ?? 'Internal error in Salesforce library',
+            detailedMessage: detailedMessageFromSfError(error),
           },
         ],
       }

--- a/packages/salesforce-adapter/test/sfdx_parser/errors.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/errors.test.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { SfError } from '@salesforce/core'
+import { detailedMessageFromSfError } from '../../src/sfdx_parser/errors'
+
+describe('detailedMessageFromSfError', () => {
+  let message: string
+
+  describe('with an SfError', () => {
+    describe('without actions', () => {
+      beforeEach(() => {
+        message = detailedMessageFromSfError(new SfError('Error message', 'ErrorName'))
+      })
+
+      it('should return a formatted message', () => {
+        expect(message).toEqual('ErrorName: Error message')
+      })
+    })
+
+    describe('with actions', () => {
+      beforeEach(() => {
+        message = detailedMessageFromSfError(new SfError('Error message', 'ErrorName', ['Action 1', 'Action 2']))
+      })
+
+      it('should return a formatted message', () => {
+        expect(message).toEqual('ErrorName: Error message\nSuggested actions:\n* Action 1\n* Action 2')
+      })
+    })
+  })
+
+  describe('with an Error', () => {
+    beforeEach(() => {
+      message = detailedMessageFromSfError(new Error('Error message'))
+    })
+
+    it('should return the error message', () => {
+      expect(message).toEqual('Error message')
+    })
+  })
+
+  describe('with a different type', () => {
+    beforeEach(() => {
+      message = detailedMessageFromSfError('A string')
+    })
+
+    it('should return a const message', () => {
+      expect(message).toEqual('Internal error in Salesforce library')
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/sfdx_parser/errors.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/errors.test.ts
@@ -49,7 +49,7 @@ describe('detailedMessageFromSfError', () => {
     })
 
     it('should return a const message', () => {
-      expect(message).toEqual('Internal error in Salesforce library')
+      expect(message).toEqual('Internal error in Salesforce library: A string')
     })
   })
 })


### PR DESCRIPTION
We've seen `converter.convert` throwing errors in dump, so better safe than sorry on all library calls.
Also adding a fallback for all error messages just in case.

---

_Additional context for reviewer_:
Covering the error flows seems pretty tricky - will require some uncomfortable mocking. Open to suggestion or pushback on this if we think it's worth the effort.

---

_Release Notes_: 
_Salesforce adapter_:
* Return errors from parsing and dumping SFDX instead of throwing.

---

_User Notifications_: 
None