### PR TITLE
SALTO-6882: Replace `transformValues` usages in Jira with `TransformValuesSync`

### DIFF
--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -6,13 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { CORE_ANNOTATIONS, isInstanceElement } from '@salto-io/adapter-api'
-import { transformValues } from '@salto-io/adapter-utils'
+import { transformValuesSync } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { collections } from '@salto-io/lowerdash'
 import { FilterCreator } from '../filter'
 
 const log = logger(module)
-const { awu } = collections.asynciterable
 
 const isStringNumber = (value: string): boolean => !Number.isNaN(Number(value))
 
@@ -22,31 +20,29 @@ const isStringNumber = (value: string): boolean => !Number.isNaN(Number(value))
 const filter: FilterCreator = () => ({
   name: 'hiddenValuesInListsFilter',
   onFetch: async elements => {
-    await awu(elements)
-      .filter(isInstanceElement)
-      .forEach(async instance => {
-        instance.value =
-          (await transformValues({
-            values: instance.value,
-            type: await instance.getType(),
-            pathID: instance.elemID,
-            allowEmptyArrays: true,
-            allowEmptyObjects: true,
-            strict: false,
-            transformFunc: ({ value, field, path }) => {
-              const isInArray = path?.getFullNameParts().some(isStringNumber)
-              if (isInArray && field?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]) {
-                log.warn(
-                  'found hidden value in hidden field %s in list with path %s',
-                  field.elemID.getFullName(),
-                  path?.getFullName(),
-                )
-                return undefined
-              }
-              return value
-            },
-          })) ?? {}
-      })
+    elements.filter(isInstanceElement).forEach(instance => {
+      instance.value =
+        transformValuesSync({
+          values: instance.value,
+          type: instance.getTypeSync(),
+          pathID: instance.elemID,
+          allowEmptyArrays: true,
+          allowEmptyObjects: true,
+          strict: false,
+          transformFunc: ({ value, field, path }) => {
+            const isInArray = path?.getFullNameParts().some(isStringNumber)
+            if (isInArray && field?.annotations[CORE_ANNOTATIONS.HIDDEN_VALUE]) {
+              log.warn(
+                'found hidden value in hidden field %s in list with path %s',
+                field.elemID.getFullName(),
+                path?.getFullName(),
+              )
+              return undefined
+            }
+            return value
+          },
+        }) ?? {}
+    })
   },
 })
 

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -8,7 +8,7 @@
 import _ from 'lodash'
 import { Element, isInstanceElement, InstanceElement, ReferenceExpression } from '@salto-io/adapter-api'
 import { multiIndex, collections, values as lowerdashValues } from '@salto-io/lowerdash'
-import { transformValues, TransformFunc } from '@salto-io/adapter-utils'
+import { TransformFunc, transformValuesSync } from '@salto-io/adapter-utils'
 import { openapi } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 
@@ -81,17 +81,17 @@ const filter: FilterCreator = () => ({
       filter: isInstanceElementWithSelfLink,
       key: inst => [getRelativeSelfLink(inst.value)],
     })
-    await awu(instances).forEach(async inst => {
+    instances.forEach(inst => {
       inst.value =
-        (await transformValues({
+        transformValuesSync({
           values: inst.value,
-          type: await inst.getType(),
+          type: inst.getTypeSync(),
           pathID: inst.elemID,
           transformFunc: transformSelfLinkToReference(elementsBySelfLink),
           strict: false,
           allowEmptyArrays: true,
           allowEmptyObjects: true,
-        })) ?? inst.value
+        }) ?? inst.value
     })
   },
 })

--- a/packages/jira-adapter/src/filters/remove_empty_values.ts
+++ b/packages/jira-adapter/src/filters/remove_empty_values.ts
@@ -6,12 +6,9 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { isInstanceElement } from '@salto-io/adapter-api'
-import { transformValues } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import { transformValuesSync } from '@salto-io/adapter-utils'
 import { DASHBOARD_GADGET_TYPE, NOTIFICATION_SCHEME_TYPE_NAME, WEBHOOK_TYPE, WORKFLOW_TYPE_NAME } from '../constants'
 import { FilterCreator } from '../filter'
-
-const { awu } = collections.asynciterable
 
 const RELEVANT_TYPES: string[] = [
   WORKFLOW_TYPE_NAME,
@@ -23,17 +20,17 @@ const RELEVANT_TYPES: string[] = [
 const filter: FilterCreator = () => ({
   name: 'removeEmptyValuesFilter',
   onFetch: async elements => {
-    await awu(elements)
+    elements
       .filter(isInstanceElement)
       .filter(instance => RELEVANT_TYPES.includes(instance.elemID.typeName))
-      .forEach(async instance => {
+      .forEach(instance => {
         instance.value =
-          (await transformValues({
+          transformValuesSync({
             values: instance.value,
-            type: await instance.getType(),
+            type: instance.getTypeSync(),
             transformFunc: ({ value }) => value,
             strict: false,
-          })) ?? {}
+          }) ?? {}
       })
   },
 })

--- a/packages/jira-adapter/src/filters/remove_self.ts
+++ b/packages/jira-adapter/src/filters/remove_self.ts
@@ -6,11 +6,8 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { Element, isInstanceElement, isObjectType } from '@salto-io/adapter-api'
-import { transformValues } from '@salto-io/adapter-utils'
-import { collections } from '@salto-io/lowerdash'
+import { transformValuesSync } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
-
-const { awu } = collections.asynciterable
 
 /**
  * Removes 'self' values from types and instances
@@ -18,25 +15,23 @@ const { awu } = collections.asynciterable
 const filter: FilterCreator = () => ({
   name: 'removeSelfFilter',
   onFetch: async (elements: Element[]) => {
-    await awu(elements)
-      .filter(isInstanceElement)
-      .forEach(async instance => {
-        instance.value =
-          (await transformValues({
-            values: instance.value,
-            type: await instance.getType(),
-            pathID: instance.elemID,
-            strict: false,
-            allowEmptyArrays: true,
-            allowEmptyObjects: true,
-            transformFunc: ({ value, path }) => {
-              if (path?.name === 'self') {
-                return undefined
-              }
-              return value
-            },
-          })) ?? {}
-      })
+    elements.filter(isInstanceElement).forEach(instance => {
+      instance.value =
+        transformValuesSync({
+          values: instance.value,
+          type: instance.getTypeSync(),
+          pathID: instance.elemID,
+          strict: false,
+          allowEmptyArrays: true,
+          allowEmptyObjects: true,
+          transformFunc: ({ value, path }) => {
+            if (path?.name === 'self') {
+              return undefined
+            }
+            return value
+          },
+        }) ?? {}
+    })
 
     elements.filter(isObjectType).forEach(async type => {
       delete type.fields.self


### PR DESCRIPTION
`hiddenValuesInLists` and `sortLists` filters were taking very long time for large environments, hopefully making those sync will reduce the time they take.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Jira adapter_:
- Fetch optimization for large Jira envs

---
_User Notifications_: 
None