### PR TITLE
SALTO-6978: PR for sla bug

### DIFF
--- a/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
+++ b/packages/jira-adapter/src/filters/jsm_types_fetch_filter.ts
@@ -29,7 +29,7 @@ import {
   SLA_CONDITIONS_START_TYPE,
   SLA_CONDITIONS_PAUSE_TYPE,
 } from '../constants'
-import { setTypeDeploymentAnnotations, addAnnotationRecursively, findObject, findObjects } from '../utils'
+import { setTypeDeploymentAnnotations, addAnnotationRecursively, findObject } from '../utils'
 
 const { awu } = collections.asynciterable
 const jsmSupportedTypes = [
@@ -81,24 +81,20 @@ const filterCreator: FilterCreator = ({ config }) => ({
     }
 
     // SLA
-    const slaConditionTypes = findObjects(elements, [
-      SLA_CONDITIONS_STOP_TYPE,
-      SLA_CONDITIONS_START_TYPE,
-      SLA_CONDITIONS_PAUSE_TYPE,
-    ])
-    if (slaConditionTypes === undefined) {
-      return
-    }
-    slaConditionTypes
-      .filter(slaType => slaType.fields.conditionId !== undefined)
-      .forEach(slaType => {
+    ;[SLA_CONDITIONS_STOP_TYPE, SLA_CONDITIONS_START_TYPE, SLA_CONDITIONS_PAUSE_TYPE].forEach(slaTypeName => {
+      const slaType = findObject(elements, slaTypeName)
+      if (slaType === undefined) {
+        return
+      }
+      if (slaType.fields.conditionId !== undefined) {
         slaType.fields.conditionId.refType = new TypeReference(BuiltinTypes.UNKNOWN.elemID, BuiltinTypes.UNKNOWN)
-        // prevent deployment of name as it does nothing
-        if (slaType.fields.name !== undefined) {
-          slaType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE] = false
-          slaType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE] = false
-        }
-      })
+      }
+      // warn on deployment of name as it does nothing
+      if (slaType.fields.name !== undefined) {
+        slaType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE] = false
+        slaType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE] = false
+      }
+    })
   },
 })
 export default filterCreator

--- a/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
+++ b/packages/jira-adapter/test/filters/jsm_types_fetch_filter.test.ts
@@ -127,17 +127,26 @@ describe('jsmTypesFetchFilter', () => {
       const slaTypes = slaTypeNames.map(createSlaType)
       elements.push(...slaTypes)
       await filter.onFetch(elements)
-      expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual('unknown')
-      expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual('unknown')
-      expect(slaTypes[2].fields.conditionId.refType.elemID.name).toEqual('unknown')
+      expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.UNKNOWN.elemID.name)
+      expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.UNKNOWN.elemID.name)
+      expect(slaTypes[2].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.UNKNOWN.elemID.name)
     })
-    it('should not change field type if not all sla types are present', async () => {
+    it('should change field type also when not all sla types are present', async () => {
       const partialSlaTypes = slaTypeNames.slice(0, 2)
       const slaTypes = partialSlaTypes.map(createSlaType)
       elements.push(...slaTypes)
       await filter.onFetch(elements)
-      expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
-      expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.STRING.elemID.name)
+      expect(slaTypes[0].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.UNKNOWN.elemID.name)
+      expect(slaTypes[1].fields.conditionId.refType.elemID.name).toEqual(BuiltinTypes.UNKNOWN.elemID.name)
+    })
+    it('should not change the conditionId refType in SLA types if conditionId field does not exist', async () => {
+      const slaTypes = slaTypeNames.map(createSlaType)
+      slaTypes.forEach(slaType => delete slaType.fields.conditionId)
+      elements.push(...slaTypes)
+      await filter.onFetch(elements)
+      slaTypes.forEach(slaType => {
+        expect(slaType.fields.conditionId).toBeUndefined()
+      })
     })
     it('should change the deployment annotations of name field in SLA types', async () => {
       const slaTypes = slaTypeNames.map(createSlaType)
@@ -146,6 +155,15 @@ describe('jsmTypesFetchFilter', () => {
       slaTypes.forEach(slaType => {
         expect(slaType.fields.name.annotations[CORE_ANNOTATIONS.CREATABLE]).toBe(false)
         expect(slaType.fields.name.annotations[CORE_ANNOTATIONS.UPDATABLE]).toBe(false)
+      })
+    })
+    it('should not change the deployment annotations of name field in SLA types if name field does not exist', async () => {
+      const slaTypes = slaTypeNames.map(createSlaType)
+      slaTypes.forEach(slaType => delete slaType.fields.name)
+      elements.push(...slaTypes)
+      await filter.onFetch(elements)
+      slaTypes.forEach(slaType => {
+        expect(slaType.fields.name).toBeUndefined()
       })
     })
   })


### PR DESCRIPTION
Fixed CR comments from[ previous PR](https://github.com/salto-io/salto/pull/6841) + improved the logic as we are using ducktype we want to handle even a single type

---

I have decided to keep findObjects even though it is no longer in use, in case someone will want it in the future

---
_Release Notes_: 
None
---
_User Notifications_: 
None
