### PR TITLE
SALTO-7024: Using custom resolver in SFDX dump

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -486,7 +486,10 @@ export const salesforceAdapterResolveValues: ResolveValuesFunc = async (
     : resolvedElement
 }
 
-export const resolveChanges = (changes: readonly Change[], getLookupNameFunc: GetLookupNameFunc): Promise<Change[]> =>
+export const resolveSalesforceChanges = (
+  changes: readonly Change[],
+  getLookupNameFunc: GetLookupNameFunc,
+): Promise<Change[]> =>
   Promise.all(changes.map(change => resolveChangeElement(change, getLookupNameFunc, salesforceAdapterResolveValues)))
 
 type SalesforceAdapterOperations = Omit<AdapterOperations, 'deploy' | 'validate'> & {
@@ -734,7 +737,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
     const getLookupNameFunc = isDataDeployGroup
       ? getLookupNameForDataInstances(fetchProfile)
       : getLookUpName(fetchProfile)
-    const resolvedChanges = await resolveChanges(changeGroup.changes, getLookupNameFunc)
+    const resolvedChanges = await resolveSalesforceChanges(changeGroup.changes, getLookupNameFunc)
 
     await awu(resolvedChanges).filter(isAdditionChange).map(getChangeData).forEach(addDefaults)
     const filtersRunner = this.createFiltersRunner({ fetchProfile })

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -28,7 +28,14 @@ import {
   isObjectType,
   TypeReference,
 } from '@salto-io/adapter-api'
-import { filter, inspectValue, logDuration, ResolveValuesFunc, safeJsonStringify } from '@salto-io/adapter-utils'
+import {
+  filter,
+  GetLookupNameFunc,
+  inspectValue,
+  logDuration,
+  ResolveValuesFunc,
+  safeJsonStringify,
+} from '@salto-io/adapter-utils'
 import { resolveChangeElement, resolveValues, restoreChangeElement } from '@salto-io/adapter-components'
 import { MetadataObject } from '@salto-io/jsforce'
 import _ from 'lodash'
@@ -479,6 +486,9 @@ export const salesforceAdapterResolveValues: ResolveValuesFunc = async (
     : resolvedElement
 }
 
+export const resolveChanges = (changes: readonly Change[], getLookupNameFunc: GetLookupNameFunc): Promise<Change[]> =>
+  Promise.all(changes.map(change => resolveChangeElement(change, getLookupNameFunc, salesforceAdapterResolveValues)))
+
 type SalesforceAdapterOperations = Omit<AdapterOperations, 'deploy' | 'validate'> & {
   deploy: (deployOptions: SalesforceAdapterDeployOptions) => Promise<DeployResult>
   validate: (deployOptions: SalesforceAdapterDeployOptions) => Promise<DeployResult>
@@ -724,9 +734,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
     const getLookupNameFunc = isDataDeployGroup
       ? getLookupNameForDataInstances(fetchProfile)
       : getLookUpName(fetchProfile)
-    const resolvedChanges = await awu(changeGroup.changes)
-      .map(change => resolveChangeElement(change, getLookupNameFunc, salesforceAdapterResolveValues))
-      .toArray()
+    const resolvedChanges = await resolveChanges(changeGroup.changes, getLookupNameFunc)
 
     await awu(resolvedChanges).filter(isAdditionChange).map(getChangeData).forEach(addDefaults)
     const filtersRunner = this.createFiltersRunner({ fetchProfile })

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -13,7 +13,7 @@ import { AdapterFormat, Change, getChangeData, isField, isObjectType } from '@sa
 import { resolveChangeElement } from '@salto-io/adapter-components'
 import { filter } from '@salto-io/adapter-utils'
 import { collections, objects, promises, values } from '@salto-io/lowerdash'
-import { allFilters, NESTED_METADATA_TYPES } from '../adapter'
+import { allFilters, NESTED_METADATA_TYPES, salesforceAdapterResolveValues } from '../adapter'
 import { CUSTOM_METADATA, SYSTEM_FIELDS, UNSUPPORTED_SYSTEM_FIELDS, API_NAME } from '../constants'
 import { getLookUpName } from '../transformers/reference_mapping'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
@@ -146,7 +146,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
   })
 
   const resolvedChanges = await awu(supportedMetadataChanges)
-    .map(change => resolveChangeElement(change, getLookUpName(fetchProfile)))
+    .map(change => resolveChangeElement(change, getLookUpName(fetchProfile), salesforceAdapterResolveValues))
     .toArray()
   const filterRunner = filter.filtersRunner(
     {

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -10,10 +10,9 @@ import path from 'path'
 import { isSubDirectory, rm } from '@salto-io/file'
 import { logger } from '@salto-io/logging'
 import { AdapterFormat, Change, getChangeData, isField, isObjectType } from '@salto-io/adapter-api'
-import { resolveChangeElement } from '@salto-io/adapter-components'
 import { filter } from '@salto-io/adapter-utils'
-import { collections, objects, promises, values } from '@salto-io/lowerdash'
-import { allFilters, NESTED_METADATA_TYPES, salesforceAdapterResolveValues } from '../adapter'
+import { objects, promises, values } from '@salto-io/lowerdash'
+import { allFilters, NESTED_METADATA_TYPES, resolveChanges } from '../adapter'
 import { CUSTOM_METADATA, SYSTEM_FIELDS, UNSUPPORTED_SYSTEM_FIELDS, API_NAME } from '../constants'
 import { getLookUpName } from '../transformers/reference_mapping'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
@@ -39,7 +38,6 @@ import { detailedMessageFromSfError } from './errors'
 import { loadElementsFromFolder } from './sfdx_parser'
 
 const log = logger(module)
-const { awu } = collections.asynciterable
 const { withLimitedConcurrency } = promises.array
 
 const FILE_DELETE_CONCURRENCY = 100
@@ -145,9 +143,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     fetchParams: {},
   })
 
-  const resolvedChanges = await awu(supportedMetadataChanges)
-    .map(change => resolveChangeElement(change, getLookUpName(fetchProfile), salesforceAdapterResolveValues))
-    .toArray()
+  const resolvedChanges = await resolveChanges(supportedMetadataChanges, getLookUpName(fetchProfile))
   const filterRunner = filter.filtersRunner(
     {
       config: {

--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -12,7 +12,7 @@ import { logger } from '@salto-io/logging'
 import { AdapterFormat, Change, getChangeData, isField, isObjectType } from '@salto-io/adapter-api'
 import { filter } from '@salto-io/adapter-utils'
 import { objects, promises, values } from '@salto-io/lowerdash'
-import { allFilters, NESTED_METADATA_TYPES, resolveChanges } from '../adapter'
+import { allFilters, NESTED_METADATA_TYPES, resolveSalesforceChanges } from '../adapter'
 import { CUSTOM_METADATA, SYSTEM_FIELDS, UNSUPPORTED_SYSTEM_FIELDS, API_NAME } from '../constants'
 import { getLookUpName } from '../transformers/reference_mapping'
 import { buildFetchProfile } from '../fetch_profile/fetch_profile'
@@ -143,7 +143,7 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     fetchParams: {},
   })
 
-  const resolvedChanges = await resolveChanges(supportedMetadataChanges, getLookUpName(fetchProfile))
+  const resolvedChanges = await resolveSalesforceChanges(supportedMetadataChanges, getLookUpName(fetchProfile))
   const filterRunner = filter.filtersRunner(
     {
       config: {


### PR DESCRIPTION
This is required for OrderedMaps.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_:
None.
