### PR TITLE
SALTO-6759 Jamf: mask passwords

### DIFF
--- a/packages/jamf-adapter/src/definitions/fetch/transforms/configuration_profile.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/configuration_profile.ts
@@ -12,6 +12,7 @@ import {
   adjustServiceIdToTopLevel,
   adjustSiteObjectToSiteId,
   removeSelfServiceSecurityPassword,
+  maskPayloadsPassword,
 } from './utils'
 
 /*
@@ -26,6 +27,7 @@ export const adjust: definitions.AdjustFunctionSingle = async ({ value }) => {
     adjustSiteObjectToSiteId,
     adjustServiceIdToTopLevel,
     removeSelfServiceSecurityPassword,
+    maskPayloadsPassword,
   ].forEach(fn => fn(value))
   return { value }
 }

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/policy.ts
@@ -13,6 +13,7 @@ import {
   adjustServiceIdToTopLevel,
   adjustSiteObjectToSiteId,
   removeSelfServiceIcon,
+  maskPasswordsForScriptsObjectArray,
 } from './utils'
 
 /*
@@ -28,6 +29,7 @@ export const adjust: definitions.AdjustFunctionSingle = async ({ value }) => {
     removeIdsForScriptsObjectArray,
     adjustServiceIdToTopLevel,
     removeSelfServiceIcon,
+    maskPasswordsForScriptsObjectArray,
   ].forEach(fn => fn(value))
   return { value }
 }

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
@@ -10,7 +10,7 @@ import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 
-export const MASK_VALUE = '**MASKED_PASSWORD**'
+export const MASK_VALUE = '**SALTO_MASKED_VALUE**'
 
 const PASSWORD_REGEX = /<key>Password<\/key><string>.*?<\/string>/
 const MASKED_PASSWORD = `<key>Password</key><string>${MASK_VALUE}</string>`
@@ -95,10 +95,12 @@ export const removeSelfServiceSecurityPassword = (value: Values): void => {
 export const maskPayloadsPassword = (value: Values): void => {
   const payloads = _.get(value, 'general.payloads')
   if (typeof payloads === 'string') {
-    if (PASSWORD_REGEX.test(payloads)) {
+    const maskedPayloads = payloads.replace(PASSWORD_REGEX, () => {
       log.trace(`Masked value of payloads in '${_.get(value, 'general.name')}'`)
-      _.set(value, 'general.payloads', payloads.replace(PASSWORD_REGEX, MASKED_PASSWORD))
-    }
+      return MASKED_PASSWORD
+    })
+    _.set(value, 'general.payloads', maskedPayloads)
+    // TODO: change to replaceAll to support all occasions in the payloads
   }
 }
 

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
@@ -10,13 +10,13 @@ import { Values } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 
-export const MASK_VALUE = '**SALTO_MASKED_VALUE**'
+export const SALTO_MASKED_VALUE = '**SALTO_MASKED_VALUE**'
 
 const PASSWORD_REGEX = /<key>Password<\/key><string>.*?<\/string>/
-const MASKED_PASSWORD = `<key>Password</key><string>${MASK_VALUE}</string>`
+const MASKED_PASSWORD = `<key>Password</key><string>${SALTO_MASKED_VALUE}</string>`
 
 const CLIENT_SECRET_REGEX = '^client_secret=.*'
-const MASKED_CLIENT_SECRET = `client_secret=${MASK_VALUE}`
+const MASKED_CLIENT_SECRET = `client_secret=${SALTO_MASKED_VALUE}`
 
 const log = logger(module)
 

--- a/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
+++ b/packages/jamf-adapter/src/definitions/fetch/transforms/utils.ts
@@ -95,7 +95,7 @@ export const removeSelfServiceSecurityPassword = (value: Values): void => {
 export const maskPayloadsPassword = (value: Values): void => {
   const payloads = _.get(value, 'general.payloads')
   if (typeof payloads === 'string') {
-    if(PASSWORD_REGEX.test(payloads)) {
+    if (PASSWORD_REGEX.test(payloads)) {
       log.trace(`Masked value of payloads in '${_.get(value, 'general.name')}'`)
       _.set(value, 'general.payloads', payloads.replace(PASSWORD_REGEX, MASKED_PASSWORD))
     }

--- a/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
@@ -88,8 +88,7 @@ describe('adjust configuration profile', () => {
       await expect(adjustConfigurationProfile({ value, context: {}, typeName: 'typeName' })).resolves.toEqual({
         value: {
           general: {
-            payloads:
-              `<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>${SALTO_MASKED_VALUE}</string></dict></plist>`,
+            payloads: `<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>${SALTO_MASKED_VALUE}</string></dict></plist>`,
           },
         },
       })

--- a/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
@@ -79,11 +79,17 @@ describe('adjust configuration profile', () => {
   describe('maskPayloadsPassword', () => {
     it('should mask passwords within payloads', async () => {
       const value = {
-        general: { payloads: '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>1234</string></dict></plist>' },
+        general: {
+          payloads:
+            '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>1234</string></dict></plist>',
+        },
       }
       await expect(adjustConfigurationProfile({ value, context: {}, typeName: 'typeName' })).resolves.toEqual({
         value: {
-          general: { payloads: '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>**MASKED_PASSWORD**</string></dict></plist>' },
+          general: {
+            payloads:
+              '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>**MASKED_PASSWORD**</string></dict></plist>',
+          },
         },
       })
     })

--- a/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
@@ -76,4 +76,16 @@ describe('adjust configuration profile', () => {
       })
     })
   })
+  describe('maskPayloadsPassword', () => {
+    it('should mask passwords within payloads', async () => {
+      const value = {
+        general: { payloads: '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>1234</string></dict></plist>' },
+      }
+      await expect(adjustConfigurationProfile({ value, context: {}, typeName: 'typeName' })).resolves.toEqual({
+        value: {
+          general: { payloads: '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>**MASKED_PASSWORD**</string></dict></plist>' },
+        },
+      })
+    })
+  })
 })

--- a/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/configuration_profile.test.ts
@@ -6,6 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { adjustConfigurationProfile } from '../../../../src/definitions/fetch/transforms'
+import { SALTO_MASKED_VALUE } from '../../../../src/definitions/fetch/transforms/utils'
 
 describe('adjust configuration profile', () => {
   it('should throw an error if value is not a record', async () => {
@@ -88,7 +89,7 @@ describe('adjust configuration profile', () => {
         value: {
           general: {
             payloads:
-              '<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>**MASKED_PASSWORD**</string></dict></plist>',
+              `<?xml version="1.0" encoding="UTF-8"?><plist version="1"><dict><key>Password</key><string>${SALTO_MASKED_VALUE}</string></dict></plist>`,
           },
         },
       })

--- a/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
@@ -70,10 +70,7 @@ describe('adjust policy', () => {
       const value = {
         a: 'a',
         general: {},
-        scripts: [
-          { parameter4: 'yay' },
-          { parameter5: 'client_secret=823463286532896589' },
-        ],
+        scripts: [{ parameter4: 'yay' }, { parameter5: 'client_secret=823463286532896589' }],
         b: 'b',
       }
       await expect(adjustPolicy({ value, context: {}, typeName: 'policy' })).resolves.toEqual({

--- a/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
@@ -6,6 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { adjustPolicy } from '../../../../src/definitions/fetch/transforms'
+import { MASK_VALUE } from '../../../../src/definitions/fetch/transforms/utils'
 
 describe('adjust policy', () => {
   it('should throw an error if value is not a record', async () => {
@@ -59,6 +60,27 @@ describe('adjust policy', () => {
           a: 'a',
           general: {},
           scripts: [{ anotherField: 'yay' }, { anotherField: 'hopa' }],
+          b: 'b',
+        },
+      })
+    })
+  })
+  describe('maskPasswordsForScriptsObjectArray', () => {
+    it('should mask passwords within scripts object array', async () => {
+      const value = {
+        a: 'a',
+        general: {},
+        scripts: [
+          { parameter4: 'yay' },
+          { parameter5: 'client_secret=823463286532896589' },
+        ],
+        b: 'b',
+      }
+      await expect(adjustPolicy({ value, context: {}, typeName: 'policy' })).resolves.toEqual({
+        value: {
+          a: 'a',
+          general: {},
+          scripts: [{ parameter4: 'yay' }, { parameter5: `client_secret=${MASK_VALUE}` }],
           b: 'b',
         },
       })

--- a/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
+++ b/packages/jamf-adapter/test/definitions/fetch/transform/policy.test.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { adjustPolicy } from '../../../../src/definitions/fetch/transforms'
-import { MASK_VALUE } from '../../../../src/definitions/fetch/transforms/utils'
+import { SALTO_MASKED_VALUE } from '../../../../src/definitions/fetch/transforms/utils'
 
 describe('adjust policy', () => {
   it('should throw an error if value is not a record', async () => {
@@ -77,7 +77,7 @@ describe('adjust policy', () => {
         value: {
           a: 'a',
           general: {},
-          scripts: [{ parameter4: 'yay' }, { parameter5: `client_secret=${MASK_VALUE}` }],
+          scripts: [{ parameter4: 'yay' }, { parameter5: `client_secret=${SALTO_MASKED_VALUE}` }],
           b: 'b',
         },
       })

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -37,7 +37,7 @@ const maskHeaders = (headers: Header[], headersToMask: string[], id: ElemID): vo
   headers
     .filter(({ name }) => headerRegexes.some(regex => regex.test(name)))
     .forEach(header => {
-      log.debug(`Masked header ${header.name} in ${id.getFullName()}`)
+      log.trace(`Masked header ${header.name} in ${id.getFullName()}`)
       header.value = MASK_VALUE
     })
 }
@@ -60,7 +60,7 @@ const maskValues = (instance: InstanceElement, masking: MaskingConfig): void => 
           _.isString(value) &&
           masking.secretRegexps.some(matcher => lowerdashRegex.isFullRegexMatch(value, matcher))
         ) {
-          log.debug(`Masked value ${path?.getFullName()}`)
+          log.trace(`Masked value ${path?.getFullName()}`)
           return MASK_VALUE
         }
         return value


### PR DESCRIPTION
Mask passwords within policy scripts and configuration_profiles payloads

---

_Additional context for reviewer_

---
_Release Notes_: 

_Jamf_adapter_:
- Mask passwords within policy scripts and configuration_profiles payloads

---
_User Notifications_: 
Passwords within policy scripts and configuration_profiles payloads will be masked
