### PR TITLE
SALTO-6830: Sorting converted map values in pre deploy

### DIFF
--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -497,7 +497,11 @@ const convertFieldsBackToLists = async (
   mapFieldDef: Record<string, MapDef>,
   elementType: string,
 ): Promise<void> => {
-  const toVals = (values: Values): Values[] => Object.values(values).flat()
+  const toVals = (values: Values): Values[] =>
+    Object.entries(values)
+      .sort(([key1, _val1], [key2, _val2]) => key1.localeCompare(key2))
+      .map(([_key, val]) => val)
+      .flat()
 
   const backToArrays = (baseElement: Element): Element => {
     const elementsToConvert = []

--- a/packages/salesforce-adapter/test/filters/convert_maps.test.ts
+++ b/packages/salesforce-adapter/test/filters/convert_maps.test.ts
@@ -630,6 +630,7 @@ describe('Convert maps filter', () => {
   describe('Convert inner field to map', () => {
     let lwcBefore: InstanceElement
     let lwcAfter: InstanceElement
+    let lwcSorted: InstanceElement
     let elements: Element[]
     type FilterType = FilterWith<'onFetch' | 'preDeploy'>
     let filter: FilterType
@@ -641,6 +642,18 @@ describe('Convert maps filter', () => {
             lwcResource: [
               { filePath: 'lwc/dir/lwc.js', source: 'lwc.ts' },
               { filePath: 'lwc/dir/__mocks__/lwc.js', source: 'lwc.ts' },
+            ],
+          },
+        },
+        mockTypes.LightningComponentBundle,
+      )
+      lwcSorted = createInstanceElement(
+        {
+          fullName: 'lwc',
+          lwcResources: {
+            lwcResource: [
+              { filePath: 'lwc/dir/__mocks__/lwc.js', source: 'lwc.ts' },
+              { filePath: 'lwc/dir/lwc.js', source: 'lwc.ts' },
             ],
           },
         },
@@ -677,7 +690,7 @@ describe('Convert maps filter', () => {
         await filter.preDeploy([toChange({ after: lwcDeploy })])
       })
       it('should return inner field back to list', async () => {
-        expect(lwcDeploy).toEqual(lwcBefore)
+        expect(lwcDeploy).toEqual(lwcSorted)
       })
     })
   })


### PR DESCRIPTION
This will give us consistent ordering in SFDX and shouldn't affect deployments (the current order we send is basically random).

---

_Additional context for reviewer_

---

_Release Notes_: 
_Salesforce_:
* Consistent ordering for values in SFDX which are represented in NaCl using maps (e.g. profiles).

---

_User Notifications_: 
None.
