### PR TITLE
SALTO-7047: Improve performance of workspace update

### DIFF
--- a/packages/workspace/src/workspace/elements_source.ts
+++ b/packages/workspace/src/workspace/elements_source.ts
@@ -16,7 +16,6 @@ import {
   ReadOnlyElementsSource,
   ContainerTypeName,
   TypeElement,
-  compareElementIDs,
 } from '@salto-io/adapter-api'
 import { collections, values } from '@salto-io/lowerdash'
 import { resolvePath } from '@salto-io/adapter-utils'
@@ -159,39 +158,3 @@ export const mapReadOnlyElementsSource = (
   has: id => source.has(id),
   list: () => source.list(),
 })
-
-export const createOverrideReadOnlyElementsSource = (
-  source: ReadOnlyElementsSource,
-  overrideElements: Record<string, Element | undefined>,
-): ReadOnlyElementsSource => {
-  const isOmittedByOverride = (id: string | undefined): boolean =>
-    id !== undefined && id in overrideElements && overrideElements[id] === undefined
-
-  const list: ReadOnlyElementsSource['list'] = async () =>
-    awu(
-      collections.asynciterable.iterateTogether(
-        await source.list(),
-        awu(
-          Object.values(overrideElements)
-            .filter(values.isDefined)
-            .map(elem => elem.elemID)
-            .sort(compareElementIDs),
-        ),
-        compareElementIDs,
-      ),
-    )
-      .filter(({ after: idFromOverride }) => !isOmittedByOverride(idFromOverride?.getFullName()))
-      .map(({ before: idFromSource, after: idFromOverride }) => idFromOverride ?? idFromSource)
-      .filter(values.isDefined)
-
-  const get: ReadOnlyElementsSource['get'] = async id =>
-    id.getFullName() in overrideElements ? overrideElements[id.getFullName()] : source.get(id)
-
-  return {
-    get,
-    getAll: async () => awu(await list()).map(get),
-    has: async id =>
-      id.getFullName() in overrideElements ? overrideElements[id.getFullName()] !== undefined : source.has(id),
-    list,
-  }
-}

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -26,7 +26,7 @@ import { ThenableIterable } from '@salto-io/lowerdash/src/collections/asyncitera
 import _ from 'lodash'
 import AsyncLock from 'async-lock'
 import { MergeError, MergeResult } from '../../merger'
-import { ElementsSource, createOverrideReadOnlyElementsSource } from '../elements_source'
+import { ElementsSource } from '../elements_source'
 import { RemoteMap, RemoteMapEntry, RemoteMapCreator } from '../remote_map'
 
 const { awu } = collections.asynciterable
@@ -71,7 +71,6 @@ export type RecoveryOverrideFunc = (
 export type CacheChangeSetUpdate = {
   src1Changes?: ChangeSet<Change<Element>>
   src2Changes?: ChangeSet<Change<Element>>
-  src2Overrides?: Record<string, Element | undefined>
   recoveryOverride?: RecoveryOverrideFunc
   src1Prefix: string
   src2Prefix: string
@@ -218,9 +217,7 @@ export const createMergeManager = async (
   }> => {
     const { src1Changes: possibleSrc1Changes, src2Changes: possibleSrc2Changes } = cacheUpdate
     const src1 = sources[cacheUpdate.src1Prefix]
-    const src2 = values.isDefined(cacheUpdate.src2Overrides)
-      ? createOverrideReadOnlyElementsSource(sources[cacheUpdate.src2Prefix], cacheUpdate.src2Overrides)
-      : sources[cacheUpdate.src2Prefix]
+    const src2 = sources[cacheUpdate.src2Prefix]
     const src1Changes =
       possibleSrc1Changes ?? createEmptyChangeSet(await hashes.get(getSourceHashKey(cacheUpdate.src1Prefix)))
     const src2Changes =

--- a/packages/workspace/test/workspace/elements_source.test.ts
+++ b/packages/workspace/test/workspace/elements_source.test.ts
@@ -5,15 +5,8 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { BuiltinTypes, ElemID, ObjectType, Element, ReadOnlyElementsSource } from '@salto-io/adapter-api'
-import { collections } from '@salto-io/lowerdash'
-import {
-  createInMemoryElementSource,
-  createOverrideReadOnlyElementsSource,
-  RemoteElementSource,
-} from '../../src/workspace/elements_source'
-
-const { awu } = collections.asynciterable
+import { BuiltinTypes, ElemID } from '@salto-io/adapter-api'
+import { createInMemoryElementSource, RemoteElementSource } from '../../src/workspace/elements_source'
 
 describe('RemoteElementSource', () => {
   let elemSource: RemoteElementSource
@@ -39,115 +32,6 @@ describe('RemoteElementSource', () => {
     })
     it('should return true when there are no elements', async () => {
       expect(await createInMemoryElementSource([]).isEmpty()).toEqual(true)
-    })
-  })
-})
-
-describe('overrideReadOnlyElementsSource', () => {
-  let originalElem: ObjectType
-  let overriddenElem: ObjectType
-  let changedOverriddenElem: ObjectType
-  let removedElem: ObjectType
-  let newElem: ObjectType
-  let source: RemoteElementSource
-  let overrideSource: ReadOnlyElementsSource
-  beforeEach(() => {
-    originalElem = new ObjectType({ elemID: new ElemID('test', 'type') })
-    overriddenElem = new ObjectType({ elemID: new ElemID('test', 'override'), annotations: { value: 'orig' } })
-    removedElem = new ObjectType({ elemID: new ElemID('test', 'removed') })
-    source = createInMemoryElementSource([originalElem, overriddenElem])
-    changedOverriddenElem = overriddenElem.clone()
-    changedOverriddenElem.annotations.value = 'changed'
-    newElem = new ObjectType({ elemID: new ElemID('test', 'new') })
-    overrideSource = createOverrideReadOnlyElementsSource(source, {
-      [overriddenElem.elemID.getFullName()]: changedOverriddenElem,
-      [removedElem.elemID.getFullName()]: undefined,
-      [newElem.elemID.getFullName()]: newElem,
-    })
-  })
-  describe('list', () => {
-    let listResult: string[]
-    beforeEach(async () => {
-      listResult = await awu(await overrideSource.list())
-        .map(id => id.getFullName())
-        .toArray()
-    })
-    it('should return an ordered list of IDs', () => {
-      const sortedList = listResult.map(id => id).sort()
-      expect(listResult).toEqual(sortedList)
-    })
-    it('should omit ids that were removed by overrides', () => {
-      expect(listResult).not.toContainEqual(removedElem.elemID.getFullName())
-    })
-    it('should return ids from original source without override removals', () => {
-      expect(listResult).toContainValues([newElem, overriddenElem, originalElem].map(elem => elem.elemID.getFullName()))
-    })
-  })
-  describe('has', () => {
-    it('should return true for ids from the origin that were no removed', async () => {
-      await expect(overrideSource.has(overriddenElem.elemID)).resolves.toBeTrue()
-      await expect(overrideSource.has(originalElem.elemID)).resolves.toBeTrue()
-    })
-    it('should return true for ids that were added by overrides', async () => {
-      await expect(overrideSource.has(newElem.elemID)).resolves.toBeTrue()
-    })
-    it('should return false for ids that were removed by overrides', async () => {
-      await expect(overrideSource.has(removedElem.elemID)).resolves.toBeFalse()
-    })
-  })
-  describe('get', () => {
-    describe('with overridden element', () => {
-      let result: ObjectType
-      beforeEach(async () => {
-        result = await overrideSource.get(overriddenElem.elemID)
-      })
-      it('should return the value from the override', () => {
-        expect(result.annotations).toEqual(changedOverriddenElem.annotations)
-      })
-    })
-
-    describe('with removed element', () => {
-      let result: ObjectType
-      beforeEach(async () => {
-        result = await overrideSource.get(removedElem.elemID)
-      })
-      it('should return undefined', () => {
-        expect(result).toBeUndefined()
-      })
-    })
-    describe('with added element', () => {
-      let result: ObjectType
-      beforeEach(async () => {
-        result = await overrideSource.get(newElem.elemID)
-      })
-      it('should return the value from the override', () => {
-        expect(result.isEqual(newElem)).toBeTrue()
-      })
-    })
-    describe('with unchanged element', () => {
-      let result: ObjectType
-      beforeEach(async () => {
-        result = await overrideSource.get(originalElem.elemID)
-      })
-      it('should return the original element', () => {
-        expect(result.isEqual(originalElem)).toBeTrue()
-      })
-    })
-  })
-  describe('getAll', () => {
-    let result: Element[]
-    beforeEach(async () => {
-      result = await awu(await overrideSource.getAll()).toArray()
-    })
-    it('should return elements ordered by ID', () => {
-      const sortedList = result.map(elem => elem.elemID.getFullName()).sort()
-      expect(result.map(elem => elem.elemID.getFullName())).toEqual(sortedList)
-    })
-    it('should omit elements that were removed by overrides', () => {
-      expect(result).not.toContainEqual(removedElem)
-    })
-    it('should return elements from original source without override removals', () => {
-      expect(result).toContainValues([newElem, changedOverriddenElem, originalElem])
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -146,6 +146,65 @@ describe('workspace', () => {
         new Error('Workspace with no environments is illegal'),
       )
     })
+    describe('when a field that has a hidden part is deleted from the nacl', () => {
+      let mainType: ObjectType
+      let workspace: Workspace
+      beforeEach(async () => {
+        const files = {
+          'bla.nacl': `type dummy.Type {
+            dummy.FieldType field {
+              visible = "asd"
+            }
+          }`,
+        }
+        const fieldType = new ObjectType({
+          elemID: new ElemID('dummy', 'FieldType'),
+          annotationRefsOrTypes: { visible: BuiltinTypes.STRING, hidden: BuiltinTypes.HIDDEN_STRING },
+        })
+        mainType = new ObjectType({
+          elemID: new ElemID('dummy', 'Type'),
+          fields: {
+            field: { refType: fieldType, annotations: { visible: 'asd', hidden: 'asd' } },
+          },
+        })
+        const state = mockState([fieldType, mainType])
+        const dirStore = mockDirStore([], false, files)
+        const remoteMapCreator = persistentMockCreateRemoteMap()
+        // Create the caches before making a change to the nacl
+        const tmpWorkspace = await createWorkspace(
+          dirStore,
+          state,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          remoteMapCreator,
+        )
+        await tmpWorkspace.elements()
+
+        // Make the change to the nacl
+        await dirStore.set({ filename: 'bla.nacl', buffer: 'type dummy.Type {}' })
+
+        // Load the workspace with the caches from the previous load
+        workspace = await createWorkspace(
+          dirStore,
+          state,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          remoteMapCreator,
+        )
+      })
+      it('should remove the field from the element', async () => {
+        const elements = await workspace.elements()
+        const type = (await elements.get(mainType.elemID)) as ObjectType
+        expect(type).toBeInstanceOf(ObjectType)
+        expect(type.fields).not.toHaveProperty('field')
+      })
+    })
   })
   describe('elements', () => {
     let workspace: Workspace


### PR DESCRIPTION
The override mechanism is replaced by fixing the original element source to return the correct result The issue that the override mechanism was there to solve was that if a field was removed from NaCl, we should remove the hidden part of the field as well.

This didn't work in the original code because the state element source would try to merge it with the element from the workspace cache but the element in the workspace cache was not updated yet, so it still had that field.

Changing the element source to use the element from the nacl cache instead (which is updated before) should solve the issue

---

_Additional context for reviewer_
It seems like the original issue that the overrides code solves was never actually covered in unit tests, I did verify it manually and added the missing unit test in this PR.

The scenario is to have a field with a hidden annotation in an environment, and then delete that field from the nacl (by editing the nacl manually).
before this fix, without the override code, the field would not be fully deleted from the workspace (the hidden part would remain)

---
_Release Notes_: 
Core:
- Improve performance of updating workspace cache

---
_User Notifications_: 
_None_