### PR TITLE
SALTO-4230: Extract DiscoveryAIModel content to a static file

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -342,6 +342,7 @@ const METADATA_TO_RETRIEVE = [
   'CustomPermission',
   'Dashboard', // contains encoded zip content, is under a folder
   'DashboardFolder',
+  'DiscoveryAIModel',
   'Document', // contains encoded zip content, is under a folder
   'DocumentFolder',
   'EclairGeoData', // contains encoded zip content


### PR DESCRIPTION
SALTO-4230: Extract DiscoveryAIModel content to a static file

---
Retrieve already includes functionality for extracting content of instance into a static file [here](https://github.com/salto-io/salto/blob/fad42b019fdd1370af9c3c689d37862da1cf6d7b/packages/salesforce-adapter/src/transformers/xml_transformer.ts#L447C9-L447C36).
This PR adds the discoveryAIModel to Retrieve.

---
Workspace Diff: https://github.com/salto-io/almog-sf/commit/3dc65d070328a0e8c63384226fbab9fa675a2a49

---
_Release Notes_: 
_Salesforce Adapter_:
- Extract DiscoveryAIModel content to a static file.

---
_User Notifications_: 
_Salesforce Adapter_:
- Content field in DiscoveryAIModel instances will be converted to static files.
- New static files will be created.
