### PR TITLE
SALTO-6946: Protecting unsafe call to toMD5

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -252,6 +252,10 @@ const oauthConnection = (params: OauthConnectionParams): Connection => {
   })
 
   conn.on('refresh', accessToken => {
+    if (typeof accessToken !== 'string') {
+      log.warn('Got a non string access token: %s', inspectValue(accessToken))
+      return
+    }
     log.debug('accessToken has been refreshed', {
       accessToken: toMD5(accessToken),
     })

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -252,7 +252,7 @@ const oauthConnection = (params: OauthConnectionParams): Connection => {
   })
 
   conn.on('refresh', accessToken => {
-    if (typeof accessToken !== 'string') {
+    if (!_.isString(accessToken)) {
       log.warn('Got a non string access token: %s', inspectValue(accessToken))
       return
     }


### PR DESCRIPTION
Looks like we can get `undefined` here in some flows.

---

_Additional context for reviewer_
None.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
