### PR TITLE
SALTO-6865: add empty links to workflow transitions

### DIFF
--- a/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/workflowV2/workflow_filter.ts
@@ -686,9 +686,10 @@ const insertConditionGroups: WalkOnFunc = ({ value, path }): WALK_NEXT_STEP => {
 // Jira has a bug that causes global transition with a destination status to become a looped transition without a status
 // as a workaround we add an empty links array
 // We should remove this once the bug is fixed - https://jira.atlassian.com/browse/JRACLOUD-85033
-const insertEmptyLinksToGlobalTransition: WalkOnFunc = ({ value, path }): WALK_NEXT_STEP => {
+// this bug affects all transition types that lack links.
+const insertEmptyLinksToTransition: WalkOnFunc = ({ value, path }): WALK_NEXT_STEP => {
   const nameParts = path.getFullNameParts()
-  if (_.isPlainObject(value) && nameParts.length > 4 && nameParts[4] === 'transitions' && value?.type === 'GLOBAL') {
+  if (_.isPlainObject(value) && nameParts.length > 4 && nameParts[4] === 'transitions' && value?.links === undefined) {
     value.links = []
   }
   if (isInstanceElement(value) || path.name === 'transitions') {
@@ -738,7 +739,7 @@ const getWorkflowForDeploy = async (
   joinResolutionProperties(resolvedInstance.value.transitions)
   walkOnElement({ element: resolvedInstance, func: replaceStatusIdWithUuid(statusIdToUuid) })
   walkOnElement({ element: resolvedInstance, func: insertConditionGroups })
-  walkOnElement({ element: resolvedInstance, func: insertEmptyLinksToGlobalTransition })
+  walkOnElement({ element: resolvedInstance, func: insertEmptyLinksToTransition })
   return resolvedInstance
 }
 

--- a/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
+++ b/packages/jira-adapter/test/filters/workflowV2/workflow_filter.test.ts
@@ -1307,6 +1307,34 @@ It is strongly recommended to rename these transitions so they are unique in Jir
           })
         })
 
+        it('should add empty links to transitions when links are missing', async () => {
+          workflowInstance.value.transitions[TRANSITION_NAME_TO_KEY.Create].links = undefined
+          workflowInstance.value.transitions[TRANSITION_NAME_TO_KEY.GlobalTransition].links = undefined
+          await filter.preDeploy([toChange({ after: workflowInstance })])
+
+          // transitions without links should have an empty array
+          expect(workflowInstance.value.workflows[0].transitions[0]).toEqual({
+            ...WORKFLOW_PAYLOAD.workflows[0].transitions[0],
+            links: [],
+          })
+          expect(workflowInstance.value.workflows[0].transitions[2]).toEqual({
+            ...WORKFLOW_PAYLOAD.workflows[0].transitions[2],
+            links: [],
+          })
+
+          // transitions with links should have the same links
+          expect(workflowInstance.value.workflows[0].transitions[1]).toEqual({
+            ...WORKFLOW_PAYLOAD.workflows[0].transitions[1],
+            links: [
+              {
+                fromPort: 3,
+                fromStatusReference: 'uuid1',
+                toPort: 7,
+              },
+            ],
+          })
+        })
+
         describe('resolution properties', () => {
           beforeEach(() => {
             workflowInstance.value.transitions[TRANSITION_NAME_TO_KEY.Create].properties = [


### PR DESCRIPTION
_add empty links to workflow transitions_

---

_Additional context for reviewer_
* we should add the link list when `links = undefined`

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
