### PR TITLE
SALTO-6901: Removing `fetchProfilesUsingReadApi` optional feature

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -153,7 +153,7 @@ salesforce {
 
 | Name                                           | Default when undefined  | Description                                                                                                                                                                                                                                    |
 | ---------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [metadata](#metadata-configuration-options)    | Fetch all metdata       | Specified the metadata fetch                                                                                                                                                                                                                   |
+| [metadata](#metadata-configuration-options)    | Fetch all metadata       | Specified the metadata fetch                                                                                                                                                                                                                   |
 | [data](#data-management-configuration-options) | {} (do not manage data) | Data management configuration object names will not be fetched in case they are matched in includeObjects                                                                                                                                      |
 | fetchAllCustomSettings                         | true                    | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option                                                                                        |
 | [optionalFeatures](#optional-features)         | {} (all enabled)        | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved                          |
@@ -191,15 +191,14 @@ salesforce {
 | describeSObjects                  | true                   | Fetch additional information about CustomObjects from the soap API                                                                                                    |
 | formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                           |
 | fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact           |
-| fetchProfilesUsingReadApi         | false                  | Use the Salesforce Metadata Read API to fetch Profile instances. This will reduce the accuracy of the data and may result in crashes, but may be needed for debugging |
 | skipAliases                       | false                  | Do not create aliases for Metadata Elements                                                                                                                           |
 
 ### Limits
 
 | Name                             | Default when undefined | Description                                                        |
 | -------------------------------- | ---------------------- | ------------------------------------------------------------------ |
-| maxExtraDependenciesQuerySize    | 500                    | Max size of each individual request in the extra depencies filter  |
-| maxExtraDependenciesResponseSize | 1950                   | Max size of each individual response in the extra depencies filter |
+| maxExtraDependenciesQuerySize    | 500                    | Max size of each individual request in the extra dependencies filter  |
+| maxExtraDependenciesResponseSize | 1950                   | Max size of each individual response in the extra dependencies filter |
 
 ### Warning settings
 
@@ -253,7 +252,7 @@ salesforce {
 | Name              | Behavior                                                                                          |
 | ----------------- | ------------------------------------------------------------------------------------------------- |
 | "ExcludeInstance" | Do not fetch instances that contain a reference whose target was not fetched                      |
-| "BrokenReference" | Fetch the instance and create Salto references to non-existant targets.                           |
+| "BrokenReference" | Fetch the instance and create Salto references to non-existent targets.                           |
 | "InternalId"      | Fetch the instance and keep the existing field value (the internal ID of the referenced instance) |
 
 #### Object ID settings configuration options
@@ -279,7 +278,7 @@ salesforce {
 | [retry](#client-retry-options)                                | `{}` (no overrides)                                   | Configuration for retrying on errors                                                               |
 | [maxConcurrentApiRequests](#rate-limit-configuration-options) | `{}` (no overrides)                                   | Limits on the number of concurrent requests of different types                                     |
 | [dataRetry](#client-data-retry-options)                       | `{}` (no overrides)                                   | Configuration for retrying on specific errors regarding data objects (for custom object instances) |
-| [readMetadataChunkSize](#read-metadata-chunk-size)            | 10 except for Profile and PermissionSet (which are 1) | Configuration for specifing the size of the chunk in readMetadata                                  |
+| [readMetadataChunkSize](#read-metadata-chunk-size)            | 10 except for Profile and PermissionSet (which are 1) | Configuration for specifying the size of the chunk in readMetadata                                  |
 
 #### Client polling options
 
@@ -300,7 +299,7 @@ salesforce {
 | testLevel          | `NoTestRun` (development) `RunLocalTests` (production) | Specifies which tests are run as part of a deployment. possible values are: `NoTestRun`, `RunSpecifiedTests`, `RunLocalTests` and `RunAllTestsInOrg`                                                                     |
 | runTests           | `[]` (no tests)                                        | A list of Apex tests to run during deployment, must configure `RunSpecifiedTests` in `testLevel` for this option to work                                                                                                 |
 | deleteBeforeUpdate | `false`                                                | If `true`, deploy will make deletions before any other deployed change                                                                                                                                                   |
-| flsProfiles        | `["System Administraor"]`                              | When deploying new CustomFields and CustomObjects, Salto will make them visible to the specified Profiles                                                                                                                |
+| flsProfiles        | `["System Administrator"]`                              | When deploying new CustomFields and CustomObjects, Salto will make them visible to the specified Profiles                                                                                                                |
 
 For more details see the DeployOptions section in the [salesforce documentation of the deploy API](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm)
 

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -557,9 +557,6 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
       // in profiles. If custom objects are fetched via the read API, we have to fetch profiles using that API too.
       _.pull(this.metadataToRetrieve, CUSTOM_OBJECT, PROFILE_METADATA_TYPE)
     }
-    if (fetchProfile.isFeatureEnabled('fetchProfilesUsingReadApi')) {
-      _.pull(this.metadataToRetrieve, PROFILE_METADATA_TYPE)
-    }
     log.debug('going to fetch salesforce account configuration..')
     const fieldTypes = Types.getAllFieldTypes()
     const hardCodedTypes = [

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -28,7 +28,6 @@ type OptionalFeaturesDefaultValues = {
 const PREFER_ACTIVE_FLOW_VERSIONS_DEFAULT = false
 
 const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
-  fetchProfilesUsingReadApi: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
   extraDependenciesV2: true,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -106,7 +106,6 @@ export type OptionalFeatures = {
   skipAliases?: boolean
   formulaDeps?: boolean
   fetchCustomObjectUsingRetrieveApi?: boolean
-  fetchProfilesUsingReadApi?: boolean
   toolingDepsOfCurrentNamespace?: boolean
   useLabelAsAlias?: boolean
   extendedCustomFieldInformation?: boolean
@@ -821,7 +820,6 @@ const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
     skipAliases: { refType: BuiltinTypes.BOOLEAN },
     formulaDeps: { refType: BuiltinTypes.BOOLEAN },
     fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
-    fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
     toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
     useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
     extendedCustomFieldInformation: { refType: BuiltinTypes.BOOLEAN },


### PR DESCRIPTION
It's no longer used and is not tested.
Also fixing a couple of typos.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
_Salesforce_:
* Removing the `fetchProfilesUsingReadApi` optional feature.

---
_User Notifications_: 
None.
