### PR TITLE
SALTO-1132: Removed extra '\n' from init command response

### DIFF
--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -91,15 +91,14 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static initFailed(msg: string): string {
-    return `Could not initiate workspace: ${msg}\n`
+    return `Could not initiate workspace: ${msg}`
   }
 
   private static readonly ACCOUNT_ADD_HELP = 'Use `salto account add <service-name>` to add accounts to the environment'
 
   public static initCompleted(): string {
     return `Initiated empty workspace
-${Prompts.ACCOUNT_ADD_HELP}
-`
+${Prompts.ACCOUNT_ADD_HELP}`
   }
 
   public static readonly FETCH_HEADER = 'Fetching and applying changes from the account(s)'

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -68,6 +68,9 @@ describe('init command', () => {
         input: {},
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
+      expect(output.stdout.content).toContain(
+        'Initiated empty workspace\nUse `salto account add <service-name>` to add accounts to the environment',
+      )
       expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.success, 1, expect.objectContaining({}))
@@ -94,6 +97,9 @@ describe('init command', () => {
         },
       })
       expect(output.stdout.content.includes('Initiated')).toBeTruthy()
+      expect(output.stdout.content).toContain(
+        'Initiated empty workspace\nUse `salto account add <service-name>` to add accounts to the environment',
+      )
       expect(telemetry.sendCountEvent).toHaveBeenCalledTimes(2)
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.start, 1, expect.objectContaining({}))
       expect(telemetry.sendCountEvent).toHaveBeenCalledWith(eventsNames.success, 1, expect.objectContaining({}))

--- a/packages/cli/test/commands/init.test.ts
+++ b/packages/cli/test/commands/init.test.ts
@@ -120,7 +120,7 @@ describe('init command', () => {
       ...cliCommandArgs,
       input: {},
     })
-    expect(output.stderr.content).toEqual(`Could not initiate workspace: existing salto workspace in ${path}\n\n`)
+    expect(output.stderr.content).toEqual(`Could not initiate workspace: existing salto workspace in ${path}\n`)
     expect(output.stdout.content).toEqual('')
   })
 })


### PR DESCRIPTION
SALTO-1132: Removed extra '\n' from init command response

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_