### PR TITLE
SALT-6999: (Salesforce) Profiles & PS Elements fixer should omit default values from Instance

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
@@ -310,10 +310,10 @@ export const getProfilesAndPsBrokenReferenceFields = async ({
           [sectionName, sectionEntryKey, ...makeArray(sourceField)].join('.'),
           target,
         ],
-        // Unlike in the findWeakReferences, we don't want to filter out the entries that don't have a target
+        // Unlike in findWeakReferences, we don't want to filter out the entries that don't have a target
         // here, and we should handle all of them. The filters are implemented in order to reduce the amount
         // of total references we create, and we create references only when we need to
-        // (When the value of the entry is not the default value from Salesforce).
+        // (When the value of the entry is not the default value from Salesforce). This optimization is not required here.
         applyFilter: false,
       }),
     )

--- a/packages/salesforce-adapter/test/custom_references/profiles_and_permission_sets.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/profiles_and_permission_sets.test.ts
@@ -767,6 +767,11 @@ describe('Profiles And Permission Sets Custom References', () => {
           apexClass: 'sbaa__ApexClass',
           enabled: true,
         },
+        // Make sure we omit values even though we don't create custom references for them.
+        DefaultAccessNonExisting: {
+          apexClass: 'DefaultAccessNonExisting',
+          enabled: 'true',
+        },
       },
       flowAccesses: {
         SomeFlow: {
@@ -907,6 +912,7 @@ describe('Profiles And Permission Sets Custom References', () => {
           createCustomObjectType('TestObj__c', {}),
           new InstanceElement('SomeApplication', mockTypes.CustomApplication, {}),
           new InstanceElement('SomeApexClass', mockTypes.ApexClass, {}),
+          new InstanceElement('DefaultAccessNonExisting', mockTypes.ApexClass, {}),
           new InstanceElement('SomeFlow', mockTypes.Flow, {}),
           new InstanceElement('Account_Account_Layout@bs', mockTypes.Layout, {}),
           new InstanceElement('SomeApexPage', mockTypes.ApexPage, {}),


### PR DESCRIPTION
(Salesforce) Profiles & PS Elements fixer should omit default values from Instance

---

Prior to this PR the fixer didn't omit values where we don't create references for.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_