### PR TITLE
Upgrade @salto-io/node-diff3

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -48,7 +48,7 @@
     "@salto-io/microsoft-entra-adapter": "0.4.5",
     "@salto-io/microsoft-security-adapter": "0.4.5",
     "@salto-io/netsuite-adapter": "0.4.5",
-    "@salto-io/node-diff3": "3.1.0-salto.1",
+    "@salto-io/node-diff3": "3.1.2-salto.1",
     "@salto-io/okta-adapter": "0.4.5",
     "@salto-io/pagerduty-adapter": "0.4.5",
     "@salto-io/parser": "0.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4266,7 +4266,7 @@ __metadata:
     "@salto-io/microsoft-entra-adapter": 0.4.5
     "@salto-io/microsoft-security-adapter": 0.4.5
     "@salto-io/netsuite-adapter": 0.4.5
-    "@salto-io/node-diff3": 3.1.0-salto.1
+    "@salto-io/node-diff3": 3.1.2-salto.1
     "@salto-io/okta-adapter": 0.4.5
     "@salto-io/pagerduty-adapter": 0.4.5
     "@salto-io/parser": 0.4.5
@@ -5034,10 +5034,10 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@salto-io/node-diff3@npm:3.1.0-salto.1":
-  version: 3.1.0-salto.1
-  resolution: "@salto-io/node-diff3@npm:3.1.0-salto.1"
-  checksum: 01e6b3aede5edf95de0f63aaea0ed28abc95ca9088cffc8b29f4efb6e5c2ce6e59f1c1d68bb665ddd6c513907f0fa0cf830c6c0fdd4fcc0e4288977d0ce024a5
+"@salto-io/node-diff3@npm:3.1.2-salto.1":
+  version: 3.1.2-salto.1
+  resolution: "@salto-io/node-diff3@npm:3.1.2-salto.1"
+  checksum: bf1b08adec6e19e899bb4197dd5a12b2348b780636d00c7cbf915bfc35678cdc47b72e2dd05d10a4c6f029b07e0c753fb7f9b919d929e40f8743abe1aab79f64
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
https://github.com/salto-io/node-diff3 is now rebased on the latest https://github.com/bhousel/node-diff3 code.
This rebase is possible because we're now using node 18, and before that there were dependencies in bhousel/node-diff3 that required that.

There are no changes in the algorithm code between the versions - https://github.com/bhousel/node-diff3/compare/a94dbaa1307b6c6ff578479a7a51f1b587e8ed7d...4d91ac7d5e2ca1a96b15ec21fac0fa19908ae2fd

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None