### PR TITLE
Fix NS config suggestions when there are config overrides

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.ts
@@ -63,7 +63,7 @@ export const realAdapter = (
     client,
     elementsSource: buildElementsSourceFromElements(elements),
     config: config ?? { fetch: fullFetchConfig() },
-    userConfig: config ?? { fetch: fullFetchConfig() },
+    originalConfig: config ?? { fetch: fullFetchConfig() },
     ...(adapterParams || { getElemIdFunc: mockGetElemIdFunc }),
   })
   return { client, adapter }

--- a/packages/netsuite-adapter/e2e_test/adapter.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.ts
@@ -63,6 +63,7 @@ export const realAdapter = (
     client,
     elementsSource: buildElementsSourceFromElements(elements),
     config: config ?? { fetch: fullFetchConfig() },
+    userConfig: config ?? { fetch: fullFetchConfig() },
     ...(adapterParams || { getElemIdFunc: mockGetElemIdFunc }),
   })
   return { client, adapter }

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -219,8 +219,10 @@ export interface NetsuiteAdapterParams {
   filePathRegexSkipList?: string[]
   // callback function to get an existing elemId or create a new one by the ServiceIds values
   getElemIdFunc?: ElemIdGetter
-  // config that is determined by the user
+  // config to use in the adapter
   config: NetsuiteConfig
+  // config that is determined by the user
+  userConfig: NetsuiteConfig
 }
 
 export default class NetsuiteAdapter implements AdapterOperations {
@@ -229,6 +231,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly typesToSkip: string[]
   private readonly filePathRegexSkipList: string[]
   private readonly additionalDependencies: AdditionalDependencies
+  private readonly config: NetsuiteConfig
   private readonly userConfig: NetsuiteConfig
   private getElemIdFunc?: ElemIdGetter
   private fixElementsFunc: FixElementsFunc
@@ -261,12 +264,14 @@ export default class NetsuiteAdapter implements AdapterOperations {
     filePathRegexSkipList = [],
     getElemIdFunc,
     config,
+    userConfig,
   }: NetsuiteAdapterParams) {
     this.client = client
     this.elementsSource = elementsSource
     this.typesToSkip = typesToSkip.concat(makeArray(config.typesToSkip))
     this.filePathRegexSkipList = filePathRegexSkipList.concat(makeArray(config.filePathRegexSkipList))
-    this.userConfig = config
+    this.config = config
+    this.userConfig = userConfig
     this.getElemIdFunc = getElemIdFunc
     this.fetchInclude = config.fetch.include
     this.fetchExclude = config.fetch.exclude
@@ -351,7 +356,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     ])
     const { query: netsuiteBundlesQuery, bundlesToInclude } = buildNetsuiteBundlesQuery(
       installedBundles,
-      this.userConfig.excludeBundles ?? [],
+      this.config.excludeBundles ?? [],
     )
     const fetchQueryWithBundles = andQuery(fetchQuery, netsuiteBundlesQuery)
     const timeZoneAndFormat = getTimeDateFormat(configRecords)
@@ -368,8 +373,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       progressReporter.reportProgress({ message: 'Fetching file cabinet items' })
       const result = await this.client.importFileCabinetContent(
         updatedFetchQuery,
-        this.userConfig.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
-        this.userConfig.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
+        this.config.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
+        this.config.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
       )
       progressReporter.reportProgress({ message: 'Fetching instances' })
       return result
@@ -379,7 +384,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       const scriptIdsSet = new Set(instancesIds.map(item => item.instanceId))
       const lockedCustomRecordTypesScriptIds = _.uniq(
         (failedTypes.lockedError[CUSTOM_RECORD_TYPE] ?? []).concat(
-          this.userConfig.fetch.lockedElementsToExclude?.types
+          this.config.fetch.lockedElementsToExclude?.types
             .filter(isIdsQuery)
             .filter(type => type.name === CUSTOM_RECORD_TYPE)
             .flatMap(type => type.ids ?? [])
@@ -454,7 +459,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
     ] = await Promise.all([
       getStandardAndCustomElements(),
       getDataElements(this.client, fetchQueryWithBundles, this.getElemIdFunc),
-      getSuiteQLTableElements(this.userConfig, this.elementsSource, isPartial),
+      getSuiteQLTableElements(this.config, this.elementsSource, isPartial),
     ])
 
     progressReporter.reportProgress({ message: 'Running filters for additional information' })
@@ -550,6 +555,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       isPartial,
     )
 
+    // we use here `userConfig` because it doesn't include changes that were done to `config` in `netsuiteConfigFromConfig`
     const updatedConfig = getConfigFromConfigChanges(failures, this.userConfig)
 
     const partialFetchData = setPartialFetchData(isPartial, deletedElements)
@@ -626,10 +632,10 @@ export default class NetsuiteAdapter implements AdapterOperations {
   @logDuration('deploying account configuration')
   public async deploy({ changeGroup: { changes, groupID } }: DeployOptions): Promise<DeployResult> {
     const changesToDeploy = changes.map(cloneChange)
-    const { internalIdToTypes } = getTypesToInternalId(this.userConfig.suiteAppClient?.additionalSuiteQLTables ?? [])
+    const { internalIdToTypes } = getTypesToInternalId(this.config.suiteAppClient?.additionalSuiteQLTables ?? [])
     const suiteQLNameToInternalIdsMap = await getUpdatedSuiteQLNameToInternalIdsMap(
       this.client,
-      this.userConfig,
+      this.config,
       this.elementsSource,
       changesToDeploy,
       internalIdToTypes,
@@ -669,7 +675,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         filtersRunner: (changesGroupId, suiteQLNameToInternalIdsMap) =>
           this.createFiltersRunner({ operation: 'deploy', changesGroupId, suiteQLNameToInternalIdsMap }),
         elementsSource: this.elementsSource,
-        config: this.userConfig,
+        config: this.config,
       }),
       getChangeGroupIds: getChangeGroupIdsFunc(this.client.isSuiteAppConfigured()),
       dependencyChanger,

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -222,7 +222,7 @@ export interface NetsuiteAdapterParams {
   // config to use in the adapter
   config: NetsuiteConfig
   // config that is determined by the user
-  userConfig: NetsuiteConfig
+  originalConfig: NetsuiteConfig
 }
 
 export default class NetsuiteAdapter implements AdapterOperations {
@@ -232,7 +232,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
   private readonly filePathRegexSkipList: string[]
   private readonly additionalDependencies: AdditionalDependencies
   private readonly config: NetsuiteConfig
-  private readonly userConfig: NetsuiteConfig
+  private readonly originalConfig: NetsuiteConfig
   private getElemIdFunc?: ElemIdGetter
   private fixElementsFunc: FixElementsFunc
   private readonly fetchInclude: QueryParams
@@ -264,14 +264,14 @@ export default class NetsuiteAdapter implements AdapterOperations {
     filePathRegexSkipList = [],
     getElemIdFunc,
     config,
-    userConfig,
+    originalConfig,
   }: NetsuiteAdapterParams) {
     this.client = client
     this.elementsSource = elementsSource
     this.typesToSkip = typesToSkip.concat(makeArray(config.typesToSkip))
     this.filePathRegexSkipList = filePathRegexSkipList.concat(makeArray(config.filePathRegexSkipList))
     this.config = config
-    this.userConfig = userConfig
+    this.originalConfig = originalConfig
     this.getElemIdFunc = getElemIdFunc
     this.fetchInclude = config.fetch.include
     this.fetchExclude = config.fetch.exclude
@@ -555,8 +555,8 @@ export default class NetsuiteAdapter implements AdapterOperations {
       isPartial,
     )
 
-    // we use here `userConfig` because it doesn't include changes that were done to `config` in `netsuiteConfigFromConfig`
-    const updatedConfig = getConfigFromConfigChanges(failures, this.userConfig)
+    // we use here `originalConfig` because it doesn't include changes that were done to `config` in `netsuiteConfigFromConfig`
+    const updatedConfig = getConfigFromConfigChanges(failures, this.originalConfig)
 
     const partialFetchData = setPartialFetchData(isPartial, deletedElements)
 

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -117,7 +117,7 @@ const netsuiteCredentialsFromCredentials = (credsInstance: Readonly<InstanceElem
 }
 
 const getAdapterOperations = (context: AdapterOperationsContext): AdapterOperations => {
-  const { config: adapterConfig, userConfig } = netsuiteConfigFromConfig(context.config)
+  const { config: adapterConfig, originalConfig } = netsuiteConfigFromConfig(context.config)
   const credentials = netsuiteCredentialsFromCredentials(context.credentials)
 
   const globalLimiter = new Bottleneck({
@@ -152,7 +152,7 @@ const getAdapterOperations = (context: AdapterOperationsContext): AdapterOperati
     client: new NetsuiteClient(sdfClient, suiteAppClient),
     elementsSource: context.elementsSource,
     config: adapterConfig,
-    userConfig,
+    originalConfig,
     getElemIdFunc: context.getElemIdFunc,
   })
 }

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -117,7 +117,7 @@ const netsuiteCredentialsFromCredentials = (credsInstance: Readonly<InstanceElem
 }
 
 const getAdapterOperations = (context: AdapterOperationsContext): AdapterOperations => {
-  const adapterConfig = netsuiteConfigFromConfig(context.config)
+  const { config: adapterConfig, userConfig } = netsuiteConfigFromConfig(context.config)
   const credentials = netsuiteCredentialsFromCredentials(context.credentials)
 
   const globalLimiter = new Bottleneck({
@@ -152,6 +152,7 @@ const getAdapterOperations = (context: AdapterOperationsContext): AdapterOperati
     client: new NetsuiteClient(sdfClient, suiteAppClient),
     elementsSource: context.elementsSource,
     config: adapterConfig,
+    userConfig,
     getElemIdFunc: context.getElemIdFunc,
   })
 }

--- a/packages/netsuite-adapter/src/config/config_creator.ts
+++ b/packages/netsuite-adapter/src/config/config_creator.ts
@@ -212,16 +212,16 @@ export const instanceLimiterCreator =
 
 export const netsuiteConfigFromConfig = (
   configInstance: Readonly<InstanceElement> | undefined,
-): { config: NetsuiteConfig; userConfig: NetsuiteConfig } => {
+): { config: NetsuiteConfig; originalConfig: NetsuiteConfig } => {
   if (!configInstance) {
     log.warn('missing config instance - using netsuite adapter config with full fetch')
     return {
       config: { fetch: fullFetchConfig() },
-      userConfig: { fetch: fullFetchConfig() },
+      originalConfig: { fetch: fullFetchConfig() },
     }
   }
-  const { value: userConfig } = configInstance
-  validateConfig(userConfig)
-  const config = updatedConfig(userConfig)
-  return { config, userConfig }
+  const { value: originalConfig } = configInstance
+  validateConfig(originalConfig)
+  const config = updatedConfig(originalConfig)
+  return { config, originalConfig }
 }

--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -290,19 +290,10 @@ function validateMaxInstancesPerType(
   }
 }
 
-function validateClientConfig(
-  client: Record<string, unknown>,
-  fetchTargetDefined: boolean,
-): asserts client is ClientConfig {
+function validateClientConfig(client: Record<string, unknown>): asserts client is ClientConfig {
   validatePlainObject(client, CONFIG.client)
-  const { fetchAllTypesAtOnce, installedSuiteApps, maxInstancesPerType } = _.pick(client, Object.values(CLIENT_CONFIG))
+  const { installedSuiteApps, maxInstancesPerType } = _.pick(client, Object.values(CLIENT_CONFIG))
 
-  if (fetchAllTypesAtOnce && fetchTargetDefined) {
-    log.warn(
-      `${CLIENT_CONFIG.fetchAllTypesAtOnce} is not supported with ${CONFIG.fetchTarget}. Ignoring ${CLIENT_CONFIG.fetchAllTypesAtOnce}`,
-    )
-    client[CLIENT_CONFIG.fetchAllTypesAtOnce] = false
-  }
   if (installedSuiteApps !== undefined) {
     validateInstalledSuiteApps(installedSuiteApps)
   }
@@ -493,7 +484,7 @@ export function validateConfig(input: Record<string, unknown>): asserts input is
     }
     if (config.client !== undefined) {
       validatePlainObject(config.client, CONFIG.client)
-      validateClientConfig(config.client, config.fetchTarget !== undefined)
+      validateClientConfig(config.client)
     }
     if (config.fetchTarget !== undefined) {
       validatePlainObject(config.fetchTarget, CONFIG.fetchTarget)

--- a/packages/netsuite-adapter/src/sdf_folder_loader.ts
+++ b/packages/netsuite-adapter/src/sdf_folder_loader.ts
@@ -22,7 +22,7 @@ const loadElementsFromFolder = async (
   filters = localFilters,
 ): Promise<FetchResult> => {
   const isPartial = true
-  const config = netsuiteConfigFromConfig(configInstance)
+  const { config } = netsuiteConfigFromConfig(configInstance)
   const { typeToInternalId, internalIdToTypes } = getTypesToInternalId(
     config.suiteAppClient?.additionalSuiteQLTables ?? [],
   )

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -176,7 +176,7 @@ describe('Adapter', () => {
     elementsSource: buildElementsSourceFromElements([]),
     filtersCreators: [firstDummyFilter, secondDummyFilter, resolveValuesFilter],
     config,
-    userConfig: config,
+    originalConfig: config,
     getElemIdFunc: mockGetElemIdFunc,
   })
 
@@ -319,7 +319,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configInput,
-          userConfig: configInput,
+          originalConfig: configInput,
           getElemIdFunc: mockGetElemIdFunc,
         })
       it('should fetch all types and instances without those in Types To Skip, skipList and exclude when fetch config, skipList and typeToSkip are defined', async () => {
@@ -368,7 +368,7 @@ describe('Adapter', () => {
         elementsSource: buildElementsSourceFromElements([dummyElement]),
         filtersCreators: [firstDummyFilter, secondDummyFilter],
         config: conf,
-        userConfig: conf,
+        originalConfig: conf,
         getElemIdFunc: mockGetElemIdFunc,
       })
 
@@ -403,7 +403,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: conf,
-          userConfig: conf,
+          originalConfig: conf,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -421,7 +421,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([dummyElement]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: conf,
-          userConfig: conf,
+          originalConfig: conf,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -677,7 +677,7 @@ describe('Adapter', () => {
             elementsSource: buildElementsSourceFromElements(scriptidListInstances),
             filtersCreators: [],
             config,
-            userConfig: config,
+            originalConfig: config,
             getElemIdFunc: mockGetElemIdFunc,
           })
           client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -745,7 +745,7 @@ describe('Adapter', () => {
             elementsSource: buildElementsSourceFromElements(scriptidListInstances),
             filtersCreators: [],
             config,
-            userConfig: config,
+            originalConfig: config,
             getElemIdFunc: mockGetElemIdFunc,
           })
           client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -795,7 +795,7 @@ describe('Adapter', () => {
             },
           },
         },
-        userConfig: config,
+        originalConfig: config,
         getElemIdFunc: mockGetElemIdFunc,
       })
       client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -1153,7 +1153,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter, resolveValuesFilter],
           config: configWithAdditionalSdfDependencies,
-          userConfig: config,
+          originalConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -1210,7 +1210,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [],
           config: { fetch: fullFetchConfig() },
-          userConfig: config,
+          originalConfig: config,
         })
       })
       it('should return correct deploy errors', async () => {
@@ -1347,7 +1347,7 @@ describe('Adapter', () => {
         elementsSource,
         filtersCreators: [firstDummyFilter, secondDummyFilter],
         config,
-        userConfig: config,
+        originalConfig: config,
         getElemIdFunc: mockGetElemIdFunc,
       })
     })
@@ -1417,7 +1417,7 @@ describe('Adapter', () => {
               filePaths: [],
             },
           },
-          userConfig: config,
+          originalConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
       })
@@ -1487,7 +1487,7 @@ describe('Adapter', () => {
               filePaths: [],
             },
           },
-          userConfig: config,
+          originalConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -1503,7 +1503,7 @@ describe('Adapter', () => {
           config: {
             ...config,
           },
-          userConfig: config,
+          originalConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -176,6 +176,7 @@ describe('Adapter', () => {
     elementsSource: buildElementsSourceFromElements([]),
     filtersCreators: [firstDummyFilter, secondDummyFilter, resolveValuesFilter],
     config,
+    userConfig: config,
     getElemIdFunc: mockGetElemIdFunc,
   })
 
@@ -318,6 +319,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: configInput,
+          userConfig: configInput,
           getElemIdFunc: mockGetElemIdFunc,
         })
       it('should fetch all types and instances without those in Types To Skip, skipList and exclude when fetch config, skipList and typeToSkip are defined', async () => {
@@ -366,6 +368,7 @@ describe('Adapter', () => {
         elementsSource: buildElementsSourceFromElements([dummyElement]),
         filtersCreators: [firstDummyFilter, secondDummyFilter],
         config: conf,
+        userConfig: conf,
         getElemIdFunc: mockGetElemIdFunc,
       })
 
@@ -400,6 +403,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: conf,
+          userConfig: conf,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -417,6 +421,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([dummyElement]),
           filtersCreators: [firstDummyFilter, secondDummyFilter],
           config: conf,
+          userConfig: conf,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -672,6 +677,7 @@ describe('Adapter', () => {
             elementsSource: buildElementsSourceFromElements(scriptidListInstances),
             filtersCreators: [],
             config,
+            userConfig: config,
             getElemIdFunc: mockGetElemIdFunc,
           })
           client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -739,6 +745,7 @@ describe('Adapter', () => {
             elementsSource: buildElementsSourceFromElements(scriptidListInstances),
             filtersCreators: [],
             config,
+            userConfig: config,
             getElemIdFunc: mockGetElemIdFunc,
           })
           client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -788,6 +795,7 @@ describe('Adapter', () => {
             },
           },
         },
+        userConfig: config,
         getElemIdFunc: mockGetElemIdFunc,
       })
       client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
@@ -1145,6 +1153,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [firstDummyFilter, secondDummyFilter, resolveValuesFilter],
           config: configWithAdditionalSdfDependencies,
+          userConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -1201,6 +1210,7 @@ describe('Adapter', () => {
           elementsSource: buildElementsSourceFromElements([]),
           filtersCreators: [],
           config: { fetch: fullFetchConfig() },
+          userConfig: config,
         })
       })
       it('should return correct deploy errors', async () => {
@@ -1337,6 +1347,7 @@ describe('Adapter', () => {
         elementsSource,
         filtersCreators: [firstDummyFilter, secondDummyFilter],
         config,
+        userConfig: config,
         getElemIdFunc: mockGetElemIdFunc,
       })
     })
@@ -1406,6 +1417,7 @@ describe('Adapter', () => {
               filePaths: [],
             },
           },
+          userConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
       })
@@ -1475,6 +1487,7 @@ describe('Adapter', () => {
               filePaths: [],
             },
           },
+          userConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 
@@ -1490,6 +1503,7 @@ describe('Adapter', () => {
           config: {
             ...config,
           },
+          userConfig: config,
           getElemIdFunc: mockGetElemIdFunc,
         })
 

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -353,6 +353,7 @@ describe('NetsuiteAdapter creator', () => {
           filePathRegexSkipList: ['^/Templates.*'],
           client: clientConfig,
         },
+        userConfig: config.value,
         elementsSource,
         getElemIdFunc: mockGetElemIdFunc,
       })
@@ -385,6 +386,7 @@ describe('NetsuiteAdapter creator', () => {
             },
             fetchTarget: expect.any(Object),
           },
+          userConfig: conf.value,
           elementsSource,
           getElemIdFunc: mockGetElemIdFunc,
         })
@@ -399,6 +401,7 @@ describe('NetsuiteAdapter creator', () => {
         expect(NetsuiteAdapter).toHaveBeenCalledWith({
           client: expect.any(Object),
           config: { fetch: fullFetchConfig() },
+          userConfig: { fetch: fullFetchConfig() },
           elementsSource,
           getElemIdFunc: mockGetElemIdFunc,
         })

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -353,7 +353,7 @@ describe('NetsuiteAdapter creator', () => {
           filePathRegexSkipList: ['^/Templates.*'],
           client: clientConfig,
         },
-        userConfig: config.value,
+        originalConfig: config.value,
         elementsSource,
         getElemIdFunc: mockGetElemIdFunc,
       })
@@ -386,7 +386,7 @@ describe('NetsuiteAdapter creator', () => {
             },
             fetchTarget: expect.any(Object),
           },
-          userConfig: conf.value,
+          originalConfig: conf.value,
           elementsSource,
           getElemIdFunc: mockGetElemIdFunc,
         })
@@ -401,7 +401,7 @@ describe('NetsuiteAdapter creator', () => {
         expect(NetsuiteAdapter).toHaveBeenCalledWith({
           client: expect.any(Object),
           config: { fetch: fullFetchConfig() },
-          userConfig: { fetch: fullFetchConfig() },
+          originalConfig: { fetch: fullFetchConfig() },
           elementsSource,
           getElemIdFunc: mockGetElemIdFunc,
         })

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -29,8 +29,8 @@ describe('netsuite config creator', () => {
 
   const netsuiteConfigFromConfig = (configInstance: Readonly<InstanceElement> | undefined): NetsuiteConfig => {
     const clonedConfig = configInstance?.clone()
-    const { config: adapterConfig, userConfig } = getConfig(configInstance)
-    expect(userConfig).toEqual(clonedConfig?.value ?? { fetch: fullFetchConfig() })
+    const { config: adapterConfig, originalConfig } = getConfig(configInstance)
+    expect(originalConfig).toEqual(clonedConfig?.value ?? { fetch: fullFetchConfig() })
     return adapterConfig
   }
 

--- a/packages/netsuite-adapter/test/config/config_creator.test.ts
+++ b/packages/netsuite-adapter/test/config/config_creator.test.ts
@@ -8,8 +8,12 @@
 import { regex } from '@salto-io/lowerdash'
 import { ElemID, InstanceElement } from '@salto-io/adapter-api'
 import { createDefaultInstanceFromType } from '@salto-io/adapter-utils'
-import { InstanceLimiterFunc, configType } from '../../src/config/types'
-import { instanceLimiterCreator, netsuiteConfigFromConfig, fullFetchConfig } from '../../src/config/config_creator'
+import { InstanceLimiterFunc, NetsuiteConfig, configType } from '../../src/config/types'
+import {
+  instanceLimiterCreator,
+  netsuiteConfigFromConfig as getConfig,
+  fullFetchConfig,
+} from '../../src/config/config_creator'
 import {
   GROUPS_TO_DATA_FILE_TYPES,
   DEFAULT_MAX_INSTANCES_VALUE,
@@ -22,6 +26,13 @@ describe('netsuite config creator', () => {
   beforeEach(async () => {
     config = await createDefaultInstanceFromType(ElemID.CONFIG_NAME, configType)
   })
+
+  const netsuiteConfigFromConfig = (configInstance: Readonly<InstanceElement> | undefined): NetsuiteConfig => {
+    const clonedConfig = configInstance?.clone()
+    const { config: adapterConfig, userConfig } = getConfig(configInstance)
+    expect(userConfig).toEqual(clonedConfig?.value ?? { fetch: fullFetchConfig() })
+    return adapterConfig
+  }
 
   it('should return config when config instance is undefined', () => {
     expect(netsuiteConfigFromConfig(undefined)).toEqual({
@@ -114,6 +125,15 @@ describe('netsuite config creator', () => {
         filePaths: ['/SuiteScripts/file.txt', '/Templates/[^/]*\\.html', '/SuiteScripts/'],
         customRecords: {},
       })
+    })
+    it('should override FETCH_ALL_TYPES_AT_ONCE if received FETCH_TARGET', () => {
+      config.value.fetchTarget = {
+        filePaths: ['aaa'],
+      }
+      config.value.client = {
+        fetchAllTypesAtOnce: true,
+      }
+      expect(netsuiteConfigFromConfig(config).client?.fetchAllTypesAtOnce).toEqual(false)
     })
   })
 


### PR DESCRIPTION
The config suggestions should be on the config instance that the adapter receives from core, without the modifications that are done in `config_creator`, otherwise we might return a modification to a field that was override using a config override, which isn't allowed.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Fix NS config suggestions when there are config overrides

---
_User Notifications_: 
None