### PR TITLE
SALTO-6845: (Bugfix) Salesforce `picklistAsMaps` feature does not work for environments with CPQ

### DIFF
--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -16,7 +16,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     : undefined,
   coverageThreshold: {
     global: {
-      branches: 87.53,
+      branches: 87.50,
       functions: 94,
       lines: 95,
       statements: 95,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -23,9 +23,13 @@ import {
   PartialFetchData,
   Element,
   isInstanceElement,
+  Field,
+  isField,
+  isObjectType,
+  TypeReference,
 } from '@salto-io/adapter-api'
-import { filter, inspectValue, logDuration, safeJsonStringify } from '@salto-io/adapter-utils'
-import { resolveChangeElement, restoreChangeElement } from '@salto-io/adapter-components'
+import { filter, inspectValue, logDuration, ResolveValuesFunc, safeJsonStringify } from '@salto-io/adapter-utils'
+import { resolveChangeElement, resolveValues, restoreChangeElement } from '@salto-io/adapter-components'
 import { MetadataObject } from '@salto-io/jsforce'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
@@ -201,6 +205,7 @@ export const allFilters: Array<FilterCreator> = [
   emailTemplateFilter,
   // standardValueSetFilter should run before convertMapsFilter
   standardValueSetFilter,
+  cpqLookupFieldsFilter,
   // convertMapsFilter should run before profile fieldReferencesFilter
   convertMapsFilter,
   // picklistReferences should run after convertMapsFilter and before fieldReferencesFilter
@@ -209,7 +214,6 @@ export const allFilters: Array<FilterCreator> = [
   customObjectInstanceReferencesFilter,
   cpqReferencableFieldReferencesFilter,
   cpqCustomScriptFilter,
-  cpqLookupFieldsFilter,
   // cpqRulesAndConditionsFilter depends on cpqReferencableFieldReferencesFilter
   cpqRulesAndConditionsRefsFilter,
   animationRulesFilter,
@@ -430,6 +434,40 @@ const getIncludedTypesFromElementsSource = async (
 type CreateFiltersRunnerParams = {
   fetchProfile: FetchProfile
   contextOverrides?: Partial<FilterContext>
+}
+
+const isOrderedMapTypeOrRefType = (typeRef: TypeElement | TypeReference): boolean =>
+  typeRef.elemID.name.startsWith('OrderedMap<')
+
+const isFieldWithOrderedMapAnnotation = (field: Field): boolean =>
+  Object.values(field.getTypeSync().annotationRefTypes).some(isOrderedMapTypeOrRefType)
+
+const isElementWithOrderedMap = (element: Element): boolean => {
+  if (isField(element)) {
+    return isFieldWithOrderedMapAnnotation(element)
+  }
+  if (isInstanceElement(element)) {
+    return Object.values(element.getTypeSync().fields).some(field => isOrderedMapTypeOrRefType(field.getTypeSync()))
+  }
+  if (isObjectType(element)) {
+    return Object.values(element.fields).some(isFieldWithOrderedMapAnnotation)
+  }
+  return false
+}
+
+export const salesforceAdapterResolveValues: ResolveValuesFunc = async (
+  element,
+  getLookUpNameFunc,
+  elementsSource,
+  allowEmpty = true,
+) => {
+  const resolvedElement = await resolveValues(element, getLookUpNameFunc, elementsSource, allowEmpty)
+  // Since OrderedMaps' order values reference values that may contain references, we should resolve the Element twice
+  // in order to fully resolve it. An example use-case for this is the Field `SBQQ__ProductRule__c.SBQQ__LookupObject__c`
+  // Where the `fullName` of the Picklist values is a Reference to a Custom Object.
+  return isElementWithOrderedMap(resolvedElement)
+    ? resolveValues(resolvedElement, getLookUpNameFunc, elementsSource, allowEmpty)
+    : resolvedElement
 }
 
 type SalesforceAdapterOperations = Omit<AdapterOperations, 'deploy' | 'validate'> & {
@@ -672,7 +710,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
       ? getLookupNameForDataInstances(fetchProfile)
       : getLookUpName(fetchProfile)
     const resolvedChanges = await awu(changeGroup.changes)
-      .map(change => resolveChangeElement(change, getLookupNameFunc))
+      .map(change => resolveChangeElement(change, getLookupNameFunc, salesforceAdapterResolveValues))
       .toArray()
 
     await awu(resolvedChanges).filter(isAdditionChange).map(getChangeData).forEach(addDefaults)

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -628,8 +628,9 @@ const filter: FilterCreator = ({ config }) => ({
     })
 
     const fields = elements.filter(isObjectType).flatMap(obj => Object.values(obj.fields))
+    const primitiveTypesByName = _.keyBy(elements.filter(isPrimitiveType), e => e.elemID.name)
     await awu(Object.entries(annotationDefsByType)).forEach(async ([fieldTypeName, annotationToMapDef]) => {
-      const fieldType = elements.filter(isPrimitiveType).find(e => e.elemID.name === fieldTypeName)
+      const fieldType = primitiveTypesByName[fieldTypeName]
       if (fieldType === undefined) {
         log.warn('Cannot find PrimitiveType %s. Skipping converting Fields of this type to maps', fieldTypeName)
         return

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -118,7 +118,9 @@ const isMapperInput = (val: unknown): val is MapperInput =>
   _.isString(val) || isResolvedReferenceExpressionToElement(val)
 
 export const defaultMapper: MapperFunc = val =>
-  (_.isString(val) ? val : apiNameSync(val.value) ?? '').split(API_NAME_SEPARATOR).map(v => naclCase(v))
+  stringifyMapperInput(val)
+    .split(API_NAME_SEPARATOR)
+    .map(v => naclCase(v))
 
 /**
  * Convert a string value of a file path to the map index key.

--- a/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
+++ b/packages/salesforce-adapter/src/filters/cpq/lookup_fields.ts
@@ -45,6 +45,7 @@ import {
   CPQ_DISCOUNT_SCHEDULE,
   API_NAME_SEPARATOR,
 } from '../../constants'
+import { apiNameSync } from '../utils'
 
 const { awu } = collections.asynciterable
 
@@ -142,16 +143,12 @@ const transformObjectLookupValueSetFullNames = async (
   ) => ReferenceExpression | string | undefined,
 ): Promise<ObjectType> => {
   const lookupFields = await getLookupFields(object)
-  lookupFields.forEach(field => transformLookupValueSetFullNames(field, transformFullNameFn))
+  await awu(lookupFields).forEach(field => transformLookupValueSetFullNames(field, transformFullNameFn))
   return object
 }
 
 const replaceLookupObjectValueSetValuesWithReferences = async (customObjects: ObjectType[]): Promise<void> => {
-  const apiNameToCustomObject = Object.fromEntries(
-    await awu(customObjects)
-      .map(async object => [await apiName(object), object])
-      .toArray(),
-  )
+  const apiNameToCustomObject = _.keyBy(customObjects, customObject => apiNameSync(customObject) ?? '')
   const relevantObjects = await awu(customObjects)
     .filter(async object => Object.keys(LOOKUP_FIELDS).includes(await apiName(object)))
     .toArray()
@@ -170,9 +167,9 @@ const replaceLookupObjectValueSetValuesWithReferences = async (customObjects: Ob
     const elementToRef = isCustomFieldLookupDef(lookupDef)
       ? apiNameToCustomObject[lookupDef.objectContext]?.fields[mappedFullName]
       : apiNameToCustomObject[mappedFullName]
-    return elementToRef !== undefined ? new ReferenceExpression(elementToRef.elemID) : fullName
+    return elementToRef !== undefined ? new ReferenceExpression(elementToRef.elemID, elementToRef) : fullName
   }
-  relevantObjects.forEach(object => transformObjectLookupValueSetFullNames(object, transformFullNameToRef))
+  await awu(relevantObjects).forEach(object => transformObjectLookupValueSetFullNames(object, transformFullNameToRef))
 }
 
 const transformFullNameToApiName = (

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -770,7 +770,7 @@ describe('Convert maps filter', () => {
         },
       })
 
-      elements = [myCustomObj]
+      elements = [myCustomObj, picklistType, multiselectPicklistType]
       filter = filterCreator({
         config: {
           ...defaultFilterContext,
@@ -790,6 +790,7 @@ describe('Convert maps filter', () => {
         expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
         expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
         expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
+        expect(picklistType.annotationRefTypes.valueSet?.elemID.name).toEqual('OrderedMap<valueSet>')
       })
 
       it('should convert MultiselectPicklist valueSet type to ordered map', async () => {
@@ -798,6 +799,7 @@ describe('Convert maps filter', () => {
         expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
         expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
         expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
+        expect(multiselectPicklistType.annotationRefTypes.valueSet?.elemID.name).toEqual('OrderedMap<valueSet>')
       })
 
       it('should convert annotation value to map (Picklist)', () => {
@@ -821,7 +823,7 @@ describe('Convert maps filter', () => {
       let changes: Change[]
       beforeEach(async () => {
         // This fetch will convert the Picklist valueSet type to OrderedMap
-        await filter.onFetch([myCustomObj])
+        await filter.onFetch([myCustomObj, picklistType, multiselectPicklistType])
         changes = [toChange({ after: myCustomObj })]
         await filter.preDeploy(changes)
       })

--- a/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
+++ b/packages/salesforce-adapter/test/filters/cpq/lookup_fields.test.ts
@@ -192,7 +192,7 @@ describe('lookup_object filter', () => {
         const lookupObjetField = (mockProductElm as ObjectType).fields[CPQ_LOOKUP_OBJECT_NAME]
         expect(lookupObjetField).toBeDefined()
         expect(lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName).toEqual(
-          new ReferenceExpression(mockObjectElemID),
+          new ReferenceExpression(mockObjectElemID, mockObject),
         )
         expect(lookupObjetField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName).toEqual('nonExistingObject')
       })
@@ -206,10 +206,10 @@ describe('lookup_object filter', () => {
         const defaultObjectField = (mockConfigurationAttr as ObjectType).fields[CPQ_DEFAULT_OBJECT_FIELD]
         expect(defaultObjectField).toBeDefined()
         expect(defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName).toEqual(
-          new ReferenceExpression(mockQuoteElemID),
+          new ReferenceExpression(mockQuoteElemID, mockQuote),
         )
         expect(defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName).toEqual(
-          new ReferenceExpression(mockObjectElemID),
+          new ReferenceExpression(mockObjectElemID, mockObject),
         )
         expect(defaultObjectField.annotations[FIELD_ANNOTATIONS.VALUE_SET][2].fullName).toEqual('nonExistingObject')
       })
@@ -223,10 +223,10 @@ describe('lookup_object filter', () => {
         const constraintFieldField = (priceScheduling as ObjectType).fields[CPQ_CONSTRAINT_FIELD]
         expect(constraintFieldField).toBeDefined()
         expect(constraintFieldField.annotations[FIELD_ANNOTATIONS.VALUE_SET][0].fullName).toEqual(
-          new ReferenceExpression(mockQuote.fields[CPQ_ACCOUNT].elemID),
+          new ReferenceExpression(mockQuote.fields[CPQ_ACCOUNT].elemID, mockQuote.fields[CPQ_ACCOUNT]),
         )
         expect(constraintFieldField.annotations[FIELD_ANNOTATIONS.VALUE_SET][1].fullName).toEqual(
-          new ReferenceExpression(mockQuote.fields[existingFieldName].elemID),
+          new ReferenceExpression(mockQuote.fields[existingFieldName].elemID, mockQuote.fields[existingFieldName]),
         )
         expect(constraintFieldField.annotations[FIELD_ANNOTATIONS.VALUE_SET][2].fullName).toEqual('nonExistingField')
       })

--- a/packages/salesforce-adapter/test/resolve_changes.test.ts
+++ b/packages/salesforce-adapter/test/resolve_changes.test.ts
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  BuiltinTypes,
+  ElemID,
+  Field,
+  getChangeData,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  toChange,
+} from '@salto-io/adapter-api'
+import { resolveChangeElement } from '@salto-io/adapter-components'
+import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { SALESFORCE } from '../src/constants'
+import { createOrderedMapType } from '../src/filters/convert_maps'
+import { mockTypes } from './mock_elements'
+import { salesforceAdapterResolveValues } from '../src/adapter'
+
+import { getLookUpName } from '../src/transformers/reference_mapping'
+import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
+
+describe('Resolve Salesforce Changes', () => {
+  let getLookupNameFunc: GetLookupNameFunc
+  beforeEach(() => {
+    getLookupNameFunc = getLookUpName(buildFetchProfile({ fetchParams: {} }))
+  })
+  describe('Elements with OrderedMaps', () => {
+    const ORDERED_MAP_FIELD_NAME = 'orderedMapField'
+    const EXPECTED_RESOLVED_VALUE = { stringValue: 'Product2' } as const
+
+    let orderedMapType: ObjectType
+    let fieldType: ObjectType
+    let field: Field
+    let orderedMapFieldValue: {
+      values: Record<string, { stringValue: ReferenceExpression }>
+      order: ReferenceExpression[]
+    }
+    beforeEach(() => {
+      const innerType = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'InnerType'),
+        fields: {
+          stringValue: { refType: BuiltinTypes.STRING },
+        },
+      })
+      orderedMapType = createOrderedMapType(innerType)
+      fieldType = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'FieldType'),
+        annotationRefsOrTypes: {
+          [ORDERED_MAP_FIELD_NAME]: orderedMapType,
+        },
+      })
+      const valueToResolve = { stringValue: new ReferenceExpression(mockTypes.Product2.elemID, mockTypes.Product2) }
+      orderedMapFieldValue = {
+        values: {
+          Product2: valueToResolve,
+        },
+        order: [new ReferenceExpression(new ElemID(SALESFORCE, 'RefToValue'), valueToResolve)],
+      }
+      field = new Field(mockTypes.Account, 'testField', fieldType, {
+        [ORDERED_MAP_FIELD_NAME]: orderedMapFieldValue,
+      })
+    })
+    describe('Field Change', () => {
+      it('should resolve both the values and order values', async () => {
+        const resolvedField = getChangeData(
+          await resolveChangeElement(toChange({ after: field }), getLookupNameFunc, salesforceAdapterResolveValues),
+        )
+        expect(resolvedField.annotations[ORDERED_MAP_FIELD_NAME]).toEqual({
+          values: { Product2: EXPECTED_RESOLVED_VALUE },
+          order: [EXPECTED_RESOLVED_VALUE],
+        })
+      })
+    })
+    describe('ObjectType Change', () => {
+      let objectType: ObjectType
+      beforeEach(() => {
+        objectType = mockTypes.Account.clone()
+        objectType.fields.testField = field
+      })
+      it('should resolve both the values and order values', async () => {
+        const resolvedObject = getChangeData(
+          await resolveChangeElement(
+            toChange({ after: objectType }),
+            getLookupNameFunc,
+            salesforceAdapterResolveValues,
+          ),
+        )
+        expect(resolvedObject.fields.testField.annotations[ORDERED_MAP_FIELD_NAME]).toEqual({
+          values: { Product2: EXPECTED_RESOLVED_VALUE },
+          order: [EXPECTED_RESOLVED_VALUE],
+        })
+      })
+    })
+    describe('InstanceElement Change', () => {
+      let instance: InstanceElement
+      beforeEach(() => {
+        const instanceType = new ObjectType({
+          elemID: new ElemID(SALESFORCE, 'InstanceType'),
+          fields: {
+            [ORDERED_MAP_FIELD_NAME]: { refType: orderedMapType },
+          },
+        })
+        instance = new InstanceElement('testInstance', instanceType, {
+          [ORDERED_MAP_FIELD_NAME]: orderedMapFieldValue,
+        })
+      })
+      it('should resolve both the values and order values', async () => {
+        const resolvedInstance = getChangeData(
+          await resolveChangeElement(toChange({ after: instance }), getLookupNameFunc, salesforceAdapterResolveValues),
+        )
+        expect(resolvedInstance.value[ORDERED_MAP_FIELD_NAME]).toEqual({
+          values: { Product2: EXPECTED_RESOLVED_VALUE },
+          order: [EXPECTED_RESOLVED_VALUE],
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
(Bugfix) Salesforce picklistAsMaps feature does not work for environments with CPQ 

---

For environments that manage CPQ metadata, turning on the `picklistAsMaps` feature makes fetch fail violently. This PR exposes two issues in the adapter:

1. `convert_maps` filter should be able to key-by `ReferenceExpression` value.
2. If `OrderedMap` order value references value with unresolved references, the Element won't be fully resolved.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_