### PR TITLE
SALTO-6939: Add reference to SLA's conditionId

### DIFF
--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -148,6 +148,9 @@ export const AUTOMATION_RETRY_PERIODS = [0, 1000 * 60, 1000 * 60 * 5] // 0, 1 mi
 export const WORKFLOW_RETRY_PERIODS = [0, 1000 * 3, 1000 * 9, 1000 * 27, 1000 * 81] // 0, 3 seconds, 9 seconds, 27 seconds, 81 seconds
 export const PROJECT_IDS = 'projectIds'
 export const CONTEXTS = 'contexts'
+export const SLA_CONDITIONS_STOP_TYPE = 'SLA__config__definition__stop'
+export const SLA_CONDITIONS_PAUSE_TYPE = 'SLA__config__definition__pause'
+export const SLA_CONDITIONS_START_TYPE = 'SLA__config__definition__start'
 // almost constant functions
 export const fetchFailedWarnings = (name: string): string =>
   `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -113,6 +113,13 @@ export const resolutionAndPriorityToTypeName: referenceUtils.ContextValueMapperF
   return undefined
 }
 
+const factorKeyTypeMapper: referenceUtils.ContextValueMapperFunc = val => {
+  if (val === 'status-sla-condition-factory') {
+    return STATUS_TYPE_NAME
+  }
+  return undefined
+}
+
 export type ReferenceContextStrategyName =
   | 'parentSelectedFieldType'
   | 'parentFieldType'
@@ -120,6 +127,7 @@ export type ReferenceContextStrategyName =
   | 'parentFieldId'
   | 'parentField'
   | 'gadgetPropertyValue'
+  | 'statusByNeighborFactorKey'
 
 export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   parentSelectedFieldType: neighborContextFunc({
@@ -138,6 +146,10 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
     contextValueMapper: resolutionAndPriorityToTypeName,
   }),
   gadgetPropertyValue: gadgetValuesContextFunc,
+  statusByNeighborFactorKey: neighborContextFunc({
+    contextFieldName: 'factoryKey',
+    contextValueMapper: factorKeyTypeMapper,
+  }),
 }
 
 const groupNameSerialize: GetLookupNameFunc = ({ ref }) =>
@@ -1407,8 +1419,8 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
       parentTypes: [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE],
     },
     serializationStrategy: 'id',
-    // no missing references strategy - field can have string values as well
-    target: { type: STATUS_TYPE_NAME },
+    missingRefStrategy: 'typeAndValue',
+    target: { typeContext: 'statusByNeighborFactorKey' },
   },
   // Hack to handle missing references when the type is unknown
   {

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -72,6 +72,9 @@ import {
   OBJECT_TYPE_ICON_TYPE,
   OBJECT_SCHEMA_STATUS_TYPE,
   OBJECT_SCHEMA_GLOBAL_STATUS_TYPE,
+  SLA_CONDITIONS_STOP_TYPE,
+  SLA_CONDITIONS_START_TYPE,
+  SLA_CONDITIONS_PAUSE_TYPE,
 } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
@@ -1397,6 +1400,15 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     src: { field: 'typeValueMulti', parentTypes: [OBJECT_TYPE_ATTRIBUTE_TYPE] },
     serializationStrategy: 'groupStrategyByOriginalName',
     target: { type: GROUP_TYPE_NAME },
+  },
+  {
+    src: {
+      field: 'conditionId',
+      parentTypes: [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE],
+    },
+    serializationStrategy: 'id',
+    // no missing references strategy - field can have string values as well
+    target: { type: STATUS_TYPE_NAME },
   },
   // Hack to handle missing references when the type is unknown
   {

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -63,7 +63,8 @@ export const findObjects = (elements: Element[], names: string[]): ObjectType[] 
   const types = elements.filter(isObjectType).filter(element => names.includes(element.elemID.name))
 
   if (types.length !== names.length) {
-    log.warn(`some of ${names.join(',')} types not found`)
+    const missingTypes = names.filter(name => !types.map(t => t.elemID.name).includes(name)).join(', ')
+    log.warn(`could not find the following objects: ${missingTypes}`)
     return undefined
   }
   return types

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -59,6 +59,16 @@ export const findObject = (elements: Element[], name: string): ObjectType | unde
   return type
 }
 
+export const findObjects = (elements: Element[], names: string[]): ObjectType[] | undefined => {
+  const types = elements.filter(isObjectType).filter(element => names.includes(element.elemID.name))
+
+  if (types.length !== names.length) {
+    log.warn(`some of ${names.join(',')} types not found`)
+    return undefined
+  }
+  return types
+}
+
 export const addAnnotationRecursively = async (type: ObjectType, annotation: string): Promise<void> =>
   awu(Object.values(type.fields)).forEach(async field => {
     if (!field.annotations[annotation]) {

--- a/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
@@ -49,6 +49,7 @@ describe('jsmTypesFetchFilter', () => {
   let projectInstance: InstanceElement
   const customerPermissionsType = createEmptyType(CUSTOMER_PERMISSIONS_TYPE)
   let customerPermissionsInstance: InstanceElement
+  const slaTypeNames = [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE]
 
   beforeEach(() => {
     const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
@@ -94,7 +95,7 @@ describe('jsmTypesFetchFilter', () => {
         new ReferenceExpression(projectInstance.elemID, projectInstance),
       )
     })
-    it('should disable deployment of icon field in object type icon', async () => {
+    it('should change the deployment annotations of icon field in object type icon', async () => {
       const objectTypeIconType = new ObjectType({
         elemID: new ElemID(JIRA, 'ObjectTypeIcon'),
         fields: {
@@ -109,7 +110,6 @@ describe('jsmTypesFetchFilter', () => {
       expect(objectTypeIconType.fields.icon.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBe(false)
     })
     it('should change conditionId refType to unknown in SLA types', async () => {
-      const slaTypeNames = [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE]
       const slaTypes = slaTypeNames.map(
         typeName =>
           new ObjectType({
@@ -132,8 +132,8 @@ describe('jsmTypesFetchFilter', () => {
       expect(slaTypes[2].fields.conditionId.refType.elemID.name).toEqual('unknown')
     })
     it('should not change field type if not all sla types are present', async () => {
-      const slaTypeNames = [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE]
-      const slaTypes = slaTypeNames.map(
+      const partialSlaTypes = slaTypeNames.slice(0, 2)
+      const slaTypes = partialSlaTypes.map(
         typeName =>
           new ObjectType({
             elemID: new ElemID(JIRA, typeName),
@@ -153,8 +153,7 @@ describe('jsmTypesFetchFilter', () => {
       expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
       expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
     })
-    it('should disable deployment of name field in SLA types', async () => {
-      const slaTypeNames = [SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE]
+    it('should change the deployment annotations of name field in SLA types', async () => {
       const slaTypes = slaTypeNames.map(
         typeName =>
           new ObjectType({

--- a/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
@@ -41,6 +41,20 @@ jest.mock('@salto-io/adapter-components', () => {
   }
 })
 
+const createSlaType = (typeName: string): ObjectType =>
+  new ObjectType({
+    elemID: new ElemID(JIRA, typeName),
+    fields: {
+      conditionId: {
+        refType: BuiltinTypes.STRING,
+      },
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
+      },
+    },
+  })
+
 describe('jsmTypesFetchFilter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch'>
   let filter: FilterType
@@ -110,21 +124,7 @@ describe('jsmTypesFetchFilter', () => {
       expect(objectTypeIconType.fields.icon.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBe(false)
     })
     it('should change conditionId refType to unknown in SLA types', async () => {
-      const slaTypes = slaTypeNames.map(
-        typeName =>
-          new ObjectType({
-            elemID: new ElemID(JIRA, typeName),
-            fields: {
-              conditionId: {
-                refType: BuiltinTypes.STRING,
-              },
-              name: {
-                refType: BuiltinTypes.STRING,
-                annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
-              },
-            },
-          }),
-      )
+      const slaTypes = slaTypeNames.map(createSlaType)
       elements.push(...slaTypes)
       await filter.onFetch(elements)
       expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual('unknown')
@@ -133,42 +133,14 @@ describe('jsmTypesFetchFilter', () => {
     })
     it('should not change field type if not all sla types are present', async () => {
       const partialSlaTypes = slaTypeNames.slice(0, 2)
-      const slaTypes = partialSlaTypes.map(
-        typeName =>
-          new ObjectType({
-            elemID: new ElemID(JIRA, typeName),
-            fields: {
-              conditionId: {
-                refType: BuiltinTypes.STRING,
-              },
-              name: {
-                refType: BuiltinTypes.STRING,
-                annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
-              },
-            },
-          }),
-      )
+      const slaTypes = partialSlaTypes.map(createSlaType)
       elements.push(...slaTypes)
       await filter.onFetch(elements)
       expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
       expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
     })
     it('should change the deployment annotations of name field in SLA types', async () => {
-      const slaTypes = slaTypeNames.map(
-        typeName =>
-          new ObjectType({
-            elemID: new ElemID(JIRA, typeName),
-            fields: {
-              conditionId: {
-                refType: BuiltinTypes.STRING,
-              },
-              name: {
-                refType: BuiltinTypes.STRING,
-                annotations: { [CORE_ANNOTATIONS.CREATABLE]: true, [CORE_ANNOTATIONS.UPDATABLE]: true },
-              },
-            },
-          }),
-      )
+      const slaTypes = slaTypeNames.map(createSlaType)
       elements.push(...slaTypes)
       await filter.onFetch(elements)
       slaTypes.forEach(slaType => {


### PR DESCRIPTION
Added references the the SLA's conditionId
---

See ticket.
JSM SLA has some conditions that can be defined. Some of them are for specific statuses, and they require reference in the conditioned field.
Also, I changed the deployment annotation for the name field, as changes to it will not change anything in the service

Noise reduction will follow

---
_Release Notes_: 
Jira Adapter:
* Added reference support to SLA's status conditions

---
_User Notifications_: 
Jira Adapter:
* SLA's conditioned can turn from a number to a reference
