### PR TITLE
SALTO-6901: Deprecating `skipAliases` optional feature

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -156,7 +156,6 @@ salesforce {
 | [metadata](#metadata-configuration-options)    | Fetch all metadata      | Specified the metadata fetch                                                                                                                                                                                                                   |
 | [data](#data-management-configuration-options) | {} (do not manage data) | Data management configuration object names will not be fetched in case they are matched in includeObjects                                                                                                                                      |
 | fetchAllCustomSettings                         | true                    | Whether to fetch all the custom settings instances. When false, it is still possible to choose specific custom settings instances via the `data` option                                                                                        |
-| [optionalFeatures](#optional-features)         | {} (all enabled)        | Granular control over which features are enabled in the adapter, by default all features are enabled in order to get the most information. can be used to turn off features that cause problems until they are solved                          |
 | [limits](#limits)                              | {} (no overrides)       | Granular control over which limits are used by the adapter in some filters, by default all options are optimized to get the most information for the general case. Can be used to configure features that cause problems until they are solved |
 | maxInstancesPerType                            | 5000                    | Do not fetch metadataTypes and CustomObjects with more instances than this number, and add those to the exclude lists                                                                                                                          |
 | preferActiveFlowVersions                       | false                   | When set to false, flows' latest version will be fetched. Otherwise, flows' active version will be fetched if exists                                                                                                                           |
@@ -178,12 +177,6 @@ salesforce {
 | namespace    | ".\*" (All namespaces) | A regular expression of a namespace to query with              |
 | metadataType | ".\*" (All types)      | A regular expression of a metadata type to query with          |
 | name         | ".\*" (All names)      | A regular expression of a metadata instance name to query with |
-
-### Optional Features
-
-| Name        | Default when undefined | Description                                 |
-| ----------- | ---------------------- | ------------------------------------------- |
-| skipAliases | false                  | Do not create aliases for Metadata Elements |
 
 ### Limits
 

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -12,7 +12,6 @@ type OptionalFeaturesDefaultValues = {
 }
 
 const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
-  skipAliases: false,
   extendedCustomFieldInformation: false,
   importantValues: true,
   hideTypesFolder: true,

--- a/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_metadata_to_object_type.ts
@@ -20,7 +20,7 @@ import {
 import { collections, values } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
-import { FilterContext, FilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import { CUSTOM_METADATA, CUSTOM_METADATA_META_TYPE, CUSTOM_METADATA_SUFFIX, CUSTOM_OBJECT } from '../constants'
 import { createCustomObjectChange, createCustomTypeFromCustomObjectInstance } from './custom_objects_to_object_type'
 import { apiName, createMetaType, isMetadataObjectType } from '../transformers/transformer'
@@ -40,14 +40,12 @@ const { awu, groupByAsync } = collections.asynciterable
 const createCustomMetadataRecordType = async (
   instance: InstanceElement,
   customMetadataType: ObjectType,
-  config: FilterContext,
   metaType?: ObjectType,
 ): Promise<ObjectType> => {
   const objectType = await createCustomTypeFromCustomObjectInstance({
     instance,
     metadataType: CUSTOM_METADATA,
     metaType,
-    config,
   })
   objectType.fields = {
     ...objectType.fields,
@@ -91,7 +89,7 @@ const filterCreator: FilterCreator = ({ config }) => {
         ? createMetaType(CUSTOM_METADATA_META_TYPE, undefined, 'Custom Metadata')
         : undefined
       const customMetadataRecordTypes = await awu(customMetadataInstances)
-        .map(instance => createCustomMetadataRecordType(instance, customMetadataType, config, customMetadataMetaType))
+        .map(instance => createCustomMetadataRecordType(instance, customMetadataType, customMetadataMetaType))
         .toArray()
       _.pullAll(elements, customMetadataInstances)
       customMetadataRecordTypes.forEach(e => elements.push(e))

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -89,7 +89,7 @@ import {
   CUSTOM_SETTINGS_META_TYPE,
   CUSTOM_FIELD_DEPLOYABLE_TYPES,
 } from '../constants'
-import { FilterContext, FilterCreator } from '../filter'
+import { FilterCreator } from '../filter'
 import {
   Types,
   isCustomObject,
@@ -484,14 +484,12 @@ export const createCustomTypeFromCustomObjectInstance = async ({
   metaType,
   fieldsToSkip = [],
   metadataType: objectMetadataType,
-  config,
 }: {
   instance: InstanceElement
   typesFromInstance?: TypesFromInstance
   metaType?: ObjectType
   fieldsToSkip?: string[]
   metadataType?: string
-  config: FilterContext
 }): Promise<ObjectType> => {
   const name = instance.value[INSTANCE_FULL_NAME_FIELD]
   const label = instance.value[LABEL]
@@ -522,16 +520,13 @@ export const createCustomTypeFromCustomObjectInstance = async ({
       object.fields[field.name] = field
     }
   })
-  if (!config.fetchProfile.isFeatureEnabled('skipAliases')) {
-    object.annotations[CORE_ANNOTATIONS.ALIAS] = await getInstanceAlias(instance as MetadataInstanceElement)
-  }
+  object.annotations[CORE_ANNOTATIONS.ALIAS] = await getInstanceAlias(instance as MetadataInstanceElement)
   return object
 }
 
 const createFromInstance = async (
   instance: InstanceElement,
   typesFromInstance: TypesFromInstance,
-  config: FilterContext,
   metaTypes?: MetaTypes,
   fieldsToSkip?: string[],
 ): Promise<Element[]> => {
@@ -543,7 +538,6 @@ const createFromInstance = async (
         ? getMetaType(metaTypes, instance, hasCustomSuffix(instance.value[INSTANCE_FULL_NAME_FIELD]))
         : undefined,
     fieldsToSkip,
-    config,
   })
   const nestedMetadataInstances = await createNestedMetadataInstances(
     instance,
@@ -956,7 +950,7 @@ const filterCreator: FilterCreator = ({ config, client }) => {
       )
 
       await awu(customObjectInstances)
-        .flatMap(instance => createFromInstance(instance, typesFromInstance, config, metaTypes, fieldsToSkip))
+        .flatMap(instance => createFromInstance(instance, typesFromInstance, metaTypes, fieldsToSkip))
         // Make sure we do not override existing metadata types with custom objects
         // this can happen with standard objects having the same name as a metadata type
         .filter(elem => !existingElementIDs.has(elem.elemID.getFullName()))

--- a/packages/salesforce-adapter/src/filters/metadata_instances_aliases.ts
+++ b/packages/salesforce-adapter/src/filters/metadata_instances_aliases.ts
@@ -7,21 +7,15 @@
  */
 import { CORE_ANNOTATIONS, Element } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { getInstanceAlias } from './utils'
 import { isMetadataInstanceElement, MetadataInstanceElement } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
-const log = logger(module)
 
-const filterCreator: FilterCreator = ({ config }) => ({
+const filterCreator: FilterCreator = () => ({
   name: 'metadataInstancesAliases',
   onFetch: async (elements: Element[]): Promise<void> => {
-    if (config.fetchProfile.isFeatureEnabled('skipAliases')) {
-      log.debug('not adding aliases to metadata instances.')
-      return
-    }
     await awu(elements)
       .filter(isMetadataInstanceElement)
       .forEach(async instance => {

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -96,7 +96,6 @@ export type MetadataParams = {
 }
 
 const OPTIONAL_FEATURES = [
-  'skipAliases',
   'extendedCustomFieldInformation',
   'importantValues',
   'hideTypesFolder',
@@ -129,6 +128,7 @@ const DEPRECATED_OPTIONAL_FEATURES = [
   'profilePaths',
   'removeReferenceFromFilterItemToRecordType',
   'sharingRulesMaps',
+  'skipAliases',
   'storeProfilesAndPermissionSetsBrokenPaths',
   'taskAndEventCustomFields',
   'toolingDepsOfCurrentNamespace',

--- a/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
+++ b/packages/salesforce-adapter/test/filters/custom_metadata_to_object_type.test.ts
@@ -53,12 +53,7 @@ describe('customMetadataToObjectTypeFilter', () => {
 
   beforeEach(() => {
     filter = filterCreator({
-      config: {
-        ...defaultFilterContext,
-        fetchProfile: buildFetchProfile({
-          fetchParams: { optionalFeatures: { skipAliases: false } },
-        }),
-      },
+      config: defaultFilterContext,
     }) as FilterWith<'onFetch' | 'preDeploy' | 'onDeploy'>
   })
 
@@ -152,7 +147,6 @@ describe('customMetadataToObjectTypeFilter', () => {
             elementsSource: buildElementsSourceFromElements([mockTypes.CustomMetadata]),
             fetchProfile: buildFetchProfile({
               fetchParams: {
-                optionalFeatures: { skipAliases: false },
                 target: ['CustomObject'],
               },
             }),

--- a/packages/salesforce-adapter/test/filters/metadata_instances_aliases.test.ts
+++ b/packages/salesforce-adapter/test/filters/metadata_instances_aliases.test.ts
@@ -8,7 +8,6 @@
 import { CORE_ANNOTATIONS, InstanceElement, Element } from '@salto-io/adapter-api'
 import filterCreator from '../../src/filters/metadata_instances_aliases'
 import { defaultFilterContext } from '../utils'
-import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 import { LABEL } from '../../src/constants'
@@ -41,39 +40,17 @@ describe('metadataInstancesAliases filter', () => {
     instances = [basicInstance, instanceWithLabel, instanceWithNamespaceAndLabel]
     fetchElements = [...instances]
   })
-  describe('when skipAliases is enabled', () => {
-    beforeEach(() => {
-      filter = filterCreator({
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({
-            fetchParams: { optionalFeatures: { skipAliases: true } },
-          }),
-        },
-      }) as typeof filter
-    })
-    it('should not add aliases', async () => {
-      await filter.onFetch(fetchElements)
-      expect(instances).toSatisfyAll(instance => instance.annotations[CORE_ANNOTATIONS.ALIAS] === undefined)
-    })
+
+  beforeEach(() => {
+    filter = filterCreator({
+      config: defaultFilterContext,
+    }) as typeof filter
   })
 
-  describe('when skipAliases is disabled', () => {
-    beforeEach(() => {
-      filter = filterCreator({
-        config: {
-          ...defaultFilterContext,
-          fetchProfile: buildFetchProfile({
-            fetchParams: { optionalFeatures: { skipAliases: false } },
-          }),
-        },
-      }) as typeof filter
-    })
-    it('should add correct aliases', async () => {
-      await filter.onFetch(fetchElements)
-      expect(basicInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('TestInstance')
-      expect(instanceWithLabel.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Test Label')
-      expect(instanceWithNamespaceAndLabel.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Test Label (SBQQ)')
-    })
+  it('should add correct aliases', async () => {
+    await filter.onFetch(fetchElements)
+    expect(basicInstance.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('TestInstance')
+    expect(instanceWithLabel.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Test Label')
+    expect(instanceWithNamespaceAndLabel.annotations[CORE_ANNOTATIONS.ALIAS]).toEqual('Test Label (SBQQ)')
   })
 })


### PR DESCRIPTION
It's no longer in use.

---

_Additional context for reviewer_

---

_Release Notes_: 
_Salesforce_:
* Deprecating `skipAliases` optional feature.

---

_User Notifications_: 
None.
