### PR TITLE
CLI changed the fetch fromEnv option to fromEnvironment

### DIFF
--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -257,7 +257,7 @@ type FetchArgs = {
   regenerateSaltoIds: boolean
   regenerateSaltoIdsForSelectors?: string[]
   fromWorkspace?: string
-  fromEnv?: string
+  fromEnvironment?: string
   fromState: boolean
   withChangesDetection?: boolean
 } & AccountsArg &
@@ -280,13 +280,16 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
     regenerateSaltoIds,
     regenerateSaltoIdsForSelectors: regenerateSaltoIdsForSelectorsInput = [],
     fromWorkspace,
-    fromEnv,
+    fromEnvironment,
     fromState,
     withChangesDetection,
   } = input
 
-  if ([fromEnv, fromWorkspace].some(values.isDefined) && ![fromEnv, fromWorkspace].every(values.isDefined)) {
-    errorOutputLine('The fromEnv and fromWorkspace arguments must both be provided.', output)
+  if (
+    [fromEnvironment, fromWorkspace].some(values.isDefined) &&
+    ![fromEnvironment, fromWorkspace].every(values.isDefined)
+  ) {
+    errorOutputLine('The fromEnvironment and fromWorkspace arguments must both be provided.', output)
     outputLine(EOL, output)
     return CliExitCode.UserInputError
   }
@@ -322,8 +325,8 @@ export const action: WorkspaceCommandAction<FetchArgs> = async ({
     cliTelemetry,
     output,
     fetch:
-      fromWorkspace && fromEnv
-        ? createFetchFromWorkspaceCommand(fetchFromWorkspace, fromWorkspace, fromEnv, fromState)
+      fromWorkspace && fromEnvironment
+        ? createFetchFromWorkspaceCommand(fetchFromWorkspace, fromWorkspace, fromEnvironment, fromState)
         : apiFetch,
     getApprovedChanges: cliGetApprovedChanges,
     shouldUpdateConfig: cliShouldUpdateConfig,
@@ -381,10 +384,10 @@ const fetchDef = createWorkspaceCommand({
         type: 'string',
       },
       {
-        name: 'fromEnv',
+        name: 'fromEnvironment',
         alias: 'we',
         required: false,
-        description: 'Fetch the data from another workspace at this path from this env',
+        description: 'Fetch the data from another workspace at this path from this environment',
         type: 'string',
       },
       {

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -766,7 +766,7 @@ describe('fetch command', () => {
               stateOnly: false,
               fromState: false,
               regenerateSaltoIds: false,
-              fromEnv: env,
+              fromEnvironment: env,
               fromWorkspace: sourcePath,
             },
             workspace,
@@ -798,7 +798,7 @@ describe('fetch command', () => {
               stateOnly: false,
               fromState: true,
               regenerateSaltoIds: false,
-              fromEnv: env,
+              fromEnvironment: env,
               fromWorkspace: sourcePath,
             },
             workspace,
@@ -830,7 +830,7 @@ describe('fetch command', () => {
               stateOnly: false,
               fromState: false,
               regenerateSaltoIds: false,
-              fromEnv: 'what*env*er',
+              fromEnvironment: 'what*env*er',
               fromWorkspace: 'where*env*er',
             },
             workspace,
@@ -849,14 +849,14 @@ describe('fetch command', () => {
             stateOnly: false,
             fromState: false,
             regenerateSaltoIds: false,
-            fromEnv: 'what*env*er',
+            fromEnvironment: 'what*env*er',
           },
           workspace,
         })
         expect(retValue).toEqual(CliExitCode.UserInputError)
       })
 
-      it('should return user input error if the from fromWorkspace argument is provided without the from fromEnv argument', async () => {
+      it('should return user input error if the from fromWorkspace argument is provided without the from fromEnvironment argument', async () => {
         const workspace = mocks.mockWorkspace({ uid: 'target' })
         const retValue = await action({
           ...cliCommandArgs,


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
