### PR TITLE
SALTO-7004: Add references from Network instances to EmailTemplates

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -19,6 +19,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   picklistsAsMaps: false,
   retrieveSettings: false,
   genAiReferences: false,
+  networkReferences: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -952,6 +952,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     src: { field: 'welcomeTemplate', parentTypes: ['Network'] },
     target: { type: 'EmailTemplate' },
   },
+  {
+    src: { field: 'picassoSite', parentTypes: ['Network'] },
+    target: { type: 'ExperienceBundle' },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -224,6 +224,37 @@ const GEN_AI_REFERENCES_DEF: FieldReferenceDefinition[] = [
   },
 ]
 
+const NETWORK_REFERENCES_DEF: FieldReferenceDefinition[] = [
+  {
+    src: { field: 'changePasswordTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'chgEmailVerNewTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'chgEmailVerOldTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'forgotPasswordTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'lockoutTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'verificationTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'welcomeTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+]
+
 /**
  * The rules for finding and resolving values into (and back from) reference expressions.
  * Overlaps between rules are allowed, and the first successful conversion wins.
@@ -940,22 +971,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'recordField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
-  {
-    src: { field: 'changePasswordTemplate', parentTypes: ['Network'] },
-    target: { type: 'EmailTemplate' },
-  },
-  {
-    src: { field: 'forgotPasswordTemplate', parentTypes: ['Network'] },
-    target: { type: 'EmailTemplate' },
-  },
-  {
-    src: { field: 'welcomeTemplate', parentTypes: ['Network'] },
-    target: { type: 'EmailTemplate' },
-  },
-  {
-    src: { field: 'picassoSite', parentTypes: ['Network'] },
-    target: { type: 'ExperienceBundle' },
-  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>
@@ -1100,7 +1115,9 @@ const getLookUpNameImpl = ({
 }
 
 export const getDefsFromFetchProfile = (fetchProfile: FetchProfile): FieldReferenceDefinition[] =>
-  fieldNameToTypeMappingDefs.concat(fetchProfile.isFeatureEnabled('genAiReferences') ? GEN_AI_REFERENCES_DEF : [])
+  fieldNameToTypeMappingDefs
+    .concat(fetchProfile.isFeatureEnabled('genAiReferences') ? GEN_AI_REFERENCES_DEF : [])
+    .concat(fetchProfile.isFeatureEnabled('networkReferences') ? NETWORK_REFERENCES_DEF : [])
 
 /**
  * Translate a reference expression back to its original value before deploy.

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -940,6 +940,18 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'recordField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
+  {
+    src: { field: 'changePasswordTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'forgotPasswordTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
+  {
+    src: { field: 'welcomeTemplate', parentTypes: ['Network'] },
+    target: { type: 'EmailTemplate' },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -103,6 +103,7 @@ const OPTIONAL_FEATURES = [
   'picklistsAsMaps',
   'retrieveSettings',
   'genAiReferences',
+  'networkReferences',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',


### PR DESCRIPTION
SALTO-7004: Add references from Network instances to EmailTemplates

---

Workspace Diff: https://github.com/salto-io/almog-sf/commit/902045fdd193a05d8c770e27bb619f1218bfe7f2?diff=unified

---
_Release Notes_: 
None

---
_User Notifications_:
_Salesforce_:
Added references from Network to EmailTemplate instance under the feature **networkReferences** in **optionalFeatures**
