### PR TITLE
SALTO-7045 add `installedVersions` to `AdapterSuccessInstallResult`

### DIFF
--- a/packages/adapter-api/src/adapter.ts
+++ b/packages/adapter-api/src/adapter.ts
@@ -169,7 +169,7 @@ export type AdapterOperationsContext = {
 export type AdapterSuccessInstallResult = {
   success: true
   installedVersion: string
-  additionallyInstalledVersions?: string[]
+  installedVersions: string[]
 }
 
 export type AdapterFailureInstallResult = {

--- a/packages/adapter-api/test/adapter.test.ts
+++ b/packages/adapter-api/test/adapter.test.ts
@@ -103,6 +103,7 @@ describe('adapter', () => {
       const result = isAdapterSuccessInstallResult({
         success: true,
         installedVersion: 'version',
+        installedVersions: ['version'],
       })
       expect(result).toEqual(true)
     })

--- a/packages/core/test/common/helpers.ts
+++ b/packages/core/test/common/helpers.ts
@@ -42,7 +42,11 @@ export const createMockAdapter = (
       ),
       optionsType,
     },
-    install: mockFunction<Required<Adapter>['install']>().mockResolvedValue({ success: true, installedVersion: '1' }),
+    install: mockFunction<Required<Adapter>['install']>().mockResolvedValue({
+      success: true,
+      installedVersion: '1',
+      installedVersions: ['1'],
+    }),
     adapterFormat: {
       isInitializedFolder: mockFunction<NonNullable<AdapterFormat['isInitializedFolder']>>().mockResolvedValue({
         result: false,

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -171,7 +171,11 @@ export const adapter: Adapter = {
   configType,
   install: async (): Promise<AdapterInstallResult> => {
     try {
-      return await SdkDownloadService.download()
+      const result = await SdkDownloadService.download()
+      if (result.success) {
+        return { ...result, installedVersions: [result.installedVersion] }
+      }
+      return result
     } catch (err) {
       return { success: false, errors: [err.message ?? err] }
     }


### PR DESCRIPTION
@ori-moisis's suggestion:
instead of having `installedVersion` and `additionallyInstalledVersions?` , return `installedVersions` that contain all of the installed versions and later deprecate `installedVersion`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Adapter API:
- add `installedVersions` to `AdapterSuccessInstallResult`

---
_User Notifications_: 
None