### PR TITLE
SALTO-6969: Add service URL support for Microsoft Entra elements

### DIFF
--- a/packages/microsoft-security-adapter/src/constants/entra.ts
+++ b/packages/microsoft-security-adapter/src/constants/entra.ts
@@ -12,6 +12,8 @@ const { recursiveNestedTypeName } = fetchUtils.element
 
 const toEntraTypeName = (typeName: string): string => `Entra${typeName}`
 
+export const SERVICE_BASE_URL = 'https://entra.microsoft.com'
+
 /* Fields */
 export const APP_ROLE_ASSIGNMENT_FIELD_NAME = 'appRoleAssignments'
 export const APP_ROLES_FIELD_NAME = 'appRoles'

--- a/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
@@ -23,6 +23,7 @@ import { CONTEXT_LIFE_CYCLE_POLICY_MANAGED_GROUP_TYPES } from '../../../constant
 import { createCustomizationsWithBasePathForFetch } from '../shared/utils'
 
 const {
+  SERVICE_BASE_URL,
   SERVICE_PRINCIPAL_APP_ROLE_ASSIGNMENT_TYPE_NAME,
   CUSTOM_SECURITY_ATTRIBUTE_ALLOWED_VALUES_TYPE_NAME,
   DELEGATED_PERMISSION_CLASSIFICATION_TYPE_NAME,
@@ -67,6 +68,7 @@ const APP_ROLES_FIELD_CUSTOMIZATIONS = {
   },
 }
 
+// TODO SALTO-6996: Add service url to missing instances once we can use a custom function to generate it
 const graphV1Customizations: FetchCustomizations = {
   [GROUP_TYPE_NAME]: {
     requests: [
@@ -150,6 +152,10 @@ const graphV1Customizations: FetchCustomizations = {
     element: {
       topLevel: {
         isTopLevel: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_IAM/GroupDetailsMenuBlade/~/Overview/groupId/{id}',
+        },
       },
       fieldCustomizations: {
         ...ID_FIELD_TO_HIDE,
@@ -204,6 +210,10 @@ const graphV1Customizations: FetchCustomizations = {
       topLevel: {
         isTopLevel: true,
         singleton: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_IAM/GroupsManagementMenuBlade/~/Lifecycle/menuId/Overview',
+        },
       },
       fieldCustomizations: ID_FIELD_TO_HIDE,
     },
@@ -528,6 +538,10 @@ const graphV1Customizations: FetchCustomizations = {
     element: {
       topLevel: {
         isTopLevel: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_ConditionalAccess/AuthStrengths.ReactView',
+        },
       },
       fieldCustomizations: ID_FIELD_TO_HIDE,
     },
@@ -632,6 +646,10 @@ const graphV1Customizations: FetchCustomizations = {
         elemID: {
           parts: [{ fieldName: 'id' }],
         },
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_IAM/DomainDnsRecordsBlade/domainName/{id}',
+        },
       },
     },
   },
@@ -724,6 +742,10 @@ const graphBetaCustomizations: FetchCustomizations = {
     element: {
       topLevel: {
         isTopLevel: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_IAM/AdminUnitDetailsMenuBlade/~/AdminUnitPropertiesPreview/adminUnitId/{id}/adminUnitName/{displayName}',
+        },
       },
       fieldCustomizations: ID_FIELD_TO_HIDE,
     },
@@ -791,6 +813,10 @@ const graphBetaCustomizations: FetchCustomizations = {
     element: {
       topLevel: {
         isTopLevel: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_ConditionalAccess/PolicyBlade/policyId/{id}',
+        },
       },
       fieldCustomizations: ID_FIELD_TO_HIDE,
     },
@@ -810,6 +836,10 @@ const graphBetaCustomizations: FetchCustomizations = {
     element: {
       topLevel: {
         isTopLevel: true,
+        serviceUrl: {
+          baseUrl: SERVICE_BASE_URL,
+          path: '/#view/Microsoft_AAD_ConditionalAccess/ConditionalAccessBlade/~/NamedLocations',
+        },
       },
       fieldCustomizations: ID_FIELD_TO_HIDE,
     },


### PR DESCRIPTION
Add service url to specific Entra instances.
Some types requires service url customization (for example we need the negation of some value in the url), which is not supported yet.

---
_Release Notes_: 
_Microsoft Security adapter:_
* Add service url to specific Entra instances.

---
_User Notifications_: 