### PR TITLE
SALTO-6828: Convert MS security permission errors into warning

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/fetch/shared/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/shared/fetch.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { definitions } from '@salto-io/adapter-components'
+import { definitions, fetch as fetchUtils } from '@salto-io/adapter-components'
 import { Options } from '../../types'
 import { DEFAULT_FIELD_CUSTOMIZATIONS, DEFAULT_ID_PARTS } from './defaults'
 import { createEntraCustomizations } from '../entra/fetch'
@@ -27,6 +27,7 @@ export const createFetchDefinitions = (
     default: {
       resource: {
         serviceIDFields: ['id'],
+        onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([403])
       },
       element: {
         topLevel: {

--- a/packages/microsoft-security-adapter/src/definitions/fetch/shared/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/shared/fetch.ts
@@ -27,7 +27,7 @@ export const createFetchDefinitions = (
     default: {
       resource: {
         serviceIDFields: ['id'],
-        onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([403])
+        onError: fetchUtils.errors.createGetInsufficientPermissionsErrorFunction([403]),
       },
       element: {
         topLevel: {


### PR DESCRIPTION
Convert 403 errors to fetch warnings

---

_Additional context for reviewer_
I saw we get 403 when we lack of permissions, we can iterate once we see more relevant status codes.

---

_Release Notes_: 

_Microsoft Security Adapter_:
- Create fetch warning for while detecting there are missing permissions during fetch

---
_User Notifications_: 
None
