### PR TITLE
SALTO-6048: Remove adding JWK to exclude list migration

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -38,7 +38,7 @@ import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
 import { CLIENT_CONFIG, FETCH_CONFIG, OLD_API_DEFINITIONS_CONFIG } from './config'
-import { configType, getExcludeJWKConfigSuggestion, OktaUserConfig, OktaUserFetchConfig } from './user_config'
+import { configType, OktaUserConfig } from './user_config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -77,7 +77,6 @@ import {
   APP_LOGO_TYPE_NAME,
   BRAND_LOGO_TYPE_NAME,
   FAV_ICON_TYPE_NAME,
-  JWK_TYPE_NAME,
   OKTA,
   USER_TYPE_NAME,
 } from './constants'
@@ -155,24 +154,6 @@ export interface OktaAdapterParams {
   accountName?: string
 }
 
-/**
- * Temporary adjusment to support migration of JsonWebKey type into the exclude list
- */
-const createElementQueryWithJsonWebKey = (
-  fetchConfig: OktaUserFetchConfig,
-  criteria: Record<string, elementUtils.query.QueryCriterion>,
-): elementUtils.query.ElementQuery => {
-  const isJWKExcluded = fetchConfig.exclude.find(fetchEnrty => fetchEnrty.type === JWK_TYPE_NAME)
-  const isJWKIncluded = fetchConfig.include.find(fetchEntry => fetchEntry.type === JWK_TYPE_NAME)
-  const updatedConfig =
-    !isJWKExcluded && !isJWKIncluded
-      ? {
-          ...fetchConfig,
-          exclude: fetchConfig.exclude.concat({ type: JWK_TYPE_NAME }),
-        }
-      : fetchConfig
-  return elementUtils.query.createElementQuery(updatedConfig, criteria)
-}
 export default class OktaAdapter implements AdapterOperations {
   private createFiltersRunner: (usersPromise?: Promise<User[]>) => Required<Filter>
   private client: OktaClient
@@ -208,7 +189,7 @@ export default class OktaAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: paginate,
     })
-    this.fetchQuery = createElementQueryWithJsonWebKey(this.userConfig.fetch, fetchCriteria)
+    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig.fetch, fetchCriteria)
     this.accountName = accountName
 
     const definitions = {
@@ -358,7 +339,6 @@ export default class OktaAdapter implements AdapterOperations {
     const configChanges = (getElementsConfigChanges ?? [])
       .concat(classicOrgConfigSuggestion ?? [])
       .concat(oauthConfigChange ?? [])
-      .concat(getExcludeJWKConfigSuggestion(this.configInstance) ?? [])
     const updatedConfig =
       !_.isEmpty(configChanges) && this.configInstance
         ? definitionsUtils.getUpdatedConfigFromConfigChanges({

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -73,13 +73,7 @@ import policyPrioritiesFilter, {
 } from './filters/policy_priority'
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
-import {
-  APP_LOGO_TYPE_NAME,
-  BRAND_LOGO_TYPE_NAME,
-  FAV_ICON_TYPE_NAME,
-  OKTA,
-  USER_TYPE_NAME,
-} from './constants'
+import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA, USER_TYPE_NAME } from './constants'
 import { getLookUpNameCreator } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances, shouldConvertUserIds } from './user_utils'
 import { isClassicEngineOrg, logUsersCount } from './utils'

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -6,12 +6,8 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { elements, definitions } from '@salto-io/adapter-components'
-import { BuiltinTypes, CORE_ANNOTATIONS, InstanceElement, createRestriction } from '@salto-io/adapter-api'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { logger } from '@salto-io/logging'
+import { BuiltinTypes, CORE_ANNOTATIONS, createRestriction } from '@salto-io/adapter-api'
 import { JWK_TYPE_NAME, OKTA, USER_TYPE_NAME } from './constants'
-
-const log = logger(module)
 
 type GetUsersStrategy = 'searchQuery' | 'allUsers'
 
@@ -129,31 +125,3 @@ export const configType = definitions.createUserConfigType({
   omitElemID: false,
   pathsToOmitFromDefaultConfig: ['fetch.enableMissingReferences', 'fetch.getUsersStrategy'],
 })
-
-/*
- * Temporary config suggestion to migrate existing configs to exclude JWK type
- */
-export const getExcludeJWKConfigSuggestion = (
-  userConfig: Readonly<InstanceElement> | undefined,
-): definitions.ConfigChangeSuggestion | undefined => {
-  const typesToExclude = userConfig?.value?.fetch?.exclude
-  const typesToInclude = userConfig?.value?.fetch?.include
-  if (!Array.isArray(typesToExclude) || !Array.isArray(typesToInclude)) {
-    log.error(
-      'failed creating config suggestion to exclude JsonWebKey type, expected fetch.exclude and fetch.include to be an array, but instead got %s',
-      safeJsonStringify({ exclude: typesToExclude, include: typesToInclude }),
-    )
-    return undefined
-  }
-  const isJWKExcluded = typesToExclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
-  const isJWKIncluded = typesToInclude.find(fetchEnty => fetchEnty?.type === JWK_TYPE_NAME)
-  if (!isJWKExcluded && !isJWKIncluded) {
-    return {
-      type: 'typeToExclude',
-      value: JWK_TYPE_NAME,
-      reason:
-        'JsonWebKey type is excluded by default. To include it, explicitly add "JsonWebKey" type into the include list.',
-    }
-  }
-  return undefined
-}


### PR DESCRIPTION
As part of SALTO-6048, We added migration to migrate all existing envs to have `JWK` type in their exclude list
It has been long enough since, and all active envs are migrated, so it's safe to remove this now

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
