### PR TITLE
SALTO-7080: Log when resolving ref to undefined

### DIFF
--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -372,7 +372,7 @@ export const generateLookupFunc = <
     if (!isRelativeSerializer(strategy)) {
       const serializedValue = await strategy.serialize({ ref, field, element, path })
       if (serializedValue === undefined) {
-        log.error('failed to serialize reference in to %s in path %s', ref.elemID.getFullName(), path?.getFullName())
+        log.error('failed to serialize reference to %s in path %s', ref.elemID.getFullName(), path?.getFullName())
       }
       return serializedValue
     }

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -370,7 +370,11 @@ export const generateLookupFunc = <
         element,
       }) ?? ReferenceSerializationStrategyLookup.fullValue
     if (!isRelativeSerializer(strategy)) {
-      return strategy.serialize({ ref, field, element, path })
+      const serializedValue = await strategy.serialize({ ref, field, element, path })
+      if (serializedValue === undefined) {
+        log.error('failed to serialize reference in to %s in path %s', ref.elemID.getFullName(), path?.getFullName())
+      }
+      return serializedValue
     }
     return cloneDeepWithoutRefs(ref.value)
   }


### PR DESCRIPTION
For easier debugging when `serialize` returns undefined

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
