### PR TITLE
SALTO-1830 Post deploy message

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -92,27 +92,10 @@ const printDeploymentSummary = async (
     },
     {} as Record<DeploySummaryResult, DetailedChangeId[]>,
   )
-  outputLine(formatDeploymentSummary(dictionaryB), output)
-  // const failure: DeploySummaryResult = 'failure'
-  // const partialSuccess: DeploySummaryResult = 'partial-success'
-  // const success: DeploySummaryResult = 'success'
-  // if (
-  //   !Object.prototype.hasOwnProperty.call(dictionaryB, failure) &&
-  //   !Object.prototype.hasOwnProperty.call(dictionaryB, partialSuccess)
-  // ) {
-  //   outputLine(Prompts.SUCCESSFUL_DEPLOYMENT, output)
-  // } else {
-  //   outputLine(Prompts.NOT_SUCCESSFUL_DEPLOYMENT, output)
-  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, success)) {
-  //     outputLine(formatDeploymentSummaryResult(dictionaryB[success], success), output)
-  //   }
-  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, partialSuccess)) {
-  //     outputLine(formatDeploymentSummaryResult(dictionaryB[partialSuccess], partialSuccess), output)
-  //   }
-  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, failure)) {
-  //     outputLine(formatDeploymentSummaryResult(dictionaryB[failure], failure), output)
-  //   }
-  // }
+  const formattedDeploymentSummary: string | undefined = formatDeploymentSummary(dictionaryB)
+  if (formattedDeploymentSummary != undefined) {
+    outputLine(formattedDeploymentSummary, output)
+  }
 }
 
 export const shouldDeploy = async (actions: Plan, checkOnly: boolean): Promise<boolean> => {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -269,10 +269,27 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
       summary[changeError.elemID.getFullName()] !== 'failure' || changeError.deployActions?.postAction?.showOnFailure,
   )
 
+  const postDeployActionsOutputPartialSuccess = Object.keys(summary).filter(key => summary[key] === 'partial-success')
+  if (postDeployActionsOutputPartialSuccess.length > 0) {
+    outputLine('\n', output)
+    outputLine(`${postDeployActionsOutputPartialSuccess.length} elements partially succeeded deployment`, output)
+    outputLine(postDeployActionsOutputPartialSuccess.join('\n'), output)
+    outputLine('\n', output)
+  }
+
+  const postDeployActionsOutputFailures = Object.keys(summary).filter(key => summary[key] === 'failure')
+  if (postDeployActionsOutputFailures.length > 0) {
+    outputLine('\n', output)
+    outputLine(`${postDeployActionsOutputFailures.length} elements failed deployment`, output)
+    outputLine(postDeployActionsOutputFailures.join('\n'), output)
+    outputLine('\n', output)
+  }
+
   const postDeployActionsOutput = formatDeployActions({
     wsChangeErrors: changeErrorsForPostDeployOutput,
     isPreDeploy: false,
   })
+
   outputLine(postDeployActionsOutput.join('\n'), output)
   if (result.extraProperties?.groups !== undefined) {
     outputLine(formatGroups(result.extraProperties?.groups, checkOnly), output)

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -86,8 +86,8 @@ const printDeploymentSummary = async (
 ): Promise<void> => {
   const dictionaryB = Object.entries(summary).reduce(
     (acc, [key, value]) => {
-      acc[value] = acc[value] || [] // Ensure an array exists for this value
-      acc[value].push(key) // Add the key to the array
+      acc[value] = acc[value] || []
+      acc[value].push(key)
       return acc
     },
     {} as Record<DeploySummaryResult, DetailedChangeId[]>,
@@ -306,21 +306,6 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
       summary[changeError.elemID.getFullName()] !== 'failure' || changeError.deployActions?.postAction?.showOnFailure,
   )
   await printDeploymentSummary(summary, output)
-  // const postDeployActionsOutputPartialSuccess = Object.keys(summary).filter(key => summary[key] === 'partial-success')
-  // if (postDeployActionsOutputPartialSuccess.length > 0) {
-  //   outputLine('\n', output)
-  //   outputLine(`${postDeployActionsOutputPartialSuccess.length} elements partially succeeded deployment`, output)
-  //   outputLine(postDeployActionsOutputPartialSuccess.join('\n'), output)
-  //   outputLine('\n', output)
-  // }
-
-  // const postDeployActionsOutputFailures = Object.keys(summary).filter(key => summary[key] === 'failure')
-  // if (postDeployActionsOutputFailures.length > 0) {
-  //   outputLine('\n', output)
-  //   outputLine(`${postDeployActionsOutputFailures.length} elements failed deployment`, output)
-  //   outputLine(postDeployActionsOutputFailures.join('\n'), output)
-  //   outputLine('\n', output)
-  // }
 
   const postDeployActionsOutput = formatDeployActions({
     wsChangeErrors: changeErrorsForPostDeployOutput,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -21,7 +21,6 @@ import { logger } from '@salto-io/logging'
 import { Workspace } from '@salto-io/workspace'
 import { mkdirp, writeFile } from '@salto-io/file'
 import path from 'path'
-import { DetailedChangeId, DeploySummaryResult } from '@salto-io/core/src/core/deploy'
 import { WorkspaceCommandAction, createWorkspaceCommand } from '../command_builder'
 import { AccountsArg, ACCOUNTS_OPTION, getAndValidateActiveAccounts, getTagsForAccounts } from './common/accounts'
 import { CliOutput, CliExitCode, CliTelemetry } from '../types'
@@ -77,24 +76,6 @@ const printStartDeploy = async (output: CliOutput, executingDeploy: boolean, che
     outputLine(deployPhaseHeader(checkOnly), output)
   } else {
     outputLine(cancelDeployOutput(checkOnly), output)
-  }
-}
-
-const printDeploymentSummary = async (
-  summary: Record<DetailedChangeId, DeploySummaryResult>,
-  output: CliOutput,
-): Promise<void> => {
-  const summaryResultToId = Object.entries(summary).reduce(
-    (acc, [key, value]) => {
-      acc[value] = acc[value] || []
-      acc[value].push(key)
-      return acc
-    },
-    {} as Record<DeploySummaryResult, DetailedChangeId[]>,
-  )
-  const formattedDeploymentSummary: string | undefined = formatDeploymentSummary(summaryResultToId)
-  if (formattedDeploymentSummary !== undefined) {
-    outputLine(formattedDeploymentSummary, output)
   }
 }
 
@@ -283,12 +264,17 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
   }
 
   const requested = Array.from(actionPlan.itemsByEvalOrder()).flatMap(item => Array.from(item.changes()))
-  const summary = summarizeDeployChanges(requested, result.appliedChanges ?? [])
+  const { elemIdToResult, resultToElemId } = summarizeDeployChanges(requested, result.appliedChanges ?? [])
   const changeErrorsForPostDeployOutput = actionPlan.changeErrors.filter(
     changeError =>
-      summary[changeError.elemID.getFullName()] !== 'failure' || changeError.deployActions?.postAction?.showOnFailure,
+      elemIdToResult[changeError.elemID.getFullName()] !== 'failure' ||
+      changeError.deployActions?.postAction?.showOnFailure,
   )
-  await printDeploymentSummary(summary, output)
+
+  const formattedDeploymentSummary = formatDeploymentSummary(resultToElemId)
+  if (formattedDeploymentSummary !== undefined) {
+    outputLine(formattedDeploymentSummary, output)
+  }
 
   const postDeployActionsOutput = formatDeployActions({
     wsChangeErrors: changeErrorsForPostDeployOutput,

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -93,7 +93,7 @@ const printDeploymentSummary = async (
     {} as Record<DeploySummaryResult, DetailedChangeId[]>,
   )
   const formattedDeploymentSummary: string | undefined = formatDeploymentSummary(dictionaryB)
-  if (formattedDeploymentSummary != undefined) {
+  if (formattedDeploymentSummary !== undefined) {
     outputLine(formattedDeploymentSummary, output)
   }
 }

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -270,17 +270,14 @@ export const action: WorkspaceCommandAction<DeployArgs> = async ({
       elemIdToResult[changeError.elemID.getFullName()] !== 'failure' ||
       changeError.deployActions?.postAction?.showOnFailure,
   )
-
   const formattedDeploymentSummary = formatDeploymentSummary(resultToElemId)
-  if (formattedDeploymentSummary !== undefined) {
+  if (formattedDeploymentSummary) {
     outputLine(formattedDeploymentSummary, output)
   }
-
   const postDeployActionsOutput = formatDeployActions({
     wsChangeErrors: changeErrorsForPostDeployOutput,
     isPreDeploy: false,
   })
-
   outputLine(postDeployActionsOutput.join('\n'), output)
   if (result.extraProperties?.groups !== undefined) {
     outputLine(formatGroups(result.extraProperties?.groups, checkOnly), output)

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -84,7 +84,35 @@ const printDeploymentSummary = async (
   summary: Record<DetailedChangeId, DeploySummaryResult>,
   output: CliOutput,
 ): Promise<void> => {
-  outputLine(formatDeploymentSummary(summary), output)
+  const dictionaryB = Object.entries(summary).reduce(
+    (acc, [key, value]) => {
+      acc[value] = acc[value] || [] // Ensure an array exists for this value
+      acc[value].push(key) // Add the key to the array
+      return acc
+    },
+    {} as Record<DeploySummaryResult, DetailedChangeId[]>,
+  )
+  outputLine(formatDeploymentSummary(dictionaryB), output)
+  // const failure: DeploySummaryResult = 'failure'
+  // const partialSuccess: DeploySummaryResult = 'partial-success'
+  // const success: DeploySummaryResult = 'success'
+  // if (
+  //   !Object.prototype.hasOwnProperty.call(dictionaryB, failure) &&
+  //   !Object.prototype.hasOwnProperty.call(dictionaryB, partialSuccess)
+  // ) {
+  //   outputLine(Prompts.SUCCESSFUL_DEPLOYMENT, output)
+  // } else {
+  //   outputLine(Prompts.NOT_SUCCESSFUL_DEPLOYMENT, output)
+  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, success)) {
+  //     outputLine(formatDeploymentSummaryResult(dictionaryB[success], success), output)
+  //   }
+  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, partialSuccess)) {
+  //     outputLine(formatDeploymentSummaryResult(dictionaryB[partialSuccess], partialSuccess), output)
+  //   }
+  //   if (Object.prototype.hasOwnProperty.call(dictionaryB, failure)) {
+  //     outputLine(formatDeploymentSummaryResult(dictionaryB[failure], failure), output)
+  //   }
+  // }
 }
 
 export const shouldDeploy = async (actions: Plan, checkOnly: boolean): Promise<boolean> => {

--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -84,7 +84,7 @@ const printDeploymentSummary = async (
   summary: Record<DetailedChangeId, DeploySummaryResult>,
   output: CliOutput,
 ): Promise<void> => {
-  const dictionaryB = Object.entries(summary).reduce(
+  const summaryResultToId = Object.entries(summary).reduce(
     (acc, [key, value]) => {
       acc[value] = acc[value] || []
       acc[value].push(key)
@@ -92,7 +92,7 @@ const printDeploymentSummary = async (
     },
     {} as Record<DeploySummaryResult, DetailedChangeId[]>,
   )
-  const formattedDeploymentSummary: string | undefined = formatDeploymentSummary(dictionaryB)
+  const formattedDeploymentSummary: string | undefined = formatDeploymentSummary(summaryResultToId)
   if (formattedDeploymentSummary !== undefined) {
     outputLine(formattedDeploymentSummary, output)
   }

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -363,7 +363,7 @@ export const formatDeploymentSummary = (
         headline,
         [succeeded, partiallySucceeded, failed].filter(item => item != null).join('\n'),
         emptyLine(),
-        Prompts.EXPLAIN_DEPLOYMENT_RESULT,
+        Prompts.EXPLAIN_DEPLOYMENT_SUMMARY,
         emptyLine(),
       ].join('\n')
 }

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -9,6 +9,7 @@ import _ from 'lodash'
 import { EOL } from 'os'
 import chalk from 'chalk'
 import wu, { WuIterable } from 'wu'
+import { DetailedChangeId, DeploySummaryResult } from '@salto-io/core/src/core/deploy'
 import {
   Element,
   isInstanceElement,
@@ -324,6 +325,13 @@ export const formatDeployActions = ({
       deployAction.documentationURL ?? '',
     ]),
   ]
+}
+
+export const formatDeploymentSummary = async (
+  summary: Record<DetailedChangeId, DeploySummaryResult>,
+): Promise<string> => {
+  const tempRet = 's'
+  return tempRet
 }
 
 export const formatExecutionPlan = async (

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -9,7 +9,6 @@ import _ from 'lodash'
 import { EOL } from 'os'
 import chalk from 'chalk'
 import wu, { WuIterable } from 'wu'
-import { DetailedChangeId, DeploySummaryResult } from '@salto-io/core'
 import {
   Element,
   isInstanceElement,
@@ -44,6 +43,8 @@ import {
   getSupportedServiceAdapterNames,
   DeployError,
   GroupProperties,
+  DetailedChangeId,
+  DeploySummaryResult,
 } from '@salto-io/core'
 import { errors, SourceLocation, WorkspaceComponents } from '@salto-io/workspace'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
@@ -354,13 +355,14 @@ export const formatDeploymentSummary = (
       : null
   const failed =
     summary[failureResult].length > 0 ? formatDeploymentSummaryResult(summary[failureResult], failureResult) : null
-  return !(summary[failureResult].length > 0) && !(summary[partialSuccessResult].length > 0)
-    ? summary[successResult].length > 0
+  const noFailedElements =
+    succeeded !== null
       ? [emptyLine(), Prompts.DEPLOYMENT_SUMMARY_HEADLINE, Prompts.ALL_DEPLOYMENT_ELEMENTS_SUCCEEDED, emptyLine()].join(
           '\n',
         )
       : undefined
-    : !(summary[successResult].length > 0) && !(summary[partialSuccessResult].length > 0)
+  const foundFailedElements =
+    succeeded === null && partiallySucceeded === null
       ? [emptyLine(), headline, Prompts.ALL_DEPLOYMENT_ELEMENTS_FAILED, emptyLine()].join('\n')
       : [
           emptyLine(),
@@ -370,6 +372,7 @@ export const formatDeploymentSummary = (
           Prompts.DEPLOYMENT_SUMMARY_LEGEND,
           emptyLine(),
         ].join('\n')
+  return failed === null && partiallySucceeded === null ? noFailedElements : foundFailedElements
 }
 
 export const formatExecutionPlan = async (

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -329,9 +329,9 @@ export const formatDeployActions = ({
 
 export const formatDeploymentSummaryResult = (ids: DetailedChangeId[], result: DeploySummaryResult): string => {
   const mapping: Record<DeploySummaryResult, DetailedChangeId | null> = {
-    failure: Prompts.DEPLOYMENT_STATUS['failure'],
-    'partial-success': Prompts.DEPLOYMENT_STATUS['partialSuccess'],
-    success: Prompts.DEPLOYMENT_STATUS['success'],
+    failure: Prompts.DEPLOYMENT_STATUS.failure,
+    'partial-success': Prompts.DEPLOYMENT_STATUS.partialSuccess,
+    success: Prompts.DEPLOYMENT_STATUS.success,
   }
 
   const sign: string | null = mapping[result]
@@ -342,21 +342,21 @@ export const formatDeploymentSummaryResult = (ids: DetailedChangeId[], result: D
 export const formatDeploymentSummary = (
   summary: Record<DeploySummaryResult, DetailedChangeId[]>,
 ): string | undefined => {
-  const failure: DeploySummaryResult = 'failure'
-  const partialSuccess: DeploySummaryResult = 'partial-success'
-  const success: DeploySummaryResult = 'success'
+  const failureResult: DeploySummaryResult = 'failure'
+  const partialSuccessResult: DeploySummaryResult = 'partial-success'
+  const successResult: DeploySummaryResult = 'success'
   const headline: string = Prompts.DEPLOYMENT_SUMMARY_HEADLINE
-  const succeeded: string | null = Object.prototype.hasOwnProperty.call(summary, success)
-    ? formatDeploymentSummaryResult(summary[success], success)
+  const succeeded: string | null = Object.prototype.hasOwnProperty.call(summary, successResult)
+    ? formatDeploymentSummaryResult(summary[successResult], successResult)
     : null
-  const partiallySucceeded: string | null = Object.prototype.hasOwnProperty.call(summary, partialSuccess)
-    ? formatDeploymentSummaryResult(summary[partialSuccess], partialSuccess)
+  const partiallySucceeded: string | null = Object.prototype.hasOwnProperty.call(summary, partialSuccessResult)
+    ? formatDeploymentSummaryResult(summary[partialSuccessResult], partialSuccessResult)
     : null
-  const failed: string | null = Object.prototype.hasOwnProperty.call(summary, failure)
-    ? formatDeploymentSummaryResult(summary[failure], failure)
+  const failed: string | null = Object.prototype.hasOwnProperty.call(summary, failureResult)
+    ? formatDeploymentSummaryResult(summary[failureResult], failureResult)
     : null
-  return !Object.prototype.hasOwnProperty.call(summary, failure) &&
-    !Object.prototype.hasOwnProperty.call(summary, partialSuccess)
+  return !Object.prototype.hasOwnProperty.call(summary, failureResult) &&
+    !Object.prototype.hasOwnProperty.call(summary, partialSuccessResult)
     ? undefined
     : [
         emptyLine(),

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -339,11 +339,13 @@ export const formatDeploymentSummaryResult = (ids: DetailedChangeId[], result: D
   return lines
 }
 
-export const formatDeploymentSummary = (summary: Record<DeploySummaryResult, DetailedChangeId[]>): string => {
+export const formatDeploymentSummary = (
+  summary: Record<DeploySummaryResult, DetailedChangeId[]>,
+): string | undefined => {
   const failure: DeploySummaryResult = 'failure'
   const partialSuccess: DeploySummaryResult = 'partial-success'
   const success: DeploySummaryResult = 'success'
-  const headline: string = Prompts.NOT_SUCCESSFUL_DEPLOYMENT
+  const headline: string = Prompts.DEPLOYMENT_SUMMARY_HEADLINE
   const succeeded: string | null = Object.prototype.hasOwnProperty.call(summary, success)
     ? formatDeploymentSummaryResult(summary[success], success)
     : null
@@ -355,7 +357,7 @@ export const formatDeploymentSummary = (summary: Record<DeploySummaryResult, Det
     : null
   return !Object.prototype.hasOwnProperty.call(summary, failure) &&
     !Object.prototype.hasOwnProperty.call(summary, partialSuccess)
-    ? ''
+    ? undefined
     : [
         emptyLine(),
         headline,

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -343,11 +343,7 @@ export const formatDeploymentSummary = (summary: Record<DeploySummaryResult, Det
   const failure: DeploySummaryResult = 'failure'
   const partialSuccess: DeploySummaryResult = 'partial-success'
   const success: DeploySummaryResult = 'success'
-  const headline: string =
-    !Object.prototype.hasOwnProperty.call(summary, failure) &&
-    !Object.prototype.hasOwnProperty.call(summary, partialSuccess)
-      ? Prompts.SUCCESSFUL_DEPLOYMENT
-      : Prompts.NOT_SUCCESSFUL_DEPLOYMENT
+  const headline: string = Prompts.NOT_SUCCESSFUL_DEPLOYMENT
   const succeeded: string | null = Object.prototype.hasOwnProperty.call(summary, success)
     ? formatDeploymentSummaryResult(summary[success], success)
     : null
@@ -357,12 +353,17 @@ export const formatDeploymentSummary = (summary: Record<DeploySummaryResult, Det
   const failed: string | null = Object.prototype.hasOwnProperty.call(summary, failure)
     ? formatDeploymentSummaryResult(summary[failure], failure)
     : null
-  return [
-    emptyLine(),
-    headline,
-    [succeeded, partiallySucceeded, failed].filter(item => item != null).join('\n'),
-    emptyLine(),
-  ].join('\n')
+  return !Object.prototype.hasOwnProperty.call(summary, failure) &&
+    !Object.prototype.hasOwnProperty.call(summary, partialSuccess)
+    ? ''
+    : [
+        emptyLine(),
+        headline,
+        [succeeded, partiallySucceeded, failed].filter(item => item != null).join('\n'),
+        emptyLine(),
+        Prompts.EXPLAIN_DEPLOYMENT_RESULT,
+        emptyLine(),
+      ].join('\n')
 }
 
 export const formatExecutionPlan = async (

--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -327,11 +327,42 @@ export const formatDeployActions = ({
   ]
 }
 
-export const formatDeploymentSummary = async (
-  summary: Record<DetailedChangeId, DeploySummaryResult>,
-): Promise<string> => {
-  const tempRet = 's'
-  return tempRet
+export const formatDeploymentSummaryResult = (ids: DetailedChangeId[], result: DeploySummaryResult): string => {
+  const mapping: Record<DeploySummaryResult, DetailedChangeId | null> = {
+    failure: Prompts.DEPLOYMENT_STATUS['failure'],
+    'partial-success': Prompts.DEPLOYMENT_STATUS['partialSuccess'],
+    success: Prompts.DEPLOYMENT_STATUS['success'],
+  }
+
+  const sign: string | null = mapping[result]
+  const lines: string = ids.map(st => ` ${sign} ${st}`).join('\n')
+  return lines
+}
+
+export const formatDeploymentSummary = (summary: Record<DeploySummaryResult, DetailedChangeId[]>): string => {
+  const failure: DeploySummaryResult = 'failure'
+  const partialSuccess: DeploySummaryResult = 'partial-success'
+  const success: DeploySummaryResult = 'success'
+  const headline: string =
+    !Object.prototype.hasOwnProperty.call(summary, failure) &&
+    !Object.prototype.hasOwnProperty.call(summary, partialSuccess)
+      ? Prompts.SUCCESSFUL_DEPLOYMENT
+      : Prompts.NOT_SUCCESSFUL_DEPLOYMENT
+  const succeeded: string | null = Object.prototype.hasOwnProperty.call(summary, success)
+    ? formatDeploymentSummaryResult(summary[success], success)
+    : null
+  const partiallySucceeded: string | null = Object.prototype.hasOwnProperty.call(summary, partialSuccess)
+    ? formatDeploymentSummaryResult(summary[partialSuccess], partialSuccess)
+    : null
+  const failed: string | null = Object.prototype.hasOwnProperty.call(summary, failure)
+    ? formatDeploymentSummaryResult(summary[failure], failure)
+    : null
+  return [
+    emptyLine(),
+    headline,
+    [succeeded, partiallySucceeded, failed].filter(item => item != null).join('\n'),
+    emptyLine(),
+  ].join('\n')
 }
 
 export const formatExecutionPlan = async (

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -55,6 +55,13 @@ export default class Prompts {
     eq: '|',
   }
 
+  public static readonly DEPLOYMENT_STATUS = {
+    partialSuccess: chalk.yellow.bold('P'),
+    success: chalk.green.bold('S'),
+    failure: chalk.red.bold('F'),
+    eq: '|',
+  }
+
   public static readonly START_ACTION = {
     modify: 'Changing',
     add: 'Creating',
@@ -89,6 +96,9 @@ export default class Prompts {
 
   public static readonly DID_YOU_MEAN = 'Did you mean'
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
+
+  public static readonly SUCCESSFUL_DEPLOYMENT = 'Deployment was successful'
+  public static readonly NOT_SUCCESSFUL_DEPLOYMENT = "Couldn't deploy all elements\nDeployment summary:"
 
   public static initFailed(msg: string): string {
     return `Could not initiate workspace: ${msg}\n`

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -56,9 +56,9 @@ export default class Prompts {
   }
 
   public static readonly DEPLOYMENT_STATUS = {
-    partialSuccess: chalk.yellow.bold('P'),
-    success: chalk.green.bold('S'),
-    failure: chalk.red.bold('F'),
+    partialSuccess: chalk.yellow('P'),
+    success: chalk.green('S'),
+    failure: chalk.red('F'),
     eq: '|',
   }
 
@@ -98,7 +98,9 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static readonly DEPLOYMENT_SUMMARY_HEADLINE = chalk.bgBlack.bold('Deployment summary:')
-  public static readonly EXPLAIN_DEPLOYMENT_SUMMARY =
+  public static readonly ALL_DEPLOYMENT_ELEMENTS_FAILED = `${chalk.red('X')} All elements failed deployment`
+  public static readonly ALL_DEPLOYMENT_ELEMENTS_SUCCEEDED = `${chalk.green('\u2713')} All elements succeeded deployment`
+  public static readonly DEPLOYMENT_SUMMARY_LEGEND =
     chalk.gray(`Deployment status is indicated with the following symbols:
   ${Prompts.DEPLOYMENT_STATUS.success} success
   ${Prompts.DEPLOYMENT_STATUS.partialSuccess} partial success

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -97,8 +97,12 @@ export default class Prompts {
   public static readonly DID_YOU_MEAN = 'Did you mean'
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
-  public static readonly SUCCESSFUL_DEPLOYMENT = 'Deployment was successful'
-  public static readonly NOT_SUCCESSFUL_DEPLOYMENT = "Couldn't deploy all elements\nDeployment summary:"
+  public static readonly NOT_SUCCESSFUL_DEPLOYMENT = chalk.bgBlack.bold('Deployment summary:')
+  public static readonly EXPLAIN_DEPLOYMENT_RESULT =
+    chalk.gray(`Deployment status is indicated with the following symbols:
+  ${Prompts.DEPLOYMENT_STATUS.success} success
+  ${Prompts.DEPLOYMENT_STATUS.partialSuccess} partial success
+  ${Prompts.DEPLOYMENT_STATUS.failure} failure`)
 
   public static initFailed(msg: string): string {
     return `Could not initiate workspace: ${msg}\n`

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -98,7 +98,7 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static readonly DEPLOYMENT_SUMMARY_HEADLINE = chalk.bgBlack.bold('Deployment summary:')
-  public static readonly EXPLAIN_DEPLOYMENT_RESULT =
+  public static readonly EXPLAIN_DEPLOYMENT_SUMMARY =
     chalk.gray(`Deployment status is indicated with the following symbols:
   ${Prompts.DEPLOYMENT_STATUS.success} success
   ${Prompts.DEPLOYMENT_STATUS.partialSuccess} partial success

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -97,7 +97,7 @@ export default class Prompts {
   public static readonly DID_YOU_MEAN = 'Did you mean'
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
-  public static readonly NOT_SUCCESSFUL_DEPLOYMENT = chalk.bgBlack.bold('Deployment summary:')
+  public static readonly DEPLOYMENT_SUMMARY_HEADLINE = chalk.bgBlack.bold('Deployment summary:')
   public static readonly EXPLAIN_DEPLOYMENT_RESULT =
     chalk.gray(`Deployment status is indicated with the following symbols:
   ${Prompts.DEPLOYMENT_STATUS.success} success

--- a/packages/cli/src/prompts.ts
+++ b/packages/cli/src/prompts.ts
@@ -98,8 +98,8 @@ export default class Prompts {
   public static readonly DESCRIBE_NOT_FOUND = 'Unknown element type.'
 
   public static readonly DEPLOYMENT_SUMMARY_HEADLINE = chalk.bgBlack.bold('Deployment summary:')
-  public static readonly ALL_DEPLOYMENT_ELEMENTS_FAILED = `${chalk.red('X')} All elements failed deployment`
-  public static readonly ALL_DEPLOYMENT_ELEMENTS_SUCCEEDED = `${chalk.green('\u2713')} All elements succeeded deployment`
+  public static readonly ALL_DEPLOYMENT_ELEMENTS_FAILED = `${chalk.red('X')} All elements failed to deploy`
+  public static readonly ALL_DEPLOYMENT_ELEMENTS_SUCCEEDED = `${chalk.green('\u2713')} All elements were successfully deployed`
   public static readonly DEPLOYMENT_SUMMARY_LEGEND =
     chalk.gray(`Deployment status is indicated with the following symbols:
   ${Prompts.DEPLOYMENT_STATUS.success} success

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -10,12 +10,12 @@ import * as saltoCoreModule from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
 import * as saltoFileModule from '@salto-io/file'
 import { Artifact, Change } from '@salto-io/adapter-api'
+import chalk from 'chalk'
 import Prompts from '../../src/prompts'
 import { CliExitCode } from '../../src/types'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { action } from '../../src/commands/deploy'
-import chalk from 'chalk'
 
 const mockDeploy = mocks.deploy
 const mockPreview = mocks.preview
@@ -544,8 +544,8 @@ describe('deploy command', () => {
       })
       it('should print all failed elements as failed', async () => {
         expect(output.stdout.content).toContain(Prompts.DEPLOYMENT_SUMMARY_HEADLINE)
-        expect(output.stdout.content).toContain(chalk.red.bold('F') + ' instance_test')
-        expect(output.stdout.content).toContain(chalk.red.bold('F') + ' test_instance')
+        expect(output.stdout.content).toContain(`${chalk.red.bold('F')} instance_test`)
+        expect(output.stdout.content).toContain(`${chalk.red.bold('F')} test_instance`)
       })
       it('should not print succeeded or partially succeeded', async () => {
         expect(output.stdout.content).not.toContain(chalk.green.bold('S'))
@@ -572,9 +572,9 @@ describe('deploy command', () => {
         })
       })
       it('should print all the elements and their deployment status', async () => {
-        expect(output.stdout.content).toContain(chalk.red.bold('F') + ' instance_test')
-        expect(output.stdout.content).toContain(chalk.green.bold('S') + ' test_instance')
-        expect(output.stdout.content).toContain(chalk.yellow.bold('P') + ' tester_instance')
+        expect(output.stdout.content).toContain(`${chalk.red.bold('F')} instance_test`)
+        expect(output.stdout.content).toContain(`${chalk.green.bold('S')} test_instance`)
+        expect(output.stdout.content).toContain(`${chalk.yellow.bold('P')} tester_instance`)
       })
     })
   })

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -15,6 +15,7 @@ import { CliExitCode } from '../../src/types'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
 import { action } from '../../src/commands/deploy'
+import { summarizeDeployChanges } from '../../../core/src/core/deploy/deploy_summary'
 
 const mockDeploy = mocks.deploy
 const mockPreview = mocks.preview
@@ -52,6 +53,7 @@ describe('deploy command', () => {
   let workspace: mocks.MockWorkspace
   let output: mocks.MockCliOutput
   let cliCommandArgs: mocks.MockCommandArgs
+  let summarizeDeployChangesSpy: jest.SpyInstance
   const accounts = ['salesforce']
   const mockGetUserBooleanInput = callbacks.getUserBooleanInput as jest.Mock
   const mockShouldCancel = callbacks.shouldCancelCommand as jest.Mock
@@ -65,6 +67,7 @@ describe('deploy command', () => {
     workspace = mocks.mockWorkspace({})
     mockGetUserBooleanInput.mockReset()
     mockShouldCancel.mockReset()
+    jest.spyOn(saltoCoreModule, 'summarizeDeployChanges')
   })
 
   describe('when deploying changes', () => {
@@ -490,6 +493,31 @@ describe('deploy command', () => {
         workspace,
       })
       expect(workspace.setCurrentEnv).toHaveBeenCalledWith(mocks.withEnvironmentParam, false)
+    })
+  })
+  describe('Post deployment summary', () => {
+    describe('when deployment is successful', () => {
+      beforeEach(async () => {
+        await action({
+          ...cliCommandArgs,
+          input: {
+            force: false,
+            dryRun: false,
+            detailedPlan: true,
+            checkOnly: false,
+            accounts,
+          },
+          workspace,
+        })
+      })
+      it('should not print anything', async () => {})
+    })
+    describe('when deployment failed', () => {
+      it('should print all failed elements as failed', async () => {})
+      it('should not print succeeded or partially succeeded', async () => {})
+    })
+    describe('when deployment is partially successful', () => {
+      it('should print all the elements and their deployment status', async () => {})
     })
   })
 })

--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -13,6 +13,7 @@ export {
   summarizeDeployChanges,
   DeploySummaryResult,
   DetailedChangeDeploySummaryResult,
+  DetailedChangeId,
 } from './src/core/deploy'
 export {
   getAdaptersCredentialsTypes,

--- a/packages/core/src/core/deploy/deploy_summary.ts
+++ b/packages/core/src/core/deploy/deploy_summary.ts
@@ -194,12 +194,27 @@ const summarizeDeployChange = (
 export const summarizeDeployChanges = (
   requested: Change[],
   applied: Change[],
-): Record<DetailedChangeId, DeploySummaryResult> => {
+): {
+  elemIdToResult: Record<DetailedChangeId, DeploySummaryResult>
+  resultToElemId: Record<DeploySummaryResult, DetailedChangeId[]>
+} => {
   const appliedById = _.keyBy(applied, c => getChangeData(c).elemID.getFullName())
-  return Object.fromEntries(
+  const elemIdToResult = Object.fromEntries(
     requested.flatMap(requestedChange => {
       const requestedChangeId = getChangeData(requestedChange).elemID.getFullName()
       return summarizeDeployChange(requestedChange, appliedById?.[requestedChangeId])
     }),
   )
+  const resultToElemId: Record<DeploySummaryResult, DetailedChangeId[]> = {
+    success: [],
+    failure: [],
+    'partial-success': [],
+  }
+
+  Object.entries(elemIdToResult).forEach(([changeId, resultValue]) => {
+    if (resultToElemId[resultValue]) {
+      resultToElemId[resultValue].push(changeId)
+    }
+  })
+  return { elemIdToResult, resultToElemId }
 }

--- a/packages/core/test/core/deploy/deploy_summary.test.ts
+++ b/packages/core/test/core/deploy/deploy_summary.test.ts
@@ -30,15 +30,27 @@ describe('summarizeDeployChanges', () => {
     it('should return the requested change ids as success, when added correctly', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
       const appliedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'success',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [firstEmployeeInstance.elemID.getFullName()],
+        failure: [],
+        'partial-success': [],
       })
     })
     it('should return the requested change ids as partial-success, when they were partially added', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
       const appliedChanges: Change[] = [{ action: 'add', data: { after: createEmployee({ name: 'FirstEmployee' }) } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'partial-success',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [],
+        'partial-success': [firstEmployeeInstance.elemID.getFullName()],
       })
     })
     it('should return the requested change ids as failure, when applied as modification', () => {
@@ -46,21 +58,39 @@ describe('summarizeDeployChanges', () => {
       const appliedChanges: Change[] = [
         { action: 'modify', data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOffice } },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'failure',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [firstEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
       })
     })
     it('should return the requested change ids as failure, when they wrongfully got removed', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
       const appliedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'failure',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [firstEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
       })
     })
     it('should return the added requested detailed changes ids as failure, when none were applied', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, [])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, [])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'failure',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [firstEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
       })
     })
   })
@@ -68,8 +98,14 @@ describe('summarizeDeployChanges', () => {
     it('should return the requested change ids as failure, when they wrongfully got added', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
       const appliedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'failure',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [firstEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
       })
     })
     it('should return the requested change ids as failure, when applied as modification', () => {
@@ -77,21 +113,39 @@ describe('summarizeDeployChanges', () => {
       const appliedChanges: Change[] = [
         { action: 'modify', data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOffice } },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'partial-success',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [],
+        'partial-success': [firstEmployeeInstance.elemID.getFullName()],
       })
     })
     it('should return the requested change ids as success, when removed correctly', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
       const appliedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'success',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [firstEmployeeInstance.elemID.getFullName()],
+        failure: [],
+        'partial-success': [],
       })
     })
     it('should return the removed requested detailed changes ids as failure, when none were applied', () => {
       const modifyRequestedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, [])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, [])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [firstEmployeeInstance.elemID.getFullName()]: 'failure',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [],
+        failure: [firstEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
       })
     })
   })
@@ -106,10 +160,17 @@ describe('summarizeDeployChanges', () => {
         { action: 'modify', data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOffice } },
       ]
       const appliedChanges: Change[] = [{ action: 'add', data: { after: firstEmployeeWithNewNickNameAndOffice } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
+        saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
     })
     it('should return the requested modified detailed changes ids as failure, when none were applied', () => {
       const modifyRequestedChanges: Change[] = [
@@ -121,10 +182,17 @@ describe('summarizeDeployChanges', () => {
           },
         },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, [])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, [])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
+        saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
     })
     it('should return the requested modified detailed changes ids as failure, when they were not applied', () => {
       const modifyRequestedChanges: Change[] = [
@@ -145,19 +213,33 @@ describe('summarizeDeployChanges', () => {
           },
         },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedRequestedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedRequestedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
+        saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
     })
     it('should return the requested detailed changes ids as success, when modified correctly', () => {
       const modifyRequestedChanges: Change[] = [
         { action: 'modify', data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOffice } },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, modifyRequestedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, modifyRequestedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'success',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'success',
       })
+      expect(deploymentSummary.resultToElemId.success).toIncludeSameMembers([
+        saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId.failure).toEqual([])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
     })
     it('should return the requested detailed changes ids as partial success when they were partially created', () => {
       const modifyRequestedChanges: Change[] = [
@@ -169,9 +251,15 @@ describe('summarizeDeployChanges', () => {
           data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOfficePartiallyCreated },
         },
       ]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'success',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'partial-success',
+      })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()],
+        failure: [],
+        'partial-success': [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()],
       })
     })
     it('should return the requested detailed changes ids as failure, when they wrongfully got removed', () => {
@@ -179,10 +267,17 @@ describe('summarizeDeployChanges', () => {
         { action: 'modify', data: { before: firstEmployeeInstance, after: firstEmployeeWithNewNickNameAndOffice } },
       ]
       const appliedChanges: Change[] = [{ action: 'remove', data: { before: firstEmployeeInstance } }]
-      expect(summarizeDeployChanges(modifyRequestedChanges, appliedChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(modifyRequestedChanges, appliedChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
+        saltoEmployeeInstanceInstanceID.createNestedID('nicknames', '1').getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('office').getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
     })
   })
   describe('changes with different actions', () => {
@@ -198,30 +293,58 @@ describe('summarizeDeployChanges', () => {
           },
         },
       ]
-
-      expect(summarizeDeployChanges(requestedChanges, [])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(requestedChanges, [])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoOffice.elemID.getFullName()]: 'failure',
         [anotherSaltoEmployeeInstance.elemID.getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('hobby').getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId['failure']).toIncludeSameMembers([
+        saltoOffice.elemID.getFullName(),
+        anotherSaltoEmployeeInstance.elemID.getFullName(),
+        saltoEmployeeInstanceInstanceID.createNestedID('hobby').getFullName(),
+      ])
+
+      expect(deploymentSummary.resultToElemId['success']).toEqual([])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
     })
     it('should return requested change ids as failure when none were applied', () => {
-      expect(summarizeDeployChanges(AddRemoveChanges, [])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(AddRemoveChanges, [])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployee.elemID.getFullName()]: 'failure',
         [saltoEmployeeInstance.elemID.getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
+        saltoEmployee.elemID.getFullName(),
+        saltoEmployeeInstance.elemID.getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
     })
     it('should return failures on changes that were not applied', () => {
-      expect(summarizeDeployChanges(AddRemoveChanges, [AddRemoveChanges[0]])).toEqual({
+      const deploymentSummary = summarizeDeployChanges(AddRemoveChanges, [AddRemoveChanges[0]])
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployee.elemID.getFullName()]: 'success',
         [saltoEmployeeInstance.elemID.getFullName()]: 'failure',
       })
+      expect(deploymentSummary.resultToElemId).toEqual({
+        success: [saltoEmployee.elemID.getFullName()],
+        failure: [saltoEmployeeInstance.elemID.getFullName()],
+        'partial-success': [],
+      })
     })
     it('should return success summary when all changes were applied', () => {
-      expect(summarizeDeployChanges(AddRemoveChanges, AddRemoveChanges)).toEqual({
+      const deploymentSummary = summarizeDeployChanges(AddRemoveChanges, AddRemoveChanges)
+      expect(deploymentSummary.elemIdToResult).toEqual({
         [saltoEmployee.elemID.getFullName()]: 'success',
         [saltoEmployeeInstance.elemID.getFullName()]: 'success',
       })
+      expect(deploymentSummary.resultToElemId.success).toIncludeSameMembers([
+        saltoEmployee.elemID.getFullName(),
+        saltoEmployeeInstance.elemID.getFullName(),
+      ])
+      expect(deploymentSummary.resultToElemId.failure).toEqual([])
+      expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
     })
   })
 })

--- a/packages/core/test/core/deploy/deploy_summary.test.ts
+++ b/packages/core/test/core/deploy/deploy_summary.test.ts
@@ -299,13 +299,13 @@ describe('summarizeDeployChanges', () => {
         [anotherSaltoEmployeeInstance.elemID.getFullName()]: 'failure',
         [saltoEmployeeInstanceInstanceID.createNestedID('hobby').getFullName()]: 'failure',
       })
-      expect(deploymentSummary.resultToElemId['failure']).toIncludeSameMembers([
+      expect(deploymentSummary.resultToElemId.failure).toIncludeSameMembers([
         saltoOffice.elemID.getFullName(),
         anotherSaltoEmployeeInstance.elemID.getFullName(),
         saltoEmployeeInstanceInstanceID.createNestedID('hobby').getFullName(),
       ])
 
-      expect(deploymentSummary.resultToElemId['success']).toEqual([])
+      expect(deploymentSummary.resultToElemId.success).toEqual([])
       expect(deploymentSummary.resultToElemId['partial-success']).toEqual([])
     })
     it('should return requested change ids as failure when none were applied', () => {


### PR DESCRIPTION
added post deployment summary to the cli
![image](https://github.com/user-attachments/assets/4ff9e689-325b-4851-bb65-2117f7086885)
![image](https://github.com/user-attachments/assets/e04423f3-ae2f-40bf-a1b0-dba8ee56f767)
![image](https://github.com/user-attachments/assets/52b71b76-5800-4872-92a0-ef8baa55c322)
![image](https://github.com/user-attachments/assets/aee2d029-ea7a-482f-b1f2-6fec15168c02)




---

when deployment isn't fully successful, post deployment summary will be printed listing which elements where deployed successfully, which were partially successful and which have failed

---
_Release Notes_: 
CLI:
added post deployment summary

---
_User Notifications_: 
none
