### PR TITLE
SALTO-6711 skip getting additional dependent instances when there are…

### DIFF
--- a/packages/workspace/src/workspace/dependents.ts
+++ b/packages/workspace/src/workspace/dependents.ts
@@ -51,6 +51,12 @@ const getDependentIDsFromReferenceSourceIndex = async (
 
       const dependentIDs = await getDependentIDs(elemIDs)
 
+      // if there are no dependent types we can return `dependentIDs` and avoid
+      // iterating `elementsSource.list()` to get the additional dependent instances.
+      if (!dependentIDs.some(id => id.idType === 'type')) {
+        return dependentIDs
+      }
+
       // in `referenceSourcesIndex` there are no references between types and their instances
       // so we should add the instances of the types that are in `addedIDs` as well.
       const additionalDependentInstanceIDs = await awu(await elementsSource.list())


### PR DESCRIPTION
… no dependent types

When getting elements dependents using the `referenceSources` index we run `elementsSource.list()` in order to get the instances of the dependent types. When there are no dependent types we can skip it.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
