### PR TITLE
SALTO-6759 Jamf: revert omitting payloads in configuration profiles

### DIFF
--- a/packages/jamf-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/fetch.ts
@@ -406,7 +406,7 @@ const createCustomizations = (
         },
         transformation: {
           root: 'os_x_configuration_profile',
-          omit: ['general.uuid', 'general.payloads'],
+          omit: ['general.uuid'],
           adjust: transforms.adjustConfigurationProfile,
         },
       },
@@ -465,7 +465,7 @@ const createCustomizations = (
         },
         transformation: {
           root: 'configuration_profile',
-          omit: ['general.uuid', 'general.payloads'],
+          omit: ['general.uuid'],
           adjust: transforms.adjustConfigurationProfile,
         },
       },


### PR DESCRIPTION
SALTO-6759 Jamf: revert omitting payloads in configuration profiles - will mask the relevant password instead

---

_Additional context for reviewer_
https://github.com/salto-io/salto/pull/6875

---
_Release Notes_: 
None

---
_User Notifications_: 
None
