### PR TITLE
SALTO-6954:  Removing some async calls from maps filter and CV

### DIFF
--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -57,7 +57,7 @@ import { metadataType } from '../transformers/transformer'
 import { GLOBAL_VALUE_SET } from './global_value_sets'
 import { STANDARD_VALUE_SET } from './standard_value_sets'
 import { FetchProfile } from '../types'
-import { apiNameSync } from './utils'
+import { apiNameSync, metadataTypeSync } from './utils'
 
 const { awu } = collections.asynciterable
 const { isDefined } = lowerdashValues
@@ -605,23 +605,14 @@ export const getChangesWithFieldType = (changes: ReadonlyArray<Change>, fieldTyp
   return fieldChanges.concat(objectTypeChanges)
 }
 
-export const findInstancesToConvert = (elements: Element[], targetMetadataType: string): Promise<InstanceElement[]> => {
+export const findInstancesToConvert = (elements: Element[], targetMetadataType: string): InstanceElement[] => {
   const instances = elements.filter(isInstanceElement)
-  return awu(instances)
-    .filter(async e => (await metadataType(e)) === targetMetadataType)
-    .toArray()
+  return instances.filter(e => metadataTypeSync(e) === targetMetadataType)
 }
 
-export const findTypeToConvert = async (
-  elements: Element[],
-  targetMetadataType: string,
-): Promise<ObjectType | undefined> => {
+export const findTypeToConvert = (elements: Element[], targetMetadataType: string): ObjectType | undefined => {
   const types = elements.filter(isObjectType)
-  return (
-    await awu(types)
-      .filter(async e => (await metadataType(e)) === targetMetadataType)
-      .toArray()
-  )[0]
+  return types.filter(e => metadataTypeSync(e) === targetMetadataType)[0]
 }
 
 /**
@@ -635,8 +626,8 @@ const filter: FilterCreator = ({ config }) => ({
     const annotationDefsByType = getAnnotationDefsByType(config.fetchProfile)
 
     await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
-      const instancesToConvert = await findInstancesToConvert(elements, targetMetadataType)
-      const typeToConvert = await findTypeToConvert(elements, targetMetadataType)
+      const instancesToConvert = findInstancesToConvert(elements, targetMetadataType)
+      const typeToConvert = findTypeToConvert(elements, targetMetadataType)
       const mapFieldDef = metadataTypeToFieldToMapDef[targetMetadataType]
       if (isDefined(typeToConvert)) {
         if (instancesToConvert.length === 0) {


### PR DESCRIPTION
It should slightly improve performance.

---

_Additional context for reviewer_
This was originally implemented in https://github.com/salto-io/salto/pull/6827 but was reverted due to a bug in fetching profiles.
The bug was the extra `async` keyword in https://github.com/salto-io/salto/pull/6827/files#diff-616666620c2c1d68e89a7ac6aa5f3734f3a73fd036150009bca8124f97faa0bfR610. This is now removed.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
