### PR TITLE
SALTO-7020: Add parent relationship to metadata instances within folders

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -127,6 +127,7 @@ import mergeProfilesWithSourceValuesFilter from './filters/merge_profiles_with_s
 import flowCoordinatesFilter from './filters/flow_coordinates'
 import taskAndEventCustomFields from './filters/task_and_event_custom_fields'
 import picklistReferences from './filters/picklist_references'
+import addParentToInstancesWithinFolderFilter from './filters/add_parent_to_instances_within_folder'
 import { getConfigFromConfigChanges } from './config_change'
 import { Filter, FilterResult, FilterContext, FilterCreator } from './filter'
 import {
@@ -287,6 +288,7 @@ export const allFilters: Array<FilterCreator> = [
   flowCoordinatesFilter,
   // createChangedAtSingletonInstanceFilter should run last
   changedAtSingletonFilter,
+  addParentToInstancesWithinFolderFilter,
 ]
 
 export interface SalesforceAdapterParams {

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -20,6 +20,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   genAiReferences: true,
   networkReferences: false,
   extendFetchTargets: false,
+  addParentToInstancesWithinFolder: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/filters/add_parent_to_instances_within_folder.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_instances_within_folder.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { logger } from '@salto-io/logging'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { addElementParentReference, apiNameSync, buildElementsSourceForFetch, metadataTypeSync } from './utils'
+
+const { isDefined } = lowerDashValues
+const { toArrayAsync } = collections.asynciterable
+const { DefaultMap } = collections.map
+const log = logger(module)
+
+type FolderInstancesIndex = Map<string, Record<string, InstanceElement>>
+
+const getFolderInstance = (
+  instance: InstanceElement,
+  folderInstancesIndex: FolderInstancesIndex,
+): InstanceElement | undefined => {
+  const { folderType } = instance.getTypeSync().annotations
+  const folderName = apiNameSync(instance)?.split('/')[0] ?? ''
+  return folderInstancesIndex.get(folderType)?.[folderName]
+}
+
+const isInstanceWithinFolder = (instance: InstanceElement): boolean =>
+  isDefined(instance.getTypeSync().annotations.folderType)
+
+const createFolderInstancesIndex = (elements: Element[]): FolderInstancesIndex => {
+  const folderInstancesIndex = new DefaultMap<string, Record<string, InstanceElement>>(() => ({}))
+  elements.filter(isInstanceElement).forEach(folderInstance => {
+    if (folderInstance.getTypeSync().annotations.folderContentType) {
+      folderInstancesIndex.get(metadataTypeSync(folderInstance))[apiNameSync(folderInstance) ?? ''] = folderInstance
+    }
+  })
+  return folderInstancesIndex
+}
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'addParentToInstancesWithinFolderFilter',
+  onFetch: async (elements: Element[]) => {
+    if (!config.fetchProfile.isFeatureEnabled('addParentToInstancesWithinFolder')) {
+      return
+    }
+    const folderInstancesIndex = createFolderInstancesIndex(
+      await toArrayAsync(await buildElementsSourceForFetch(elements, config).getAll()),
+    )
+    const count: number = elements
+      .filter(isInstanceElement)
+      .filter(isInstanceWithinFolder)
+      .reduce((acc, instance) => {
+        const parent = getFolderInstance(instance, folderInstancesIndex)
+        if (isDefined(parent)) {
+          addElementParentReference(instance, parent)
+          return acc + 1
+        }
+        return acc
+      }, 0)
+    log.debug('addParentToInstancesWithinFolderFilter created %d references in total', count)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -104,6 +104,7 @@ const OPTIONAL_FEATURES = [
   'genAiReferences',
   'networkReferences',
   'extendFetchTargets',
+  'addParentToInstancesWithinFolder',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',

--- a/packages/salesforce-adapter/test/filters/add_parent_to_instances_within_folder.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_instances_within_folder.test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { CORE_ANNOTATIONS, Element, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockTypes } from '../mock_elements'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { FilterWith } from './mocks'
+import filterCreator from '../../src/filters/add_parent_to_instances_within_folder'
+import { defaultFilterContext } from '../utils'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+
+describe('addParentToInstancesWithinFolderFilter', () => {
+  describe('onFetch', () => {
+    let elements: Element[]
+    let elementsSource: Element[]
+    let emailTemplateInstance: Element
+    let emailFolderInstance: Element
+    let reportInstance: Element
+    let reportFolderInstance: Element
+    let documentInstance: Element
+    let documentFolderInstance: Element
+    let dashboardInstance: Element
+    let dashboardFolderInstance: Element
+
+    beforeEach(() => {
+      emailFolderInstance = createInstanceElement({ fullName: 'MarketingFolder' }, mockTypes.EmailFolder)
+      elementsSource = [emailFolderInstance]
+      elements = [
+        (emailTemplateInstance = createInstanceElement(
+          { fullName: 'MarketingFolder/WelcomeEmail' },
+          mockTypes.EmailTemplate,
+        )),
+        (reportInstance = createInstanceElement({ fullName: 'SalesFolder/QuarterlySales' }, mockTypes.Report)),
+        (reportFolderInstance = createInstanceElement({ fullName: 'SalesFolder' }, mockTypes.ReportFolder)),
+        (documentInstance = createInstanceElement({ fullName: 'SharedDocs/Policy' }, mockTypes.Document)),
+        (documentFolderInstance = createInstanceElement({ fullName: 'SharedDocs' }, mockTypes.DocumentFolder)),
+        (dashboardInstance = createInstanceElement(
+          { fullName: 'Dashboards/PerformanceDashboard' },
+          mockTypes.Dashboard,
+        )),
+        (dashboardFolderInstance = createInstanceElement({ fullName: 'Dashboards' }, mockTypes.DashboardFolder)),
+        ...Object.values(mockTypes),
+      ]
+    })
+    describe('when the instances are within folder', () => {
+      describe('when addParentToInstancesWithinFolder is Enabled', () => {
+        beforeEach(async () => {
+          const filter: FilterWith<'onFetch'> = filterCreator({
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildFetchProfile({
+                fetchParams: { target: [], optionalFeatures: { addParentToInstancesWithinFolder: true } },
+              }),
+              elementsSource: buildElementsSourceFromElements(elementsSource),
+            },
+          }) as FilterWith<'onFetch'>
+          await filter.onFetch(elements)
+        })
+        it('should add parent annotation to email template', async () => {
+          expect(emailTemplateInstance.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+            new ReferenceExpression(emailFolderInstance.elemID, emailFolderInstance),
+          )
+        })
+        it('should add parent annotation to report', () => {
+          expect(reportInstance.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+            new ReferenceExpression(reportFolderInstance.elemID, reportFolderInstance),
+          )
+        })
+        it('should add parent annotation to document', () => {
+          expect(documentInstance.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+            new ReferenceExpression(documentFolderInstance.elemID, documentFolderInstance),
+          )
+        })
+        it('should add parent annotation to dashboard', () => {
+          expect(dashboardInstance.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+            new ReferenceExpression(dashboardFolderInstance.elemID, dashboardFolderInstance),
+          )
+        })
+      })
+      describe('when addParentToInstancesWithinFolder is Disabled', () => {
+        beforeEach(async () => {
+          const filter: FilterWith<'onFetch'> = filterCreator({
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildFetchProfile({
+                fetchParams: { target: [], optionalFeatures: { addParentToInstancesWithinFolder: false } },
+              }),
+              elementsSource: buildElementsSourceFromElements(elementsSource),
+            },
+          }) as FilterWith<'onFetch'>
+          await filter.onFetch(elements)
+        })
+        it('should not create parent annotation', () => {
+          expect(emailTemplateInstance.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+          expect(reportInstance.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+          expect(documentInstance.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+          expect(dashboardInstance.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+        })
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -303,6 +303,30 @@ export const mockTypes = {
       folderContentType: 'EmailTemplate',
     },
   }),
+  ReportFolder: createMetadataObjectType({
+    annotations: {
+      metadataType: 'ReportFolder',
+      dirName: 'reports',
+      hasMetaFile: true,
+      folderContentType: 'Report',
+    },
+  }),
+  DocumentFolder: createMetadataObjectType({
+    annotations: {
+      metadataType: 'DocumentFolder',
+      dirName: 'documents',
+      hasMetaFile: true,
+      folderContentType: 'Document',
+    },
+  }),
+  DashboardFolder: createMetadataObjectType({
+    annotations: {
+      metadataType: 'DashboardFolder',
+      dirName: 'dashboards',
+      hasMetaFile: true,
+      folderContentType: 'Dashboard',
+    },
+  }),
   AssignmentRules: createMetadataObjectType({
     annotations: {
       metadataType: ASSIGNMENT_RULES_METADATA_TYPE,
@@ -402,10 +426,35 @@ export const mockTypes = {
       metadataType: 'EmailTemplate',
       suffix: 'email',
       dirName: 'emails',
+      folderType: 'EmailFolder',
     },
     fields: {
       content: { refType: BuiltinTypes.STRING },
       attachments: { refType: new ListType(BuiltinTypes.STRING) },
+    },
+  }),
+  Report: createMetadataObjectType({
+    annotations: {
+      folderType: 'ReportFolder',
+      suffix: 'report',
+      dirName: 'reports',
+      metadataType: 'Report',
+    },
+  }),
+  Document: createMetadataObjectType({
+    annotations: {
+      hasMetaFile: true,
+      folderType: 'DocumentFolder',
+      dirName: 'documents',
+      metadataType: 'Document',
+    },
+  }),
+  Dashboard: createMetadataObjectType({
+    annotations: {
+      folderType: 'DashboardFolder',
+      suffix: 'dashboard',
+      dirName: 'dashboards',
+      metadataType: 'Dashboard',
     },
   }),
   RecordType: createMetadataObjectType({


### PR DESCRIPTION
SALTO-7020: Add parent relationship to metadata instances within folders

---
Workspace Diff: https://github.com/salto-io/almog-sf/commit/87210277c3ecd008ba1df96b7b8762a94be85c76

---
_Release Notes_: 
_Salesforce Adapter_:
- Add parent relationship to instances within folders.

---
_User Notifications_: 
_Salesforce Adapter_:
- **_parent** annotation will be added to some of the instances that are within Folders, instances of types:
  - EmailTemplate
  - Report
  - Document
  - Dashboard