### PR TITLE
SALTO-6900: Removing `remote` from all SF filters

### DIFF
--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -88,7 +88,6 @@ export const WARNING_MESSAGE =
  */
 const filter: FilterCreator = ({ client, config }) => ({
   name: 'addMissingIdsFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -134,7 +134,6 @@ export const WARNING_MESSAGE =
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectAuthorFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -52,7 +52,6 @@ export const WARNING_MESSAGE =
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'dataInstancesAuthorFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
@@ -70,7 +70,6 @@ const setAuthorInformationForInstancesOfType = async ({
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'nestedInstancesAuthorFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -58,7 +58,6 @@ export const WARNING_MESSAGE =
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'sharingRulesAuthorFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
+++ b/packages/salesforce-adapter/src/filters/create_missing_installed_packages_instances.ts
@@ -27,7 +27,6 @@ const createMissingInstalledPackageInstance = (file: FileProperties, installedPa
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'createMissingInstalledPackagesInstancesFilter',
-  remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult | undefined> => {
     if (client === undefined) {
       return

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -434,7 +434,6 @@ const buildCustomObjectPrefixKeyMap = async (elements: Element[]): Promise<Recor
 
 const filter: FilterCreator = ({ client, config }) => ({
   name: 'customObjectInstanceReferencesFilter',
-  remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (client === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_from_soap_describe.ts
@@ -132,7 +132,6 @@ const WARNING_MESSAGE = 'Encountered an error while trying to fetch additional i
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectsFromDescribeFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     filterName: 'describeSObjects',
     warningMessage: WARNING_MESSAGE,

--- a/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_instances.ts
@@ -695,7 +695,6 @@ const createInaccessibleFieldsFetchWarning = (objectType: ObjectType, inaccessib
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customObjectsInstancesFilter',
-  remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (client === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
+++ b/packages/salesforce-adapter/src/filters/custom_settings_filter.ts
@@ -30,7 +30,6 @@ const logInvalidCustomSettings = async (invalidCustomSettings: CustomObjectFetch
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'customSettingsFilter',
-  remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (client === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -24,7 +24,6 @@ export const WARNING_MESSAGE =
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'elementsUrlFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
@@ -120,7 +120,6 @@ const filterCreator: FilterCreator = ({ client, config }) => {
   const valuesToRestoreByElemId: Record<string, ValuesToRestoreOnDeploy> = {}
   return {
     name: 'extendTriggersMetadata',
-    remote: true,
     onFetch: ensureSafeFilterFetch({
       config,
       filterName: 'extendTriggersMetadata',

--- a/packages/salesforce-adapter/src/filters/extra_dependencies.ts
+++ b/packages/salesforce-adapter/src/filters/extra_dependencies.ts
@@ -332,7 +332,6 @@ export const WARNING_MESSAGE =
  */
 const creator: FilterCreator = ({ client, config }) => ({
   name: 'extraDependenciesFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/flows_filter.ts
+++ b/packages/salesforce-adapter/src/filters/flows_filter.ts
@@ -187,7 +187,6 @@ const getFlowInstances = async (
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'flowsFilter',
-  remote: true,
   onFetch: async (elements: Element[]): Promise<FilterResult> => {
     if (client === undefined) {
       return {}

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -151,7 +151,6 @@ export const WARNING_MESSAGE = 'Failed to fetch OrganizationSettings.'
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: FILTER_NAME,
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -46,7 +46,6 @@ export const WARNING_MESSAGE =
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'profilePathsFilter',
-  remote: true,
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,

--- a/packages/salesforce-adapter/src/filters/settings_type.ts
+++ b/packages/salesforce-adapter/src/filters/settings_type.ts
@@ -61,7 +61,6 @@ const getSettingsTypeName = (typeName: string): string => typeName.concat(SETTIN
  */
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: 'settingsFilter',
-  remote: true,
   /**
    * Add all settings types and instances as filter.
    *

--- a/packages/salesforce-adapter/src/filters/standard_value_sets.ts
+++ b/packages/salesforce-adapter/src/filters/standard_value_sets.ts
@@ -199,7 +199,6 @@ export const makeFilter =
     const fieldToRemovedValueSetName = new Map<string, string>()
     return {
       name: 'standardValueSetFilter',
-      remote: true,
       /**
        * Upon fetch, retrieve standard value sets and
        * modify references to them in fetched elements


### PR DESCRIPTION
It's no longer supported.

---

_Additional context for reviewer_
None.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
