### PR TITLE
SAAS-11665: Fix default config creator for Salesforce Adapter in the CLI

### DIFF
--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -234,7 +234,7 @@ export const optionsType = createMatchingObjectType<SalesforceConfigOptionsType>
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   let configInstance = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
   const appendProfilesAndPermissionSetsExclude = (instance: InstanceElement): void => {
-    const excludeSection = instance.value.fetch?.metadata?.exclude
+    const excludeSection = instance.value?.fetch?.metadata?.exclude
     if (Array.isArray(excludeSection)) {
       instance.value.fetch.metadata.exclude = [...excludeSection, ...excludeProfilesAndPermissionSets]
     } else {

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -234,7 +234,7 @@ export const optionsType = createMatchingObjectType<SalesforceConfigOptionsType>
 export const getConfig = async (options?: InstanceElement): Promise<InstanceElement> => {
   let configInstance = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
   const appendProfilesAndPermissionSetsExclude = (instance: InstanceElement): void => {
-    const excludeSection = instance.value.fetch.metadata.exclude
+    const excludeSection = instance.value.fetch?.metadata?.exclude
     if (Array.isArray(excludeSection)) {
       instance.value.fetch.metadata.exclude = [...excludeSection, ...excludeProfilesAndPermissionSets]
     } else {


### PR DESCRIPTION
Fix default config creator for Salesforce Adapter in the CLI

---

Since the `configCreatorInput` instance is undefined, we created the instance with Profiles and PermissionSets included.
Opened a followup ticket: https://salto-io.atlassian.net/browse/SALTO-6925

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
