### PR TITLE
SALTO-6956: Remove deprecated loadWorkspace api

### DIFF
--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -175,7 +175,6 @@ export const loadLocalElementsSources = async ({
   persistent = true,
 }: {
   baseDir: string
-  localStorage?: string // TODO: remove unused argument (kept backwards compatibility)
   envs: ReadonlyArray<string>
   remoteMapCreator: remoteMap.RemoteMapCreator
   stateStaticFilesSource?: staticFiles.StateStaticFilesSource

--- a/packages/core/src/local-workspace/workspace.ts
+++ b/packages/core/src/local-workspace/workspace.ts
@@ -284,14 +284,14 @@ type LoadLocalWorkspaceArgs = {
   ignoreFileChanges?: boolean
 }
 
-const loadLocalWorkspaceImpl = async ({
+export async function loadLocalWorkspace({
   path: lookupDir,
   configOverrides,
   persistent = true,
   credentialSource,
   stateStaticFilesSource,
   ignoreFileChanges = false,
-}: LoadLocalWorkspaceArgs): Promise<Workspace> => {
+}: LoadLocalWorkspaceArgs): Promise<Workspace> {
   const baseDir = await locateWorkspaceRoot(path.resolve(lookupDir))
   if (_.isUndefined(baseDir)) {
     throw new NotAWorkspaceError()
@@ -355,29 +355,6 @@ const loadLocalWorkspaceImpl = async ({
       }
     },
   }
-}
-
-// As a transitionary step, we support both a string input and an argument object
-export function loadLocalWorkspace(args: LoadLocalWorkspaceArgs): Promise<Workspace>
-// @deprecated
-export function loadLocalWorkspace(
-  lookupDir: string,
-  configOverrides?: DetailedChange[],
-  persistent?: boolean,
-): Promise<Workspace>
-
-export async function loadLocalWorkspace(
-  args: string | LoadLocalWorkspaceArgs,
-  configOverrides?: DetailedChange[],
-  persistent = true,
-): Promise<Workspace> {
-  if (_.isString(args)) {
-    log.warn(
-      'Using deprecated argument format for loadLocalWorkspace, this type of call will be deprecated soon. please pass an arguments object instead',
-    )
-    return loadLocalWorkspaceImpl({ path: args, configOverrides, persistent })
-  }
-  return loadLocalWorkspaceImpl(args)
 }
 
 export const initLocalWorkspace = async (

--- a/packages/core/test/workspace/local/workspace.test.ts
+++ b/packages/core/test/workspace/local/workspace.test.ts
@@ -230,25 +230,6 @@ describe('local workspace', () => {
           )
         })
       })
-      describe('when called with deprecated arguments format', () => {
-        beforeEach(async () => {
-          await loadLocalWorkspace('my_path', [], false)
-        })
-        it('should pass the arguments correctly', () => {
-          expect(mockExists).toHaveBeenCalledWith(expect.stringMatching(/.*\/my_path\/salto\.config/))
-          expect(mockLoad).toHaveBeenCalledWith(
-            expect.anything(),
-            expect.anything(),
-            expect.anything(),
-            expect.anything(),
-            expect.anything(),
-            expect.anything(),
-            false,
-            undefined,
-            expect.anything(),
-          )
-        })
-      })
     })
   })
 


### PR DESCRIPTION
None

---

_Release Notes_: 

Remove deprecated API of loadWorkspace - that was added here - https://github.com/salto-io/salto/pull/2895 ( over 2 years ago)

---

_User Notifications_: 
None