### PR TITLE
SALTO-7068: Set a hardcoded element ID for the Okta Dashboard app

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -40,7 +40,7 @@ import {
 import { isGroupPushEntry } from '../../filters/group_push'
 import { extractSchemaIdFromUserType } from './types/user_type'
 import { isNotMappingToAuthenticatorApp } from './types/profile_mapping'
-import { assignPolicyIdsToApplication } from './types/application'
+import { assignPolicyIdsToApplication, isOktaDashboard } from './types/application'
 import { shouldConvertUserIds } from '../../user_utils'
 import { isNotDeletedEmailDomain } from './types/email_domain'
 import { isDefaultDomain } from './types/domain'
@@ -420,7 +420,15 @@ const createCustomizations = ({
       topLevel: {
         isTopLevel: true,
         serviceUrl: { path: '/admin/app/{name}/instance/{id}/#tab-general' },
-        elemID: { parts: [{ fieldName: 'label' }] },
+        elemID: {
+          parts: [
+            { fieldName: 'label', condition: value => !isOktaDashboard(value) },
+            // "Okta Dashboard" is a special app that can only have one instance. We need to ensure its element ID is
+            // identical across all environments, so we hardcode it and not depend on its label, which can change.
+            // TODO(SALTO-7005): Remove fieldName from this definition.
+            { fieldName: '', condition: isOktaDashboard, custom: () => () => 'Okta Dashboard' },
+          ],
+        },
         allowEmptyArrays: true,
       },
       fieldCustomizations: {

--- a/packages/okta-adapter/src/definitions/fetch/types/application.ts
+++ b/packages/okta-adapter/src/definitions/fetch/types/application.ts
@@ -92,3 +92,6 @@ export const isCustomApp = (value: Values, subdomain?: string): boolean => {
   const isCustomAppName = subdomainMatch || customAppNamePatternMatch
   return [AUTO_LOGIN_APP, SAML_2_0_APP].includes(value.signOnMode) && isCustomAppName
 }
+
+// Okta Dashboard is a special app that can only have one instance. We need to ensure its element ID is identical across all environments.
+export const isOktaDashboard = (value: Values): boolean => value?.name === 'okta_enduser'

--- a/packages/okta-adapter/src/filters/app_logo.ts
+++ b/packages/okta-adapter/src/filters/app_logo.ts
@@ -124,8 +124,8 @@ const appLogoFilter: FilterCreator = ({ definitions, getElemIdFunc }) => ({
     const appLogoType = createFileType(APP_LOGO_TYPE_NAME)
     elements.push(appLogoType)
 
-    const elemIDDef = definitionsUtils.queryWithDefault(definitions.fetch?.instances ?? {}).query(APPLICATION_TYPE_NAME)
-      ?.element?.topLevel?.elemID
+    const typeDef = definitionsUtils.queryWithDefault(definitions.fetch?.instances ?? {}).query(APPLICATION_TYPE_NAME)
+    const elemIDDef = typeDef?.element?.topLevel?.elemID
     if (elemIDDef === undefined) {
       log.error('Could not find elemID definition for %s, skipping appLogoFilter', APPLICATION_TYPE_NAME)
       return undefined
@@ -134,6 +134,7 @@ const appLogoFilter: FilterCreator = ({ definitions, getElemIdFunc }) => ({
       elemIDDef,
       typeID: new ElemID('okta', APPLICATION_TYPE_NAME),
       getElemIdFunc,
+      serviceIDDef: typeDef?.resource?.serviceIDFields,
     })
     const allInstances = await Promise.all(
       appsWithLogo.map(async app => getAppLogo({ client, app, appLogoType, elemIDFunc })),


### PR DESCRIPTION
The Okta Dashboard app is a singleton - only one of its type is allowed. However, it has an autogenerated `id` from the service, and we use its label as the element ID, which users can change. We want the element ID to be fixed, so that deploying Okta Dashboard app changes between environments where that app's label was changed, to modify the correct app and not apply an add+remove change (which is disallowed by the service).

This PR also fixes a bug in computing `AppLogo` element IDs (which are based on their parent app ID) - before this fix, element IDs for `AppLogo`s were always recomputed regardless of whether `--regenerate-salto-ids` was supplied or not.

---

_Additional context for reviewer_:
I manually tested that running `fetch` without `--regenerate-salto-ids` results in zero changes.
And [here's the workspace diff](https://github.com/salto-io/amir-okta/commit/33799f1d8f1b0ed4668fad8a48b02829baa36d42) for running _with_ `--regenerate-salto-ids`.

---
_Release Notes_: 
_Okta adapter_:
- Fixed a bug where modification deployments of the "Okta Dashboard" application would fail if the app had different labels between the environments in the deployment.

---
_User Notifications_: 
- When regenerating Salto IDs, the "Okta Dashboard" application instance's element ID will change to "Okta Dashboard" even if its label was changed.