### PR TITLE
SALTO-7007 Omit inactive (not activated) workspaces

### DIFF
--- a/packages/zendesk-adapter/src/inactive.ts
+++ b/packages/zendesk-adapter/src/inactive.ts
@@ -8,7 +8,7 @@
 import { InstanceElement } from '@salto-io/adapter-api'
 import { definitions, fetch } from '@salto-io/adapter-components'
 import { ZendeskConfig, FETCH_CONFIG, OMIT_INACTIVE_DEFAULT } from './config'
-import { TICKET_FORM_TYPE_NAME, WEBHOOK_TYPE_NAME } from './constants'
+import { TICKET_FORM_TYPE_NAME, WEBHOOK_TYPE_NAME, WORKSPACE_TYPE_NAME } from './constants'
 
 /**
  * Helper for omitting inactive instances during the initial fetch, in order to avoid creating their standalone
@@ -36,6 +36,9 @@ export const filterOutInactiveInstancesForType = (
     if (typeName === WEBHOOK_TYPE_NAME) {
       return instances.filter(instance => instance.value.status !== 'inactive')
     }
+    if (typeName === WORKSPACE_TYPE_NAME) {
+      return instances.filter(instance => instance.value.activated !== false)
+    }
     return instances.filter(instance => instance.value.active !== false)
   }
 }
@@ -59,6 +62,9 @@ export const filterOutInactiveItemForType = (config: ZendeskConfig): ((item: fet
     }
     if (typeName === WEBHOOK_TYPE_NAME) {
       return item.value?.status !== 'inactive'
+    }
+    if (typeName === WORKSPACE_TYPE_NAME) {
+      return item.value?.activated !== false
     }
     return item.value?.active !== false
   }

--- a/packages/zendesk-adapter/test/inactive.test.ts
+++ b/packages/zendesk-adapter/test/inactive.test.ts
@@ -27,6 +27,9 @@ describe('omit inactive', () => {
   const webhook3 = new InstanceElement('webhook3', webhookObjType, { name: 'test' })
   const ticketForm = new ObjectType({ elemID: new ElemID(ZENDESK, 'ticket_form') })
   const ticketForm1 = new InstanceElement('inst1', ticketForm, { name: 'test', active: false })
+  const workspace = new ObjectType({ elemID: new ElemID(ZENDESK, 'workspace') })
+  const workspace1 = new InstanceElement('workspace1', workspace, { title: 'inactive workspace', activated: false })
+  const workspace2 = new InstanceElement('workspace2', workspace, { title: 'active workspace', activated: true })
 
   const activeTicketFieldItem = {
     value: {
@@ -123,6 +126,25 @@ describe('omit inactive', () => {
     context: {},
   }
 
+  const activeWorkspaceItem = {
+    value: {
+      id: 123,
+      title: 'active workspace',
+      activated: true,
+    },
+    typeName: 'workspace',
+    context: {},
+  }
+  const inactiveWorkspaceItem = {
+    value: {
+      id: 123,
+      title: 'inactive workspace',
+      activated: false,
+    },
+    typeName: 'workspace',
+    context: {},
+  }
+
   const valueGeneratedItems = [
     activeTicketFieldItem,
     activeCustomRoleItem,
@@ -131,6 +153,8 @@ describe('omit inactive', () => {
     inactiveViewItem,
     activeWebhookItem,
     inactiveWebhookItem,
+    activeWorkspaceItem,
+    inactiveWorkspaceItem,
   ]
 
   describe('onFetch', () => {
@@ -156,12 +180,16 @@ describe('omit inactive', () => {
           webhook1.elemID.getFullName(),
           webhook3.elemID.getFullName(),
         ])
+        expect(instanceFilter([workspace1, workspace2]).map(elem => elem.elemID.getFullName())).toEqual([
+          workspace2.elemID.getFullName(),
+        ])
         expect(instanceFilter([view1]).map(elem => elem.elemID.getFullName())).toEqual([])
         expect(valueGeneratedItems.filter(item => itemFilter(item))).toEqual([
           activeTicketFieldItem,
           activeCustomRoleItem,
           activeOrganizationFieldItem,
           activeWebhookItem,
+          activeWorkspaceItem,
         ])
       })
       it('should not omit instance of types that we need their inactive instances for reorder', async () => {

--- a/packages/zendesk-adapter/test/inactive.test.ts
+++ b/packages/zendesk-adapter/test/inactive.test.ts
@@ -216,7 +216,7 @@ describe('omit inactive', () => {
           const config = _.cloneDeep(DEFAULT_CONFIG)
           config[FETCH_CONFIG].omitInactive = {
             default: false,
-            customizations: { trigger: true, macro: true, webhook: true, view: true },
+            customizations: { trigger: true, macro: true, webhook: true, view: true, workspace: true },
           }
           itemFilter = filterOutInactiveItemForType(config)
           instanceFilter = filterOutInactiveInstancesForType(config)
@@ -232,11 +232,15 @@ describe('omit inactive', () => {
             webhook1.elemID.getFullName(),
             webhook3.elemID.getFullName(),
           ])
+          expect(instanceFilter([workspace1, workspace2]).map(elem => elem.elemID.getFullName())).toEqual([
+            workspace2.elemID.getFullName(),
+          ])
           expect(valueGeneratedItems.filter(item => itemFilter(item))).toEqual([
             activeTicketFieldItem,
             activeCustomRoleItem,
             activeOrganizationFieldItem,
             activeWebhookItem,
+            activeWorkspaceItem,
           ])
         })
       })
@@ -262,6 +266,10 @@ describe('omit inactive', () => {
             webhook1.elemID.getFullName(),
             webhook2.elemID.getFullName(),
             webhook3.elemID.getFullName(),
+          ])
+          expect(instanceFilter([workspace1, workspace2]).map(elem => elem.elemID.getFullName())).toEqual([
+            workspace1.elemID.getFullName(),
+            workspace2.elemID.getFullName(),
           ])
           expect(valueGeneratedItems.filter(item => itemFilter(item))).toEqual(valueGeneratedItems)
         })


### PR DESCRIPTION
Omit explicitly inactive workspaces as they have a different indicator field

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
__Zendesk Adapter:__
* Bug fix: inactive workspaces will be removed if omitInactive is set.