### PR TITLE
SALTO-6964: fix dummy adapter exclude config

### DIFF
--- a/packages/dummy-adapter/src/generator.ts
+++ b/packages/dummy-adapter/src/generator.ts
@@ -1128,7 +1128,6 @@ export const generateElements = async (
     .concat(users)
     .concat([new ObjectType({ elemID: new ElemID(DUMMY_ADAPTER, 'noPath'), fields: {} })])
     .concat(envObjects)
-    .filter(e => !elementsToExclude.has(e.elemID.getFullName()))
 
   progressReporter.reportProgress({ message: 'Generating extra elements' })
   const elementSourceForExtraElements = elementSource.createInMemoryElementSource(allElements)
@@ -1137,7 +1136,7 @@ export const generateElements = async (
     elementSourceForExtraElements,
   )
   progressReporter.reportProgress({ message: 'Generation done' })
-  return allElements.concat(extraElements)
+  return allElements.concat(extraElements).filter(e => !elementsToExclude.has(e.elemID.getFullName()))
 }
 
 export const generateFetchErrorsFromConfig = (

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -346,4 +346,14 @@ describe('generator', () => {
       expect(fetchErrors).toBeUndefined()
     })
   })
+  describe('elementsToExclude', () => {
+    const elemToExclude = 'dummy.Full.instance.FullInst1'
+    let elements: Element[]
+    beforeEach(async () => {
+      elements = await generateElements({ ...testParams, elementsToExclude: [elemToExclude] }, mockProgressReporter)
+    })
+    it('should not include elements that are explicitly excluded', () => {
+      expect(elements.map(elem => elem.elemID.getFullName())).not.toContainEqual(elemToExclude)
+    })
+  })
 })


### PR DESCRIPTION
Exclude config did not affect extra elements

---

_Additional context for reviewer_
Bug was introduced in https://github.com/salto-io/salto/pull/6833

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_