### PR TITLE
SALTO-7054: NS: Avoid having RegexMismatchValidationError warning for apparently valid scriptIds

### DIFF
--- a/packages/netsuite-adapter/scripts/types_generation/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generation/types_generator.py
@@ -706,6 +706,9 @@ type_name_to_special_script_id_prefix = {
     'customtransactiontype': '^(customtransaction|customsale|custompurchase)[0-9a-z_]+', # https://{account_id}.app.netsuite.com/app/help/helpcenter.nl?fid=section_1520439377.html
     'kpiscorecard': '^(custkpiscorecard|kpiscorecard)[0-9a-z_]+', # The kpiscorecard prefix appeared when fetching the Extended Dev account
     'emailtemplate': 'standardemailtemplate|standardpaymentlinktransactionemailtemplate|^custemailtmpl[0-9a-z_]+', # The standardemailtemplate scriptid appeared to a certain customer's account & standardpaymentlinktransactionemailtemplate appeared when fetching from 2021.2 release preview
+    'role': '^customrole[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
+    'savedsearch': '^customsearch[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
+    'reportdefinition': '^customreport[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
 }
 
 fields_to_create = {

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/reportdefinition.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/reportdefinition.ts
@@ -121,7 +121,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]+' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]*' }),
         },
       } /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customreport’. */,
       name: {

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/role.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/role.ts
@@ -128,7 +128,7 @@ export const roleType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customrole[0-9a-z_]+' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customrole[0-9a-z_]*' }),
         },
       } /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customrole’. */,
       centertype: {

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/savedsearch.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/savedsearch.ts
@@ -50,7 +50,7 @@ export const savedsearchType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customsearch[0-9a-z_]+' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customsearch[0-9a-z_]*' }),
         },
       } /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customsearch’. */,
       definition: {

--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -469,7 +469,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
         annotations: {
           _required: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]+' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]*' }),
         },
       },
       definition: {

--- a/packages/netsuite-adapter/src/type_parsers/saved_search_parsing/parsed_saved_search.ts
+++ b/packages/netsuite-adapter/src/type_parsers/saved_search_parsing/parsed_saved_search.ts
@@ -219,7 +219,7 @@ export const savedsearchType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customsearch[0-9a-z_]+' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customsearch[0-9a-z_]*' }),
         },
       } /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customsearch’. */,
       definition: {


### PR DESCRIPTION
The code that was added to `types_generator.py` wasn't really tested, but only added so it won't get overridden next time we will generate types.

I used https://app.datadoghq.com/logs?query=status%3Awarn%20RegexMismatchValidationError%20-%2Areportdefinition%2A%20-%2Acustomsearch%2A%20-%2Acustomrole%2A&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&fromUser=true&messageDisplay=inline&refresh_mode=sliding&storage=hot&stream_sort=desc&viz=stream&from_ts=1733300418316&to_ts=1733905218316&live=true in order to find which elements suffer from the issue.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
