### PR TITLE
SALTO-7049: add pariallyFetchedAccounts to FetchResult

### DIFF
--- a/packages/cli/test/commands/adapter_format.test.ts
+++ b/packages/cli/test/commands/adapter_format.test.ts
@@ -73,6 +73,7 @@ describe('apply-patch command', () => {
         fetchErrors: [],
         success: true,
         updatedConfig: {},
+        partiallyFetchedAccounts: new Set(['salesforce']),
       })
 
       exitCode = await applyPatchAction({
@@ -114,6 +115,7 @@ describe('apply-patch command', () => {
         fetchErrors: [],
         success: true,
         updatedConfig: {},
+        partiallyFetchedAccounts: new Set(['salesforce']),
       })
       exitCode = await applyPatchAction({
         ...cliCommandArgs,
@@ -167,6 +169,7 @@ describe('apply-patch command', () => {
         fetchErrors: [],
         success: true,
         updatedConfig: {},
+        partiallyFetchedAccounts: new Set(['salesforce']),
       })
       exitCode = await applyPatchAction({
         ...cliCommandArgs,
@@ -207,6 +210,7 @@ describe('apply-patch command', () => {
         fetchErrors: [],
         success: true,
         updatedConfig: {},
+        partiallyFetchedAccounts: new Set(['salesforce']),
       })
       exitCode = await applyPatchAction({
         ...cliCommandArgs,

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -652,6 +652,7 @@ describe('fetch command', () => {
           ],
           updatedConfig: {},
           success: true,
+          partiallyFetchedAccounts: new Set(['salesforce']),
         })
         beforeEach(async () => {
           const workspace = mocks.mockWorkspace({})

--- a/packages/core/src/api.ts
+++ b/packages/core/src/api.ts
@@ -274,6 +274,7 @@ export const fetch: FetchFunc = async (
     configChanges,
     accountNameToConfigMessage,
     unmergedElements,
+    partiallyFetchedAccounts,
   } = await fetchChanges(
     accountToAdapter,
     await workspace.elements(),
@@ -298,6 +299,7 @@ export const fetch: FetchFunc = async (
     configChanges,
     updatedConfig,
     accountNameToConfigMessage,
+    partiallyFetchedAccounts,
   }
 }
 
@@ -329,6 +331,7 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
     configChanges,
     accountNameToConfigMessage,
     unmergedElements,
+    partiallyFetchedAccounts,
   } = await fetchChangesFromWorkspace(
     otherWorkspace,
     fetchAccounts,
@@ -355,6 +358,7 @@ export const fetchFromWorkspace: FetchFromWorkspaceFunc = async ({
     configChanges,
     accountNameToConfigMessage,
     progressEmitter,
+    partiallyFetchedAccounts,
   }
 }
 

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -217,6 +217,7 @@ export const calculatePatch = async ({
     mergeErrors: beforeMergeErrors,
     mergedElements: mergedBeforeElements,
   } = await loadElementsAndMerge(fromDir, loadElementsFromFolder, adapterContext)
+  const partiallyFetchedAccounts = new Set([accountName])
   if (beforeMergeErrors.length > 0) {
     return {
       changes: [],
@@ -224,7 +225,7 @@ export const calculatePatch = async ({
       fetchErrors: [],
       success: false,
       updatedConfig: {},
-      partiallyFetchedAccounts: new Set([accountName]),
+      partiallyFetchedAccounts,
     }
   }
   const {
@@ -240,7 +241,7 @@ export const calculatePatch = async ({
       fetchErrors: [],
       success: false,
       updatedConfig: {},
-      partiallyFetchedAccounts: new Set([accountName]),
+      partiallyFetchedAccounts,
     }
   }
   const { changes } = await calcFetchChanges({
@@ -257,7 +258,7 @@ export const calculatePatch = async ({
     fetchErrors: [...(beforeLoadErrors ?? []), ...(afterLoadErrors ?? [])],
     success: true,
     updatedConfig: {},
-    partiallyFetchedAccounts: new Set([accountName]),
+    partiallyFetchedAccounts,
   }
 }
 

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -224,6 +224,7 @@ export const calculatePatch = async ({
       fetchErrors: [],
       success: false,
       updatedConfig: {},
+      partiallyFetchedAccounts: new Set([accountName]),
     }
   }
   const {
@@ -239,6 +240,7 @@ export const calculatePatch = async ({
       fetchErrors: [],
       success: false,
       updatedConfig: {},
+      partiallyFetchedAccounts: new Set([accountName]),
     }
   }
   const { changes } = await calcFetchChanges({
@@ -255,6 +257,7 @@ export const calculatePatch = async ({
     fetchErrors: [...(beforeLoadErrors ?? []), ...(afterLoadErrors ?? [])],
     success: true,
     updatedConfig: {},
+    partiallyFetchedAccounts: new Set([accountName]),
   }
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,7 @@ export type FetchResult = {
   configChanges?: Plan
   updatedConfig: Record<string, InstanceElement[]>
   accountNameToConfigMessage?: Record<string, string>
+  partiallyFetchedAccounts: Set<string>
 }
 
 export type GroupProperties = AdapterGroupProperties & {

--- a/packages/core/test/core/adapter_format.test.ts
+++ b/packages/core/test/core/adapter_format.test.ts
@@ -234,6 +234,7 @@ describe('calculatePatch', () => {
       expect(res.fetchErrors).toHaveLength(0)
       expect(res.mergeErrors).toHaveLength(0)
       expect(res.changes).toHaveLength(2)
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 
@@ -257,6 +258,7 @@ describe('calculatePatch', () => {
       expect(res.mergeErrors).toHaveLength(0)
       expect(res.changes).toHaveLength(1)
       expect(res.changes[0].change.id.name).toEqual('f')
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 
@@ -277,6 +279,7 @@ describe('calculatePatch', () => {
       expect(res.fetchErrors).toHaveLength(0)
       expect(res.mergeErrors).toHaveLength(0)
       expect(res.changes).toHaveLength(0)
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 
@@ -294,6 +297,7 @@ describe('calculatePatch', () => {
       expect(res.fetchErrors).toHaveLength(0)
       expect(res.changes).toHaveLength(0)
       expect(res.mergeErrors).toHaveLength(1)
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 
@@ -325,6 +329,7 @@ describe('calculatePatch', () => {
       expect(res.changes).toHaveLength(1)
       expect(res.mergeErrors).toHaveLength(0)
       expect(res.fetchErrors).toHaveLength(1)
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 
@@ -351,6 +356,7 @@ describe('calculatePatch', () => {
       expect(res.changes).toHaveLength(1)
       const firstChange = (await awu(res.changes).toArray())[0]
       expect(firstChange.pendingChanges).toHaveLength(1)
+      expect(res.partiallyFetchedAccounts).toEqual(new Set(['mock']))
     })
   })
 

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -277,6 +277,20 @@ describe('fetch', () => {
           )
           expect(fetchChangesResult.elements).toEqual([newTypeBaseModifiedDifferentId])
         })
+        it('should return partiallyFetchedAccounts correctly', async () => {
+          mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce({
+            elements: [newTypeBaseModified],
+            partialFetchData: { isPartial: true },
+          })
+          const fetchChangesResult = await fetchChanges(
+            mockAdapters,
+            createInMemoryElementSource([]),
+            createInMemoryElementSource([newTypeBaseDifferentAdapterID, typeWithFieldDifferentID]),
+            { [newTypeDifferentAdapterID.adapter]: 'dummy' },
+            [],
+          )
+          expect(fetchChangesResult.partiallyFetchedAccounts).toEqual(new Set([newTypeDifferentAdapterID.adapter]))
+        })
       })
       describe('fetch is not partial', () => {
         it('should not ignore deletions', async () => {
@@ -371,6 +385,19 @@ describe('fetch', () => {
           expect(accountChange.data.before.resValue).toBe(6)
         }
       })
+      it('should return an empty partiallyFetchedAccounts correctly', async () => {
+        mockAdapters[newTypeDifferentAdapterID.adapter].fetch.mockResolvedValueOnce({
+          elements: [newTypeBaseModified],
+        })
+        const fetchChangesResult = await fetchChanges(
+          mockAdapters,
+          createInMemoryElementSource([newTypeBaseModifiedDifferentId, typeWithFieldDifferentID]),
+          createInMemoryElementSource([]),
+          { [newTypeDifferentAdapterID.adapter]: 'dummy' },
+          [],
+        )
+        expect(fetchChangesResult.partiallyFetchedAccounts).toEqual(new Set())
+      })
 
       describe('multiple adapters', () => {
         const adapters = {
@@ -402,6 +429,20 @@ describe('fetch', () => {
           expect(resultChanges.length).toBe(1)
           expect(resultChanges[0].change.action).toBe('remove')
           expect(getChangeData(resultChanges[0].change).elemID.adapter).toBe('dummy2')
+        })
+
+        it('should return partiallyFetchedAccounts correctly', async () => {
+          const fetchChangesResult = await fetchChanges(
+            adapters,
+            createInMemoryElementSource([
+              new ObjectType({ elemID: new ElemID('dummy1', 'type') }),
+              new ObjectType({ elemID: new ElemID('dummy2', 'type') }),
+            ]),
+            createInMemoryElementSource([]),
+            { dummy1AccountName: 'dummy1', dummy2: 'dummy2' },
+            [],
+          )
+          expect(fetchChangesResult.partiallyFetchedAccounts).toEqual(new Set(['dummy1AccountName']))
         })
       })
 


### PR DESCRIPTION
_add pariallyFetchedAccounts to FetchResult_

---

_Additional context for reviewer_

The motivation is to differ between fetch operation types in the backend (full, custom or changed based).
partiallyFetchAccounts is filled with accounts that do any kind of a partial fetch, and we want to expose it to the SAAS.

---
_Release Notes_: 
_Core_:
* `FetchResult` will contain `partiallyFetchedAccounts` to differentiate between partial and full fetches.


---
_User Notifications_: 
_None_
