### PR TITLE
SALTO-2432 remove unneeded async logic from reference strategy finder

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -967,12 +967,12 @@ export class FieldReferenceResolver {
   }
 }
 
-export type ReferenceResolverFinder = (field: Field, element: Element) => Promise<FieldReferenceResolver[]>
+type AsyncReferenceResolverFinder = (field: Field, element: Element) => Promise<FieldReferenceResolver[]>
 
 /**
  * Generates a function that filters the relevant resolvers for a given field.
  */
-export const generateReferenceResolverFinder = (defs: FieldReferenceDefinition[]): ReferenceResolverFinder => {
+export const generateReferenceResolverFinder = (defs: FieldReferenceDefinition[]): AsyncReferenceResolverFinder => {
   const referenceDefinitions = defs.map(def => FieldReferenceResolver.create(def))
 
   const matchersByFieldName = _(referenceDefinitions)


### PR DESCRIPTION
Probably won't make a big difference, but we know async is adding overhead and there's no need for loading the type when we only care about the typename that's already available on the instance's elem id.

(this is not the case in salesforce, but it is currently in all other adapters - and salesforce has its own variant of this implementation for this reason, so it's not impacted - but the reuse of shared functions meant not all async calls could be fully removed. we can do that if we make sure the types are always available on the salesforce side before entering this filter, but I didn't want to add that as a prereq for this smaller change).

---
_Release Notes_: 
None

---
_User Notifications_: 
None