### PR TITLE
SALTO-6213: Moving index.ts to package root

### DIFF
--- a/packages/e2e-credentials-store/index.ts
+++ b/packages/e2e-credentials-store/index.ts
@@ -5,12 +5,12 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import cliMain from './cli'
+import cliMain from './src/cli'
 
-export { default as creds, CredsSpec, CredsLease } from './jest-environment/creds'
+export { default as creds, CredsSpec, CredsLease } from './src/jest-environment/creds'
 
-export { default as createEnvUtils } from './process_env'
-export { SaltoE2EJestEnvironment, JestEnvironmentConstructorArgs } from './jest-environment/index'
-export { default as IntervalScheduler } from './jest-environment/interval_scheduler'
-export * from './types'
+export { default as createEnvUtils } from './src/process_env'
+export { SaltoE2EJestEnvironment, JestEnvironmentConstructorArgs } from './src/jest-environment/index'
+export { default as IntervalScheduler } from './src/jest-environment/interval_scheduler'
+export * from './src/types'
 export const cli = { main: cliMain }

--- a/packages/e2e-credentials-store/package.json
+++ b/packages/e2e-credentials-store/package.json
@@ -11,10 +11,10 @@
     "access": "public"
   },
   "files": [
-    "dist/src"
+    "dist"
   ],
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../build_utils/turbo_run.sh build-ts ; ../../build_utils/turbo_run.sh lint",
     "build-ts": "tsc -b",

--- a/packages/persistent-pool/index.ts
+++ b/packages/persistent-pool/index.ts
@@ -5,6 +5,6 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-export { repo as dynamoDbRepo, DynamoRepoOpts as DynamoDbRepoOpts } from './lib/dynamodb/dynamodb_repo'
-export * from './types'
-export { default as RenewedLease, RenewedLeaseOpts } from './lib/renewed_lease'
+export { repo as dynamoDbRepo, DynamoRepoOpts as DynamoDbRepoOpts } from './src/lib/dynamodb/dynamodb_repo'
+export * from './src/types'
+export { default as RenewedLease, RenewedLeaseOpts } from './src/lib/renewed_lease'

--- a/packages/persistent-pool/package.json
+++ b/packages/persistent-pool/package.json
@@ -11,10 +11,10 @@
     "access": "public"
   },
   "files": [
-    "dist/src"
+    "dist"
   ],
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../build_utils/turbo_run.sh build-ts ; ../../build_utils/turbo_run.sh lint",
     "build-ts": "tsc -b",

--- a/packages/persistent-pool/test/lib/renewed_lease.test.ts
+++ b/packages/persistent-pool/test/lib/renewed_lease.test.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { RenewedLease, Pool, Lease, LeaseUpdateOpts, InstanceNotLeasedError } from '../../src/index'
+import { RenewedLease, Pool, Lease, LeaseUpdateOpts, InstanceNotLeasedError } from '../..'
 import { createMockPool } from '../mock_repo'
 
 jest.useFakeTimers({ legacyFakeTimers: true })

--- a/packages/persistent-pool/test/mock_repo.ts
+++ b/packages/persistent-pool/test/mock_repo.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { mockFunction } from '@salto-io/test-utils'
-import { Repo, Pool, LeaseWithStatus } from '../src/index'
+import { Repo, Pool, LeaseWithStatus } from '..'
 
 export const createMockPool = <T>(): jest.Mocked<Pool<T>> => ({
   [Symbol.asyncIterator]: jest.fn<AsyncIterator<LeaseWithStatus<T>>, []>(),


### PR DESCRIPTION
This saves the need for custom knip configuration for these packages and aligns better with our conventions in other packages.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.