### PR TITLE
Add s3 logs for error visibility

### DIFF
--- a/packages/local-workspace/jest.config.js
+++ b/packages/local-workspace/jest.config.js
@@ -17,7 +17,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
       branches: 86.5,
       functions: 93.4,
       lines: 94.4,
-      statements: 94.9,
+      statements: 94.8,
     },
   },
   setupFilesAfterEnv: ['@salto-io/jest-extended/all', '@salto-io/element-test-utils/all'],

--- a/packages/local-workspace/src/s3_dir_store.ts
+++ b/packages/local-workspace/src/s3_dir_store.ts
@@ -9,7 +9,7 @@ import path from 'path'
 import { logger } from '@salto-io/logging'
 import * as AWS from '@aws-sdk/client-s3'
 import { createS3Client } from '@salto-io/aws-utils'
-import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { dirStore, staticFiles } from '@salto-io/workspace'
 import Bottleneck from 'bottleneck'
 import getStream from 'get-stream'
@@ -50,7 +50,7 @@ export const buildS3DirectoryStore = ({
       })
 
       if (!(s3Obj.Body instanceof Readable)) {
-        log.error('Received unexpected body type from s3.getObject: %s', safeJsonStringify(s3Obj.Body))
+        log.error('Received unexpected body type from s3.getObject: %s', inspectValue(s3Obj.Body))
         return undefined
       }
 

--- a/packages/local-workspace/src/s3_dir_store.ts
+++ b/packages/local-workspace/src/s3_dir_store.ts
@@ -55,10 +55,18 @@ export const buildS3DirectoryStore = ({
       }
 
       const buffer = await getStream.buffer(s3Obj.Body)
-
+      if (buffer === undefined) {
+        log.warn(
+          'Failed to read file %s from S3 bucket %s with body %s',
+          fullFilePath,
+          bucketName,
+          safeJsonStringify(s3Obj.Body),
+        )
+      }
       return { buffer, filename: filePath }
     } catch (err) {
       if (err.name === 'NoSuchKey') {
+        log.warn('File %s not found in S3 bucket %s', fullFilePath, bucketName)
         return undefined
       }
       log.warn('Failed to read file %s from S3 bucket %s', fullFilePath, bucketName)


### PR DESCRIPTION
Related to an issue where S3 returned an empty content.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
