### PR TITLE
SALTO-5888 Jira DC: Fail on API-config with JSM on

### DIFF
--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -39,10 +39,12 @@ function validateConfig(config: Values, isDataCenter: boolean): asserts config i
   Object.values(getApiDefinitions(apiDefinitions)).forEach(swaggerDef => {
     validateSwaggerApiDefinitionConfig('apiDefinitions', swaggerDef)
   })
-  if(isDataCenter) {
-    if(fetch.enableJSM || fetch.enableJSMPremium || fetch.enableJsmExperimental) {
+  if (isDataCenter) {
+    if (fetch.enableJSM || fetch.enableJSMPremium || fetch.enableJsmExperimental) {
       log.error('JSM is not supported in Jira DC config')
-      throw new Error('Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again')
+      throw new Error(
+        'Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again',
+      )
     }
   }
   validateJiraFetchConfig({

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -44,7 +44,7 @@ function validateConfig(config: Values, isDataCenter: boolean): asserts config i
       log.error('JSM is not supported in Jira DC config')
       throw new Error(
         'Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again\n' +
-        'More information about Jira configuration options in Salto can be found here: https://github.com/salto-io/salto/blob/main/packages/jira-adapter/config_doc.md'
+          'More information about Jira configuration options in Salto can be found here: https://github.com/salto-io/salto/blob/main/packages/jira-adapter/config_doc.md',
       )
     }
   }

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -41,7 +41,7 @@ function validateConfig(config: Values, isDataCenter: boolean): asserts config i
   })
   if(isDataCenter) {
     if(fetch.enableJSM || fetch.enableJSMPremium || fetch.enableJsmExperimental) {
-      log.error("JSM is not supported in Jira DC config")
+      log.error('JSM is not supported in Jira DC config')
       throw new Error('Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again')
     }
   }

--- a/packages/jira-adapter/src/adapter_creator.ts
+++ b/packages/jira-adapter/src/adapter_creator.ts
@@ -43,7 +43,8 @@ function validateConfig(config: Values, isDataCenter: boolean): asserts config i
     if (fetch.enableJSM || fetch.enableJSMPremium || fetch.enableJsmExperimental) {
       log.error('JSM is not supported in Jira DC config')
       throw new Error(
-        'Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again',
+        'Failed to load Jira config. JSM is not supported for Jira DC, please remove enableJSM flag from the config file and try again\n' +
+        'More information about Jira configuration options in Salto can be found here: https://github.com/salto-io/salto/blob/main/packages/jira-adapter/config_doc.md'
       )
     }
   }

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -111,7 +111,7 @@ describe('adapter creator', () => {
         ).toThrow()
       })
 
-      it('should fail to create operations', () => {
+      it('should fail on validating Jira DC config with JSM enabled', () => {
         credentialsInstance.value = { ...credentialsInstance.value, isDataCenter: true }
         expect(() =>
           adapter.operations({

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -123,7 +123,7 @@ describe('adapter creator', () => {
                 enableJSM: true,
               },
             } as unknown as JiraConfig),
-          })
+          }),
         ).toThrow()
       })
     })

--- a/packages/jira-adapter/test/adapter_creator.test.ts
+++ b/packages/jira-adapter/test/adapter_creator.test.ts
@@ -110,6 +110,22 @@ describe('adapter creator', () => {
           }),
         ).toThrow()
       })
+
+      it('should fail to create operations', () => {
+        credentialsInstance.value = { ...credentialsInstance.value, isDataCenter: true }
+        expect(() =>
+          adapter.operations({
+            elementsSource,
+            credentials: credentialsInstance,
+            config: createConfigInstance({
+              ...getDefaultConfig({ isDataCenter: true }),
+              fetch: {
+                enableJSM: true,
+              },
+            } as unknown as JiraConfig),
+          })
+        ).toThrow()
+      })
     })
   })
 })


### PR DESCRIPTION
SALTO-5888 Jira DC: Fail on API-config with JSM on

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
