### PR TITLE
SALTO 6824: Add workspace validate command to the CLI

### DIFF
--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -65,7 +65,7 @@ type CommandInnerDef<T> = {
 
 export type WorkspaceCommandArgs<T> = Omit<DefActionInput<T>, 'workspacePath'> & { workspace: Workspace }
 
-export type WorkspaceCommandAction<T = {}> = (args: WorkspaceCommandArgs<T>) => Promise<CliExitCode>
+export type WorkspaceCommandAction<T> = (args: WorkspaceCommandArgs<T>) => Promise<CliExitCode>
 
 export type WorkspaceCommandDef<T> = {
   properties: CommandOptions<T>

--- a/packages/cli/src/command_builder.ts
+++ b/packages/cli/src/command_builder.ts
@@ -65,7 +65,7 @@ type CommandInnerDef<T> = {
 
 export type WorkspaceCommandArgs<T> = Omit<DefActionInput<T>, 'workspacePath'> & { workspace: Workspace }
 
-export type WorkspaceCommandAction<T> = (args: WorkspaceCommandArgs<T>) => Promise<CliExitCode>
+export type WorkspaceCommandAction<T = {}> = (args: WorkspaceCommandArgs<T>) => Promise<CliExitCode>
 
 export type WorkspaceCommandDef<T> = {
   properties: CommandOptions<T>

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -16,8 +16,6 @@ import {
   formatStepStart,
   formatStepFailed,
   formatStepCompleted,
-  error,
-  warn,
 } from '../formatter'
 import { outputLine, errorOutputLine } from '../outputer'
 import Prompts from '../prompts'
@@ -209,13 +207,13 @@ export const wsValidateAction: WorkspaceCommandAction = async ({ workspace, outp
   const { status, errors } = await validateWorkspace(workspace)
 
   if (status === 'Error') {
-    spinner.fail(error(`Workspace has ${errors.length === 1 ? 'an error' : 'errors'}:`))
+    spinner.fail(`Workspace has ${errors.length === 1 ? 'an error' : 'errors'}:`)
     await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), output)
     return CliExitCode.Success
   }
 
   if (status === 'Warning') {
-    spinner.fail(warn(`Workspace has ${errors.length === 1 ? 'a warning' : 'warnings'}:`))
+    spinner.fail(`Workspace has ${errors.length === 1 ? 'a warning' : 'warnings'}:`)
     await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), output)
     return CliExitCode.Success
   }

--- a/packages/cli/src/commands/workspace.ts
+++ b/packages/cli/src/commands/workspace.ts
@@ -16,11 +16,14 @@ import {
   formatStepStart,
   formatStepFailed,
   formatStepCompleted,
+  error,
+  warn,
 } from '../formatter'
 import { outputLine, errorOutputLine } from '../outputer'
 import Prompts from '../prompts'
 import { CliExitCode } from '../types'
 import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
+import { formatWorkspaceErrors, printWorkspaceErrors, validateWorkspace } from '../workspace/workspace'
 
 type CleanArgs = {
   force: boolean
@@ -201,13 +204,41 @@ const setStateProviderDef = createWorkspaceCommand({
   },
 })
 
+export const wsValidateAction: WorkspaceCommandAction = async ({ workspace, output, spinnerCreator }) => {
+  const spinner = spinnerCreator('Checking workspace...', {})
+  const { status, errors } = await validateWorkspace(workspace)
+
+  if (status === 'Error') {
+    spinner.fail(error(`Workspace has ${errors.length === 1 ? 'an error' : 'errors'}:`))
+    await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), output)
+    return CliExitCode.Success
+  }
+
+  if (status === 'Warning') {
+    spinner.fail(warn(`Workspace has ${errors.length === 1 ? 'a warning' : 'warnings'}:`))
+    await printWorkspaceErrors(status, await formatWorkspaceErrors(workspace, errors), output)
+    return CliExitCode.Success
+  }
+
+  spinner.succeed('Workspace is valid')
+  return CliExitCode.Success
+}
+
+const wsValidateDef = createWorkspaceCommand({
+  properties: {
+    name: 'validate',
+    description: 'Log the errors on the workspace',
+  },
+  action: wsValidateAction,
+})
+
 // Group definition
 const wsGroupDef = createCommandGroupDef({
   properties: {
     name: 'workspace',
     description: 'Workspace administration commands',
   },
-  subCommands: [wsCleanDef, cacheGroupDef, setStateProviderDef],
+  subCommands: [wsCleanDef, cacheGroupDef, setStateProviderDef, wsValidateDef],
 })
 
 export default wsGroupDef

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -100,7 +100,7 @@ export const formatWorkspaceErrors = async (workspace: Workspace, errors: Iterab
     )
   ).join(EOL)
 
-const printWorkspaceErrors = async (
+export const printWorkspaceErrors = async (
   status: WorkspaceStatusErrors['status'],
   errorsStr: string,
   { stdout, stderr }: CliOutput,

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -9,7 +9,7 @@ import * as core from '@salto-io/core'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { cleanAction, cacheUpdateAction, setStateProviderAction, wsValidateAction } from '../../src/commands/workspace'
-import { CliExitCode } from '../../src/types'
+import { CliExitCode, Spinner } from '../../src/types'
 import * as workspaceFunctions from '../../src/workspace/workspace'
 
 jest.mock('../../src/workspace/workspace', () => ({
@@ -320,57 +320,81 @@ describe('workspace command group', () => {
 
   describe('validate command', () => {
     const commandName = 'validate'
-    const cliCommandArgs: mocks.MockCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-    const workspace: mocks.MockWorkspace = mocks.mockWorkspace({})
+    let cliCommandArgs: mocks.MockCommandArgs
+    let workspace: mocks.MockWorkspace
+    let spinner: Spinner
+    let spinnerOutput: string[]
+
+    beforeEach(() => {
+      spinnerOutput = []
+      cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
+      workspace = mocks.mockWorkspace({})
+      spinner = {
+        succeed: (text: string) => spinnerOutput.push(text),
+        fail: (text: string) => spinnerOutput.push(text),
+      }
+    })
 
     describe('when workspace is valid', () => {
-      it('should indicate the workspace is valid', async () => {
+      beforeEach(async () => {
         mockedWorkspaceFunctions.validateWorkspace.mockResolvedValueOnce(
           Promise.resolve({
             status: 'Valid',
             errors: [],
           }),
         )
-        const result = await wsValidateAction({
+        await wsValidateAction({
           ...cliCommandArgs,
           input: {},
           workspace,
+          spinnerCreator: () => spinner,
         })
+      })
+      it('should indicate the workspace is valid', () => {
         expect(workspaceFunctions.printWorkspaceErrors).not.toHaveBeenCalled()
-        expect(result).toEqual(CliExitCode.Success)
+        expect(spinnerOutput.length).toEqual(1)
+        expect(spinnerOutput[0]).toContain('valid')
       })
     })
     describe('when workspace is not valid', () => {
       describe('when workspace has a warning', () => {
-        it('should indicate the workspace is not valid and specify the warnings', async () => {
+        beforeEach(async () => {
           mockedWorkspaceFunctions.validateWorkspace.mockResolvedValueOnce(
             Promise.resolve({
               status: 'Warning',
               errors: [],
             }),
           )
-          const result = await wsValidateAction({
+          await wsValidateAction({
             ...cliCommandArgs,
             input: {},
             workspace,
+            spinnerCreator: () => spinner,
           })
+        })
+        it('should indicate the workspace is not valid and specify the warnings', () => {
           expect(workspaceFunctions.printWorkspaceErrors).toHaveBeenCalled()
-          expect(result).toEqual(CliExitCode.Success)
+          expect(spinnerOutput.length).toEqual(1)
+          expect(spinnerOutput[0]).toContain('warning')
         })
       })
       describe('when workspace has an error', () => {
-        it('should indicate the workspace is not valid and specify the errors', async () => {
+        beforeEach(async () => {
           mockedWorkspaceFunctions.validateWorkspace.mockResolvedValueOnce({
             status: 'Error',
             errors: [],
           })
-          const result = await wsValidateAction({
+          await wsValidateAction({
             ...cliCommandArgs,
             input: {},
             workspace,
+            spinnerCreator: () => spinner,
           })
+        })
+        it('should indicate the workspace is not valid and specify the errors', () => {
           expect(workspaceFunctions.printWorkspaceErrors).toHaveBeenCalled()
-          expect(result).toEqual(CliExitCode.Success)
+          expect(spinnerOutput.length).toEqual(1)
+          expect(spinnerOutput[0]).toContain('error')
         })
       })
     })


### PR DESCRIPTION
Added workspace validate command to the CLI

---

_Additional context for reviewer_

The CLI output should appear as follows:

Valid workspace:
<img width="448" alt="image" src="https://github.com/user-attachments/assets/86f30eea-b4e8-423f-b659-6d205433378e">

Workspace with errors:
<img width="806" alt="image" src="https://github.com/user-attachments/assets/9edc9d2d-d0fd-4a41-b1e2-ee3575e91392">

Workspace with warnings:
<img width="1382" alt="image" src="https://github.com/user-attachments/assets/5ee48d29-2d02-4a4b-80b8-7acf18896baa">


---

_Release Notes_:
CLI: 
Users can use the validate command as part of the workspace sub-commands. This command will indicate whether the workspace is valid or, if not, specify the errors or warnings and provide links to their locations.

---
_None_
