### PR TITLE
SALTO-7021 return missing required field validation error on the parent elemID

### DIFF
--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -653,7 +653,7 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0].message).toMatch('Field reqStr is required but has no value')
-          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqStr'))
+          expect(errors[0].elemID).toEqual(extInst.elemID)
         })
 
         it('should return error when required object field is missing', async () => {
@@ -668,7 +668,7 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0].message).toMatch(`Field ${extType.fields.reqNested.name} is required but has no value`)
-          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested'))
+          expect(errors[0].elemID).toEqual(extInst.elemID)
         })
 
         it('should return error when lists elements missing required fields', async () => {
@@ -700,7 +700,7 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0].message).toMatch(`Field ${simpleType.fields.bool.name} is required but has no value`)
-          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', '1', 'bool'))
+          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', '1'))
         })
 
         it('should return error when element inside a map is missing a required field', async () => {
@@ -725,7 +725,7 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0].message).toMatch(`Field ${simpleType.fields.bool.name} is required but has no value`)
-          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', 'b', 'bool'))
+          expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('reqNested', 'b'))
         })
 
         it('should not return validation errors when the value is a legal reference', async () => {
@@ -1460,7 +1460,7 @@ describe('Elements validation', () => {
         )
         expect(errors).toHaveLength(2)
         expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested'))
-        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('nested', 'bool'))
+        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('nested'))
       })
 
       it('should not return error on list/primitive mismatch if inner type is valid', async () => {
@@ -1509,7 +1509,7 @@ describe('Elements validation', () => {
         )
         expect(errors).toContainEqual(
           expect.objectContaining({
-            elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid1', 'bool'),
+            elemID: extInst.elemID.createNestedID('mapOfObject', 'invalid1'),
             error: 'Field bool is required but has no value',
           }),
         )
@@ -1576,7 +1576,7 @@ describe('Elements validation', () => {
           createInMemoryElementSource([extInst, nestedType, ...(await getFieldsAndAnnoTypes(nestedType))]),
         )
         expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested', '1', 'bool'))
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('nested', '1'))
       })
 
       it('should not return error list/object mismatch with non-empty valid array', async () => {
@@ -1701,7 +1701,7 @@ describe('Elements validation', () => {
           createInMemoryElementSource([extInst, nestedType, ...(await getFieldsAndAnnoTypes(nestedType))]),
         )
         expect(errors).toHaveLength(1)
-        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', '1', 'bool'))
+        expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', '1'))
       })
 
       it('should return an error when primitive instead of list object item', async () => {
@@ -1713,7 +1713,7 @@ describe('Elements validation', () => {
         expect(errors).toHaveLength(2)
         expect(errors[0].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', '1'))
         // TODO: The second error is a strange UX and we should not have it
-        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', '1', 'bool'))
+        expect(errors[1].elemID).toEqual(extInst.elemID.createNestedID('listOfObject', '1'))
       })
 
       it('should return error list item mismatch', async () => {


### PR DESCRIPTION
When there's a missing required field, we currently return the error on the missing field's elemID itself, which means that we can't get the location of the error in a nacl file (since it doesn't exist). In that case we should return the `MissingRequiredFieldValidationError` error on the parent elemID.
In case of an empty list, we return the same error if the field is required. In that case we still return the elemID of the list, because it exists.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None