### PR TITLE
SALTO-2905: Supporting settings in SFDX

### DIFF
--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -44,9 +44,6 @@ const { withLimitedConcurrency } = promises.array
 const FILE_DELETE_CONCURRENCY = 100
 
 export const UNSUPPORTED_TYPES = new Set([
-  // Salto uses non-standard type names here (SFDX names them all "Settings", we have a separate type for each one)
-  // This causes us to always think the settings in the project need to be deleted
-  'Settings',
   // For documents with a file extension (e.g. bla.txt) the SF API returns their fullName with the extension (so "bla.txt")
   // but the SFDX convert code loads them as a component with a fullName without the extension (so "bla").
   // This causes us to always think documents with an extension in the project need to be deleted
@@ -66,10 +63,6 @@ const isSupportedMetadataChange = (change: Change): boolean => {
   const element = getChangeData(change)
   const metadataTypeName = metadataTypeSync(element)
   if (UNSUPPORTED_TYPES.has(metadataTypeName)) {
-    return false
-  }
-  if (UNSUPPORTED_TYPES.has('Settings') && element.elemID.isConfigInstance() && metadataTypeName.endsWith('Settings')) {
-    // Settings have all kinds of metadata type names, but they all end with "Settings"
     return false
   }
   return true

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_parser.ts
@@ -181,6 +181,9 @@ export const loadElementsFromFolder: LoadElementsFromFolderFunc = async ({ baseD
         // this should make the filters not assume all elements are in the elements list
         // this is needed because, for example, we want to search for references to elements outside of the folder elements
         target: allTypes.map(metadataTypeSync),
+        optionalFeatures: {
+          retrieveSettings: true,
+        },
       },
     })
 

--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
@@ -399,8 +399,7 @@ describe('dumpElementsToFolder', () => {
       let dumpResult: DumpElementsResult
       beforeAll(async () => {
         const labelInstance = new InstanceElement('label1', mockTypes.CustomLabel, { fullName: 'label1' })
-        const settingsInstance = new InstanceElement(ElemID.CONFIG_NAME, mockTypes.TestSettings, { fullName: 'Test' })
-        changes = [toChange({ after: labelInstance }), toChange({ after: settingsInstance })]
+        changes = [toChange({ after: labelInstance })]
         dumpResult = await dumpElementsToFolder({
           baseDir: project.name(),
           changes,


### PR DESCRIPTION
The new settings filter no longer relies on the client so it works for SFDX.

---

_Additional context for reviewer_:
Interestingly, we don't need to do anything pre-deploy because they way settings are deployed is super weird in SF.

---

_Release Notes_: 
_Salesforce_:
* Add support for settings types in SFDX.

---

_User Notifications_: 
None.