### PR TITLE
SALTO-6917 Jira: run sort-lists filter on relevant types only

### DIFF
--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -11,9 +11,13 @@ import _ from 'lodash'
 import {
   AUTOMATION_TYPE,
   DASHBOARD_TYPE,
+  FIELD_CONFIGURATION_SCHEME_TYPE,
+  ISSUE_TYPE_SCREEN_SCHEME_TYPE,
   NOTIFICATION_EVENT_TYPE_NAME,
   NOTIFICATION_SCHEME_TYPE_NAME,
+  PERMISSION_SCHEME_TYPE_NAME,
   PROJECT_ROLE_TYPE,
+  REQUEST_TYPE_NAME,
   WORKFLOW_CONFIGURATION_TYPE,
   WORKFLOW_RULES_TYPE_NAME,
   WORKFLOW_STATUS_TYPE_NAME,
@@ -132,6 +136,19 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
   },
 }
 
+const TYPES_TO_SORT = new Set<string>([
+  PERMISSION_SCHEME_TYPE_NAME,
+  ISSUE_TYPE_SCREEN_SCHEME_TYPE,
+  AUTOMATION_TYPE,
+  FIELD_CONFIGURATION_SCHEME_TYPE,
+  NOTIFICATION_SCHEME_TYPE_NAME,
+  DASHBOARD_TYPE,
+  PROJECT_ROLE_TYPE,
+  REQUEST_TYPE_NAME,
+  WORKFLOW_TYPE_NAME,
+  WORKFLOW_CONFIGURATION_TYPE,
+])
+
 const getValue = (value: Value): Value => (isResolvedReferenceExpression(value) ? value.elemID.getFullName() : value)
 
 const sortLists = (instance: InstanceElement, isDataCenter: boolean): void => {
@@ -169,7 +186,10 @@ const sortLists = (instance: InstanceElement, isDataCenter: boolean): void => {
 const filter: FilterCreator = ({ client }) => ({
   name: 'sortListsFilter',
   onFetch: async elements => {
-    elements.filter(isInstanceElement).forEach(instance => sortLists(instance, client.isDataCenter))
+    elements
+      .filter(isInstanceElement)
+      .filter(instance => TYPES_TO_SORT.has(instance.elemID.typeName))
+      .forEach(instance => sortLists(instance, client.isDataCenter))
   },
 })
 

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -136,6 +136,7 @@ const VALUES_TO_SORT: Record<string, Record<string, string[]>> = {
   },
 }
 
+// Top level element type names of the above VALUES_TO_SORT
 const TYPES_TO_SORT = new Set<string>([
   PERMISSION_SCHEME_TYPE_NAME,
   ISSUE_TYPE_SCREEN_SCHEME_TYPE,

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -228,7 +228,7 @@ describe('sortListsFilter', () => {
 
     it('should sort inner lists', async () => {
       const type = new ObjectType({
-        elemID: new ElemID(JIRA, 'someType'),
+        elemID: new ElemID(JIRA, DASHBOARD_TYPE),
         fields: {
           schemes: {
             refType: new ListType(permissionSchemeType),

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -267,5 +267,46 @@ describe('sortListsFilter', () => {
         ],
       })
     })
+
+    it('should not sort inner lists if type not in supported-type list', async () => {
+      const type = new ObjectType({
+        elemID: new ElemID(JIRA, 'some_type'),
+        fields: {
+          schemes: {
+            refType: new ListType(permissionSchemeType),
+          },
+        },
+      })
+      const inst = new InstanceElement('instance', type, {
+        schemes: [
+          {
+            permissions: [
+              {
+                permission: 'B',
+              },
+              {
+                permission: 'A',
+              },
+            ],
+          },
+        ],
+      })
+
+      await filter.onFetch?.([inst])
+      expect(inst.value).toEqual({
+        schemes: [
+          {
+            permissions: [
+              {
+                permission: 'B',
+              },
+              {
+                permission: 'A',
+              },
+            ],
+          },
+        ],
+      })
+    })
   })
 })


### PR DESCRIPTION
SALTO-6917 Jira: run sort-lists filter on relevant types only

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
