### PR TITLE
SALTO-7031: (Bug-fix) Salesforce CBF with `retrieveSettings` leads to merge Errors

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -917,7 +917,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
   }
 
   @logDuration('fetching Metadata Settings types')
-  private async fetchMetadataSettingsTypes({
+  public async fetchMetadataSettingsTypes({
     instances,
     knownTypes,
     standardSettingsMetaType,

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -442,8 +442,6 @@ const getIncludedTypesFromElementsSource = async (
     .filter(metadataType => !isCustomObjectSync(metadataType))
     // custom types (CustomMetadata / CustomObject (non-standard) / CustomSettings)
     .filter(metadataType => !isCustomType(metadataType))
-    // settings types
-    .filter(metadataType => !metadataType.isSettings)
     .filter(type => metadataQuery.isTypeMatch(apiNameSync(type) ?? ''))
     .toArray()
 
@@ -645,13 +643,14 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
 
     progressReporter.reportProgress({ message: 'Fetching Metadata Settings types' })
     const standardSettingsMetaType = fetchProfile.isFeatureEnabled('metaTypes') ? StandardSettingsMetaType : undefined
-    const settingsTypes = fetchProfile.isFeatureEnabled('retrieveSettings')
-      ? await this.fetchMetadataSettingsTypes({
-          instances: metadataInstancesElements,
-          knownTypes: hardCodedTypesMap,
-          standardSettingsMetaType,
-        })
-      : []
+    const settingsTypes =
+      fetchProfile.isFeatureEnabled('retrieveSettings') && !withChangesDetection
+        ? await this.fetchMetadataSettingsTypes({
+            instances: metadataInstancesElements,
+            knownTypes: hardCodedTypesMap,
+            standardSettingsMetaType,
+          })
+        : []
 
     const elements = [
       ...[metadataMetaType, standardSettingsMetaType].filter(isDefined),

--- a/packages/salesforce-adapter/test/fetch_with_changes_detection.test.ts
+++ b/packages/salesforce-adapter/test/fetch_with_changes_detection.test.ts
@@ -321,4 +321,17 @@ describe('Salesforce Fetch With Changes Detection', () => {
       })
     })
   })
+  describe('Retrieve Settings', () => {
+    let fetchMetadataSettingsTypesSpy: jest.SpyInstance
+    describe('when retrieveSettings is enabled', () => {
+      beforeEach(() => {
+        setupMocks()
+        fetchMetadataSettingsTypesSpy = jest.spyOn(adapter, 'fetchMetadataSettingsTypes')
+      })
+      it('should not attempt to retrieve Settings metadata types', async () => {
+        await adapter.fetch({ ...mockFetchOpts, withChangesDetection: true })
+        expect(fetchMetadataSettingsTypesSpy).not.toHaveBeenCalled()
+      })
+    })
+  })
 })


### PR DESCRIPTION
(Bug-fix) Salesforce CBF with `retrieveSettings` leads to merge Errors

---

The merge errors were due to the fact the subtypes of the settings were fetched in CBF and were also included in the Elements source.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
