### PR TITLE
SALTO-6939: Add the ability to disable custom references from config (Jira)

### DIFF
--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -8,12 +8,7 @@
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { InstanceElement, Adapter, Values } from '@salto-io/adapter-api'
-import {
-  client as clientUtils,
-  combineCustomReferenceGetters,
-  config as configUtils,
-  definitions,
-} from '@salto-io/adapter-components'
+import { client as clientUtils, config as configUtils, definitions } from '@salto-io/adapter-components'
 import JiraClient from './client/client'
 import JiraAdapter from './adapter'
 import { Credentials, basicAuthCredentialsType } from './auth'
@@ -22,7 +17,7 @@ import { createConnection, validateCredentials } from './client/connection'
 import { SCRIPT_RUNNER_API_DEFINITIONS } from './constants'
 import { configCreator } from './config_creator'
 import ScriptRunnerClient from './client/script_runner_client'
-import { weakReferenceHandlers } from './weak_references'
+import { getCustomReferences } from './weak_references'
 
 const log = logger(module)
 const { createRetryOptions, DEFAULT_RETRY_OPTS, DEFAULT_TIMEOUT_OPTS } = clientUtils
@@ -77,6 +72,7 @@ const adapterConfigFromConfig = (
     masking: null,
     scriptRunnerApiDefinitions: null,
     jsmApiDefinitions: null,
+    customReferences: null,
   }
   Object.keys(fullConfig)
     .filter(k => !Object.keys(adapterConfig).includes(k))
@@ -134,7 +130,5 @@ export const adapter: Adapter = {
   },
   configType,
   configCreator,
-  getCustomReferences: combineCustomReferenceGetters(
-    _.mapValues(weakReferenceHandlers, handler => handler.findWeakReferences),
-  ),
+  getCustomReferences,
 }

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -84,6 +84,20 @@ export type MaskingConfig = {
   secretRegexps: string[]
 }
 
+export const CUSTOM_REFERENCES_CONFIG = 'customReferences'
+
+export const customReferencesHandlersNames = [
+  'automationProjects',
+  'fieldConfigurationsHandler',
+  'queueFieldsHandler',
+  'contextProjectsHandler',
+  'fieldContextsHandler',
+] as const
+
+export type CustomReferencesHandlers = (typeof customReferencesHandlersNames)[number]
+
+export type JiraCustomReferencesConfig = Record<CustomReferencesHandlers, boolean>
+
 export type JiraConfig = {
   client: JiraClientConfig
   fetch: JiraFetchConfig
@@ -92,6 +106,7 @@ export type JiraConfig = {
   masking: MaskingConfig
   [SCRIPT_RUNNER_API_DEFINITIONS]?: JiraDuckTypeConfig
   [JSM_DUCKTYPE_API_DEFINITIONS]?: JiraDuckTypeConfig
+  [CUSTOM_REFERENCES_CONFIG]?: JiraCustomReferencesConfig
 }
 
 const jspUrlsType = createMatchingObjectType<Partial<JspUrls>>({
@@ -355,6 +370,20 @@ const maskingConfigType = createMatchingObjectType<Partial<MaskingConfig>>({
   },
 })
 
+const customReferencesConfigType = createMatchingObjectType<Partial<JiraCustomReferencesConfig>>({
+  elemID: new ElemID(JIRA, 'customReferencesConfig'),
+  fields: {
+    automationProjects: { refType: BuiltinTypes.BOOLEAN },
+    fieldConfigurationsHandler: { refType: BuiltinTypes.BOOLEAN },
+    queueFieldsHandler: { refType: BuiltinTypes.BOOLEAN },
+    contextProjectsHandler: { refType: BuiltinTypes.BOOLEAN },
+    fieldContextsHandler: { refType: BuiltinTypes.BOOLEAN },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 export const configType = createMatchingObjectType<Partial<JiraConfig>>({
   elemID: new ElemID(JIRA),
   fields: {
@@ -375,6 +404,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
         elemIdPrefix: 'ducktype',
       }),
     },
+    [CUSTOM_REFERENCES_CONFIG]: { refType: customReferencesConfigType },
   },
   annotations: {
     [CORE_ANNOTATIONS.DEFAULT]: _.omit(PARTIAL_DEFAULT_CONFIG, [
@@ -397,6 +427,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'deploy.ignoreMissingExtensions',
       SCRIPT_RUNNER_API_DEFINITIONS,
       JSM_DUCKTYPE_API_DEFINITIONS,
+      CUSTOM_REFERENCES_CONFIG,
     ]),
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },

--- a/packages/jira-adapter/src/fix_elements/index.ts
+++ b/packages/jira-adapter/src/fix_elements/index.ts
@@ -9,10 +9,10 @@
 import _ from 'lodash'
 import { FixElementsFunc } from '@salto-io/adapter-api'
 import { FixElementsArgs } from './types'
-import { weakReferenceHandlers } from '../weak_references'
+import { customReferenceHandlers } from '../weak_references'
 import { removeMissingExtensionsTransitionRulesHandler } from './remove_missing_extension_transition_rules'
 
 export const createFixElementFunctions = (args: FixElementsArgs): Record<string, FixElementsFunc> => ({
-  ..._.mapValues(weakReferenceHandlers, handler => handler.removeWeakReferences(args)),
+  ..._.mapValues(customReferenceHandlers, handler => handler.removeWeakReferences(args)),
   removeMissingExtensionsTransitionRules: removeMissingExtensionsTransitionRulesHandler(args),
 })

--- a/packages/jira-adapter/src/weak_references/index.ts
+++ b/packages/jira-adapter/src/weak_references/index.ts
@@ -5,6 +5,10 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import _ from 'lodash'
+import { InstanceElement } from '@salto-io/adapter-api'
+import { combineCustomReferenceGetters } from '@salto-io/adapter-components'
+import { CUSTOM_REFERENCES_CONFIG, CustomReferencesHandlers, JiraCustomReferencesConfig } from '../config/config'
 import { automationProjectsHandler } from './automation_projects'
 import { WeakReferencesHandler } from './weak_references_handler'
 import { fieldConfigurationsHandler } from './field_configuration_items'
@@ -12,10 +16,27 @@ import { queueFieldsHandler } from './queue_columns'
 import { contextProjectsHandler } from './context_projects'
 import { fieldContextsHandler } from './field_contexts'
 
-export const weakReferenceHandlers: Record<string, WeakReferencesHandler> = {
+export const customReferenceHandlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
   automationProjects: automationProjectsHandler,
   fieldConfigurationsHandler,
   queueFieldsHandler,
   contextProjectsHandler,
   fieldContextsHandler,
 }
+
+const defaultCustomReferencesConfig: Required<JiraCustomReferencesConfig> = {
+  automationProjects: true,
+  fieldConfigurationsHandler: true,
+  queueFieldsHandler: true,
+  contextProjectsHandler: true,
+  fieldContextsHandler: true,
+}
+
+const getCustomReferencesConfig = (
+  customReferencesConfig?: JiraCustomReferencesConfig,
+): Required<JiraCustomReferencesConfig> => _.defaults({}, customReferencesConfig, defaultCustomReferencesConfig)
+
+export const getCustomReferences = combineCustomReferenceGetters(
+  _.mapValues(customReferenceHandlers, handler => handler.findWeakReferences),
+  (adapterConfig: InstanceElement) => getCustomReferencesConfig(adapterConfig.value[CUSTOM_REFERENCES_CONFIG]),
+)


### PR DESCRIPTION
Add the ability to disable / enable specific custom references funcs from Jira config

---
Added this ability as in certain large Jira envs we might create too many references
By default all custom reference func are enabled

Usage example - 
```
jira {
  fetch = { ... }
  customReferences = {
    fieldConfigurationsHandler = false
  }
}
```

---
_Release Notes_: 
None

---
_User Notifications_: 
None 
