### PR TITLE
SALTO-6963: fix resolve types when passing multiple fragments

### DIFF
--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -306,19 +306,16 @@ export const resolve = (
 
       // Since fields technically reference their parent type with the .parent property
       // we need to make sure to resolve all field parents as well
-      const fieldParents = elementsToResolve.filter(isField).map(field => field.parent)
+      const fieldParents = _.uniqBy(
+        elementsToResolve.filter(isField).map(field => field.parent),
+        elem => elem.elemID.getFullName(),
+      )
 
       // We assume that if we got a field and its parent type in the same resolve call, the field's
       // parent will point to the same object type that we got to resolve, so we don't need to resolve
       // both.
       const elementIDsToResolve = new Set(elements.map(elem => elem.elemID.getFullName()))
-      const fieldParentsToResolve = fieldParents.filter(elem => {
-        if (!elementIDsToResolve.has(elem.elemID.getFullName())) {
-          elementIDsToResolve.add(elem.elemID.getFullName())
-          return true
-        }
-        return false
-      })
+      const fieldParentsToResolve = fieldParents.filter(elem => !elementIDsToResolve.has(elem.elemID.getFullName()))
       const allElementsToResolve = elementsToResolve.concat(fieldParentsToResolve)
 
       const resolvedElements = new Map(

--- a/packages/workspace/src/expressions.ts
+++ b/packages/workspace/src/expressions.ts
@@ -311,7 +311,15 @@ export const resolve = (
       // We assume that if we got a field and its parent type in the same resolve call, the field's
       // parent will point to the same object type that we got to resolve, so we don't need to resolve
       // both.
-      const allElementsToResolve = _.uniqBy(elementsToResolve.concat(fieldParents), elem => elem.elemID.getFullName())
+      const elementIDsToResolve = new Set(elements.map(elem => elem.elemID.getFullName()))
+      const fieldParentsToResolve = fieldParents.filter(elem => {
+        if (!elementIDsToResolve.has(elem.elemID.getFullName())) {
+          elementIDsToResolve.add(elem.elemID.getFullName())
+          return true
+        }
+        return false
+      })
+      const allElementsToResolve = elementsToResolve.concat(fieldParentsToResolve)
 
       const resolvedElements = new Map(
         allElementsToResolve

--- a/packages/workspace/test/core/expressions.test.ts
+++ b/packages/workspace/test/core/expressions.test.ts
@@ -758,4 +758,22 @@ describe('Test Salto Expressions', () => {
       })
     })
   })
+
+  describe('when resolving split instances', () => {
+    let resolvedType: ObjectType
+    let resolvedInstances: InstanceElement[]
+    beforeEach(async () => {
+      const type = new ObjectType({ elemID: new ElemID('salto', 'type') })
+      const fragment1 = new InstanceElement('inst', new TypeReference(type.elemID), { a: 1 })
+      const fragment2 = new InstanceElement('inst', new TypeReference(type.elemID), { b: 1 })
+
+      const resolved = await resolve([type, fragment1, fragment2], createInMemoryElementSource([]))
+      ;[resolvedType, ...resolvedInstances] = resolved as [ObjectType, ...InstanceElement[]]
+    })
+    it('should resolve the type on all fragments', () => {
+      expect(resolvedInstances).toHaveLength(2)
+      expect(resolvedInstances[0].refType.type).toBe(resolvedType)
+      expect(resolvedInstances[1].refType.type).toBe(resolvedType)
+    })
+  })
 })


### PR DESCRIPTION
When multiple fragments of the same element were passed, only one of them was resolved This fixes the code so we will resolve all the fragments

---

_Additional context for reviewer_
This still leaves a bit of "unstable" behavior in that if there are references point to the element which is split, we will resolve them to point to one of the fragments, we do not guarantee which one

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_