### PR TITLE
Update config_doc.md

### DIFF
--- a/packages/jira-adapter/config_doc.md
+++ b/packages/jira-adapter/config_doc.md
@@ -95,9 +95,9 @@ jira {
 ## Masking configuration options
 
 | Name              | Default when undefined | Description                                                        |
-| ----------------- | ---------------------- | ------------------------------------------------------------------ |
+| ----------------- | ---------------------- | -------------------------------------------------------------------|
 | automationHeaders | []                     | List of regexes of header keys in Automations to mask their values |
-| secretRegexps     | []                     | List of regexes of strings to mask all across the workspace        |
+| secretRegexps     | []                     | List of regexes of secret values to mask all across the workspace  |
 
 ## Fetch entry options
 


### PR DESCRIPTION
explain secretRegexps are for matching values and not fields

_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
