### PR TITLE
SALTO-7076: Add lint rules to prevent invalid imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -200,7 +200,20 @@ export default [
       'no-restricted-imports': [
         'error',
         {
-          patterns: ['**/dist/**', 'src/*'],
+          patterns: [
+            {
+              group: ['src/*'],
+              message: 'Imports into src should be relative (start with ../ or ./)',
+            },
+            {
+              group: ['**/dist/**', '@salto-io/**/src/**'],
+              message: 'Must not import directly from an internal file of a package, import from the top level package instead',
+            },
+            {
+              group: ['**/test/**', '**/e2e_test/**'],
+              message: 'Test files are not distributed with the package, must not import from test files in the src folder',
+            },
+          ],
         },
       ],
 

--- a/packages/adapter-components/test/resolve_utils.test.ts
+++ b/packages/adapter-components/test/resolve_utils.test.ts
@@ -25,7 +25,7 @@ import {
   TemplateExpression,
 } from '@salto-io/adapter-api'
 import { GetLookupNameFunc, ResolveValuesFunc } from '@salto-io/adapter-utils'
-import { templateExpressionToStaticFile } from '@salto-io/parser/src/utils'
+import { parserUtils } from '@salto-io/parser'
 import { resolveValues, resolveChangeElement, createChangeElementResolver } from '../src/resolve_utils'
 import { restoreValues } from '../src/restore_utils'
 
@@ -72,7 +72,7 @@ describe('resolve utils func', () => {
 
     const firstRef = new InstanceElement('first', refType, { from: 'Milano', to: 'Minsk', obj: { a: 1 } })
 
-    const templateFileValue = templateExpressionToStaticFile(
+    const templateFileValue = parserUtils.templateExpressionToStaticFile(
       new TemplateExpression({
         parts: [
           'Well, you made a long journey from ',

--- a/packages/cli/e2e_test/helpers/workspace.ts
+++ b/packages/cli/e2e_test/helpers/workspace.ts
@@ -25,6 +25,7 @@ import { collections } from '@salto-io/lowerdash'
 import { findElement } from '@salto-io/adapter-utils'
 import commandDefs from '../../src/commands'
 import cli from '../../src/cli'
+// eslint-disable-next-line no-restricted-imports
 import { mockSpinnerCreator, MockWriteStream } from '../../test/mocks'
 import { CliOutput, CliExitCode } from '../../src/types'
 import { validateWorkspace } from '../../src/workspace/workspace'

--- a/packages/core/test/local-workspace/workspace.test.ts
+++ b/packages/core/test/local-workspace/workspace.test.ts
@@ -7,9 +7,9 @@
  */
 import { Adapter, ElemID, GetCustomReferencesFunc, InstanceElement, ObjectType } from '@salto-io/adapter-api'
 import { mockFunction } from '@salto-io/test-utils'
-import { mockAdaptersConfigSource } from '@salto-io/workspace/test/common/workspace'
 import { getCustomReferences } from '../../src/local-workspace/workspace'
 import { adapterCreators } from '../../src/core/adapters'
+import { mockAdaptersConfigSource } from '../common/workspace'
 
 describe('local workspace', () => {
   beforeEach(() => jest.clearAllMocks())

--- a/packages/jira-adapter/src/dependency_changers/object_type_order_to_schema.ts
+++ b/packages/jira-adapter/src/dependency_changers/object_type_order_to_schema.ts
@@ -7,7 +7,6 @@
  */
 
 import {
-  DependencyChange,
   DependencyChanger,
   InstanceElement,
   RemovalChange,
@@ -18,15 +17,8 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { deployment } from '@salto-io/adapter-components'
-import { collections } from '@salto-io/lowerdash'
 import { getParent, hasValidParent } from '@salto-io/adapter-utils'
 import { OBJECT_SCHEMA_TYPE, OBJECT_TYPE_ORDER_TYPE } from '../constants'
-
-type SetId = collections.set.SetId
-
-const createDependencyChange = (objectTypeOrderKey: SetId, objectSchemaKey: SetId): DependencyChange[] => [
-  dependencyChange('remove', objectTypeOrderKey, objectSchemaKey),
-]
 
 /*
  * This dependency changer is used to remove a dependency from objectTypeOrder to its schema
@@ -58,12 +50,7 @@ export const objectTypeOrderToSchemaDependencyChanger: DependencyChanger = async
   return objectTypeOrderChanges
     .filter(change => hasValidParent(getChangeData(change.change)))
     .flatMap(change => {
-      const objectTypeOrderChange = change as deployment.dependency.ChangeWithKey<RemovalChange<InstanceElement>>
-      const parentObjectSchemaKey = fullNameToChangeKey[
-        getParent(getChangeData(change.change)).elemID.getFullName()
-      ] as SetId
-      return parentObjectSchemaKey === undefined
-        ? []
-        : createDependencyChange(objectTypeOrderChange.key, parentObjectSchemaKey)
+      const parentObjectSchemaKey = fullNameToChangeKey[getParent(getChangeData(change.change)).elemID.getFullName()]
+      return parentObjectSchemaKey === undefined ? [] : dependencyChange('remove', change.key, parentObjectSchemaKey)
     })
 }

--- a/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
+++ b/packages/jira-adapter/src/filters/layouts/layout_service_operations.ts
@@ -17,7 +17,7 @@ import {
   Value,
 } from '@salto-io/adapter-api'
 import { values as lowerDashValues } from '@salto-io/lowerdash'
-import { createSchemeGuard, getParent, hasValidParent, naclCase, pathNaclCase, filter } from '@salto-io/adapter-utils'
+import { createSchemeGuard, getParent, hasValidParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { elements as adapterElements, config as configUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { setTypeDeploymentAnnotations, addAnnotationRecursively } from '../../utils'
@@ -37,6 +37,7 @@ import {
 } from './layout_types'
 import { ISSUE_LAYOUT_TYPE, ISSUE_VIEW_TYPE, JIRA, REQUEST_FORM_TYPE, REQUEST_TYPE_NAME } from '../../constants'
 import { DEFAULT_API_DEFINITIONS } from '../../config/api_config'
+import { FilterResult } from '../../filter'
 
 const log = logger(module)
 const { isDefined } = lowerDashValues
@@ -231,7 +232,7 @@ export const fetchRequestTypeDetails = async ({
   fetchQuery: adapterElements.query.ElementQuery
   getElemIdFunc?: ElemIdGetter | undefined
   typeName: LayoutTypeName
-}): Promise<void | filter.FilterResult> => {
+}): Promise<void | FilterResult> => {
   if (client.isDataCenter || !config.fetch.enableJSM || !fetchQuery.isTypeMatch(typeName)) {
     return
   }

--- a/packages/microsoft-security-adapter/test/definitions/deploy/intune/utils/target_apps.test.ts
+++ b/packages/microsoft-security-adapter/test/definitions/deploy/intune/utils/target_apps.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
-import { DeployRequestCondition } from '@salto-io/adapter-components/src/definitions/system/deploy'
+import { definitions } from '@salto-io/adapter-components'
 import { targetApps } from '../../../../../src/definitions/deploy/intune/utils'
 import { contextMock } from '../../../../mocks'
 import { APPLICATION_CONFIGURATION_MANAGED_APP_TYPE_NAME } from '../../../../../src/constants/intune'
@@ -59,7 +59,7 @@ describe('apps configuration definition utils', () => {
     })
 
     describe('condition', () => {
-      let condition: DeployRequestCondition | undefined
+      let condition: definitions.deploy.DeployRequestCondition | undefined
       beforeEach(() => {
         ;({ condition } = targetApps.createTargetAppsDeployDefinition({
           resourcePath: '/test',

--- a/packages/netsuite-adapter/test/filters/add_referencing_workbook.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_referencing_workbook.test.ts
@@ -18,7 +18,7 @@ import {
   isReferenceExpression,
   toChange,
 } from '@salto-io/adapter-api'
-import { buildElementsSourceFromElements } from '@salto-io/adapter-utils/src/element_source'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import filterCreator from '../../src/filters/add_referencing_workbooks'
 import { LocalFilterOpts } from '../../src/filter'
 import { parsedDatasetType } from '../../src/type_parsers/analytics_parsers/parsed_dataset'

--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -79,6 +79,7 @@ import { Credentials } from '../src/auth'
 import { credsLease, realAdapter, Reals } from './adapter'
 import { mockDefaultValues } from './mock_elements'
 import { OktaOptions } from '../src/definitions/types'
+// eslint-disable-next-line no-restricted-imports
 import { createFetchQuery } from '../test/utils'
 import './jest_matchers'
 

--- a/packages/salesforce-adapter/e2e_test/adapter.test.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.test.ts
@@ -66,6 +66,7 @@ import {
   assertMetadataObjectType,
 } from '../src/transformers/transformer'
 import realAdapter from './adapter'
+// eslint-disable-next-line no-restricted-imports
 import {
   findElements,
   findStandardFieldsObject,
@@ -77,6 +78,7 @@ import SalesforceClient, { API_VERSION } from '../src/client/client'
 import SalesforceAdapter from '../src/adapter'
 import { fromRetrieveResult, createDeployPackage } from '../src/transformers/xml_transformer'
 import { addDefaults } from '../src/filters/utils'
+// eslint-disable-next-line no-restricted-imports
 import { mockTypes, lwcJsResourceContent, lwcHtmlResourceContent, mockDefaultValues } from '../test/mock_elements'
 import {
   objectExists,

--- a/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
+++ b/packages/salesforce-adapter/e2e_test/custom_object_instances.test.ts
@@ -31,6 +31,7 @@ import { apiName, isInstanceOfCustomObject } from '../src/transformers/transform
 import customObjectsFromDescribeFilter from '../src/filters/custom_objects_from_soap_describe'
 import customObjectsToObjectTypeFilter from '../src/filters/custom_objects_to_object_type'
 import customObjectsInstancesFilter from '../src/filters/custom_objects_instances'
+// eslint-disable-next-line no-restricted-imports
 import { createCustomSettingsObject } from '../test/utils'
 import { CUSTOM_OBJECT, LIST_CUSTOM_SETTINGS_TYPE } from '../src/constants'
 import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'

--- a/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
+++ b/packages/salesforce-adapter/e2e_test/quick_deploy.test.ts
@@ -13,6 +13,7 @@ import realAdapter from './adapter'
 import { API_VERSION } from '../src/client/client'
 import { SalesforceConfig, UsernamePasswordCredentials } from '../src/types'
 import { testHelpers } from './jest_environment'
+// eslint-disable-next-line no-restricted-imports
 import { mockTypes } from '../test/mock_elements'
 import { createInstanceElement, MetadataInstanceElement } from '../src/transformers/transformer'
 import { nullProgressReporter } from './utils'

--- a/packages/salesforce-adapter/e2e_test/setup.ts
+++ b/packages/salesforce-adapter/e2e_test/setup.ts
@@ -13,6 +13,7 @@ import { CustomField, ProfileInfo } from '../src/client/types'
 import { createDeployPackage } from '../src/transformers/xml_transformer'
 import { MetadataValues, createInstanceElement } from '../src/transformers/transformer'
 import SalesforceClient from '../src/client/client'
+// eslint-disable-next-line no-restricted-imports
 import { mockTypes, mockDefaultValues } from '../test/mock_elements'
 import { removeMetadataIfAlreadyExists } from './utils'
 

--- a/packages/salesforce-adapter/e2e_test/utils.ts
+++ b/packages/salesforce-adapter/e2e_test/utils.ts
@@ -33,6 +33,7 @@ import {
   isInstanceOfCustomObject,
 } from '../src/transformers/transformer'
 import { fetchMetadataType } from '../src/fetch'
+// eslint-disable-next-line no-restricted-imports
 import { defaultFilterContext } from '../test/utils'
 import { DeployProgressReporter } from '../src/adapter_creator'
 

--- a/packages/salesforce-adapter/e2e_test/workflow.test.ts
+++ b/packages/salesforce-adapter/e2e_test/workflow.test.ts
@@ -31,6 +31,7 @@ import {
   WORKFLOW_ACTION_ALERT_METADATA_TYPE,
 } from '../src/constants'
 import SalesforceAdapter from '../src/adapter'
+// eslint-disable-next-line no-restricted-imports
 import { findElements } from '../test/utils'
 import {
   getMetadataInstance,

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -52,6 +52,7 @@ import {
   MockDeployProgressReporter,
   createMockProgressReporter,
 } from './utils'
+// eslint-disable-next-line no-restricted-imports
 import { createElement, removeElement } from '../e2e_test/utils'
 import { mockTypes, mockDefaultValues } from './mock_elements'
 import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete, mockRetrieveResult } from './connection'

--- a/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
+++ b/packages/salesforce-adapter/test/fetch_installed_packages.test.ts
@@ -6,13 +6,15 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { ObjectType, isInstanceElement, InstanceElement } from '@salto-io/adapter-api'
-import { makeArray } from '@salto-io/lowerdash/src/collections/array'
+import { collections } from '@salto-io/lowerdash'
 import { INSTALLED_PACKAGE_METADATA, INSTANCE_FULL_NAME_FIELD } from '../src/constants'
 import mockClient from './client'
 import { fetchMetadataInstances } from '../src/fetch'
 import { buildMetadataQuery } from '../src/fetch_profile/metadata_query'
 import { mockFileProperties, MockFilePropertiesInput } from './connection'
 import { mockTypes } from './mock_elements'
+
+const { makeArray } = collections.array
 
 describe('Test fetching installed package metadata', () => {
   type MockFetchArgs = {

--- a/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
+++ b/packages/salesforce-adapter/test/filters/profile_permissions.test.ts
@@ -18,7 +18,7 @@ import {
   TypeReference,
   createRefToElmWithValue,
 } from '@salto-io/adapter-api'
-import { isDefined } from '@salto-io/lowerdash/src/values'
+import { values } from '@salto-io/lowerdash'
 import filterCreator from '../../src/filters/profile_permissions'
 import * as constants from '../../src/constants'
 import { ProfileInfo } from '../../src/client/types'
@@ -74,7 +74,7 @@ describe('Profile Permissions filter', () => {
       .filter(isInstanceOfTypeChangeSync(constants.PROFILE_METADATA_TYPE))
       .map(getChangeData)
       .map(instance => apiNameSync(instance))
-      .filter(isDefined)
+      .filter(values.isDefined)
 
   let filter: FilterWith<'preDeploy' | 'onDeploy'>
 

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -21,7 +21,6 @@ import {
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
 import { collections, values } from '@salto-io/lowerdash'
-import { ThenableIterable } from '@salto-io/lowerdash/src/collections/asynciterable'
 
 import _ from 'lodash'
 import AsyncLock from 'async-lock'
@@ -241,8 +240,8 @@ export const createMergeManager = async (
     await hashes.set(mergedHashKey, postChangeHash)
 
     const getElementsToMerge = async (): Promise<{
-      src1ElementsToMerge: ThenableIterable<Element>
-      src2ElementsToMerge: ThenableIterable<Element>
+      src1ElementsToMerge: AsyncIterable<Element>
+      src2ElementsToMerge: AsyncIterable<Element>
       potentialDeletedIds: Set<string>
     }> => {
       const getChangeAndDeleteIds = (

--- a/packages/zendesk-adapter/test/filters/guide_theme.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_theme.test.ts
@@ -20,7 +20,7 @@ import {
   toChange,
 } from '@salto-io/adapter-api'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
-import { staticFileToTemplateExpression } from '@salto-io/parser/src/utils'
+import { parserUtils } from '@salto-io/parser'
 import { DEFAULT_CONFIG, FETCH_CONFIG } from '../../src/config'
 import { BRAND_TYPE_NAME, GUIDE_THEME_TYPE_NAME, THEME_SETTINGS_TYPE_NAME, ZENDESK } from '../../src/constants'
 import { FilterCreator } from '../../src/filter'
@@ -252,7 +252,7 @@ describe('filterCreator', () => {
               content: Buffer.from('file2content'),
             }),
           )
-          const templateExpression = await staticFileToTemplateExpression(
+          const templateExpression = await parserUtils.staticFileToTemplateExpression(
             liveThemeWithId.value.root.files['fileWithReference_js@v'].content,
           )
           expect(templateExpression).toEqual({

--- a/turbo.json
+++ b/turbo.json
@@ -3,32 +3,23 @@
   "tasks": {
     "build-ts": {
       "outputLogs": "new-only",
-      "outputs": [
-        "dist/**"
-      ],
-      "dependsOn": [
-        "^build-ts"
-      ]
+      "outputs": ["dist/**"],
+      "dependsOn": ["^build-ts"]
     },
     "lint": {
       "outputLogs": "new-only",
+      "inputs": ["$TURBO_DEFAULT$", "eslint.config.mjs", "../../eslint.config.mjs"],
       "outputs": []
     },
     "check-format": {
       "outputLogs": "new-only",
-      "outputs": [
-        ".check-format.cache"
-      ]
+      "outputs": [".check-format.cache"]
     },
     "test": {
-      "dependsOn": [ "^build-ts"],
+      "dependsOn": ["^build-ts"],
       "outputLogs": "new-only",
-      "env": [
-        "SALTO_DEPENDENCIES_HASH"
-      ],
-      "outputs": [
-        "coverage/**"
-      ]
+      "env": ["SALTO_DEPENDENCIES_HASH"],
+      "outputs": ["coverage/**"]
     },
     "clean": {
       "cache": false


### PR DESCRIPTION
Add rules to prevent importing from files that are not distributed to NPM

also fix turbo config to re-run lint if the eslint configuration is changed

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_