### PR TITLE
SALTO-6898: Using retrieve API for settings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -39,6 +39,8 @@ import {
   createInstanceElement,
   isCustom,
   MetadataMetaType,
+  createMetadataTypeElements,
+  StandardSettingsMetaType,
 } from './transformers/transformer'
 import layoutFilter from './filters/layouts'
 import customObjectsFromDescribeFilter from './filters/custom_objects_from_soap_describe'
@@ -64,7 +66,8 @@ import flowFilter from './filters/flow'
 import addMissingIdsFilter from './filters/add_missing_ids'
 import animationRulesFilter from './filters/animation_rules'
 import samlInitMethodFilter from './filters/saml_initiation_method'
-import settingsFilter from './filters/settings_type'
+import legacySettingsFilter from './filters/settings_type'
+import settingsFilter from './filters/settings_types'
 import workflowFilter, { WORKFLOW_FIELD_TO_TYPE } from './filters/workflow'
 import topicsForObjectsFilter from './filters/topics_for_objects'
 import globalValueSetFilter from './filters/global_value_sets'
@@ -123,6 +126,7 @@ import {
   isCustomObjectSync,
   isCustomType,
   isInstanceOfCustomObjectSync,
+  isInstanceOfTypeSync,
   isMetadataInstanceElementSync,
   listMetadataObjects,
   metadataTypeSync,
@@ -163,7 +167,6 @@ import { createListApexClassesDef, createListMissingWaveDataflowsDef } from './c
 import { SalesforceAdapterDeployOptions } from './adapter_creator'
 
 const { awu } = collections.asynciterable
-const { makeArray } = collections.array
 const { partition } = promises.array
 const { concatObjects } = objects
 const { isDefined } = values
@@ -173,6 +176,7 @@ const log = logger(module)
 export const allFilters: Array<FilterCreator> = [
   waveStaticFilesFilter,
   createMissingInstalledPackagesInstancesFilter,
+  legacySettingsFilter,
   settingsFilter,
   // should run before customObjectsFilter
   workflowFilter,
@@ -341,6 +345,7 @@ const METADATA_TO_RETRIEVE = [
   'ReportFolder',
   'ReportType',
   'Scontrol', // contains encoded zip content
+  'Settings',
   'SharingRules',
   'SiteDotCom', // contains encoded zip content
   'StaticResource', // contains encoded zip content
@@ -568,32 +573,40 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
       ...Types.getAnnotationTypes(),
       ...Object.values(ArtificialTypes),
     ]
+    const hardCodedTypesMap = new Map(
+      hardCodedTypes
+        .map(type => [apiNameSync(type), type] as [string | undefined, TypeElement])
+        .filter((namedType): namedType is [string, TypeElement] => namedType[0] !== undefined),
+    )
     const metadataMetaType = fetchProfile.isFeatureEnabled('metaTypes') ? MetadataMetaType : undefined
     const metadataTypeInfosPromise = this.listMetadataTypes(fetchProfile.metadataQuery)
-    const metadataTypesPromise = this.fetchTypes({
+
+    progressReporter.reportProgress({ message: 'Fetching types' })
+    const metadataTypes = await this.fetchTypes({
       metadataQuery,
       withChangesDetection,
       metadataTypeInfosPromise,
-      hardCodedTypes,
+      hardCodedTypes: hardCodedTypesMap,
       metadataMetaType,
     })
-    progressReporter.reportProgress({ message: 'Fetching types' })
-    const metadataTypes = await metadataTypesPromise
 
-    const metadataInstancesPromise = this.fetchMetadataInstances(
-      metadataTypeInfosPromise,
-      metadataTypesPromise,
-      fetchProfile,
-    )
     progressReporter.reportProgress({ message: 'Fetching instances' })
     const { elements: metadataInstancesElements, configChanges: metadataInstancesConfigInstances } =
-      await metadataInstancesPromise
+      await this.fetchMetadataInstances(metadataTypeInfosPromise, metadataTypes, fetchProfile)
+
+    progressReporter.reportProgress({ message: 'Fetching additional types' })
+    const standardSettingsMetaType = fetchProfile.isFeatureEnabled('metaTypes') ? StandardSettingsMetaType : undefined
+    const additionalMetadataTypes = fetchProfile.isFeatureEnabled('retrieveSettings')
+      ? await this.fetchAdditionalMetadataTypes(metadataInstancesElements, hardCodedTypesMap, standardSettingsMetaType)
+      : []
+
     const elements = [
-      ...makeArray(metadataMetaType),
+      ...[metadataMetaType, standardSettingsMetaType].filter(isDefined),
       ...fieldTypes,
       ...hardCodedTypes,
       ...metadataTypes,
       ...metadataInstancesElements,
+      ...additionalMetadataTypes,
     ]
     progressReporter.reportProgress({
       message: 'Running filters for additional information',
@@ -764,7 +777,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
     metadataQuery: MetadataQuery
     withChangesDetection: boolean
     metadataTypeInfosPromise: Promise<MetadataObject[]>
-    hardCodedTypes: TypeElement[]
+    hardCodedTypes: Map<string, TypeElement>
     metadataMetaType?: ObjectType
   }): Promise<TypeElement[]> {
     if (!withChangesDetection) {
@@ -789,15 +802,10 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
   @logDuration('fetching metadata types')
   private async fetchMetadataTypes(
     typeInfoPromise: Promise<MetadataObject[]>,
-    knownMetadataTypes: TypeElement[],
+    knownTypes: Map<string, TypeElement>,
     metaType?: ObjectType,
   ): Promise<TypeElement[]> {
     const typeInfos = await typeInfoPromise
-    const knownTypes = new Map<string, TypeElement>(
-      await awu(knownMetadataTypes)
-        .map(async mdType => [await apiName(mdType), mdType] as [string, TypeElement])
-        .toArray(),
-    )
     const baseTypeNames = new Set(typeInfos.map(type => type.xmlName))
     const childTypeNames = new Set(typeInfos.flatMap(type => type.childXmlNames).filter(values.isDefined))
     return (
@@ -812,7 +820,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
   @logDuration('fetching instances')
   private async fetchMetadataInstances(
     typeInfoPromise: Promise<MetadataObject[]>,
-    types: Promise<TypeElement[]>,
+    types: TypeElement[],
     fetchProfile: FetchProfile,
   ): Promise<FetchElements<InstanceElement[]>> {
     const readInstances = async (metadataTypes: ObjectType[]): Promise<FetchElements<InstanceElement[]>> => {
@@ -830,7 +838,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
 
     const typeInfos = await typeInfoPromise
     const topLevelTypeNames = typeInfos.map(info => info.xmlName)
-    const topLevelTypes = await awu(await types)
+    const topLevelTypes = await awu(types)
       .filter(isMetadataObjectType)
       .filter(async t => topLevelTypeNames.includes(await apiName(t)) || t.annotations.folderContentType !== undefined)
       .toArray()
@@ -856,6 +864,46 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
       elements: _.flatten(allInstances.map(instances => instances.elements)),
       configChanges: _.flatten(allInstances.map(instances => instances.configChanges)),
     }
+  }
+
+  @logDuration('fetching additional types')
+  private async fetchAdditionalMetadataTypes(
+    instances: InstanceElement[],
+    knownTypes: Map<string, TypeElement>,
+    standardSettingsMetaType?: ObjectType,
+  ): Promise<TypeElement[]> {
+    const createSettingsType = async (settingsTypeName: string): Promise<ObjectType[]> => {
+      const typeFields = await this.client.describeMetadataType(settingsTypeName)
+      try {
+        return await createMetadataTypeElements({
+          name: settingsTypeName,
+          fields: typeFields.valueTypeFields,
+          knownTypes,
+          baseTypeNames: new Set([settingsTypeName]),
+          childTypeNames: new Set(),
+          client: this.client,
+          isSettings: true,
+          annotations: {
+            suffix: 'settings',
+            dirName: constants.SETTINGS_DIR_NAME,
+          },
+          metaType: standardSettingsMetaType,
+        })
+      } catch (e) {
+        log.error('Failed to fetch settings type %s reason: %o', settingsTypeName, e)
+        return []
+      }
+    }
+
+    return (
+      await Promise.all(
+        instances
+          .filter(isInstanceOfTypeSync(constants.SETTINGS_METADATA_TYPE))
+          .map(instance => instance.value[constants.INSTANCE_FULL_NAME_FIELD]?.concat(constants.SETTINGS_METADATA_TYPE))
+          .filter(isDefined)
+          .map(typeName => createSettingsType(typeName)),
+      )
+    ).flat()
   }
 
   private async createMetadataInstances(

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -305,6 +305,8 @@ export const SUBTYPES_PATH = 'Subtypes'
 export const INSTALLED_PACKAGES_PATH = 'InstalledPackages'
 export const OBJECT_FIELDS_PATH = 'Fields'
 
+export const SETTINGS_DIR_NAME = 'settings'
+
 // Limits
 export const MAX_METADATA_RESTRICTION_VALUES = 500
 export const MAX_TOTAL_CONCURRENT_API_REQUEST = 100

--- a/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
@@ -244,14 +244,14 @@ const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
   return refs
 }
 
-const instanceEntriesTargets = (instance: InstanceElement, metadataQuery?: MetadataQuery<ElemID>): Dictionary<ElemID> =>
+const instanceEntriesTargets = (instance: InstanceElement, metadataQuery: MetadataQuery<ElemID>): Dictionary<ElemID> =>
   _(
     mapInstanceSections(instance, (sectionName, sectionEntryKey, target, sourceField): [string, ElemID] => [
       [sectionName, sectionEntryKey, ...makeArray(sourceField)].join('.'),
       target,
     ]),
   )
-    .filter(([, target]) => metadataQuery?.isInstanceIncluded(target) ?? true)
+    .filter(([, target]) => metadataQuery.isInstanceIncluded(target))
     .fromPairs()
     .value()
 

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -11,7 +11,6 @@ import {
   FetchProfile,
   FetchParameters,
   METADATA_CONFIG,
-  OptionalFeatures,
   MetadataQuery,
   CustomReferencesSettings,
 } from '../types'
@@ -20,40 +19,9 @@ import { buildMetadataQuery, validateMetadataParams } from './metadata_query'
 import { DEFAULT_MAX_INSTANCES_PER_TYPE, DEFAULT_MAX_ITEMS_IN_RETRIEVE_REQUEST } from '../constants'
 import { mergeWithDefaultImportantValues } from './important_values'
 import { customReferencesConfiguration } from '../custom_references/handlers'
-
-type OptionalFeaturesDefaultValues = {
-  [FeatureName in keyof OptionalFeatures]?: boolean
-}
+import { isFeatureEnabled } from './optional_features'
 
 const PREFER_ACTIVE_FLOW_VERSIONS_DEFAULT = false
-
-const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
-  fetchProfilesUsingReadApi: false,
-  skipAliases: false,
-  toolingDepsOfCurrentNamespace: false,
-  extraDependenciesV2: true,
-  extendedCustomFieldInformation: false,
-  importantValues: true,
-  hideTypesFolder: true,
-  omitStandardFieldsNonDeployableValues: true,
-  metaTypes: false,
-  cpqRulesAndConditionsRefs: true,
-  flowCoordinates: true,
-  improvedDataBrokenReferences: true,
-  taskAndEventCustomFields: true,
-  sharingRulesMaps: true,
-  excludeNonRetrievedProfilesRelatedInstances: true,
-  waveMetadataSupport: true,
-  indexedEmailTemplateAttachments: true,
-  skipParsingXmlNumbers: true,
-  logDiffsFromParsingXmlNumbers: true,
-  extendTriggersMetadata: true,
-  removeReferenceFromFilterItemToRecordType: true,
-  storeProfilesAndPermissionSetsBrokenPaths: true,
-  picklistsAsMaps: false,
-  lightningPageFieldItemReference: true,
-  retrieveSettings: false,
-}
 
 type BuildFetchProfileParams = {
   fetchParams: FetchParameters
@@ -61,9 +29,6 @@ type BuildFetchProfileParams = {
   metadataQuery?: MetadataQuery
   maxItemsInRetrieveRequest?: number
 }
-
-export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>
-  optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true
 
 export const buildFetchProfile = ({
   fetchParams,

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -52,6 +52,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   storeProfilesAndPermissionSetsBrokenPaths: true,
   picklistsAsMaps: false,
   lightningPageFieldItemReference: true,
+  retrieveSettings: false,
 }
 
 type BuildFetchProfileParams = {

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -62,6 +62,9 @@ type BuildFetchProfileParams = {
   maxItemsInRetrieveRequest?: number
 }
 
+export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>
+  optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true
+
 export const buildFetchProfile = ({
   fetchParams,
   customReferencesSettings,
@@ -82,7 +85,7 @@ export const buildFetchProfile = ({
   const enabledCustomReferencesHandlers = customReferencesConfiguration(customReferencesSettings)
   return {
     dataManagement: data && buildDataManagement(data),
-    isFeatureEnabled: name => optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true,
+    isFeatureEnabled: name => isFeatureEnabled(name, optionalFeatures),
     isCustomReferencesHandlerEnabled: name => enabledCustomReferencesHandlers[name] ?? false,
     shouldFetchAllCustomSettings: () => fetchAllCustomSettings ?? true,
     maxInstancesPerType: maxInstancesPerType ?? DEFAULT_MAX_INSTANCES_PER_TYPE,

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -38,7 +38,7 @@ import {
   NESTED_TYPE_TO_PARENT_TYPE,
 } from '../last_change_date_of_types_with_nested_instances'
 import { getFetchTargetsWithDependencies, includesSettingsTypes } from './metadata_types'
-import { isFeatureEnabled } from './fetch_profile'
+import { isFeatureEnabled } from './optional_features'
 
 const { makeArray } = collections.array
 const { isDefined } = values

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -38,6 +38,7 @@ import {
   NESTED_TYPE_TO_PARENT_TYPE,
 } from '../last_change_date_of_types_with_nested_instances'
 import { getFetchTargetsWithDependencies, includesSettingsTypes } from './metadata_types'
+import { isFeatureEnabled } from './fetch_profile'
 
 const { makeArray } = collections.array
 const { isDefined } = values
@@ -96,7 +97,11 @@ export const buildMetadataQuery = ({ fetchParams }: BuildMetadataQueryParams): M
   const fullExcludeList: MetadataQueryParams[] = [
     ...(metadata.exclude ?? []),
     ...PERMANENT_SKIP_LIST,
-    ...makeArray(fetchParams.optionalFeatures?.retrieveSettings ? undefined : { metadataType: SETTINGS_METADATA_TYPE }),
+    ...makeArray(
+      isFeatureEnabled('retrieveSettings', fetchParams.optionalFeatures)
+        ? undefined
+        : { metadataType: SETTINGS_METADATA_TYPE },
+    ),
   ]
 
   const isIncludedInTargetedFetch = (type: string): boolean => {
@@ -108,7 +113,7 @@ export const buildMetadataQuery = ({ fetchParams }: BuildMetadataQueryParams): M
 
   const include = metadata.include
     ? metadata.include.concat(
-        fetchParams.optionalFeatures?.retrieveSettings &&
+        isFeatureEnabled('retrieveSettings', fetchParams.optionalFeatures) &&
           includesSettingsTypes(metadata.include.map(({ metadataType }) => metadataType).filter(isDefined) ?? [])
           ? [{ metadataType: SETTINGS_METADATA_TYPE }]
           : [],
@@ -128,7 +133,7 @@ export const buildMetadataQuery = ({ fetchParams }: BuildMetadataQueryParams): M
     )
 
   const fixSettingsType = (metadataType: string, name: string): string =>
-    fetchParams.optionalFeatures?.retrieveSettings && metadataType === SETTINGS_METADATA_TYPE
+    isFeatureEnabled('retrieveSettings', fetchParams.optionalFeatures) && metadataType === SETTINGS_METADATA_TYPE
       ? name.concat(SETTINGS_METADATA_TYPE)
       : metadataType
 

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -93,14 +93,10 @@ export const buildMetadataQuery = ({ fetchParams }: BuildMetadataQueryParams): M
   if (target !== undefined) {
     log.debug('targeted fetch types: %o', target)
   }
-  const fullExcludeList = [
+  const fullExcludeList: MetadataQueryParams[] = [
     ...(metadata.exclude ?? []),
     ...PERMANENT_SKIP_LIST,
-    ...makeArray(
-      fetchParams.optionalFeatures?.retrieveSettings
-        ? undefined
-        : ({ metadataType: SETTINGS_METADATA_TYPE } as MetadataQueryParams),
-    ),
+    ...makeArray(fetchParams.optionalFeatures?.retrieveSettings ? undefined : { metadataType: SETTINGS_METADATA_TYPE }),
   ]
 
   const isIncludedInTargetedFetch = (type: string): boolean => {

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
@@ -13,6 +13,7 @@ import {
   FLOW_METADATA_TYPE,
   PROFILE_METADATA_TYPE,
   PROFILE_RELATED_METADATA_TYPES,
+  SETTINGS_METADATA_TYPE,
   TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../constants'
 
@@ -643,10 +644,14 @@ export const isMetadataTypeWithoutDependencies = (
 export const isMetadataTypeWithDependency = (metadataType: string): metadataType is MetadataTypeWithDependencies =>
   (METADATA_TYPES_WITH_DEPENDENCIES as ReadonlyArray<string>).includes(metadataType)
 
+const isSettingsType = (typeName: string): boolean => typeName.endsWith(SETTINGS_METADATA_TYPE)
+export const includesSettingsTypes = (typeNames: readonly string[]): boolean => typeNames.some(isSettingsType)
+
 export const getFetchTargetsWithDependencies = (targets: string[]): string[] => {
   const result = [...targets]
   const handledTypesWithDependencies: MetadataTypeWithDependencies[] = []
   let typesWithDependencies = targets.filter(isMetadataTypeWithDependency)
+
   while (!_.isEmpty(typesWithDependencies)) {
     _(METADATA_TYPE_TO_DEPENDENCIES)
       .pick(typesWithDependencies)
@@ -658,5 +663,10 @@ export const getFetchTargetsWithDependencies = (targets: string[]): string[] => 
       .filter(isMetadataTypeWithDependency)
       .filter(typeWithDependency => !handledTypesWithDependencies.includes(typeWithDependency))
   }
+
+  if (includesSettingsTypes(result)) {
+    result.push(SETTINGS_METADATA_TYPE)
+  }
+
   return _(result).uniq().value()
 }

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
@@ -644,8 +644,8 @@ export const isMetadataTypeWithoutDependencies = (
 export const isMetadataTypeWithDependency = (metadataType: string): metadataType is MetadataTypeWithDependencies =>
   (METADATA_TYPES_WITH_DEPENDENCIES as ReadonlyArray<string>).includes(metadataType)
 
-const isSettingsType = (typeName: string): boolean => typeName.endsWith(SETTINGS_METADATA_TYPE)
-export const includesSettingsTypes = (typeNames: readonly string[]): boolean => typeNames.some(isSettingsType)
+export const includesSettingsTypes = (typeNames: readonly string[]): boolean =>
+  typeNames.some(typeName => typeName.endsWith(SETTINGS_METADATA_TYPE))
 
 export const getFetchTargetsWithDependencies = (targets: string[]): string[] => {
   const result = [...targets]

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { OptionalFeatures } from '../types'
+
+type OptionalFeaturesDefaultValues = {
+  [FeatureName in keyof OptionalFeatures]?: boolean
+}
+
+const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
+  fetchProfilesUsingReadApi: false,
+  skipAliases: false,
+  toolingDepsOfCurrentNamespace: false,
+  extraDependenciesV2: true,
+  extendedCustomFieldInformation: false,
+  importantValues: true,
+  hideTypesFolder: true,
+  omitStandardFieldsNonDeployableValues: true,
+  metaTypes: false,
+  cpqRulesAndConditionsRefs: true,
+  flowCoordinates: true,
+  improvedDataBrokenReferences: true,
+  taskAndEventCustomFields: true,
+  sharingRulesMaps: true,
+  excludeNonRetrievedProfilesRelatedInstances: true,
+  waveMetadataSupport: true,
+  indexedEmailTemplateAttachments: true,
+  skipParsingXmlNumbers: true,
+  logDiffsFromParsingXmlNumbers: true,
+  extendTriggersMetadata: true,
+  removeReferenceFromFilterItemToRecordType: true,
+  storeProfilesAndPermissionSetsBrokenPaths: true,
+  picklistsAsMaps: false,
+  lightningPageFieldItemReference: true,
+  retrieveSettings: false,
+}
+
+export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>
+  optionalFeatures?.[name] ?? optionalFeaturesDefaultValues[name] ?? true

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -9,14 +9,9 @@ import { Element, isObjectType, ObjectType, TypeElement } from '@salto-io/adapte
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { FilterResult, FilterCreator } from '../filter'
-import {
-  createMetadataTypeElements,
-  apiName,
-  createMetaType,
-  metadataAnnotationTypes,
-} from '../transformers/transformer'
+import { createMetadataTypeElements, apiName, StandardSettingsMetaType } from '../transformers/transformer'
 import SalesforceClient from '../client/client'
-import { SETTINGS_METADATA_TYPE, STANDARD_SETTINGS_META_TYPE } from '../constants'
+import { SETTINGS_DIR_NAME, SETTINGS_METADATA_TYPE } from '../constants'
 import { fetchMetadataInstances } from '../fetch'
 import { listMetadataObjects } from './utils'
 
@@ -44,7 +39,7 @@ const createSettingsType = async (
       isSettings: true,
       annotations: {
         suffix: 'settings',
-        dirName: 'settings',
+        dirName: SETTINGS_DIR_NAME,
       },
       metaType,
     })
@@ -67,7 +62,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
    * @param elements
    */
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
-    if (client === undefined) {
+    if (config.fetchProfile.isFeatureEnabled('retrieveSettings') || client === undefined) {
       return {}
     }
 
@@ -87,9 +82,7 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
     const objectTypes = elements.filter(isObjectType)
     await awu(objectTypes).forEach(async e => knownTypes.set(await apiName(e), e))
 
-    const metaType = config.fetchProfile.isFeatureEnabled('metaTypes')
-      ? createMetaType(STANDARD_SETTINGS_META_TYPE, metadataAnnotationTypes, 'Standard Settings')
-      : undefined
+    const metaType = config.fetchProfile.isFeatureEnabled('metaTypes') ? StandardSettingsMetaType : undefined
     const settingsTypes = (
       await Promise.all(
         settingsTypeInfos

--- a/packages/salesforce-adapter/src/filters/settings_types.ts
+++ b/packages/salesforce-adapter/src/filters/settings_types.ts
@@ -47,18 +47,10 @@ const filterCreator: FilterCreator = ({ config }) => ({
     const oldInstances = elements.filter(isInstanceOfTypeSync(SETTINGS_METADATA_TYPE))
     const settingsTypes = elements.filter(isObjectType).filter(type => type.annotations.dirName === SETTINGS_DIR_NAME)
 
-    const settingsTypeByName = _(settingsTypes)
-      .keyBy(type => apiNameSync(type) ?? 'missing')
-      .value()
-    if (settingsTypeByName.missing) {
-      log.error('Got settings type with missing api name: %s', inspectValue(settingsTypeByName.missing))
-    }
+    const settingsTypeByName = _.keyBy(settingsTypes, type => apiNameSync(type) ?? '')
 
     const newInstances = oldInstances
-      .map((instance: InstanceElement): [string | undefined, InstanceElement] => [
-        getSettingsTypeName(instance),
-        instance,
-      ])
+      .map<[string | undefined, InstanceElement]>(instance => [getSettingsTypeName(instance), instance])
       .filter(
         (namedInstance: [string | undefined, InstanceElement]): namedInstance is [string, InstanceElement] =>
           namedInstance[0] !== undefined,
@@ -79,7 +71,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
       })
       .filter(isDefined)
     _.pullAll(elements, oldInstances)
-    elements.push(...newInstances)
+    newInstances.forEach(instance => elements.push(instance))
   },
 
   // after onFetch, the settings types have annotations.metadataType === '<name>Settings',

--- a/packages/salesforce-adapter/src/filters/settings_types.ts
+++ b/packages/salesforce-adapter/src/filters/settings_types.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import { Element, ElemID, InstanceElement, isObjectType } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { values } from '@salto-io/lowerdash'
+import { inspectValue, pathNaclCase } from '@salto-io/adapter-utils'
+import { FilterCreator } from '../filter'
+import {
+  INSTANCE_FULL_NAME_FIELD,
+  RECORDS_PATH,
+  SALESFORCE,
+  SETTINGS_DIR_NAME,
+  SETTINGS_METADATA_TYPE,
+  SETTINGS_PATH,
+} from '../constants'
+import { apiNameSync, isInstanceOfTypeSync } from './utils'
+
+const { isDefined } = values
+const log = logger(module)
+
+const getSettingsTypeName = (settings: InstanceElement): string | undefined => {
+  const apiName = apiNameSync(settings)
+  if (apiName === undefined) {
+    log.error('No api name for settings type: %s', inspectValue(settings))
+    return undefined
+  }
+
+  return apiName.concat(SETTINGS_METADATA_TYPE)
+}
+
+/**
+ * Match instances of the Settings metadata type to their specific types.
+ */
+const filterCreator: FilterCreator = ({ config }) => ({
+  name: 'settingsFilterV2',
+  onFetch: async (elements: Element[]): Promise<void> => {
+    if (!config.fetchProfile.isFeatureEnabled('retrieveSettings')) {
+      return
+    }
+
+    const oldInstances = elements.filter(isInstanceOfTypeSync(SETTINGS_METADATA_TYPE))
+    const settingsTypes = elements.filter(isObjectType).filter(type => type.annotations.dirName === SETTINGS_DIR_NAME)
+
+    const settingsTypeByName = _(settingsTypes)
+      .keyBy(type => apiNameSync(type) ?? 'missing')
+      .value()
+    if (settingsTypeByName.missing) {
+      log.error('Got settings type with missing api name: %s', inspectValue(settingsTypeByName.missing))
+    }
+
+    const newInstances = oldInstances
+      .map((instance: InstanceElement): [string | undefined, InstanceElement] => [
+        getSettingsTypeName(instance),
+        instance,
+      ])
+      .filter(
+        (namedInstance: [string | undefined, InstanceElement]): namedInstance is [string, InstanceElement] =>
+          namedInstance[0] !== undefined,
+      )
+      .map(([typeName, instance]) => {
+        const type = settingsTypeByName[typeName]
+        if (type === undefined) {
+          log.error('Could not find type for settings instance: %s', inspectValue(instance))
+          return undefined
+        }
+
+        return new InstanceElement(ElemID.CONFIG_NAME, type, instance.value, [
+          SALESFORCE,
+          RECORDS_PATH,
+          SETTINGS_PATH,
+          pathNaclCase(instance.value[INSTANCE_FULL_NAME_FIELD]),
+        ])
+      })
+      .filter(isDefined)
+    _.pullAll(elements, oldInstances)
+    elements.push(...newInstances)
+  },
+
+  // after onFetch, the settings types have annotations.metadataType === '<name>Settings',
+  // which causes deploy to fail (SALTO-1081).
+  // We currently don't fix the metadata type in a preDeploy & onDeploy mechanism,
+  // since the '<name>Settings' format is required for comparison with the type specified in the
+  // deploy response, which is also in this format (after preDeploy and before onDeploy).
+  // instead, we change the type in the deploy pkg (PR #1727).
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -102,6 +102,7 @@ import {
   SALESFORCE_DATE_PLACEHOLDER,
   SECURITY_CLASSIFICATION,
   SETTINGS_PATH,
+  STANDARD_SETTINGS_META_TYPE,
   TYPES_PATH,
   VALUE_SET_DEFINITION_FIELDS,
   VALUE_SET_FIELDS,
@@ -1492,6 +1493,11 @@ export const createMetaType = (
   })
 
 export const MetadataMetaType = createMetaType(METADATA_META_TYPE, metadataAnnotationTypes, 'Metadata type')
+export const StandardSettingsMetaType = createMetaType(
+  STANDARD_SETTINGS_META_TYPE,
+  metadataAnnotationTypes,
+  'Standard Settings',
+)
 
 export type MetadataObjectType = ObjectType & {
   annotations: ObjectType['annotations'] & MetadataTypeAnnotations

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -35,6 +35,7 @@ import {
   INTERNAL_ID_FIELD,
   LIGHTNING_COMPONENT_BUNDLE_METADATA_TYPE,
   SETTINGS_METADATA_TYPE,
+  SETTINGS_DIR_NAME,
 } from '../constants'
 import {
   apiName,
@@ -75,7 +76,7 @@ export const getManifestTypeName = (type: MetadataObjectType): string =>
 
   // Salesforce quirk - settings instances should be deployed under Settings type,
   // although their received type is "<name>Settings"
-  type.annotations.dirName === 'settings'
+  type.annotations.dirName === SETTINGS_DIR_NAME
     ? SETTINGS_METADATA_TYPE
     : type.annotations.folderContentType ?? type.annotations.metadataType
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -129,6 +129,7 @@ const OPTIONAL_FEATURES = [
   'removeReferenceFromFilterItemToRecordType',
   'picklistsAsMaps',
   'lightningPageFieldItemReference',
+  'retrieveSettings',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = ['generateRefsInProfiles'] as const
 export type OptionalFeatures = {

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -20,6 +20,7 @@ import {
   CUSTOM_OBJECT,
   FLOW_DEFINITION_METADATA_TYPE,
   FLOW_METADATA_TYPE,
+  SETTINGS_METADATA_TYPE,
   TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../../src/constants'
 import { MetadataInstance, MetadataQuery } from '../../src/types'
@@ -166,6 +167,7 @@ describe('buildMetadataQuery', () => {
         })
       })
     })
+
     it('filter with namespace', () => {
       const query = buildMetadataQuery({
         fetchParams: {
@@ -568,6 +570,7 @@ describe('buildMetadataQuery', () => {
       })
     })
   })
+
   describe('with InFolderMetadataType', () => {
     const inFolderType = 'Report'
     const folderType = `${inFolderType}Folder`
@@ -611,6 +614,7 @@ describe('buildMetadataQuery', () => {
       })
     })
   })
+
   describe('with FolderMetadataType', () => {
     const folderType = 'ReportFolder'
     let query: MetadataQuery
@@ -731,6 +735,7 @@ describe('buildMetadataQuery', () => {
       })
     })
   })
+
   describe('buildMetadataQueryForFetchWithChangesDetection', () => {
     const INCLUDED_TYPE = 'Role'
     const EXCLUDED_TYPE = 'CustomLabels'
@@ -872,6 +877,7 @@ describe('buildMetadataQuery', () => {
       })
     })
   })
+
   describe('buildFilePropsMetadataQuery', () => {
     const CHANGED_AT = '2023-11-07T00:00:00.000Z'
 
@@ -949,6 +955,51 @@ describe('buildMetadataQuery', () => {
           })
         })
       })
+    })
+  })
+
+  describe('with settings types', () => {
+    let query: MetadataQuery
+
+    beforeEach(() => {
+      query = buildMetadataQuery({
+        fetchParams: {
+          metadata: {
+            include: [{ metadataType: 'AccountSettings' }],
+          },
+          optionalFeatures: {
+            retrieveSettings: true,
+          },
+        },
+      })
+    })
+
+    it('should include the Settings type', () => {
+      expect(query.isTypeMatch(SETTINGS_METADATA_TYPE)).toBeTrue()
+    })
+
+    it('should match the included settings instance', () => {
+      expect(
+        query.isInstanceMatch({
+          name: 'Account',
+          namespace: '',
+          metadataType: 'Settings',
+          isFolderType: false,
+          changedAt: undefined,
+        }),
+      ).toBeTrue()
+    })
+
+    it('should not match a different settings instance', () => {
+      expect(
+        query.isInstanceMatch({
+          name: 'Company',
+          namespace: '',
+          metadataType: 'Settings',
+          isFolderType: false,
+          changedAt: undefined,
+        }),
+      ).toBeFalse()
     })
   })
 })

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_types.test.ts
@@ -15,7 +15,7 @@ import {
   SALESFORCE_METADATA_TYPES,
   MetadataTypeWithoutDependencies,
 } from '../../src/fetch_profile/metadata_types'
-import { PROFILE_RELATED_METADATA_TYPES } from '../../src/constants'
+import { PROFILE_RELATED_METADATA_TYPES, SETTINGS_METADATA_TYPE } from '../../src/constants'
 
 describe('Salesforce MetadataTypes', () => {
   const getDuplicates = (array: ReadonlyArray<string>): ReadonlyArray<string> =>
@@ -69,6 +69,14 @@ describe('Salesforce MetadataTypes', () => {
           'Flow',
           'Profile',
           ...PROFILE_RELATED_METADATA_TYPES,
+        ])
+      })
+    })
+    describe('when fetch targets include a settings type', () => {
+      it('should include the Settings type', () => {
+        expect(getFetchTargetsWithDependencies(['AccountSettings'])).toIncludeSameMembers([
+          'AccountSettings',
+          SETTINGS_METADATA_TYPE,
         ])
       })
     })

--- a/packages/salesforce-adapter/test/filters/settings_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/settings_type.test.ts
@@ -28,6 +28,9 @@ describe('Test Settings Type', () => {
           metadata: {
             exclude: [{ metadataType: 'CaseSettings' }],
           },
+          optionalFeatures: {
+            retrieveSettings: false,
+          },
         },
       }),
     },

--- a/packages/salesforce-adapter/test/filters/settings_types.test.ts
+++ b/packages/salesforce-adapter/test/filters/settings_types.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { InstanceElement, isInstanceElement, ObjectType, Element } from '@salto-io/adapter-api'
+import filterCreator from '../../src/filters/settings_types'
+import {
+  INSTANCE_FULL_NAME_FIELD,
+  METADATA_TYPE,
+  RECORDS_PATH,
+  SALESFORCE,
+  SETTINGS_DIR_NAME,
+} from '../../src/constants'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+import { createMetadataTypeElement, defaultFilterContext } from '../utils'
+import { FilterWith } from './mocks'
+import { mockTypes } from '../mock_elements'
+
+const createSettingsType = (name: string): ObjectType =>
+  createMetadataTypeElement(name, {
+    annotations: {
+      dirName: SETTINGS_DIR_NAME,
+    },
+  })
+
+const createSettingsInstance = (name: string): InstanceElement =>
+  new InstanceElement(
+    name,
+    mockTypes.Settings,
+    {
+      [INSTANCE_FULL_NAME_FIELD]: name,
+    },
+    [SALESFORCE, RECORDS_PATH, SETTINGS_DIR_NAME, name],
+  )
+
+describe('Test Settings Types', () => {
+  const filter = filterCreator({
+    config: {
+      ...defaultFilterContext,
+      fetchProfile: buildFetchProfile({
+        fetchParams: {
+          optionalFeatures: {
+            retrieveSettings: true,
+          },
+        },
+      }),
+    },
+  }) as FilterWith<'onFetch'>
+
+  describe('on fetch', () => {
+    let elements: Element[]
+
+    describe('when all settings instances have matching types', () => {
+      let types: ObjectType[]
+      let beforeInstances: InstanceElement[]
+
+      beforeEach(async () => {
+        types = [createSettingsType('AccountSettings'), createSettingsType('CompanySettings')]
+        beforeInstances = [createSettingsInstance('Account'), createSettingsInstance('Company')]
+        elements = (types as Element[]).concat(beforeInstances)
+        await filter.onFetch(elements)
+      })
+
+      it('should include all settings types', () => {
+        expect(elements).toIncludeAllMembers(types)
+      })
+
+      it('should map all settings instances to the matching type', () => {
+        expect(elements.filter(isInstanceElement).map(instance => instance.getTypeSync())).toEqual(types)
+      })
+    })
+
+    describe('when settings types are missing', () => {
+      beforeEach(async () => {
+        elements = [createSettingsInstance('Account'), createSettingsInstance('Company')]
+        await filter.onFetch(elements)
+      })
+
+      it('should drop the settings instances', () => {
+        expect(elements).toBeEmpty()
+      })
+    })
+
+    describe('when settings type is missing an api name', () => {
+      let settingsType: ObjectType
+
+      beforeEach(async () => {
+        settingsType = createSettingsType('AccountSettings')
+        delete settingsType.annotations[METADATA_TYPE]
+        elements = [settingsType, createSettingsInstance('Account')]
+        await filter.onFetch(elements)
+      })
+
+      it('should drop the settings instance', () => {
+        expect(elements).toEqual([settingsType])
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -50,6 +50,12 @@ import {
   WORKFLOW_METADATA_TYPE,
   WORKFLOW_TASK_METADATA_TYPE,
   WORKFLOW_RULE_METADATA_TYPE,
+  CPQ_QUOTE_TERM,
+  CPQ_ADVANCED_CONDITION_FIELD,
+  SETTINGS_DIR_NAME,
+  CUSTOM_METADATA_TYPE_NAME,
+  CPQ_TERM_CONDITION,
+  CPQ_INDEX_FIELD,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -57,7 +63,6 @@ import { API_VERSION } from '../src/client/client'
 import { WORKFLOW_FIELD_TO_TYPE } from '../src/filters/workflow'
 import { createCustomObjectType } from './utils'
 import { SORT_ORDER } from '../src/change_validators/duplicate_rules_sort_order'
-import * as constants from '../src/constants'
 
 const SBAA_APPROVAL_RULE_TYPE = createCustomObjectType(SBAA_APPROVAL_RULE, {
   fields: {
@@ -85,10 +90,10 @@ const CPQ_PRICE_RULE_TYPE = createCustomObjectType(CPQ_PRICE_RULE, {
     [OWNER_ID]: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
-        [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
-        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-        [constants.API_NAME]: OWNER_ID,
+        [FIELD_ANNOTATIONS.CREATABLE]: true,
+        [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [API_NAME]: OWNER_ID,
       },
     },
   },
@@ -107,18 +112,18 @@ const CPQ_PRODUCT_RULE_TYPE = createCustomObjectType(CPQ_PRODUCT_RULE, {
     [OWNER_ID]: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
-        [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
-        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-        [constants.API_NAME]: OWNER_ID,
+        [FIELD_ANNOTATIONS.CREATABLE]: true,
+        [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [API_NAME]: OWNER_ID,
       },
     },
   },
 })
 
-const CPQ_QUOTE_TERM_TYPE = createCustomObjectType(constants.CPQ_QUOTE_TERM, {
+const CPQ_QUOTE_TERM_TYPE = createCustomObjectType(CPQ_QUOTE_TERM, {
   fields: {
-    [constants.CPQ_ADVANCED_CONDITION_FIELD]: {
+    [CPQ_ADVANCED_CONDITION_FIELD]: {
       refType: BuiltinTypes.STRING,
       annotations: {
         [FIELD_ANNOTATIONS.QUERYABLE]: true,
@@ -129,10 +134,10 @@ const CPQ_QUOTE_TERM_TYPE = createCustomObjectType(constants.CPQ_QUOTE_TERM, {
     [OWNER_ID]: {
       refType: BuiltinTypes.STRING,
       annotations: {
-        [constants.FIELD_ANNOTATIONS.CREATABLE]: true,
-        [constants.FIELD_ANNOTATIONS.UPDATEABLE]: true,
-        [constants.FIELD_ANNOTATIONS.QUERYABLE]: true,
-        [constants.API_NAME]: OWNER_ID,
+        [FIELD_ANNOTATIONS.CREATABLE]: true,
+        [FIELD_ANNOTATIONS.UPDATEABLE]: true,
+        [FIELD_ANNOTATIONS.QUERYABLE]: true,
+        [API_NAME]: OWNER_ID,
       },
     },
   },
@@ -348,7 +353,13 @@ export const mockTypes = {
       },
     },
   }),
-
+  Settings: createMetadataObjectType({
+    annotations: {
+      metadataType: SETTINGS_METADATA_TYPE,
+      dirName: SETTINGS_DIR_NAME,
+      suffix: 'settings',
+    },
+  }),
   TestSettings: createMetadataObjectType({
     annotations: {
       metadataType: 'TestSettings',
@@ -372,7 +383,7 @@ export const mockTypes = {
     },
   }),
   CustomMetadata: new ObjectType({
-    elemID: new ElemID(SALESFORCE, constants.CUSTOM_METADATA_TYPE_NAME),
+    elemID: new ElemID(SALESFORCE, CUSTOM_METADATA_TYPE_NAME),
     annotations: {
       metadataType: 'CustomMetadata',
       dirName: 'customMetadata',
@@ -753,10 +764,10 @@ export const mockTypes = {
       },
     },
   }),
-  [constants.CPQ_QUOTE_TERM]: CPQ_QUOTE_TERM_TYPE,
-  [constants.CPQ_TERM_CONDITION]: createCustomObjectType(constants.CPQ_TERM_CONDITION, {
+  [CPQ_QUOTE_TERM]: CPQ_QUOTE_TERM_TYPE,
+  [CPQ_TERM_CONDITION]: createCustomObjectType(CPQ_TERM_CONDITION, {
     fields: {
-      [constants.CPQ_QUOTE_TERM]: {
+      [CPQ_QUOTE_TERM]: {
         refType: Types.primitiveDataTypes.Lookup,
         annotations: {
           [FIELD_ANNOTATIONS.QUERYABLE]: true,
@@ -764,7 +775,7 @@ export const mockTypes = {
           [FIELD_ANNOTATIONS.UPDATEABLE]: true,
         },
       },
-      [constants.CPQ_INDEX_FIELD]: {
+      [CPQ_INDEX_FIELD]: {
         refType: BuiltinTypes.NUMBER,
         annotations: {
           [FIELD_ANNOTATIONS.QUERYABLE]: true,


### PR DESCRIPTION
Using retrieve API for fetching settings and moving it to the main fetch code (instead of in a filter).
Gated by the `retrieveSettings` optional feature.

---

_Additional context for reviewer_:
WS diff: https://github.com/salto-io/ariel-small/commit/a719c02cddd0de90510c0fbae7d252aaf70b7731
Leaving improving the deploy code for a later PR, this one is getting pretty big.

---

_Release Notes_: 
_Salesforce_:
* Using the retrieve API for settings which returns slightly different results.

---
_User Notifications_: 
_Salesforce_:
* When enabling the `retrieveSettings` optional feature settings instances will have some slight changes.
