### PR TITLE
SALTO-7043: Fix VS Code Jest tests debug setup

### DIFF
--- a/packages/adapter-api/.vscode/launch.json
+++ b/packages/adapter-api/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "adapter-api Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/adapter-components/.vscode/launch.json
+++ b/packages/adapter-components/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "adapter-components Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/adapter-utils/.vscode/launch.json
+++ b/packages/adapter-utils/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "adapter-utils Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/aws-utils/.vscode/launch.json
+++ b/packages/aws-utils/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "aws-utils Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/cli/.vscode/launch.json
+++ b/packages/cli/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "cli Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/confluence-adapter/.vscode/launch.json
+++ b/packages/confluence-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "confluence-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/core/.vscode/launch.json
+++ b/packages/core/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "core Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/dag/.vscode/launch.json
+++ b/packages/dag/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "dag Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/dummy-adapter/.vscode/launch.json
+++ b/packages/dummy-adapter/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "dummy-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/file/.vscode/launch.json
+++ b/packages/file/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "file Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/packages/google-workspace-adapter/.vscode/launch.json
+++ b/packages/google-workspace-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "google-workspace-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/intercom-adapter/.vscode/launch.json
+++ b/packages/intercom-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "intercom-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/jamf-adapter/.vscode/launch.json
+++ b/packages/jamf-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "jamf-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/jira-adapter/.vscode/launch.json
+++ b/packages/jira-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "jira-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/lang-server/.vscode/launch.json
+++ b/packages/lang-server/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "lang-server Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/local-workspace/.vscode/launch.json
+++ b/packages/local-workspace/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "local workspace Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/logging/.vscode/launch.json
+++ b/packages/logging/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "logging Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/lowerdash/.vscode/launch.json
+++ b/packages/lowerdash/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "lowerdash Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/microsoft-entra-adapter/.vscode/launch.json
+++ b/packages/microsoft-entra-adapter/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "microsoft-entra-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/microsoft-security-adapter/.vscode/launch.json
+++ b/packages/microsoft-security-adapter/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "microsoft-security-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/netsuite-adapter/.vscode/launch.json
+++ b/packages/netsuite-adapter/.vscode/launch.json
@@ -6,7 +6,12 @@
       "request": "launch",
       "name": "netsuite-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/okta-adapter/.vscode/launch.json
+++ b/packages/okta-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "okta-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/pagerduty-adapter/.vscode/launch.json
+++ b/packages/pagerduty-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "pagerduty-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/salesforce-adapter/.vscode/launch.json
+++ b/packages/salesforce-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "salesforce-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/sap-adapter/.vscode/launch.json
+++ b/packages/sap-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "sap-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/serviceplaceholder-adapter/.vscode/launch.json
+++ b/packages/serviceplaceholder-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "serviceplaceholder-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/stripe-adapter/.vscode/launch.json
+++ b/packages/stripe-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "stripe-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/vscode/.vscode/launch.json
+++ b/packages/vscode/.vscode/launch.json
@@ -15,7 +15,12 @@
       "request": "launch",
       "name": "Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/packages/workato-adapter/.vscode/launch.json
+++ b/packages/workato-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "workato-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/workspace/.vscode/launch.json
+++ b/packages/workspace/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "workspace Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/zendesk-adapter/.vscode/launch.json
+++ b/packages/zendesk-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "zendesk-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"

--- a/packages/zuora-billing-adapter/.vscode/launch.json
+++ b/packages/zuora-billing-adapter/.vscode/launch.json
@@ -9,7 +9,12 @@
       "request": "launch",
       "name": "zuora-billing-adapter Debug Jest Tests",
       "cwd": "${workspaceFolder}",
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
@@ -22,7 +27,12 @@
       "env": {
         "RUN_E2E_TESTS": "1"
       },
-      "args": ["${workspaceRoot}/node_modules/.bin/jest", "--runInBand", "--config", "${workspaceRoot}/jest.config.js"],
+      "args": [
+        "${workspaceFolder}/../../node_modules/.bin/jest",
+        "--runInBand",
+        "--config",
+        "${workspaceFolder}/jest.config.js"
+      ],
       "outFiles": [],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"


### PR DESCRIPTION
It was looking for Jest's binary in the wrong place 

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
