### PR TITLE
SALTO-5929: (Salesforce) LightningPage FieldItem references

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -52,6 +52,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   removeReferenceFromFilterItemToRecordType: false,
   storeProfilesAndPermissionSetsBrokenPaths: true,
   picklistsAsMaps: false,
+  lightningPageFieldItemReference: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/filters/field_references.ts
+++ b/packages/salesforce-adapter/src/filters/field_references.ts
@@ -22,8 +22,8 @@ import {
   generateReferenceResolverFinder,
   ReferenceContextStrategyName,
   FieldReferenceDefinition,
-  fieldNameToTypeMappingDefs,
   getLookUpName,
+  getDefsFromFetchProfile,
 } from '../transformers/reference_mapping'
 import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE,
@@ -211,7 +211,7 @@ const filter: FilterCreator = ({ config }) => ({
     await addReferences(
       elements,
       buildElementsSourceForFetch(elements, config),
-      fieldNameToTypeMappingDefs,
+      getDefsFromFetchProfile(config.fetchProfile),
       typesToIgnore,
       createContextStrategyLookups(config.fetchProfile),
     )

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -129,6 +129,7 @@ export type OptionalFeatures = {
   storeProfilesAndPermissionSetsBrokenPaths?: boolean
   removeReferenceFromFilterItemToRecordType?: boolean
   picklistsAsMaps?: boolean
+  lightningPageFieldItemReference?: boolean
 }
 
 export type ChangeValidatorName =
@@ -843,6 +844,7 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     storeProfilesAndPermissionSetsBrokenPaths: { refType: BuiltinTypes.BOOLEAN },
     removeReferenceFromFilterItemToRecordType: { refType: BuiltinTypes.BOOLEAN },
     picklistsAsMaps: { refType: BuiltinTypes.BOOLEAN },
+    lightningPageFieldItemReference: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -691,6 +691,7 @@ export const mockTypes = {
       SBQQ__Template__c: {
         refType: Types.primitiveDataTypes.MasterDetail,
         annotations: {
+          [API_NAME]: 'SBQQ__LineColumn__c.SBQQ__Template__c',
           [FIELD_ANNOTATIONS.REFERENCE_TO]: ['SBQQ__Template__c'],
           [FIELD_ANNOTATIONS.QUERYABLE]: true,
         },
@@ -771,6 +772,14 @@ export const mockTypes = {
           [FIELD_ANNOTATIONS.UPDATEABLE]: true,
         },
       },
+    },
+  }),
+  FieldInstance: createMetadataObjectType({
+    annotations: {
+      metadataType: 'FieldInstance',
+    },
+    fields: {
+      fieldItem: { refType: BuiltinTypes.STRING },
     },
   }),
 }


### PR DESCRIPTION
(Salesforce) LightningPage FieldItem references

---

- Workspace Diff: https://github.com/salto-io/tamir-sf/commit/1083e2b2d5058a5d3cfc4d68a0d736f6ba60bf0a
- Added a new serialization strategy with UTs.

---
_Release Notes_: 
_Salesforce Adapter_:
- Added references from LightningPage instances to CustomFields (requires the `lightningPageFieldItemReference` optional feature)

---
_User Notifications_: 
Salesforce:
- When enabling the feature `lightningPageFieldItemReference`, expect changes to existing LightningPage nacls.
