### PR TITLE
SALTO-6919: fix convertJsonIdsToReferences

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -420,17 +420,12 @@ const replaceFormulasWithTemplates = ({
       const idRegex = /\d+/
       const match = expression.match(idRegex)
       if (!match || !match.index) {
-        log.error(`Error parsing id in expression, could not find a match: ${expression}`)
+        log.warn(`Error parsing id in expression, could not find a match: ${expression}`)
         return expression
       }
       const id = match[0]
       const prefix = expression.slice(0, match.index)
-      const suffix = expression.slice(match.index + id?.length, expression.length)
-      // should always be false, used for type check
-      if (id === undefined) {
-        log.error(`Error parsing id in expression: ${expression}`)
-        return expression
-      }
+      const suffix = expression.slice(match.index + id.length, expression.length)
       const instance = instancesById[id]
       if (instance === undefined && !enableMissingReferences) {
         return expression

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -59,7 +59,7 @@ const TICKET_FIELD_SPLIT = '(?:(ticket.ticket_field|ticket.ticket_field_option_t
 const KEY_SPLIT = '(?:([^ ]+\\.custom_fields)\\.)'
 const TITLE_SPLIT = '(?:([^ ]+)\\.(title))'
 const SPLIT_REGEX = `${TICKET_FIELD_SPLIT}|${KEY_SPLIT}|${TITLE_SPLIT}`
-const ID_KEY_IN_JSON_REGEX = /("id"\s*:\s*\d+)/
+const ID_KEY_IN_JSON_REGEX = /("id"\s*:\s*"?\d+"?)/
 export const TICKET_TICKET_FIELD = 'ticket.ticket_field'
 export const TICKET_TICKET_FIELD_OPTION_TITLE = 'ticket.ticket_field_option_title'
 export const TICKET_ORGANIZATION_FIELD = 'ticket.organization.custom_fields'
@@ -416,8 +416,16 @@ const replaceFormulasWithTemplates = ({
       if (!ID_KEY_IN_JSON_REGEX.test(expression)) {
         return expression
       }
+      // "id": "29607168675603" or "id": 29607168675603
       const idRegex = /\d+/
-      const id = expression.match(idRegex)?.[0]
+      const match = expression.match(idRegex)
+      if (!match || !match.index) {
+        log.error(`Error parsing id in expression, could not find a match: ${expression}`)
+        return expression
+      }
+      const id = match[0]
+      const prefix = expression.slice(0, match.index)
+      const suffix = expression.slice(match.index + id?.length, expression.length)
       // should always be false, used for type check
       if (id === undefined) {
         log.error(`Error parsing id in expression: ${expression}`)
@@ -428,9 +436,8 @@ const replaceFormulasWithTemplates = ({
         return expression
       }
 
-      const expressionWithoutId = expression.replace(idRegex, '')
       const idInstance = instance ?? createMissingInstance(ZENDESK, 'unknown', id)
-      return [expressionWithoutId, new ReferenceExpression(idInstance.elemID, idInstance)]
+      return [prefix, new ReferenceExpression(idInstance.elemID, idInstance), suffix ?? '']
     })
   }
 

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -331,7 +331,7 @@ describe('handle templates filter', () => {
           ['dcno', '{{dc.not_exists}}'],
           [
             'testJson',
-            `{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ${placeholder3.value.id},\n\t\t\t\t"testdc": "${dynamicContentRecord.value.placeholder}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": ${placeholder3.value.id}\n}\n`,
+            `{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ${placeholder3.value.id},\n\t\t\t\t"testdc": "${dynamicContentRecord.value.placeholder}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": "${placeholder3.value.id}"\n}\n`,
           ],
         ],
       },
@@ -498,7 +498,7 @@ describe('handle templates filter', () => {
             parts: [
               `{\n\t"ticket": {\n\t\t"custom_fields": [\n\t\t\t{\n\t\t\t\t"id": ${placeholder3.value.id},\n\t\t\t\t"testdc": "{{`,
               new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
-              `}}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": ${placeholder3.value.id}\n}\n`,
+              `}}"\n\t\t\t}\n\t\t],\n\t\t"id": ${placeholder2.value.id}\n\t},\n\t"id": "${placeholder3.value.id}"\n}\n`,
             ],
           }),
         ],
@@ -796,9 +796,9 @@ describe('handle templates filter', () => {
             new ReferenceExpression(dynamicContentRecord.elemID, dynamicContentRecord),
             '}}"\n\t\t\t}\n\t\t],\n\t\t"id": ',
             new ReferenceExpression(placeholder2.elemID, placeholder2),
-            '\n\t},\n\t"id": ',
+            '\n\t},\n\t"id": "',
             new ReferenceExpression(placeholder3.elemID, placeholder3),
-            '\n}\n',
+            '"\n}\n',
           ],
         }),
       )


### PR DESCRIPTION
fix convertJsonIdsToReferences to work when json looks like this:
"id":"\<number\>"

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
