### PR TITLE
SALTO-6949 fix tag id field definition

### DIFF
--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -940,7 +940,7 @@ const createCustomizations = (): Record<
         isTopLevel: true,
       },
       fieldCustomizations: {
-        id: { hide: true, fieldType: 'number' },
+        id: { fieldType: 'string' },
       },
     },
   },


### PR DESCRIPTION
It appears the tag id field was incorrectly defined when switching to the new infra.

---
_Release Notes_: 

_Zendesk adapter_:
* Fix warnings of the form "Error validating "zendesk.tag.instance.<>.id": Invalid value type for serviceid_number"

---
_User Notifications_: 
None