### PR TITLE
SALTO-6955: Support all adapter format methods in dummy adapter

### DIFF
--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -21,10 +21,12 @@ import { getUserBooleanInput } from '../callbacks'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
+const APPLY_PATCH_ADAPTERS = ['salesforce', 'netsuite', 'dummy'] as const
+type ApplyPatchAdapters = (typeof APPLY_PATCH_ADAPTERS)[number]
 type ApplyPatchArgs = {
   fromDir: string
   toDir: string
-  accountName: 'salesforce' | 'netsuite'
+  accountName: ApplyPatchAdapters
   targetEnvs?: string[]
   updateStateInEnvs?: string[]
 } & UpdateModeArg
@@ -124,7 +126,7 @@ const applyPatchCmd = createWorkspaceCommand({
           'The account name for elements, this determines the expected format of the elements in the directories',
         type: 'string',
         required: true,
-        choices: ['salesforce', 'netsuite'],
+        choices: [...APPLY_PATCH_ADAPTERS],
       },
       {
         name: 'targetEnvs',
@@ -159,9 +161,12 @@ const applyPatchCmd = createWorkspaceCommand({
   action: applyPatchAction,
 })
 
+const SYNC_WORKSPACE_ADAPTERS = ['salesforce', 'dummy'] as const
+type SyncWorkspaceAdapters = (typeof SYNC_WORKSPACE_ADAPTERS)[number]
+
 type SyncWorkspaceToFolderArgs = {
   toDir: string
-  accountName: 'salesforce'
+  accountName: SyncWorkspaceAdapters
   force: boolean
 }
 export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceToFolderArgs> = async ({
@@ -218,7 +223,7 @@ const syncToWorkspaceCmd = createWorkspaceCommand({
         type: 'string',
         alias: 'a',
         description: 'The name of the account to synchronize to the project',
-        choices: ['salesforce'],
+        choices: [...SYNC_WORKSPACE_ADAPTERS],
         default: 'salesforce',
       },
       {

--- a/packages/dummy-adapter/jest.config.js
+++ b/packages/dummy-adapter/jest.config.js
@@ -13,10 +13,10 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   collectCoverageFrom: ['!<rootDir>/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 83.78,
-      functions: 94.45,
-      lines: 97.28,
-      statements: 97.26,
+      branches: 82.7,
+      functions: 92.3,
+      lines: 97.1,
+      statements: 96.9,
     },
   },
   setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],

--- a/packages/dummy-adapter/jest.config.js
+++ b/packages/dummy-adapter/jest.config.js
@@ -13,10 +13,10 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   collectCoverageFrom: ['!<rootDir>/index.ts'],
   coverageThreshold: {
     global: {
-      branches: 82.7,
+      branches: 84.1,
       functions: 92.3,
-      lines: 97.1,
-      statements: 96.9,
+      lines: 97.16,
+      statements: 96.92,
     },
   },
   setupFilesAfterEnv: ['@salto-io/element-test-utils/all'],

--- a/packages/dummy-adapter/package.json
+++ b/packages/dummy-adapter/package.json
@@ -33,6 +33,7 @@
     "@salto-io/adapter-api": "0.4.7",
     "@salto-io/adapter-components": "0.4.7",
     "@salto-io/adapter-utils": "0.4.7",
+    "@salto-io/local-workspace": "0.4.7",
     "@salto-io/logging": "0.4.7",
     "@salto-io/lowerdash": "0.4.7",
     "@salto-io/parser": "0.4.7",

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -16,19 +16,18 @@ import {
   ConfigCreator,
   createRestriction,
   AdapterFormat,
+  Change,
 } from '@salto-io/adapter-api'
-import { createDefaultInstanceFromType, inspectValue } from '@salto-io/adapter-utils'
+import { createDefaultInstanceFromType, inspectValue, getDetailedChanges } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { initLocalWorkspace, loadLocalWorkspace } from '@salto-io/local-workspace'
 import { logger } from '@salto-io/logging'
+import { Workspace } from '@salto-io/workspace'
 import _ from 'lodash'
 import DummyAdapter from './adapter'
-import {
-  GeneratorParams,
-  DUMMY_ADAPTER,
-  defaultParams,
-  changeErrorType,
-  fetchErrorType,
-  generateExtraElementsFromPaths,
-} from './generator'
+import { GeneratorParams, DUMMY_ADAPTER, defaultParams, changeErrorType, fetchErrorType } from './generator'
+
+const { awu } = collections.asynciterable
 
 const log = logger(module)
 
@@ -66,9 +65,107 @@ const getCustomReferences: GetCustomReferencesFunc = async elements =>
       ]
     : []
 
-const loadElementsFromFolder: AdapterFormat['loadElementsFromFolder'] = async ({ baseDir, elementsSource }) => ({
-  elements: await generateExtraElementsFromPaths([baseDir], elementsSource),
-})
+const loadWorkspace = async ({ baseDir, persistent }: { baseDir: string; persistent: boolean }): Promise<Workspace> =>
+  loadLocalWorkspace({
+    path: baseDir,
+    persistent,
+    getConfigTypes: async () => [],
+    getCustomReferences: async elements => getCustomReferences(elements),
+  })
+
+const loadElementsFromFolder: AdapterFormat['loadElementsFromFolder'] = async ({ baseDir }) => {
+  let workspace: Workspace | undefined
+  try {
+    workspace = await loadWorkspace({ baseDir, persistent: true })
+    const elements = await workspace.elements()
+    return { elements: await awu(await elements.getAll()).toArray() }
+  } catch (error) {
+    return {
+      elements: [],
+      errors: [
+        {
+          severity: 'Error',
+          message: 'Failed loadElementsFromFolder in Dummy project',
+          detailedMessage: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    }
+  } finally {
+    await workspace?.close()
+  }
+}
+
+const dumpElementsToFolder: AdapterFormat['dumpElementsToFolder'] = async ({ baseDir, changes }) => {
+  let workspace: Workspace | undefined
+  try {
+    workspace = await loadWorkspace({ baseDir, persistent: true })
+    await workspace.updateNaclFiles(
+      changes.flatMap(c => getDetailedChanges(c)),
+      'isolated',
+    )
+    await workspace.flush()
+    return {
+      unappliedChanges: [] as Change[],
+      errors: [],
+    }
+  } catch (error) {
+    return {
+      unappliedChanges: [],
+      errors: [
+        {
+          severity: 'Error',
+          message: 'Failed dumpElementsToFolder in Dummy project',
+          detailedMessage: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    }
+  } finally {
+    await workspace?.close()
+  }
+}
+
+const initFolder: AdapterFormat['initFolder'] = async ({ baseDir }) => {
+  let workspace: Workspace | undefined
+  try {
+    workspace = await initLocalWorkspace(baseDir, 'dummy', [], async () => [])
+    return {
+      errors: [],
+    }
+  } catch (error) {
+    return {
+      errors: [
+        {
+          severity: 'Error',
+          message: 'Failed initializing Dummy project',
+          detailedMessage: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    }
+  } finally {
+    await workspace?.close()
+  }
+}
+
+const isInitializedFolder: AdapterFormat['isInitializedFolder'] = async ({ baseDir }) => {
+  let workspace: Workspace | undefined
+  try {
+    workspace = await loadWorkspace({ baseDir, persistent: false })
+    return { result: true, errors: [] }
+  } catch (error) {
+    return {
+      result: false,
+      errors: [
+        {
+          severity: 'Error',
+          message: 'Failed checking if dummy project is initialized',
+          detailedMessage: error instanceof Error ? error.message : String(error),
+        },
+      ],
+    }
+  } finally {
+    await workspace?.close()
+  }
+}
 
 const objectFieldType = new ObjectType({
   elemID: new ElemID(DUMMY_ADAPTER, 'objectFieldType'),
@@ -213,5 +310,8 @@ export const adapter: Adapter = {
   configCreator,
   adapterFormat: {
     loadElementsFromFolder,
+    dumpElementsToFolder,
+    initFolder,
+    isInitializedFolder,
   },
 }

--- a/packages/dummy-adapter/src/adapter_creator.ts
+++ b/packages/dummy-adapter/src/adapter_creator.ts
@@ -86,7 +86,7 @@ const loadElementsFromFolder: AdapterFormat['loadElementsFromFolder'] = async ({
         {
           severity: 'Error',
           message: 'Failed loadElementsFromFolder in Dummy project',
-          detailedMessage: error instanceof Error ? error.message : String(error),
+          detailedMessage: inspectValue(error),
         },
       ],
     }
@@ -115,7 +115,7 @@ const dumpElementsToFolder: AdapterFormat['dumpElementsToFolder'] = async ({ bas
         {
           severity: 'Error',
           message: 'Failed dumpElementsToFolder in Dummy project',
-          detailedMessage: error instanceof Error ? error.message : String(error),
+          detailedMessage: inspectValue(error),
         },
       ],
     }
@@ -137,7 +137,7 @@ const initFolder: AdapterFormat['initFolder'] = async ({ baseDir }) => {
         {
           severity: 'Error',
           message: 'Failed initializing Dummy project',
-          detailedMessage: error instanceof Error ? error.message : String(error),
+          detailedMessage: inspectValue(error),
         },
       ],
     }
@@ -158,7 +158,7 @@ const isInitializedFolder: AdapterFormat['isInitializedFolder'] = async ({ baseD
         {
           severity: 'Error',
           message: 'Failed checking if dummy project is initialized',
-          detailedMessage: error instanceof Error ? error.message : String(error),
+          detailedMessage: inspectValue(error),
         },
       ],
     }

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -195,7 +195,7 @@ describe('adapter creator', () => {
         it('should return errors', () => {
           expect(initFolderResult.errors).toEqual([
             {
-              detailedMessage: 'oh no!',
+              detailedMessage: expect.any(String),
               message: 'Failed initializing Dummy project',
               severity: 'Error',
             },
@@ -242,7 +242,7 @@ describe('adapter creator', () => {
         expect(isInitializedFolderResult.result).toEqual(false)
         expect(isInitializedFolderResult.errors).toEqual([
           {
-            detailedMessage: '',
+            detailedMessage: expect.any(String),
             message: 'Failed checking if dummy project is initialized',
             severity: 'Error',
           },

--- a/packages/dummy-adapter/test/adapter_creator.test.ts
+++ b/packages/dummy-adapter/test/adapter_creator.test.ts
@@ -5,10 +5,20 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import fs from 'fs'
-import readdirp from 'readdirp'
-import { ObjectType, InstanceElement, ConfigCreator, ElemID, FetchResult } from '@salto-io/adapter-api'
+import {
+  ObjectType,
+  InstanceElement,
+  ConfigCreator,
+  ElemID,
+  FetchResult,
+  DumpElementsResult,
+  toChange,
+  InitFolderResult,
+  IsInitializedFolderResult,
+} from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements, createDefaultInstanceFromType } from '@salto-io/adapter-utils'
+import * as loadLocalWorkspaceModule from '@salto-io/local-workspace'
+import { Workspace } from '@salto-io/workspace'
 import { adapter } from '../src/adapter_creator'
 import { defaultParams, DUMMY_ADAPTER } from '../src/generator'
 import DummyAdapter from '../src/adapter'
@@ -23,8 +33,16 @@ jest.mock('readdirp', () => ({
   promise: jest.fn(),
 }))
 
-const mockedFs = fs as jest.Mocked<typeof fs>
-const mockedReaddirp = readdirp as jest.Mocked<typeof readdirp>
+jest.mock('@salto-io/local-workspace', () => {
+  const actual = jest.requireActual('@salto-io/local-workspace')
+  return {
+    ...actual,
+    loadLocalWorkspace: jest.fn().mockImplementation(actual.loadLocalWorkspace),
+    initLocalWorkspace: jest.fn().mockImplementation(actual.initLocalWorkspace),
+  }
+})
+
+const mockedLocalWorkspace = jest.mocked(loadLocalWorkspaceModule)
 
 describe('adapter creator', () => {
   it('should return a config containing all of the generator params', () => {
@@ -59,52 +77,176 @@ describe('adapter creator', () => {
       }),
     ).toBeInstanceOf(DummyAdapter)
   })
-  describe('loadElementsFromFolder', () => {
-    let loadedElements: FetchResult | undefined
-    describe('When the path exists and contains a valid NaCl file', () => {
-      const naclFileContents = `
-      type dummy.Full {
-        strField: string
-        numField: number
-        annotations {
-        }
-      }
-  
-      dummy.Full FullInst1 {
-          strField = "STR1"
-          numField = 111
-      }
-      `
+  describe('adapter format', () => {
+    let dummyObject: ObjectType
+    beforeEach(() => {
+      jest.clearAllMocks()
+    })
+    describe('loadElementsFromFolder', () => {
+      let fetchResult: FetchResult
+      const mockClose = jest.fn()
       beforeEach(async () => {
-        mockedFs.readFileSync.mockImplementationOnce(() => naclFileContents)
-        mockedReaddirp.promise.mockImplementation(
-          async (dir): Promise<readdirp.EntryInfo[]> =>
-            Promise.resolve([
-              {
-                path: 'fullInst.nacl.mock',
-                fullPath: `${dir}/fullInst.nacl.mock`,
-                basename: 'fullInst.nacl.mock',
-              },
-            ]),
-        )
-        loadedElements = await adapter.adapterFormat?.loadElementsFromFolder?.({
-          baseDir: 'some_path',
-          elementsSource: buildElementsSourceFromElements([]),
+        dummyObject = new ObjectType({ elemID: new ElemID('dummy', 'test') })
+        mockedLocalWorkspace.loadLocalWorkspace.mockResolvedValue({
+          elements: () => buildElementsSourceFromElements([dummyObject]),
+          close: mockClose,
+        } as unknown as Workspace)
+      })
+      describe('when it fails', () => {
+        beforeEach(async () => {
+          mockedLocalWorkspace.loadLocalWorkspace.mockResolvedValue({
+            elements: () => {
+              throw new Error('oh no!')
+            },
+            close: mockClose,
+          } as unknown as Workspace)
+          fetchResult = (await adapter.adapterFormat?.loadElementsFromFolder?.({
+            baseDir: 'some_path',
+            elementsSource: buildElementsSourceFromElements([]),
+          })) as FetchResult
+        })
+        it('should call workspace.close when done', () => {
+          expect(mockClose).toHaveBeenCalledTimes(1)
         })
       })
-      it('should fetch elements from the correct dir', () => {
-        expect(mockedFs.readFileSync).toHaveBeenCalledWith('some_path/fullInst.nacl.mock', 'utf8')
+      describe('when load succeeds', () => {
+        beforeEach(async () => {
+          fetchResult = (await adapter.adapterFormat?.loadElementsFromFolder?.({
+            baseDir: 'some_path',
+            elementsSource: buildElementsSourceFromElements([]),
+          })) as FetchResult
+        })
+        it('should load the elements from the workspace', () => {
+          expect(fetchResult.elements).toEqual([dummyObject])
+        })
+        it('should call workspace.close when done', () => {
+          expect(mockClose).toHaveBeenCalledTimes(1)
+        })
       })
-      it('should load the NaCl file from the provided dir', () => {
-        const objectType = loadedElements?.elements.find(e => e.elemID.name === 'Full') as ObjectType
-        expect(objectType).toBeInstanceOf(ObjectType)
-        expect(objectType.elemID).toEqual(new ElemID(DUMMY_ADAPTER, 'Full'))
-
-        const instanceElement = loadedElements?.elements.find(e => e.elemID.name === 'FullInst1') as InstanceElement
-        expect(instanceElement).toBeInstanceOf(InstanceElement)
-        expect(instanceElement.value.strField).toEqual('STR1')
-        expect(instanceElement.value.numField).toEqual(111)
-        expect(instanceElement.elemID).toEqual(new ElemID(DUMMY_ADAPTER, 'Full', 'instance', 'FullInst1'))
+    })
+    describe('dumpElementsToFolder', () => {
+      let dumpElementsToFolderResult: DumpElementsResult
+      const mockUpdateNaclFiles = jest.fn()
+      const mockFlush = jest.fn()
+      const mockClose = jest.fn()
+      beforeEach(() => {
+        jest.clearAllMocks()
+        mockUpdateNaclFiles.mockReset()
+        mockedLocalWorkspace.loadLocalWorkspace.mockResolvedValue({
+          elements: () => buildElementsSourceFromElements([dummyObject]),
+          updateNaclFiles: mockUpdateNaclFiles,
+          flush: mockFlush,
+          close: mockClose,
+        } as unknown as Workspace)
+      })
+      describe('on error', () => {
+        beforeEach(async () => {
+          mockUpdateNaclFiles.mockRejectedValue('oh no!')
+          dumpElementsToFolderResult = (await adapter.adapterFormat?.dumpElementsToFolder?.({
+            changes: [toChange({ before: dummyObject })],
+            baseDir: 'some_path',
+            elementsSource: buildElementsSourceFromElements([]),
+          })) as DumpElementsResult
+        })
+        it('should call close', () => {
+          expect(mockClose).toHaveBeenCalledTimes(1)
+        })
+      })
+      describe('when dump elements succeeds', () => {
+        beforeEach(async () => {
+          dumpElementsToFolderResult = (await adapter.adapterFormat?.dumpElementsToFolder?.({
+            changes: [toChange({ before: dummyObject })],
+            baseDir: 'some_path',
+            elementsSource: buildElementsSourceFromElements([]),
+          })) as DumpElementsResult
+        })
+        it('should return no errors, and no unapplied changes', () => {
+          expect(dumpElementsToFolderResult.errors).toEqual([])
+          expect(dumpElementsToFolderResult.unappliedChanges).toEqual([])
+        })
+        it('should call updateNaclFiles', () => {
+          expect(mockUpdateNaclFiles).toHaveBeenCalledTimes(1)
+        })
+        it('should call close', () => {
+          expect(mockClose).toHaveBeenCalledTimes(1)
+        })
+        it('should call flush', () => {
+          expect(mockFlush).toHaveBeenCalledTimes(1)
+        })
+      })
+    })
+    describe('initFolder', () => {
+      let initFolderResult: InitFolderResult
+      const mockClose = jest.fn()
+      beforeEach(async () => {
+        dummyObject = new ObjectType({ elemID: new ElemID('dummy', 'test') })
+        mockedLocalWorkspace.initLocalWorkspace.mockResolvedValue({ close: mockClose } as unknown as Workspace)
+        initFolderResult = (await adapter.adapterFormat?.initFolder?.({
+          baseDir: 'some_path',
+        })) as InitFolderResult
+      })
+      describe('on error', () => {
+        beforeEach(async () => {
+          mockedLocalWorkspace.initLocalWorkspace.mockRejectedValue(new Error('oh no!'))
+          initFolderResult = (await adapter.adapterFormat?.initFolder?.({
+            baseDir: 'some_path',
+          })) as InitFolderResult
+        })
+        it('should return errors', () => {
+          expect(initFolderResult.errors).toEqual([
+            {
+              detailedMessage: 'oh no!',
+              message: 'Failed initializing Dummy project',
+              severity: 'Error',
+            },
+          ])
+        })
+        it('should call workspace.close when done', () => {
+          expect(mockClose).toHaveBeenCalledTimes(1)
+        })
+      })
+      it('should init the local workspace', () => {
+        expect(mockedLocalWorkspace.initLocalWorkspace).toHaveBeenCalledWith(
+          'some_path',
+          'dummy',
+          [],
+          expect.any(Function),
+        )
+      })
+      it('should return no errors', () => {
+        expect(initFolderResult.errors).toEqual([])
+      })
+      it('should call workspace.close when done', () => {
+        expect(mockClose).toHaveBeenCalledTimes(1)
+      })
+    })
+    describe('isInitializedFolder', () => {
+      let isInitializedFolderResult: IsInitializedFolderResult
+      const mockClose = jest.fn()
+      it('should return true if loadWorkspace succeeds, and close the workspace', async () => {
+        mockedLocalWorkspace.loadLocalWorkspace.mockResolvedValue({
+          elements: () => buildElementsSourceFromElements([dummyObject]),
+          close: mockClose,
+        } as unknown as Workspace)
+        isInitializedFolderResult = (await adapter.adapterFormat?.isInitializedFolder?.({
+          baseDir: 'some_path',
+        })) as IsInitializedFolderResult
+        expect(isInitializedFolderResult.result).toEqual(true)
+        expect(mockClose).toHaveBeenCalledTimes(1)
+      })
+      it('should return false if loadWorkspace fails', async () => {
+        mockedLocalWorkspace.loadLocalWorkspace.mockRejectedValue(new Error())
+        isInitializedFolderResult = (await adapter.adapterFormat?.isInitializedFolder?.({
+          baseDir: 'some_path',
+        })) as IsInitializedFolderResult
+        expect(isInitializedFolderResult.result).toEqual(false)
+        expect(isInitializedFolderResult.errors).toEqual([
+          {
+            detailedMessage: '',
+            message: 'Failed checking if dummy project is initialized',
+            severity: 'Error',
+          },
+        ])
       })
     })
   })

--- a/packages/dummy-adapter/test/generator.test.ts
+++ b/packages/dummy-adapter/test/generator.test.ts
@@ -73,8 +73,7 @@ describe('generator', () => {
         expect(_.uniq(profiles.map(p => p.elemID.getFullName()))).toHaveLength(testParams.numOfProfiles)
         expect(records).toHaveLength(testParams.numOfRecords + 5) // 5 default instance fragments
       })
-      // eslint-disable-next-line
-      it.skip('should create list and map types', async () => {
+      it('should create list and map types', async () => {
         const run1 = await generateElements(
           {
             ...testParams,

--- a/packages/dummy-adapter/tsconfig.json
+++ b/packages/dummy-adapter/tsconfig.json
@@ -11,6 +11,7 @@
     { "path": "../adapter-components" },
     { "path": "../adapter-utils" },
     { "path": "../element-test-utils" },
+    { "path": "../local-workspace" },
     { "path": "../logging" },
     { "path": "../lowerdash" },
     { "path": "../parser" },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4265,6 +4265,7 @@ __metadata:
     "@salto-io/adapter-components": 0.4.7
     "@salto-io/adapter-utils": 0.4.7
     "@salto-io/element-test-utils": 0.4.7
+    "@salto-io/local-workspace": 0.4.7
     "@salto-io/logging": 0.4.7
     "@salto-io/lowerdash": 0.4.7
     "@salto-io/parser": 0.4.7


### PR DESCRIPTION
This is rebased on [https://github.com/salto-io/salto/pull/6853 &](https://github.com/salto-io/salto/pull/6944)

Keeping this in draft until the above is merged.

So please only review the last commit


---

_Additional context for reviewer_

None

---

_Release Notes_: 
None

---

_User Notifications_: 
None