### PR TITLE
SALTO-7026: Hiding types folder in E2E tests

### DIFF
--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -179,13 +179,7 @@ export const runFetch = async (
       ...(inputEnvironment ? ['-e', inputEnvironment] : []),
       '-m',
       isolated ? 'isolated' : 'override',
-      ...(configOverrides ?? [])
-        // Temporary workaround until https://salto-io.atlassian.net/browse/SALTO-5544 is implemented
-        .concat([
-          'salesforce.fetch.optionalFeatures.hideTypesFolder=false',
-          'e2esalesforce.fetch.optionalFeatures.hideTypesFolder=false',
-        ])
-        .flatMap(override => ['-C', override]),
+      ...(configOverrides ?? []).flatMap(override => ['-C', override]),
     ],
   })
   expect(result).toEqual(CliExitCode.Success)


### PR DESCRIPTION
It's time.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
