### PR TITLE
SALTO-5023: Do not allow Activating Flow of type InvalidDraft

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flows.ts
+++ b/packages/salesforce-adapter/src/change_validators/flows.ts
@@ -269,10 +269,10 @@ const activeFlowValidator =
       .filter(isModificationChange)
       .filter(isActivatingChange)
       .map(change => {
+        if (getFlowStatus(change.data.before) === INVALID_DRAFT) {
+          return activateInvalidFlowError(getChangeData(change))
+        }
         if (isActivatingChangeOnly(change)) {
-          if (getFlowStatus(change.data.before) === INVALID_DRAFT) {
-            return activateInvalidFlowError(getChangeData(change))
-          }
           return activatingFlowError(getChangeData(change), isEnableFlowDeployAsActiveEnabled)
         }
         return activeFlowModificationError(getChangeData(change), isEnableFlowDeployAsActiveEnabled, baseUrl)

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -357,6 +357,7 @@ export const CURRENCY_ISO_CODE = 'CurrencyIsoCode'
 export const ACTIVE_VERSION_NUMBER = 'activeVersionNumber'
 export const STATUS = 'status'
 export const ACTIVE = 'Active'
+export const INVALID_DRAFT = 'InvalidDraft'
 
 // Metadata types
 export const PATH_ASSISTANT_METADATA_TYPE = 'PathAssistant'


### PR DESCRIPTION
SALTO-5023: Do not allow Activating Flow of type InvalidDraft

---
_Additional context for reviewer_:
![image](https://github.com/user-attachments/assets/978006da-1f0e-4323-9c72-9824024226a5)

---
_None_ 

---
_None_
