### PR TITLE
SALTO-6171: Create "Info" message when adding a user in status PROVISIONED (Okta)

### DIFF
--- a/packages/okta-adapter/src/change_validators/index.ts
+++ b/packages/okta-adapter/src/change_validators/index.ts
@@ -36,6 +36,7 @@ import { disabledAuthenticatorsInMfaPolicyValidator } from './disabled_authentic
 import { oidcIdentityProviderValidator } from './oidc_idp'
 import { everyoneGroupAssignments } from './everyone_group_assignments'
 import { emailDomainAdditionValidator } from './email_domain_addition'
+import { provisionedUserAdditions } from './provisioned_user_addition'
 import OktaClient from '../client/client'
 import {
   API_DEFINITIONS_CONFIG,
@@ -114,6 +115,7 @@ export default ({
     oidcIdentityProvider: oidcIdentityProviderValidator,
     everyoneGroupAssignments,
     emailDomainAddition: emailDomainAdditionValidator,
+    provisionedUserAdditions,
   }
 
   return createChangeValidator({

--- a/packages/okta-adapter/src/change_validators/provisioned_user_addition.ts
+++ b/packages/okta-adapter/src/change_validators/provisioned_user_addition.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ChangeValidator,
+  getChangeData,
+  isInstanceChange,
+  isAdditionChange,
+  AdditionChange,
+  InstanceElement,
+} from '@salto-io/adapter-api'
+import { USER_TYPE_NAME } from '../constants'
+
+const isProvisionedUser = (change: AdditionChange<InstanceElement>): boolean =>
+  getChangeData(change).elemID.typeName === USER_TYPE_NAME && getChangeData(change).value.status === 'PROVISIONED'
+
+/**
+ * When adding a user in PROVISIONED status, the user will be sent an email with either an activation link or a one-time token.
+ */
+export const provisionedUserAdditions: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionChange)
+    .filter(isProvisionedUser)
+    .map(change => ({
+      elemID: getChangeData(change).elemID,
+      severity: 'Info' as const,
+      message: 'User will be emailed to complete the activation process',
+      detailedMessage:
+        'Salto does not configure authentication for newly added users. The user will receive an email with instructions to complete the activation process.',
+    }))

--- a/packages/okta-adapter/src/change_validators/provisioned_user_addition.ts
+++ b/packages/okta-adapter/src/change_validators/provisioned_user_addition.ts
@@ -15,7 +15,7 @@ import {
 } from '@salto-io/adapter-api'
 import { USER_TYPE_NAME } from '../constants'
 
-const isProvisionedUser = (change: AdditionChange<InstanceElement>): boolean =>
+const isProvisionedUserAdditionChange = (change: AdditionChange<InstanceElement>): boolean =>
   getChangeData(change).elemID.typeName === USER_TYPE_NAME && getChangeData(change).value.status === 'PROVISIONED'
 
 /**
@@ -25,7 +25,7 @@ export const provisionedUserAdditions: ChangeValidator = async changes =>
   changes
     .filter(isInstanceChange)
     .filter(isAdditionChange)
-    .filter(isProvisionedUser)
+    .filter(isProvisionedUserAdditionChange)
     .map(change => ({
       elemID: getChangeData(change).elemID,
       severity: 'Info' as const,

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -69,6 +69,7 @@ const changeValidatorNames = [
   'oidcIdentityProvider',
   'everyoneGroupAssignments',
   'emailDomainAddition',
+  'provisionedUserAdditions',
 ] as const
 
 export type ChangeValidatorName = (typeof changeValidatorNames)[number]

--- a/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
+++ b/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
@@ -18,20 +18,20 @@ describe('provisionedUserAdditions', () => {
       const change = toChange({ after: instance })
       const result = await provisionedUserAdditions([change])
       expect(result).toHaveLength(1)
-      expect(result[0]).toMatchObject({
+      expect(result).toMatchObject([{
         elemID: instance.elemID,
         severity: 'Info',
         message: 'User will be emailed to complete the activation process',
         detailedMessage:
           'Salto does not configure authentication for newly added users. The user will receive an email with instructions to complete the activation process.',
-      })
+      }])
     })
 
     it('should not create change errors for users with STAGED status', async () => {
       const instance = new InstanceElement('user2', userType, { status: 'STAGED' })
       const change = toChange({ after: instance })
       const result = await provisionedUserAdditions([change])
-      expect(result).toHaveLength(0)
+      expect(result).toMatchObject([])
     })
   })
 
@@ -43,7 +43,7 @@ describe('provisionedUserAdditions', () => {
         toChange({ before: instanceBefore, after: instanceAfter }),
         toChange({ before: instanceAfter }),
       ])
-      expect(result).toHaveLength(0)
+      expect(result).toMatchObject([])
     })
   })
 })

--- a/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
+++ b/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
@@ -18,13 +18,15 @@ describe('provisionedUserAdditions', () => {
       const change = toChange({ after: instance })
       const result = await provisionedUserAdditions([change])
       expect(result).toHaveLength(1)
-      expect(result).toMatchObject([{
-        elemID: instance.elemID,
-        severity: 'Info',
-        message: 'User will be emailed to complete the activation process',
-        detailedMessage:
-          'Salto does not configure authentication for newly added users. The user will receive an email with instructions to complete the activation process.',
-      }])
+      expect(result).toMatchObject([
+        {
+          elemID: instance.elemID,
+          severity: 'Info',
+          message: 'User will be emailed to complete the activation process',
+          detailedMessage:
+            'Salto does not configure authentication for newly added users. The user will receive an email with instructions to complete the activation process.',
+        },
+      ])
     })
 
     it('should not create change errors for users with STAGED status', async () => {

--- a/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
+++ b/packages/okta-adapter/test/change_validators/provisioned_user_addition.test.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { OKTA, USER_TYPE_NAME } from '../../src/constants'
+import { provisionedUserAdditions } from '../../src/change_validators/provisioned_user_addition'
+
+describe('provisionedUserAdditions', () => {
+  const userType = new ObjectType({ elemID: new ElemID(OKTA, USER_TYPE_NAME) })
+
+  describe('addition changes', () => {
+    it('should create change error with level Info when user is created with PROVISIONED status', async () => {
+      const instance = new InstanceElement('user1', userType, { status: 'PROVISIONED' })
+      const change = toChange({ after: instance })
+      const result = await provisionedUserAdditions([change])
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        elemID: instance.elemID,
+        severity: 'Info',
+        message: 'User will be emailed to complete the activation process',
+        detailedMessage:
+          'Salto does not configure authentication for newly added users. The user will receive an email with instructions to complete the activation process.',
+      })
+    })
+
+    it('should not create change errors for users with STAGED status', async () => {
+      const instance = new InstanceElement('user2', userType, { status: 'STAGED' })
+      const change = toChange({ after: instance })
+      const result = await provisionedUserAdditions([change])
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('removal or modification changes', () => {
+    it('should not create change errors for removed or modified users with PROVISIONED status', async () => {
+      const instanceBefore = new InstanceElement('user3', userType, { status: 'STAGED' })
+      const instanceAfter = new InstanceElement('user3', userType, { status: 'PROVISIONED' })
+      const result = await provisionedUserAdditions([
+        toChange({ before: instanceBefore, after: instanceAfter }),
+        toChange({ before: instanceAfter }),
+      ])
+      expect(result).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
Indicate admins that added users will receive an email when adding those using Salto.

---

_Additional context for reviewer_


---
_Release Notes_: 

_Okta adapter_:
- Add a change validator to indicate that users added in status provisioned will receive an email to complete activation.  

---
_User Notifications_: 
None
