### PR TITLE
SALTO-6904: Rename Salesforce OrderedMap type to not use container type syntax

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -155,6 +155,7 @@ import {
   CUSTOM_OBJECT_ID_FIELD,
   FLOW_METADATA_TYPE,
   LAST_MODIFIED_DATE,
+  ORDERED_MAP_PREFIX,
   OWNER_ID,
   PROFILE_RELATED_METADATA_TYPES,
   WAVE_DATAFLOW_METADATA_TYPE,
@@ -441,7 +442,7 @@ type CreateFiltersRunnerParams = {
 }
 
 const isOrderedMapTypeOrRefType = (typeRef: TypeElement | TypeReference): boolean =>
-  typeRef.elemID.name.startsWith('OrderedMap<')
+  typeRef.elemID.name.startsWith(ORDERED_MAP_PREFIX)
 
 const isFieldWithOrderedMapAnnotation = (field: Field): boolean =>
   Object.values(field.getTypeSync().annotationRefTypes).some(isOrderedMapTypeOrRefType)

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -446,6 +446,8 @@ export const CHANGED_AT_SINGLETON = 'ChangedAtSingleton'
 export const PROFILE_AND_PERMISSION_SETS_BROKEN_PATHS = 'ProfilesAndPermissionSetsBrokenPaths'
 export const PATHS_FIELD = 'paths'
 
+export const ORDERED_MAP_PREFIX = 'OrderedMapOf'
+
 export const getTypePath = (name: string, isTopLevelType = true): string[] => [
   SALESFORCE,
   TYPES_PATH,

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -94,7 +94,7 @@ export const ORDERED_MAP_ORDER_FIELD = 'order'
 
 export const createOrderedMapType = <T extends TypeElement>(innerType: T): ObjectType =>
   new ObjectType({
-    elemID: new ElemID('salesforce', `OrderedMap<${innerType.elemID.name}>`),
+    elemID: new ElemID('salesforce', `OrderedMapOf${innerType.elemID.name}`),
     fields: {
       [ORDERED_MAP_VALUES_FIELD]: {
         refType: new MapType(innerType),

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -27,7 +27,7 @@ import { createInstanceElement, Types } from '../../src/transformers/transformer
 import { mockTypes } from '../mock_elements'
 import { FilterWith } from './mocks'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
-import { FIELD_ANNOTATIONS } from '../../src/constants'
+import { FIELD_ANNOTATIONS, ORDERED_MAP_PREFIX } from '../../src/constants'
 import { getLookUpName } from '../../src/transformers/reference_mapping'
 import { salesforceAdapterResolveValues } from '../../src/adapter'
 
@@ -728,7 +728,7 @@ describe('Convert maps filter', () => {
 
     it('should convert field type to ordered map', async () => {
       const fieldType = await gvsType.fields.customValue.getType()
-      expect(fieldType.elemID.typeName).toEqual('OrderedMap<CustomValue>')
+      expect(fieldType.elemID.typeName).toEqual(`${ORDERED_MAP_PREFIX}CustomValue`)
     })
 
     it('should convert instance value to map ', () => {
@@ -794,19 +794,21 @@ describe('Convert maps filter', () => {
       it('should convert Picklist valueSet type to ordered map', async () => {
         expect(myCustomObj.fields.myPicklist.getTypeSync()).toEqual(picklistType)
         const valueSetType = picklistType.annotationRefTypes.valueSet as TypeReference<ObjectType>
-        expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
+        expect(valueSetType.elemID.typeName).toEqual(`${ORDERED_MAP_PREFIX}valueSet`)
         expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
         expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
-        expect(picklistType.annotationRefTypes.valueSet?.elemID.name).toEqual('OrderedMap<valueSet>')
+        expect(picklistType.annotationRefTypes.valueSet?.elemID.name).toEqual(`${ORDERED_MAP_PREFIX}valueSet`)
       })
 
       it('should convert MultiselectPicklist valueSet type to ordered map', async () => {
         expect(myCustomObj.fields.myMultiselectPicklist.getTypeSync()).toEqual(multiselectPicklistType)
         const valueSetType = multiselectPicklistType.annotationRefTypes.valueSet as TypeReference<ObjectType>
-        expect(valueSetType.elemID.typeName).toEqual('OrderedMap<valueSet>')
+        expect(valueSetType.elemID.typeName).toEqual(`${ORDERED_MAP_PREFIX}valueSet`)
         expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
         expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
-        expect(multiselectPicklistType.annotationRefTypes.valueSet?.elemID.name).toEqual('OrderedMap<valueSet>')
+        expect(multiselectPicklistType.annotationRefTypes.valueSet?.elemID.name).toEqual(
+          `${ORDERED_MAP_PREFIX}valueSet`,
+        )
       })
 
       it('should convert annotation value to map (Picklist)', () => {


### PR DESCRIPTION
Rename Salesforce OrderedMap type to not use container type syntax

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
