### PR TITLE
SALTO-7076: Add lint rules to prevent invalid imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,7 +200,20 @@ export default [
       'no-restricted-imports': [
         'error',
         {
-          patterns: ['**/dist/**', 'src/*'],
+          patterns: [
+            {
+              group: ['src/*'],
+              message: 'Imports into src should be relative (start with ../ or ./)',
+            },
+            {
+              group: ['**/dist/**', '@salto-io/**/src/**'],
+              message: 'Must not import directly from an internal file of a package, import from the top level package instead',
+            },
+            {
+              group: ['**/test/**', '**/e2e_test/**'],
+              message: 'Test files are not distributed with the package, must not import from test files in the src folder',
+            },
+          ]
         },
       ],
 


### PR DESCRIPTION
Add rules to prevent importing from files that are not distributed to NPM

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_