### PR TITLE
SALTO-7051 Delete old Salto flags

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -80,10 +80,8 @@ import {
   isElementIdMatchSelectors,
   updateElementsWithAlternativeAccount,
   Workspace,
-  flags,
 } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
-import { CORE_FLAGS } from './flags'
 import { StepEvents } from './deploy'
 import { getPlan, Plan } from './plan'
 import { AdapterEvents, createAdapterProgressReporter } from './adapters/progress'
@@ -264,10 +262,6 @@ const autoMergeChange: ChangeTransformFunction = async change => {
     return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
   if (_.isArray(current) && _.isArray(incoming) && isTypeOfOrUndefined(base, _.isArray)) {
-    if (flags.getSaltoFlagBool(CORE_FLAGS.autoMergeListsDisabled)) {
-      log.debug('skipping list auto merge since the autoMergeListsDisabled core flag is true')
-      return [change]
-    }
     const merged = mergeLists(changeId, { current, base, incoming })
     return [merged !== undefined ? toMergedChange(change, merged) : change]
   }
@@ -307,11 +301,6 @@ const toListModificationChange = ({
   serviceChanges: types.NonEmptyArray<DetailedChangeWithBaseChange>
   pendingChanges: DetailedChangeWithBaseChange[]
 }): FetchChange | undefined => {
-  if (flags.getSaltoFlagBool(CORE_FLAGS.autoMergeListsDisabled)) {
-    log.debug('skip creating list modification change since the autoMergeListsDisabled core flag is true')
-    return undefined
-  }
-
   if (!types.isNonEmptyArray(pendingChanges)) {
     return undefined
   }
@@ -1479,7 +1468,7 @@ export const getFetchAdapterAndServicesSetup = async ({
     ignoreStateElemIdMapping,
     ignoreStateElemIdMappingForSelectors,
   })
-  const resolveTypes = !flags.getSaltoFlagBool(CORE_FLAGS.skipResolveTypesInElementSource)
+  const resolveTypes = true
   const adaptersCreatorConfigs = await getAdaptersCreatorConfigs(
     fetchAccounts,
     await workspace.accountCredentials(fetchAccounts),

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -1,9 +1,0 @@
-/*
- * Copyright 2024 Salto Labs Ltd.
- * Licensed under the Salto Terms of Use (the "License");
- * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
- *
- * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
- */
-
-export const CORE_FLAGS = {} as const

--- a/packages/core/src/core/flags.ts
+++ b/packages/core/src/core/flags.ts
@@ -6,8 +6,4 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-export const CORE_FLAGS = {
-  skipResolveTypesInElementSource: 'SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE',
-  autoMergeListsDisabled: 'AUTO_MERGE_LISTS_DISABLE',
-  failPlanOnCircularDependencies: 'FAIL_PLAN_ON_CIRCULAR_DEPENDENCY',
-} as const
+export const CORE_FLAGS = {} as const

--- a/packages/core/src/core/plan/group.ts
+++ b/packages/core/src/core/plan/group.ts
@@ -8,7 +8,6 @@
 import wu from 'wu'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
-import { flags } from '@salto-io/workspace'
 import { DataNodeMap, NodeId, buildAcyclicGroupedGraph, GroupDAG, GroupKeyFunc } from '@salto-io/dag'
 import {
   Change,
@@ -22,7 +21,6 @@ import {
   isObjectTypeChange,
   isFieldChange,
 } from '@salto-io/adapter-api'
-import { CORE_FLAGS } from '../flags'
 
 const log = logger(module)
 const { awu } = collections.asynciterable
@@ -135,15 +133,9 @@ export const buildGroupedGraphFromDiffGraph = (
   }
 
   const diffGraphWithoutRedundantFieldNodes = removeRedundantFieldNodes(diffGraph, groupKey)
-  const shouldFailOnCircularDependency = flags.getSaltoFlagBool(CORE_FLAGS.failPlanOnCircularDependencies)
-  log.debug(
-    'building acyclic grouped graph with failPlanOnCircularDependencies value: %s',
-    shouldFailOnCircularDependency,
-  )
   return buildAcyclicGroupedGraph({
     source: diffGraphWithoutRedundantFieldNodes,
     groupKey,
-    shouldFailOnCircularDependency,
     disjointGroups,
   })
 }

--- a/packages/core/test/core/plan/plan.test.ts
+++ b/packages/core/test/core/plan/plan.test.ts
@@ -142,83 +142,45 @@ describe('getPlan', () => {
   })
 
   describe('getPlan with dependency cycle', () => {
-    describe('when SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY is enabled', () => {
-      beforeAll(() => {
-        process.env.SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY = '1'
-      })
-
-      it('should fail on addition if fields create a dependency cycle', async () => {
-        await expect(planWithFieldDependencyCycle(true)).rejects.toThrow()
-      })
-
-      it('should fail on removal if fields create a dependency cycle', async () => {
-        await expect(planWithFieldDependencyCycle(false)).rejects.toThrow()
-      })
-
-      it('should fail when plan has dependency cycle', async () => {
-        // Without change validators
-        await expect(planWithDependencyCycle(false)).rejects.toThrow()
-        // With change validators
-        await expect(planWithDependencyCycle(true)).rejects.toThrow()
-      })
-
-      afterAll(() => {
-        delete process.env.SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY
-      })
+    it('should omit fields from plan they create a dependency cycle on addition', async () => {
+      const plan = await planWithFieldDependencyCycle(true)
+      const planItems = [...plan.itemsByEvalOrder()]
+      expect(planItems).toHaveLength(6)
+      const [dependencyErrors, otherErrors] = _.partition(plan.changeErrors, isDependencyError)
+      expect(otherErrors).toHaveLength(2)
+      expect(dependencyErrors).toHaveLength(1)
     })
 
-    describe('when SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY is disabled', () => {
-      beforeAll(() => {
-        process.env.SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY = '0'
-      })
+    it('should omit fields from plan they create a dependency cycle on', async () => {
+      const plan = await planWithFieldDependencyCycle(false)
+      const planItems = [...plan.itemsByEvalOrder()]
+      expect(planItems).toHaveLength(6)
+      const [dependencyErrors, otherErrors] = _.partition(plan.changeErrors, isDependencyError)
+      expect(otherErrors).toHaveLength(2)
+      expect(dependencyErrors).toHaveLength(0)
+    })
 
-      it('should omit fields from plan they create a dependency cycle on addition', async () => {
-        const plan = await planWithFieldDependencyCycle(true)
-        const planItems = [...plan.itemsByEvalOrder()]
-        expect(planItems).toHaveLength(6)
-        const [dependencyErrors, otherErrors] = _.partition(plan.changeErrors, isDependencyError)
-        expect(otherErrors).toHaveLength(2)
-        expect(dependencyErrors).toHaveLength(1)
-      })
+    it('should create plan and omit and dependency cycle from it', async () => {
+      // Without change validators
+      const planWithNoValidators = await planWithDependencyCycle(false)
+      const planWithNoValidatorsItems = [...planWithNoValidators.itemsByEvalOrder()]
+      expect(planWithNoValidatorsItems).toHaveLength(4)
+      const circularDependencyErrors = planWithNoValidators.changeErrors.filter(isCircularDependencyChangeError)
+      expect(circularDependencyErrors).toHaveLength(2)
+      expect(circularDependencyErrors.map(err => err.elemID.getFullName())).toEqual(['salto.employee', 'salto.office'])
 
-      it('should omit fields from plan they create a dependency cycle on', async () => {
-        const plan = await planWithFieldDependencyCycle(false)
-        const planItems = [...plan.itemsByEvalOrder()]
-        expect(planItems).toHaveLength(6)
-        const [dependencyErrors, otherErrors] = _.partition(plan.changeErrors, isDependencyError)
-        expect(otherErrors).toHaveLength(2)
-        expect(dependencyErrors).toHaveLength(0)
-      })
-
-      it('should create plan and omit and dependency cycle from it', async () => {
-        // Without change validators
-        const planWithNoValidators = await planWithDependencyCycle(false)
-        const planWithNoValidatorsItems = [...planWithNoValidators.itemsByEvalOrder()]
-        expect(planWithNoValidatorsItems).toHaveLength(4)
-        const circularDependencyErrors = planWithNoValidators.changeErrors.filter(isCircularDependencyChangeError)
-        expect(circularDependencyErrors).toHaveLength(2)
-        expect(circularDependencyErrors.map(err => err.elemID.getFullName())).toEqual([
-          'salto.employee',
-          'salto.office',
-        ])
-
-        // With change validators
-        const plainWithValidators = await planWithDependencyCycle(true)
-        const planWithValidatorsItems = [...plainWithValidators.itemsByEvalOrder()]
-        expect(planWithValidatorsItems).toHaveLength(4)
-        const circularDependencyErrorsWithValidators = planWithNoValidators.changeErrors.filter(
-          isCircularDependencyChangeError,
-        )
-        expect(circularDependencyErrorsWithValidators).toHaveLength(2)
-        expect(circularDependencyErrorsWithValidators.map(err => err.elemID.getFullName())).toEqual([
-          'salto.employee',
-          'salto.office',
-        ])
-      })
-
-      afterAll(() => {
-        delete process.env.SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY
-      })
+      // With change validators
+      const plainWithValidators = await planWithDependencyCycle(true)
+      const planWithValidatorsItems = [...plainWithValidators.itemsByEvalOrder()]
+      expect(planWithValidatorsItems).toHaveLength(4)
+      const circularDependencyErrorsWithValidators = planWithNoValidators.changeErrors.filter(
+        isCircularDependencyChangeError,
+      )
+      expect(circularDependencyErrorsWithValidators).toHaveLength(2)
+      expect(circularDependencyErrorsWithValidators.map(err => err.elemID.getFullName())).toEqual([
+        'salto.employee',
+        'salto.office',
+      ])
     })
   })
 

--- a/packages/dag/test/group.test.ts
+++ b/packages/dag/test/group.test.ts
@@ -30,7 +30,7 @@ describe('buildGroupGraph', () => {
   }
 
   it('should return empty group graph for empty origin', () => {
-    subject = buildAcyclicGroupedGraph({ source: origin, groupKey, shouldFailOnCircularDependency: true }).graph
+    subject = buildAcyclicGroupedGraph({ source: origin, groupKey }).graph
     expect(getGroupNodes()).toEqual([])
   })
 
@@ -38,7 +38,7 @@ describe('buildGroupGraph', () => {
     origin.addNode('n1', ['n2', 'n3'], 'n1_data')
     origin.addNode('n2', ['n3'], 'n2_data')
     origin.addNode('n3', [], 'n3_data')
-    subject = buildAcyclicGroupedGraph({ source: origin, groupKey, shouldFailOnCircularDependency: true }).graph
+    subject = buildAcyclicGroupedGraph({ source: origin, groupKey }).graph
 
     const groupGraph = getGroupNodes()
     expect(groupGraph).toHaveLength(3)
@@ -51,7 +51,7 @@ describe('buildGroupGraph', () => {
     origin.addNode('group1_n1', [], 'n1_data')
     origin.addNode('group1_n2', [], 'n2_data')
     origin.addNode('group1_n3', [], 'n3_data')
-    subject = buildAcyclicGroupedGraph({ source: origin, groupKey, shouldFailOnCircularDependency: true }).graph
+    subject = buildAcyclicGroupedGraph({ source: origin, groupKey }).graph
 
     const groupGraph = getGroupNodes()
     expect(groupGraph).toHaveLength(1)
@@ -71,7 +71,6 @@ describe('buildGroupGraph', () => {
         source: origin,
         groupKey,
         disjointGroups: new Set(['group1']),
-        shouldFailOnCircularDependency: true,
       }).graph
 
       const groupGraph = getGroupNodes()
@@ -90,7 +89,6 @@ describe('buildGroupGraph', () => {
         source: origin,
         groupKey,
         disjointGroups: new Set(['group1']),
-        shouldFailOnCircularDependency: true,
       }).graph
 
       const groupGraph = getGroupNodes()
@@ -110,7 +108,6 @@ describe('buildGroupGraph', () => {
         source: origin,
         groupKey,
         disjointGroups: new Set(['group1', 'group2']),
-        shouldFailOnCircularDependency: true,
       }).graph
 
       const groupGraph = getGroupNodes()
@@ -129,7 +126,6 @@ describe('buildGroupGraph', () => {
           source: origin,
           groupKey,
           disjointGroups: new Set(['group1']),
-          shouldFailOnCircularDependency: true,
         }),
       ).toThrow()
     })
@@ -193,7 +189,6 @@ describe('buildGroupGraph', () => {
       const groupGraph = buildAcyclicGroupedGraph({
         source: srcGraph,
         groupKey: groupKeyFunc,
-        shouldFailOnCircularDependency: true,
       }).graph
       verifyGroupGraphOrder(groupGraph, edges, 2)
     })
@@ -221,35 +216,19 @@ describe('buildGroupGraph', () => {
         ['n8', 'n7'],
       ]
 
-      describe('when shouldFailOnCircularDependency is true', () => {
-        it('should throw circular dependency error', () => {
-          const [srcGraph, groupKeyFunc] = buildSrcGraphAndGroupKeyFunc(groups, edges)
-          expect(() =>
-            buildAcyclicGroupedGraph({
-              source: srcGraph,
-              groupKey: groupKeyFunc,
-              shouldFailOnCircularDependency: true,
-            }),
-          ).toThrow()
+      it('should remove the nodes that cause the cycle', () => {
+        const [srcGraph, groupKeyFunc] = buildSrcGraphAndGroupKeyFunc(groups, edges)
+        const { graph, removedCycles } = buildAcyclicGroupedGraph({
+          source: srcGraph,
+          groupKey: groupKeyFunc,
         })
-      })
+        expect(removedCycles).toHaveLength(2)
+        expect(removedCycles[0]).toEqual(['n1', 'n2', 'n3', 'n4'])
+        expect(removedCycles[1]).toEqual(['n7', 'n8'])
 
-      describe('when shouldFailOnCircularDependency false', () => {
-        it('should remove the nodes that cause the cycle', () => {
-          const [srcGraph, groupKeyFunc] = buildSrcGraphAndGroupKeyFunc(groups, edges)
-          const { graph, removedCycles } = buildAcyclicGroupedGraph({
-            source: srcGraph,
-            groupKey: groupKeyFunc,
-            shouldFailOnCircularDependency: false,
-          })
-          expect(removedCycles).toHaveLength(2)
-          expect(removedCycles[0]).toEqual(['n1', 'n2', 'n3', 'n4'])
-          expect(removedCycles[1]).toEqual(['n7', 'n8'])
-
-          expect(graph.size).toEqual(1)
-          expect(graph.nodeData.size).toEqual(1)
-          expect(graph.edges().length).toEqual(0)
-        })
+        expect(graph.size).toEqual(1)
+        expect(graph.nodeData.size).toEqual(1)
+        expect(graph.edges().length).toEqual(0)
       })
     })
 
@@ -269,7 +248,6 @@ describe('buildGroupGraph', () => {
       const groupGraph = buildAcyclicGroupedGraph({
         source: srcGraph,
         groupKey: groupKeyFunc,
-        shouldFailOnCircularDependency: true,
       }).graph
       verifyGroupGraphOrder(groupGraph, edges, 2)
     })
@@ -290,7 +268,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 3)
       })
@@ -314,7 +291,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 6)
       })
@@ -342,7 +318,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 6)
       })
@@ -369,7 +344,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 6)
       })
@@ -391,7 +365,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 3)
       })
@@ -414,7 +387,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 3)
       })
@@ -443,7 +415,6 @@ describe('buildGroupGraph', () => {
         const groupGraph = buildAcyclicGroupedGraph({
           source: srcGraph,
           groupKey: groupKeyFunc,
-          shouldFailOnCircularDependency: true,
         }).graph
         verifyGroupGraphOrder(groupGraph, edges, 7)
       })

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -22,7 +22,6 @@ export const getSaltoFlagBool = (flagName: string): boolean => {
 }
 
 export const WORKSPACE_FLAGS = {
-  useOldDependentsCalculation: 'USE_OLD_DEPENDENTS_CALCULATION',
   createFilenamesToElementIdsMapping: 'CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING',
   useSplitSourceMapInUpdate: 'USE_SPLIT_SOURCE_MAP_IN_UPDATE',
 } as const


### PR DESCRIPTION
Delete the following flags:
`SALTO_SKIP_RESOLVE_TYPES_IN_ELEMENT_SOURCE`
`SALTO_AUTO_MERGE_LISTS_DISABLE`
`SALTO_FAIL_PLAN_ON_CIRCULAR_DEPENDENCY`
`SALTO_USE_OLD_DEPENDENTS_CALCULATION`

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Delete old Salto flags

---
_User Notifications_: 
None