### PR TITLE
SALTO-5282: Add deploy support for authorization servers

### DIFF
--- a/packages/adapter-components/src/deployment/deploy/requester.ts
+++ b/packages/adapter-components/src/deployment/deploy/requester.ts
@@ -359,7 +359,7 @@ export const getRequester = <TOptions extends APIDefinitionsOptions>({
         if (!request.earlySuccess) {
           const { client, path, method } = request.endpoint
           log.trace(
-            'skipping call s.%s(%s) for change %s action %s because the condition was not met',
+            'skipping call %s.%s(%s) for change %s action %s because the condition was not met',
             client,
             path,
             method,

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -45,6 +45,7 @@ import {
   PROFILE_MAPPING_TYPE_NAME,
   SIGN_IN_PAGE_TYPE_NAME,
   ERROR_PAGE_TYPE_NAME,
+  AUTHORIZATION_SERVER,
 } from '../../constants'
 import {
   APP_POLICIES,
@@ -56,6 +57,7 @@ import { isActivationChange, isDeactivationChange } from './utils/status'
 import * as simpleStatus from './utils/simple_status'
 import { isCustomApp } from '../fetch/types/application'
 import { addBrandIdToRequest } from './types/email_domain'
+import { isSystemScope } from './types/authorization_servers'
 
 const log = logger(module)
 
@@ -916,6 +918,61 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
+    [AUTHORIZATION_SERVER]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/authorizationServers', method: 'post' },
+                transformation: { omit: ['status'] },
+              },
+              copyFromResponse: {
+                toSharedContext: simpleStatus.toSharedContext,
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/authorizationServers/{id}', method: 'put' },
+                transformation: { omit: ['status'] },
+              },
+              condition: simpleStatus.modificationCondition,
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/authorizationServers/{id}', method: 'delete' },
+              },
+            },
+          ],
+          activate: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/authorizationServers/{id}/lifecycle/activate', method: 'post' },
+              },
+              condition: {
+                custom: simpleStatus.activationCondition,
+              },
+            },
+          ],
+          deactivate: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/authorizationServers/{id}/lifecycle/deactivate', method: 'post' },
+              },
+              condition: {
+                custom: simpleStatus.deactivationCondition,
+              },
+            },
+          ],
+        },
+      },
+      toActionNames: simpleStatus.toActionNames,
+      actionDependencies: simpleStatus.actionDependencies,
+    },
     OAuth2Scope: {
       requestsByAction: {
         customizations: {
@@ -926,6 +983,27 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                   path: '/api/v1/authorizationServers/{parent_id}/scopes',
                   method: 'post',
                 },
+              },
+              condition: {
+                custom:
+                  () =>
+                  ({ change }) =>
+                    !isSystemScope(change),
+              },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/authorizationServers/{parent_id}/scopes',
+                  method: 'get',
+                  queryArgs: { q: '{name}' },
+                },
+              },
+              condition: {
+                custom:
+                  () =>
+                  ({ change }) =>
+                    isSystemScope(change),
               },
             },
           ],
@@ -951,6 +1029,9 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
+      toActionNames: ({ change }) =>
+        isAdditionChange(change) && isSystemScope(change) ? ['add', 'modify'] : [change.action],
+      actionDependencies: [{ first: 'add', second: 'modify' }],
     },
     OAuth2Claim: {
       requestsByAction: {

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -991,11 +991,14 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                     !isSystemScope(change),
               },
             },
+            // This request retrieves system scopes that are automatically created when an authorization server is created.
+            // We use a GET request to fetch the scope ID, and then subsequently modify it to match the requested values.
             {
               request: {
                 endpoint: {
                   path: '/api/v1/authorizationServers/{parent_id}/scopes',
                   method: 'get',
+                  // scopes names are unique within an authorization server
                   queryArgs: { q: '{name}' },
                 },
               },

--- a/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
@@ -8,4 +8,5 @@
 
 import { Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
 
+// System scopes are built-in default scopes that can't be added or removed.
 export const isSystemScope = (change: Change<InstanceElement>): boolean => getChangeData(change).value.system === true

--- a/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
@@ -1,0 +1,11 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
+
+export const isSystemScope = (change: Change<InstanceElement>): boolean => getChangeData(change).value.system === true

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1144,7 +1144,7 @@ const createCustomizations = ({
           standalone: {
             typeName: 'AuthorizationServerPolicy',
             addParentAnnotation: true,
-            referenceFromParent: true,
+            referenceFromParent: false,
             nestPathUnderParent: true,
           },
         },
@@ -1152,7 +1152,7 @@ const createCustomizations = ({
           standalone: {
             typeName: 'OAuth2Scope',
             addParentAnnotation: true,
-            referenceFromParent: true,
+            referenceFromParent: false,
             nestPathUnderParent: true,
           },
         },
@@ -1160,7 +1160,7 @@ const createCustomizations = ({
           standalone: {
             typeName: 'OAuth2Claim',
             addParentAnnotation: true,
-            referenceFromParent: true,
+            referenceFromParent: false,
             nestPathUnderParent: true,
           },
         },

--- a/packages/okta-adapter/src/definitions/requests/clients.ts
+++ b/packages/okta-adapter/src/definitions/requests/clients.ts
@@ -88,6 +88,8 @@ export const createClientDefinitions = (
           '/api/v1/zones/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
           '/api/v1/idps/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
           '/api/v1/idps/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/authorizationServers/{id}/lifecycle/activate': OMIT_STATUS_REQUEST_BODY,
+          '/api/v1/authorizationServers/{id}/lifecycle/deactivate': OMIT_STATUS_REQUEST_BODY,
           '/api/v1/brands/{parent_id}/templates/email/{name}': {
             get: {
               omitBody: true,

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -3227,14 +3227,13 @@ describe('adapter', () => {
     describe('deploy authorization servers', () => {
       it('should successfully add an authorization server', async () => {
         loadMockReplies('authorization_server_add.json')
-        const authServerAddition = authServerInstance.clone()
-        authServerAddition.value = {
+        const authServerAddition = new InstanceElement('authServerAddition', authServerType, {
           name: 'test',
           description: 'test',
-          audiences: authServerInstance.value.audiences,
+          audiences: ['api://default'],
           issuerMode: 'DYNAMIC',
           default: false,
-        }
+        })
         const result = await operations.deploy({
           changeGroup: {
             groupID: authServerAddition.elemID.getFullName(),
@@ -3253,7 +3252,7 @@ describe('adapter', () => {
         loadMockReplies('authorization_server_modify_and_activate.json')
         const afterAuthServerInstance = authServerInstance.clone()
         afterAuthServerInstance.value.status = 'ACTIVE'
-        afterAuthServerInstance.value.audiences = ['api://default/activate']
+        afterAuthServerInstance.value.audiences = ['api://default/change']
         const result = await operations.deploy({
           changeGroup: {
             groupID: authServerInstance.elemID.getFullName(),
@@ -3270,7 +3269,7 @@ describe('adapter', () => {
         authServerInstance.value.status = 'ACTIVE'
         const afterAuthServerInstance = authServerInstance.clone()
         afterAuthServerInstance.value.status = INACTIVE_STATUS
-        afterAuthServerInstance.value.audiences = ['api://default/deactivate']
+        afterAuthServerInstance.value.audiences = ['api://default/change']
         const result = await operations.deploy({
           changeGroup: {
             groupID: authServerInstance.elemID.getFullName(),

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -530,6 +530,9 @@ describe('adapter', () => {
     let orgSettingType: ObjectType
     let userTypeType: ObjectType
     let userSchemaType: ObjectType
+    let scopeType: ObjectType
+    let authServerType: ObjectType
+    let authServerInstance: InstanceElement
     const emailTemplateType = new ObjectType({
       elemID: new ElemID(OKTA, EMAIL_TEMPLATE_TYPE_NAME),
       fields: {
@@ -553,17 +556,6 @@ describe('adapter', () => {
       id: 'brand-fakeid1',
       name: 'subdomain.example.com',
       removePoweredByOkta: false,
-    })
-    const authorizationServerType = new ObjectType({
-      elemID: new ElemID(OKTA, AUTHORIZATION_SERVER),
-      fields: {
-        id: {
-          refType: BuiltinTypes.SERVICE_ID,
-        },
-      },
-    })
-    const authorizationServer = new InstanceElement('authorizationServer', authorizationServerType, {
-      id: 'authorizationserver-fakeid1',
     })
 
     beforeEach(() => {
@@ -608,6 +600,30 @@ describe('adapter', () => {
             refType: BuiltinTypes.SERVICE_ID,
           },
         },
+      })
+      scopeType = new ObjectType({
+        elemID: new ElemID(OKTA, 'OAuth2Scope'),
+        fields: {
+          id: { refType: BuiltinTypes.SERVICE_ID },
+          name: { refType: BuiltinTypes.STRING },
+        },
+      })
+      authServerType = new ObjectType({
+        elemID: new ElemID(OKTA, AUTHORIZATION_SERVER),
+        fields: {
+          id: {
+            refType: BuiltinTypes.SERVICE_ID,
+          },
+        },
+      })
+      authServerInstance = new InstanceElement('authorizationServer', authServerType, {
+        id: 'authorizationserver-fakeid1',
+        status: INACTIVE_STATUS,
+        name: 'default',
+        description: 'Default Authorization Server for your Applications',
+        default: true,
+        issuerMode: 'ORG_URL',
+        audiences: ['api://default'],
       })
     })
 
@@ -668,7 +684,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const result = await operations.deploy({
@@ -697,7 +713,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const result = await operations.deploy({
@@ -727,7 +743,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const activatedAuthorizationServerPolicy = authorizationServerPolicy.clone()
@@ -758,7 +774,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const activatedAuthorizationServerPolicy = authorizationServerPolicy.clone()
@@ -789,7 +805,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const activatedAuthorizationServerPolicy = authorizationServerPolicy.clone()
@@ -818,7 +834,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const activatedAuthorizationServerPolicy = authorizationServerPolicy.clone()
@@ -848,7 +864,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const activatedAuthorizationServerPolicy = authorizationServerPolicy.clone()
@@ -878,7 +894,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
         const result = await operations.deploy({
@@ -3119,7 +3135,6 @@ describe('adapter', () => {
     describe('deploy authorization server claims', () => {
       let claimType: ObjectType
       let claimInstance: InstanceElement
-      let scopeType: ObjectType
       let scopeInstance: InstanceElement
 
       beforeEach(() => {
@@ -3139,15 +3154,8 @@ describe('adapter', () => {
             },
           },
         })
-        scopeType = new ObjectType({
-          elemID: new ElemID(OKTA, 'OAuth2Scope'),
-          fields: {
-            id: { refType: BuiltinTypes.SERVICE_ID },
-            name: { refType: BuiltinTypes.STRING },
-          },
-        })
         scopeInstance = new InstanceElement('scope', scopeType, { name: 'address' }, undefined, {
-          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+          [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
         })
         claimInstance = new InstanceElement(
           'claim',
@@ -3166,7 +3174,7 @@ describe('adapter', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authorizationServer.elemID, authorizationServer)],
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
           },
         )
       })
@@ -3214,6 +3222,140 @@ describe('adapter', () => {
         expect(result.errors).toHaveLength(0)
         expect(result.appliedChanges).toHaveLength(1)
         expect(nock.pendingMocks()).toHaveLength(0)
+      })
+    })
+    describe('deploy authorization servers', () => {
+      it('should successfully add an authorization server', async () => {
+        loadMockReplies('authorization_server_add.json')
+        const authServerAddition = authServerInstance.clone()
+        authServerAddition.value = {
+          name: 'test',
+          description: 'test',
+          audiences: authServerInstance.value.audiences,
+          issuerMode: 'DYNAMIC',
+          default: false,
+        }
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: authServerAddition.elemID.getFullName(),
+            changes: [toChange({ after: authServerAddition })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual(
+          'authorizationserver-fakeid1',
+        )
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
+      it('should succeessfully modify and activate an authorization server', async () => {
+        loadMockReplies('authorization_server_modify_and_activate.json')
+        const afterAuthServerInstance = authServerInstance.clone()
+        afterAuthServerInstance.value.status = 'ACTIVE'
+        afterAuthServerInstance.value.audiences = ['api://default/activate']
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: authServerInstance.elemID.getFullName(),
+            changes: [toChange({ before: authServerInstance, after: afterAuthServerInstance })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
+      it('should successfully modify and deactivate an authorization server', async () => {
+        loadMockReplies('authorization_server_modify_and_deactivate.json')
+        authServerInstance.value.status = 'ACTIVE'
+        const afterAuthServerInstance = authServerInstance.clone()
+        afterAuthServerInstance.value.status = INACTIVE_STATUS
+        afterAuthServerInstance.value.audiences = ['api://default/deactivate']
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: authServerInstance.elemID.getFullName(),
+            changes: [toChange({ before: authServerInstance, after: afterAuthServerInstance })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
+      it('should successfully remove an authorization server', async () => {
+        loadMockReplies('authorization_server_remove.json')
+        authServerInstance.value.id = 'authorizationserver-fakeid1'
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: authServerInstance.elemID.getFullName(),
+            changes: [toChange({ before: authServerInstance })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
+    })
+    describe('deploy authorization server scopes', () => {
+      it('should successfully add a custom authorization server scope', async () => {
+        const customScope = new InstanceElement(
+          'customScope',
+          scopeType,
+          {
+            name: 'custom',
+            system: false,
+            metadataPublish: 'NO_CLIENTS',
+            consent: 'IMPLICIT',
+            optional: false,
+            default: false,
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
+          },
+        )
+        loadMockReplies('authorization_server_add_custom_scope.json')
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: customScope.elemID.getFullName(),
+            changes: [toChange({ after: customScope })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual('scope-fakeid')
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
+      it('should successfully add a system authorization server scope', async () => {
+        const systemScope = new InstanceElement(
+          'systemScope',
+          scopeType,
+          {
+            name: 'address',
+            system: true,
+            metadataPublish: 'ALL_CLIENTS',
+            consent: 'IMPLICIT',
+            optional: false,
+            default: false,
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
+          },
+        )
+        loadMockReplies('authorization_server_add_system_scope.json')
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: systemScope.elemID.getFullName(),
+            changes: [toChange({ after: systemScope })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual('scope-fakeid')
       })
     })
   })

--- a/packages/okta-adapter/test/mock_replies/authorization_server_add.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_add.json
@@ -1,0 +1,32 @@
+[
+  {
+    "path": "/api/v1/authorizationServers",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "authorizationserver-fakeid1",
+      "name": "test",
+      "description": "testtest",
+      "audiences": ["api://default"],
+      "issuerMode": "DYNAMIC",
+      "status": "ACTIVE",
+      "created": "2024-11-03T20:01:09.000Z",
+      "lastUpdated": "2024-11-03T20:01:09.000Z",
+      "default": false,
+      "_links": {}
+    },
+    "body": {
+      "name": "test",
+      "description": "test",
+      "audiences": ["api://default"],
+      "issuerMode": "DYNAMIC",
+      "default": false
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1730664128"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_add_custom_scope.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_add_custom_scope.json
@@ -1,0 +1,30 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/scopes",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "scope-fakeid",
+      "name": "custom",
+      "system": false,
+      "metadataPublish": "NO_CLIENTS",
+      "consent": "IMPLICIT",
+      "optional": false,
+      "default": false
+    },
+    "body": {
+      "name": "custom",
+      "system": false,
+      "metadataPublish": "NO_CLIENTS",
+      "consent": "IMPLICIT",
+      "optional": false,
+      "default": false
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1730893117"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_add_system_scope.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_add_system_scope.json
@@ -1,0 +1,63 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/scopes?q=address",
+    "scope": "",
+    "method": "GET",
+    "status": 200,
+    "response": [
+      {
+        "id": "scope-fakeid",
+        "name": "address",
+        "system": true,
+        "metadataPublish": "ALL_CLIENTS",
+        "consent": "IMPLICIT",
+        "optional": false,
+        "default": false,
+        "_links": {}
+      }
+    ],
+    "body": {
+      "name": "address",
+      "system": true,
+      "metadataPublish": "ALL_CLIENTS",
+      "consent": "IMPLICIT",
+      "optional": false,
+      "default": false
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "76",
+      "x-rate-limit-reset": "1730887858"
+    }
+  },
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/scopes/scope-fakeid",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "scope-fakeid",
+      "name": "address",
+      "system": true,
+      "metadataPublish": "ALL_CLIENTS",
+      "consent": "IMPLICIT",
+      "optional": false,
+      "default": false,
+      "_links": {}
+    },
+    "body": {
+      "id": "scope-fakeid",
+      "name": "address",
+      "system": true,
+      "metadataPublish": "ALL_CLIENTS",
+      "consent": "IMPLICIT",
+      "optional": false,
+      "default": false
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "34",
+      "x-rate-limit-reset": "1730887858"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_activate.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_activate.json
@@ -1,0 +1,46 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "authorizationserver-fakeid1",
+      "name": "default",
+      "description": "Default Authorization Server for your Applications",
+      "audiences": ["api://default/activate"],
+      "issuerMode": "ORG_URL",
+      "status": "INACTIVE",
+      "created": "2022-09-08T12:57:31.000Z",
+      "lastUpdated": "2024-11-03T19:58:20.000Z",
+      "default": true,
+      "_links": {}
+    },
+    "body": {
+      "id": "authorizationserver-fakeid1",
+      "name": "default",
+      "description": "Default Authorization Server for your Applications",
+      "audiences": ["api://default/activate"],
+      "issuerMode": "ORG_URL",
+      "default": true
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1730663959"
+    }
+  },
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/lifecycle/activate",
+    "scope": "",
+    "method": "POST",
+    "status": 204,
+    "response": "",
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "97",
+      "x-rate-limit-reset": "1730663959"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_activate.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_activate.json
@@ -8,7 +8,7 @@
       "id": "authorizationserver-fakeid1",
       "name": "default",
       "description": "Default Authorization Server for your Applications",
-      "audiences": ["api://default/activate"],
+      "audiences": ["api://default/change"],
       "issuerMode": "ORG_URL",
       "status": "INACTIVE",
       "created": "2022-09-08T12:57:31.000Z",
@@ -20,7 +20,7 @@
       "id": "authorizationserver-fakeid1",
       "name": "default",
       "description": "Default Authorization Server for your Applications",
-      "audiences": ["api://default/activate"],
+      "audiences": ["api://default/change"],
       "issuerMode": "ORG_URL",
       "default": true
     },

--- a/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_deactivate.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_deactivate.json
@@ -1,0 +1,46 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/lifecycle/deactivate",
+    "scope": "",
+    "method": "POST",
+    "status": 204,
+    "response": "",
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "93",
+      "x-rate-limit-reset": "1730663887"
+    }
+  },
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "authorizationserver-fakeid1",
+      "name": "default",
+      "description": "Default Authorization Server for your Applications",
+      "audiences": ["api://default"],
+      "issuerMode": "ORG_URL",
+      "status": "INACTIVE",
+      "created": "2022-09-08T12:57:31.000Z",
+      "lastUpdated": "2024-11-03T19:57:52.000Z",
+      "default": true,
+      "_links": {}
+    },
+    "body": {
+      "id": "authorizationserver-fakeid1",
+      "name": "default",
+      "description": "Default Authorization Server for your Applications",
+      "audiences": ["api://default/deactivate"],
+      "issuerMode": "ORG_URL",
+      "default": true
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "92",
+      "x-rate-limit-reset": "1730663887"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_deactivate.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_modify_and_deactivate.json
@@ -33,7 +33,7 @@
       "id": "authorizationserver-fakeid1",
       "name": "default",
       "description": "Default Authorization Server for your Applications",
-      "audiences": ["api://default/deactivate"],
+      "audiences": ["api://default/change"],
       "issuerMode": "ORG_URL",
       "default": true
     },

--- a/packages/okta-adapter/test/mock_replies/authorization_server_remove.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_remove.json
@@ -1,0 +1,14 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "98",
+      "x-rate-limit-reset": "1730698877"
+    }
+  }
+]


### PR DESCRIPTION
Added deploy support for authorization servers.

---

_Additional context for reviewer_

I added deploy support for auth servers. Okta accounts come with a default servers, and additional servers can be configured. Each server comes with scopes, claims the policies.
On auth server addition, some scopes and claims might be created (there's no consistent list of the scopes and claims that will be created, but they will have `system = true` property. 

Included in this PR -
- Support for auth servers action (add, activate..)
- Handle auto creation for scopes additions - In case of addition of system scopes, we'll fetch the added scope and then modify it to ensure the scope is updated with the requested values
- remove the reference from auth servers to their scopes, claims and policies. It was needed to avoid the circular dependency + it adds no value.

This PR doesn't handle system claims (as it doesn't work exactly like scopes), I plan to add it in a separate one.

---
_Release Notes_: 

_Okta_adapter_:
- Add deploy support for authorization servers

---
_User Notifications_: 

_Okta adapter_:
- Authorization servers will no longer contain reference to their scopes, claims and policies (the reference exists in the other way)