### PR TITLE
SALTO-7058: Fix CLI deploy summary

### DIFF
--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -109,6 +109,28 @@ export const applyFunctionToChangeData = async <T extends Change<unknown>>(
   return change
 }
 
+export const applyFunctionToChangeDataSync = <T extends Change<unknown>>(
+  change: T,
+  func: (arg: ChangeData<T>) => ChangeData<T>,
+): T => {
+  if (isAdditionChange(change)) {
+    return { ...change, data: { after: func(change.data.after) } }
+  }
+  if (isRemovalChange(change)) {
+    return { ...change, data: { before: func(change.data.before) } }
+  }
+  if (isModificationChange(change)) {
+    return {
+      ...change,
+      data: {
+        before: func(change.data.before),
+        after: func(change.data.after),
+      },
+    }
+  }
+  return change
+}
+
 /**
  * Generate synthetic object types for validating / transforming map type values.
  *

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -85,6 +85,7 @@ import {
   validateArray,
   getParentElemID,
   getParentAsyncWithElementsSource,
+  applyFunctionToChangeDataSync,
 } from '../src/utils'
 import { buildElementsSourceFromElements } from '../src/element_source'
 
@@ -1969,12 +1970,15 @@ describe('Test utils.ts', () => {
     })
   })
 
-  describe('applyFunctionToChangeData', () => {
+  describe.each([
+    { name: 'applyFunctionToChangeData', functionToTest: applyFunctionToChangeData },
+    { name: 'applyFunctionToChangeDataSync', functionToTest: applyFunctionToChangeDataSync },
+  ])('$name', ({ functionToTest }) => {
     const transformFunc = (): string => 'changed'
     describe('with addition change', () => {
       let transformedChange: AdditionChange<string>
       beforeEach(async () => {
-        transformedChange = await applyFunctionToChangeData(
+        transformedChange = await functionToTest(
           { action: 'add', data: { after: 'orig' }, path: ['path'] },
           transformFunc,
         )
@@ -1989,10 +1993,7 @@ describe('Test utils.ts', () => {
     describe('with removal change', () => {
       let transformedChange: RemovalChange<string>
       beforeEach(async () => {
-        transformedChange = await applyFunctionToChangeData(
-          { action: 'remove', data: { before: 'orig' } },
-          transformFunc,
-        )
+        transformedChange = await functionToTest({ action: 'remove', data: { before: 'orig' } }, transformFunc)
       })
       it('should change the before value', () => {
         expect(transformedChange.data.before).toEqual('changed')
@@ -2001,7 +2002,7 @@ describe('Test utils.ts', () => {
     describe('with modification change', () => {
       let transformedChange: ModificationChange<string>
       beforeEach(async () => {
-        transformedChange = await applyFunctionToChangeData(
+        transformedChange = await functionToTest(
           { action: 'modify', data: { before: 'orig', after: 'orig' } },
           transformFunc,
         )


### PR DESCRIPTION
The deploy summary in the CLI was incorrect when changes were not fully applied

---

_Additional context for reviewer_

---
_Release Notes_: 
CLI:
- Fixed issue where deploy summary would not show failed or partially successful changes correctly

---
_User Notifications_: 
_None_