### PR TITLE
SALTO-6765: Fail fetch if credentials are invalid

### DIFF
--- a/packages/adapter-components/src/auth/oauth.ts
+++ b/packages/adapter-components/src/auth/oauth.ts
@@ -121,7 +121,7 @@ export const oauthAccessTokenRefresh = async ({
   } catch (error) {
     log.error(
       'Failed to get access token, error: %s, stack: %s',
-      safeJsonStringify({ data: error?.response?.data, status: error?.response?.status }),
+      safeJsonStringify({ message: error?.message, status: error?.response?.status }),
       error.stack,
     )
     throw new UnauthorizedError(error?.message)

--- a/packages/adapter-components/src/auth/oauth.ts
+++ b/packages/adapter-components/src/auth/oauth.ts
@@ -124,6 +124,6 @@ export const oauthAccessTokenRefresh = async ({
       safeJsonStringify({ data: error?.response?.data, status: error?.response?.status }),
       error.stack,
     )
-    throw new UnauthorizedError(error)
+    throw new UnauthorizedError(error?.message)
   }
 }

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -200,22 +200,21 @@ export const axiosConnection = <TCredentials>({
   timeout = 0,
 }: AxiosConnectionParams<TCredentials>): Connection<TCredentials> => {
   const login = async (credentials: TCredentials): Promise<AuthenticatedAPIConnection> => {
-    const httpClient = axios.create({
-      baseURL: await baseURLFunc(credentials),
-      ...(await authParamsFunc(credentials)),
-      maxBodyLength: Infinity,
-    })
-    httpClient.interceptors.request.use(
-      config => {
-        config.timeout = timeout
-        return config
-      },
-      null,
-      { runWhen: config => ['get', 'head', 'options'].includes(config.method ?? '') },
-    )
-    axiosRetry(httpClient, retryOptions)
-
     try {
+      const httpClient = axios.create({
+        baseURL: await baseURLFunc(credentials),
+        ...(await authParamsFunc(credentials)),
+        maxBodyLength: Infinity,
+      })
+      httpClient.interceptors.request.use(
+        config => {
+          config.timeout = timeout
+          return config
+        },
+        null,
+        { runWhen: config => ['get', 'head', 'options'].includes(config.method ?? '') },
+      )
+      axiosRetry(httpClient, retryOptions)
       const accountInfo = await credValidateFunc({ credentials, connection: httpClient })
       return Object.assign(httpClient, { accountInfo })
     } catch (e) {

--- a/packages/adapter-components/src/client/http_connection.ts
+++ b/packages/adapter-components/src/client/http_connection.ts
@@ -17,6 +17,7 @@ import axiosRetry, { IAxiosRetryConfig } from 'axios-retry'
 import { AccountInfo, CredentialError } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { ClientRetryConfig, ClientTimeoutConfig } from '../definitions/user/client_config'
+import { AdapterFetchError } from '../config_deprecated'
 import { DEFAULT_RETRY_OPTS, DEFAULT_TIMEOUT_OPTS } from './constants'
 
 const log = logger(module)
@@ -221,6 +222,10 @@ export const axiosConnection = <TCredentials>({
       log.error(`Login failed: ${e}, stack: ${e.stack}`)
       if (e.response?.status === 401 || e instanceof UnauthorizedError) {
         throw new UnauthorizedError('Unauthorized - update credentials and try again')
+      }
+      // TODO SALTO-6869 remove the special handling of AdapterFetchError
+      if (e instanceof AdapterFetchError) {
+        throw e
       }
       throw new Error(`Login failed with error: ${e.message ?? e}`)
     }

--- a/packages/adapter-components/src/fetch/element/element.ts
+++ b/packages/adapter-components/src/fetch/element/element.ts
@@ -18,6 +18,7 @@ import { FetchApiDefinitionsOptions } from '../../definitions/system/fetch'
 import { ConfigChangeSuggestion, NameMappingFunctionMap, ResolveCustomNameMappingOptionsType } from '../../definitions'
 import { omitAllInstancesValues } from './instance_utils'
 import { AbortFetchOnFailure } from '../errors'
+import { UnauthorizedError } from '../../client'
 
 const log = logger(module)
 
@@ -75,9 +76,9 @@ export const getElementGenerator = <Options extends FetchApiDefinitionsOptions>(
   }
 
   const handleError: ElementGenerator['handleError'] = ({ typeName, error }) => {
-    // This can happen if the error was thrown inside a sub-type that has failEntireFetch set to true.
+    // AbortFetchOnFailure can happen if the error was thrown inside a sub-type that has failEntireFetch set to true.
     // In this case we should not call the parent's onError function.
-    if (error instanceof AbortFetchOnFailure) {
+    if (error instanceof AbortFetchOnFailure || error instanceof UnauthorizedError) {
       throw error
     }
 

--- a/packages/adapter-components/test/auth/oauth.test.ts
+++ b/packages/adapter-components/test/auth/oauth.test.ts
@@ -8,6 +8,7 @@
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
 import { oauthClientCredentialsBearerToken, oauthAccessTokenRefresh } from '../../src/auth'
+import { UnauthorizedError } from '../../src/client'
 
 describe('oauth', () => {
   describe('oauthClientCredentialsBearerToken', () => {
@@ -177,7 +178,7 @@ describe('oauth', () => {
           refreshToken: 'refresh',
           retryOptions: { retries: 2 },
         }),
-      ).rejects.toThrow(new Error('Request failed with status code 400'))
+      ).rejects.toThrow(new UnauthorizedError('Request failed with status code 400'))
     })
     it('should throw error on unexpected token type', async () => {
       mockAxiosAdapter.onPost('/oauth/token').reply(200, {
@@ -196,7 +197,7 @@ describe('oauth', () => {
           refreshToken: 'refresh',
           retryOptions: { retries: 2 },
         }),
-      ).rejects.toThrow(new Error('Unsupported token type mac'))
+      ).rejects.toThrow(new UnauthorizedError('Unsupported token type mac'))
     })
     it('should retry on transient errors', async () => {
       mockAxiosAdapter.onPost('/oauth/token').reply(503).onPost('/oauth/token').reply(200, {

--- a/packages/adapter-components/test/fetch/element/element.test.ts
+++ b/packages/adapter-components/test/fetch/element/element.test.ts
@@ -21,6 +21,7 @@ import { getElementGenerator } from '../../../src/fetch/element/element'
 import { AbortFetchOnFailure } from '../../../src/fetch/errors'
 import { ConfigChangeSuggestion, queryWithDefault } from '../../../src/definitions'
 import { InstanceFetchApiDefinitions } from '../../../src/definitions/system/fetch'
+import { UnauthorizedError } from '../../../src/client'
 
 describe('element', () => {
   const typeID = new ElemID('myAdapter', 'myType')
@@ -327,6 +328,27 @@ describe('element', () => {
         })
       })
 
+      describe('when UnauthorizedError is thrown and no error hanlder is defined', () => {
+        it('should throw the error', () => {
+          const generator = getElementGenerator({
+            adapterName: 'myAdapter',
+            defQuery: queryWithDefault<InstanceFetchApiDefinitions, string>({
+              customizations: {
+                myType: {
+                  element: { topLevel: { isTopLevel: true } },
+                  resource: {
+                    directFetch: true,
+                  },
+                },
+              },
+            }),
+            customNameMappingFunctions: {},
+          })
+          expect(() =>
+            generator.handleError({ typeName: 'myType', error: new UnauthorizedError('invalid creds') }),
+          ).toThrow(UnauthorizedError)
+        })
+      })
       describe('when onError defined with configSuggestion', () => {
         const configSuggestion: ConfigChangeSuggestion = {
           reason: 'test',

--- a/packages/jira-adapter/test/client/script_runner_client.test.ts
+++ b/packages/jira-adapter/test/client/script_runner_client.test.ts
@@ -65,7 +65,9 @@ describe('scriptRunnerClient', () => {
       it('should throw correct error when cannot get JWT address', async () => {
         mockAxios.onGet(JWT_ACCESS_URL).reply(400, { response: 'asd', errorMessages: ['error message'] })
         await expect(async () => scriptRunnerClient.get({ url: '/myPath' })).rejects.toThrow(
-          new Error(`Failed to get ${JWT_ACCESS_URL} with error: Request failed with status code 400. error message`),
+          new Error(
+            `Login failed with error: Failed to get ${JWT_ACCESS_URL} with error: Request failed with status code 400. error message`,
+          ),
         )
       })
       it('should fail when JWT address object is not in the right format', async () => {

--- a/packages/microsoft-security-adapter/src/client/connection.ts
+++ b/packages/microsoft-security-adapter/src/client/connection.ts
@@ -51,7 +51,7 @@ const getAccessToken = async ({ tenantId, clientId, clientSecret, refreshToken }
   } catch (e) {
     log.error(
       'Failed to get access token, error: %s, stack: %s',
-      safeJsonStringify({ data: e?.response?.data, status: e?.response?.status }),
+      safeJsonStringify({ message: e?.message, status: e?.response?.status }),
       e.stack,
     )
     throw new clientUtils.UnauthorizedError('Invalid Credentials')

--- a/packages/microsoft-security-adapter/src/client/connection.ts
+++ b/packages/microsoft-security-adapter/src/client/connection.ts
@@ -54,7 +54,7 @@ const getAccessToken = async ({ tenantId, clientId, clientSecret, refreshToken }
       safeJsonStringify({ data: e?.response?.data, status: e?.response?.status }),
       e.stack,
     )
-    throw e
+    throw new clientUtils.UnauthorizedError('Invalid Credentials')
   }
 }
 

--- a/packages/zuora-billing-adapter/test/adapter_creator.test.ts
+++ b/packages/zuora-billing-adapter/test/adapter_creator.test.ts
@@ -254,7 +254,7 @@ describe('adapter creator', () => {
           production: false,
         }),
       ),
-    ).rejects.toThrow(new Error('Request failed with status code 500'))
+    ).rejects.toThrow(new Error('Login failed with error: Request failed with status code 500'))
     expect(connection.createConnection).toHaveBeenCalledTimes(1)
   })
 


### PR DESCRIPTION
Also added throw `Unauthorized Error` when generating the token in OAuth flow (cause it's called before validate credentials)

---

_Additional context for reviewer_
additionally, I wrapped `login` func in try-catch as well, as `authParamsFunc` might make network calls

---
_Release Notes_: 

_Okta adapter_:
- Fix a bug causing fetch not to fail on credentials error

_Zendesk adapter_:
- Fix a bug causing fetch not to fail on credentials error

_Microsoft adapter_:
- Fix a bug causing fetch not to fail on credentials error

---
_User Notifications_: 
None
