### PR TITLE
SALTO-6818: Making less assumptions in custom objects to object type

### DIFF
--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -36,7 +36,14 @@ import {
   toServiceIdsString,
   OBJECT_SERVICE_ID,
 } from '@salto-io/adapter-api'
-import { findObjectType, transformValues, getParents, pathNaclCase, naclCase } from '@salto-io/adapter-utils'
+import {
+  findObjectType,
+  transformValues,
+  getParents,
+  pathNaclCase,
+  naclCase,
+  inspectValue,
+} from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import {
   API_NAME,
@@ -409,7 +416,7 @@ const createNestedMetadataInstances = (
     .flatMap(([name, type]) => {
       const nestedInstancesValues = makeArray(instance.value[name])
       if (_.isEmpty(nestedInstancesValues)) {
-        return [] as InstanceElement[]
+        return []
       }
       const removeDuplicateInstances = (instances: Values[]): Values[] =>
         _(instances).keyBy(INSTANCE_FULL_NAME_FIELD).values().value()
@@ -424,7 +431,7 @@ const createNestedMetadataInstances = (
         const instanceFileName = pathNaclCase(instanceName)
         const typeFolderName = pathNaclCase(nestedMetadataTypeToReplaceDirName[type.elemID.name] ?? type.elemID.name)
         nestedInstanceValues[INSTANCE_FULL_NAME_FIELD] = fullName
-        const path = [...(objectType.path as string[]).slice(0, -1), typeFolderName, instanceFileName]
+        const path = [...(objectType.path ?? []).slice(0, -1), typeFolderName, instanceFileName]
         return new InstanceElement(instanceName, type, nestedInstanceValues, path, {
           [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(objectType.elemID, objectType)],
         })
@@ -828,20 +835,35 @@ const isSideEffectRemoval =
 
 const typesToMergeFromInstance = async (elements: Element[]): Promise<TypesFromInstance> => {
   const fixTypesDefinitions = (typesFromInstance: TypeMap): void => {
-    const listViewType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.LIST_VIEWS] as ObjectType
+    const listViewType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.LIST_VIEWS]
+    if (!isObjectType(listViewType)) {
+      log.error('Expected list view to be an object type, got: %s', inspectValue(listViewType))
+      return
+    }
     listViewType.fields.columns.refType = createRefToElmWithValue(toListType(listViewType.fields.columns.getTypeSync()))
     listViewType.fields.filters.refType = createRefToElmWithValue(toListType(listViewType.fields.filters.getTypeSync()))
-    const fieldSetType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.FIELD_SETS] as ObjectType
+
+    const fieldSetType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.FIELD_SETS]
+    if (!isObjectType(fieldSetType)) {
+      log.error('Expected field set to be an object type, got: %s', inspectValue(listViewType))
+      return
+    }
     fieldSetType.fields.availableFields.refType = createRefToElmWithValue(
       toListType(fieldSetType.fields.availableFields.getTypeSync()),
     )
     fieldSetType.fields.displayedFields.refType = createRefToElmWithValue(
       toListType(fieldSetType.fields.displayedFields.getTypeSync()),
     )
-    const compactLayoutType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.COMPACT_LAYOUTS] as ObjectType
+
+    const compactLayoutType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.COMPACT_LAYOUTS]
+    if (!isObjectType(compactLayoutType)) {
+      log.error('Expected compact layout to be an object type, got: %s', inspectValue(listViewType))
+      return
+    }
     compactLayoutType.fields.fields.refType = createRefToElmWithValue(
       toListType(compactLayoutType.fields.fields.getTypeSync()),
     )
+
     // internalId is also the name of a field on the custom object instances, therefore
     // we override it here to have the right type for the annotation.
     // we don't want to use HIDDEN_STRING as the type for the field because on fields
@@ -970,7 +992,7 @@ const filterCreator: FilterCreator = ({ config, client }) => {
       // We only want to perform side effect removals when deploying to the service.
       if (client !== undefined) {
         const sideEffectRemovalsByObject = await groupByAsync(
-          (await awu(changes).filter(isSideEffectRemoval(removedCustomObjectNames)).toArray()) as Change[],
+          await awu(changes).filter(isSideEffectRemoval(removedCustomObjectNames)).toArray(),
           async c => (await getParentCustomObjectName(c)) ?? '',
         )
 

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -836,33 +836,37 @@ const isSideEffectRemoval =
 const typesToMergeFromInstance = async (elements: Element[]): Promise<TypesFromInstance> => {
   const fixTypesDefinitions = (typesFromInstance: TypeMap): void => {
     const listViewType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.LIST_VIEWS]
-    if (!isObjectType(listViewType)) {
+    if (isObjectType(listViewType)) {
+      listViewType.fields.columns.refType = createRefToElmWithValue(
+        toListType(listViewType.fields.columns.getTypeSync()),
+      )
+      listViewType.fields.filters.refType = createRefToElmWithValue(
+        toListType(listViewType.fields.filters.getTypeSync()),
+      )
+    } else {
       log.error('Expected list view to be an object type, got: %s', inspectValue(listViewType))
-      return
     }
-    listViewType.fields.columns.refType = createRefToElmWithValue(toListType(listViewType.fields.columns.getTypeSync()))
-    listViewType.fields.filters.refType = createRefToElmWithValue(toListType(listViewType.fields.filters.getTypeSync()))
 
     const fieldSetType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.FIELD_SETS]
-    if (!isObjectType(fieldSetType)) {
+    if (isObjectType(fieldSetType)) {
+      fieldSetType.fields.availableFields.refType = createRefToElmWithValue(
+        toListType(fieldSetType.fields.availableFields.getTypeSync()),
+      )
+      fieldSetType.fields.displayedFields.refType = createRefToElmWithValue(
+        toListType(fieldSetType.fields.displayedFields.getTypeSync()),
+      )
+    } else {
       log.error('Expected field set to be an object type, got: %s', inspectValue(listViewType))
-      return
     }
-    fieldSetType.fields.availableFields.refType = createRefToElmWithValue(
-      toListType(fieldSetType.fields.availableFields.getTypeSync()),
-    )
-    fieldSetType.fields.displayedFields.refType = createRefToElmWithValue(
-      toListType(fieldSetType.fields.displayedFields.getTypeSync()),
-    )
 
     const compactLayoutType = typesFromInstance[NESTED_INSTANCE_VALUE_NAME.COMPACT_LAYOUTS]
-    if (!isObjectType(compactLayoutType)) {
+    if (isObjectType(compactLayoutType)) {
+      compactLayoutType.fields.fields.refType = createRefToElmWithValue(
+        toListType(compactLayoutType.fields.fields.getTypeSync()),
+      )
+    } else {
       log.error('Expected compact layout to be an object type, got: %s', inspectValue(listViewType))
-      return
     }
-    compactLayoutType.fields.fields.refType = createRefToElmWithValue(
-      toListType(compactLayoutType.fields.fields.getTypeSync()),
-    )
 
     // internalId is also the name of a field on the custom object instances, therefore
     // we override it here to have the right type for the annotation.

--- a/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_objects_to_object_type.test.ts
@@ -957,6 +957,18 @@ describe('Custom Objects to Object Type filter', () => {
         })
       })
     })
+
+    describe('missing custom object type fields', () => {
+      beforeEach(async () => {
+        customObjectType.fields = {}
+        await filter.onFetch(result)
+      })
+
+      it('should convert SObject', () => {
+        const caseElements = findElements(result, 'Case')
+        expect(caseElements).toHaveLength(1)
+      })
+    })
   })
 
   describe('preDeploy and onDeploy', () => {


### PR DESCRIPTION
This came us as a bug in a test flow for parsing SFDX. Better to not make assumptions if we don't have to.

---

_Additional context for reviewer_
None.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
