### PR TITLE
SALTO-6819: Excluding changes on hidden elements from dump to folder

### DIFF
--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -11,14 +11,14 @@ import {
   AdapterFormat,
   AdapterOperationsContext,
   Change,
-  CORE_ANNOTATIONS,
   Element,
   getChangeData,
+  ReadOnlyElementsSource,
   SaltoError,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { merger, Workspace, ElementSelector, expressions, elementSource } from '@salto-io/workspace'
+import { merger, Workspace, ElementSelector, expressions, elementSource, hiddenValues } from '@salto-io/workspace'
 import { FetchResult } from '../types'
 import { adapterCreators } from './adapters'
 import { MergeErrorWithElements, getFetchAdapterAndServicesSetup, calcFetchChanges } from './fetch'
@@ -179,9 +179,14 @@ const loadElementsAndMerge = (
 
 // This is a naive approach, for a more complete implementations see workspace.filterOutHiddenChanges.
 // This is good enough for now since hidden value (etc.) changes will not affect adapter format (as far as we can tell).
-// For mixed mode, we need to partition on this test and add all the hidden changes to the unapplied changes.
-const filterHiddenChanges = (changes: ReadonlyArray<Change>): ReadonlyArray<Change> =>
-  changes.filter(change => !getChangeData(change).annotations[CORE_ANNOTATIONS.HIDDEN])
+// For mixed mode, we need to partition on the hidden elements test and add all the hidden changes to the unapplied changes.
+const filterHiddenChanges = async (
+  changes: ReadonlyArray<Change>,
+  elementsSource: ReadOnlyElementsSource,
+): Promise<ReadonlyArray<Change>> =>
+  awu(changes)
+    .filter(async change => !(await hiddenValues.isHidden(getChangeData(change), elementsSource)))
+    .toArray()
 
 type CalculatePatchArgs = {
   fromDir: string
@@ -322,7 +327,7 @@ export const syncWorkspaceToFolder = ({
       // re-dump elements that are equal, so even though we do redundant work, the end result should be correct
       const plan = await getPlan({
         before: elementSource.createInMemoryElementSource(folderElements),
-        after: elementSource.createInMemoryElementSource(workspaceElements),
+        after: adapterContext.elementsSource,
         dependencyChangers: [],
       })
       const changes = Array.from(plan.itemsByEvalOrder()).flatMap(item => Array.from(item.changes()))
@@ -338,7 +343,7 @@ export const syncWorkspaceToFolder = ({
       )
       return dumpElementsToFolder({
         baseDir,
-        changes: filterHiddenChanges(changes),
+        changes: await filterHiddenChanges(changes, adapterContext.elementsSource),
         elementsSource: adapterContext.elementsSource,
       })
     },
@@ -383,7 +388,7 @@ export const updateElementFolder = ({
       }
       return dumpElementsToFolder({
         baseDir,
-        changes: filterHiddenChanges(changes),
+        changes: await filterHiddenChanges(changes, adapterContext.elementsSource),
         elementsSource: adapterContext.elementsSource,
       })
     },

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -327,7 +327,7 @@ export const syncWorkspaceToFolder = ({
       // re-dump elements that are equal, so even though we do redundant work, the end result should be correct
       const plan = await getPlan({
         before: elementSource.createInMemoryElementSource(folderElements),
-        after: adapterContext.elementsSource,
+        after: elementSource.createInMemoryElementSource(workspaceElements),
         dependencyChangers: [],
       })
       const changes = Array.from(plan.itemsByEvalOrder()).flatMap(item => Array.from(item.changes()))


### PR DESCRIPTION
The way things currently stand (and likely forever), the adapter logic for dumping to folder never depends on these chages, so we can omit them.
This is becuase dumping to folder is (in many ways) like deploying, and we will never try to deploy changes on hidden elements because they cannot be selected in the plan.
We took a naive approach for filtering hidden changes which is good enough for now but we might choose to expand in the future.

---

_Release Notes_: 
Salesforce:
* Exclude hidden elements in SFDX.

---
_User Notifications_: 
None.
