### PR TITLE
SALTO-6841: Log error data when getAccessToken fails for Microsoft Security

### DIFF
--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -15,7 +15,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   coverageThreshold: {
     global: {
       statements: 98.15,
-      branches: 89.25,
+      branches: 87.8,
       functions: 93.63,
       lines: 98.06,
     },

--- a/packages/microsoft-security-adapter/src/client/connection.ts
+++ b/packages/microsoft-security-adapter/src/client/connection.ts
@@ -51,7 +51,7 @@ const getAccessToken = async ({ tenantId, clientId, clientSecret, refreshToken }
   } catch (e) {
     log.error(
       'Failed to get access token, error: %s, stack: %s',
-      safeJsonStringify({ message: e?.message, status: e?.response?.status }),
+      safeJsonStringify({ data: e?.response?.data, status: e?.response?.status }),
       e.stack,
     )
     throw new clientUtils.UnauthorizedError('Invalid Credentials')


### PR DESCRIPTION
Logging the error message doesn't provide the information needed, so we log the response data instead. We don't expect MS to return secrets in this response.

For example, when failing to retrieve the access token due to MFA enabled. 

When logging only the message we get:
`Failed to get access token, error: {"message":"Request failed with status code 400","status":400}, stack: AxiosError: Request failed with status code 400`

However, when we log the error response data we get:
`Failed to get access token, error: {"data":{"error":"invalid_grant","error_description":"AADSTS50158: External security challenge not satisfied. User will be redirected to another page or authentication provider to satisfy additional authentication challenges. Trace ID: <ID> Correlation ID: <ID> Timestamp: <TS>","error_codes":[50158],"timestamp":"<TS>","trace_id":"<ID>","correlation_id":"<ID>","error_uri":"https://login.microsoftonline.com/error?code=50158","suberror":"basic_action","claims":"{\"access_token\":{\"capolids\":{\"essential\":true,\"values\":[\"<ID>\"]}}}"},"status":400}, stack: AxiosError: Request failed with status code 400`

Which provides a better explanation.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
