### PR TITLE
SALTO-7037: add end_user_conditions and agent_conditions fields if they are missing from the form during deploy

### DIFF
--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -148,6 +148,8 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
   }
   const clonedInst = after.clone()
   clonedInst.value.ticket_field_ids = (clonedInst.value.ticket_field_ids ?? []).concat(finalRemovedFields)
+  clonedInst.value.end_user_conditions = clonedInst.value.end_user_conditions ?? []
+  clonedInst.value.agent_conditions = clonedInst.value.agent_conditions ?? []
   return clonedInst
 }
 

--- a/packages/zendesk-adapter/src/filters/ticket_form.ts
+++ b/packages/zendesk-adapter/src/filters/ticket_form.ts
@@ -148,8 +148,8 @@ const getChangeWithoutRemovedFields = (change: ModificationChange<InstanceElemen
   }
   const clonedInst = after.clone()
   clonedInst.value.ticket_field_ids = (clonedInst.value.ticket_field_ids ?? []).concat(finalRemovedFields)
-  clonedInst.value.end_user_conditions = clonedInst.value.end_user_conditions ?? []
-  clonedInst.value.agent_conditions = clonedInst.value.agent_conditions ?? []
+  clonedInst.value.end_user_conditions ??= []
+  clonedInst.value.agent_conditions ??= []
   return clonedInst
 }
 

--- a/packages/zendesk-adapter/test/filters/ticket_form.test.ts
+++ b/packages/zendesk-adapter/test/filters/ticket_form.test.ts
@@ -202,8 +202,8 @@ describe('ticket form filter', () => {
       })
       const afterTicketForm = beforeTicketForm.clone()
       afterTicketForm.value.ticket_field_ids = [1, 11]
-      afterTicketForm.value.agent_conditions = []
-      afterTicketForm.value.end_user_conditions = []
+      afterTicketForm.value.agent_conditions = undefined
+      afterTicketForm.value.end_user_conditions = undefined
 
       const intermediateTicketForm = beforeTicketForm.clone()
       intermediateTicketForm.value.ticket_field_ids = [1, 11, 123, 1234]


### PR DESCRIPTION
add end_user_conditions and agent_conditions fields if they are missing from the form during deploy

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
