### PR TITLE
SALTO-4990: Salesforce: picklist refs: Handle RecordType instances without `picklistValues`

### DIFF
--- a/packages/salesforce-adapter/src/filters/picklist_references.ts
+++ b/packages/salesforce-adapter/src/filters/picklist_references.ts
@@ -125,7 +125,7 @@ const filterCreator: FilterCreator = ({ config }) => {
       elements
         .filter(isInstanceOfTypeSync(RECORD_TYPE_METADATA_TYPE))
         .flatMap(recordType =>
-          recordType.value.picklistValues.map((picklistValueItem: PicklistValuesItem) => [
+          recordType.value.picklistValues?.map((picklistValueItem: PicklistValuesItem) => [
             recordType,
             picklistValueItem,
           ]),
@@ -146,7 +146,7 @@ const filterCreator: FilterCreator = ({ config }) => {
         .map(getChangeData)
         .filter(isInstanceOfTypeSync(RECORD_TYPE_METADATA_TYPE))
         .flatMap(recordType =>
-          recordType.value.picklistValues.map((picklistValueItem: PicklistValuesItem) => [
+          recordType.value.picklistValues?.map((picklistValueItem: PicklistValuesItem) => [
             recordType,
             picklistValueItem,
           ]),

--- a/packages/salesforce-adapter/test/filters/picklist_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/picklist_references.test.ts
@@ -79,6 +79,7 @@ describe('picklistReferences filter', () => {
   type FilterType = FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   let filter: FilterType
   let recordType: InstanceElement
+  let recordTypeWithoutPicklistValues: InstanceElement
 
   beforeEach(async () => {
     filter = filterCreator({
@@ -135,7 +136,14 @@ describe('picklistReferences filter', () => {
         [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(accountObjectType.elemID, accountObjectType)],
       },
     )
-    const elements = [recordType]
+
+    recordTypeWithoutPicklistValues = new InstanceElement(
+      'RecordType',
+      mockTypes.RecordType,
+      { }, undefined, { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(accountObjectType.elemID, accountObjectType)],
+      },
+    )
+    const elements = [recordType, recordTypeWithoutPicklistValues]
     await filter.onFetch(elements)
   })
 
@@ -232,7 +240,7 @@ describe('picklistReferences filter', () => {
 
     describe('onDeploy: modify picklist values to reference expressions', () => {
       beforeEach(async () => {
-        await filter.onDeploy([toChange({ after: recordType })])
+        await filter.onDeploy([toChange({ after: recordType }), toChange({ after: recordTypeWithoutPicklistValues })])
       })
       it('should create references to GlobalValueSet', async () => {
         expect(recordType.value.picklistValues[0].values).toEqual([


### PR DESCRIPTION
See title

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None