### PR TITLE
SALTO-6213: Moving E2E creds store index to root

### DIFF
--- a/packages/e2e-credentials-store/index.ts
+++ b/packages/e2e-credentials-store/index.ts
@@ -5,12 +5,12 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import cliMain from './cli'
+import cliMain from './src/cli'
 
-export { default as creds, CredsSpec, CredsLease } from './jest-environment/creds'
+export { default as creds, CredsSpec, CredsLease } from './src/jest-environment/creds'
 
-export { default as createEnvUtils } from './process_env'
-export { SaltoE2EJestEnvironment, JestEnvironmentConstructorArgs } from './jest-environment/index'
-export { default as IntervalScheduler } from './jest-environment/interval_scheduler'
-export * from './types'
+export { default as createEnvUtils } from './src/process_env'
+export { SaltoE2EJestEnvironment, JestEnvironmentConstructorArgs } from './src/jest-environment/index'
+export { default as IntervalScheduler } from './src/jest-environment/interval_scheduler'
+export * from './src/types'
 export const cli = { main: cliMain }

--- a/packages/e2e-credentials-store/package.json
+++ b/packages/e2e-credentials-store/package.json
@@ -11,10 +11,10 @@
     "access": "public"
   },
   "files": [
-    "dist/src"
+    "dist"
   ],
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../build_utils/turbo_run.sh build-ts ; ../../build_utils/turbo_run.sh lint",
     "build-ts": "tsc -b",


### PR DESCRIPTION
This is the convention for other packages and will save the need for bespoke knip configuration.

---

_Additional context for reviewer_
Still need to address persistent-pool but it's giving me trouble.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
