### PR TITLE
SALTO-6166: Avoid serializing redundant values

### DIFF
--- a/packages/workspace/src/serializer/elements.ts
+++ b/packages/workspace/src/serializer/elements.ts
@@ -34,6 +34,7 @@ import {
   isTypeReference,
   isVariableExpression,
   PlaceholderObjectType,
+  isField,
 } from '@salto-io/adapter-api'
 import { DuplicateAnnotationError, MergeError, isMergeError } from '../merger/internal/common'
 import { DuplicateInstanceKeyError } from '../merger/internal/instances'
@@ -191,7 +192,7 @@ export const serializeStream = async <T = Element>({
 
   const elemIdReplacer = (
     id: ElemID,
-  ): Omit<types.PickDataFields<ElemID>, 'nestingLevel' | 'name'> & { readonly nameParts: ReadonlyArray<string> } => ({
+  ): Pick<ElemID, 'adapter' | 'typeName' | 'idType'> & { readonly nameParts: ReadonlyArray<string> } => ({
     adapter: id.adapter,
     typeName: id.typeName,
     idType: id.idType,
@@ -200,12 +201,14 @@ export const serializeStream = async <T = Element>({
 
   const referenceExpressionReplacer = (e: ReferenceExpression): ReferenceExpression & SerializedClass => {
     if (e.value === undefined || referenceSerializerMode === 'keepRef' || !isVariableExpression(e)) {
-      return saltoClassReplacer(e.createWithValue(undefined))
+      // eslint-disable-next-line no-use-before-define
+      return saltoClassReplacer(_.cloneDeepWith(e.createWithValue(undefined), replacer))
     }
     // Replace ref with value in order to keep the result from changing between
     // a fetch and a deploy.
     if (isElement(e.value)) {
-      return saltoClassReplacer(new ReferenceExpression(e.value.elemID))
+      // eslint-disable-next-line no-use-before-define
+      return saltoClassReplacer(_.cloneDeepWith(new ReferenceExpression(e.value.elemID), replacer))
     }
     // eslint-disable-next-line no-use-before-define
     return _.cloneDeepWith(e.value, replacer)
@@ -215,19 +218,30 @@ export const serializeStream = async <T = Element>({
     isPrimitiveType(v)
       ? new PrimitiveType({ elemID: v.elemID, primitive: v.primitive })
       : new ObjectType({ elemID: v.elemID })
+
   const referenceTypeReplacer = (e: TypeReference): TypeReference & SerializedClass => {
     if (referenceSerializerMode === 'keepRef') {
       if (isType(e.type) && !isContainerType(e.type)) {
-        return saltoClassReplacer(new TypeReference(e.elemID, resolveCircles(e.type)))
+        // eslint-disable-next-line no-use-before-define
+        return saltoClassReplacer(_.cloneDeepWith(new TypeReference(e.elemID, resolveCircles(e.type)), replacer))
       }
     }
-    return saltoClassReplacer(new TypeReference(e.elemID))
+    // eslint-disable-next-line no-use-before-define
+    return saltoClassReplacer(_.cloneDeepWith(new TypeReference(e.elemID), replacer))
   }
 
+  const fieldReplacer = (field: Field): Pick<Field, 'elemID' | 'annotations' | 'refType'> & SerializedClass =>
+    // eslint-disable-next-line no-use-before-define
+    _.cloneDeepWith(_.pick(saltoClassReplacer(field), SALTO_CLASS_FIELD, 'elemID', 'annotations', 'refType'), replacer)
+
+  const replacerRootMarker = Symbol('root marker for replacer')
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const replacer = (v: any, k: any): any => {
     if (k !== undefined) {
-      if (isType(v) && !isContainerType(v)) {
+      if (k !== replacerRootMarker && isType(v) && !isContainerType(v)) {
+        // If we encounter a type anywhere except at the root, we serialize a placeholder instead
+        // this shouldn't actually happen, but worth protecting against because if it does happen
+        // it will cause a cycle and make the subsequent JSON.stringify fail
         return saltoClassReplacer(resolveCircles(v))
       }
       if (isReferenceExpression(v)) {
@@ -239,6 +253,9 @@ export const serializeStream = async <T = Element>({
       if (isStaticFile(v)) {
         return staticFileReplacer(v)
       }
+      if (isField(v)) {
+        return fieldReplacer(v)
+      }
       if (isSaltoSerializable(v)) {
         return saltoClassReplacer(_.cloneDeepWith(v, replacer))
       }
@@ -248,14 +265,9 @@ export const serializeStream = async <T = Element>({
     }
     return undefined
   }
-  const clonedElements = elements.map(element => {
-    if (isElement(element)) {
-      const clone = _.cloneDeepWith(element, replacer)
-      return isSaltoSerializable(element) ? saltoClassReplacer(clone) : clone
-    }
-    const clone = _.cloneDeepWith({ element }, replacer)
-    return clone.element
-  })
+  const clonedElements = elements.map(element =>
+    isSaltoSerializable(element) ? replacer(element, replacerRootMarker) : _.cloneDeepWith(element, replacer),
+  )
 
   // Avoiding Promise.all to not reach Promise.all limit
   await awu(promises).forEach(promise => promise)

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -325,6 +325,7 @@ describe('State/cache serialization', () => {
       const serialized = await serialize([reference])
       expect(serialized).toContain('ReferenceExpression')
       expect(serialized).not.toContain('ObjectType')
+      expect(serialized).not.toContain('fullName')
       expect(await deserializeValues(serialized)).toEqual([reference.createWithValue(undefined)])
     })
     it('should serialize and deserialize type references', async () => {
@@ -333,6 +334,7 @@ describe('State/cache serialization', () => {
       const serialized = await serialize([reference])
       expect(serialized).toContain('TypeReference')
       expect(serialized).not.toContain('ObjectType')
+      expect(serialized).not.toContain('fullName')
       expect(await deserializeValues(serialized)).toEqual([new TypeReference(reference.elemID)])
     })
     it('should serialize and deserialize static files', async () => {
@@ -354,6 +356,16 @@ describe('State/cache serialization', () => {
       expect(mockStaticFileReviver).toHaveBeenCalledWith(
         new StaticFile({ filepath: staticFile.filepath, hash: staticFile.hash }),
       )
+    })
+    it('should serialize fields without values that are not used for deserialize', async () => {
+      const obj = new ObjectType({
+        elemID: new ElemID('dummy', 'test'),
+        fields: { field: { refType: BuiltinTypes.STRING } },
+      })
+      const fieldToSerialize = obj.fields.field
+      const serialized = await serialize([obj, fieldToSerialize])
+      expect(serialized).not.toContain('parent')
+      expect(serialized).not.toContain('fullName')
     })
   })
 

--- a/packages/workspace/test/serializer/serializer.test.ts
+++ b/packages/workspace/test/serializer/serializer.test.ts
@@ -357,7 +357,7 @@ describe('State/cache serialization', () => {
         new StaticFile({ filepath: staticFile.filepath, hash: staticFile.hash }),
       )
     })
-    it('should serialize fields without values that are not used for deserialize', async () => {
+    it('serialized fields should not contain values that are not used for deserialize', async () => {
       const obj = new ObjectType({
         elemID: new ElemID('dummy', 'test'),
         fields: { field: { refType: BuiltinTypes.STRING } },


### PR DESCRIPTION
When serializing element IDs and Fields, only write the attributes that are needed to deserialize

---

_Additional context for reviewer_
On an example workspace (relatively small salesforce environment) - this reduced the overall size of the cache (rocksdb)  from 21MB to 14MB
most likely, this would mostly scale with the number of references in the workspace...

---
_Release Notes_: 
Core:
- Reduced size of state file and cache

---
_User Notifications_: 
_None_