### PR TITLE
SALTO-6903: Avoid creating a unified source map for many files

### DIFF
--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -20,3 +20,9 @@ export const getSaltoFlagBool = (flagName: string): boolean => {
   }
   return Boolean(parsedFlagValue)
 }
+
+export const WORKSPACE_FLAGS = {
+  useOldDependentsCalculation: 'USE_OLD_DEPENDENTS_CALCULATION',
+  createFilenamesToElementIdsMapping: 'CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING',
+  useSplitSourceMapInUpdate: 'USE_SPLIT_SOURCE_MAP_IN_UPDATE',
+} as const

--- a/packages/workspace/src/workspace/dependents.ts
+++ b/packages/workspace/src/workspace/dependents.ts
@@ -9,15 +9,13 @@ import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { ElemID, Element, ReadOnlyElementsSource, isElement } from '@salto-io/adapter-api'
-import { getSaltoFlagBool } from '../flags'
+import { getSaltoFlagBool, WORKSPACE_FLAGS } from '../flags'
 import { ReferenceIndexEntry } from './reference_indexes'
 import { ReadOnlyRemoteMap } from './remote_map'
 import { ParsedNaclFile } from './nacl_files/parsed_nacl_file'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
-
-const USE_OLD_DEPENDENTS_CALCULATION_FLAG = 'USE_OLD_DEPENDENTS_CALCULATION'
 
 const getDependentIDsFromReferenceSourceIndex = async (
   elemIDs: ElemID[],
@@ -130,7 +128,7 @@ export const getDependents = async (
   getElementReferencedFiles: (id: ElemID) => Promise<string[]>,
   getParsedNaclFile: (filename: string) => Promise<ParsedNaclFile | undefined>,
 ): Promise<Element[]> => {
-  const dependentIDs = getSaltoFlagBool(USE_OLD_DEPENDENTS_CALCULATION_FLAG)
+  const dependentIDs = getSaltoFlagBool(WORKSPACE_FLAGS.useOldDependentsCalculation)
     ? await getDependentIDsFromReferencedFiles(elemIDs, getElementReferencedFiles, getParsedNaclFile)
     : await getDependentIDsFromReferenceSourceIndex(elemIDs, referenceSourcesIndex, elementsSource)
 

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -45,7 +45,7 @@ export type DetailedChangeWithSource = DetailedChange & {
   requiresIndent?: boolean
 }
 
-export const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
+const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
   `${path.join(...(pathParts ?? ['unsorted']))}${FILE_EXTENSION}`
 
 type PositionInParent = {

--- a/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_file_update.ts
@@ -45,7 +45,7 @@ export type DetailedChangeWithSource = DetailedChange & {
   requiresIndent?: boolean
 }
 
-const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
+export const createFileNameFromPath = (pathParts?: ReadonlyArray<string>): string =>
   `${path.join(...(pathParts ?? ['unsorted']))}${FILE_EXTENSION}`
 
 type PositionInParent = {

--- a/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/nacl_files_source.ts
@@ -61,7 +61,7 @@ import { RemoteMap, RemoteMapCreator } from '../remote_map'
 import { ParsedNaclFile } from './parsed_nacl_file'
 import { createParseResultCache, ParsedNaclFileCache } from './parsed_nacl_files_cache'
 import { isInvalidStaticFile } from '../static_files/common'
-import { getSaltoFlagBool } from '../../flags'
+import { getSaltoFlagBool, WORKSPACE_FLAGS } from '../../flags'
 
 const { awu } = collections.asynciterable
 type ThenableIterable<T> = collections.asynciterable.ThenableIterable<T>
@@ -75,10 +75,9 @@ export type RoutingMode = 'isolated' | 'default' | 'align' | 'override'
 export const FILE_EXTENSION = '.nacl'
 export const HASH_KEY = 'hash'
 
-const CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING_FLAG = 'CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING'
-
 const PARSE_CONCURRENCY = 100
 const DUMP_CONCURRENCY = 100
+const SOURCE_MAP_READ_CONCURRENCY = 10
 // TODO: this should moved into cache implementation
 const CACHE_READ_CONCURRENCY = 100
 const UPDATE_INDEX_CONCURRENCY = 100
@@ -380,9 +379,9 @@ const buildNaclFilesState = async ({
   const staticFilesIndexDeletions: Record<string, Set<string>> = {}
   // We need to iterate over this twice - so no point in making this iterable :/
   const relevantElementIDs: ElemID[] = []
-  const newElementsToMerge: AsyncIterable<Element>[] = []
+  const newElementsToMerge: Element[] = []
 
-  const shouldCreateFilenameToElementIDsMapping = getSaltoFlagBool(CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING_FLAG)
+  const shouldCreateFilenameToElementIDsMapping = getSaltoFlagBool(WORKSPACE_FLAGS.createFilenamesToElementIdsMapping)
   log.debug('shouldCreateFilenameToElementIDsMapping is %s', shouldCreateFilenameToElementIDsMapping)
 
   const filenameToElementIDFullNames =
@@ -501,9 +500,7 @@ const buildNaclFilesState = async ({
           currentNaclFileElements.map(e => e.elemID.getFullName()),
         )
         relevantElementIDs.push(...currentNaclFileElements.map(e => e.elemID), ...oldNaclFileElementIDs)
-        if (!_.isEmpty(currentNaclFileElements)) {
-          newElementsToMerge.push(awu(currentNaclFileElements as Element[]))
-        }
+        currentNaclFileElements.forEach(element => newElementsToMerge.push(element))
         // This is temp and should be removed when we change the init flow
         // This happens now cause we get here with ParsedNaclFiles that originate from the cache
         if (values.isDefined(naclFile.buffer)) {
@@ -557,9 +554,9 @@ const buildNaclFilesState = async ({
         ),
       )
     })
-    .filter(values.isDefined) as AsyncIterable<Element>
+    .filter(values.isDefined)
   const changes = (await buildNewMergedElementsAndErrors({
-    afterElements: awu(newElementsToMerge).flat().concat(unmodifiedFragments),
+    afterElements: awu(newElementsToMerge).concat(unmodifiedFragments),
     relevantElementIDs: awu(relevantElementIDs),
     currentElements: currentState.mergedElements,
     currentErrors: currentState.mergeErrors,
@@ -866,16 +863,10 @@ const buildNaclFilesSource = (
     await awu(emptyNaclFiles).forEach(naclFile => naclFilesStore.delete(naclFile.filename))
   }
 
-  const groupChangesByFilename = async (
+  const getChangeLocationsForFiles = async (
     changes: DetailedChange[],
-  ): Promise<Record<string, DetailedChangeWithSource[]>> => {
-    const naclFiles = _.uniq(
-      await awu(changes)
-        .map(change => change.id)
-        .flatMap(elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))
-        .toArray(),
-    )
-
+    naclFiles: string[],
+  ): Promise<DetailedChangeWithSource[]> => {
     const { parsedNaclFiles } = await getState()
     log.debug('Nacl source %s getting source maps for %d nacl files', sourceName, naclFiles.length)
     const changedFileSourceMaps = (
@@ -884,7 +875,7 @@ const buildNaclFilesSource = (
           const parsedNaclFile = await parsedNaclFiles.get(naclFile)
           return values.isDefined(parsedNaclFile) ? getSourceMap(parsedNaclFile.filename, false) : undefined
         }),
-        CACHE_READ_CONCURRENCY,
+        SOURCE_MAP_READ_CONCURRENCY,
       )
     ).filter(values.isDefined)
 
@@ -892,9 +883,78 @@ const buildNaclFilesSource = (
       acc.merge(sourceMap)
       return acc
     }, new parser.SourceMap())
+
     const changesWithLocation = getChangesToUpdate(changes, mergedSourceMap).flatMap(change =>
       getChangeLocations(change, mergedSourceMap),
     )
+
+    return changesWithLocation
+  }
+
+  const getChangesWithLocationsSplitSourceMap = async (
+    changes: DetailedChange[],
+  ): Promise<DetailedChangeWithSource[]> => {
+    // Create separate source maps for groups of files and then find the location for each group of files separately
+    const currentState = await getState()
+
+    const changesByTopLevel = _.groupBy(changes, change => change.id.createTopLevelParentID().parent.getFullName())
+    // Note - by using the top level ID, we might read files that are not strictly needed
+    // e.g - if the element is split between two files, but our change is in one of them, we will parse the other file as well.
+    const potentialFilesByElementID = _.zipObject(
+      Object.keys(changesByTopLevel),
+      await currentState.elementsIndex.getMany(Object.keys(changesByTopLevel)),
+    )
+    // Note - this is not ideal grouping, in theory this grouping could cause us to read the same file(s) multiple times.
+    // This grouping should be good enough under the assumption that in most cases elements are either:
+    // 1. in a single file that contains only one element (most elements)
+    // 2. split to multiple files that all contain only one element (less common, mostly used for very large elements)
+    // 3. in a single file that contains other elements as well (less common, mostly used for large numbers of very small elements)
+
+    // Examples of a case where we would read the same file twice:
+    // - Element A exists in files 1,2,3
+    // - Element B exists in file 1
+    // With the current logic, this will cause us to read file 1 twice, but this should not affect the correctness of the result.
+    // Note that we do not cache the source maps on purpose - they consume too much memory.
+    const changesByFiles = _.groupBy(
+      Object.entries(changesByTopLevel).map(([id, elementChanges]) => ({
+        elementChanges,
+        potentialFiles: potentialFilesByElementID[id],
+      })),
+      ({ potentialFiles }) => potentialFiles?.join(','),
+    )
+    const changesWithLocationsByFiles = await withLimitedConcurrency(
+      Object.values(changesByFiles).map(
+        changeGroups => () =>
+          getChangeLocationsForFiles(
+            changeGroups.flatMap(group => group.elementChanges),
+            // this is grouped by potential files, so all groups have the same list here
+            changeGroups[0].potentialFiles ?? [],
+          ),
+      ),
+      SOURCE_MAP_READ_CONCURRENCY,
+    )
+    return changesWithLocationsByFiles.flat()
+  }
+
+  const getChangesWithLocationsUnifiedSourceMap = async (
+    changes: DetailedChange[],
+  ): Promise<DetailedChangeWithSource[]> => {
+    // Create a unified source map for all files and find the locations for all changes together
+    const naclFiles = _.uniq(
+      await awu(changes)
+        .map(change => change.id)
+        .flatMap(elemID => getElementNaclFiles(elemID.createTopLevelParentID().parent))
+        .toArray(),
+    )
+    return getChangeLocationsForFiles(changes, naclFiles)
+  }
+
+  const groupChangesByFilename = async (
+    changes: DetailedChange[],
+  ): Promise<Record<string, DetailedChangeWithSource[]>> => {
+    const changesWithLocation = getSaltoFlagBool(WORKSPACE_FLAGS.useSplitSourceMapInUpdate)
+      ? await getChangesWithLocationsSplitSourceMap(changes)
+      : await getChangesWithLocationsUnifiedSourceMap(changes)
 
     return _.groupBy(
       changesWithLocation,
@@ -1191,23 +1251,5 @@ export const naclFilesSource = async (
   staticFilesSource: StaticFilesSource,
   remoteMapCreator: RemoteMapCreator,
   persistent: boolean,
-  parsedFiles?: ParsedNaclFile[],
-): Promise<NaclFilesSource> => {
-  const state =
-    parsedFiles !== undefined
-      ? (
-          await buildNaclFilesState({
-            newNaclFiles: parsedFiles,
-            currentState: await createNaclFilesState(remoteMapCreator, staticFilesSource, sourceName, persistent),
-          })
-        ).state
-      : undefined
-  return buildNaclFilesSource(
-    sourceName,
-    naclFilesStore,
-    staticFilesSource,
-    remoteMapCreator,
-    persistent,
-    state !== undefined ? Promise.resolve(state) : undefined,
-  )
-}
+): Promise<NaclFilesSource> =>
+  buildNaclFilesSource(sourceName, naclFilesStore, staticFilesSource, remoteMapCreator, persistent)

--- a/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
+++ b/packages/workspace/test/workspace/nacl_files/nacl_files_source.test.ts
@@ -552,38 +552,6 @@ describe.each([false, true])(
       })
     })
 
-    describe('init with parsed files', () => {
-      it('should return elements from given parsed files', async () => {
-        const filename = 'mytest.nacl'
-        const elemID = new ElemID('dummy', 'elem')
-        const elem = new ObjectType({ elemID, path: ['test', 'new'] })
-        const elements = [elem]
-        const parsedFiles: ParsedNaclFile[] = [
-          {
-            filename,
-            elements: () => Promise.resolve(elements),
-            buffer: '',
-            data: {
-              errors: () => Promise.resolve([]),
-              referenced: () => Promise.resolve([]),
-              staticFiles: () => Promise.resolve([]),
-            },
-          },
-        ]
-        const naclSource = naclFilesSource(
-          '',
-          mockDirStore,
-          mockedStaticFilesSource,
-          () => Promise.resolve(new InMemoryRemoteMap()),
-          true,
-          parsedFiles,
-        )
-        const parsed = await (await naclSource).getParsedNaclFile(filename)
-        expect(parsed).toBeDefined()
-        expect(await (parsed as ParsedNaclFile).elements()).toEqual([elem])
-      })
-    })
-
     describe('getParsedNaclFile', () => {
       let naclSource: NaclFilesSource
       const mockFileData = { buffer: 'someData {}', filename: 'somefile.nacl' }


### PR DESCRIPTION
When finding locations for changes, try to avoid creating a single source map. We suspect this single source map consumes a lot of memory.

Instead, try to group changes by which files that could be located in, and for each group create a source map just from the relevant file(s).

This is all behind a flag: SALTO_USE_SPLIT_SOURCE_MAP_IN_UPDATE

---

_Additional context for reviewer_
Some results from a reproduction with the dummy adapter - having 70 large files (~50k lines each).
Fetch with a single change per file:

  | Peak memory in relevant part | Time in code | Total fetch time
-- | -- | -- | --
Old code | before: 1014, peak: 2441.8, after: 965.7 | 16.25 | 122505 ms |  
New code | before: 948.5, peak: 1905.1 (mid run GC to 926.1), after: 1027.7 | 15.04 | 121357 ms |  

Fetch with many changes per file (~25k changes)


  | Peak memory in relevant part | Time in code | Total fetch time
-- | -- | -- | --
Old code | before: 8123.4, peak: 8649.7→(GC to 7523.4)→8774.6, after: 8677.2 | 63.25 | 555964 ms |  
New code | before: 8129.2, peak: 8681.9 (mid run GC to 7577.6), after: 8066.5 | 76.24 | 527406 ms |  

---
_Release Notes_: 
Core:
- Add flag SALTO_USE_SPLIT_SOURCE_MAP_IN_UPDATE which should improve memory consumption when updating many large NaCl files, currently off by default

---
_User Notifications_: 
_None_