### PR TITLE
SALTO-6889 Jira: do not scan ProjectComponents when indexing references

### DIFF
--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -21,13 +21,13 @@ const filter: FilterCreator = ({ config }) => ({
     const fixedDefs = referencesRules.map(def =>
       config.fetch.enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
-    const contextElements = elements
+    // Remove once SALTO-6889 is done: ProjectComponents have no references, so don't need to scan them
+    const relevantElements = elements
       .filter(isInstanceElement)
-      // Remove once SALTO-6889 is done: ProjectComponents have no references, so don't need to scan them
       .filter(instance => instance.elemID.typeName !== PROJECT_COMPONENT_TYPE)
     await referenceUtils.addReferences({
-      elements,
-      contextElements,
+      elements: relevantElements,
+      contextElements: elements,
       fieldsToGroupBy: ['id', 'name', 'originalName', 'groupId', 'key'],
       defs: fixedDefs,
       contextStrategyLookup,


### PR DESCRIPTION
SALTO-6889 Jira: do not scan ProjectComponents when indexing references

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
