### PR TITLE
Revert "SALTO-7076: Add lint rules to prevent invalid imports"

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,20 +200,7 @@ export default [
       'no-restricted-imports': [
         'error',
         {
-          patterns: [
-            {
-              group: ['src/*'],
-              message: 'Imports into src should be relative (start with ../ or ./)',
-            },
-            {
-              group: ['**/dist/**', '@salto-io/**/src/**'],
-              message: 'Must not import directly from an internal file of a package, import from the top level package instead',
-            },
-            {
-              group: ['**/test/**', '**/e2e_test/**'],
-              message: 'Test files are not distributed with the package, must not import from test files in the src folder',
-            },
-          ]
+          patterns: ['**/dist/**', 'src/*'],
         },
       ],
 


### PR DESCRIPTION
Reverts salto-io/salto#6954

Reverting because it didn't really validate the files and some fixes are required first