### PR TITLE
SALTO-6901: Deprecating elements URLs optional feature

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -183,7 +183,6 @@ salesforce {
 
 | Name                              | Default when undefined | Description                                                                                                                                                           |
 | --------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| elementsUrls                      | true                   | Populate URLs for your salesforce configuration elements and enable quick navigation from Salto to the corresponding salesforce screen                                |
 | addMissingIds                     | true                   | Populate Salesforce internal ids for a few types that require special handling                                                                                        |
 | profilePaths                      | true                   | Update file names for profiles whose API name is different from their display name                                                                                    |
 | authorInformation                 | true                   | Populate Salesforce author information about who and when last changed Salesforce configuration elements.                                                             |

--- a/packages/salesforce-adapter/src/filters/elements_url.ts
+++ b/packages/salesforce-adapter/src/filters/elements_url.ts
@@ -27,7 +27,6 @@ const filterCreator: FilterCreator = ({ client, config }) => ({
   onFetch: ensureSafeFilterFetch({
     warningMessage: WARNING_MESSAGE,
     config,
-    filterName: 'elementsUrls',
     fetchFilterFunc: async (elements: Element[]) => {
       if (client === undefined) {
         return

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -96,7 +96,6 @@ export type MetadataParams = {
 }
 
 const OPTIONAL_FEATURES = [
-  'elementsUrls',
   'profilePaths',
   'addMissingIds',
   'authorInformation',
@@ -129,7 +128,12 @@ const OPTIONAL_FEATURES = [
   'lightningPageFieldItemReference',
   'retrieveSettings',
 ] as const
-const DEPRECATED_OPTIONAL_FEATURES = ['generateRefsInProfiles', 'extraDependencies', 'extraDependenciesV2'] as const
+const DEPRECATED_OPTIONAL_FEATURES = [
+  'elementsUrls',
+  'extraDependencies',
+  'extraDependenciesV2',
+  'generateRefsInProfiles',
+] as const
 export type OptionalFeatures = {
   [key in (typeof OPTIONAL_FEATURES)[number]]?: boolean
 }

--- a/packages/salesforce-adapter/test/filters/elements_url.test.ts
+++ b/packages/salesforce-adapter/test/filters/elements_url.test.ts
@@ -22,7 +22,6 @@ import SalesforceClient from '../../src/client/client'
 import { Filter, FilterResult } from '../../src/filter'
 import elementsUrlFilter, { WARNING_MESSAGE } from '../../src/filters/elements_url'
 import { defaultFilterContext } from '../utils'
-import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import * as ElementsUrlRetrieverModule from '../../src/elements_url_retriever/elements_url_retriever'
 
 describe('elements url filter', () => {
@@ -151,22 +150,6 @@ describe('elements url filter', () => {
         message: WARNING_MESSAGE,
         detailedMessage: WARNING_MESSAGE,
       })
-    })
-  })
-  describe('when feature is disabled', () => {
-    it('should not run any query', async () => {
-      connection.instanceUrl = 'https://salto5-dev-ed.my.salesforce.com'
-      filter = elementsUrlFilter({
-        client,
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({
-            fetchParams: { optionalFeatures: { elementsUrls: false } },
-          }),
-        },
-      })
-      await filter.onFetch?.([standardObject])
-      expect(standardObject.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toBeUndefined()
     })
   })
 })


### PR DESCRIPTION
It's no longer used.

---

_Additional context for reviewer_
None.

---

_Release Notes_: 
_Salesforce_:
* Deprecating the `elementsUrls` optional feature.

---

_User Notifications_: 
None.
