### PR TITLE
SALTO-6866: Switch MS Entra Administrative Unit deployment definition to use the beta API

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
@@ -107,53 +107,6 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
     parentResourceName: 'servicePrincipals',
     typeName: SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME,
   }),
-  [ADMINISTRATIVE_UNIT_TYPE_NAME]: {
-    requestsByAction: {
-      customizations: {
-        add: [
-          {
-            request: {
-              endpoint: {
-                path: '/directory/administrativeUnits',
-                method: 'post',
-              },
-              transformation: {
-                omit: [MEMBERS_FIELD_NAME],
-              },
-            },
-          },
-        ],
-        modify: [
-          {
-            request: {
-              endpoint: {
-                path: '/directory/administrativeUnits/{id}',
-                method: 'patch',
-              },
-              transformation: {
-                omit: [MEMBERS_FIELD_NAME],
-              },
-            },
-            condition: {
-              transformForCheck: {
-                omit: [MEMBERS_FIELD_NAME],
-              },
-            },
-          },
-        ],
-        remove: [
-          {
-            request: {
-              endpoint: {
-                path: '/directory/administrativeUnits/{id}',
-                method: 'delete',
-              },
-            },
-          },
-        ],
-      },
-    },
-  },
   [ADMINISTRATIVE_UNIT_MEMBERS_TYPE_NAME]: {
     requestsByAction: {
       customizations: {
@@ -741,6 +694,53 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
 }
 
 const graphBetaCustomDefinitions: DeployCustomDefinitions = {
+  [ADMINISTRATIVE_UNIT_TYPE_NAME]: {
+    requestsByAction: {
+      customizations: {
+        add: [
+          {
+            request: {
+              endpoint: {
+                path: '/administrativeUnits',
+                method: 'post',
+              },
+              transformation: {
+                omit: [MEMBERS_FIELD_NAME],
+              },
+            },
+          },
+        ],
+        modify: [
+          {
+            request: {
+              endpoint: {
+                path: '/administrativeUnits/{id}',
+                method: 'patch',
+              },
+              transformation: {
+                omit: [MEMBERS_FIELD_NAME],
+              },
+            },
+            condition: {
+              transformForCheck: {
+                omit: [MEMBERS_FIELD_NAME],
+              },
+            },
+          },
+        ],
+        remove: [
+          {
+            request: {
+              endpoint: {
+                path: '/administrativeUnits/{id}',
+                method: 'delete',
+              },
+            },
+          },
+        ],
+      },
+    },
+  },
   [AUTHENTICATION_METHOD_POLICY_TYPE_NAME]: {
     requestsByAction: {
       customizations: {


### PR DESCRIPTION
The current deploy definition, which uses the MS Graph v1.0 API, no longer works.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Microsoft Security adapter:_
* Fix Administrative Unit deployment.

---
_User Notifications_: 
