### PR TITLE
SALTO-7045 add `additionallyInstalledVersions` to `AdapterSuccessInstallResult`

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -166,8 +166,17 @@ export type AdapterOperationsContext = {
   accountName?: string
 } & AdapterBaseContext
 
-export type AdapterSuccessInstallResult = { success: true; installedVersion: string }
-export type AdapterFailureInstallResult = { success: false; errors: string[] }
+export type AdapterSuccessInstallResult = {
+  success: true
+  installedVersion: string
+  additionallyInstalledVersions?: string[]
+}
+
+export type AdapterFailureInstallResult = {
+  success: false
+  errors: string[]
+}
+
 export type AdapterInstallResult = AdapterSuccessInstallResult | AdapterFailureInstallResult
 
 export const isAdapterSuccessInstallResult = (result: AdapterInstallResult): result is AdapterSuccessInstallResult =>


### PR DESCRIPTION
This will be used in https://github.com/salto-io/salto/pull/6921

---

_Additional context for reviewer_

---
_Release Notes_: 
Adapter API:
- add `additionallyInstalledVersions` to `AdapterSuccessInstallResult`

---
_User Notifications_: 
None