### PR TITLE
SALTO-6606 Fix faulty OR clause in Zendesk config

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2871,13 +2871,13 @@ const ThemesReferenceJavascriptReferenceLookupStrategyType = createMatchingObjec
     minimumDigitAmount: {
       refType: BuiltinTypes.NUMBER,
       annotations: {
-        _required: true,
+        _required: false,
       },
     },
     prefix: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        _required: true,
+        _required: false,
       },
     },
   },

--- a/packages/zendesk-adapter/src/filters/template_engines/creator.ts
+++ b/packages/zendesk-adapter/src/filters/template_engines/creator.ts
@@ -21,12 +21,24 @@ export type TemplateEngineCreator = (
   javascriptReferenceLookupStrategy: Themes['referenceOptions']['javascriptReferenceLookupStrategy'],
 ) => string | TemplateExpression
 
+const isNumericValuesStrategy = (
+  javascriptReferenceLookupStrategy: Themes['referenceOptions']['javascriptReferenceLookupStrategy'],
+): javascriptReferenceLookupStrategy is { strategy: 'numericValues'; minimumDigitAmount: number } =>
+  javascriptReferenceLookupStrategy?.strategy === 'numericValues' &&
+  javascriptReferenceLookupStrategy?.minimumDigitAmount !== undefined
+
+const isVarNamePrefixStrategy = (
+  javascriptReferenceLookupStrategy: Themes['referenceOptions']['javascriptReferenceLookupStrategy'],
+): javascriptReferenceLookupStrategy is { strategy: 'varNamePrefix'; prefix: string } =>
+  javascriptReferenceLookupStrategy?.strategy === 'varNamePrefix' &&
+  javascriptReferenceLookupStrategy?.prefix !== undefined
+
 const extractOrParseByStrategy = (
   scripts: PotentialReference<string>[],
   idsToElements: Record<string, InstanceElement>,
   javascriptReferenceLookupStrategy: Themes['referenceOptions']['javascriptReferenceLookupStrategy'],
 ): PotentialReference<string | TemplateExpression>[] => {
-  if (javascriptReferenceLookupStrategy?.strategy === 'numericValues') {
+  if (isNumericValuesStrategy(javascriptReferenceLookupStrategy)) {
     return scripts.map(script => ({
       value: extractNumericValueIdsFromScripts(
         idsToElements,
@@ -36,7 +48,7 @@ const extractOrParseByStrategy = (
       loc: script.loc,
     }))
   }
-  if (javascriptReferenceLookupStrategy?.strategy === 'varNamePrefix') {
+  if (isVarNamePrefixStrategy(javascriptReferenceLookupStrategy)) {
     return scripts.flatMap(script => {
       const parsedScripts = parsePotentialReferencesByPrefix(
         script.value,

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -17,15 +17,11 @@ export type Themes = {
   brands?: string[]
   referenceOptions: {
     enableReferenceLookup: boolean
-    javascriptReferenceLookupStrategy?:
-      | {
-          strategy: 'numericValues'
-          minimumDigitAmount: number
-        }
-      | {
-          strategy: 'varNamePrefix'
-          prefix: string
-        }
+    javascriptReferenceLookupStrategy?: {
+      strategy: 'numericValues' | 'varNamePrefix'
+      minimumDigitAmount?: number
+      prefix?: string
+    }
   }
 }
 


### PR DESCRIPTION
The nacl doesn't support an OR type.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
