### PR TITLE
SALTO-6875: Add reportDeployOperationInfo to the DeployProgressReporter 

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -63,13 +63,21 @@ export type ProgressReporter = {
   reportProgress: (progress: Progress) => void
 }
 
+export type DeployOperationInfo = Partial<{
+  serviceDeploymentId: string
+}>
+
+export type DeployProgressReporter = ProgressReporter & {
+  reportDeployOperationInfo?: (info: DeployOperationInfo) => void
+}
+
 export type FetchOptions = {
   progressReporter: ProgressReporter
   withChangesDetection?: boolean
 }
 
 export type DeployOptions = {
-  progressReporter: ProgressReporter
+  progressReporter: DeployProgressReporter
   changeGroup: ChangeGroup
 }
 

--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -10,7 +10,7 @@ import SalesforceAdapter, {
   adapter as salesforceAdapter,
   UsernamePasswordCredentials,
   OauthAccessTokenCredentials,
-  DeployProgressReporter,
+  SalesforceDeployProgressReporter,
 } from '@salto-io/salesforce-adapter'
 // eslint-disable-next-line no-restricted-imports
 import {
@@ -107,7 +107,7 @@ export const getSalesforceClient = (credentials: UsernamePasswordCredentials): S
     config: { deploy: { purgeOnDelete: true } },
   })
 
-export const nullProgressReporter: DeployProgressReporter = {
+export const nullProgressReporter: SalesforceDeployProgressReporter = {
   reportProgress: () => {},
   reportMetadataProgress: () => {},
   reportDataProgress: () => {},

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -7,6 +7,7 @@
  */
 import _ from 'lodash'
 import { collections, promises } from '@salto-io/lowerdash'
+import { inspectValue } from '@salto-io/adapter-utils'
 import {
   PlanItem,
   Plan,
@@ -168,6 +169,7 @@ const deployPlan = async (
         (item: PlanItem, step: ItemStatus, details?: string) => updateAction(item, step, details),
         accounts,
         checkOnly,
+        operationInfo => outputLine(`Reported operation info: ${inspectValue(operationInfo)}`, output),
       )
     : { success: true, errors: [] }
   const nonErroredActions = Object.keys(actions).filter(

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -27,6 +27,7 @@ import {
   isFieldChange,
   isRemovalChange,
   ObjectType,
+  DeployProgressReporter,
   ReferenceMapping,
   TopLevelElement,
 } from '@salto-io/adapter-api'
@@ -162,6 +163,7 @@ export const deploy = async (
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   accounts = workspace.accounts(),
   checkOnly = false,
+  reportDeployOperationInfo?: DeployProgressReporter['reportDeployOperationInfo'],
 ): Promise<DeployResult> => {
   const changedElements = elementSource.createInMemoryElementSource()
   const adaptersElementSource = buildElementsSourceFromElements([], [changedElements, await workspace.elements()])
@@ -198,6 +200,7 @@ export const deploy = async (
     reportProgress,
     postDeployAction,
     checkOnly,
+    reportDeployOperationInfo,
   )
 
   // Add workspace elements as an additional context for resolve so that we can resolve

--- a/packages/core/src/core/deploy/deploy_actions.ts
+++ b/packages/core/src/core/deploy/deploy_actions.ts
@@ -20,6 +20,7 @@ import {
   SaltoErrorType,
   ProgressReporter,
   Progress,
+  DeployProgressReporter,
 } from '@salto-io/adapter-api'
 import { applyDetailedChanges, detailedCompare } from '@salto-io/adapter-utils'
 import { NodeSkippedError, WalkError } from '@salto-io/dag'
@@ -127,6 +128,7 @@ export const deployActions = async (
   reportProgress: (item: PlanItem, status: ItemStatus, details?: string) => void,
   postDeployAction: (appliedChanges: ReadonlyArray<Change>) => Promise<void>,
   checkOnly: boolean,
+  reportDeployOperationInfo?: DeployProgressReporter['reportDeployOperationInfo'],
 ): Promise<DeployActionResult> => {
   const appliedChanges: Change[] = []
   const groups: GroupProperties[] = []
@@ -142,6 +144,7 @@ export const deployActions = async (
       try {
         const progressReporter = {
           reportProgress: (progress: Progress) => reportProgress(item, 'started', progress.message),
+          reportDeployOperationInfo,
         }
         const result = await deployAction(item, adapters, checkOnly, progressReporter)
         result.appliedChanges.forEach(appliedChange => appliedChanges.push(appliedChange))

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -34,7 +34,7 @@ import {
 } from '../src/transformers/transformer'
 import { fetchMetadataType } from '../src/fetch'
 import { defaultFilterContext } from '../test/utils'
-import { DeployProgressReporter } from '../src/adapter_creator'
+import { SalesforceDeployProgressReporter } from '../src/adapter_creator'
 
 const { makeArray } = collections.array
 const { toArrayAsync } = collections.asynciterable
@@ -183,7 +183,7 @@ export const removeElementIfAlreadyExists = async (
   }
 }
 
-export const nullProgressReporter: DeployProgressReporter = {
+export const nullProgressReporter: SalesforceDeployProgressReporter = {
   reportProgress: () => {},
   reportMetadataProgress: () => {},
   reportDataProgress: () => {},

--- a/packages/salesforce-adapter/index.ts
+++ b/packages/salesforce-adapter/index.ts
@@ -7,7 +7,7 @@
  */
 
 export { default } from './src/adapter'
-export { adapter, DeployProgressReporter } from './src/adapter_creator'
+export { adapter, SalesforceDeployProgressReporter } from './src/adapter_creator'
 export { default as SalesforceClient } from './src/client/client'
 export { UsernamePasswordCredentials, OauthAccessTokenCredentials } from './src/types'
 export { getAllInstances } from './src/filters/custom_objects_instances'

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -15,6 +15,7 @@ import {
   Values,
   ProgressReporter,
   DeployOptions,
+  DeployProgressReporter,
 } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { DeployResult } from '@salto-io/jsforce-types'
@@ -223,19 +224,19 @@ In Addition, ${configFromFetch.message}`,
   return configFromFetch
 }
 
-export type DeployProgressReporter = ProgressReporter & {
+export type SalesforceDeployProgressReporter = DeployProgressReporter & {
   reportMetadataProgress: (args: { result: DeployResult; suffix?: string }) => void
   reportDataProgress: (successInstances: number) => void
 }
 
 export type SalesforceAdapterDeployOptions = DeployOptions & {
-  progressReporter: DeployProgressReporter
+  progressReporter: SalesforceDeployProgressReporter
 }
 
 export const createDeployProgressReporter = async (
   progressReporter: ProgressReporter,
   client: SalesforceClient,
-): Promise<DeployProgressReporter> => {
+): Promise<SalesforceDeployProgressReporter> => {
   let deployResult: DeployResult | undefined
   let suffix: string | undefined
   let deployedDataInstances = 0
@@ -295,7 +296,7 @@ export const adapter: Adapter = {
       credentials,
       config: config[CLIENT_CONFIG],
     })
-    let deployProgressReporterPromise: Promise<DeployProgressReporter> | undefined
+    let deployProgressReporterPromise: Promise<SalesforceDeployProgressReporter> | undefined
 
     const createSalesforceAdapter = (): SalesforceAdapter => {
       const { elementsSource, getElemIdFunc } = context

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -513,9 +513,12 @@ describe('SalesforceAdapter CRUD', () => {
               progressReporter,
             })
           })
-          it('should deploy', () => {
+          it('should deploy and report the operation info', () => {
             expect(result.errors).toBeEmpty()
             expect(result.appliedChanges).toHaveLength(1)
+            expect(progressReporter.getReportedOperationInfo()).toEqual({
+              serviceDeploymentId: '5',
+            })
             expect(progressReporter.getReportedMessages()).toSatisfyAny(
               message =>
                 message.endsWith(ProgressReporterSuffix.QuickDeploy) &&

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -517,7 +517,7 @@ describe('SalesforceAdapter CRUD', () => {
             expect(result.errors).toBeEmpty()
             expect(result.appliedChanges).toHaveLength(1)
             expect(progressReporter.getReportedOperationInfo()).toEqual({
-              serviceDeploymentId: '5',
+              serviceDeploymentId: expect.any(String),
             })
             expect(progressReporter.getReportedMessages()).toSatisfyAny(
               message =>


### PR DESCRIPTION
Add reportDeployOperationInfo to the DeployProgressReporter 

---

This is a required step for adding the ability to cancel running validations in Salesforce.

---
_Release Notes_: 
_Core_:
- Add the ability to report `serviceDeploymentId` as part of a running validation/deployment

---
_User Notifications_: 
_None_
