### PR TITLE
SALTO-5569 remove deprecated remote map key

### DIFF
--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -302,7 +302,7 @@ export const mockWorkspace = ({
     pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
     topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
     accounts: new InMemoryRemoteMap([{ key: 'account_names', value: accounts }]),
-    saltoMetadata: new InMemoryRemoteMap<string, wsState.StateMetadataKey>(),
+    saltoMetadata: new InMemoryRemoteMap(),
     staticFilesSource: mockStateStaticFilesSource(),
     deprecated: {
       accountsUpdateDate: new InMemoryRemoteMap<Date>(),

--- a/packages/core/test/common/state.ts
+++ b/packages/core/test/common/state.ts
@@ -39,7 +39,7 @@ export const mockState = (
     elements: elementSource.createInMemoryElementSource(elements),
     pathIndex: new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>(index),
     accounts: new remoteMap.InMemoryRemoteMap([{ key: 'account_names', value: accounts }]),
-    saltoMetadata: new remoteMap.InMemoryRemoteMap<string, 'version'>([{ key: 'version', value: '0.0.1' }]),
+    saltoMetadata: new remoteMap.InMemoryRemoteMap(),
     staticFilesSource: mockStaticFilesSource(),
     topLevelPathIndex: new remoteMap.InMemoryRemoteMap<pathIndex.Path[]>(index),
     deprecated: {

--- a/packages/workspace/src/workspace/state/index.ts
+++ b/packages/workspace/src/workspace/state/index.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-export { State, StateData, StateMetadataKey, buildStateData, createStateNamespace } from './state'
+export { State, StateData, buildStateData, createStateNamespace } from './state'
 export { buildHistoryStateStaticFilesSource } from './static_files_sources/history_static_files_source'
 export { buildOverrideStateStaticFilesSource } from './static_files_sources/override_static_files_source'
 export { buildInMemState } from './in_mem'

--- a/packages/workspace/src/workspace/state/state.ts
+++ b/packages/workspace/src/workspace/state/state.ts
@@ -14,8 +14,6 @@ import { serialize, deserializeSingleElement } from '../../serializer/elements'
 import { StateStaticFilesSource } from '../static_files/common'
 import { StateConfig } from '../config/workspace_config_types'
 
-export type StateMetadataKey = 'version' | 'hash'
-
 export type UpdateStateElementsArgs = {
   changes: DetailedChange[]
   unmergedElements?: Element[]
@@ -26,7 +24,7 @@ export type StateData = {
   elements: RemoteElementSource
   accounts: RemoteMap<string[], 'account_names'>
   pathIndex: PathIndex
-  saltoMetadata: RemoteMap<string, StateMetadataKey>
+  saltoMetadata: RemoteMap<string, 'hash'>
   staticFilesSource: StateStaticFilesSource
   topLevelPathIndex: PathIndex
   deprecated: {
@@ -93,7 +91,7 @@ export const buildStateData = async (
     deserialize: async data => JSON.parse(data),
     persistent,
   }),
-  saltoMetadata: await remoteMapCreator<string, StateMetadataKey>({
+  saltoMetadata: await remoteMapCreator<string, 'hash'>({
     namespace: createStateNamespace(envName, 'salto_metadata'),
     serialize: async data => data,
     deserialize: async data => data,

--- a/packages/workspace/test/common/workspace.ts
+++ b/packages/workspace/test/common/workspace.ts
@@ -116,7 +116,7 @@ export const createState = (elements: Element[], persistent = true): State =>
       referenceSources: new InMemoryRemoteMap(),
       accounts: new InMemoryRemoteMap([{ key: 'account_names', value: [] }]),
       changedBy: new InMemoryRemoteMap([{ key: 'name@@account', value: ['elemId'] }]),
-      saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
+      saltoMetadata: new InMemoryRemoteMap(),
       staticFilesSource: mockStaticFilesSource(),
       deprecated: {
         accountsUpdateDate: new InMemoryRemoteMap(),

--- a/packages/workspace/test/workspace/state.test.ts
+++ b/packages/workspace/test/workspace/state.test.ts
@@ -56,7 +56,7 @@ describe('state', () => {
       accounts: new InMemoryRemoteMap([{ key: 'account_names', value: [adapter] }]),
       pathIndex,
       topLevelPathIndex,
-      saltoMetadata: new InMemoryRemoteMap([{ key: 'version', value: '0.0.1' }]),
+      saltoMetadata: new InMemoryRemoteMap(),
       staticFilesSource: stateStaticFilesSource,
       deprecated: {
         accountsUpdateDate: new InMemoryRemoteMap([{ key: adapter, value: new Date() }]),


### PR DESCRIPTION
The 'version' key of the `saltoMetadata` remote map is not in use anymore.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
