### PR TITLE
SALTO-6817: Fix AddJsmProjectValidator to address only jira cloud 

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -144,7 +144,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     defaultAdditionQueueValidator: defaultAdditionQueueValidator(config),
     automationToAssets: automationToAssetsValidator(config),
     defaultAttributeValidator: defaultAttributeValidator(config, client),
-    addJsmProject: addJsmProjectValidator,
+    addJsmProject: addJsmProjectValidator(client),
     deleteLabelAtttribute: deleteLabelAtttributeValidator(config),
     jsmPermissions: jsmPermissionsValidator(config, client),
     assetsObjectFieldConfigurationAql: assetsObjectFieldConfigurationAqlValidator(client),

--- a/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
+++ b/packages/jira-adapter/test/change_validators/adding_jsm_project.test.ts
@@ -9,14 +9,18 @@
 import { InstanceElement, ReadOnlyElementsSource, toChange, SeverityLevel } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { PROJECT_TYPE } from '../../src/constants'
-import { createEmptyType } from '../utils'
 import { addJsmProjectValidator } from '../../src/change_validators/adding_jsm_project'
+import JiraClient from '../../src/client/client'
+import { createEmptyType, mockClient } from '../utils'
 
 describe('addJsmProjectValidator', () => {
   let elementsSource: ReadOnlyElementsSource
   let projectInstace: InstanceElement
   let accountInfoInstance: InstanceElement
+  let client: JiraClient
   beforeEach(() => {
+    const mockCli = mockClient()
+    client = mockCli.client
     projectInstace = new InstanceElement('projectInstace', createEmptyType(PROJECT_TYPE), {
       projectTypeKey: 'service_desk',
       description: 'test',
@@ -35,7 +39,7 @@ describe('addJsmProjectValidator', () => {
   it('should return error is if JSM is disabled in the service and trying to add JSM project', async () => {
     const changes = [toChange({ after: projectInstace })]
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
@@ -48,7 +52,7 @@ describe('addJsmProjectValidator', () => {
   it('should return error if account info is not found', async () => {
     const changes = [toChange({ after: projectInstace })]
     elementsSource = buildElementsSourceFromElements([])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
@@ -62,7 +66,7 @@ describe('addJsmProjectValidator', () => {
     const changes = [toChange({ after: projectInstace })]
     accountInfoInstance = new InstanceElement('_config', createEmptyType('AccountInfo'), {})
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
@@ -78,7 +82,7 @@ describe('addJsmProjectValidator', () => {
       license: {},
     })
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([
       {
         elemID: projectInstace.elemID,
         severity: 'Error' as SeverityLevel,
@@ -92,7 +96,7 @@ describe('addJsmProjectValidator', () => {
     const changes = [toChange({ after: projectInstace })]
     projectInstace.value.projectTypeKey = 'business'
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([])
   })
   it('should not return error if JSM is enabled in the service as Free edition', async () => {
     const changes = [toChange({ after: projectInstace })]
@@ -111,7 +115,7 @@ describe('addJsmProjectValidator', () => {
       },
     })
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([])
   })
   it('should not return error if JSM is enabled in the service as Paid edition', async () => {
     const changes = [toChange({ after: projectInstace })]
@@ -130,17 +134,24 @@ describe('addJsmProjectValidator', () => {
       },
     })
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([])
   })
   it('should not return error for modification changes', async () => {
     const projAfter = projectInstace.clone()
     projAfter.value.description = 'new description'
     const changes = [toChange({ before: projectInstace, after: projAfter })]
     elementsSource = buildElementsSourceFromElements([accountInfoInstance])
-    expect(await addJsmProjectValidator(changes, elementsSource)).toEqual([])
+    expect(await addJsmProjectValidator(client)(changes, elementsSource)).toEqual([])
   })
   it('should not return error if elementsSource is undefined', async () => {
     const changes = [toChange({ after: projectInstace })]
-    expect(await addJsmProjectValidator(changes, undefined)).toEqual([])
+    expect(await addJsmProjectValidator(client)(changes, undefined)).toEqual([])
+  })
+  it('should not return error if client is data center', async () => {
+    const changes = [toChange({ after: projectInstace })]
+    const dcMockCli = mockClient(true)
+    const dcClient = dcMockCli.client
+    elementsSource = buildElementsSourceFromElements([accountInfoInstance])
+    expect(await addJsmProjectValidator(dcClient)(changes, elementsSource)).toEqual([])
   })
 })


### PR DESCRIPTION
In this PR I fixed AddJsmProjectValidator to address only jira cloud 

---

_Additional context for reviewer_
During deployment of a JSM project to our Jira DC instance, the operation failed due to the addJsmProjectValidator being incorrectly applied to both DC and Cloud environments. After disabling the validator, the deployment succeeded.
The validator logic needs to be updated to address only Cloud environments.

---
_Release Notes_: 
* [SALTO-6817](https://salto-io.atlassian.net/browse/SALTO-6817) - Users will be able to deploy JSM projects (Only the projects, without subTypes) to their DC instances. 
---
_User Notifications_: 
None


[SALTO-6817]: https://salto-io.atlassian.net/browse/SALTO-6817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ