### PR TITLE
SALTO-7040: Salesforce fetchTargets filter should not run in partial fetch

### DIFF
--- a/packages/salesforce-adapter/src/filters/fetch_targets.ts
+++ b/packages/salesforce-adapter/src/filters/fetch_targets.ts
@@ -66,6 +66,9 @@ const filterCreator: FilterCreator = ({ config }) => ({
     warningMessage: 'Error occurred when attempting to populate Fetch Targets',
     config,
     fetchFilterFunc: async elements => {
+      if (config.fetchProfile.metadataQuery.isPartialFetch()) {
+        return
+      }
       const fetchTargetsInstance = new InstanceElement(
         ElemID.CONFIG_NAME,
         ArtificialTypes.FetchTargets,

--- a/packages/salesforce-adapter/test/filters/fetch_targets.test.ts
+++ b/packages/salesforce-adapter/test/filters/fetch_targets.test.ts
@@ -47,25 +47,49 @@ describe('fetch targets filter', () => {
       elements = [customObjectType, customObjectTypeWithLookup]
     })
     describe('when feature is enabled', () => {
-      beforeEach(() => {
-        filter = filterCreator({
-          config: {
-            ...defaultFilterContext,
-            fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures: { extendFetchTargets: true } } }),
-          },
-        }) as typeof filter
+      describe('when fetch is full', () => {
+        beforeEach(() => {
+          filter = filterCreator({
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildFetchProfile({ fetchParams: { optionalFeatures: { extendFetchTargets: true } } }),
+            },
+          }) as typeof filter
+        })
+
+        it('should create a fetch targets instance with correct custom objects and lookups', async () => {
+          await filter.onFetch(elements)
+          const fetchTargetsInstance = elements
+            .filter(isInstanceElement)
+            .find(e => e.getTypeSync() === ArtificialTypes.FetchTargets) as InstanceElement
+          expect(fetchTargetsInstance).toBeDefined()
+          expect(fetchTargetsInstance.value).toEqual({
+            customObjects: [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT_WITH_LOOKUP_NAME],
+            customObjectsLookups: {
+              [CUSTOM_OBJECT_WITH_LOOKUP_NAME]: [CUSTOM_OBJECT_NAME, 'Account', 'Contact'],
+            },
+          })
+        })
       })
-      it('should create a fetch targets instance with correct custom objects and lookups', async () => {
-        await filter.onFetch(elements)
-        const fetchTargetsInstance = elements
-          .filter(isInstanceElement)
-          .find(e => e.getTypeSync() === ArtificialTypes.FetchTargets) as InstanceElement
-        expect(fetchTargetsInstance).toBeDefined()
-        expect(fetchTargetsInstance.value).toEqual({
-          customObjects: [CUSTOM_OBJECT_NAME, CUSTOM_OBJECT_WITH_LOOKUP_NAME],
-          customObjectsLookups: {
-            [CUSTOM_OBJECT_WITH_LOOKUP_NAME]: [CUSTOM_OBJECT_NAME, 'Account', 'Contact'],
-          },
+
+      describe('when fetch is partial', () => {
+        beforeEach(() => {
+          filter = filterCreator({
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildFetchProfile({
+                fetchParams: { target: [], optionalFeatures: { extendFetchTargets: true } },
+              }),
+            },
+          }) as typeof filter
+        })
+
+        it('should not create a fetch targets instance', async () => {
+          await filter.onFetch(elements)
+          const fetchTargetsInstance = elements
+            .filter(isInstanceElement)
+            .find(e => e.getTypeSync() === ArtificialTypes.FetchTargets)
+          expect(fetchTargetsInstance).toBeUndefined()
         })
       })
     })


### PR DESCRIPTION
SALTO-7040: Salesforce fetchTargets filter should not run in partial fetch

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_