### PR TITLE
SALTO-5462: Support deployment of Filter's owners

### DIFF
--- a/packages/jira-adapter/src/filters/filter.ts
+++ b/packages/jira-adapter/src/filters/filter.ts
@@ -5,6 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import { logger } from '@salto-io/logging'
 import {
   getChangeData,
   isAdditionOrModificationChange,
@@ -12,13 +13,27 @@ import {
   Change,
   ChangeDataType,
   Value,
+  CORE_ANNOTATIONS,
+  Element,
+  InstanceElement,
+  ModificationChange,
+  AdditionChange,
+  isModificationChange,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import Joi from 'joi'
+import { resolveChangeElement } from '@salto-io/adapter-components'
+import _ from 'lodash'
 import { FilterCreator } from '../filter'
 import { FILTER_TYPE_NAME, SHARE_PERMISSION_FIELDS } from '../constants'
+import { findObject } from '../utils'
+import { defaultDeployChange, deployChanges } from '../deployment/standard_deployment'
+import JiraClient from '../client/client'
+import { JiraConfig } from '../config/config'
+import { getLookUpName } from '../reference_mapping'
 
+const log = logger(module)
 const { makeArray } = collections.array
 const USER = 'user'
 
@@ -59,13 +74,79 @@ const changePermissionFieldFormat = (changes: Change<ChangeDataType>[], changeFu
     })
 }
 
-// handles the permissions format change. The share permission is not relevant for dc, as there is no option for it there
-const filter: FilterCreator = () => ({
+// handles the permissions format change. The share permission is not relevant for dc, as there is no option for it thereimport { FILTER_TYPE_NAME } from '../constants'
+
+const deployOwner = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient,
+): Promise<void> => {
+  const resolvedChange = await resolveChangeElement(change, getLookUpName)
+  const beforeOwnerAccountId = isModificationChange(resolvedChange)
+    ? resolvedChange.data.before.value.owner.id
+    : undefined
+  const afterOwnerAccountId = resolvedChange.data.after.value.owner
+
+  const instance = getChangeData(change)
+  if (beforeOwnerAccountId !== afterOwnerAccountId) {
+    await client.put({
+      url: `/rest/api/3/filter/${instance.value.id}/owner`,
+      data: {
+        accountId: afterOwnerAccountId,
+      },
+    })
+  }
+}
+
+const deployFilter = async (
+  change: ModificationChange<InstanceElement> | AdditionChange<InstanceElement>,
+  client: JiraClient,
+  config: JiraConfig,
+): Promise<void> => {
+  await defaultDeployChange({
+    change,
+    client,
+    apiDefinitions: config.apiDefinitions,
+    fieldsToIgnore: ['owner'],
+  })
+
+  await deployOwner(change, client)
+}
+
+const filter: FilterCreator = ({ config, client }) => ({
   name: 'filtersFilter',
+  onFetch: async (elements: Element[]): Promise<void> => {
+    const filterConfiguration = findObject(elements, FILTER_TYPE_NAME)
+    if (filterConfiguration === undefined) {
+      log.warn('filterConfiguration type was not found')
+      return
+    }
+    filterConfiguration.fields.owner.annotations = {
+      [CORE_ANNOTATIONS.CREATABLE]: true,
+      [CORE_ANNOTATIONS.UPDATABLE]: true,
+    }
+  },
   preDeploy: async (changes: Change<ChangeDataType>[]) => {
     changePermissionFieldFormat(changes, toDeploymentFormat)
   },
+  deploy: async (changes: Change<InstanceElement>[]) => {
+    const [relevantChanges, leftoverChanges] = _.partition(
+      changes,
+      change =>
+        isInstanceChange(change) &&
+        isAdditionOrModificationChange(change) &&
+        getChangeData(change).elemID.typeName === FILTER_TYPE_NAME,
+    )
 
+    const deployResult = await deployChanges(
+      relevantChanges.filter(isInstanceChange).filter(isAdditionOrModificationChange),
+      async change => deployFilter(change, client, config),
+    )
+
+    return {
+      leftoverChanges,
+      deployResult,
+    }
+  },
   onDeploy: async (changes: Change<ChangeDataType>[]) => {
     changePermissionFieldFormat(changes, toNaclFormat)
   },

--- a/packages/jira-adapter/src/filters/filter.ts
+++ b/packages/jira-adapter/src/filters/filter.ts
@@ -115,12 +115,12 @@ const deployFilter = async (
 const filter: FilterCreator = ({ config, client }) => ({
   name: 'filtersFilter',
   onFetch: async (elements: Element[]): Promise<void> => {
-    const filterConfiguration = findObject(elements, FILTER_TYPE_NAME)
-    if (filterConfiguration === undefined) {
-      log.warn('filterConfiguration type was not found')
+    const filterType = findObject(elements, FILTER_TYPE_NAME)
+    if (filterType === undefined) {
+      log.warn('filterType type was not found')
       return
     }
-    filterConfiguration.fields.owner.annotations = {
+    filterType.fields.owner.annotations = {
       [CORE_ANNOTATIONS.CREATABLE]: true,
       [CORE_ANNOTATIONS.UPDATABLE]: true,
     }

--- a/packages/jira-adapter/test/filters/filter.test.ts
+++ b/packages/jira-adapter/test/filters/filter.test.ts
@@ -5,16 +5,62 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { InstanceElement, toChange } from '@salto-io/adapter-api'
-import { createEmptyType, getFilterParams } from '../utils'
+import {
+  CORE_ANNOTATIONS,
+  InstanceElement,
+  toChange,
+  BuiltinTypes,
+  ObjectType,
+  ElemID,
+  Change,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { MockInterface } from '@salto-io/test-utils'
+import { deployment, client as clientUtils } from '@salto-io/adapter-components'
+import { createEmptyType, getFilterParams, mockClient } from '../utils'
 import filtersFilter from '../../src/filters/filter'
 import { Filter } from '../../src/filter'
+import { FILTER_TYPE_NAME, JIRA } from '../../src/constants'
+import JiraClient from '../../src/client/client'
+import { getDefaultConfig, JiraConfig } from '../../src/config/config'
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    deployment: {
+      ...actual.deployment,
+      deployChange: jest.fn(),
+    },
+  }
+})
 
 describe('filtersFilter', () => {
   let filter: Filter
+  let type: ObjectType
+  let connection: MockInterface<clientUtils.APIConnection>
+  let client: JiraClient
+  let config: JiraConfig
 
   beforeEach(async () => {
-    filter = filtersFilter(getFilterParams())
+    const { connection: conn, client: cli, paginator } = mockClient()
+    connection = conn
+    client = cli
+    config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    filter = filtersFilter(getFilterParams({ client, paginator, config }))
+    type = new ObjectType({
+      elemID: new ElemID(JIRA, FILTER_TYPE_NAME),
+      fields: {
+        owner: { refType: BuiltinTypes.STRING },
+      },
+    })
+  })
+  it('should turn owner field CREATABLE & UPDATEABLE annotations to true on fetch', async () => {
+    await filter.onFetch?.([type])
+    expect(type.fields.owner.annotations).toEqual({
+      [CORE_ANNOTATIONS.UPDATABLE]: true,
+      [CORE_ANNOTATIONS.CREATABLE]: true,
+    })
   })
   it('should replace user field on pre deploy', async () => {
     const instance = new InstanceElement('instance', createEmptyType('Filter'), {
@@ -86,6 +132,73 @@ describe('filtersFilter', () => {
       },
     ])
   })
+  describe('deploy', () => {
+    let change: Change<InstanceElement>
+    const deployChangeMock = deployment.deployChange as jest.MockedFunction<typeof deployment.deployChange>
+    const instance = new InstanceElement('instance', createEmptyType('Filter'), {
+      id: '1',
+      owner: '123',
+    })
+
+    beforeEach(() => {
+      deployChangeMock.mockReset()
+    })
+
+    describe('addition', () => {
+      beforeEach(() => {
+        change = toChange({ after: instance })
+      })
+      it('should add the owner to the new instance', async () => {
+        await filter.deploy?.([change])
+
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change,
+          client,
+          endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types[FILTER_TYPE_NAME]
+            .deployRequests,
+          fieldsToIgnore: ['owner'],
+        })
+
+        expect(connection.put).toHaveBeenCalledWith(
+          `/rest/api/3/filter/${instance.value.id}/owner`,
+          {
+            accountId: instance.value.owner,
+          },
+          undefined,
+        )
+      })
+    })
+
+    describe('modification', () => {
+      let instanceBefore: InstanceElement
+      beforeEach(() => {
+        instanceBefore = instance.clone()
+        change = toChange({ before: instanceBefore, after: instance })
+      })
+      it('should deploy owner when changed', async () => {
+        instance.value.owner = '234'
+        instance.value.description = 'test'
+
+        await filter.deploy?.([change])
+
+        expect(deployChangeMock).toHaveBeenCalledWith({
+          change,
+          client,
+          endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types[FILTER_TYPE_NAME]
+            .deployRequests,
+          fieldsToIgnore: ['owner'],
+        })
+
+        expect(connection.put).toHaveBeenCalledWith(
+          `/rest/api/3/filter/${instance.value.id}/owner`,
+          {
+            accountId: instance.value.owner,
+          },
+          undefined,
+        )
+      })
+    })
+  })
   it('should return user field after deploy', async () => {
     const instance = new InstanceElement('instance', createEmptyType('Filter'), {
       sharePermissions: [
@@ -155,7 +268,6 @@ describe('filtersFilter', () => {
       },
     ])
   })
-
   it('should do nothing if not a filter type', async () => {
     const instance = new InstanceElement('instance', createEmptyType('Other'), {
       editPermissions: [


### PR DESCRIPTION
Added support to deploy filter's owners (addition or modification)

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira_adapter_:
- Support deployment of Filter's owners in Jira

---
_User Notifications_: 
