### PR TITLE
SALTO-7036: Disable Salesforce features 

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -15,11 +15,11 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   extendedCustomFieldInformation: false,
   hideTypesFolder: true,
   metaTypes: false,
-  picklistsAsMaps: true,
-  retrieveSettings: true,
+  picklistsAsMaps: false,
+  retrieveSettings: false,
   genAiReferences: true,
   networkReferences: false,
-  extendFetchTargets: true,
+  extendFetchTargets: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -991,8 +991,7 @@ describe('SalesforceAdapter fetch', () => {
           7 /* range restrictions */ +
           2 /* ChangedAtSingleton type & instance */ +
           1 /* ProfilesAndPermissionSetsBrokenPaths */ +
-          2 /* FetchTargets */ +
-          1 /* OrderedMapOfvalueSet */,
+          1 /* FetchTargets */,
       )
 
       const elementsMap = _.keyBy(result, element => element.elemID.getFullName())


### PR DESCRIPTION
Disable Salesforce features that should be part of the next PROD release due to regression.

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
