### PR TITLE
SALTO-7079: move fixedTicketFormChanges from filter to a fixer

### DIFF
--- a/packages/zendesk-adapter/src/config.ts
+++ b/packages/zendesk-adapter/src/config.ts
@@ -2812,6 +2812,7 @@ export const DEFAULT_CONFIG: ZendeskConfig = {
     removeDupUsers: true,
     orderElements: true,
     deployArticlesAsDraft: false,
+    fixTicketForms: true,
   },
   [API_DEFINITIONS_CONFIG]: {
     typeDefaults: {
@@ -3130,6 +3131,7 @@ const fixerConfigType = createMatchingObjectType<Partial<ZendeskFixElementsConfi
     removeDupUsers: { refType: BuiltinTypes.BOOLEAN },
     orderElements: { refType: BuiltinTypes.BOOLEAN },
     deployArticlesAsDraft: { refType: BuiltinTypes.BOOLEAN },
+    fixTicketForms: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
@@ -28,6 +28,10 @@ type InvalidTicketForm = {
   }[]
 }
 
+type InvalidTicketFormInstance = InstanceElement & {
+  value: InvalidTicketForm
+}
+
 const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): Promise<boolean> => {
   if (elementSource === undefined) {
     log.error('Returning that customStatuses is disabled since no element source was provided')
@@ -57,9 +61,9 @@ const invalidChild = (child: Child): boolean =>
   !_.isEmpty(child.required_on_statuses.custom_statuses) &&
   child.required_on_statuses.statuses !== undefined
 
-const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceValue is InvalidTicketForm =>
-  _.isArray(instanceValue.agent_conditions) &&
-  instanceValue.agent_conditions.some(
+const isInvalidTicketForm = (instance: InstanceElement): instance is InvalidTicketFormInstance =>
+  _.isArray(instance.value.agent_conditions) &&
+  instance.value.agent_conditions.some(
     condition => _.isArray(condition.child_fields) && condition.child_fields.some(invalidChild),
   )
 
@@ -67,7 +71,7 @@ const returnValidInstance = (inst: InstanceElement): InstanceElement => {
   const clonedInst = inst.clone()
   // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
   // custom_statuses is enabled
-  if (isInvalidTicketForm(clonedInst.value)) {
+  if (isInvalidTicketForm(clonedInst)) {
     clonedInst.value.agent_conditions.forEach(condition =>
       condition.child_fields.forEach(child => {
         if (invalidChild(child)) {
@@ -103,8 +107,7 @@ export const fixTicketFormsHandler: FixElementsHandler =
       }
     }
 
-    const invalidTicketForms = elements.filter(isInstanceElement).filter(inst => isInvalidTicketForm(inst.value))
-    const fixedTicketForms = invalidTicketForms.map(returnValidInstance)
+    const fixedTicketForms = elements.filter(isInstanceElement).filter(isInvalidTicketForm).map(returnValidInstance)
     const errors = fixedTicketForms.map(toError)
 
     return {

--- a/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
@@ -69,8 +69,6 @@ const isInvalidTicketForm = (instance: InstanceElement): instance is InvalidTick
 
 const returnValidInstance = (inst: InstanceElement): InstanceElement => {
   const clonedInst = inst.clone()
-  // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
-  // custom_statuses is enabled
   if (isInvalidTicketForm(clonedInst)) {
     clonedInst.value.agent_conditions.forEach(condition =>
       condition.child_fields.forEach(child => {

--- a/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
@@ -50,15 +50,12 @@ const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): 
   return customStatusesEnabled.enabled
 }
 
-const invalidChild = (child: Child): boolean => {
-  return (
-    _.isObject(child.required_on_statuses) &&
-    child.required_on_statuses.type === SOME_STATUSES &&
-    child.required_on_statuses.custom_statuses !== undefined &&
-    !_.isEmpty(child.required_on_statuses.custom_statuses) &&
-    child.required_on_statuses.statuses !== undefined
-  )
-}
+const invalidChild = (child: Child): boolean =>
+  _.isObject(child.required_on_statuses) &&
+  child.required_on_statuses.type === SOME_STATUSES &&
+  child.required_on_statuses.custom_statuses !== undefined &&
+  !_.isEmpty(child.required_on_statuses.custom_statuses) &&
+  child.required_on_statuses.statuses !== undefined
 
 const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceValue is InvalidTicketForm =>
   _.isArray(instanceValue.agent_conditions) &&

--- a/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
+++ b/packages/zendesk-adapter/src/fix_elements/fix_ticket_forms.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ChangeError, ElemID, InstanceElement, isInstanceElement, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { ACCOUNT_FEATURES_TYPE_NAME, ZENDESK } from '../constants'
+import { FixElementsHandler } from './types'
+
+const log = logger(module)
+const SOME_STATUSES = 'SOME_STATUSES'
+
+type Child = {
+  required_on_statuses: {
+    type: string
+    statuses?: string[] // question mark to ba able to delete it later on
+    custom_statuses: number[]
+  }
+}
+
+type InvalidTicketForm = {
+  agent_conditions: {
+    child_fields: Child[]
+  }[]
+}
+
+const isCustomStatusesEnabled = async (elementSource?: ReadOnlyElementsSource): Promise<boolean> => {
+  if (elementSource === undefined) {
+    log.error('Returning that customStatuses is disabled since no element source was provided')
+    return false
+  }
+
+  const accountFeatures = await elementSource.get(
+    new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME, 'instance', ElemID.CONFIG_NAME),
+  )
+
+  if (!isInstanceElement(accountFeatures)) {
+    log.warn('Returning that customStatuses is disabled since accountFeatures is not an instance')
+    return false
+  }
+  const customStatusesEnabled = accountFeatures.value.custom_statuses_enabled
+  if (customStatusesEnabled === undefined) {
+    log.warn('Returning that customStatuses is disabled since custom_statuses_enabled does not exist')
+    return false
+  }
+  return customStatusesEnabled.enabled
+}
+
+const invalidChild = (child: Child): boolean => {
+  return (
+    _.isObject(child.required_on_statuses) &&
+    child.required_on_statuses.type === SOME_STATUSES &&
+    child.required_on_statuses.custom_statuses !== undefined &&
+    !_.isEmpty(child.required_on_statuses.custom_statuses) &&
+    child.required_on_statuses.statuses !== undefined
+  )
+}
+
+const isInvalidTicketForm = (instanceValue: Record<string, unknown>): instanceValue is InvalidTicketForm =>
+  _.isArray(instanceValue.agent_conditions) &&
+  instanceValue.agent_conditions.some(
+    condition => _.isArray(condition.child_fields) && condition.child_fields.some(invalidChild),
+  )
+
+const returnValidInstance = (inst: InstanceElement): InstanceElement => {
+  const clonedInst = inst.clone()
+  // it is true because if we get to returnValidInstance function its after we got true from isInvalidTicketForm so
+  // custom_statuses is enabled
+  if (isInvalidTicketForm(clonedInst.value)) {
+    clonedInst.value.agent_conditions.forEach(condition =>
+      condition.child_fields.forEach(child => {
+        if (invalidChild(child)) {
+          delete child.required_on_statuses.statuses
+        }
+      }),
+    )
+  }
+  return clonedInst
+}
+
+const toError = (element: InstanceElement): ChangeError => ({
+  elemID: element.elemID,
+  severity: 'Info',
+  message: 'Ticket forms fixed',
+  detailedMessage:
+    'Ticket forms condition fixed as zendesk api does not allow conditions to include both `custom_statuses` and `statuses` fields.',
+})
+
+/**
+ * zendesk does not allow deploying forms with conditions that have both `custom_statuses` field
+ * and `statuses` field. therefore, if the env has Custom Statuses enabled we will fix the form
+ * conditions to not include the `statuses` field.
+ */
+export const fixTicketFormsHandler: FixElementsHandler =
+  ({ elementsSource }) =>
+  async elements => {
+    const hasCustomStatusesEnabled = await isCustomStatusesEnabled(elementsSource)
+    if (!hasCustomStatusesEnabled) {
+      return {
+        fixedElements: [],
+        errors: [],
+      }
+    }
+
+    const invalidTicketForms = elements.filter(isInstanceElement).filter(inst => isInvalidTicketForm(inst.value))
+    const fixedTicketForms = invalidTicketForms.map(returnValidInstance)
+    const errors = fixedTicketForms.map(toError)
+
+    return {
+      fixedElements: fixedTicketForms,
+      errors,
+    }
+  }

--- a/packages/zendesk-adapter/src/fix_elements/index.ts
+++ b/packages/zendesk-adapter/src/fix_elements/index.ts
@@ -14,6 +14,7 @@ import { FixElementsArgs } from './types'
 import { removeDupUsersHandler } from './remove_dup_users'
 import { mergeListsHandler } from './merge_lists'
 import { deployArticlesAsDraftHandler } from './deploy_articles_as_drafts'
+import { fixTicketFormsHandler } from './fix_ticket_forms'
 
 export const createFixElementFunctions = (args: FixElementsArgs): Record<string, FixElementsFunc> => ({
   ..._.mapValues(customReferenceHandlers, handler => handler.removeWeakReferences(args)),
@@ -22,4 +23,5 @@ export const createFixElementFunctions = (args: FixElementsArgs): Record<string,
   // removingDupes needs to be after fallbackUsers
   removeDupUsers: removeDupUsersHandler(args),
   deployArticlesAsDraft: deployArticlesAsDraftHandler(args),
+  fixTicketForms: fixTicketFormsHandler(args),
 })

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -73,6 +73,7 @@ export const fixerNames = [
   'removeDupUsers',
   'orderElements',
   'deployArticlesAsDraft',
+  'fixTicketForms',
 ] as const
 
 type FixerNames = (typeof fixerNames)[number]

--- a/packages/zendesk-adapter/test/fix_elements/fix_ticket_forms.test.ts
+++ b/packages/zendesk-adapter/test/fix_elements/fix_ticket_forms.test.ts
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ElemID, InstanceElement, ObjectType, ReadOnlyElementsSource } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { ACCOUNT_FEATURES_TYPE_NAME, TICKET_FORM_TYPE_NAME, ZENDESK } from '../../src/constants'
+import { FixElementsArgs } from '../../src/fix_elements/types'
+import { fixTicketFormsHandler } from '../../src/fix_elements/fix_ticket_forms'
+
+const createElementSource = (customStatusesEnabled: boolean): ReadOnlyElementsSource => {
+  const accountFeaturesType = new ObjectType({
+    elemID: new ElemID(ZENDESK, ACCOUNT_FEATURES_TYPE_NAME),
+  })
+  const accountFeaturesInstance = new InstanceElement(ElemID.CONFIG_NAME, accountFeaturesType, {
+    custom_statuses_enabled: {
+      enabled: customStatusesEnabled,
+    },
+  })
+  return buildElementsSourceFromElements([accountFeaturesInstance])
+}
+
+describe('ticket form filter', () => {
+  const ticketFormType = new ObjectType({ elemID: new ElemID(ZENDESK, TICKET_FORM_TYPE_NAME) })
+  const invalidTicketForm = new InstanceElement('invalid', ticketFormType, {
+    agent_conditions: [
+      {
+        child_fields: [
+          { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved'], custom_statuses: [1] } },
+          { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'ALL_STATUSES' } },
+        ],
+      },
+      {
+        child_fields: [
+          { required_on_statuses: { type: 'SOME_STATUSES', statuses: ['solved', 'new'], custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'NO_STATUSES' } },
+        ],
+      },
+      {
+        child_fields: [{ required_on_statuses: { type: 'NO_STATUSES' } }],
+      },
+    ],
+  })
+  const fixedTicketForm = new InstanceElement('invalid', ticketFormType, {
+    agent_conditions: [
+      {
+        child_fields: [
+          { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1] } },
+          { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'ALL_STATUSES' } },
+        ],
+      },
+      {
+        child_fields: [
+          { required_on_statuses: { type: 'SOME_STATUSES', custom_statuses: [1, 2] } },
+          { required_on_statuses: { type: 'NO_STATUSES' } },
+        ],
+      },
+      {
+        child_fields: [{ required_on_statuses: { type: 'NO_STATUSES' } }],
+      },
+    ],
+  })
+  describe('deploy with custom_statuses enabled', () => {
+    it('should remove statuses when both statuses and custom_statuses appear', async () => {
+      const fixer = fixTicketFormsHandler({ elementsSource: createElementSource(true) } as FixElementsArgs)
+      const { fixedElements, errors } = await fixer([invalidTicketForm.clone()])
+
+      const expectedFixedArticle = fixedTicketForm.clone()
+      expect(fixedElements).toEqual([expectedFixedArticle])
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toEqual(
+        expect.objectContaining({
+          elemID: invalidTicketForm.elemID,
+          severity: 'Info',
+          message: 'Ticket forms fixed',
+          detailedMessage:
+            'Ticket forms condition fixed as zendesk api does not allow conditions to include both `custom_statuses` and `statuses` fields.',
+        }),
+      )
+    })
+    describe('deploy with custom_statuses disabled', () => {
+      it('should do nothing', async () => {
+        const fixer = fixTicketFormsHandler({ elementsSource: createElementSource(false) } as FixElementsArgs)
+        const { fixedElements, errors } = await fixer([invalidTicketForm.clone()])
+
+        expect(fixedElements).toEqual([])
+        expect(errors).toHaveLength(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
move fixedTicketFormChanges from filter to a fixer

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
