### PR TITLE
SALTO-6905 Update trigger skill priorities

### DIFF
--- a/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
@@ -14,7 +14,13 @@ import _ from 'lodash'
 const log = logger(module)
 
 export const TRIGGER_SKILL_FIELDS = ['add_skills', 'set_skills']
-const SKILL_WITH_PRIORITY_PATTERN = /^([a-zA-Z0-9-]+)#([01])$/ // the regex is a uuid followed by a priority number
+const SKILL_WITH_PRIORITY_PATTERN = /^([a-zA-Z0-9-]+)#([0123])$/ // the regex is a uuid followed by a priority number
+const PRIORITY_NAMES: { [key: string]: string } = {
+  '0': 'required',
+  '1': 'optional high',
+  '2': 'optional medium',
+  '3': 'optional low',
+}
 
 // This transformer parses skill priority in trigger actions.
 // See https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/
@@ -36,7 +42,7 @@ export const transform: definitions.AdjustFunctionSingle = async ({ value }) => 
           return {
             ...action,
             value: skillWithPriority[1],
-            priority: skillWithPriority[2] === '1' ? 'optional' : 'required',
+            priority: PRIORITY_NAMES[skillWithPriority[2]],
           }
         }
         if (!skillValue.match(/^[a-zA-Z0-9-]+$/)) {

--- a/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/transforms/trigger_adjuster.ts
@@ -15,7 +15,7 @@ const log = logger(module)
 
 export const TRIGGER_SKILL_FIELDS = ['add_skills', 'set_skills']
 const SKILL_WITH_PRIORITY_PATTERN = /^([a-zA-Z0-9-]+)#([0123])$/ // the regex is a uuid followed by a priority number
-const PRIORITY_NAMES: { [key: string]: string } = {
+export const PRIORITY_NAMES: { [key: string]: string } = {
   '0': 'required',
   '1': 'optional high',
   '2': 'optional medium',

--- a/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
+++ b/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
@@ -38,7 +38,15 @@ describe('trigger_adjuster', () => {
           },
           {
             field: 'set_skills',
-            value: 'optionalSkill#1',
+            value: 'optionalSkillHigh#1',
+          },
+          {
+            field: 'set_skills',
+            value: 'optionalSkillMedium#2',
+          },
+          {
+            field: 'set_skills',
+            value: 'optionalSkillLow#3',
           },
         ],
       }
@@ -53,8 +61,18 @@ describe('trigger_adjuster', () => {
             },
             {
               field: 'set_skills',
-              value: 'optionalSkill',
-              priority: 'optional',
+              value: 'optionalSkillHigh',
+              priority: 'optional high',
+            },
+            {
+              field: 'set_skills',
+              value: 'optionalSkillMedium',
+              priority: 'optional medium',
+            },
+            {
+              field: 'set_skills',
+              value: 'optionalSkillLow',
+              priority: 'optional low',
             },
           ],
         },
@@ -105,7 +123,7 @@ describe('trigger_adjuster', () => {
       actions: [
         {
           field: 'add_skills',
-          value: 'invalid#3',
+          value: 'invalid#4',
         },
       ],
     }
@@ -118,14 +136,14 @@ describe('trigger_adjuster', () => {
         actions: [
           {
             field: 'add_skills',
-            value: 'invalid#3',
+            value: 'invalid#4',
           },
         ],
       },
     })
     expect(logWarn).toHaveBeenCalledWith(
       'For trigger invalidTrigger - Failed to parse skill value with priority: %s',
-      'invalid#3',
+      'invalid#4',
     )
   })
 })

--- a/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
+++ b/packages/zendesk-adapter/test/definitions/fetch/transforms/trigger_adjuster.test.ts
@@ -79,6 +79,29 @@ describe('trigger_adjuster', () => {
       })
     })
 
+    it('should transform trigger item with a number as a priority that does not match skill priority', async () => {
+      const value = {
+        actions: [
+          {
+            field: 'add_skills',
+            value: 'skillWithLargePriority#44',
+          },
+        ],
+      }
+      const transformedItem = await transformTriggerItem({ value, context: {}, typeName: 'trigger' })
+      expect(transformedItem).toEqual({
+        value: {
+          actions: [
+            {
+              field: 'add_skills',
+              value: 'skillWithLargePriority',
+              priority: 'unknown_44',
+            },
+          ],
+        },
+      })
+    })
+
     it('should transform trigger item with mixed skill priority and non-priority skills', async () => {
       const value = {
         actions: [
@@ -123,7 +146,7 @@ describe('trigger_adjuster', () => {
       actions: [
         {
           field: 'add_skills',
-          value: 'invalid#4',
+          value: 'invalidWithABang!@?',
         },
       ],
     }
@@ -136,14 +159,14 @@ describe('trigger_adjuster', () => {
         actions: [
           {
             field: 'add_skills',
-            value: 'invalid#4',
+            value: 'invalidWithABang!@?',
           },
         ],
       },
     })
     expect(logWarn).toHaveBeenCalledWith(
       'For trigger invalidTrigger - Failed to parse skill value with priority: %s',
-      'invalid#4',
+      'invalidWithABang!@?',
     )
   })
 })

--- a/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
+++ b/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
@@ -19,8 +19,11 @@ const triggerInstance = new InstanceElement('instance', triggerType, {
   actions: [
     { field: 'set_skills', value: 'wakeBoarding', priority: 'required' },
     { field: 'no_skills_needed', value: 'breathing', priority: 'required' },
-    { field: 'add_skills', value: 'tyingShoes', priority: 'optional' },
+    { field: 'add_skills', value: 'tyingShoes', priority: 'optional high' },
     { field: 'always_fun', value: 'livingWithoutPriority' },
+    { field: 'add_skills', value: 'scubaDiving', priority: 'optional medium' },
+    { field: 'add_skills', value: 'cheeseMaking', priority: 'optional low' },
+    { field: 'set_skills', value: 'previousVersion', priority: 'optional' },
   ],
 })
 
@@ -40,6 +43,9 @@ describe('deploy trigger skills filter', () => {
         { field: 'no_skills_needed', value: 'breathing', priority: 'required' },
         { field: 'add_skills', value: 'tyingShoes#1' },
         { field: 'always_fun', value: 'livingWithoutPriority' },
+        { field: 'add_skills', value: 'scubaDiving#2' },
+        { field: 'add_skills', value: 'cheeseMaking#3' },
+        { field: 'set_skills', value: 'previousVersion#1' },
       ])
     })
   })

--- a/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
+++ b/packages/zendesk-adapter/test/filters/deploy_trigger_skills.test.ts
@@ -24,6 +24,8 @@ const triggerInstance = new InstanceElement('instance', triggerType, {
     { field: 'add_skills', value: 'scubaDiving', priority: 'optional medium' },
     { field: 'add_skills', value: 'cheeseMaking', priority: 'optional low' },
     { field: 'set_skills', value: 'previousVersion', priority: 'optional' },
+    { field: 'set_skills', value: 'isItReallyASkill', priority: 'unknown_12' },
+    { field: 'set_skills', value: 'thisIsActuallyAn', priority: 'invalidCase' },
   ],
 })
 
@@ -46,6 +48,8 @@ describe('deploy trigger skills filter', () => {
         { field: 'add_skills', value: 'scubaDiving#2' },
         { field: 'add_skills', value: 'cheeseMaking#3' },
         { field: 'set_skills', value: 'previousVersion#1' },
+        { field: 'set_skills', value: 'isItReallyASkill#12' },
+        { field: 'set_skills', value: 'thisIsActuallyAn#invalidCase' },
       ])
     })
   })


### PR DESCRIPTION
Update support for trigger priorities according to https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Zendesk Adapter:_
* Trigger skill priorities will change from `optional` to `optional high` as per  https://developer.zendesk.com/documentation/ticketing/using-the-zendesk-api/setting-skill-priority-with-skills-in-trigger-action/
