### PR TITLE
Reduce memory consumption when updating nacl files

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -525,7 +525,7 @@ const buildNaclFilesState = async ({
           referencedIndexDeletions[elementFullName] = referencedIndexDeletions[elementFullName] ?? new Set<string>()
           referencedIndexDeletions[elementFullName].add(oldNaclFile.filename)
         })
-        const oldNaclFileElementIDs = (await getElementIDsFromNaclFile(oldNaclFile)) ?? []
+        const oldNaclFileElementIDs = await getElementIDsFromNaclFile(oldNaclFile)
         oldNaclFileElementIDs.forEach(elemID => {
           const elementFullName = elemID.getFullName()
           elementsIndexDeletions[elementFullName] = elementsIndexDeletions[elementFullName] ?? new Set<string>()

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.state.test.ts
@@ -30,66 +30,76 @@ import { toParsedNaclFile } from '../../../src/workspace/nacl_files/nacl_files_s
 
 const { awu } = collections.asynciterable
 
-describe('Nacl Files Source', () => {
-  let mockDirStore: DirectoryStore<string>
-  let mockedStaticFilesSource: StaticFilesSource
-  const mockDirStoreGet = jest.fn()
+describe.each([false, true])(
+  'Nacl Files Source (CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING is %s)',
+  shouldCreateFilenamesToElementIDsMapping => {
+    let mockDirStore: DirectoryStore<string>
+    let mockedStaticFilesSource: StaticFilesSource
+    const mockDirStoreGet = jest.fn()
 
-  beforeEach(async () => {
-    mockDirStore = {
-      list: () => Promise.resolve([]),
-      isEmpty: () => Promise.resolve(false),
-      get: mockDirStoreGet.mockResolvedValue(undefined),
-      getFiles: jest.fn().mockResolvedValue([undefined]),
-      set: () => Promise.resolve(),
-      delete: () => Promise.resolve(),
-      clear: () => Promise.resolve(),
-      rename: () => Promise.resolve(),
-      renameFile: () => Promise.resolve(),
-      flush: () => Promise.resolve(),
-      mtimestamp: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
-      getTotalSize: () => Promise.resolve(0),
-      clone: () => mockDirStore,
-      getFullPath: filename => filename,
-      isPathIncluded: jest.fn().mockResolvedValue(true),
-      exists: jest.fn().mockResolvedValue(false),
-    }
-    mockedStaticFilesSource = mockStaticFilesSource()
-  })
+    beforeEach(async () => {
+      mockDirStore = {
+        list: () => Promise.resolve([]),
+        isEmpty: () => Promise.resolve(false),
+        get: mockDirStoreGet.mockResolvedValue(undefined),
+        getFiles: jest.fn().mockResolvedValue([undefined]),
+        set: () => Promise.resolve(),
+        delete: () => Promise.resolve(),
+        clear: () => Promise.resolve(),
+        rename: () => Promise.resolve(),
+        renameFile: () => Promise.resolve(),
+        flush: () => Promise.resolve(),
+        mtimestamp: jest.fn().mockImplementation(() => Promise.resolve(undefined)),
+        getTotalSize: () => Promise.resolve(0),
+        clone: () => mockDirStore,
+        getFullPath: filename => filename,
+        isPathIncluded: jest.fn().mockResolvedValue(true),
+        exists: jest.fn().mockResolvedValue(false),
+      }
+      mockedStaticFilesSource = mockStaticFilesSource()
+    })
 
-  describe('change inner state', () => {
-    let naclFileSourceTest: NaclFilesSource
-    const objectTypeElemID = ElemID.fromFullName('dummy.test')
-    const objectTypeObjectMatcher = {
-      elemID: objectTypeElemID,
-      fields: {
-        a: { refType: { elemID: BuiltinTypes.STRING.elemID } },
-        b: { refType: { elemID: BuiltinTypes.NUMBER.elemID } },
-      },
-    }
-    const instanceElementValue = { a: 'me', b: 5 }
-    const instanceElementElemID = ElemID.fromFullName('dummy.test.instance.inst')
-    const instanceElementObjectMatcher = {
-      elemID: instanceElementElemID,
-      value: instanceElementValue,
-    }
-    const newInstanceElementValue = { a: 'me again', b: 6 }
-    const newInstanceElementElemID = ElemID.fromFullName('dummy.test.instance.inst2')
-    const newInstanceElementObjectMatcher = {
-      elemID: newInstanceElementElemID,
-      value: newInstanceElementValue,
-    }
-    const file1 = {
-      filename: 'file1.nacl',
-      buffer: `
+    beforeAll(() => {
+      process.env.SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING = shouldCreateFilenamesToElementIDsMapping ? '1' : '0'
+    })
+
+    afterAll(() => {
+      delete process.env.SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING
+    })
+
+    describe('change inner state', () => {
+      let naclFileSourceTest: NaclFilesSource
+      const objectTypeElemID = ElemID.fromFullName('dummy.test')
+      const objectTypeObjectMatcher = {
+        elemID: objectTypeElemID,
+        fields: {
+          a: { refType: { elemID: BuiltinTypes.STRING.elemID } },
+          b: { refType: { elemID: BuiltinTypes.NUMBER.elemID } },
+        },
+      }
+      const instanceElementValue = { a: 'me', b: 5 }
+      const instanceElementElemID = ElemID.fromFullName('dummy.test.instance.inst')
+      const instanceElementObjectMatcher = {
+        elemID: instanceElementElemID,
+        value: instanceElementValue,
+      }
+      const newInstanceElementValue = { a: 'me again', b: 6 }
+      const newInstanceElementElemID = ElemID.fromFullName('dummy.test.instance.inst2')
+      const newInstanceElementObjectMatcher = {
+        elemID: newInstanceElementElemID,
+        value: newInstanceElementValue,
+      }
+      const file1 = {
+        filename: 'file1.nacl',
+        buffer: `
         type dummy.test {
           string a {}
         }
       `,
-    }
-    const file2 = {
-      filename: 'file2.nacl',
-      buffer: `
+      }
+      const file2 = {
+        filename: 'file2.nacl',
+        buffer: `
         type dummy.test {
           number b {}
         }
@@ -98,33 +108,33 @@ describe('Nacl Files Source', () => {
           b = 5
         }
       `,
-    }
-    beforeEach(async () => {
-      const naclFiles = [file1, file2]
-      const parsedNaclFiles = await Promise.all(
-        naclFiles.map(async naclFile =>
-          toParsedNaclFile(naclFile, await parser.parse(Buffer.from(naclFile.buffer), naclFile.filename, {})),
-        ),
-      )
-      naclFileSourceTest = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        persistentMockCreateRemoteMap(),
-        true,
-        parsedNaclFiles,
-      )
-      await naclFileSourceTest.getAll()
-    })
-    it('should includes expected elements', async () => {
-      const elements = await awu(await naclFileSourceTest.getAll()).toArray()
-      expect(elements).toHaveLength(2)
-    })
-    describe('setNaclFiles', () => {
-      it('should change existing element in one file', async () => {
-        const newFile = {
-          filename: 'file2.nacl',
-          buffer: `
+      }
+      beforeEach(async () => {
+        const naclFiles = [file1, file2]
+        const parsedNaclFiles = await Promise.all(
+          naclFiles.map(async naclFile =>
+            toParsedNaclFile(naclFile, await parser.parse(Buffer.from(naclFile.buffer), naclFile.filename, {})),
+          ),
+        )
+        naclFileSourceTest = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          persistentMockCreateRemoteMap(),
+          true,
+          parsedNaclFiles,
+        )
+        await naclFileSourceTest.getAll()
+      })
+      it('should includes expected elements', async () => {
+        const elements = await awu(await naclFileSourceTest.getAll()).toArray()
+        expect(elements).toHaveLength(2)
+      })
+      describe('setNaclFiles', () => {
+        it('should change existing element in one file', async () => {
+          const newFile = {
+            filename: 'file2.nacl',
+            buffer: `
             type dummy.test {
               number b {}
             }
@@ -133,47 +143,47 @@ describe('Nacl Files Source', () => {
               b = 6
             }
           `,
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
-        expect(res).toHaveLength(1)
-        const change = res[0] as unknown as ModificationChange<InstanceElement>
-        expect(change).toMatchObject({
-          action: 'modify',
-          data: {
-            before: { value: instanceElementValue },
-            after: { value: newInstanceElementValue },
-          },
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
+          expect(res).toHaveLength(1)
+          const change = res[0] as unknown as ModificationChange<InstanceElement>
+          expect(change).toMatchObject({
+            action: 'modify',
+            data: {
+              before: { value: instanceElementValue },
+              after: { value: newInstanceElementValue },
+            },
+          })
+          expect(await awu(await naclFileSourceTest.getAll()).toArray()).toHaveLength(2)
+          expect(await naclFileSourceTest.get(change.data.before.elemID)).toMatchObject({
+            elemID: instanceElementElemID,
+            value: newInstanceElementValue,
+          })
+          expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
         })
-        expect(await awu(await naclFileSourceTest.getAll()).toArray()).toHaveLength(2)
-        expect(await naclFileSourceTest.get(change.data.before.elemID)).toMatchObject({
-          elemID: instanceElementElemID,
-          value: newInstanceElementValue,
-        })
-        expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
-      })
-      it('should remove an element from a file', async () => {
-        const newFile = {
-          filename: 'file2.nacl',
-          buffer: `
+        it('should remove an element from a file', async () => {
+          const newFile = {
+            filename: 'file2.nacl',
+            buffer: `
             type dummy.test {
               number b {}
             }
           `,
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
-        expect(res).toHaveLength(1)
-        expect(res[0] as unknown as RemovalChange<InstanceElement>).toMatchObject({
-          action: 'remove',
-          data: { before: instanceElementObjectMatcher },
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
+          expect(res).toHaveLength(1)
+          expect(res[0] as unknown as RemovalChange<InstanceElement>).toMatchObject({
+            action: 'remove',
+            data: { before: instanceElementObjectMatcher },
+          })
+          const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
+          expect(allElements).toHaveLength(1)
+          expect(allElements[0] as ObjectType).toMatchObject(objectTypeObjectMatcher)
         })
-        const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
-        expect(allElements).toHaveLength(1)
-        expect(allElements[0] as ObjectType).toMatchObject(objectTypeObjectMatcher)
-      })
-      it('should add an element from a file', async () => {
-        const newFile = {
-          filename: 'file1.nacl',
-          buffer: `
+        it('should add an element from a file', async () => {
+          const newFile = {
+            filename: 'file1.nacl',
+            buffer: `
             type dummy.test {
               string a {}
             }
@@ -182,40 +192,40 @@ describe('Nacl Files Source', () => {
               b = 6
             }
           `,
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
-        expect(res).toHaveLength(1)
-        expect(res[0] as unknown as AdditionChange<InstanceElement>).toMatchObject({
-          action: 'add',
-          data: { after: { value: { a: 'me again', b: 6 } } },
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
+          expect(res).toHaveLength(1)
+          expect(res[0] as unknown as AdditionChange<InstanceElement>).toMatchObject({
+            action: 'add',
+            data: { after: { value: { a: 'me again', b: 6 } } },
+          })
+          const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
+          expect(allElements).toHaveLength(3)
+          expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
+          expect(await naclFileSourceTest.get(instanceElementElemID)).toMatchObject(instanceElementObjectMatcher)
+          expect(await naclFileSourceTest.get(newInstanceElementElemID)).toMatchObject(newInstanceElementObjectMatcher)
         })
-        const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
-        expect(allElements).toHaveLength(3)
-        expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
-        expect(await naclFileSourceTest.get(instanceElementElemID)).toMatchObject(instanceElementObjectMatcher)
-        expect(await naclFileSourceTest.get(newInstanceElementElemID)).toMatchObject(newInstanceElementObjectMatcher)
-      })
-      it('should not return changes if there is no change', async () => {
-        const newFile = {
-          filename: 'file1.nacl',
-          buffer: `
+        it('should not return changes if there is no change', async () => {
+          const newFile = {
+            filename: 'file1.nacl',
+            buffer: `
             type dummy.test {
               string a {
               }
             }
           `,
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
-        expect(res).toHaveLength(0)
-        const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
-        expect(allElements).toHaveLength(2)
-        expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
-        expect(await naclFileSourceTest.get(instanceElementElemID)).toMatchObject(instanceElementObjectMatcher)
-      })
-      it('should return correct elements upon update of multiple files', async () => {
-        const newFile1 = {
-          filename: 'file1.nacl',
-          buffer: `
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
+          expect(res).toHaveLength(0)
+          const allElements = await awu(await naclFileSourceTest.getAll()).toArray()
+          expect(allElements).toHaveLength(2)
+          expect(await naclFileSourceTest.get(objectTypeElemID)).toMatchObject(objectTypeObjectMatcher)
+          expect(await naclFileSourceTest.get(instanceElementElemID)).toMatchObject(instanceElementObjectMatcher)
+        })
+        it('should return correct elements upon update of multiple files', async () => {
+          const newFile1 = {
+            filename: 'file1.nacl',
+            buffer: `
             type dummy.test {
               string a {}
               string c {}
@@ -225,93 +235,93 @@ describe('Nacl Files Source', () => {
               b = 6
             }
           `,
-        }
-        const newFile2 = {
-          filename: 'file2.nacl',
-          buffer: ' ',
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile1, newFile2])).changes
-        expect(res).toHaveLength(3)
-        const newObjectTypeObjectMatcher = {
-          elemID: objectTypeElemID,
-          fields: {
-            a: { refType: { elemID: BuiltinTypes.STRING.elemID } },
-            c: { refType: { elemID: BuiltinTypes.STRING.elemID } },
-          },
-        }
-        expect(res).toMatchObject([
-          {
-            action: 'modify',
-            data: { before: objectTypeObjectMatcher, after: newObjectTypeObjectMatcher },
-          },
-          {
-            action: 'remove',
-            data: { before: instanceElementObjectMatcher },
-          },
-          {
-            action: 'add',
-            data: { after: newInstanceElementObjectMatcher },
-          },
-        ])
-      })
-      it('should update the type of an instance upon type update', async () => {
-        const newFile = {
-          filename: 'file2.nacl',
-          buffer: `
+          }
+          const newFile2 = {
+            filename: 'file2.nacl',
+            buffer: ' ',
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile1, newFile2])).changes
+          expect(res).toHaveLength(3)
+          const newObjectTypeObjectMatcher = {
+            elemID: objectTypeElemID,
+            fields: {
+              a: { refType: { elemID: BuiltinTypes.STRING.elemID } },
+              c: { refType: { elemID: BuiltinTypes.STRING.elemID } },
+            },
+          }
+          expect(res).toMatchObject([
+            {
+              action: 'modify',
+              data: { before: objectTypeObjectMatcher, after: newObjectTypeObjectMatcher },
+            },
+            {
+              action: 'remove',
+              data: { before: instanceElementObjectMatcher },
+            },
+            {
+              action: 'add',
+              data: { after: newInstanceElementObjectMatcher },
+            },
+          ])
+        })
+        it('should update the type of an instance upon type update', async () => {
+          const newFile = {
+            filename: 'file2.nacl',
+            buffer: `
             dummy.test inst {
               a = "me"
               b = 5
             }
           `,
-        }
-        const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
-        expect(res).toHaveLength(1)
-        const elements = await awu(await naclFileSourceTest.getAll()).toArray()
-        expect(elements).toHaveLength(2)
-        const instance = (await awu(elements).find(
-          e => e.elemID.getFullName() === 'dummy.test.instance.inst',
-        )) as InstanceElement
-        const objType = (await awu(elements).find(e => e.elemID.getFullName() === 'dummy.test')) as ObjectType
-        expect(objType).toBeDefined()
-        expect(instance.refType.elemID.isEqual(objType.elemID)).toBeTruthy()
-      })
-      it('should remove elements from list result upon element removal', async () => {
-        const newFile = {
-          filename: 'file2.nacl',
-          buffer: `
+          }
+          const res = (await naclFileSourceTest.setNaclFiles([newFile])).changes
+          expect(res).toHaveLength(1)
+          const elements = await awu(await naclFileSourceTest.getAll()).toArray()
+          expect(elements).toHaveLength(2)
+          const instance = (await awu(elements).find(
+            e => e.elemID.getFullName() === 'dummy.test.instance.inst',
+          )) as InstanceElement
+          const objType = (await awu(elements).find(e => e.elemID.getFullName() === 'dummy.test')) as ObjectType
+          expect(objType).toBeDefined()
+          expect(instance.refType.elemID.isEqual(objType.elemID)).toBeTruthy()
+        })
+        it('should remove elements from list result upon element removal', async () => {
+          const newFile = {
+            filename: 'file2.nacl',
+            buffer: `
             type dummy.test {
               number b {}
             }
           `,
-        }
-        expect(
-          await awu(await naclFileSourceTest.list())
-            .map(e => e.getFullName())
-            .toArray(),
-        ).toEqual(['dummy.test', 'dummy.test.instance.inst'])
-        await naclFileSourceTest.setNaclFiles([newFile])
-        expect(
-          await awu(await naclFileSourceTest.list())
-            .map(e => e.getFullName())
-            .toArray(),
-        ).toEqual(['dummy.test'])
-      })
-      it('should remove elements from the indexes upon element removal', async () => {
-        const newFile = {
-          filename: 'file2.nacl',
-          buffer: '',
-        }
-        const removedElemId = new ElemID('dummy', 'test')
-        expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId)).toEqual(['file2.nacl'])
-        await naclFileSourceTest.setNaclFiles([newFile])
-        expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId)).toEqual([])
-      })
-      describe('splitted elements', () => {
-        describe('fragmented in all files', () => {
-          let naclFileSourceWithFragments: NaclFilesSource
-          const splittedFile1 = {
-            filename: 'file1.nacl',
-            buffer: `
+          }
+          expect(
+            await awu(await naclFileSourceTest.list())
+              .map(e => e.getFullName())
+              .toArray(),
+          ).toEqual(['dummy.test', 'dummy.test.instance.inst'])
+          await naclFileSourceTest.setNaclFiles([newFile])
+          expect(
+            await awu(await naclFileSourceTest.list())
+              .map(e => e.getFullName())
+              .toArray(),
+          ).toEqual(['dummy.test'])
+        })
+        it('should remove elements from the indexes upon element removal', async () => {
+          const newFile = {
+            filename: 'file2.nacl',
+            buffer: '',
+          }
+          const removedElemId = new ElemID('dummy', 'test')
+          expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId)).toEqual(['file2.nacl'])
+          await naclFileSourceTest.setNaclFiles([newFile])
+          expect(await naclFileSourceTest.getElementReferencedFiles(removedElemId)).toEqual([])
+        })
+        describe('splitted elements', () => {
+          describe('fragmented in all files', () => {
+            let naclFileSourceWithFragments: NaclFilesSource
+            const splittedFile1 = {
+              filename: 'file1.nacl',
+              buffer: `
               type dummy.test2 {
                 number a {}
               }
@@ -319,10 +329,10 @@ describe('Nacl Files Source', () => {
                 string a {}
               }
             `,
-          }
-          const splittedFile2 = {
-            filename: 'file2.nacl',
-            buffer: `
+            }
+            const splittedFile2 = {
+              filename: 'file2.nacl',
+              buffer: `
               type dummy.test1 {
                 number b {}
               }
@@ -330,213 +340,216 @@ describe('Nacl Files Source', () => {
                 string c {}
               }
             `,
-          }
-          beforeEach(async () => {
-            const naclFiles = [splittedFile1, splittedFile2]
-            const parsedNaclFiles = await Promise.all(
-              naclFiles.map(async naclFile =>
-                toParsedNaclFile(naclFile, await parser.parse(Buffer.from(naclFile.buffer), naclFile.filename, {})),
-              ),
-            )
-            naclFileSourceWithFragments = await naclFilesSource(
-              '',
-              mockDirStore,
-              mockedStaticFilesSource,
-              persistentMockCreateRemoteMap(),
-              true,
-              parsedNaclFiles,
-            )
-          })
-          it('should change splitted element correctly', async () => {
-            const newFile = {
-              filename: 'file1.nacl',
-              buffer: `
+            }
+            beforeEach(async () => {
+              const naclFiles = [splittedFile1, splittedFile2]
+              const parsedNaclFiles = await Promise.all(
+                naclFiles.map(async naclFile =>
+                  toParsedNaclFile(naclFile, await parser.parse(Buffer.from(naclFile.buffer), naclFile.filename, {})),
+                ),
+              )
+              naclFileSourceWithFragments = await naclFilesSource(
+                '',
+                mockDirStore,
+                mockedStaticFilesSource,
+                persistentMockCreateRemoteMap(),
+                true,
+                parsedNaclFiles,
+              )
+            })
+            it('should change splitted element correctly', async () => {
+              const newFile = {
+                filename: 'file1.nacl',
+                buffer: `
                 type dummy.test2 {
                   string d {}
                 }
               `,
-            }
-            const currentElements = await awu(await naclFileSourceWithFragments.getAll()).toArray()
-            const res = (await naclFileSourceWithFragments.setNaclFiles([newFile])).changes
-            expect(res).toHaveLength(2)
-            const objType1ElemID = new ElemID('dummy', 'test1')
-            const objType2ElemID = new ElemID('dummy', 'test2')
-            const objType1 = {
-              before: new ObjectType({
-                elemID: objType1ElemID,
-                fields: {
-                  a: { refType: new TypeReference(BuiltinTypes.STRING.elemID) },
-                  b: { refType: new TypeReference(BuiltinTypes.NUMBER.elemID) },
-                },
-              }),
-              after: new ObjectType({
-                elemID: objType1ElemID,
-                fields: {
-                  b: {
-                    refType: new TypeReference(BuiltinTypes.NUMBER.elemID),
+              }
+              const currentElements = await awu(await naclFileSourceWithFragments.getAll()).toArray()
+              const res = (await naclFileSourceWithFragments.setNaclFiles([newFile])).changes
+              expect(res).toHaveLength(2)
+              const objType1ElemID = new ElemID('dummy', 'test1')
+              const objType2ElemID = new ElemID('dummy', 'test2')
+              const objType1 = {
+                before: new ObjectType({
+                  elemID: objType1ElemID,
+                  fields: {
+                    a: { refType: new TypeReference(BuiltinTypes.STRING.elemID) },
+                    b: { refType: new TypeReference(BuiltinTypes.NUMBER.elemID) },
                   },
-                },
-              }),
-            }
-            const objType2 = {
-              before: new ObjectType({
-                elemID: objType2ElemID,
-                fields: {
-                  a: {
-                    refType: new TypeReference(BuiltinTypes.NUMBER.elemID),
+                }),
+                after: new ObjectType({
+                  elemID: objType1ElemID,
+                  fields: {
+                    b: {
+                      refType: new TypeReference(BuiltinTypes.NUMBER.elemID),
+                    },
                   },
-                  c: {
-                    refType: new TypeReference(BuiltinTypes.STRING.elemID),
+                }),
+              }
+              const objType2 = {
+                before: new ObjectType({
+                  elemID: objType2ElemID,
+                  fields: {
+                    a: {
+                      refType: new TypeReference(BuiltinTypes.NUMBER.elemID),
+                    },
+                    c: {
+                      refType: new TypeReference(BuiltinTypes.STRING.elemID),
+                    },
                   },
-                },
-              }),
-              after: new ObjectType({
-                elemID: objType2ElemID,
-                fields: {
-                  d: {
-                    refType: new TypeReference(BuiltinTypes.STRING.elemID),
+                }),
+                after: new ObjectType({
+                  elemID: objType2ElemID,
+                  fields: {
+                    d: {
+                      refType: new TypeReference(BuiltinTypes.STRING.elemID),
+                    },
+                    c: {
+                      refType: new TypeReference(BuiltinTypes.STRING.elemID),
+                    },
                   },
-                  c: {
-                    refType: new TypeReference(BuiltinTypes.STRING.elemID),
-                  },
-                },
-              }),
-            }
-            expect(res).toEqual([
-              { action: 'modify', data: objType2 },
-              { action: 'modify', data: objType1 },
-            ])
-            expect(currentElements).toEqual([objType1.before, objType2.before])
-            expect(await awu(await naclFileSourceWithFragments.getAll()).toArray()).toEqual([
-              objType1.after,
-              objType2.after,
-            ])
+                }),
+              }
+              expect(res).toEqual([
+                { action: 'modify', data: objType2 },
+                { action: 'modify', data: objType1 },
+              ])
+              expect(currentElements).toEqual([objType1.before, objType2.before])
+              expect(await awu(await naclFileSourceWithFragments.getAll()).toArray()).toEqual([
+                objType1.after,
+                objType2.after,
+              ])
+            })
           })
         })
       })
-    })
-    describe('removeNaclFiles', () => {
-      it('should not change anything if the file does not exist', async () => {
-        expect((await naclFileSourceTest.removeNaclFiles(['blabla'])).changes).toHaveLength(0)
-        expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([
-          objectTypeObjectMatcher,
-          instanceElementObjectMatcher,
-        ])
-      })
-      it('should remove one file correctly', async () => {
-        const { changes } = await naclFileSourceTest.removeNaclFiles(['file2.nacl'])
-        expect(changes).toHaveLength(2)
-        expect((changes[0] as unknown as ModificationChange<ObjectType>).data.after.fields.b).toBeUndefined()
-        const newObjectTypeObjectMatcher = {
-          elemID: objectTypeElemID,
-          fields: { a: { refType: { elemID: BuiltinTypes.STRING.elemID } } },
-        }
-        expect(changes).toMatchObject([
-          {
-            action: 'modify',
-            data: {
-              before: objectTypeObjectMatcher,
-              after: newObjectTypeObjectMatcher,
-            },
-          },
-          {
-            action: 'remove',
-            data: { before: instanceElementObjectMatcher },
-          },
-        ])
-        const currentElements = await awu(await naclFileSourceTest.getAll()).toArray()
-        expect(currentElements).toHaveLength(1)
-        const typeElement = currentElements[0] as ObjectType
-        expect(Object.keys(typeElement.fields)).toHaveLength(1)
-        expect(typeElement).toMatchObject(newObjectTypeObjectMatcher)
-      })
-      it('should remove multiple files correctly', async () => {
-        const { changes } = await naclFileSourceTest.removeNaclFiles(['file1.nacl', 'file2.nacl'])
-        expect(changes).toMatchObject([
-          {
-            action: 'remove',
-            data: { before: objectTypeObjectMatcher },
-          },
-          {
-            action: 'remove',
-            data: { before: instanceElementObjectMatcher },
-          },
-        ])
-        expect(await awu(await naclFileSourceTest.getAll()).toArray()).toEqual([])
-      })
-    })
-    describe('updateNaclFiles', () => {
-      it('should not change anything if there are no changes', async () => {
-        expect((await naclFileSourceTest.updateNaclFiles([])).changes).toHaveLength(0)
-        expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([
-          objectTypeObjectMatcher,
-          instanceElementObjectMatcher,
-        ])
-      })
-      it('should update one element correctly', async () => {
-        const currentObjectType = await naclFileSourceTest.get(objectTypeElemID)
-        const newObjectType = new ObjectType({ elemID: objectTypeElemID, fields: {} })
-        const detailedChange = {
-          action: 'modify',
-          id: objectTypeElemID,
-          data: { before: currentObjectType, after: newObjectType },
-          path: ['file1'],
-        } as DetailedChange
-        mockDirStoreGet.mockResolvedValue(file1)
-        const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
-        expect(changes).toHaveLength(1)
-        expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path']))
-        expect(
-          _.sortBy(await awu(await naclFileSourceTest.getAll()).toArray(), e => e.elemID.getFullName()),
-        ).toMatchObject(
-          _.sortBy(
-            [
-              instanceElementObjectMatcher,
-              {
-                elemID: objectTypeElemID,
-                fields: { b: { refType: { elemID: BuiltinTypes.NUMBER.elemID } } },
+      describe('removeNaclFiles', () => {
+        it('should not change anything if the file does not exist', async () => {
+          expect((await naclFileSourceTest.removeNaclFiles(['blabla'])).changes).toHaveLength(0)
+          expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([
+            objectTypeObjectMatcher,
+            instanceElementObjectMatcher,
+          ])
+        })
+        it('should remove one file correctly', async () => {
+          const { changes } = await naclFileSourceTest.removeNaclFiles(['file2.nacl'])
+          expect(changes).toHaveLength(2)
+          expect((changes[0] as unknown as ModificationChange<ObjectType>).data.after.fields.b).toBeUndefined()
+          const newObjectTypeObjectMatcher = {
+            elemID: objectTypeElemID,
+            fields: { a: { refType: { elemID: BuiltinTypes.STRING.elemID } } },
+          }
+          expect(changes).toMatchObject([
+            {
+              action: 'modify',
+              data: {
+                before: objectTypeObjectMatcher,
+                after: newObjectTypeObjectMatcher,
               },
-            ],
-            e => e.elemID.getFullName(),
-          ),
-        )
+            },
+            {
+              action: 'remove',
+              data: { before: instanceElementObjectMatcher },
+            },
+          ])
+          const currentElements = await awu(await naclFileSourceTest.getAll()).toArray()
+          expect(currentElements).toHaveLength(1)
+          const typeElement = currentElements[0] as ObjectType
+          expect(Object.keys(typeElement.fields)).toHaveLength(1)
+          expect(typeElement).toMatchObject(newObjectTypeObjectMatcher)
+        })
+        it('should remove multiple files correctly', async () => {
+          const { changes } = await naclFileSourceTest.removeNaclFiles(['file1.nacl', 'file2.nacl'])
+          expect(changes).toMatchObject([
+            {
+              action: 'remove',
+              data: { before: objectTypeObjectMatcher },
+            },
+            {
+              action: 'remove',
+              data: { before: instanceElementObjectMatcher },
+            },
+          ])
+          expect(await awu(await naclFileSourceTest.getAll()).toArray()).toEqual([])
+        })
       })
-      it('should add an element correctly', async () => {
-        const currentObjectType = await naclFileSourceTest.get(objectTypeElemID)
-        const newInstanceElement = new InstanceElement('inst2', currentObjectType, newInstanceElementValue)
-        const detailedChange = {
-          action: 'add',
-          id: newInstanceElementElemID,
-          data: { after: newInstanceElement },
-          path: ['file1'],
-        } as DetailedChange
-        mockDirStoreGet.mockResolvedValue(file1)
-        const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
-        expect(changes).toHaveLength(1)
-        expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path', 'data']))
-        expect(getChangeData(changes[0]).isEqual(getChangeData(detailedChange))).toBeTruthy()
+      describe('updateNaclFiles', () => {
+        it('should not change anything if there are no changes', async () => {
+          expect((await naclFileSourceTest.updateNaclFiles([])).changes).toHaveLength(0)
+          expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([
+            objectTypeObjectMatcher,
+            instanceElementObjectMatcher,
+          ])
+        })
+        it('should update one element correctly', async () => {
+          const currentObjectType = await naclFileSourceTest.get(objectTypeElemID)
+          const newObjectType = new ObjectType({ elemID: objectTypeElemID, fields: {} })
+          const detailedChange = {
+            action: 'modify',
+            id: objectTypeElemID,
+            data: { before: currentObjectType, after: newObjectType },
+            path: ['file1'],
+          } as DetailedChange
+          mockDirStoreGet.mockResolvedValue(file1)
+          const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
+          expect(changes).toHaveLength(1)
+          expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path']))
+          expect(
+            _.sortBy(await awu(await naclFileSourceTest.getAll()).toArray(), e => e.elemID.getFullName()),
+          ).toMatchObject(
+            _.sortBy(
+              [
+                instanceElementObjectMatcher,
+                {
+                  elemID: objectTypeElemID,
+                  fields: { b: { refType: { elemID: BuiltinTypes.NUMBER.elemID } } },
+                },
+              ],
+              e => e.elemID.getFullName(),
+            ),
+          )
+        })
+        it('should add an element correctly', async () => {
+          const currentObjectType = await naclFileSourceTest.get(objectTypeElemID)
+          const newInstanceElement = new InstanceElement('inst2', currentObjectType, newInstanceElementValue)
+          const detailedChange = {
+            action: 'add',
+            id: newInstanceElementElemID,
+            data: { after: newInstanceElement },
+            path: ['file1'],
+          } as DetailedChange
+          mockDirStoreGet.mockResolvedValue(file1)
+          const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
+          expect(changes).toHaveLength(1)
+          expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path', 'data']))
+          expect(getChangeData(changes[0]).isEqual(getChangeData(detailedChange))).toBeTruthy()
 
-        const sortedAll = _.sortBy(await awu(await naclFileSourceTest.getAll()).toArray(), e => e.elemID.getFullName())
-        expect(sortedAll).toMatchObject(
-          _.sortBy([instanceElementObjectMatcher, objectTypeObjectMatcher, newInstanceElementObjectMatcher], e =>
+          const sortedAll = _.sortBy(await awu(await naclFileSourceTest.getAll()).toArray(), e =>
             e.elemID.getFullName(),
-          ),
-        )
-      })
-      it('should remove an element correctly', async () => {
-        const currentInstanceElement = await naclFileSourceTest.get(instanceElementElemID)
-        const detailedChange = {
-          action: 'remove',
-          id: instanceElementElemID,
-          data: { before: currentInstanceElement },
-          path: ['file2'],
-        } as DetailedChange
-        mockDirStoreGet.mockResolvedValue(file2)
-        const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
-        expect(changes).toHaveLength(1)
-        expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path']))
-        expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([objectTypeObjectMatcher])
+          )
+          expect(sortedAll).toMatchObject(
+            _.sortBy([instanceElementObjectMatcher, objectTypeObjectMatcher, newInstanceElementObjectMatcher], e =>
+              e.elemID.getFullName(),
+            ),
+          )
+        })
+        it('should remove an element correctly', async () => {
+          const currentInstanceElement = await naclFileSourceTest.get(instanceElementElemID)
+          const detailedChange = {
+            action: 'remove',
+            id: instanceElementElemID,
+            data: { before: currentInstanceElement },
+            path: ['file2'],
+          } as DetailedChange
+          mockDirStoreGet.mockResolvedValue(file2)
+          const { changes } = await naclFileSourceTest.updateNaclFiles([detailedChange])
+          expect(changes).toHaveLength(1)
+          expect(changes[0]).toMatchObject(_.omit(detailedChange, ['id', 'path']))
+          expect(await awu(await naclFileSourceTest.getAll()).toArray()).toMatchObject([objectTypeObjectMatcher])
+        })
       })
     })
-  })
-})
+  },
+)

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -98,752 +98,769 @@ const validateParsedNaclFile = async (
 
 const mockParse = jest.mocked(parser).parse
 
-describe('Nacl Files Source', () => {
-  let getChangeLocationsMock: jest.MockedFunction<typeof getChangeLocations>
-  let mockDirStore: MockInterface<DirectoryStore<string>>
-  let mockCache: ParsedNaclFileCache
-  let mockedStaticFilesSource: StaticFilesSource
+describe.each([false, true])(
+  'Nacl Files Source (CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING is %s)',
+  shouldCreateFilenamesToElementIDsMapping => {
+    let getChangeLocationsMock: jest.MockedFunction<typeof getChangeLocations>
+    let mockDirStore: MockInterface<DirectoryStore<string>>
+    let mockCache: ParsedNaclFileCache
+    let mockedStaticFilesSource: StaticFilesSource
 
-  let createdMaps: Record<string, RemoteMap<Value>> = {}
-  const mockRemoteMapCreator: RemoteMapCreator = async <T, K extends string = string>({
-    namespace,
-  }: CreateRemoteMapParams<T>): Promise<RemoteMap<T, K>> => {
-    if (createdMaps[namespace] === undefined) {
-      const realMap = new InMemoryRemoteMap()
-      const getImpl = async (key: string): Promise<Value> => (key.endsWith('hash') ? 'HASH' : realMap.get(key))
-      createdMaps[namespace] = {
-        delete: mockFunction<RemoteMap<Value>['delete']>(),
-        get: mockFunction<RemoteMap<Value>['get']>().mockImplementation(getImpl),
-        getMany: mockFunction<RemoteMap<Value>['getMany']>().mockImplementation(async keys =>
-          Promise.all(keys.map(getImpl)),
-        ),
-        has: mockFunction<RemoteMap<Value>['has']>().mockImplementation(
-          async key => key.endsWith('hash') || realMap.has(key),
-        ),
-        set: mockFunction<RemoteMap<Value>['set']>().mockImplementation(realMap.set.bind(realMap)),
-        setAll: mockFunction<RemoteMap<Value>['setAll']>().mockImplementation(realMap.setAll.bind(realMap)),
-        deleteAll: mockFunction<RemoteMap<Value>['deleteAll']>().mockImplementation(realMap.deleteAll.bind(realMap)),
-        entries: mockFunction<RemoteMap<Value>['entries']>().mockImplementation(realMap.entries.bind(realMap)),
-        keys: mockFunction<RemoteMap<Value>['keys']>().mockImplementation(realMap.keys.bind(realMap)),
-        values: mockFunction<RemoteMap<Value>['values']>().mockImplementation(realMap.values.bind(realMap)),
-        flush: mockFunction<RemoteMap<Value>['flush']>().mockImplementation(realMap.flush.bind(realMap)),
-        clear: mockFunction<RemoteMap<Value>['clear']>().mockImplementation(realMap.clear.bind(realMap)),
-        close: mockFunction<RemoteMap<Value>['close']>().mockImplementation(realMap.close.bind(realMap)),
-        isEmpty: mockFunction<RemoteMap<Value>['isEmpty']>().mockImplementation(realMap.isEmpty.bind(realMap)),
+    let createdMaps: Record<string, RemoteMap<Value>> = {}
+    const mockRemoteMapCreator: RemoteMapCreator = async <T, K extends string = string>({
+      namespace,
+    }: CreateRemoteMapParams<T>): Promise<RemoteMap<T, K>> => {
+      if (createdMaps[namespace] === undefined) {
+        const realMap = new InMemoryRemoteMap()
+        const getImpl = async (key: string): Promise<Value> => (key.endsWith('hash') ? 'HASH' : realMap.get(key))
+        createdMaps[namespace] = {
+          delete: mockFunction<RemoteMap<Value>['delete']>(),
+          get: mockFunction<RemoteMap<Value>['get']>().mockImplementation(getImpl),
+          getMany: mockFunction<RemoteMap<Value>['getMany']>().mockImplementation(async keys =>
+            Promise.all(keys.map(getImpl)),
+          ),
+          has: mockFunction<RemoteMap<Value>['has']>().mockImplementation(
+            async key => key.endsWith('hash') || realMap.has(key),
+          ),
+          set: mockFunction<RemoteMap<Value>['set']>().mockImplementation(realMap.set.bind(realMap)),
+          setAll: mockFunction<RemoteMap<Value>['setAll']>().mockImplementation(realMap.setAll.bind(realMap)),
+          deleteAll: mockFunction<RemoteMap<Value>['deleteAll']>().mockImplementation(realMap.deleteAll.bind(realMap)),
+          entries: mockFunction<RemoteMap<Value>['entries']>().mockImplementation(realMap.entries.bind(realMap)),
+          keys: mockFunction<RemoteMap<Value>['keys']>().mockImplementation(realMap.keys.bind(realMap)),
+          values: mockFunction<RemoteMap<Value>['values']>().mockImplementation(realMap.values.bind(realMap)),
+          flush: mockFunction<RemoteMap<Value>['flush']>().mockImplementation(realMap.flush.bind(realMap)),
+          clear: mockFunction<RemoteMap<Value>['clear']>().mockImplementation(realMap.clear.bind(realMap)),
+          close: mockFunction<RemoteMap<Value>['close']>().mockImplementation(realMap.close.bind(realMap)),
+          isEmpty: mockFunction<RemoteMap<Value>['isEmpty']>().mockImplementation(realMap.isEmpty.bind(realMap)),
+        }
       }
+      return createdMaps[namespace] as RemoteMap<T, K>
     }
-    return createdMaps[namespace] as RemoteMap<T, K>
-  }
 
-  beforeEach(async () => {
-    jest.clearAllMocks()
-    createdMaps = {}
-    mockDirStore = createMockDirStore([], true)
-    mockedStaticFilesSource = mockStaticFilesSource()
-    mockCache = createParseResultCache('test', persistentMockCreateRemoteMap(), mockStaticFilesSource(), true)
-    getChangeLocationsMock = getChangeLocations as jest.MockedFunction<typeof getChangeLocations>
-    getChangeLocationsMock.mockImplementation(
-      (change: DetailedChange) =>
-        ({
-          ...change,
-          location: {
-            filename: 'file',
-            start: { line: 0, row: 0, byte: 0 },
-            end: { line: 0, row: 0, byte: 0 },
-          },
-        }) as unknown as DetailedChangeWithSource[],
-    )
-  })
-
-  describe('clear', () => {
-    it('should delete everything by default', async () => {
-      mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
-      await naclSrc.load({})
-      await naclSrc.clear()
-      expect(mockDirStore.clear as jest.Mock).toHaveBeenCalledTimes(1)
-      Object.values(createdMaps).forEach(cache => expect(cache.clear).toHaveBeenCalledTimes(1))
-      expect(mockedStaticFilesSource.clear).toHaveBeenCalledTimes(1)
-    })
-
-    it('should delete only specified parts', async () => {
-      mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
-      await naclSrc.load({})
-      await naclSrc.clear({ nacl: true, staticResources: false, cache: true })
-      expect(mockDirStore.clear as jest.Mock).toHaveBeenCalledTimes(1)
-      Object.values(createdMaps).forEach(cache => expect(cache.clear).toHaveBeenCalledTimes(1))
-      expect(mockedStaticFilesSource.clear).not.toHaveBeenCalled()
-    })
-
-    it('should throw if trying to clear static resources without nacls or cache', async () => {
-      mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
-      await naclSrc.load({})
-      await expect(naclSrc.clear({ nacl: false, staticResources: true, cache: true })).rejects.toThrow(
-        'Cannot clear static resources without clearing the cache and nacls',
+    beforeEach(async () => {
+      jest.clearAllMocks()
+      createdMaps = {}
+      mockDirStore = createMockDirStore([], true)
+      mockedStaticFilesSource = mockStaticFilesSource()
+      mockCache = createParseResultCache('test', persistentMockCreateRemoteMap(), mockStaticFilesSource(), true)
+      getChangeLocationsMock = getChangeLocations as jest.MockedFunction<typeof getChangeLocations>
+      getChangeLocationsMock.mockImplementation(
+        (change: DetailedChange) =>
+          ({
+            ...change,
+            location: {
+              filename: 'file',
+              start: { line: 0, row: 0, byte: 0 },
+              end: { line: 0, row: 0, byte: 0 },
+            },
+          }) as unknown as DetailedChangeWithSource[],
       )
-      expect(mockDirStore.clear as jest.Mock).not.toHaveBeenCalled()
-      Object.values(createdMaps).forEach(cache => expect(cache.clear).not.toHaveBeenCalled())
-      expect(mockedStaticFilesSource.clear).not.toHaveBeenCalled()
     })
-  })
 
-  describe('flush', () => {
-    it('should flush everything by default', async () => {
-      mockDirStore.flush = jest.fn().mockResolvedValue(Promise.resolve())
-      mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
-      await naclSrc.load({})
-      await naclSrc.flush()
-      expect(mockDirStore.flush as jest.Mock).toHaveBeenCalledTimes(1)
-      Object.values(createdMaps).forEach(cache => expect(cache.flush).toHaveBeenCalledTimes(1))
-      expect(mockedStaticFilesSource.flush).toHaveBeenCalledTimes(1)
+    beforeAll(() => {
+      process.env.SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING = shouldCreateFilenamesToElementIDsMapping ? '1' : '0'
     })
-  })
 
-  describe('isEmpty', () => {
-    it("should use store's isEmpty", async () => {
-      mockDirStore.isEmpty = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await naclSrc.load({})
-      await naclSrc.isEmpty()
-      expect(mockDirStore.isEmpty as jest.Mock).toHaveBeenCalledTimes(1)
+    afterAll(() => {
+      delete process.env.SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING
     })
-  })
 
-  describe('load', () => {
-    it('should list files', async () => {
-      mockDirStore.list = jest.fn().mockResolvedValue(Promise.resolve([]))
-      await (
-        await naclFilesSource(
+    describe('clear', () => {
+      it('should delete everything by default', async () => {
+        mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
+        await naclSrc.load({})
+        await naclSrc.clear()
+        expect(mockDirStore.clear as jest.Mock).toHaveBeenCalledTimes(1)
+        Object.values(createdMaps).forEach(cache => expect(cache.clear).toHaveBeenCalledTimes(1))
+        expect(mockedStaticFilesSource.clear).toHaveBeenCalledTimes(1)
+      })
+
+      it('should delete only specified parts', async () => {
+        mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
+        await naclSrc.load({})
+        await naclSrc.clear({ nacl: true, staticResources: false, cache: true })
+        expect(mockDirStore.clear as jest.Mock).toHaveBeenCalledTimes(1)
+        Object.values(createdMaps).forEach(cache => expect(cache.clear).toHaveBeenCalledTimes(1))
+        expect(mockedStaticFilesSource.clear).not.toHaveBeenCalled()
+      })
+
+      it('should throw if trying to clear static resources without nacls or cache', async () => {
+        mockDirStore.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
+        await naclSrc.load({})
+        await expect(naclSrc.clear({ nacl: false, staticResources: true, cache: true })).rejects.toThrow(
+          'Cannot clear static resources without clearing the cache and nacls',
+        )
+        expect(mockDirStore.clear as jest.Mock).not.toHaveBeenCalled()
+        Object.values(createdMaps).forEach(cache => expect(cache.clear).not.toHaveBeenCalled())
+        expect(mockedStaticFilesSource.clear).not.toHaveBeenCalled()
+      })
+    })
+
+    describe('flush', () => {
+      it('should flush everything by default', async () => {
+        mockDirStore.flush = jest.fn().mockResolvedValue(Promise.resolve())
+        mockCache.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        mockedStaticFilesSource.clear = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource('', mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
+        await naclSrc.load({})
+        await naclSrc.flush()
+        expect(mockDirStore.flush as jest.Mock).toHaveBeenCalledTimes(1)
+        Object.values(createdMaps).forEach(cache => expect(cache.flush).toHaveBeenCalledTimes(1))
+        expect(mockedStaticFilesSource.flush).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('isEmpty', () => {
+      it("should use store's isEmpty", async () => {
+        mockDirStore.isEmpty = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource(
           '',
           mockDirStore,
           mockedStaticFilesSource,
           () => Promise.resolve(new InMemoryRemoteMap()),
           true,
         )
-      ).load({})
-      expect(mockDirStore.list as jest.Mock).toHaveBeenCalled()
+        await naclSrc.load({})
+        await naclSrc.isEmpty()
+        expect(mockDirStore.isEmpty as jest.Mock).toHaveBeenCalledTimes(1)
+      })
     })
-    it('should not list files if ignoreFileChanges is set', async () => {
-      mockDirStore.list = jest.fn().mockImplementation(async () => awu([]))
-      await (
-        await naclFilesSource(
-          '',
-          mockDirStore,
-          mockedStaticFilesSource,
-          () => Promise.resolve(new InMemoryRemoteMap()),
-          true,
-        )
-      ).load({ ignoreFileChanges: true })
-      expect(mockDirStore.list as jest.Mock).not.toHaveBeenCalled()
-    })
-    it('should not access rocks db when ignore file changes flag is set', async () => {
-      mockDirStore.list = jest.fn().mockImplementation(async () => awu([]))
-      const retrievedKeys: string[] = []
-      await (
-        await naclFilesSource(
-          '',
-          mockDirStore,
-          mockedStaticFilesSource,
-          <T, K extends string>() => {
-            const origMap = new InMemoryRemoteMap<T, K>()
-            const wrappedMap = {
-              ...origMap,
-              get: (key: K) => {
-                retrievedKeys.push(key)
-                return origMap.get(key)
-              },
-            } as unknown as RemoteMap<T, K>
-            return Promise.resolve(wrappedMap)
-          },
-          true,
-        )
-      ).load({ ignoreFileChanges: true })
-      expect(retrievedKeys).toEqual([])
-    })
-    describe('nacl source hash', () => {
-      describe('when hash changes to be empty', () => {
-        it('should remove the current hash from the metadata remote map', async () => {
-          // note - the default implementation returns "hash" as the "previous" hash
-          // using an empty dir store, so the update hash will be empty
-          const naclSource = await naclFilesSource(
+
+    describe('load', () => {
+      it('should list files', async () => {
+        mockDirStore.list = jest.fn().mockResolvedValue(Promise.resolve([]))
+        await (
+          await naclFilesSource(
             '',
             mockDirStore,
-            mockStaticFilesSource(),
-            mockRemoteMapCreator,
+            mockedStaticFilesSource,
+            () => Promise.resolve(new InMemoryRemoteMap()),
             true,
           )
-          const res = await naclSource.load({})
-          expect(res.postChangeHash).toBeUndefined()
-          const metadataMap = createdMaps['naclFileSource--metadata']
-          expect(metadataMap.delete).toHaveBeenCalledWith(naclFileSourceModule.HASH_KEY)
-        })
+        ).load({})
+        expect(mockDirStore.list as jest.Mock).toHaveBeenCalled()
       })
-      describe('when hash changes to non empty value', () => {
-        it('should set the new value', async () => {
-          const naclSource = await naclFilesSource(
+      it('should not list files if ignoreFileChanges is set', async () => {
+        mockDirStore.list = jest.fn().mockImplementation(async () => awu([]))
+        await (
+          await naclFilesSource(
             '',
-            createMockDirStore(),
-            mockStaticFilesSource(),
-            mockRemoteMapCreator,
+            mockDirStore,
+            mockedStaticFilesSource,
+            () => Promise.resolve(new InMemoryRemoteMap()),
             true,
           )
-          const res = await naclSource.load({})
-          expect(res.postChangeHash).toBeDefined()
-          const metadataMap = createdMaps['naclFileSource--metadata']
-          expect(metadataMap.set).toHaveBeenCalledWith(naclFileSourceModule.HASH_KEY, res.postChangeHash)
+        ).load({ ignoreFileChanges: true })
+        expect(mockDirStore.list as jest.Mock).not.toHaveBeenCalled()
+      })
+      it('should not access rocks db when ignore file changes flag is set', async () => {
+        mockDirStore.list = jest.fn().mockImplementation(async () => awu([]))
+        const retrievedKeys: string[] = []
+        await (
+          await naclFilesSource(
+            '',
+            mockDirStore,
+            mockedStaticFilesSource,
+            <T, K extends string>() => {
+              const origMap = new InMemoryRemoteMap<T, K>()
+              const wrappedMap = {
+                ...origMap,
+                get: (key: K) => {
+                  retrievedKeys.push(key)
+                  return origMap.get(key)
+                },
+              } as unknown as RemoteMap<T, K>
+              return Promise.resolve(wrappedMap)
+            },
+            true,
+          )
+        ).load({ ignoreFileChanges: true })
+        expect(retrievedKeys).toEqual([])
+      })
+      describe('nacl source hash', () => {
+        describe('when hash changes to be empty', () => {
+          it('should remove the current hash from the metadata remote map', async () => {
+            // note - the default implementation returns "hash" as the "previous" hash
+            // using an empty dir store, so the update hash will be empty
+            const naclSource = await naclFilesSource(
+              '',
+              mockDirStore,
+              mockStaticFilesSource(),
+              mockRemoteMapCreator,
+              true,
+            )
+            const res = await naclSource.load({})
+            expect(res.postChangeHash).toBeUndefined()
+            const metadataMap = createdMaps['naclFileSource--metadata']
+            expect(metadataMap.delete).toHaveBeenCalledWith(naclFileSourceModule.HASH_KEY)
+          })
+        })
+        describe('when hash changes to non empty value', () => {
+          it('should set the new value', async () => {
+            const naclSource = await naclFilesSource(
+              '',
+              createMockDirStore(),
+              mockStaticFilesSource(),
+              mockRemoteMapCreator,
+              true,
+            )
+            const res = await naclSource.load({})
+            expect(res.postChangeHash).toBeDefined()
+            const metadataMap = createdMaps['naclFileSource--metadata']
+            expect(metadataMap.set).toHaveBeenCalledWith(naclFileSourceModule.HASH_KEY, res.postChangeHash)
+          })
         })
       })
     })
-  })
 
-  describe('rename', () => {
-    it('should rename everything', async () => {
-      const newName = 'new'
-      const oldName = 'old'
-      mockDirStore.rename = jest.fn().mockResolvedValue(Promise.resolve())
-      mockCache.rename = jest.fn().mockResolvedValue(Promise.resolve())
-      mockedStaticFilesSource.rename = jest.fn().mockResolvedValue(Promise.resolve())
-      const naclSrc = await naclFilesSource(oldName, mockDirStore, mockedStaticFilesSource, mockRemoteMapCreator, true)
-      await naclSrc.load({})
-      jest.clearAllMocks()
-      await naclSrc.rename(newName)
-      expect(mockDirStore.rename).toHaveBeenCalledTimes(1)
-      expect(mockDirStore.rename).toHaveBeenCalledWith(newName)
-      expect(mockedStaticFilesSource.rename).toHaveBeenCalledTimes(1)
-      expect(mockedStaticFilesSource.rename).toHaveBeenCalledWith(newName)
+    describe('rename', () => {
+      it('should rename everything', async () => {
+        const newName = 'new'
+        const oldName = 'old'
+        mockDirStore.rename = jest.fn().mockResolvedValue(Promise.resolve())
+        mockCache.rename = jest.fn().mockResolvedValue(Promise.resolve())
+        mockedStaticFilesSource.rename = jest.fn().mockResolvedValue(Promise.resolve())
+        const naclSrc = await naclFilesSource(
+          oldName,
+          mockDirStore,
+          mockedStaticFilesSource,
+          mockRemoteMapCreator,
+          true,
+        )
+        await naclSrc.load({})
+        jest.clearAllMocks()
+        await naclSrc.rename(newName)
+        expect(mockDirStore.rename).toHaveBeenCalledTimes(1)
+        expect(mockDirStore.rename).toHaveBeenCalledWith(newName)
+        expect(mockedStaticFilesSource.rename).toHaveBeenCalledTimes(1)
+        expect(mockedStaticFilesSource.rename).toHaveBeenCalledWith(newName)
 
-      const cacheKeysToRename = ['elements_index', 'referenced_index', 'metadata', 'searchableNamesIndex']
-      cacheKeysToRename.forEach(key => {
-        const mapNames = Object.keys(createdMaps)
-          .filter(namespace => !namespace.includes('parsedResultCache'))
-          .filter(namespaces => namespaces.includes(key))
-        expect(mapNames).toHaveLength(2)
-        const [[newMap], [oldMap]] = _.partition(mapNames, name => name.includes(newName))
-        expect(createdMaps[newMap].setAll).toHaveBeenCalledTimes(1)
-        expect(createdMaps[oldMap].entries).toHaveBeenCalledTimes(1)
+        const cacheKeysToRename = ['elements_index', 'referenced_index', 'metadata', 'searchableNamesIndex']
+        cacheKeysToRename.forEach(key => {
+          const mapNames = Object.keys(createdMaps)
+            .filter(namespace => !namespace.includes('parsedResultCache'))
+            .filter(namespaces => namespaces.includes(key))
+          expect(mapNames).toHaveLength(2)
+          const [[newMap], [oldMap]] = _.partition(mapNames, name => name.includes(newName))
+          expect(createdMaps[newMap].setAll).toHaveBeenCalledTimes(1)
+          expect(createdMaps[oldMap].entries).toHaveBeenCalledTimes(1)
+        })
+
+        // make sure all new maps are created with the proper names
+        const oldNames = Object.keys(createdMaps).filter(namespaces => namespaces.includes(oldName))
+        const newNames = new Set(Object.keys(createdMaps).filter(namespaces => namespaces.includes(newName)))
+        oldNames.forEach(namespace => expect(newNames.has(namespace.replace(oldName, newName))).toBeTruthy())
       })
-
-      // make sure all new maps are created with the proper names
-      const oldNames = Object.keys(createdMaps).filter(namespaces => namespaces.includes(oldName))
-      const newNames = new Set(Object.keys(createdMaps).filter(namespaces => namespaces.includes(newName)))
-      oldNames.forEach(namespace => expect(newNames.has(namespace.replace(oldName, newName))).toBeTruthy())
     })
-  })
 
-  describe('getTotalSize', () => {
-    it('should calc getTotalSize', async () => {
-      mockDirStore.getTotalSize = jest.fn().mockResolvedValue(Promise.resolve(100))
-      mockedStaticFilesSource.getTotalSize = jest.fn().mockResolvedValue(Promise.resolve(200))
-      const totalSize = await (
-        await naclFilesSource(
+    describe('getTotalSize', () => {
+      it('should calc getTotalSize', async () => {
+        mockDirStore.getTotalSize = jest.fn().mockResolvedValue(Promise.resolve(100))
+        mockedStaticFilesSource.getTotalSize = jest.fn().mockResolvedValue(Promise.resolve(200))
+        const totalSize = await (
+          await naclFilesSource(
+            '',
+            mockDirStore,
+            mockedStaticFilesSource,
+            () => Promise.resolve(new InMemoryRemoteMap()),
+            true,
+          )
+        ).getTotalSize()
+        expect(totalSize).toEqual(300)
+        expect(mockDirStore.getTotalSize).toHaveBeenCalledTimes(1)
+        expect(mockedStaticFilesSource.getTotalSize).toHaveBeenCalledTimes(1)
+      })
+    })
+
+    describe('parse optimization', () => {
+      const change = createChange()
+      it('should not parse file when updating single add changes in a new file', async () => {
+        const naclSrc = await naclFilesSource(
           '',
           mockDirStore,
           mockedStaticFilesSource,
           () => Promise.resolve(new InMemoryRemoteMap()),
           true,
         )
-      ).getTotalSize()
-      expect(totalSize).toEqual(300)
-      expect(mockDirStore.getTotalSize).toHaveBeenCalledTimes(1)
-      expect(mockedStaticFilesSource.getTotalSize).toHaveBeenCalledTimes(1)
+        await naclSrc.load({})
+        await naclSrc.updateNaclFiles([change])
+        expect(mockParse).not.toHaveBeenCalled()
+      })
     })
-  })
 
-  describe('parse optimization', () => {
-    const change = createChange()
-    it('should not parse file when updating single add changes in a new file', async () => {
-      const naclSrc = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await naclSrc.load({})
-      await naclSrc.updateNaclFiles([change])
-      expect(mockParse).not.toHaveBeenCalled()
-    })
-  })
+    describe('removing static files', () => {
+      const elemID = new ElemID('salesforce', 'new_elem')
+      const filepath = 'to/the/superbowl'
+      const afterFilePath = 'to/the/superbowl2'
+      const sfile = new StaticFile({ filepath, hash: 'XI' })
+      let src: NaclFilesSource
+      beforeEach(async () => {
+        src = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
+        )
+        await src.load({})
+      })
+      it('should not parse file when updating single add changes in a new file', async () => {
+        const change = {
+          id: elemID,
+          action: 'remove',
+          data: { before: sfile },
+          path: ['new', 'file'],
+        } as DetailedChange
+        await src.updateNaclFiles([change])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+      })
+      it('should delete before file when path is changed', async () => {
+        const change = {
+          id: elemID,
+          action: 'modify',
+          data: { before: sfile, after: new StaticFile({ filepath: afterFilePath, hash: 'XI' }) },
+          path: ['new', 'file'],
+        } as DetailedChange
+        await src.updateNaclFiles([change])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+      })
+      it('should delete before file when it is no longer a static file', async () => {
+        const change = {
+          id: elemID,
+          action: 'modify',
+          data: { before: sfile, after: '' },
+          path: ['new', 'file'],
+        } as DetailedChange
+        await src.updateNaclFiles([change])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
+      })
+      it('should not delete static file if the change is only in content and not in path', async () => {
+        const change = {
+          id: elemID,
+          action: 'modify',
+          data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
+          path: ['new', 'file'],
+        } as DetailedChange
+        await src.updateNaclFiles([change])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
+      })
+      it('should not delete static file if there are multiple appearances of it (in different files)', async () => {
+        getChangeLocationsMock.mockImplementationOnce(
+          (change: DetailedChange) =>
+            ({
+              ...change,
+              location: {
+                filename: 'file1',
+                start: { line: 0, row: 0, byte: 0 },
+                end: { line: 0, row: 0, byte: 0 },
+              },
+            }) as unknown as DetailedChangeWithSource[],
+        )
+        getChangeLocationsMock.mockImplementationOnce(
+          (change: DetailedChange) =>
+            ({
+              ...change,
+              location: {
+                filename: 'file2',
+                start: { line: 0, row: 0, byte: 0 },
+                end: { line: 0, row: 0, byte: 0 },
+              },
+            }) as unknown as DetailedChangeWithSource[],
+        )
 
-  describe('removing static files', () => {
-    const elemID = new ElemID('salesforce', 'new_elem')
-    const filepath = 'to/the/superbowl'
-    const afterFilePath = 'to/the/superbowl2'
-    const sfile = new StaticFile({ filepath, hash: 'XI' })
-    let src: NaclFilesSource
-    beforeEach(async () => {
-      src = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await src.load({})
-    })
-    it('should not parse file when updating single add changes in a new file', async () => {
-      const change = {
-        id: elemID,
-        action: 'remove',
-        data: { before: sfile },
-        path: ['new', 'file'],
-      } as DetailedChange
-      await src.updateNaclFiles([change])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
-    })
-    it('should delete before file when path is changed', async () => {
-      const change = {
-        id: elemID,
-        action: 'modify',
-        data: { before: sfile, after: new StaticFile({ filepath: afterFilePath, hash: 'XI' }) },
-        path: ['new', 'file'],
-      } as DetailedChange
-      await src.updateNaclFiles([change])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
-    })
-    it('should delete before file when it is no longer a static file', async () => {
-      const change = {
-        id: elemID,
-        action: 'modify',
-        data: { before: sfile, after: '' },
-        path: ['new', 'file'],
-      } as DetailedChange
-      await src.updateNaclFiles([change])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledWith(sfile)
-    })
-    it('should not delete static file if the change is only in content and not in path', async () => {
-      const change = {
-        id: elemID,
-        action: 'modify',
-        data: { before: sfile, after: new StaticFile({ filepath, hash: 'XII' }) },
-        path: ['new', 'file'],
-      } as DetailedChange
-      await src.updateNaclFiles([change])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
-    })
-    it('should not delete static file if there are multiple appearances of it (in different files)', async () => {
-      getChangeLocationsMock.mockImplementationOnce(
-        (change: DetailedChange) =>
-          ({
-            ...change,
-            location: {
-              filename: 'file1',
-              start: { line: 0, row: 0, byte: 0 },
-              end: { line: 0, row: 0, byte: 0 },
-            },
-          }) as unknown as DetailedChangeWithSource[],
-      )
-      getChangeLocationsMock.mockImplementationOnce(
-        (change: DetailedChange) =>
-          ({
-            ...change,
-            location: {
-              filename: 'file2',
-              start: { line: 0, row: 0, byte: 0 },
-              end: { line: 0, row: 0, byte: 0 },
-            },
-          }) as unknown as DetailedChangeWithSource[],
-      )
-
-      const newInstanceElement1 = new InstanceElement(
-        'inst1',
-        new ObjectType({ elemID: new ElemID('dummy', 'type') }),
-        {
-          file2: sfile,
-        },
-      )
-      const newInstanceElement2 = new InstanceElement(
-        'inst2',
-        new ObjectType({ elemID: new ElemID('dummy', 'type') }),
-        {
-          file2: sfile,
-        },
-      )
-      const detailedChange1 = {
-        action: 'add',
-        id: newInstanceElement1.elemID,
-        data: { after: newInstanceElement1 },
-      } as DetailedChange
-      const detailedChange2 = {
-        action: 'add',
-        id: newInstanceElement2.elemID,
-        data: { after: newInstanceElement2 },
-      } as DetailedChange
-
-      await src.updateNaclFiles([detailedChange1, detailedChange2])
-
-      const removal = {
-        id: newInstanceElement1.elemID.createNestedID('file'),
-        action: 'remove',
-        data: { before: sfile },
-      } as DetailedChange
-      await src.updateNaclFiles([removal])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
-    })
-    it('should not delete static file if the file was both added and deleted', async () => {
-      getChangeLocationsMock.mockImplementationOnce(
-        (change: DetailedChange) =>
-          ({
-            ...change,
-            location: {
-              filename: 'file1',
-              start: { line: 0, row: 0, byte: 0 },
-              end: { line: 0, row: 0, byte: 0 },
-            },
-          }) as unknown as DetailedChangeWithSource[],
-      )
-      getChangeLocationsMock.mockImplementationOnce(
-        (change: DetailedChange) =>
-          ({
-            ...change,
-            location: {
-              filename: 'file2',
-              start: { line: 0, row: 0, byte: 0 },
-              end: { line: 0, row: 0, byte: 0 },
-            },
-          }) as unknown as DetailedChangeWithSource[],
-      )
-      const changeAdd = {
-        id: new ElemID('salesforce', 'new_elem2'),
-        action: 'add',
-        data: { after: new StaticFile({ filepath, hash: 'XII' }) },
-        path: ['new', 'file'],
-      } as DetailedChange
-      const changeDelete = {
-        id: elemID,
-        action: 'remove',
-        data: { before: new StaticFile({ filepath, hash: 'XII' }) },
-        path: ['old', 'file2'],
-      } as DetailedChange
-      await src.updateNaclFiles([changeAdd, changeDelete])
-      expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
-    })
-  })
-
-  describe('init with parsed files', () => {
-    it('should return elements from given parsed files', async () => {
-      const filename = 'mytest.nacl'
-      const elemID = new ElemID('dummy', 'elem')
-      const elem = new ObjectType({ elemID, path: ['test', 'new'] })
-      const elements = [elem]
-      const parsedFiles: ParsedNaclFile[] = [
-        {
-          filename,
-          elements: () => Promise.resolve(elements),
-          buffer: '',
-          data: {
-            errors: () => Promise.resolve([]),
-            referenced: () => Promise.resolve([]),
-            staticFiles: () => Promise.resolve([]),
+        const newInstanceElement1 = new InstanceElement(
+          'inst1',
+          new ObjectType({ elemID: new ElemID('dummy', 'type') }),
+          {
+            file2: sfile,
           },
-        },
-      ]
-      const naclSource = naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-        parsedFiles,
-      )
-      const parsed = await (await naclSource).getParsedNaclFile(filename)
-      expect(parsed).toBeDefined()
-      expect(await (parsed as ParsedNaclFile).elements()).toEqual([elem])
-    })
-  })
+        )
+        const newInstanceElement2 = new InstanceElement(
+          'inst2',
+          new ObjectType({ elemID: new ElemID('dummy', 'type') }),
+          {
+            file2: sfile,
+          },
+        )
+        const detailedChange1 = {
+          action: 'add',
+          id: newInstanceElement1.elemID,
+          data: { after: newInstanceElement1 },
+        } as DetailedChange
+        const detailedChange2 = {
+          action: 'add',
+          id: newInstanceElement2.elemID,
+          data: { after: newInstanceElement2 },
+        } as DetailedChange
 
-  describe('getParsedNaclFile', () => {
-    let naclSource: NaclFilesSource
-    const mockFileData = { buffer: 'someData {}', filename: 'somefile.nacl' }
+        await src.updateNaclFiles([detailedChange1, detailedChange2])
 
-    beforeEach(async () => {
-      naclSource = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-    })
-
-    it('should return undefined if file doenst exist', async () => {
-      await naclSource.load({})
-      expect(await (await naclSource.getParsedNaclFile('nonExistentFile'))?.elements()).toBeUndefined()
-    })
-    it('should return parseResult when state is undefined', async () => {
-      const elemID = new ElemID('dummy', 'elem')
-      const elem = new ObjectType({ elemID, path: ['test', 'new'] })
-      const elements = [elem]
-      ;(mockDirStore.get as jest.Mock).mockResolvedValue(mockFileData)
-      mockParse.mockResolvedValueOnce({ elements, errors: [] })
-      await validateParsedNaclFile(
-        await naclSource.getParsedNaclFile(mockFileData.filename),
-        mockFileData.filename,
-        elements,
-        [],
-      )
-    })
-    it('should return undefined if state is undefined and file does not exist', async () => {
-      ;(mockDirStore.get as jest.Mock).mockResolvedValue(undefined)
-      expect(await naclSource.getParsedNaclFile(mockFileData.filename)).toEqual(undefined)
-    })
-
-    it('should cache referenced result on parsedNaclFile', async () => {
-      ;(mockDirStore.get as jest.Mock).mockResolvedValue(mockFileData)
-      const elements = [new ObjectType({ elemID: new ElemID('dummy', 'elem') })]
-      mockParse.mockResolvedValueOnce({ elements, errors: [] })
-      const mockGetElementReferenced = jest.spyOn(naclFileSourceModule, 'getElementReferenced')
-      const parsed = await naclSource.getParsedNaclFile(mockFileData.filename)
-      expect(parsed).toBeDefined()
-      await parsed?.data.referenced()
-      expect(mockGetElementReferenced).toHaveBeenCalled()
-      mockGetElementReferenced.mockClear()
-      await parsed?.data.referenced()
-      expect(mockGetElementReferenced).not.toHaveBeenCalled()
-    })
-
-    it('should return static file references', async () => {
-      mockDirStore.get.mockResolvedValue(mockFileData)
-      const elements = [
-        new InstanceElement('inst', new ObjectType({ elemID: new ElemID('dummy', 'type') }), {
-          file: new StaticFile({ filepath: 'file', content: Buffer.from('asd') }),
-          missing: new MissingStaticFile('miss'),
-        }),
-      ]
-      mockParse.mockResolvedValueOnce({ elements, errors: [] })
-      const parsed = await naclSource.getParsedNaclFile(mockFileData.filename)
-      expect(parsed).toBeDefined()
-      const staticFiles = await parsed?.data.staticFiles()
-      expect(staticFiles).toBeDefined()
-      expect(staticFiles).toHaveLength(2)
-      expect(staticFiles?.sort()).toEqual(['file', 'miss'])
-    })
-  })
-
-  describe('list', () => {
-    let src: NaclFilesSource
-    beforeEach(async () => {
-      src = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await src.load({})
-      await src.updateNaclFiles([createChange()])
-    })
-
-    it('should list all elements', async () => {
-      expect(await awu(await src.list()).toArray()).toHaveLength(1)
-    })
-  })
-
-  describe('getSearchableNames', () => {
-    let src: NaclFilesSource
-    beforeEach(async () => {
-      src = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await src.load({})
-      await src.updateNaclFiles([createChange()])
-    })
-
-    it('should list all searchable elements', async () => {
-      expect(await src.getSearchableNames()).toEqual(['salesforce.new_elem', 'salesforce.new_elem.field.myField'])
-    })
-  })
-
-  describe('non persistent naclFileSource', () => {
-    it('should not allow flush when the ws is non-persistent', async () => {
-      const nonPSrc = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false,
-      )
-      await expect(nonPSrc.flush()).rejects.toThrow()
-    })
-  })
-
-  describe('getStaticFileByHash', () => {
-    const staticFileSource = mockStaticFilesSource()
-    const staticFile = new StaticFile({
-      content: Buffer.from(''),
-      filepath: 'aaa.txt',
-      encoding: 'utf-8',
-      hash: 'aaa',
-    })
-    it('should return the file it is present and the hashes match', async () => {
-      staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
-      const src = await naclFilesSource(
-        '',
-        mockDirStore,
-        staticFileSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false,
-      )
-      expect(await src.getStaticFile({ filePath: staticFile.filepath, encoding: staticFile.encoding })).toEqual(
-        staticFile,
-      )
-    })
-  })
-
-  describe('isPathIncluded', () => {
-    let src: NaclFilesSource
-    const staticFileSource = mockStaticFilesSource([
-      new StaticFile({
-        content: Buffer.from('FFF'),
-        filepath: 'static-files/fff.txt',
-        hash: '###',
-      }),
-    ])
-    beforeEach(async () => {
-      src = await naclFilesSource(
-        '',
-        mockDirStore,
-        staticFileSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        false,
-      )
-    })
-    it('should mark a path of a nacl file as included', () => {
-      ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(true)
-      expect(src.isPathIncluded('whateves.nacl')).toEqual({
-        included: true,
-        isNacl: true,
+        const removal = {
+          id: newInstanceElement1.elemID.createNestedID('file'),
+          action: 'remove',
+          data: { before: sfile },
+        } as DetailedChange
+        await src.updateNaclFiles([removal])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
+      })
+      it('should not delete static file if the file was both added and deleted', async () => {
+        getChangeLocationsMock.mockImplementationOnce(
+          (change: DetailedChange) =>
+            ({
+              ...change,
+              location: {
+                filename: 'file1',
+                start: { line: 0, row: 0, byte: 0 },
+                end: { line: 0, row: 0, byte: 0 },
+              },
+            }) as unknown as DetailedChangeWithSource[],
+        )
+        getChangeLocationsMock.mockImplementationOnce(
+          (change: DetailedChange) =>
+            ({
+              ...change,
+              location: {
+                filename: 'file2',
+                start: { line: 0, row: 0, byte: 0 },
+                end: { line: 0, row: 0, byte: 0 },
+              },
+            }) as unknown as DetailedChangeWithSource[],
+        )
+        const changeAdd = {
+          id: new ElemID('salesforce', 'new_elem2'),
+          action: 'add',
+          data: { after: new StaticFile({ filepath, hash: 'XII' }) },
+          path: ['new', 'file'],
+        } as DetailedChange
+        const changeDelete = {
+          id: elemID,
+          action: 'remove',
+          data: { before: new StaticFile({ filepath, hash: 'XII' }) },
+          path: ['old', 'file2'],
+        } as DetailedChange
+        await src.updateNaclFiles([changeAdd, changeDelete])
+        expect(mockedStaticFilesSource.delete).toHaveBeenCalledTimes(0)
       })
     })
 
-    it('should mark a static file as included', () => {
-      ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
-      expect(src.isPathIncluded('static-files/fff.txt')).toEqual({
-        included: true,
-        isNacl: false,
+    describe('init with parsed files', () => {
+      it('should return elements from given parsed files', async () => {
+        const filename = 'mytest.nacl'
+        const elemID = new ElemID('dummy', 'elem')
+        const elem = new ObjectType({ elemID, path: ['test', 'new'] })
+        const elements = [elem]
+        const parsedFiles: ParsedNaclFile[] = [
+          {
+            filename,
+            elements: () => Promise.resolve(elements),
+            buffer: '',
+            data: {
+              errors: () => Promise.resolve([]),
+              referenced: () => Promise.resolve([]),
+              staticFiles: () => Promise.resolve([]),
+            },
+          },
+        ]
+        const naclSource = naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
+          parsedFiles,
+        )
+        const parsed = await (await naclSource).getParsedNaclFile(filename)
+        expect(parsed).toBeDefined()
+        expect(await (parsed as ParsedNaclFile).elements()).toEqual([elem])
       })
     })
 
-    it('should mark a missing file as not included', () => {
-      ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
-      expect(src.isPathIncluded('whateves.nacl')).toEqual({
-        included: false,
-      })
-    })
-  })
-  describe('getElementFileNames', () => {
-    it('should return correct result if there are files', async () => {
-      const src1 = await naclFilesSource(
-        '',
-        mockDirStore,
-        mockedStaticFilesSource,
-        () => Promise.resolve(new InMemoryRemoteMap()),
-        true,
-      )
-      await src1.load({})
-      await src1.updateNaclFiles([createChange()])
-      const res = await src1.getElementFileNames()
-      expect(Array.from(res.entries())).toEqual([['salesforce.new_elem', ['file']]])
-    })
-  })
-  describe('getDanglingStaticFiles', () => {
-    let beforeElem: InstanceElement
-    let afterElem: InstanceElement
-    let result: StaticFile[] = []
-    const staticFile1 = new StaticFile({ filepath: 'path1', hash: 'hash1' })
-    const staticFile2 = new StaticFile({ filepath: 'path2', hash: 'hash2' })
-    const staticFile3 = new StaticFile({ filepath: 'path3', hash: 'hash3' })
-    const staticFile4 = new StaticFile({ filepath: 'path4', hash: 'hash4' })
-    const staticFile5 = new StaticFile({ filepath: 'path5', hash: 'hash5' })
-    const staticFile6 = new StaticFile({ filepath: 'path6', hash: 'hash6' })
-    const staticFile7 = new StaticFile({ filepath: 'path7', hash: 'hash7' })
+    describe('getParsedNaclFile', () => {
+      let naclSource: NaclFilesSource
+      const mockFileData = { buffer: 'someData {}', filename: 'somefile.nacl' }
 
-    beforeAll(async () => {
-      beforeElem = new InstanceElement('elem', new ObjectType({ elemID: new ElemID('salesforce', 'type') }), {
-        f1: staticFile1, // To modify
-        f2: staticFile2, // To remove
-        f3: staticFile5, // To change location
-        a: { f3: staticFile3 }, // To modify
-        b: { f4: staticFile4 }, // To remove
-        stays: staticFile7, // To stay
-        remove: staticFile7, // To remove - shouldn't be returned
-      })
-      afterElem = beforeElem.clone()
-
-      afterElem.value.f1 = staticFile6
-      afterElem.value.f5 = staticFile5
-      delete afterElem.value.f2
-      delete afterElem.value.f3
-      afterElem.value.a = 's'
-      delete afterElem.value.b
-      delete afterElem.value.remove
-
-      const staticFilesIndex = {
-        get: async (staticFile: string) => (staticFile !== 'path7' ? ['singleNaclPath'] : ['multi', 'naclPaths']),
-      }
-      result = await getDanglingStaticFiles(detailedCompare(beforeElem, afterElem), staticFilesIndex)
-      expect(result).toHaveLength(4)
-    })
-    it('should return static file that was modified', () => {
-      expect(result).toContain(staticFile1)
-    })
-    it('should return static file that was removed', () => {
-      expect(result).toContain(staticFile2)
-    })
-    it('should return static file nested inside modification of another field', () => {
-      expect(result).toContain(staticFile3)
-    })
-    it('should return static file nested inside removal of another field', () => {
-      expect(result).toContain(staticFile4)
-    })
-    it('should not return static file if the path in element has changed', () => {
-      expect(result).not.toContain(staticFile5)
-    })
-    it('should not return removed static file if it is still referenced in another field', () => {
-      expect(result).not.toContain(staticFile7)
-    })
-
-    describe('when there are no static files in the changes before', () => {
-      let mockStaticFilesIndex: Pick<RemoteMap<string[]>, 'get'>
-
-      beforeAll(async () => {
-        const beforeElemWithoutStaticFiles = await transformElement({
-          element: beforeElem,
-          strict: false,
-          transformFunc: ({ value }) => (isStaticFile(value) ? undefined : value),
-        })
-        mockStaticFilesIndex = { get: jest.fn() }
-        result = await getDanglingStaticFiles(
-          detailedCompare(beforeElemWithoutStaticFiles, afterElem),
-          mockStaticFilesIndex,
+      beforeEach(async () => {
+        naclSource = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
         )
       })
-      it('should return empty list', () => {
-        expect(result).toBeEmpty()
+
+      it('should return undefined if file doenst exist', async () => {
+        await naclSource.load({})
+        expect(await (await naclSource.getParsedNaclFile('nonExistentFile'))?.elements()).toBeUndefined()
       })
-      it('should not query staticFilesIndex', () => {
-        expect(mockStaticFilesIndex.get).not.toHaveBeenCalled()
+      it('should return parseResult when state is undefined', async () => {
+        const elemID = new ElemID('dummy', 'elem')
+        const elem = new ObjectType({ elemID, path: ['test', 'new'] })
+        const elements = [elem]
+        ;(mockDirStore.get as jest.Mock).mockResolvedValue(mockFileData)
+        mockParse.mockResolvedValueOnce({ elements, errors: [] })
+        await validateParsedNaclFile(
+          await naclSource.getParsedNaclFile(mockFileData.filename),
+          mockFileData.filename,
+          elements,
+          [],
+        )
+      })
+      it('should return undefined if state is undefined and file does not exist', async () => {
+        ;(mockDirStore.get as jest.Mock).mockResolvedValue(undefined)
+        expect(await naclSource.getParsedNaclFile(mockFileData.filename)).toEqual(undefined)
+      })
+
+      it('should cache referenced result on parsedNaclFile', async () => {
+        ;(mockDirStore.get as jest.Mock).mockResolvedValue(mockFileData)
+        const elements = [new ObjectType({ elemID: new ElemID('dummy', 'elem') })]
+        mockParse.mockResolvedValueOnce({ elements, errors: [] })
+        const mockGetElementReferenced = jest.spyOn(naclFileSourceModule, 'getElementReferenced')
+        const parsed = await naclSource.getParsedNaclFile(mockFileData.filename)
+        expect(parsed).toBeDefined()
+        await parsed?.data.referenced()
+        expect(mockGetElementReferenced).toHaveBeenCalled()
+        mockGetElementReferenced.mockClear()
+        await parsed?.data.referenced()
+        expect(mockGetElementReferenced).not.toHaveBeenCalled()
+      })
+
+      it('should return static file references', async () => {
+        mockDirStore.get.mockResolvedValue(mockFileData)
+        const elements = [
+          new InstanceElement('inst', new ObjectType({ elemID: new ElemID('dummy', 'type') }), {
+            file: new StaticFile({ filepath: 'file', content: Buffer.from('asd') }),
+            missing: new MissingStaticFile('miss'),
+          }),
+        ]
+        mockParse.mockResolvedValueOnce({ elements, errors: [] })
+        const parsed = await naclSource.getParsedNaclFile(mockFileData.filename)
+        expect(parsed).toBeDefined()
+        const staticFiles = await parsed?.data.staticFiles()
+        expect(staticFiles).toBeDefined()
+        expect(staticFiles).toHaveLength(2)
+        expect(staticFiles?.sort()).toEqual(['file', 'miss'])
       })
     })
-  })
-})
+
+    describe('list', () => {
+      let src: NaclFilesSource
+      beforeEach(async () => {
+        src = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
+        )
+        await src.load({})
+        await src.updateNaclFiles([createChange()])
+      })
+
+      it('should list all elements', async () => {
+        expect(await awu(await src.list()).toArray()).toHaveLength(1)
+      })
+    })
+
+    describe('getSearchableNames', () => {
+      let src: NaclFilesSource
+      beforeEach(async () => {
+        src = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
+        )
+        await src.load({})
+        await src.updateNaclFiles([createChange()])
+      })
+
+      it('should list all searchable elements', async () => {
+        expect(await src.getSearchableNames()).toEqual(['salesforce.new_elem', 'salesforce.new_elem.field.myField'])
+      })
+    })
+
+    describe('non persistent naclFileSource', () => {
+      it('should not allow flush when the ws is non-persistent', async () => {
+        const nonPSrc = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          false,
+        )
+        await expect(nonPSrc.flush()).rejects.toThrow()
+      })
+    })
+
+    describe('getStaticFileByHash', () => {
+      const staticFileSource = mockStaticFilesSource()
+      const staticFile = new StaticFile({
+        content: Buffer.from(''),
+        filepath: 'aaa.txt',
+        encoding: 'utf-8',
+        hash: 'aaa',
+      })
+      it('should return the file it is present and the hashes match', async () => {
+        staticFileSource.getStaticFile = jest.fn().mockResolvedValueOnce(staticFile)
+        const src = await naclFilesSource(
+          '',
+          mockDirStore,
+          staticFileSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          false,
+        )
+        expect(await src.getStaticFile({ filePath: staticFile.filepath, encoding: staticFile.encoding })).toEqual(
+          staticFile,
+        )
+      })
+    })
+
+    describe('isPathIncluded', () => {
+      let src: NaclFilesSource
+      const staticFileSource = mockStaticFilesSource([
+        new StaticFile({
+          content: Buffer.from('FFF'),
+          filepath: 'static-files/fff.txt',
+          hash: '###',
+        }),
+      ])
+      beforeEach(async () => {
+        src = await naclFilesSource(
+          '',
+          mockDirStore,
+          staticFileSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          false,
+        )
+      })
+      it('should mark a path of a nacl file as included', () => {
+        ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(true)
+        expect(src.isPathIncluded('whateves.nacl')).toEqual({
+          included: true,
+          isNacl: true,
+        })
+      })
+
+      it('should mark a static file as included', () => {
+        ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
+        expect(src.isPathIncluded('static-files/fff.txt')).toEqual({
+          included: true,
+          isNacl: false,
+        })
+      })
+
+      it('should mark a missing file as not included', () => {
+        ;(mockDirStore.isPathIncluded as jest.Mock).mockReturnValue(false)
+        expect(src.isPathIncluded('whateves.nacl')).toEqual({
+          included: false,
+        })
+      })
+    })
+    describe('getElementFileNames', () => {
+      it('should return correct result if there are files', async () => {
+        const src1 = await naclFilesSource(
+          '',
+          mockDirStore,
+          mockedStaticFilesSource,
+          () => Promise.resolve(new InMemoryRemoteMap()),
+          true,
+        )
+        await src1.load({})
+        await src1.updateNaclFiles([createChange()])
+        const res = await src1.getElementFileNames()
+        expect(Array.from(res.entries())).toEqual([['salesforce.new_elem', ['file']]])
+      })
+    })
+    describe('getDanglingStaticFiles', () => {
+      let beforeElem: InstanceElement
+      let afterElem: InstanceElement
+      let result: StaticFile[] = []
+      const staticFile1 = new StaticFile({ filepath: 'path1', hash: 'hash1' })
+      const staticFile2 = new StaticFile({ filepath: 'path2', hash: 'hash2' })
+      const staticFile3 = new StaticFile({ filepath: 'path3', hash: 'hash3' })
+      const staticFile4 = new StaticFile({ filepath: 'path4', hash: 'hash4' })
+      const staticFile5 = new StaticFile({ filepath: 'path5', hash: 'hash5' })
+      const staticFile6 = new StaticFile({ filepath: 'path6', hash: 'hash6' })
+      const staticFile7 = new StaticFile({ filepath: 'path7', hash: 'hash7' })
+
+      beforeAll(async () => {
+        beforeElem = new InstanceElement('elem', new ObjectType({ elemID: new ElemID('salesforce', 'type') }), {
+          f1: staticFile1, // To modify
+          f2: staticFile2, // To remove
+          f3: staticFile5, // To change location
+          a: { f3: staticFile3 }, // To modify
+          b: { f4: staticFile4 }, // To remove
+          stays: staticFile7, // To stay
+          remove: staticFile7, // To remove - shouldn't be returned
+        })
+        afterElem = beforeElem.clone()
+
+        afterElem.value.f1 = staticFile6
+        afterElem.value.f5 = staticFile5
+        delete afterElem.value.f2
+        delete afterElem.value.f3
+        afterElem.value.a = 's'
+        delete afterElem.value.b
+        delete afterElem.value.remove
+
+        const staticFilesIndex = {
+          get: async (staticFile: string) => (staticFile !== 'path7' ? ['singleNaclPath'] : ['multi', 'naclPaths']),
+        }
+        result = await getDanglingStaticFiles(detailedCompare(beforeElem, afterElem), staticFilesIndex)
+        expect(result).toHaveLength(4)
+      })
+      it('should return static file that was modified', () => {
+        expect(result).toContain(staticFile1)
+      })
+      it('should return static file that was removed', () => {
+        expect(result).toContain(staticFile2)
+      })
+      it('should return static file nested inside modification of another field', () => {
+        expect(result).toContain(staticFile3)
+      })
+      it('should return static file nested inside removal of another field', () => {
+        expect(result).toContain(staticFile4)
+      })
+      it('should not return static file if the path in element has changed', () => {
+        expect(result).not.toContain(staticFile5)
+      })
+      it('should not return removed static file if it is still referenced in another field', () => {
+        expect(result).not.toContain(staticFile7)
+      })
+
+      describe('when there are no static files in the changes before', () => {
+        let mockStaticFilesIndex: Pick<RemoteMap<string[]>, 'get'>
+
+        beforeAll(async () => {
+          const beforeElemWithoutStaticFiles = await transformElement({
+            element: beforeElem,
+            strict: false,
+            transformFunc: ({ value }) => (isStaticFile(value) ? undefined : value),
+          })
+          mockStaticFilesIndex = { get: jest.fn() }
+          result = await getDanglingStaticFiles(
+            detailedCompare(beforeElemWithoutStaticFiles, afterElem),
+            mockStaticFilesIndex,
+          )
+        })
+        it('should return empty list', () => {
+          expect(result).toBeEmpty()
+        })
+        it('should not query staticFilesIndex', () => {
+          expect(mockStaticFilesIndex.get).not.toHaveBeenCalled()
+        })
+      })
+    })
+  },
+)


### PR DESCRIPTION
In `nacl_files_source.ts` we need the current element IDs in each modified file. Instead of getting them by calling `elements()` that reads and deserialize all of the elements in the nacl file, we can use the `elementsIndex` that holds a mapping between `ElemID` and the files it's in.
This is currently disabled by default and can be enabled with an env var - `SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING`

---

_Additional context for reviewer_

The change in the tests is the addition of `describe.each([false, true])` with the env var's value on all of the tests in each file.

---
_Release Notes_: 
Workspace:
- Reduce memory consumption when updating nacl files (enabled with an env var - `SALTO_CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING`)

---
_User Notifications_: 
None