### PR TITLE
SALTO-7027: (Bug-fix) Salesforce OrderedMap types are missing from the workspace

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -452,7 +452,7 @@ type CreateFiltersRunnerParams = {
   contextOverrides?: Partial<FilterContext>
 }
 
-const isOrderedMapTypeOrRefType = (typeRef: TypeElement | TypeReference): boolean =>
+export const isOrderedMapTypeOrRefType = (typeRef: TypeElement | TypeReference): boolean =>
   typeRef.elemID.name.startsWith(ORDERED_MAP_PREFIX)
 
 const isFieldWithOrderedMapAnnotation = (field: Field): boolean =>

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -32,7 +32,6 @@ import {
   TypeElement,
   ElemID,
   isObjectTypeChange,
-  BuiltinTypes,
   isPrimitiveType,
   isReferenceExpression,
   isElement,
@@ -103,11 +102,14 @@ export const createOrderedMapType = <T extends TypeElement>(innerType: T): Objec
         },
       },
       [ORDERED_MAP_ORDER_FIELD]: {
-        refType: new ListType(BuiltinTypes.STRING),
+        refType: new ListType(innerType),
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
         },
       },
+    },
+    annotations: {
+      [CORE_ANNOTATIONS.HIDDEN]: true,
     },
   })
 
@@ -387,8 +389,8 @@ const updateFieldTypes = async (
   instanceType: ObjectType | TypeElement,
   nonUniqueMapFields: string[],
   instanceMapFieldDef: Record<string, MapDef>,
-): Promise<void> => {
-  await awu(Object.entries(instanceMapFieldDef)).forEach(async ([fieldName, mapDef]) => {
+): Promise<ObjectType[]> =>
+  awu(Object.entries(instanceMapFieldDef)).reduce<ObjectType[]>(async (acc, [fieldName, mapDef]) => {
     const field = await getField(instanceType, fieldName.split('.'))
     if (isDefined(field)) {
       const fieldType = await field.getType()
@@ -401,7 +403,9 @@ const updateFieldTypes = async (
         if (mapDef.nested) {
           field.refType = createRefToElmWithValue(new MapType(new MapType(innerType)))
         } else if (mapDef.maintainOrder) {
-          field.refType = createRefToElmWithValue(createOrderedMapType(innerType))
+          const orderedMapType = createOrderedMapType(innerType)
+          acc.push(orderedMapType)
+          field.refType = createRefToElmWithValue(orderedMapType)
         } else {
           field.refType = createRefToElmWithValue(new MapType(innerType))
         }
@@ -412,21 +416,21 @@ const updateFieldTypes = async (
           const keyFieldType = deepInnerType.fields[mapDef.key]
           if (!keyFieldType) {
             log.error('could not find key field %s for field %s', mapDef.key, field.elemID.getFullName())
-            return
+            return acc
           }
           keyFieldType.annotations[CORE_ANNOTATIONS.REQUIRED] = true
         }
       }
     }
-  })
-}
+    return acc
+  }, [])
 
 const updateAnnotationRefTypes = async (
   typeElement: TypeElement,
   nonUniqueMapFields: string[],
   mapFieldDef: Record<string, MapDef>,
-): Promise<void> => {
-  await awu(Object.entries(mapFieldDef)).forEach(async ([fieldName, mapDef]) => {
+): Promise<ObjectType[]> =>
+  awu(Object.entries(mapFieldDef)).reduce<ObjectType[]>(async (acc, [fieldName, mapDef]) => {
     const fieldType = _.get(typeElement.annotationRefTypes, fieldName).type
     // navigate to the right field type
     if (isDefined(fieldType) && !isMapType(fieldType)) {
@@ -437,7 +441,9 @@ const updateAnnotationRefTypes = async (
       if (mapDef.nested) {
         typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(new MapType(new MapType(innerType)))
       } else if (mapDef.maintainOrder) {
-        typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(createOrderedMapType(innerType))
+        const orderedMapType = createOrderedMapType(innerType)
+        acc.push(orderedMapType)
+        typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(orderedMapType)
       } else {
         typeElement.annotationRefTypes[fieldName] = createRefToElmWithValue(new MapType(innerType))
       }
@@ -448,13 +454,13 @@ const updateAnnotationRefTypes = async (
         const keyFieldType = deepInnerType.fields[mapDef.key]
         if (!keyFieldType) {
           log.error('could not find key field %s for type %s', mapDef.key, fieldType.elemID.getFullName())
-          return
+          return acc
         }
         keyFieldType.annotations[CORE_ANNOTATIONS.REQUIRED] = true
       }
     }
-  })
-}
+    return acc
+  }, [])
 
 const convertElementFieldsToMaps = async (
   elementsToConvert: Element[],
@@ -625,39 +631,45 @@ const filter: FilterCreator = ({ config }) => ({
     const metadataTypeToFieldToMapDef = getMetadataTypeToFieldToMapDef(config.fetchProfile)
     const annotationDefsByType = getAnnotationDefsByType(config.fetchProfile)
 
-    await awu(Object.keys(metadataTypeToFieldToMapDef)).forEach(async targetMetadataType => {
-      const instancesToConvert = findInstancesToConvert(elements, targetMetadataType)
-      const typeToConvert = findTypeToConvert(elements, targetMetadataType)
-      const mapFieldDef = metadataTypeToFieldToMapDef[targetMetadataType]
-      if (isDefined(typeToConvert)) {
-        if (instancesToConvert.length === 0) {
-          await updateFieldTypes(typeToConvert, [], mapFieldDef)
-        } else {
+    await awu(Object.keys(metadataTypeToFieldToMapDef))
+      .flatMap<ObjectType>(async targetMetadataType => {
+        const instancesToConvert = findInstancesToConvert(elements, targetMetadataType)
+        const typeToConvert = findTypeToConvert(elements, targetMetadataType)
+        const mapFieldDef = metadataTypeToFieldToMapDef[targetMetadataType]
+        if (isDefined(typeToConvert)) {
+          if (instancesToConvert.length === 0) {
+            return updateFieldTypes(typeToConvert, [], mapFieldDef)
+          }
           const nonUniqueMapFields = await convertElementFieldsToMaps(
             instancesToConvert,
             mapFieldDef,
             targetMetadataType,
           )
-          await updateFieldTypes(typeToConvert, nonUniqueMapFields, mapFieldDef)
+          return updateFieldTypes(typeToConvert, nonUniqueMapFields, mapFieldDef)
         }
-      }
-    })
+        return []
+      })
+      .uniquify(newType => newType.elemID.getFullName())
+      .forEach(newType => elements.push(newType))
 
     const fields = elements.filter(isObjectType).flatMap(obj => Object.values(obj.fields))
     const primitiveTypesByName = _.keyBy(elements.filter(isPrimitiveType), e => e.elemID.name)
-    await awu(Object.entries(annotationDefsByType)).forEach(async ([fieldTypeName, annotationToMapDef]) => {
-      const fieldType = primitiveTypesByName[fieldTypeName]
-      if (fieldType === undefined) {
-        log.warn('Cannot find PrimitiveType %s. Skipping converting Fields of this type to maps', fieldTypeName)
-        return
-      }
-      const fieldsToConvert = fields.filter(field => fieldType.elemID.isEqual(field.getTypeSync().elemID))
-      if (fieldsToConvert.length === 0) {
-        return
-      }
-      const nonUniqueMapFields = await convertElementFieldsToMaps(fieldsToConvert, annotationToMapDef, fieldTypeName)
-      await updateAnnotationRefTypes(fieldType, nonUniqueMapFields, annotationToMapDef)
-    })
+    await awu(Object.entries(annotationDefsByType))
+      .flatMap<ObjectType>(async ([fieldTypeName, annotationToMapDef]) => {
+        const fieldType = primitiveTypesByName[fieldTypeName]
+        if (fieldType === undefined) {
+          log.warn('Cannot find PrimitiveType %s. Skipping converting Fields of this type to maps', fieldTypeName)
+          return []
+        }
+        const fieldsToConvert = fields.filter(field => fieldType.elemID.isEqual(field.getTypeSync().elemID))
+        if (fieldsToConvert.length === 0) {
+          return []
+        }
+        const nonUniqueMapFields = await convertElementFieldsToMaps(fieldsToConvert, annotationToMapDef, fieldTypeName)
+        return updateAnnotationRefTypes(fieldType, nonUniqueMapFields, annotationToMapDef)
+      })
+      .uniquify(newType => newType.elemID.getFullName())
+      .forEach(newType => elements.push(newType))
   },
 
   preDeploy: async changes => {

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -29,7 +29,7 @@ import { FilterWith } from './mocks'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { FIELD_ANNOTATIONS, ORDERED_MAP_PREFIX } from '../../src/constants'
 import { getLookUpName } from '../../src/transformers/reference_mapping'
-import { salesforceAdapterResolveValues } from '../../src/adapter'
+import { isOrderedMapTypeOrRefType, salesforceAdapterResolveValues } from '../../src/adapter'
 
 type layoutAssignmentType = { layout: string; recordType?: string }
 
@@ -798,6 +798,12 @@ describe('Convert maps filter', () => {
         expect(valueSetType.type?.fields.values.refType.elemID.typeName).toEqual('Map<salesforce.valueSet>')
         expect(valueSetType.type?.fields.order.refType.elemID.typeName).toEqual('List<string>')
         expect(picklistType.annotationRefTypes.valueSet?.elemID.name).toEqual(`${ORDERED_MAP_PREFIX}valueSet`)
+        expect(
+          elements
+            .filter(isObjectType)
+            .filter(isOrderedMapTypeOrRefType)
+            .map(orderedMapType => orderedMapType.elemID.name),
+        ).toEqual([`${ORDERED_MAP_PREFIX}valueSet`])
       })
 
       it('should convert MultiselectPicklist valueSet type to ordered map', async () => {
@@ -809,6 +815,12 @@ describe('Convert maps filter', () => {
         expect(multiselectPicklistType.annotationRefTypes.valueSet?.elemID.name).toEqual(
           `${ORDERED_MAP_PREFIX}valueSet`,
         )
+        expect(
+          elements
+            .filter(isObjectType)
+            .filter(isOrderedMapTypeOrRefType)
+            .map(orderedMapType => orderedMapType.elemID.name),
+        ).toEqual([`${ORDERED_MAP_PREFIX}valueSet`])
       })
 
       it('should convert annotation value to map (Picklist)', () => {


### PR DESCRIPTION
(Bug-fix) Salesforce OrderedMap types are missing from the workspace

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
