### PR TITLE
SALTO-6800 SALTO-6799 salesforce adapter - GenAi references

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -37,6 +37,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   picklistsAsMaps: false,
   lightningPageFieldItemReference: true,
   retrieveSettings: false,
+  genAiReferences: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -227,6 +227,21 @@ const LIGHTNING_PAGE_FIELD_ITEM_REFERENCE_DEF: FieldReferenceDefinition = {
   target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
 }
 
+const GEN_AI_REFERENCES_DEF: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'genAiFunctionName', parentTypes: ['GenAiPlannerFunctionDef'] },
+    target: { type: 'GenAiFunction' },
+  },
+  {
+    src: { field: 'genAiPluginName', parentTypes: ['GenAiPlannerFunctionDef'] },
+    target: { type: 'GenAiPlugin' },
+  },
+  {
+    src: { field: 'functionName', parentTypes: ['GenAiPluginFunctionDef'] },
+    target: { type: 'GenAiFunction' },
+  },
+]
+
 /**
  * The rules for finding and resolving values into (and back from) reference expressions.
  * Overlaps between rules are allowed, and the first successful conversion wins.
@@ -1080,6 +1095,7 @@ export const getDefsFromFetchProfile = (fetchProfile: FetchProfile): FieldRefere
     .concat(
       fetchProfile.isFeatureEnabled('lightningPageFieldItemReference') ? [LIGHTNING_PAGE_FIELD_ITEM_REFERENCE_DEF] : [],
     )
+    .concat(fetchProfile.isFeatureEnabled('genAiReferences') ? GEN_AI_REFERENCES_DEF : [])
 
 /**
  * Translate a reference expression back to its original value before deploy.

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -130,6 +130,7 @@ const OPTIONAL_FEATURES = [
   'picklistsAsMaps',
   'lightningPageFieldItemReference',
   'retrieveSettings',
+  'genAiReferences',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = ['generateRefsInProfiles'] as const
 export type OptionalFeatures = {


### PR DESCRIPTION
SALTO-6800 SALTO-6799 salesforce adapter - GenAi references
---

_Additional context for reviewer_:
commit with the WS changes: https://github.com/Uri-Bar/salesforce1/commit/7b1d3ba747c3d79f47cd26700a9b4a01f9b9280e

---
_Release Notes_: 
none

---
_User Notifications_: 
SF: added references in GenAiPlugin and GenAiPlanner under the genAiReferences optionalFeatures
