### PR TITLE
SALTO-6995: Add element-test-utils package

### DIFF
--- a/packages/adapter-api/jest.config.js
+++ b/packages/adapter-api/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 71.92,
     },
   },
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
 })

--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -35,6 +35,8 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@jest/expect-utils": "^29.7.0",
+    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "@types/node": "^18.9.0",

--- a/packages/adapter-api/test/setup.ts
+++ b/packages/adapter-api/test/setup.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import type { Tester } from '@jest/expect-utils'
+import { expect } from '@jest/globals'
+import { ElemID } from '../src/element_id'
+
+// We cannot import this from @salto-io/element-test-utils because it would cause a cyclic dependency
+// so we have to define this here separately
+export const isEqualElemID: Tester = function isEqualElemID(a, b) {
+  if (a instanceof ElemID && b instanceof ElemID) {
+    return a.isEqual(b)
+  }
+  return undefined
+}
+
+expect.addEqualityTesters([isEqualElemID])

--- a/packages/adapter-components/jest.config.js
+++ b/packages/adapter-components/jest.config.js
@@ -19,4 +19,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/adapter-components/package.json
+++ b/packages/adapter-components/package.json
@@ -53,6 +53,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/adapter-components/tsconfig.json
+++ b/packages/adapter-components/tsconfig.json
@@ -8,12 +8,13 @@
   },
   "include": ["src/**/*", "test/**/*", "index.ts", "test/**/*.json"],
   "references": [
-    { "path": "../dag" },
-    { "path": "../lowerdash" },
-    { "path": "../logging" },
     { "path": "../adapter-api" },
     { "path": "../adapter-utils" },
-    { "path": "../test-utils" },
-    { "path": "../parser" }
+    { "path": "../dag" },
+    { "path": "../element-test-utils" },
+    { "path": "../logging" },
+    { "path": "../lowerdash" },
+    { "path": "../parser" },
+    { "path": "../test-utils" }
   ]
 }

--- a/packages/adapter-utils/jest.config.js
+++ b/packages/adapter-utils/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 80,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -42,6 +42,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/adapter-utils/tsconfig.json
+++ b/packages/adapter-utils/tsconfig.json
@@ -8,9 +8,10 @@
   },
   "include": ["src/**/*", "test/**/*", "index.ts"],
   "references": [
-    { "path": "../lowerdash" },
-    { "path": "../logging" },
     { "path": "../adapter-api" },
+    { "path": "../element-test-utils" },
+    { "path": "../logging" },
+    { "path": "../lowerdash" },
     { "path": "../test-utils" }
   ]
 }

--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -26,4 +26,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 94.75,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/express": "^4.17.7",
     "@types/inquirer": "7.3.1",

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -17,12 +17,13 @@
     { "path": "../core" },
     { "path": "../dag" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../file" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
+    { "path": "../parser" },
     { "path": "../salesforce-adapter" },
     { "path": "../test-utils" },
-    { "path": "../workspace" },
-    { "path": "../parser" }
+    { "path": "../workspace" }
   ]
 }

--- a/packages/confluence-adapter/jest.config.js
+++ b/packages/confluence-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 93,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/confluence-adapter/package.json
+++ b/packages/confluence-adapter/package.json
@@ -41,6 +41,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/confluence-adapter/tsconfig.json
+++ b/packages/confluence-adapter/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/core/jest.config.js
+++ b/packages/core/jest.config.js
@@ -23,5 +23,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 90,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,6 +62,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -8,11 +8,12 @@
   "include": ["src/**/*", "src/**/*.json", "test/**/*", "index.ts"],
   "references": [
     { "path": "../adapter-api" },
-    { "path": "../adapter-utils" },
     { "path": "../adapter-components" },
+    { "path": "../adapter-utils" },
     { "path": "../confluence-adapter" },
     { "path": "../dag" },
     { "path": "../dummy-adapter" },
+    { "path": "../element-test-utils" },
     { "path": "../google-workspace-adapter" },
     { "path": "../intercom-adapter" },
     { "path": "../jamf-adapter" },
@@ -23,6 +24,7 @@
     { "path": "../microsoft-security-adapter" },
     { "path": "../netsuite-adapter" },
     { "path": "../okta-adapter" },
+    { "path": "../pagerduty-adapter" },
     { "path": "../salesforce-adapter" },
     { "path": "../sap-adapter" },
     { "path": "../serviceplaceholder-adapter" },
@@ -32,7 +34,6 @@
     { "path": "../workspace" },
     { "path": "../local-workspace" },
     { "path": "../zendesk-adapter" },
-    { "path": "../zuora-billing-adapter" },
-    { "path": "../pagerduty-adapter" }
+    { "path": "../zuora-billing-adapter" }
   ]
 }

--- a/packages/dummy-adapter/jest.config.js
+++ b/packages/dummy-adapter/jest.config.js
@@ -19,4 +19,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 93,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/dummy-adapter/package.json
+++ b/packages/dummy-adapter/package.json
@@ -43,6 +43,7 @@
     "unique-names-generator": "^4.3.1"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/seedrandom": "^2.4.28",
     "eslint": "^9.6.0",

--- a/packages/dummy-adapter/tsconfig.json
+++ b/packages/dummy-adapter/tsconfig.json
@@ -8,11 +8,12 @@
   "include": ["src/**/*", "test/**/*", "index.ts", "test/**/*.json"],
   "references": [
     { "path": "../adapter-api" },
-    { "path": "../adapter-utils" },
-    { "path": "../lowerdash" },
-    { "path": "../workspace" },
     { "path": "../adapter-components" },
+    { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
-    { "path": "../parser" }
+    { "path": "../lowerdash" },
+    { "path": "../parser" },
+    { "path": "../workspace" }
   ]
 }

--- a/packages/element-test-utils/README.md
+++ b/packages/element-test-utils/README.md
@@ -1,0 +1,22 @@
+# Salto - element test utilities
+
+---
+
+This package contains utilities for working with the [jest framework](https://jestjs.io/) and salto elements.
+
+## Usage
+
+The standard way to use the jest extensions in this package is to install them all by adding
+
+```
+setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
+```
+
+to the jest config file.
+This will automatically install all custom matchers and equality testers to all test files in the project
+
+## Contribute
+
+See documentation about [Equality Testers](https://jestjs.io/docs/expect#expectaddequalitytesterstesters) and [Custom matchers](https://jestjs.io/docs/expect#expectextendmatchers)
+
+Make sure to add any new tester or matcher to the `all.ts` file so they will be registered.

--- a/packages/element-test-utils/eslint.config.mjs
+++ b/packages/element-test-utils/eslint.config.mjs
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import path from 'path'
+import { fileURLToPath } from 'node:url'
+
+import baseConfig from '../../eslint.config.mjs'
+import adapterApiRules from '../../eslint/adapter-api.rules.js'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const configs = ['./tsconfig.json']
+
+const config = baseConfig.concat(adapterApiRules).concat({
+  languageOptions: {
+    parserOptions: {
+      tsconfigRootDir: __dirname,
+      project: configs.map(config => path.resolve(__dirname, config)),
+    },
+  },
+})
+
+export default config

--- a/packages/element-test-utils/index.ts
+++ b/packages/element-test-utils/index.ts
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+export * from './src/custom_equality'

--- a/packages/element-test-utils/jest.config.js
+++ b/packages/element-test-utils/jest.config.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+const deepMerge = require('../../build_utils/deep_merge')
+
+module.exports = deepMerge(require('../../jest.base.config.js'), {
+  displayName: 'element-test-utils',
+  rootDir: `${__dirname}`,
+  collectCoverageFrom: ['!<rootDir>/index.ts', '!<rootDir>/src/all.ts'],
+  coverageThreshold: {
+    global: {
+      branches: 99,
+      functions: 100,
+      lines: 100,
+      statements: 100,
+    },
+  },
+})

--- a/packages/element-test-utils/package.json
+++ b/packages/element-test-utils/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@salto-io/element-test-utils",
+  "version": "0.4.6",
+  "license": "SEE LICENSE IN LICENSE",
+  "description": "Test utilities for jest with Salto Elements",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/salto-io/salto"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "dist/src"
+  ],
+  "types": "dist/src/index.d.ts",
+  "scripts": {
+    "build": "../../build_utils/turbo_run.sh build-ts ; ../../build_utils/turbo_run.sh lint",
+    "test": "jest",
+    "clean": "rm -rf ./dist .eslintcache",
+    "watch-test": "yarn tsc-watch",
+    "build-ts": "tsc -b",
+    "watch-ts": "tsc -b -w",
+    "lint": "eslint --max-warnings 0 ./",
+    "lint-fix": "yarn lint --fix",
+    "format": "prettier --write . --ignore-path=../../.prettierignore --ignore-path=../../.gitignore --ignore-path=.gitignore",
+    "check-format": "prettier --check . --ignore-path=../../.prettierignore --ignore-path=../../.gitignore --ignore-path=.gitignore"
+  },
+  "exports": {
+    ".": "./index.ts",
+    "./all": "./src/all.ts"
+  },
+  "dependencies": {
+    "@salto-io/adapter-api": "0.4.6"
+  },
+  "devDependencies": {
+    "@jest/expect-utils": "^29.7.0",
+    "@jest/globals": "^29.7.0",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^18.9.0",
+    "eslint": "^9.6.0",
+    "jest": "^29.7.0",
+    "prettier": "3.2.5",
+    "ts-jest": "^29.2.0",
+    "tsc-watch": "^2.2.1",
+    "turbo": "^2.0.6",
+    "typescript": "4.8.4"
+  }
+}

--- a/packages/element-test-utils/src/all.ts
+++ b/packages/element-test-utils/src/all.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { expect } from '@jest/globals'
+import { isEqualElemID } from './custom_equality'
+
+expect.addEqualityTesters([isEqualElemID])

--- a/packages/element-test-utils/src/custom_equality.ts
+++ b/packages/element-test-utils/src/custom_equality.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { Tester } from '@jest/expect-utils'
+import { ElemID } from '@salto-io/adapter-api'
+
+export const isEqualElemID: Tester = function isEqualElemID(a, b) {
+  if (a instanceof ElemID && b instanceof ElemID) {
+    return a.isEqual(b)
+  }
+  return undefined
+}

--- a/packages/element-test-utils/test/custom_equality.test.ts
+++ b/packages/element-test-utils/test/custom_equality.test.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { TesterContext } from '@jest/expect-utils'
+import { ElemID } from '@salto-io/adapter-api'
+import { isEqualElemID as isEqualElemIDUnbound } from '../src/custom_equality'
+
+describe('isEqualElemID', () => {
+  let mockTesterContext: TesterContext
+  let isEqualElemID: OmitThisParameter<typeof isEqualElemIDUnbound>
+  beforeEach(() => {
+    mockTesterContext = { equals: () => false }
+    isEqualElemID = isEqualElemIDUnbound.bind(mockTesterContext)
+  })
+  describe('when called with element IDs', () => {
+    describe('when IDs are equal', () => {
+      it('should return true', () => {
+        expect(isEqualElemID(new ElemID('dummy', 'test'), new ElemID('dummy', 'test'), [])).toBe(true)
+      })
+    })
+    describe('when IDs are different', () => {
+      it('should return false', () => {
+        expect(isEqualElemID(new ElemID('dummy', 'test'), new ElemID('dummy', 'test2'), [])).toBe(false)
+      })
+    })
+  })
+  describe('when called with a value that is not an ElemID', () => {
+    it('should return undefined', () => {
+      expect(isEqualElemID(1, 2, [])).toBeUndefined()
+    })
+  })
+})

--- a/packages/element-test-utils/tsconfig.json
+++ b/packages/element-test-utils/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "baseUrl": ".",
+    "resolveJsonModule": true
+  },
+  "references": [{ "path": "../adapter-api" }],
+  "include": ["src/**/*", "test/**/*", "index.ts"]
+}

--- a/packages/google-workspace-adapter/jest.config.js
+++ b/packages/google-workspace-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 75,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/google-workspace-adapter/package.json
+++ b/packages/google-workspace-adapter/package.json
@@ -42,6 +42,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/workspace": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/google-workspace-adapter/tsconfig.json
+++ b/packages/google-workspace-adapter/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../workspace" }

--- a/packages/intercom-adapter/jest.config.js
+++ b/packages/intercom-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95.8,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/intercom-adapter/package.json
+++ b/packages/intercom-adapter/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/intercom-adapter/tsconfig.json
+++ b/packages/intercom-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/jamf-adapter/jest.config.js
+++ b/packages/jamf-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 93,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/jamf-adapter/package.json
+++ b/packages/jamf-adapter/package.json
@@ -42,6 +42,7 @@
     "xml-js": "^1.6.11"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/jamf-adapter/tsconfig.json
+++ b/packages/jamf-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/jira-adapter/jest.config.js
+++ b/packages/jira-adapter/jest.config.js
@@ -20,5 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/jira-adapter/package.json
+++ b/packages/jira-adapter/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/jira-adapter/tsconfig.json
+++ b/packages/jira-adapter/tsconfig.json
@@ -11,10 +11,11 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../dag" },
+    { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
-    { "path": "../test-utils" },
-    { "path": "../e2e-credentials-store" },
-    { "path": "../dag" }
+    { "path": "../test-utils" }
   ]
 }

--- a/packages/lang-server/jest.config.js
+++ b/packages/lang-server/jest.config.js
@@ -28,4 +28,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 41.55,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/lang-server/package.json
+++ b/packages/lang-server/package.json
@@ -39,6 +39,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/node": "^18.9.0",

--- a/packages/lang-server/tsconfig.json
+++ b/packages/lang-server/tsconfig.json
@@ -11,10 +11,11 @@
   "references": [
     { "path": "../adapter-api" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../lowerdash" },
-    { "path": "../workspace" },
     { "path": "../lowerdash" },
+    { "path": "../parser" },
     { "path": "../test-utils" },
-    { "path": "../parser" }
+    { "path": "../workspace" }
   ]
 }

--- a/packages/local-workspace/jest.config.js
+++ b/packages/local-workspace/jest.config.js
@@ -20,5 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 94.9,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/local-workspace/package.json
+++ b/packages/local-workspace/package.json
@@ -56,6 +56,7 @@
   },
   "devDependencies": {
     "@aws-sdk/util-stream-node": "3.198.0",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/async-lock": "^1.1.2",
     "@types/fs-extra": "^9.0.8",

--- a/packages/local-workspace/tsconfig.json
+++ b/packages/local-workspace/tsconfig.json
@@ -10,6 +10,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-utils" },
     { "path": "../aws-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../file" },
     { "path": "../logging" },
     { "path": "../lowerdash" },

--- a/packages/microsoft-entra-adapter/jest.config.js
+++ b/packages/microsoft-entra-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 93.31,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/microsoft-entra-adapter/package.json
+++ b/packages/microsoft-entra-adapter/package.json
@@ -39,6 +39,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/microsoft-entra-adapter/tsconfig.json
+++ b/packages/microsoft-entra-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../test-utils" }

--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       lines: 98.06,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/microsoft-security-adapter/package.json
+++ b/packages/microsoft-security-adapter/package.json
@@ -40,6 +40,7 @@
     "uuid": "^10.0.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/microsoft-security-adapter/tsconfig.json
+++ b/packages/microsoft-security-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../test-utils" }

--- a/packages/netsuite-adapter/jest.config.js
+++ b/packages/netsuite-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 90,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/netsuite-adapter/package.json
+++ b/packages/netsuite-adapter/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/async-lock": "^1.1.2",
     "@types/he": "^1.1.1",

--- a/packages/netsuite-adapter/tsconfig.json
+++ b/packages/netsuite-adapter/tsconfig.json
@@ -14,6 +14,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../file" },
     { "path": "../logging" },
     { "path": "../lowerdash" },

--- a/packages/okta-adapter/jest.config.js
+++ b/packages/okta-adapter/jest.config.js
@@ -20,7 +20,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 92,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
   moduleNameMapper: {
     // Force CommonJS build for http adapter to be available.
     // via https://github.com/axios/axios/issues/5101#issuecomment-1276572468

--- a/packages/okta-adapter/package.json
+++ b/packages/okta-adapter/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/okta-adapter/tsconfig.json
+++ b/packages/okta-adapter/tsconfig.json
@@ -11,9 +11,10 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
-    { "path": "../test-utils" },
-    { "path": "../e2e-credentials-store" }
+    { "path": "../test-utils" }
   ]
 }

--- a/packages/pagerduty-adapter/jest.config.js
+++ b/packages/pagerduty-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 92,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/pagerduty-adapter/package.json
+++ b/packages/pagerduty-adapter/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/pagerduty-adapter/tsconfig.json
+++ b/packages/pagerduty-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/parser/jest.config.js
+++ b/packages/parser/jest.config.js
@@ -23,4 +23,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 90,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -39,6 +39,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "@types/moo": "^0.5.0",

--- a/packages/parser/tsconfig.json
+++ b/packages/parser/tsconfig.json
@@ -11,6 +11,7 @@
   "references": [
     { "path": "../adapter-api" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/salesforce-adapter/jest.config.js
+++ b/packages/salesforce-adapter/jest.config.js
@@ -22,5 +22,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/salesforce-adapter/package.json
+++ b/packages/salesforce-adapter/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/jsforce-types": "^0.1.0",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",

--- a/packages/salesforce-adapter/tsconfig.json
+++ b/packages/salesforce-adapter/tsconfig.json
@@ -15,6 +15,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../file" },
     { "path": "../logging" },
     { "path": "../lowerdash" },

--- a/packages/sap-adapter/jest.config.js
+++ b/packages/sap-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 0,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/sap-adapter/package.json
+++ b/packages/sap-adapter/package.json
@@ -36,6 +36,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/sap-adapter/tsconfig.json
+++ b/packages/sap-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" }
   ]
 }

--- a/packages/serviceplaceholder-adapter/jest.config.js
+++ b/packages/serviceplaceholder-adapter/jest.config.js
@@ -21,4 +21,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/serviceplaceholder-adapter/package.json
+++ b/packages/serviceplaceholder-adapter/package.json
@@ -38,6 +38,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/serviceplaceholder-adapter/tsconfig.json
+++ b/packages/serviceplaceholder-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" }
   ]

--- a/packages/stripe-adapter/jest.config.js
+++ b/packages/stripe-adapter/jest.config.js
@@ -20,5 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 99,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/stripe-adapter/package.json
+++ b/packages/stripe-adapter/package.json
@@ -37,6 +37,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "axios": "^1.7.2",

--- a/packages/stripe-adapter/tsconfig.json
+++ b/packages/stripe-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" }
   ]
 }

--- a/packages/vscode/jest.config.js
+++ b/packages/vscode/jest.config.js
@@ -28,4 +28,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 41.55,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -106,6 +106,7 @@
     "wu": "^2.1.0"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/vscode": "^1.36",
     "eslint": "^9.6.0",

--- a/packages/vscode/tsconfig.json
+++ b/packages/vscode/tsconfig.json
@@ -16,10 +16,11 @@
   "include": ["src/**/*", "test/**/*", "e2e_test/**/*"],
   "references": [
     { "path": "../core" },
+    { "path": "../element-test-utils" },
+    { "path": "../file" },
     { "path": "../lang-server" },
     { "path": "../lowerdash" },
-    { "path": "../file" },
-    { "path": "../workspace" },
-    { "path": "../parser" }
+    { "path": "../parser" },
+    { "path": "../workspace" }
   ]
 }

--- a/packages/workato-adapter/jest.config.js
+++ b/packages/workato-adapter/jest.config.js
@@ -19,4 +19,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/workato-adapter/package.json
+++ b/packages/workato-adapter/package.json
@@ -39,6 +39,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/workato-adapter/tsconfig.json
+++ b/packages/workato-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../test-utils" }

--- a/packages/workspace/jest.config.js
+++ b/packages/workspace/jest.config.js
@@ -23,5 +23,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 90,
     },
   },
-  setupFilesAfterEnv: ['jest-extended/all'],
+  setupFilesAfterEnv: ['jest-extended/all', '@salto-io/element-test-utils/all'],
 })

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -40,6 +40,7 @@
   },
   "devDependencies": {
     "@salto-io/dag": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/workspace/tsconfig.json
+++ b/packages/workspace/tsconfig.json
@@ -12,9 +12,10 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-utils" },
     { "path": "../dag" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
-    { "path": "../test-utils" },
-    { "path": "../parser" }
+    { "path": "../parser" },
+    { "path": "../test-utils" }
   ]
 }

--- a/packages/zendesk-adapter/jest.config.js
+++ b/packages/zendesk-adapter/jest.config.js
@@ -20,4 +20,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/zendesk-adapter/package.json
+++ b/packages/zendesk-adapter/package.json
@@ -52,6 +52,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@salto-io/workspace": "0.4.6",
     "@types/jest": "^29.5.12",

--- a/packages/zendesk-adapter/tsconfig.json
+++ b/packages/zendesk-adapter/tsconfig.json
@@ -11,12 +11,13 @@
     { "path": "../adapter-api" },
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
+    { "path": "../dag" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
+    { "path": "../parser" },
     { "path": "../test-utils" },
-    { "path": "../workspace" },
-    { "path": "../dag" },
-    { "path": "../parser" }
+    { "path": "../workspace" }
   ]
 }

--- a/packages/zuora-billing-adapter/jest.config.js
+++ b/packages/zuora-billing-adapter/jest.config.js
@@ -22,4 +22,5 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       statements: 95,
     },
   },
+  setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],
 })

--- a/packages/zuora-billing-adapter/package.json
+++ b/packages/zuora-billing-adapter/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.4.6",
+    "@salto-io/element-test-utils": "0.4.6",
     "@salto-io/test-utils": "0.4.6",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/zuora-billing-adapter/tsconfig.json
+++ b/packages/zuora-billing-adapter/tsconfig.json
@@ -12,6 +12,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../e2e-credentials-store" },
+    { "path": "../element-test-utils" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../test-utils" }

--- a/salto.code-workspace
+++ b/salto.code-workspace
@@ -45,6 +45,10 @@
       "path": "packages/e2e-credentials-store",
     },
     {
+      "name": "element-test-utils",
+      "path": "packages/element-test-utils",
+    },
+    {
       "name": "microsoft-entra-adapter",
       "path": "packages/microsoft-entra-adapter",
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3920,6 +3920,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@salto-io/adapter-api@workspace:packages/adapter-api"
   dependencies:
+    "@jest/expect-utils": ^29.7.0
+    "@jest/globals": ^29.7.0
     "@salto-io/dag": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
@@ -3945,6 +3947,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/dag": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/parser": 0.4.6
@@ -3985,6 +3988,7 @@ __metadata:
   resolution: "@salto-io/adapter-utils@workspace:packages/adapter-utils"
   dependencies:
     "@salto-io/adapter-api": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4039,6 +4043,7 @@ __metadata:
     "@salto-io/core": 0.4.6
     "@salto-io/dag": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/file": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
@@ -4093,6 +4098,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4121,6 +4127,7 @@ __metadata:
     "@salto-io/confluence-adapter": 0.4.6
     "@salto-io/dag": 0.4.6
     "@salto-io/dummy-adapter": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/google-workspace-adapter": 0.4.6
     "@salto-io/intercom-adapter": 0.4.6
     "@salto-io/jamf-adapter": 0.4.6
@@ -4186,6 +4193,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/parser": 0.4.6
@@ -4234,6 +4242,25 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@salto-io/element-test-utils@0.4.6, @salto-io/element-test-utils@workspace:packages/element-test-utils":
+  version: 0.0.0-use.local
+  resolution: "@salto-io/element-test-utils@workspace:packages/element-test-utils"
+  dependencies:
+    "@jest/expect-utils": ^29.7.0
+    "@jest/globals": ^29.7.0
+    "@salto-io/adapter-api": 0.4.6
+    "@types/jest": ^29.5.12
+    "@types/node": ^18.9.0
+    eslint: ^9.6.0
+    jest: ^29.7.0
+    prettier: 3.2.5
+    ts-jest: ^29.2.0
+    tsc-watch: ^2.2.1
+    turbo: ^2.0.6
+    typescript: 4.8.4
+  languageName: unknown
+  linkType: soft
+
 "@salto-io/file@0.4.6, @salto-io/file@workspace:packages/file":
   version: 0.0.0-use.local
   resolution: "@salto-io/file@workspace:packages/file"
@@ -4266,6 +4293,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/workspace": 0.4.6
@@ -4294,6 +4322,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4318,6 +4347,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4347,6 +4377,7 @@ __metadata:
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/dag": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4413,6 +4444,7 @@ __metadata:
   dependencies:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/parser": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4442,6 +4474,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/aws-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/file": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
@@ -4570,6 +4603,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4596,6 +4630,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4624,6 +4659,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/file": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
@@ -4682,6 +4718,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4715,6 +4752,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4738,6 +4776,7 @@ __metadata:
   dependencies:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4804,6 +4843,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/file": 0.4.6
     "@salto-io/jsforce": ^1.9.4
     "@salto-io/jsforce-types": ^0.1.0
@@ -4855,6 +4895,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@types/jest": ^29.5.12
     "@types/lodash": ^4.14.168
@@ -4878,6 +4919,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@types/jest": ^29.5.12
@@ -4902,6 +4944,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@types/jest": ^29.5.12
     "@types/lodash": ^4.14.168
@@ -4958,6 +5001,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -4985,6 +5029,7 @@ __metadata:
     "@salto-io/adapter-api": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/dag": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/parser": 0.4.6
@@ -5016,6 +5061,7 @@ __metadata:
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/dag": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/parser": 0.4.6
@@ -5057,6 +5103,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.6
     "@salto-io/adapter-utils": 0.4.6
     "@salto-io/e2e-credentials-store": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/logging": 0.4.6
     "@salto-io/lowerdash": 0.4.6
     "@salto-io/test-utils": 0.4.6
@@ -17780,6 +17827,7 @@ __metadata:
   resolution: "salto-vscode@workspace:packages/vscode"
   dependencies:
     "@salto-io/core": 0.4.6
+    "@salto-io/element-test-utils": 0.4.6
     "@salto-io/file": 0.4.6
     "@salto-io/lang-server": 0.4.6
     "@salto-io/lowerdash": 0.4.6


### PR DESCRIPTION
The first thing this package implements is an override for jest expect that compares element IDs using a custom matcher

---

_Additional context for reviewer_
Required for #6862

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_