### PR TITLE
SALTO-3464: fix noise in enhanced search

### DIFF
--- a/packages/jira-adapter/src/common/script_runner.ts
+++ b/packages/jira-adapter/src/common/script_runner.ts
@@ -10,4 +10,5 @@ import { FILTER_TYPE_NAME } from '../constants'
 
 export const isEnhancedSearchInstance = (instance: InstanceElement): boolean =>
   instance.elemID.typeName === FILTER_TYPE_NAME &&
-  instance.value.description?.startsWith('Filter managed by Enhanced Search')
+  (instance.value.description?.startsWith('Filter managed by Enhanced Search') ||
+    instance.value.description?.startsWith('Filter managed by ScriptRunner'))

--- a/packages/jira-adapter/src/filters/webhook/webhook.ts
+++ b/packages/jira-adapter/src/filters/webhook/webhook.ts
@@ -85,8 +85,8 @@ const getWebhookValues = async (client: JiraClient): Promise<Values[]> => {
     throw new Error('Received invalid response from webhooks request')
   }
   return response.data.map((webhook: Values) => ({
-    id: getIdFromSelf(webhook.self),
     ...webhook,
+    id: getIdFromSelf(webhook.self),
   }))
 }
 

--- a/packages/jira-adapter/test/filters/script_runner/enhanced_search/enhanced_search_noise_filter.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/enhanced_search/enhanced_search_noise_filter.test.ts
@@ -28,6 +28,11 @@ describe('enhancedSearchNoiseFilter', () => {
     await filter.onFetch([instance])
     expect(instance.value.jql).toEqual('ENHANCED_SEARCH_ISSUE_TERMS')
   })
+  it('should replace noise in jql for older versions', async () => {
+    instance.value.description = 'Filter managed by ScriptRunner: issueFunction in linkedIssuesOf'
+    await filter.onFetch([instance])
+    expect(instance.value.jql).toEqual('ENHANCED_SEARCH_ISSUE_TERMS')
+  })
   it('should not replace noise in jql if there is no closing bracket', async () => {
     instance.value.jql = 'issue in (1, 2, 3'
     await filter.onFetch([instance])


### PR DESCRIPTION
Added support for older filters 

---

I also made a minor fix for webhooks
Noise reduction will follow

---
_Release Notes_: 
Jira Adapter:
* JQL cleaning for Enhanced Search will now work also for older filters

---
_User Notifications_: 
Jira Adapter:
* The variable part of the jql in old Enhanced Search  filters will be replaced with a constant string
