### PR TITLE
SALTO-6994: Avoid redundant copy of fetch changes

### DIFF
--- a/packages/cli/src/commands/fetch.ts
+++ b/packages/cli/src/commands/fetch.ts
@@ -222,19 +222,17 @@ export const fetchCommand = async ({
     }
   }
 
-  // Unpack changes to array so we can iterate on them more than once
-  const changes = [...fetchResult.changes]
-  cliTelemetry.changes(changes.length)
+  cliTelemetry.changes(fetchResult.changes.length)
 
   const updatingWsSucceeded = stateOnly
-    ? await applyChangesToState(changes)
+    ? await applyChangesToState(fetchResult.changes)
     : await applyChangesToWorkspace({
         workspace,
         cliTelemetry,
         force,
         shouldCalcTotalSize,
         output,
-        changes,
+        changes: fetchResult.changes,
         mode,
         approveChangesCallback: getApprovedChanges,
         applyProgress: fetchProgress,

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -204,7 +204,7 @@ const toChangesWithPath =
 
     const originalElements = accountElementByFullName(changeID)
     if (originalElements.length === 0) {
-      log.trace(`no original elements found for change element id ${changeID.getFullName()}`)
+      log.debug('no original elements found for change element id %s', changeID.getFullName())
       return [change]
     }
 


### PR DESCRIPTION
---

_Additional context for reviewer_
in the past the changes here were an iterator
they are an array now, so there is no point in creating this copy

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_