### PR TITLE
SALTO-6995: fix element test utils types path

### DIFF
--- a/packages/element-test-utils/package.json
+++ b/packages/element-test-utils/package.json
@@ -14,7 +14,7 @@
     "dist/src",
     "dist/index.*"
   ],
-  "types": "dist/src/index.d.ts",
+  "types": "dist/index.d.ts",
   "scripts": {
     "build": "../../build_utils/turbo_run.sh build-ts ; ../../build_utils/turbo_run.sh lint",
     "test": "jest",

--- a/packages/element-test-utils/src/all.ts
+++ b/packages/element-test-utils/src/all.ts
@@ -7,6 +7,6 @@
  */
 
 import { expect } from '@jest/globals'
-import { isEqualElemID } from './custom_equality'
+import { allEqualityTesters } from './custom_equality'
 
-expect.addEqualityTesters([isEqualElemID])
+expect.addEqualityTesters(allEqualityTesters)

--- a/packages/element-test-utils/src/custom_equality.ts
+++ b/packages/element-test-utils/src/custom_equality.ts
@@ -14,3 +14,5 @@ export const isEqualElemID: Tester = function isEqualElemID(a, b) {
   }
   return undefined
 }
+
+export const allEqualityTesters = [isEqualElemID]


### PR DESCRIPTION
Also export "allEqualityTesters" as an array so if more are added in the future, depending packages won't have to change

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_