### PR TITLE
SALTO-6802: Remove hidden field annotation from automation service desk

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1625,7 +1625,13 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
   Automation: {
     transformation: {
-      fieldsToOmit: [{ fieldName: 'ruleHome' }, { fieldName: 'schemaVersion' }, { fieldName: 'idUuid' }],
+      fieldsToOmit: [
+        { fieldName: 'ruleHome' },
+        { fieldName: 'schemaVersion' },
+        { fieldName: 'idUuid' },
+        // serviceDesk is referenced from the associated request type, so we don't need to keep it in the automation component
+        { fieldName: 'serviceDesk' },
+      ],
       serviceUrl: '/jira/settings/automation#/rule/{id}',
       idFields: ['name', PROJECTS_FIELD], // idFields is handled separately in automation filter.
     },

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -187,12 +187,6 @@ export const createAutomationTypes = (): {
       objectTypeId: { refType: BuiltinTypes.STRING },
       templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
-      serviceDesk: {
-        refType: BuiltinTypes.STRING,
-        annotations: {
-          [CORE_ANNOTATIONS.HIDDEN_VALUE]: true,
-        },
-      },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -7,9 +7,11 @@
  */
 import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
 import { transformValues } from '@salto-io/adapter-utils'
+import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 
+const log = logger(module)
 const { awu } = collections.asynciterable
 
 const isStringNumber = (value: string): boolean => !Number.isNaN(Number(value))
@@ -34,6 +36,7 @@ const filter: FilterCreator = () => ({
             transformFunc: ({ value, field, path }) => {
               const isInArray = path?.getFullNameParts().some(isStringNumber)
               if (isInArray && field?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]) {
+                log.warn('found hidden value in hidden field %s in list with path %s', field.elemID.getFullName(), path?.getFullName())
                 return undefined
               }
               return value


### PR DESCRIPTION
This PRs remove the hidden field annotation from Automation type
This actually (almost) did no harm due to `hiddenValuesInListsFilter` which removed this value and basically turned it into omit.

Also added log for visibility.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
