### PR TITLE
SALTO-6901: Removing the `generateRefsInProfiles` optional feature

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -192,7 +192,6 @@ salesforce {
 | formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                           |
 | fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact           |
 | fetchProfilesUsingReadApi         | false                  | Use the Salesforce Metadata Read API to fetch Profile instances. This will reduce the accuracy of the data and may result in crashes, but may be needed for debugging |
-| generateRefsInProfiles            | false                  | Generate references from profiles. This will have a significant performance impact, but will provide references from profiles to fields and elements.                 |
 | skipAliases                       | false                  | Do not create aliases for Metadata Elements                                                                                                                           |
 
 ### Limits

--- a/packages/salesforce-adapter/src/additional_references.ts
+++ b/packages/salesforce-adapter/src/additional_references.ts
@@ -97,10 +97,6 @@ const fieldRefsFromProfileOrPermissionSet = async (
   potentialTarget: AdditionOrModificationChange,
 ): Promise<ReferenceMapping[]> => {
   /**
-   * Note: if the adapter config `generateRefsInProfiles` is set then these fields will already contain the correct
-   * references, in which case we will create duplicate references and drop them. We won't crash because we don't
-   * actually look at the content of any field/annotation, only on the keys in the provided profile section.
-   *
    * Note: We use the section keys (as opposed to a field that contains the apiName of the referred entity) because
    * there is no such field in the fieldPermissions section
    */

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -29,7 +29,6 @@ const PREFER_ACTIVE_FLOW_VERSIONS_DEFAULT = false
 
 const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   fetchProfilesUsingReadApi: false,
-  generateRefsInProfiles: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
   extraDependenciesV2: true,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -106,7 +106,6 @@ export type OptionalFeatures = {
   skipAliases?: boolean
   formulaDeps?: boolean
   fetchCustomObjectUsingRetrieveApi?: boolean
-  generateRefsInProfiles?: boolean
   fetchProfilesUsingReadApi?: boolean
   toolingDepsOfCurrentNamespace?: boolean
   useLabelAsAlias?: boolean
@@ -822,7 +821,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
-    generateRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
     fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
     toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },


### PR DESCRIPTION
It isn't used anywhere.

---

_Additional context for reviewer_
None.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
