### PR TITLE
SALTO-7039: Enforce MS Security OAuth flow to select an account

### DIFF
--- a/packages/microsoft-security-adapter/src/client/oauth.ts
+++ b/packages/microsoft-security-adapter/src/client/oauth.ts
@@ -53,7 +53,7 @@ export const createOAuthRequest = (userInput: InstanceElement): OAuthRequestPara
   const baseUrl = getAuthenticationBaseUrl(tenantId)
   const redirectUri = getRedirectUri(port)
   const scope = `offline_access ${getOAuthRequiredScopes(userInput.value)}`
-  const url = `${baseUrl}/authorize?client_id=${clientId}&response_type=code&redirect_uri=${redirectUri}&scope=${scope}`
+  const url = `${baseUrl}/authorize?client_id=${clientId}&response_type=code&redirect_uri=${redirectUri}&scope=${scope}&prompt=select_account`
 
   return {
     url,


### PR DESCRIPTION
Currently, the OAuth flow for connecting to MS Security fails if the user is logged into Microsoft with a different account than the one they wish to use for authentication.

This PR enforces the OAuth flow to prompt the user to select the account they want to authenticate with.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Microsoft Security adapter:_
* Enforce MS Security OAuth flow to select an account

---
_User Notifications_: 
None