### PR TITLE
SALTO-6991: create element ID full name only if needed

### DIFF
--- a/packages/adapter-api/src/comparison.ts
+++ b/packages/adapter-api/src/comparison.ts
@@ -192,6 +192,9 @@ const compareSpecialValuesWithCircularRefs = (
   if (typeof first === 'string' && typeof second === 'string') {
     return compareStringsIgnoreNewlineDifferences(first, second)
   }
+  if (first instanceof ElemID && second instanceof ElemID) {
+    return first.isEqual(second)
+  }
   return undefined
 }
 

--- a/packages/adapter-api/src/element_id.ts
+++ b/packages/adapter-api/src/element_id.ts
@@ -120,13 +120,12 @@ export class ElemID {
   readonly typeName: string
   readonly idType: ElemIDType
   private readonly nameParts: ReadonlyArray<string>
-  private readonly fullName: string
+  private fullName?: string
   constructor(adapter: string, typeName?: string, idType?: ElemIDType, ...name: ReadonlyArray<string>) {
     this.adapter = adapter
     this.typeName = _.isEmpty(typeName) ? ElemID.CONFIG_NAME : (typeName as string)
     this.idType = idType || ElemID.getDefaultIdType(adapter)
     this.nameParts = name
-    this.fullName = this.generateFullName()
   }
 
   get name(): string {
@@ -166,6 +165,9 @@ export class ElemID {
   }
 
   getFullName(): string {
+    if (this.fullName === undefined) {
+      this.fullName = this.generateFullName()
+    }
     return this.fullName
   }
 


### PR DESCRIPTION
Reverts salto-io/salto#6888 (re-introducing salto-io/salto#6862)

Before this change, the string with the full name of the element ID was always created even if it was never used Changed this to create the string the first time it is needed.

---
Release Notes:
Core:
- Improvements to memory consumption when working with large numbers of changes

---
_User Notifications_: 
_None_