### PR TITLE
Reduce asynchronousity in nacl files update

### DIFF
--- a/packages/parser/src/parser/types.ts
+++ b/packages/parser/src/parser/types.ts
@@ -7,15 +7,13 @@
  */
 
 import { SaltoError, Element } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
 import { HclParseError } from './internal/types'
 import { SourceMap } from './source_map'
 
-type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
 export type ParseError = HclParseError & SaltoError
 
 export type ParseResult = {
-  elements: ThenableIterable<Element>
+  elements: Element[]
   errors: ParseError[]
   sourceMap?: SourceMap
 }

--- a/packages/workspace/src/workspace/nacl_files/index.ts
+++ b/packages/workspace/src/workspace/nacl_files/index.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-export { ParsedNaclFile, ParsedNaclFileData } from './parsed_nacl_file'
+export { ParsedNaclFile } from './parsed_nacl_file'
 export { ChangeSet } from './elements_cache'
 export {
   NaclFile,

--- a/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
+++ b/packages/workspace/src/workspace/nacl_files/parsed_nacl_file.ts
@@ -8,10 +8,24 @@
 import { Element } from '@salto-io/adapter-api'
 import { parser } from '@salto-io/parser'
 
-export type ParsedNaclFileData = {
-  errors: () => Promise<parser.ParseError[] | undefined>
+type SyncParsedNaclFileData = {
+  errors: () => parser.ParseError[]
   referenced: () => Promise<string[]>
   staticFiles: () => Promise<string[]>
+}
+
+type ParsedNaclFileData = {
+  errors: () => Promise<parser.ParseError[] | undefined>
+  referenced: () => Promise<string[] | undefined>
+  staticFiles: () => Promise<string[] | undefined>
+}
+
+export type SyncParsedNaclFile = {
+  filename: string
+  elements: () => Element[]
+  data: SyncParsedNaclFileData
+  buffer?: string
+  sourceMap?: () => parser.SourceMap
 }
 
 export type ParsedNaclFile = {
@@ -19,5 +33,5 @@ export type ParsedNaclFile = {
   elements: () => Promise<Element[] | undefined>
   data: ParsedNaclFileData
   buffer?: string
-  sourceMap?: () => Promise<parser.SourceMap | undefined>
+  sourceMap: () => Promise<parser.SourceMap | undefined>
 }

--- a/packages/workspace/test/common/nacl_file_source.ts
+++ b/packages/workspace/test/common/nacl_file_source.ts
@@ -122,6 +122,7 @@ export const createMockNaclFileSource = (
       },
       elements: () => Promise.resolve(naclFiles[filename] || []),
       buffer: '',
+      sourceMap: () => Promise.resolve(undefined),
     })),
     getElementNaclFiles: mockFunction<NaclFilesSource['getElementNaclFiles']>().mockImplementation(async elemID =>
       getElementNaclFiles(elemID),

--- a/packages/workspace/test/common/nacl_file_store.ts
+++ b/packages/workspace/test/common/nacl_file_store.ts
@@ -338,6 +338,7 @@ export const mockParseCache = (): ParsedNaclFileCache => ({
         referenced: () => Promise.resolve([]),
         staticFiles: () => Promise.resolve([]),
       },
+      sourceMap: () => Promise.resolve(undefined),
     }),
   flush: () => Promise.resolve(undefined),
   clear: () => Promise.resolve(),

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -25,7 +25,7 @@ import { parser } from '@salto-io/parser'
 import { detailedCompare, transformElement } from '@salto-io/adapter-utils'
 import { DirectoryStore } from '../../../src/workspace/dir_store'
 
-import { naclFilesSource, NaclFilesSource } from '../../../src/workspace/nacl_files'
+import { naclFilesSource, NaclFilesSource, ParsedNaclFile } from '../../../src/workspace/nacl_files'
 import { StaticFilesSource, MissingStaticFile } from '../../../src/workspace/static_files'
 import { ParsedNaclFileCache, createParseResultCache } from '../../../src/workspace/nacl_files/parsed_nacl_files_cache'
 
@@ -36,7 +36,6 @@ import {
   RemoteMap,
   CreateRemoteMapParams,
 } from '../../../src/workspace/remote_map'
-import { ParsedNaclFile } from '../../../src/workspace/nacl_files/parsed_nacl_file'
 import * as naclFileSourceModule from '../../../src/workspace/nacl_files/nacl_files_source'
 import { mockDirStore as createMockDirStore } from '../../common/nacl_file_store'
 import { getDanglingStaticFiles } from '../../../src/workspace/nacl_files/nacl_files_source'

--- a/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/parsed_nacl_files_cache.test.ts
@@ -7,7 +7,7 @@
  */
 import { ObjectType, ElemID, Value, SeverityLevel } from '@salto-io/adapter-api'
 import { parser } from '@salto-io/parser'
-import { ParsedNaclFile } from '../../../src/workspace/nacl_files'
+import { ParsedNaclFile, SyncParsedNaclFile } from '../../../src/workspace/nacl_files/parsed_nacl_file'
 import { InMemoryRemoteMap, CreateRemoteMapParams, RemoteMap } from '../../../src/workspace/remote_map'
 import { createParseResultCache, ParsedNaclFileCache } from '../../../src/workspace/nacl_files/parsed_nacl_files_cache'
 import { StaticFilesSource } from '../../../src/workspace/static_files'
@@ -54,7 +54,7 @@ describe('ParsedNaclFileCache', () => {
     buffer: mockCacheFileContent,
     lastModified: beforeTimestamp,
   }
-  let parsedDummy: ParsedNaclFile
+  let parsedDummy: SyncParsedNaclFile
 
   const dummy2Filename = 'dummy2.nacl'
   const mockCacheFileContentDummy2 = 'content2'
@@ -83,7 +83,7 @@ describe('ParsedNaclFileCache', () => {
     buffer: mockCacheFileContentDummy2,
     lastModified: beforeTimestamp,
   }
-  let parsedDummy2: ParsedNaclFile
+  let parsedDummy2: SyncParsedNaclFile
 
   const toDeleteFilename = 'toDelete.nacl'
   const toDeleteContent = 'toDelete'
@@ -111,7 +111,7 @@ describe('ParsedNaclFileCache', () => {
     buffer: toDeleteContent,
     lastModified: someDateTimestamp,
   }
-  let parsedToDelete: ParsedNaclFile
+  let parsedToDelete: SyncParsedNaclFile
 
   const toDelete2Filename = 'toDelete2.nacl'
   const toDelete2Content = 'toDelete2'
@@ -139,7 +139,7 @@ describe('ParsedNaclFileCache', () => {
     buffer: toDelete2Content,
     lastModified: someDateTimestamp,
   }
-  let parsedToDelete2: ParsedNaclFile
+  let parsedToDelete2: SyncParsedNaclFile
 
   const initDummyFilename = 'initDummy.nacl'
   const mockCacheFileContentInitDummy = 'content'
@@ -168,9 +168,9 @@ describe('ParsedNaclFileCache', () => {
     buffer: mockCacheFileContentInitDummy,
     lastModified: beforeTimestamp,
   }
-  let parsedInitDummy: ParsedNaclFile
+  let parsedInitDummy: SyncParsedNaclFile
 
-  const parsedWithoutBuffer = (parsed: ParsedNaclFile): ParsedNaclFile => {
+  const parsedWithoutBuffer = (parsed: SyncParsedNaclFile): SyncParsedNaclFile => {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { buffer, ...parsedWithoutBuff } = parsed
     return parsedWithoutBuff
@@ -179,21 +179,21 @@ describe('ParsedNaclFileCache', () => {
   const fileExistsInCache = async (filename: string): Promise<boolean> =>
     (await (await cache.get(filename)).elements()) !== undefined
 
-  const validateParsedNaclFileEquals = async (p1: ParsedNaclFile, p2: ParsedNaclFile): Promise<void> => {
-    expect(await p1.elements()).toEqual(await p2.elements())
+  const validateParsedNaclFileEquals = async (p1: ParsedNaclFile, p2: SyncParsedNaclFile): Promise<void> => {
+    expect(await p1.elements()).toEqual(p2.elements())
     expect(p1.filename).toEqual(p2.filename)
-    expect(await p1.sourceMap?.()).toEqual(await p2.sourceMap?.())
-    expect(await p1.data.errors()).toEqual(await p2.data.errors())
+    expect(await p1.sourceMap?.()).toEqual(p2.sourceMap?.())
+    expect((await p1.data.errors()) ?? []).toEqual(p2.data.errors())
     expect(await p1.data.referenced()).toEqual(await p2.data.referenced())
   }
 
   beforeAll(async () => {
     jest.spyOn(Date, 'now').mockImplementation(() => someDateTimestamp)
-    parsedInitDummy = await toParsedNaclFile(initDummyParsedKey, parseResultWithoutMD5InitDummy)
-    parsedDummy = await toParsedNaclFile(dummyParsedKey, parseResultWithoutMD5)
-    parsedDummy2 = await toParsedNaclFile(dummy2ParsedKey, parseResultWithoutMD5Dummy2)
-    parsedToDelete = await toParsedNaclFile(toDeleteKey, toDeleteParseResult)
-    parsedToDelete2 = await toParsedNaclFile(toDelete2Key, toDelete2ParseResult)
+    parsedInitDummy = toParsedNaclFile(initDummyParsedKey, parseResultWithoutMD5InitDummy)
+    parsedDummy = toParsedNaclFile(dummyParsedKey, parseResultWithoutMD5)
+    parsedDummy2 = toParsedNaclFile(dummy2ParsedKey, parseResultWithoutMD5Dummy2)
+    parsedToDelete = toParsedNaclFile(toDeleteKey, toDeleteParseResult)
+    parsedToDelete2 = toParsedNaclFile(toDelete2Key, toDelete2ParseResult)
   })
 
   beforeEach(async () => {
@@ -399,7 +399,7 @@ describe('ParsedNaclFileCache', () => {
     beforeEach(async () => {
       await cache.put(
         dummyFilename,
-        await toParsedNaclFile(dummyParsedKey, {
+        toParsedNaclFile(dummyParsedKey, {
           elements: [dummyObjectType],
           errors: [errorA],
           sourceMap,
@@ -407,7 +407,7 @@ describe('ParsedNaclFileCache', () => {
       )
       await cache.put(
         toDeleteFilename,
-        await toParsedNaclFile(toDeleteKey, {
+        toParsedNaclFile(toDeleteKey, {
           elements: [toDeleteObjectType],
           errors: [errorB],
           sourceMap,
@@ -424,7 +424,7 @@ describe('ParsedNaclFileCache', () => {
     it('Should unset errors when none exist', async () => {
       await cache.put(
         toDeleteFilename,
-        await toParsedNaclFile(toDeleteKey, {
+        toParsedNaclFile(toDeleteKey, {
           elements: [toDeleteObjectType],
           errors: [],
           sourceMap,


### PR DESCRIPTION
Split `ParsedNaclFile` into two types:
- `ParsedNaclFile` returns getters that are non-async
- `CachedParsedNaclFile` returns getters that are async (same as current implementation of `ParsedNaclFile`)

Whenever possible use `ParsedNaclFile`, in order to remove redundant `await`s in the code.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Reduce asynchronousity in nacl files update

---
_User Notifications_: 
None