### PR TITLE
SALTO-4062: Support Custom Roles in Okta

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -436,6 +436,13 @@ const createChangesForDeploy = async (
       removePoweredByOkta: true,
     },
   })
+  const role = createInstance({
+    typeName: ROLE_TYPE_NAME,
+    types,
+    valuesOverride: {
+      label: createName('role'),
+    },
+  })
   const identityProvider = createInstance({
     typeName: IDENTITY_PROVIDER_TYPE_NAME,
     types,
@@ -540,6 +547,7 @@ const createChangesForDeploy = async (
     toChange({ after: app }),
     toChange({ after: appGroupAssignment }),
     toChange({ after: brand }),
+    toChange({ after: role }),
     toChange({ after: identityProvider }),
     toChange({ after: authServerPolicyA }),
     toChange({ after: authServerPolicyB }),

--- a/packages/okta-adapter/e2e_test/mock_elements.ts
+++ b/packages/okta-adapter/e2e_test/mock_elements.ts
@@ -25,6 +25,7 @@ import {
   PASSWORD_RULE_TYPE_NAME,
   AUTHORIZATION_POLICY,
   AUTHORIZATION_POLICY_RULE,
+  ROLE_TYPE_NAME,
 } from '../src/constants'
 
 export const mockDefaultValues: Record<string, Values> = {
@@ -418,5 +419,24 @@ export const mockDefaultValues: Record<string, Values> = {
         refreshTokenWindowMinutes: 10080,
       },
     },
+  },
+  [ROLE_TYPE_NAME]: {
+    description: 'deploy',
+    permissions: [
+      {
+        label: 'okta.groups.manage',
+      },
+      {
+        label: 'okta.users.groupMembership.manage',
+      },
+      {
+        label: 'okta.users.userprofile.manage',
+        conditions: {
+          include: {
+            'okta_ResourceAttribute_User_Profile@fdd': ['profileUrl', 'zipCode', 'city'],
+          },
+        },
+      },
+    ],
   },
 }

--- a/packages/okta-adapter/src/change_validators/standard_role_deployments.ts
+++ b/packages/okta-adapter/src/change_validators/standard_role_deployments.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ChangeValidator, getChangeData, isInstanceChange, InstanceElement, Change } from '@salto-io/adapter-api'
+import { ROLE_TYPE_NAME } from '../constants'
+import { ROLE_TYPE_TO_LABEL } from '../filters/standard_roles'
+
+const STANDARD_ROLE_TYPES = new Set(Object.keys(ROLE_TYPE_TO_LABEL))
+const isStandardRoleChange = (change: Change<InstanceElement>): boolean =>
+  getChangeData(change).value.type !== undefined && STANDARD_ROLE_TYPES.has(getChangeData(change).value.type)
+
+/**
+ * Block deployments of standard Okta roles
+ */
+export const standardRoleDeployments: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(change => getChangeData(change).elemID.typeName === ROLE_TYPE_NAME)
+    .filter(isStandardRoleChange)
+    .map(getChangeData)
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as const,
+      message: 'Standard roles cannot be deployed',
+      detailedMessage: 'Okta does not support deployments of standard roles.',
+    }))

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -17,7 +17,7 @@ import {
   isRemovalChange,
   Values,
 } from '@salto-io/adapter-api'
-import { getParents, validatePlainObject } from '@salto-io/adapter-utils'
+import { getParents, naclCase, validatePlainObject } from '@salto-io/adapter-utils'
 import { AdditionalAction, ClientOptions } from '../types'
 import {
   APPLICATION_TYPE_NAME,
@@ -47,6 +47,7 @@ import {
   ERROR_PAGE_TYPE_NAME,
   AUTHORIZATION_SERVER,
   GROUP_RULE_TYPE_NAME,
+  ROLE_TYPE_NAME,
 } from '../../constants'
 import {
   APP_POLICIES,
@@ -60,6 +61,7 @@ import { isCustomApp } from '../fetch/types/application'
 import { addBrandIdToRequest } from './types/email_domain'
 import { isSystemScope } from './types/authorization_servers'
 import { isActiveGroupRuleChange } from './types/group_rules'
+import { adjustRoleAdditionChange, isPermissionChangeOfAddedRole } from './types/roles'
 
 const log = logger(module)
 
@@ -1316,6 +1318,95 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
+    [ROLE_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles', method: 'post' },
+                transformation: {
+                  adjust: adjustRoleAdditionChange,
+                },
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles/{id}', method: 'put' },
+                transformation: { omit: ['permissions'] },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles/{id}', method: 'delete' },
+              },
+            },
+          ],
+        },
+      },
+      recurseIntoPath: [
+        {
+          fieldPath: ['permissions'],
+          typeName: 'Permission',
+          changeIdFields: ['label'],
+          onActions: ['add', 'modify'],
+        },
+      ],
+    },
+    Permission: {
+      requestsByAction: {
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles/{parent_id}/permissions/{label}', method: 'post' },
+                transformation: { omit: ['label'] },
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles/{parent_id}/permissions/{label}', method: 'put' },
+                transformation: { omit: ['label'] },
+              },
+              condition: {
+                custom:
+                  () =>
+                  ({ change, changeGroup, sharedContext }) => {
+                    if (isPermissionChangeOfAddedRole(change, changeGroup)) {
+                      // only make request for permission that their "conditions" were not deployed yet
+                      if (sharedContext[naclCase(getChangeData(change).value.label)]) {
+                        log.debug('deploying permission condition for %s', getChangeData(change).elemID.getFullName())
+                        return true
+                      }
+                      return false
+                    }
+                    return true
+                  },
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: { path: '/api/v1/iam/roles/{parent_id}/permissions/{label}', method: 'delete' },
+              },
+            },
+          ],
+        },
+      },
+      toActionNames: ({ change, changeGroup }) => {
+        if (isAdditionChange(change) && isPermissionChangeOfAddedRole(change, changeGroup)) {
+          return ['modify']
+        }
+        return [change.action]
+      },
+    },
   }
 
   return _.merge(standardRequestDefinitions, customDefinitions)
@@ -1340,5 +1431,10 @@ export const createDeployDefinitions = (): DeployApiDefinitions => ({
     },
     customizations: createCustomizations(),
   },
-  dependencies: [],
+  dependencies: [
+    {
+      first: { type: ROLE_TYPE_NAME, action: 'add' },
+      second: { type: 'Permission', action: 'modify' },
+    },
+  ],
 })

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -17,7 +17,7 @@ import {
   isRemovalChange,
   Values,
 } from '@salto-io/adapter-api'
-import { getParents, naclCase, validatePlainObject } from '@salto-io/adapter-utils'
+import { getParents, validatePlainObject } from '@salto-io/adapter-utils'
 import { AdditionalAction, ClientOptions } from '../types'
 import {
   APPLICATION_TYPE_NAME,
@@ -61,7 +61,7 @@ import { isCustomApp } from '../fetch/types/application'
 import { addBrandIdToRequest } from './types/email_domain'
 import { isSystemScope } from './types/authorization_servers'
 import { isActiveGroupRuleChange } from './types/group_rules'
-import { adjustRoleAdditionChange, isPermissionChangeOfAddedRole } from './types/roles'
+import { adjustRoleAdditionChange, isPermissionChangeOfAddedRole, shouldUpdateRolePermission } from './types/roles'
 
 const log = logger(module)
 
@@ -1375,19 +1375,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 transformation: { omit: ['label'] },
               },
               condition: {
-                custom:
-                  () =>
-                  ({ change, changeGroup, sharedContext }) => {
-                    if (isPermissionChangeOfAddedRole(change, changeGroup)) {
-                      // only make request for permission that their "conditions" were not deployed yet
-                      if (sharedContext[naclCase(getChangeData(change).value.label)]) {
-                        log.debug('deploying permission condition for %s', getChangeData(change).elemID.getFullName())
-                        return true
-                      }
-                      return false
-                    }
-                    return true
-                  },
+                custom: shouldUpdateRolePermission,
               },
             },
           ],

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -1335,7 +1335,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
             {
               request: {
                 endpoint: { path: '/api/v1/iam/roles/{id}', method: 'put' },
-                transformation: { omit: ['permissions'] },
+                transformation: { omit: ['id', 'permissions'] },
               },
             },
           ],

--- a/packages/okta-adapter/src/definitions/deploy/types/roles.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/roles.ts
@@ -74,7 +74,7 @@ export const shouldUpdateRolePermission: definitions.deploy.DeployRequestConditi
     const parentName = isReferenceExpression(parent) ? parent.elemID.getFullName() : undefined
     if (parentName !== undefined && isPermissionChangeOfAddedRole(change, changeGroup)) {
       // only make request for permission that their "conditions" were not deployed yet
-      if (_.get(sharedContext, [parentName, naclCase(inst.value.label)]) !== undefined) {
+      if (_.get(sharedContext, [parentName, naclCase(inst.value.label)]) === true) {
         log.debug('deploying permission condition for %s', getChangeData(change).elemID.getFullName())
         return true
       }

--- a/packages/okta-adapter/src/definitions/deploy/types/roles.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/roles.ts
@@ -8,7 +8,7 @@
 
 import _ from 'lodash'
 import { definitions } from '@salto-io/adapter-components'
-import { getParents, naclCase, safeJsonStringify, validatePlainObject } from '@salto-io/adapter-utils'
+import { getParents, safeJsonStringify, validatePlainObject } from '@salto-io/adapter-utils'
 import {
   Change,
   ChangeGroup,
@@ -39,8 +39,7 @@ export const adjustRoleAdditionChange: definitions.AdjustFunction<
   }
   const mappedPermissions = permissions.map(permission => {
     if (_.isPlainObject(permission?.conditions)) {
-      // naclCase permission.label because the label includes dots
-      _.set(sharedContext, [getChangeData(change).elemID.getFullName(), naclCase(permission.label)], true)
+      _.set(sharedContext, [getChangeData(change).elemID.getFullName(), permission.label], true)
     }
     return permission.label
   })
@@ -74,7 +73,7 @@ export const shouldUpdateRolePermission: definitions.deploy.DeployRequestConditi
     const parentName = isReferenceExpression(parent) ? parent.elemID.getFullName() : undefined
     if (parentName !== undefined && isPermissionChangeOfAddedRole(change, changeGroup)) {
       // only make request for permission that their "conditions" were not deployed yet
-      if (_.get(sharedContext, [parentName, naclCase(inst.value.label)]) === true) {
+      if (_.get(sharedContext, [parentName, inst.value.label]) === true) {
         log.debug('deploying permission condition for %s', getChangeData(change).elemID.getFullName())
         return true
       }

--- a/packages/okta-adapter/src/definitions/deploy/types/roles.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/roles.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import _ from 'lodash'
+import { definitions } from '@salto-io/adapter-components'
+import { getParents, naclCase, safeJsonStringify, validatePlainObject } from '@salto-io/adapter-utils'
+import {
+  Change,
+  ChangeGroup,
+  InstanceElement,
+  getChangeData,
+  isAdditionChange,
+  isReferenceExpression,
+} from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import { ROLE_TYPE_NAME } from '../../../constants'
+
+const log = logger(module)
+
+/**
+ * When adding a custom role, we must specify permissions for the role.
+ * In the role POST request, the permission object must be "flattened" to a list of permission labels.
+ * permission conditions, if exist, must be added in a separate request, therefore we store those in the shared context.
+ */
+export const adjustRoleAdditionChange: definitions.AdjustFunction<
+  definitions.deploy.ChangeAndExtendedContext
+> = async ({ value, context }) => {
+  const { sharedContext } = context
+  validatePlainObject(value, ROLE_TYPE_NAME)
+  const permissions = _.get(value, 'permissions')
+  if (!_.isArray(permissions)) {
+    log.error('expected permissions to be an array, instead got %s', safeJsonStringify(permissions))
+    throw new Error('missing permissions for role')
+  }
+  const mappedPermissions = permissions.map(permission => {
+    if (_.isPlainObject(permission?.conditions)) {
+      // naclCase permission.label because the label includes dots
+      _.set(sharedContext, naclCase(permission.label), true)
+    }
+    return permission.label
+  })
+  return {
+    value: {
+      ...value,
+      permissions: mappedPermissions,
+    },
+  }
+}
+
+export const isPermissionChangeOfAddedRole = (
+  change: Change<InstanceElement>,
+  changeGroup: Readonly<ChangeGroup>,
+): boolean => {
+  const parent = getParents(getChangeData(change))[0]
+  const parentName = isReferenceExpression(parent) ? parent.elemID.getFullName() : undefined
+  const parentChange = changeGroup.changes.find(c => getChangeData(c).elemID.getFullName() === parentName)
+  return parentChange !== undefined && isAdditionChange(parentChange)
+}

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -371,16 +371,6 @@ const createCustomizations = ({
             },
           },
         },
-        AppProvisioning: {
-          typeName: 'AppProvisioning',
-          context: {
-            args: {
-              appId: {
-                root: 'id',
-              },
-            },
-          },
-        },
         ...(usePrivateAPI
           ? {
               GroupPush: {

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -371,6 +371,16 @@ const createCustomizations = ({
             },
           },
         },
+        AppProvisioning: {
+          typeName: 'AppProvisioning',
+          context: {
+            args: {
+              appId: {
+                root: 'id',
+              },
+            },
+          },
+        },
         ...(usePrivateAPI
           ? {
               GroupPush: {

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -938,13 +938,41 @@ const createCustomizations = ({
   },
   Role: {
     requests: [{ endpoint: { path: '/api/v1/iam/roles' }, transformation: { root: 'roles' } }],
-    resource: { directFetch: true },
+    resource: {
+      directFetch: true,
+      recurseInto: {
+        permissions: {
+          typeName: 'Permission',
+          context: { args: { id: { root: 'id' } } },
+        },
+      },
+    },
     element: {
       topLevel: {
         isTopLevel: true,
         elemID: { parts: [{ fieldName: 'label' }] },
       },
-      fieldCustomizations: { id: { hide: true }, _links: { omit: true } },
+      fieldCustomizations: {
+        id: { hide: true },
+        _links: { omit: true },
+        permissions: { fieldType: 'list<Permission>', sort: { properties: [{ path: 'label' }] } },
+      },
+    },
+  },
+  Permission: {
+    requests: [
+      {
+        endpoint: { path: '/api/v1/iam/roles/{id}/permissions' },
+        transformation: { root: 'permissions' },
+      },
+    ],
+    resource: { directFetch: false, serviceIDFields: ['label'] },
+    element: {
+      fieldCustomizations: {
+        created: { omit: true },
+        lastUpdated: { omit: true },
+        _links: { omit: true },
+      },
     },
   },
   ResourceSet: {

--- a/packages/okta-adapter/src/filters/standard_roles.ts
+++ b/packages/okta-adapter/src/filters/standard_roles.ts
@@ -17,7 +17,7 @@ const { RECORDS_PATH } = elementUtils
  * Source for standard roles definitions:
  * https://developer.okta.com/docs/concepts/role-assignment/#standard-role-types
  */
-const ROLE_TYPE_TO_LABEL: Record<string, string> = {
+export const ROLE_TYPE_TO_LABEL: Record<string, string> = {
   API_ACCESS_MANAGEMENT_ADMIN: 'API Access Management Administrator',
   APP_ADMIN: 'Application Administrator',
   GROUP_MEMBERSHIP_ADMIN: 'Group Membership Administrator',

--- a/packages/okta-adapter/test/change_validators/standard_role_deployments.test.ts
+++ b/packages/okta-adapter/test/change_validators/standard_role_deployments.test.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { getChangeData, InstanceElement, ObjectType, ElemID, toChange } from '@salto-io/adapter-api'
+import { standardRoleDeployments } from '../../src/change_validators/standard_role_deployments'
+import { OKTA, ROLE_TYPE_NAME } from '../../src/constants'
+
+describe('standardRoleDeployments', () => {
+  const roleType = new ObjectType({ elemID: new ElemID(OKTA, ROLE_TYPE_NAME) })
+  const standardRoleInst = new InstanceElement('role1', roleType, { type: 'APP_ADMIN', label: 'App Admin' })
+  const customRoleInst = new InstanceElement('role2', roleType, { label: 'Custom Role' })
+  const changes = [
+    toChange({ before: standardRoleInst, after: standardRoleInst }),
+    toChange({ after: standardRoleInst }),
+    toChange({ before: standardRoleInst }),
+  ]
+  it.each(changes)('should return error for changes in standard roles', async change => {
+    expect(await standardRoleDeployments([change])).toEqual([
+      {
+        elemID: getChangeData(change).elemID,
+        severity: 'Error',
+        message: 'Standard roles cannot be deployed',
+        detailedMessage: 'Okta does not support deployments of standard roles.',
+      },
+    ])
+  })
+  it('should not return error for changes in custom roles', async () => {
+    const change = toChange({ after: customRoleInst })
+    const result = await standardRoleDeployments([change])
+    expect(result).toHaveLength(0)
+  })
+})

--- a/packages/okta-adapter/test/mock_replies/role_add.json
+++ b/packages/okta-adapter/test/mock_replies/role_add.json
@@ -1,0 +1,53 @@
+[
+  {
+    "path": "/api/v1/iam/roles",
+    "scope": "",
+    "method": "POST",
+    "status": 200,
+    "response": {
+      "id": "role-fakeid1",
+      "label": "test",
+      "description": "test",
+      "created": "2024-12-18T16:23:46.000Z",
+      "lastUpdated": "2024-12-18T16:23:46.000Z"
+    },
+    "body": {
+      "label": "test",
+      "description": "test",
+      "permissions": ["okta.users.userprofile.manage"]
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "799",
+      "x-rate-limit-reset": "1734539086"
+    }
+  },
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1/permissions/okta.users.userprofile.manage",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "label": "okta.users.userprofile.manage",
+      "created": "2024-12-18T16:23:46.000Z",
+      "lastUpdated": "2024-12-18T16:23:46.000Z",
+      "conditions": {
+        "include": {
+          "okta:ResourceAttribute/User/Profile": ["profileUrl", "zipCode", "city"]
+        }
+      }
+    },
+    "body": {
+      "conditions": {
+        "include": {
+          "okta:ResourceAttribute/User/Profile": ["profileUrl", "zipCode", "city"]
+        }
+      }
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "798",
+      "x-rate-limit-reset": "1734539086"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/role_modify.json
+++ b/packages/okta-adapter/test/mock_replies/role_modify.json
@@ -1,0 +1,62 @@
+[
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "role-fakeid1",
+      "label": "test",
+      "description": "test2",
+      "created": "2024-12-18T16:23:46.000Z",
+      "lastUpdated": "2024-12-18T17:51:37.000Z"
+    },
+    "body": {
+      "label": "test",
+      "description": "test2"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "799",
+      "x-rate-limit-reset": "1734544357"
+    }
+  },
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1/permissions/okta.users.userprofile.manage",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "797",
+      "x-rate-limit-reset": "1734544357"
+    }
+  },
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1/permissions/okta.users.groupMembership.manage",
+    "scope": "",
+    "method": "POST",
+    "status": 204,
+    "response": "",
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "798",
+      "x-rate-limit-reset": "1734544357"
+    }
+  },
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1/permissions/okta.groups.manage",
+    "scope": "",
+    "method": "POST",
+    "status": 204,
+    "response": "",
+    "body": {},
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "796",
+      "x-rate-limit-reset": "1734544357"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/role_remove.json
+++ b/packages/okta-adapter/test/mock_replies/role_remove.json
@@ -1,0 +1,14 @@
+[
+  {
+    "path": "/api/v1/iam/roles/role-fakeid1",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "800",
+      "x-rate-limit-remaining": "797",
+      "x-rate-limit-reset": "1734538712"
+    }
+  }
+]


### PR DESCRIPTION
Add a proper support in Okta's custom roles

---

_Additional context for reviewer_
Until now, we only fetched the name and description of the role, with no deploy support.
This PR adds the permission field for roles + support deploying those
Standard roles are not deployable and blocked using a validator.

This PR rebased on top of https://github.com/salto-io/salto/pull/6933, only the last commit is relevant

---
_Release Notes_: 

_Okta Adapter_:
- Add deploy support for Custom Roles

---
_User Notifications_: 
_Okta Adapter_:
- Custom roles elements will now include their permissions
