### PR TITLE
SALTO-6495 Add useFieldValueAsFallback option to alias components

### DIFF
--- a/packages/adapter-components/src/add_alias.ts
+++ b/packages/adapter-components/src/add_alias.ts
@@ -23,6 +23,7 @@ const log = logger(module)
 export type AliasComponent = {
   fieldName: string
   referenceFieldName?: string
+  useFieldValueAsFallback?: boolean
 }
 
 export type ConstantComponent = {
@@ -70,6 +71,9 @@ const getAliasFromField = ({
     return _.isString(fieldValue) ? fieldValue : undefined
   }
   if (!isReferenceExpression(fieldValue)) {
+    if (component.useFieldValueAsFallback === true) {
+      return _.isString(fieldValue) ? fieldValue : undefined
+    }
     log.error(`${fieldName} is treated as a reference expression but it is not`)
     return undefined
   }

--- a/packages/adapter-components/test/add_alias.test.ts
+++ b/packages/adapter-components/test/add_alias.test.ts
@@ -20,6 +20,7 @@ describe('addAliasToElements', () => {
   const categoryTypeName = 'category'
   const categoryOrderTypeName = 'category_order'
   const categoryTranslationTypeName = 'category_translation'
+  const anotherTranslationTypeName = 'another_translation'
   const ZENDESK = 'zendesk'
 
   const aliasMap: Record<string, AliasData> = {
@@ -88,6 +89,20 @@ describe('addAliasToElements', () => {
         },
       ],
     },
+    [anotherTranslationTypeName]: {
+      aliasComponents: [
+        {
+          fieldName: 'locale',
+          referenceFieldName: 'locale',
+          useFieldValueAsFallback: true,
+        },
+        {
+          fieldName: '_parent.0',
+          referenceFieldName: '_alias',
+        },
+      ],
+      separator: ' - ',
+    },
   }
 
   const appInstallationType = new ObjectType({ elemID: new ElemID(ZENDESK, appInstallationTypeName) })
@@ -99,6 +114,7 @@ describe('addAliasToElements', () => {
   const categoryType = new ObjectType({ elemID: new ElemID(ZENDESK, categoryTypeName) })
   const categoryOrderType = new ObjectType({ elemID: new ElemID(ZENDESK, categoryOrderTypeName) })
   const categoryTranslationType = new ObjectType({ elemID: new ElemID(ZENDESK, categoryTranslationTypeName) })
+  const anotherTranslationType = new ObjectType({ elemID: new ElemID(ZENDESK, anotherTranslationTypeName) })
 
   const localeInstance = new InstanceElement('instance4', localeType, {
     locale: 'en-us', // will be used for category translation
@@ -145,6 +161,17 @@ describe('addAliasToElements', () => {
     const categoryTranslationInstanceInvalid = new InstanceElement('instance9', categoryTranslationType, {
       locale: new ReferenceExpression(localeInstance.elemID),
     })
+    const anotherTranslationInstance = new InstanceElement(
+      'instance10',
+      anotherTranslationType,
+      {
+        locale: 'en-au',
+      },
+      undefined,
+      {
+        _parent: [new ReferenceExpression(categoryInstance.elemID, categoryInstance)],
+      },
+    )
     const elements = [
       appInstallationInstance,
       appInstallationInstanceInvalid,
@@ -155,6 +182,7 @@ describe('addAliasToElements', () => {
       categoryOrderInstance,
       categoryTranslationInstance,
       categoryTranslationInstanceInvalid,
+      anotherTranslationInstance,
     ]
     addAliasToElements({
       elementsMap: groupByTypeName(elements),
@@ -170,9 +198,10 @@ describe('addAliasToElements', () => {
       'category name Category Order',
       'en-us - category name',
       undefined,
+      'en-au - category name',
     ])
   })
-  it('should not crush when one of the values is undefined', async () => {
+  it('should not crash when one of the values is undefined', async () => {
     const appInstallationInstanceInvalid = new InstanceElement('instance2', appInstallationType, {
       settings: { name: undefined },
     })
@@ -183,7 +212,7 @@ describe('addAliasToElements', () => {
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
-  it('should not crush when there is not parent', async () => {
+  it('should not crash when there is not parent', async () => {
     const categoryTranslationInstance = new InstanceElement(
       'instance8',
       categoryTranslationType,
@@ -199,7 +228,7 @@ describe('addAliasToElements', () => {
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
-  it('should not crush when there is a value instead of a reference', async () => {
+  it('should not crash when there is a value instead of a reference when useFieldValueAsFallback = false', async () => {
     const categoryTranslationInstance = new InstanceElement(
       'instance8',
       categoryTranslationType,
@@ -218,7 +247,7 @@ describe('addAliasToElements', () => {
     })
     expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
   })
-  it('should not crush when there is a reference instead of a value', async () => {
+  it('should not crash when there is a reference instead of a value', async () => {
     const dynamicContentItemInstance = new InstanceElement('instance3', dynamicContentItemType, {
       name: new ReferenceExpression(localeInstance.elemID, localeInstance),
     })

--- a/packages/zendesk-adapter/src/filters/add_alias.ts
+++ b/packages/zendesk-adapter/src/filters/add_alias.ts
@@ -147,6 +147,7 @@ const aliasMap: Record<string, AliasData> = {
       {
         fieldName: 'locale_id',
         referenceFieldName: 'locale',
+        useFieldValueAsFallback: true,
       },
     ],
     separator: ' - ',
@@ -324,6 +325,7 @@ const aliasMap: Record<string, AliasData> = {
       {
         fieldName: 'locale',
         referenceFieldName: 'locale',
+        useFieldValueAsFallback: true,
       },
       {
         fieldName: '_parent.0',
@@ -355,6 +357,7 @@ const aliasMap: Record<string, AliasData> = {
       {
         fieldName: 'locale',
         referenceFieldName: 'locale',
+        useFieldValueAsFallback: true,
       },
       {
         fieldName: '_parent.0',
@@ -386,6 +389,7 @@ const aliasMap: Record<string, AliasData> = {
       {
         fieldName: 'locale',
         referenceFieldName: 'locale',
+        useFieldValueAsFallback: true,
       },
       {
         fieldName: '_parent.0',

--- a/packages/zendesk-adapter/test/filters/add_alias.test.ts
+++ b/packages/zendesk-adapter/test/filters/add_alias.test.ts
@@ -137,7 +137,7 @@ describe('add alias filter', () => {
         undefined,
       ])
     })
-    it('should not crush when one of the values is undefined', async () => {
+    it('should not crash when one of the values is undefined', async () => {
       const appInstallationInstanceInvalid = new InstanceElement('instance2', appInstallationType, {
         settings: { name: undefined },
       })
@@ -145,7 +145,7 @@ describe('add alias filter', () => {
       await filter.onFetch(elements)
       expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
     })
-    it('should not crush when there is not parent', async () => {
+    it('should not crash when there is not parent', async () => {
       const categoryTranslationInstance = new InstanceElement(
         'instance8',
         categoryTranslationType,
@@ -158,23 +158,26 @@ describe('add alias filter', () => {
       await filter.onFetch(elements)
       expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
     })
-    it('should not crush when there is a value instead of a reference', async () => {
+    it('should use the value instead of a reference if there is a useFieldValueAsFallback = true', async () => {
       const categoryTranslationInstance = new InstanceElement(
         'instance8',
         categoryTranslationType,
         {
-          locale: 'en-US',
+          locale: 'fallback',
         },
         undefined,
         {
           _parent: [new ReferenceExpression(categoryInstance.elemID, categoryInstance)],
         },
       )
-      const elements = [categoryTranslationInstance]
+      const elements = [categoryInstance, categoryTranslationInstance]
       await filter.onFetch(elements)
-      expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([undefined])
+      expect(elements.map(e => e.annotations[CORE_ANNOTATIONS.ALIAS])).toEqual([
+        'category name',
+        'fallback - category name',
+      ])
     })
-    it('should not crush when there is a reference instead of a value', async () => {
+    it('should not crash when there is a reference instead of a value', async () => {
       const dynamicContentItemInstance = new InstanceElement('instance3', dynamicContentItemType, {
         name: new ReferenceExpression(localeInstance.elemID, localeInstance),
       })


### PR DESCRIPTION
Allow fallback to the string of the alias field if it is not a reference.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
