### PR TITLE
SALTO-6812: Using empty SFDX project template

### DIFF
--- a/packages/salesforce-adapter/src/sfdx_parser/project.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/project.ts
@@ -53,7 +53,7 @@ export const createProject: InitFolderFunc = async ({ baseDir }) => {
     outputdir: path.dirname(baseDir),
     manifest: false,
     loginurl: 'https://login.salesforce.com',
-    template: 'standard',
+    template: 'empty',
     ns: '',
     defaultpackagedir: 'force-app',
     apiversion: API_VERSION,


### PR DESCRIPTION
The standard template is a bit more spammy than we would like.

---

_Salesforce adapter_: 
* Moved to using the empty template for creating SFDX projects instead of the standard template which has some extra files.

---

_User Notifications_: 
None.
