### PR TITLE
SALTO-6159 Jira assets fields

### DIFF
--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -186,7 +186,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     enableIssueLayouts: true,
     enableNewWorkflowAPI: true,
     allowUserCallFailure: false,
-    enableAssetsObjectFieldConfiguration: false,
+    enableAssetsObjectFieldConfiguration: true,
     removeFieldConfigurationDefaultValues: false,
   },
   deploy: {


### PR DESCRIPTION
Jira JSM: support assetsObjectFieldConfiguration by default

---
_Additional context for reviewer_
None

---
_Release Notes_: 

_Jira_adapter_:
- JSM: support assetsObjectFieldConfiguration by default

---
_User Notifications_: 
None
