### PR TITLE
SALTO-6964: Re-export TreeMapEntry as it is used externally

### DIFF
--- a/packages/lowerdash/src/collections/tree_map.ts
+++ b/packages/lowerdash/src/collections/tree_map.ts
@@ -8,7 +8,7 @@
 import _ from 'lodash'
 import wu, { WuIterable } from 'wu'
 
-interface TreeMapEntry<T> {
+export interface TreeMapEntry<T> {
   children: Record<string, TreeMapEntry<T>>
   value: T[]
 }


### PR DESCRIPTION
See title

---

_Additional context for reviewer_:
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None