### PR TITLE
SALTO-6672 : Okta e2e: Clean up priority instances before running tests

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -615,7 +615,7 @@ const removeAllApps = async (adapterAttr: Reals, changes: Change<InstanceElement
 const getChangesForInitialCleanup = async (elements: Element[]): Promise<Change<InstanceElement>[]> => {
   const removalChanges: Change<InstanceElement>[] = elements
     .filter(isInstanceElement)
-    .filter(inst => inst.elemID.name.startsWith(TEST_PREFIX))
+    .filter(inst => inst.elemID.name.startsWith(TEST_PREFIX) || inst.elemID.name.includes(`__${TEST_PREFIX}`))
     .filter(inst => ![APP_USER_SCHEMA_TYPE_NAME, APP_LOGO_TYPE_NAME].includes(inst.elemID.typeName))
     .map(instance => toChange({ before: instance }))
 


### PR DESCRIPTION
This PR catches more instances when doing the pre-test cleanup. Specifically I found this issue with priorities, but it looks like there are a few types whose name is `<parent>_Test<myname>` which aren't caught by the current filter.

---

_Additional context for reviewer_:
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None