### PR TITLE
SALTO-6848 Delete workspace name

### DIFF
--- a/packages/cli/src/commands/env.ts
+++ b/packages/cli/src/commands/env.ts
@@ -343,7 +343,7 @@ export const createAction: CommandDefAction<EnvCreateArgs & ConfigOverrideArg> =
         baseDir: args.workspacePath,
         remoteMapCreator,
         persistent: true,
-        workspaceConfig: { uid: workspace.uid, name: workspace.name },
+        workspaceConfig: { uid: workspace.uid },
       })
     await workspace.addEnvironment(envName, rmcToEnvSource)
     await setEnvironment(envName, args.output, workspace)

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -18,17 +18,16 @@ import { getWorkspaceTelemetryTags } from '../workspace/workspace'
 const log = logger(module)
 
 type InitArgs = {
-  workspaceName?: string
   envName?: string
 }
 
 export const action: CommandDefAction<InitArgs> = async ({
-  input: { workspaceName, envName },
+  input: { envName },
   cliTelemetry,
   output,
   workspacePath,
 }): Promise<CliExitCode> => {
-  log.debug("running workspace init command on '%s'", workspaceName)
+  log.debug('running workspace init command')
   cliTelemetry.start()
   try {
     const baseDir = path.resolve(workspacePath)
@@ -38,7 +37,7 @@ export const action: CommandDefAction<InitArgs> = async ({
       return CliExitCode.AppError
     }
     const defaultEnvName = envName ?? (await getEnvName())
-    const workspace = await initLocalWorkspace(baseDir, workspaceName, defaultEnvName)
+    const workspace = await initLocalWorkspace(baseDir, defaultEnvName)
     cliTelemetry.setTags(getWorkspaceTelemetryTags(workspace))
     cliTelemetry.success()
     outputLine(Prompts.initCompleted(), output)
@@ -62,14 +61,6 @@ const initDef = createPublicCommandDef({
         alias: 'e',
         required: false,
         description: 'The name of the first environment in the workspace',
-        type: 'string',
-      },
-    ],
-    positionalOptions: [
-      {
-        name: 'workspaceName',
-        required: false,
-        description: 'The name of the workspace',
         type: 'string',
       },
     ],

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -15,10 +15,9 @@ import { CommandArgs } from '../../src/command_builder'
 
 jest.mock('@salto-io/core', () => ({
   ...jest.requireActual<{}>('@salto-io/core'),
-  initLocalWorkspace: jest.fn().mockImplementation((_baseDir: string, workspaceName: string): Workspace => {
-    if (workspaceName === 'error') throw new Error('failed')
+  initLocalWorkspace: jest.fn().mockImplementation((_baseDir: string, envName: string): Workspace => {
+    if (envName === 'error') throw new Error('failed')
     return {
-      name: workspaceName,
       uid: '',
       currentEnv: () => 'default',
       envs: () => ['default'],
@@ -66,9 +65,7 @@ describe('init command', () => {
     it("should invoke api's init", async () => {
       await action({
         ...cliCommandArgs,
-        input: {
-          workspaceName: 'test',
-        },
+        input: {},
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
       expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
@@ -79,7 +76,7 @@ describe('init command', () => {
       await action({
         ...cliCommandArgs,
         input: {
-          workspaceName: 'error',
+          envName: 'error',
         },
       })
       expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
@@ -93,7 +90,6 @@ describe('init command', () => {
       await action({
         ...cliCommandArgs,
         input: {
-          workspaceName: 'test',
           envName: 'userEnvInput',
         },
       })
@@ -101,14 +97,13 @@ describe('init command', () => {
       expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.success, 1, expect.objectContaining({}))
-      expect(mockInitLocalWorkspace).toHaveBeenCalledWith(expect.anything(), 'test', 'userEnvInput')
+      expect(mockInitLocalWorkspace).toHaveBeenCalledWith(expect.anything(), 'userEnvInput')
     })
     it('should print errors', async () => {
       await action({
         ...cliCommandArgs,
         input: {
-          workspaceName: 'error',
-          envName: 'userEnvInput',
+          envName: 'error',
         },
       })
       expect(output.stderr.content.search('failed')).toBeGreaterThan(0)
@@ -123,9 +118,7 @@ describe('init command', () => {
     mockLocateWorkspaceRoot.mockResolvedValue(path)
     await action({
       ...cliCommandArgs,
-      input: {
-        workspaceName: 'test',
-      },
+      input: {},
     })
     expect(output.stderr.content).toEqual(`Could not initiate workspace: existing salto workspace in ${path}\n\n`)
     expect(output.stdout.content).toEqual('')

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -276,7 +276,6 @@ export const withEnvironmentParam = 'inactive'
 
 type MockWorkspaceArgs = {
   uid?: string
-  name?: string
   envs?: string[]
   accounts?: string[]
   getElements?: () => Element[]
@@ -293,7 +292,6 @@ export const mockStateStaticFilesSource = (): MockInterface<staticFiles.StateSta
 
 export const mockWorkspace = ({
   uid = '123',
-  name = '',
   envs = ['active', 'inactive'],
   accounts = ['salesforce', 'netsuite'],
   getElements = elements,
@@ -313,7 +311,6 @@ export const mockWorkspace = ({
   let currentEnv = envs[0]
   return {
     uid,
-    name,
     elements: mockFunction<Workspace['elements']>().mockResolvedValue(createInMemoryElementSource(getElements())),
     state: mockFunction<Workspace['state']>().mockImplementation(env => stateByEnv[env ?? currentEnv]),
     envs: mockFunction<Workspace['envs']>().mockReturnValue(envs),

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -382,11 +382,9 @@ export async function loadLocalWorkspace(
 
 export const initLocalWorkspace = async (
   baseDir: string,
-  name?: string,
   envName = 'default',
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource,
 ): Promise<Workspace> => {
-  const workspaceName = name ?? path.basename(path.resolve(baseDir))
   const uid = uuidv4()
   const localStorage = getLocalStoragePath(uid)
   if (await locateWorkspaceRoot(path.resolve(baseDir))) {
@@ -417,11 +415,10 @@ export const initLocalWorkspace = async (
     remoteMapCreator,
     stateStaticFilesSource,
     persistent: persistentMode,
-    workspaceConfig: { uid, name: workspaceName },
+    workspaceConfig: { uid },
   })
 
   return initWorkspace(
-    workspaceName,
     uid,
     envName,
     workspaceConfigSrc,

--- a/packages/core/src/local-workspace/workspace_config.ts
+++ b/packages/core/src/local-workspace/workspace_config.ts
@@ -91,7 +91,6 @@ export const workspaceConfigSource = async (baseDir: string, localStorage?: stri
       const userData = userDataConfigInstance({ currentEnv: config.currentEnv })
       const workspaceMetadata = workspaceMetadataConfigInstance({
         uid: config.uid,
-        name: config.name,
         staleStateThresholdMinutes: config.staleStateThresholdMinutes,
         state: config.state,
       })

--- a/packages/core/src/local-workspace/workspace_config_types.ts
+++ b/packages/core/src/local-workspace/workspace_config_types.ts
@@ -19,7 +19,7 @@ import {
 } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 
-export type WorkspaceMetadataConfig = Pick<WorkspaceConfig, 'uid' | 'name' | 'staleStateThresholdMinutes' | 'state'>
+export type WorkspaceMetadataConfig = Pick<WorkspaceConfig, 'uid' | 'staleStateThresholdMinutes' | 'state'>
 export type EnvsConfig = Pick<WorkspaceConfig, 'envs'>
 export type UserDataConfig = Pick<WorkspaceConfig, 'currentEnv'>
 

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -127,7 +127,7 @@ describe('local workspace', () => {
         envs: ['env1', 'env2'],
         remoteMapCreator: creator,
         stateStaticFilesSource: mockStaticFilesSource(),
-        workspaceConfig: { name: 'asd', uid: 'asd' },
+        workspaceConfig: { uid: 'asd' },
       })
       expect(Object.keys(elemSources.sources)).toHaveLength(3)
       const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0]).map(params => toWorkspaceRelative(params))
@@ -151,25 +151,17 @@ describe('local workspace', () => {
 
     it('should call initWorkspace with correct input', async () => {
       const envName = 'env-name'
-      const wsName = 'ws-name'
       mockExists.mockResolvedValue(false)
-      await initLocalWorkspace('.', wsName, envName)
-      expect(mockInit.mock.calls[0][0]).toBe(wsName)
-      expect(mockInit.mock.calls[0][2]).toBe(envName)
-      const envSources: ws.EnvironmentsSources = mockInit.mock.calls[0][6]
+      await initLocalWorkspace('.', envName)
+      expect(mockInit.mock.calls[0][1]).toBe(envName)
+      const envSources: ws.EnvironmentsSources = mockInit.mock.calls[0][5]
       expect(Object.keys(envSources.sources)).toHaveLength(2)
       expect(envSources.commonSourceName).toBe(COMMON_ENV_PREFIX)
       const dirStoresBaseDirs = mockCreateDirStore.mock.calls.map(c => c[0]).map(params => toWorkspaceRelative(params))
       expect(dirStoresBaseDirs).toContain(path.join(ENVS_PREFIX, envName))
-      const uuid = mockInit.mock.calls[0][1]
+      const uuid = mockInit.mock.calls[0][0]
       expect(dirStoresBaseDirs).toContain(uuid)
       expect(dirStoresBaseDirs).toContain(path.join(uuid, CREDENTIALS_CONFIG_PATH))
-    })
-
-    it('should set name according to path if name not given', async () => {
-      mockExists.mockResolvedValue(false)
-      await initLocalWorkspace('.')
-      expect(mockInit.mock.calls[0][0]).toBe(path.basename(path.resolve('.')))
     })
   })
 

--- a/packages/core/test/workspace/local/workspace_config.test.ts
+++ b/packages/core/test/workspace/local/workspace_config.test.ts
@@ -128,7 +128,6 @@ describe('workspace local config', () => {
     it('set in repo dir store', async () => {
       await configSource.setWorkspaceConfig({
         uid: '1',
-        name: 'foo',
         currentEnv: 'bar',
         envs: [],
         staleStateThresholdMinutes: 60,

--- a/packages/workspace/src/workspace/config/workspace_config_types.ts
+++ b/packages/workspace/src/workspace/config/workspace_config_types.ts
@@ -43,7 +43,6 @@ export type StateConfig = {
 
 export type WorkspaceConfig = {
   uid: string
-  name: string
   staleStateThresholdMinutes?: number
   envs: EnvConfig[]
   currentEnv: string

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -188,7 +188,6 @@ const isFromSourceWithEnv = (value: { source: FromSource } | FromSourceWithEnv):
 
 export type Workspace = {
   uid: string
-  name: string
 
   elements: (includeHidden?: boolean, env?: string) => Promise<ElementsSource>
   state: (envName?: string) => State
@@ -546,7 +545,7 @@ export const loadWorkspace = async (
   }): Promise<WorkspaceState> => {
     const initState = async (): Promise<WorkspaceState> => {
       const wsConfig = await config.getWorkspaceConfig()
-      log.debug('initializing state for workspace %s/%s', wsConfig.uid, wsConfig.name)
+      log.debug('initializing state for workspace %s', wsConfig.uid)
       log.debug('Full workspace config: %o', wsConfig)
       const states: Record<string, SingleState> = Object.fromEntries(
         await awu(envs())
@@ -1277,7 +1276,6 @@ export const loadWorkspace = async (
 
   const workspace: Workspace = {
     uid: workspaceConfig.uid,
-    name: workspaceConfig.name,
     elements: elementsImpl,
     state,
     envs,
@@ -1671,7 +1669,6 @@ export const loadWorkspace = async (
 }
 
 export const initWorkspace = async (
-  name: string,
   uid: string,
   defaultEnvName: string,
   config: WorkspaceConfigSource,
@@ -1684,7 +1681,6 @@ export const initWorkspace = async (
   log.debug('Initializing workspace with id: %s', uid)
   await config.setWorkspaceConfig({
     uid,
-    name,
     envs: [{ name: defaultEnvName, accountToServiceName: {} }],
     currentEnv: defaultEnvName,
   })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -2217,13 +2217,12 @@ salesforce.staticFile staticFileInstance {
   })
 
   describe('init', () => {
-    const workspaceConf = mockWorkspaceConfigSource({ name: 'ws-name' })
+    const workspaceConf = mockWorkspaceConfigSource({ uid: 'uid' })
     afterEach(async () => {
       delete process.env.SALTO_HOME
     })
     it('should init workspace configuration', async () => {
       const workspace = await initWorkspace(
-        'ws-name',
         'uid',
         'default',
         workspaceConf,
@@ -2250,12 +2249,11 @@ salesforce.staticFile staticFileInstance {
         async () => [],
       )
       expect((workspaceConf.setWorkspaceConfig as jest.Mock).mock.calls[0][0]).toEqual({
-        name: 'ws-name',
         uid: 'uid',
         envs: [{ name: 'default', accountToServiceName: {} }],
         currentEnv: 'default',
       })
-      expect(workspace.name).toEqual('ws-name')
+      expect(workspace.uid).toEqual('uid')
     })
   })
 


### PR DESCRIPTION
The workspace name is never used and can be removed.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Delete workspace name property from `Workspace` and `WorkspaceConfig`
- Delete workspace name param from `initWorkspace` and `initLocalWorkspace`

---
_User Notifications_: 
- Adding/deleting/renaming an env/account will delete the `name` property from `salto.config/workspace.nacl`
- New workspaces will be created without the `name` property in `salto.config/workspace.nacl`
