### PR TITLE
SALTO-6901: Removing the generateRefsInProfiles optional feature

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -153,7 +153,7 @@ salesforce {
 
 | Name                                           | Default when undefined  | Description                                                                                                                                                                                                                                    |
 | ---------------------------------------------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [metadata](#metadata-configuration-options)    | Fetch all metdata       | Specified the metadata fetch                                                                                                                                                                                                                   |
+| [metadata](#metadata-configuration-options)    | Fetch all metadata       | Specified the metadata fetch                                                                                                                                                                                                                   |
 | [data](#data-management-configuration-options) | {} (do not manage data) | Data management configuration object names will not be fetched in case they are matched in includeObjects                                                                                                                                      |
 | fetchAllCustomSettings                         | true                    | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option                                                                                        |
 | [optionalFeatures](#optional-features)         | {} (all enabled)        | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved                          |
@@ -192,15 +192,14 @@ salesforce {
 | formulaDeps                       | true                   | Parse formula fields in custom objects for additional dependencies beyond those provided by the tooling API                                                           |
 | fetchCustomObjectUsingRetrieveApi | true                   | Use the Salesforce Metadata Retrieve API to fetch CustomObjects. This should improve reliability and data accuracy, but may have a small performance impact           |
 | fetchProfilesUsingReadApi         | false                  | Use the Salesforce Metadata Read API to fetch Profile instances. This will reduce the accuracy of the data and may result in crashes, but may be needed for debugging |
-| generateRefsInProfiles            | false                  | Generate references from profiles. This will have a significant performance impact, but will provide references from profiles to fields and elements.                 |
 | skipAliases                       | false                  | Do not create aliases for Metadata Elements                                                                                                                           |
 
 ### Limits
 
 | Name                             | Default when undefined | Description                                                        |
 | -------------------------------- | ---------------------- | ------------------------------------------------------------------ |
-| maxExtraDependenciesQuerySize    | 500                    | Max size of each individual request in the extra depencies filter  |
-| maxExtraDependenciesResponseSize | 1950                   | Max size of each individual response in the extra depencies filter |
+| maxExtraDependenciesQuerySize    | 500                    | Max size of each individual request in the extra dependencies filter  |
+| maxExtraDependenciesResponseSize | 1950                   | Max size of each individual response in the extra dependencies filter |
 
 ### Warning settings
 
@@ -254,7 +253,7 @@ salesforce {
 | Name              | Behavior                                                                                          |
 | ----------------- | ------------------------------------------------------------------------------------------------- |
 | "ExcludeInstance" | Do not fetch instances that contain a reference whose target was not fetched                      |
-| "BrokenReference" | Fetch the instance and create Salto references to non-existant targets.                           |
+| "BrokenReference" | Fetch the instance and create Salto references to non-existent targets.                           |
 | "InternalId"      | Fetch the instance and keep the existing field value (the internal ID of the referenced instance) |
 
 #### Object ID settings configuration options
@@ -280,7 +279,7 @@ salesforce {
 | [retry](#client-retry-options)                                | `{}` (no overrides)                                   | Configuration for retrying on errors                                                               |
 | [maxConcurrentApiRequests](#rate-limit-configuration-options) | `{}` (no overrides)                                   | Limits on the number of concurrent requests of different types                                     |
 | [dataRetry](#client-data-retry-options)                       | `{}` (no overrides)                                   | Configuration for retrying on specific errors regarding data objects (for custom object instances) |
-| [readMetadataChunkSize](#read-metadata-chunk-size)            | 10 except for Profile and PermissionSet (which are 1) | Configuration for specifing the size of the chunk in readMetadata                                  |
+| [readMetadataChunkSize](#read-metadata-chunk-size)            | 10 except for Profile and PermissionSet (which are 1) | Configuration for specifying the size of the chunk in readMetadata                                  |
 
 #### Client polling options
 
@@ -301,7 +300,7 @@ salesforce {
 | testLevel          | `NoTestRun` (development) `RunLocalTests` (production) | Specifies which tests are run as part of a deployment. possible values are: `NoTestRun`, `RunSpecifiedTests`, `RunLocalTests` and `RunAllTestsInOrg`                                                                     |
 | runTests           | `[]` (no tests)                                        | A list of Apex tests to run during deployment, must configure `RunSpecifiedTests` in `testLevel` for this option to work                                                                                                 |
 | deleteBeforeUpdate | `false`                                                | If `true`, deploy will make deletions before any other deployed change                                                                                                                                                   |
-| flsProfiles        | `["System Administraor"]`                              | When deploying new CustomFields and CustomObjects, Salto will make them visible to the specified Profiles                                                                                                                |
+| flsProfiles        | `["System Administrator"]`                              | When deploying new CustomFields and CustomObjects, Salto will make them visible to the specified Profiles                                                                                                                |
 
 For more details see the DeployOptions section in the [salesforce documentation of the deploy API](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_deploy.htm)
 

--- a/packages/salesforce-adapter/src/additional_references.ts
+++ b/packages/salesforce-adapter/src/additional_references.ts
@@ -97,10 +97,6 @@ const fieldRefsFromProfileOrPermissionSet = async (
   potentialTarget: AdditionOrModificationChange,
 ): Promise<ReferenceMapping[]> => {
   /**
-   * Note: if the adapter config `generateRefsInProfiles` is set then these fields will already contain the correct
-   * references, in which case we will create duplicate references and drop them. We won't crash because we don't
-   * actually look at the content of any field/annotation, only on the keys in the provided profile section.
-   *
    * Note: We use the section keys (as opposed to a field that contains the apiName of the referred entity) because
    * there is no such field in the fieldPermissions section
    */

--- a/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/fetch_profile.ts
@@ -29,7 +29,6 @@ const PREFER_ACTIVE_FLOW_VERSIONS_DEFAULT = false
 
 const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   fetchProfilesUsingReadApi: false,
-  generateRefsInProfiles: false,
   skipAliases: false,
   toolingDepsOfCurrentNamespace: false,
   extraDependenciesV2: true,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -95,41 +95,44 @@ export type MetadataParams = {
   objectsToSeperateFieldsToFiles?: string[]
 }
 
+const OPTIONAL_FEATURES = [
+  'extraDependencies',
+  'extraDependenciesV2',
+  'elementsUrls',
+  'profilePaths',
+  'addMissingIds',
+  'authorInformation',
+  'describeSObjects',
+  'skipAliases',
+  'formulaDeps',
+  'fetchCustomObjectUsingRetrieveApi',
+  'fetchProfilesUsingReadApi',
+  'toolingDepsOfCurrentNamespace',
+  'useLabelAsAlias',
+  'extendedCustomFieldInformation',
+  'importantValues',
+  'hideTypesFolder',
+  'omitStandardFieldsNonDeployableValues',
+  'metaTypes',
+  'cpqRulesAndConditionsRefs',
+  'flowCoordinates',
+  'improvedDataBrokenReferences',
+  'taskAndEventCustomFields',
+  'sharingRulesMaps',
+  'excludeNonRetrievedProfilesRelatedInstances',
+  'waveMetadataSupport',
+  'indexedEmailTemplateAttachments',
+  'skipParsingXmlNumbers',
+  'logDiffsFromParsingXmlNumbers',
+  'extendTriggersMetadata',
+  'storeProfilesAndPermissionSetsBrokenPaths',
+  'removeReferenceFromFilterItemToRecordType',
+  'picklistsAsMaps',
+  'lightningPageFieldItemReference',
+] as const
+const DEPRECATED_OPTIONAL_FEATURES = ['generateRefsInProfiles'] as const
 export type OptionalFeatures = {
-  extraDependencies?: boolean
-  extraDependenciesV2?: boolean
-  elementsUrls?: boolean
-  profilePaths?: boolean
-  addMissingIds?: boolean
-  authorInformation?: boolean
-  describeSObjects?: boolean
-  skipAliases?: boolean
-  formulaDeps?: boolean
-  fetchCustomObjectUsingRetrieveApi?: boolean
-  generateRefsInProfiles?: boolean
-  fetchProfilesUsingReadApi?: boolean
-  toolingDepsOfCurrentNamespace?: boolean
-  useLabelAsAlias?: boolean
-  extendedCustomFieldInformation?: boolean
-  importantValues?: boolean
-  hideTypesFolder?: boolean
-  omitStandardFieldsNonDeployableValues?: boolean
-  metaTypes?: boolean
-  cpqRulesAndConditionsRefs?: boolean
-  flowCoordinates?: boolean
-  improvedDataBrokenReferences?: boolean
-  taskAndEventCustomFields?: boolean
-  sharingRulesMaps?: boolean
-  excludeNonRetrievedProfilesRelatedInstances?: boolean
-  waveMetadataSupport?: boolean
-  indexedEmailTemplateAttachments?: boolean
-  skipParsingXmlNumbers?: boolean
-  logDiffsFromParsingXmlNumbers?: boolean
-  extendTriggersMetadata?: boolean
-  storeProfilesAndPermissionSetsBrokenPaths?: boolean
-  removeReferenceFromFilterItemToRecordType?: boolean
-  picklistsAsMaps?: boolean
-  lightningPageFieldItemReference?: boolean
+  [key in (typeof OPTIONAL_FEATURES)[number]]?: boolean
 }
 
 export type ChangeValidatorName =
@@ -809,44 +812,13 @@ const metadataConfigType = createMatchingObjectType<MetadataParams>({
   },
 })
 
-const optionalFeaturesType = createMatchingObjectType<OptionalFeatures>({
+const optionalFeaturesType = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'optionalFeatures'),
-  fields: {
-    extraDependencies: { refType: BuiltinTypes.BOOLEAN },
-    extraDependenciesV2: { refType: BuiltinTypes.BOOLEAN },
-    elementsUrls: { refType: BuiltinTypes.BOOLEAN },
-    profilePaths: { refType: BuiltinTypes.BOOLEAN },
-    addMissingIds: { refType: BuiltinTypes.BOOLEAN },
-    authorInformation: { refType: BuiltinTypes.BOOLEAN },
-    describeSObjects: { refType: BuiltinTypes.BOOLEAN },
-    skipAliases: { refType: BuiltinTypes.BOOLEAN },
-    formulaDeps: { refType: BuiltinTypes.BOOLEAN },
-    fetchCustomObjectUsingRetrieveApi: { refType: BuiltinTypes.BOOLEAN },
-    generateRefsInProfiles: { refType: BuiltinTypes.BOOLEAN },
-    fetchProfilesUsingReadApi: { refType: BuiltinTypes.BOOLEAN },
-    toolingDepsOfCurrentNamespace: { refType: BuiltinTypes.BOOLEAN },
-    useLabelAsAlias: { refType: BuiltinTypes.BOOLEAN },
-    extendedCustomFieldInformation: { refType: BuiltinTypes.BOOLEAN },
-    importantValues: { refType: BuiltinTypes.BOOLEAN },
-    hideTypesFolder: { refType: BuiltinTypes.BOOLEAN },
-    omitStandardFieldsNonDeployableValues: { refType: BuiltinTypes.BOOLEAN },
-    metaTypes: { refType: BuiltinTypes.BOOLEAN },
-    cpqRulesAndConditionsRefs: { refType: BuiltinTypes.BOOLEAN },
-    flowCoordinates: { refType: BuiltinTypes.BOOLEAN },
-    improvedDataBrokenReferences: { refType: BuiltinTypes.BOOLEAN },
-    taskAndEventCustomFields: { refType: BuiltinTypes.BOOLEAN },
-    sharingRulesMaps: { refType: BuiltinTypes.BOOLEAN },
-    excludeNonRetrievedProfilesRelatedInstances: { refType: BuiltinTypes.BOOLEAN },
-    waveMetadataSupport: { refType: BuiltinTypes.BOOLEAN },
-    indexedEmailTemplateAttachments: { refType: BuiltinTypes.BOOLEAN },
-    skipParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
-    logDiffsFromParsingXmlNumbers: { refType: BuiltinTypes.BOOLEAN },
-    extendTriggersMetadata: { refType: BuiltinTypes.BOOLEAN },
-    storeProfilesAndPermissionSetsBrokenPaths: { refType: BuiltinTypes.BOOLEAN },
-    removeReferenceFromFilterItemToRecordType: { refType: BuiltinTypes.BOOLEAN },
-    picklistsAsMaps: { refType: BuiltinTypes.BOOLEAN },
-    lightningPageFieldItemReference: { refType: BuiltinTypes.BOOLEAN },
-  },
+  fields: Object.fromEntries(
+    (OPTIONAL_FEATURES as readonly string[])
+      .concat(DEPRECATED_OPTIONAL_FEATURES)
+      .map(name => [name, { refType: BuiltinTypes.BOOLEAN }]),
+  ),
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },


### PR DESCRIPTION
Also adding a new deprecated optional features list to allow removing old optional features without breaking user configurations.
Also fixed some typos while we're here.

---

_Additional context for reviewer_
None.

---
_Release Notes_: 
None.

---
_User Notifications_: 
None.
