### PR TITLE
SALTO-6594: Add a CV to prevent deployment of JIM field

### DIFF
--- a/packages/jira-adapter/src/change_validators/field.ts
+++ b/packages/jira-adapter/src/change_validators/field.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ChangeValidator,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  SeverityLevel,
+} from '@salto-io/adapter-api'
+
+const SEARCHER_KEY = 'com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher'
+const TYPE = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
+
+export const fieldValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .filter(change => getChangeData(change).elemID.typeName === 'Field')
+    .filter(change => change.data.after.value.searcherKey === SEARCHER_KEY && change.data.after.value.type === TYPE)
+    .map(change => ({
+      elemID: getChangeData(change).elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'SearcherKey is invalid for the field type',
+      detailedMessage: 'SearcherKey is invalid for the field type.',
+    }))

--- a/packages/jira-adapter/src/change_validators/field.ts
+++ b/packages/jira-adapter/src/change_validators/field.ts
@@ -12,19 +12,24 @@ import {
   isInstanceChange,
   SeverityLevel,
 } from '@salto-io/adapter-api'
+import { FIELD_TYPE_NAME } from '../filters/fields/constants'
 
-const SEARCHER_KEY = 'com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher'
-const TYPE = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
+export const EXACT_TEXT_SEARCHER_KEY = 'com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher'
+export const TEXT_FIELD_TYPE = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
 
 export const fieldValidator: ChangeValidator = async changes =>
   changes
     .filter(isInstanceChange)
     .filter(isAdditionOrModificationChange)
-    .filter(change => getChangeData(change).elemID.typeName === 'Field')
-    .filter(change => change.data.after.value.searcherKey === SEARCHER_KEY && change.data.after.value.type === TYPE)
-    .map(change => ({
-      elemID: getChangeData(change).elemID,
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+    .filter(
+      instance => instance.value.searcherKey === EXACT_TEXT_SEARCHER_KEY && instance.value.type === TEXT_FIELD_TYPE,
+    )
+    .map(instance => ({
+      elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'SearcherKey is invalid for the field type',
-      detailedMessage: 'SearcherKey is invalid for the field type.',
+      detailedMessage:
+        'This field was created using JIT and cannot be deployed. To resolve this issue, edit the NaCl file, and in the searchKey field, replace "exacttextsearcher" with "textsearcher".',
     }))

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -73,6 +73,7 @@ import { fieldContextOrderRemovalValidator } from './field_contexts/order_remova
 import { optionValueValidator } from './field_contexts/option_value'
 import { enhancedSearchDeploymentValidator } from './script_runner/enhanced_search_deployment'
 import { emptyProjectScopedContextValidator } from './field_contexts/empty_project_scoped_context'
+import { fieldValidator } from './field'
 
 const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator, SCOPE } =
   deployment.changeValidators
@@ -154,6 +155,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     optionValue: optionValueValidator(config),
     enhancedSearchDeployment: enhancedSearchDeploymentValidator,
     emptyProjectScopedContext: emptyProjectScopedContextValidator,
+    field: fieldValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -295,6 +295,7 @@ const CHANGE_VALIDATOR_NAMES = [
   'enhancedSearchDeployment',
   'fieldContext',
   'emptyProjectScopedContext',
+  'filter',
 ]
 
 export type ChangeValidatorName = (typeof CHANGE_VALIDATOR_NAMES)[number]

--- a/packages/jira-adapter/test/change_validators/field.test.ts
+++ b/packages/jira-adapter/test/change_validators/field.test.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { toChange, ObjectType, ElemID, InstanceElement } from '@salto-io/adapter-api'
+import { fieldValidator } from '../../src/change_validators/field'
+import { JIRA } from '../../src/constants'
+
+const EXACT_TEXT_SEARCHER_KEY = 'com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher'
+const TEXT_FIELD_TYPE = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'
+
+describe('fieldValidator', () => {
+  let type: ObjectType
+  let instance: InstanceElement
+  let afterInstance: InstanceElement
+
+  beforeEach(() => {
+    type = new ObjectType({ elemID: new ElemID(JIRA, 'Field') })
+    instance = new InstanceElement('instance', type, {
+      type: TEXT_FIELD_TYPE,
+      searcherKey: 'com.atlassian.jira.plugin.system.customfieldtypes:textsearcher',
+    })
+    afterInstance = instance.clone()
+    afterInstance.value.searcherKey = EXACT_TEXT_SEARCHER_KEY
+  })
+
+  it('should return error if created an instance with an invalid searcher key for this type', async () => {
+    expect(
+      await fieldValidator([
+        toChange({
+          after: afterInstance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'SearcherKey is invalid for the field type',
+        detailedMessage: 'SearcherKey is invalid for the field type.',
+      },
+    ])
+  })
+
+  it('should return an error if changed to the exact text searcher key', async () => {
+    expect(
+      await fieldValidator([
+        toChange({
+          before: instance,
+          after: afterInstance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: 'SearcherKey is invalid for the field type',
+        detailedMessage: 'SearcherKey is invalid for the field type.',
+      },
+    ])
+  })
+})


### PR DESCRIPTION
Added a field validator to prevent deployment of a searcherKey value for the field type 'textfield':
searcherKey = 'com.atlassian.jira.plugin.system.customfieldtypes:exacttextsearcher'
type = 'com.atlassian.jira.plugin.system.customfieldtypes:textfield'

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira_adapter_:
- Added new CV to prevent deployment of JIM field

---
_User Notifications_: 
