### PR TITLE
SALTO-6759 Jamf: omit payloads in configuration profiles

### DIFF
--- a/packages/jamf-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/fetch.ts
@@ -406,7 +406,7 @@ const createCustomizations = (
         },
         transformation: {
           root: 'os_x_configuration_profile',
-          omit: ['general.uuid'],
+          omit: ['general.uuid', 'general.payloads'],
           adjust: transforms.adjustConfigurationProfile,
         },
       },
@@ -465,7 +465,7 @@ const createCustomizations = (
         },
         transformation: {
           root: 'configuration_profile',
-          omit: ['general.uuid'],
+          omit: ['general.uuid', 'general.payloads'],
           adjust: transforms.adjustConfigurationProfile,
         },
       },


### PR DESCRIPTION
Omit `payloads` field in `os_x_configuration_profile` and in `mobile_device_configuration_profile`, as it contains a password and the whole field might be redundant

---

_Additional context for reviewer_
None

---
_Release Notes_: 

_Jamf_adapter_:
- Solve the issue of having users' passwords in configuration profile instances, within the `payload` field

---
_User Notifications_: 
Payloads field was omitted from `os_x_configuration_profile` and in `mobile_device_configuration_profile`
