### PR TITLE
SALTO-6863: Fixing task and events custom fields filter when missing types

### DIFF
--- a/packages/salesforce-adapter/src/filters/task_and_event_custom_fields.ts
+++ b/packages/salesforce-adapter/src/filters/task_and_event_custom_fields.ts
@@ -63,7 +63,7 @@ const filterCreator: FilterCreator = ({ config }) => {
               return []
             }
             const getMatchingField = (objectName: string): Field | undefined =>
-              Object.values(elementsByApiName[objectName]?.fields).find(
+              Object.values(elementsByApiName[objectName]?.fields ?? {}).find(
                 field => apiNameSync(field, true) === activityFieldName,
               )
             return [

--- a/packages/salesforce-adapter/test/filters/task_and_event_custom_fields.test.ts
+++ b/packages/salesforce-adapter/test/filters/task_and_event_custom_fields.test.ts
@@ -74,7 +74,8 @@ describe('taskAndEventCustomFieldsFilter', () => {
     })
     it('should not mutate custom fields to references if Activity is not found', async () => {
       const elements = [taskType, eventType, taskField, eventField]
-      await filter.onFetch(elements)
+      const res = await filter.onFetch(elements)
+      expect(res).toBeUndefined()
       ;[taskField, eventField].forEach(field => {
         expect(Object.keys(field.annotations).sort()).toEqual(
           [
@@ -89,6 +90,14 @@ describe('taskAndEventCustomFieldsFilter', () => {
           ].sort(),
         )
         expect(field.annotations.activityField).toBeUndefined()
+      })
+    })
+
+    describe('when types are missing', () => {
+      it('should not return errors', async () => {
+        const elements = [activityType, activityField, taskField, eventField]
+        const res = await filter.onFetch(elements)
+        expect(res).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
This problem came up in the SFDX flow.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
