### PR TITLE
SALTO-6867 Update infra to have a data field instead of body field

### DIFF
--- a/packages/adapter-components/src/definitions/system/requests/types.ts
+++ b/packages/adapter-components/src/definitions/system/requests/types.ts
@@ -34,7 +34,7 @@ export type RequestArgs = {
     omitEmpty?: boolean
   }
   // TODO support x-www-form-urlencoded + URLSearchParams
-  body?: unknown
+  data?: unknown
 }
 
 export type PollingArgs = {

--- a/packages/adapter-components/src/fetch/request/requester.ts
+++ b/packages/adapter-components/src/fetch/request/requester.ts
@@ -143,8 +143,8 @@ export const getRequester = <Options extends APIDefinitionsOptions>({
         typeName,
       )
 
-    const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'body', 'params', 'queryParamsSerializer'])
-    const callArgs = mergedEndpointDef.omitBody ? _.omit(allCallArgs, 'body') : allCallArgs
+    const allCallArgs = _.pick(mergedEndpointDef, ['queryArgs', 'headers', 'data', 'params', 'queryParamsSerializer'])
+    const callArgs = mergedEndpointDef.omitBody ? _.omit(allCallArgs, 'data') : allCallArgs
 
     log.trace(
       'traversing pages for adapter %s client %s endpoint %s.%s',

--- a/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
+++ b/packages/adapter-components/test/fetch/request/pagination/pagination.test.ts
@@ -85,14 +85,14 @@ describe('pagination', () => {
           funcCreator: paginationFuncCreator,
         },
         callArgs: {
-          body: { something: 'SOMETHING' },
+          data: { something: 'SOMETHING' },
         },
         contexts: [],
       })
       expect(result).toEqual([{ context: {}, pages: [{ a: 'a' }] }])
       expect(paginationFunc).toHaveBeenCalledTimes(1)
       expect(client.post).toHaveBeenCalledTimes(1)
-      expect(client.post).toHaveBeenCalledWith({ url: '/ep', body: { something: 'SOMETHING' } })
+      expect(client.post).toHaveBeenCalledWith({ url: '/ep', data: { something: 'SOMETHING' } })
     })
     it('should pass query args in all requests', async () => {
       paginationFunc


### PR DESCRIPTION
The current `body` field does not pass well in POST methods on fetch definitions (`sendRequest` expects a `data` field).

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
