### PR TITLE
SALTO-7065: (Bug-fix) Fetch-From with `fromState` with addition of static file causes pending change

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1141,7 +1141,7 @@ const fixStaticFilesForFromStateChanges = async (
         return
       }
       const staticFilePath = staticFileValElemID.createTopLevelParentID().path
-      const relativePath = staticFilePath.filter(pathPart => !changePath.includes(pathPart))
+      const relativePath = staticFilePath.slice(changePath.length)
       _.set(change.data.after, relativePath, actualStaticFile)
     })
   })

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -1141,7 +1141,7 @@ const fixStaticFilesForFromStateChanges = async (
         return
       }
       const staticFilePath = staticFileValElemID.createTopLevelParentID().path
-      const relativePath = staticFilePath.slice(changePath.length - 1)
+      const relativePath = staticFilePath.filter(pathPart => !changePath.includes(pathPart))
       _.set(change.data.after, relativePath, actualStaticFile)
     })
   })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2188,7 +2188,7 @@ describe('fetch from workspace', () => {
           ) as FetchChange
           expect(nestedStaticFileChange).toBeDefined()
           const complexFieldValue = getChangeData(nestedStaticFileChange.change)
-          expect(complexFieldValue).toEqual({
+          expect(complexFieldValue).toStrictEqual({
             staticFileField: fileTwo,
             staticFilesArr: [fileThree],
           })

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2212,9 +2212,9 @@ describe('fetch from workspace', () => {
               change.change.id.createTopLevelParentID().parent.isEqual(editStateExistingInstance.elemID),
             )
             .map(change => getChangeData(change.change))
-          expect(modifyStaticVals).toHaveLength(3)
+          expect(modifyStaticVals).toHaveLength(2)
           const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
-          expect(staticFileModifies).toHaveLength(3)
+          expect(staticFileModifies).toHaveLength(1)
         })
 
         it('should not have a change on the val and a error if there is a hashes mismatch (for both inner modify and a whole addition)', () => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2213,8 +2213,13 @@ describe('fetch from workspace', () => {
             )
             .map(change => getChangeData(change.change))
           expect(modifyStaticVals).toHaveLength(2)
-          const staticFileModifies = modifyStaticVals.filter(val => isStaticFile(val))
-          expect(staticFileModifies).toHaveLength(1)
+          expect(modifyStaticVals).toIncludeSameMembers([
+            fileOne,
+            {
+              staticFileField: fileTwo,
+              staticFilesArr: [fileThree],
+            },
+          ])
         })
 
         it('should not have a change on the val and a error if there is a hashes mismatch (for both inner modify and a whole addition)', () => {

--- a/packages/core/test/core/fetch.test.ts
+++ b/packages/core/test/core/fetch.test.ts
@@ -2212,7 +2212,6 @@ describe('fetch from workspace', () => {
               change.change.id.createTopLevelParentID().parent.isEqual(editStateExistingInstance.elemID),
             )
             .map(change => getChangeData(change.change))
-          expect(modifyStaticVals).toHaveLength(2)
           expect(modifyStaticVals).toIncludeSameMembers([
             fileOne,
             {


### PR DESCRIPTION
(Bug-fix) Fetch-From with `fromState` with addition of static file causes pending change

---

See comments.

---
_Release Notes_: 
_Core_:
- (Bug-fix) Fetch-From with `fromState` with addition of static file causes pending change.

---
_User Notifications_: 
_None_
