### PR TITLE
SALTO-6995: fix element-test-utils export

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -24,6 +24,9 @@
       ],
       "ignoreDependencies": ["webpack-cli"]
     },
+    "packages/element-test-utils": {
+      "entry": ["index.ts", "src/all.ts"]
+    },
     "packages/local-workspace": {
       "entry": "index.ts",
       "ignoreDependencies": ["@types/leveldown", "@types/webpack-env"]

--- a/packages/element-test-utils/package.json
+++ b/packages/element-test-utils/package.json
@@ -11,7 +11,8 @@
     "access": "public"
   },
   "files": [
-    "dist/src"
+    "dist/src",
+    "dist/index.*"
   ],
   "types": "dist/src/index.d.ts",
   "scripts": {
@@ -27,8 +28,8 @@
     "check-format": "prettier --check . --ignore-path=../../.prettierignore --ignore-path=../../.gitignore --ignore-path=.gitignore"
   },
   "exports": {
-    ".": "./index.ts",
-    "./all": "./src/all.ts"
+    ".": "./dist/index.js",
+    "./all": "./dist/src/all.js"
   },
   "dependencies": {
     "@salto-io/adapter-api": "0.4.6"


### PR DESCRIPTION
The exports section in the package pointed to files that were not exported

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_