### PR TITLE
SALTO-7078: Override zip timestamps in static resources in SFDX flow

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -104,6 +104,7 @@ import cpqReferencableFieldReferencesFilter from './filters/cpq/referencable_fie
 import hideReadOnlyValuesFilter from './filters/cpq/hide_read_only_values'
 import extraDependenciesFilter from './filters/extra_dependencies'
 import staticResourceFileExtFilter from './filters/static_resource_file_ext'
+import staticResourceZipTimestamps from './filters/static_resource_zip_timestamps'
 import xmlAttributesFilter from './filters/xml_attributes'
 import profilePathsFilter from './filters/profile_paths'
 import replaceFieldValuesFilter from './filters/replace_instance_field_values'
@@ -233,6 +234,7 @@ export const allFilters: Array<FilterCreator> = [
   topicsForObjectsFilter,
   globalValueSetFilter,
   staticResourceFileExtFilter,
+  staticResourceZipTimestamps,
   extendTriggersMetadataFilter,
   profilePathsFilter,
   territoryFilter,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -431,6 +431,7 @@ export const ESCALATION_RULE_TYPE = 'EscalationRule'
 export const CUSTOM_PERMISSION_METADATA_TYPE = 'CustomPermission'
 export const EXTERNAL_DATA_SOURCE_METADATA_TYPE = 'ExternalDataSource'
 export const OPPORTUNITY_METADATA_TYPE = 'Opportunity'
+export const STATIC_RESOURCE_METADATA_TYPE = 'StaticResource'
 
 // Wave Metadata Types
 export const WAVE_RECIPE_METADATA_TYPE = 'WaveRecipe'

--- a/packages/salesforce-adapter/src/filters/static_resource_zip_timestamps.ts
+++ b/packages/salesforce-adapter/src/filters/static_resource_zip_timestamps.ts
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import JSZip from 'jszip'
+import { collections } from '@salto-io/lowerdash'
+import { Element, InstanceElement, isStaticFile, StaticFile } from '@salto-io/adapter-api'
+import { METADATA_CONTENT_FIELD, STATIC_RESOURCE_METADATA_TYPE } from '../constants'
+import { FilterCreator } from '../filter'
+import { isInstanceOfTypeSync } from './utils'
+
+const { awu } = collections.asynciterable
+
+const DATE = new Date('2024-05-13T00:00:00.000+01:00')
+
+export type StaticResourceInstance = InstanceElement & {
+  value: {
+    contentType: string
+    [METADATA_CONTENT_FIELD]: StaticFile
+  }
+}
+
+const replaceZipTimestamp = async (data: Buffer): Promise<Buffer> => {
+  const zip = await JSZip.loadAsync(data)
+  zip.forEach((_relativePath, file) => {
+    file.date = DATE
+  })
+  return zip.generateAsync({ type: 'nodebuffer' })
+}
+
+const isStaticResourceInstance = (elem: Element): elem is StaticResourceInstance =>
+  isInstanceOfTypeSync(STATIC_RESOURCE_METADATA_TYPE)(elem) &&
+  _.isString(elem.value.contentType) &&
+  isStaticFile(elem.value[METADATA_CONTENT_FIELD])
+
+const filterCreator: FilterCreator = ({ client }) => ({
+  name: 'staticResourceZipTimestampFilter',
+  onFetch: async (elements: Element[]): Promise<void> => {
+    // Run only in the SFDX flow.
+    if (client !== undefined) {
+      return
+    }
+
+    const zipStaticResources = elements
+      .filter(isStaticResourceInstance)
+      .filter(inst => inst.value.contentType === 'application/zip')
+    await awu(zipStaticResources).forEach(async inst => {
+      const staticFile = inst.value[METADATA_CONTENT_FIELD]
+      const content = await staticFile.getContent()
+      if (content === undefined) {
+        return
+      }
+
+      inst.value[METADATA_CONTENT_FIELD] = new StaticFile({
+        filepath: staticFile.filepath,
+        content: await replaceZipTimestamp(content),
+      })
+    })
+  },
+})
+
+export default filterCreator

--- a/packages/salesforce-adapter/test/filters/static_resource_zip_timestamps.test.ts
+++ b/packages/salesforce-adapter/test/filters/static_resource_zip_timestamps.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import JSZip from 'jszip'
+import { InstanceElement, StaticFile } from '@salto-io/adapter-api'
+import filterCreator, { StaticResourceInstance } from '../../src/filters/static_resource_zip_timestamps'
+import { METADATA_CONTENT_FIELD } from '../../src/constants'
+import { defaultFilterContext } from '../utils'
+import mockClient from '../client'
+import { FilterWith } from './mocks'
+import { mockTypes } from '../mock_elements'
+
+describe('Static Resource File Extension Filter', () => {
+  let filter: FilterWith<'onFetch'>
+
+  const createZipStaticResource = async (date: Date): Promise<StaticResourceInstance> => {
+    const zip = new JSZip()
+    zip.file('file1.txt', 'content 1', { date })
+    zip.file('file2.txt', 'content 2', { date })
+    zip.file('folder/nested.txt', 'nested content', { date })
+
+    return new InstanceElement('mockStaticResource', mockTypes.StaticResource, {
+      contentType: 'application/zip',
+      [METADATA_CONTENT_FIELD]: new StaticFile({
+        filepath: 'zip.zip',
+        content: await zip.generateAsync({ type: 'nodebuffer' }),
+      }),
+    }) as StaticResourceInstance
+  }
+
+  describe('when running on zip static resources with different dates', () => {
+    let instance1: StaticResourceInstance
+    let instance2: StaticResourceInstance
+
+    beforeEach(async () => {
+      filter = filterCreator({
+        config: defaultFilterContext,
+      }) as FilterWith<'onFetch'>
+
+      instance1 = await createZipStaticResource(new Date('2020-01-01T00:00:00.000'))
+      instance2 = await createZipStaticResource(new Date())
+      await filter.onFetch([instance1, instance2])
+    })
+
+    it('should return identical static resources', () => {
+      expect(instance1.value[METADATA_CONTENT_FIELD].hash).toEqual(instance2.value[METADATA_CONTENT_FIELD].hash)
+    })
+  })
+
+  describe('when a client is passed', () => {
+    let instance: StaticResourceInstance
+    let hashBefore: string
+
+    beforeEach(async () => {
+      filter = filterCreator({
+        client: mockClient().client,
+        config: defaultFilterContext,
+      }) as FilterWith<'onFetch'>
+
+      instance = await createZipStaticResource(new Date('2020-01-01T00:00:00.000'))
+      hashBefore = instance.value[METADATA_CONTENT_FIELD].hash
+      await filter.onFetch([instance])
+    })
+
+    it('should not change the static file', () => {
+      expect(instance.value[METADATA_CONTENT_FIELD].hash).toEqual(hashBefore)
+    })
+  })
+})

--- a/salto.code-workspace
+++ b/salto.code-workspace
@@ -209,6 +209,7 @@
       "nearley",
       "netsuite",
       "nillable",
+      "nodebuffer",
       "OCURLY",
       "omni",
       "openapi",


### PR DESCRIPTION
Currently we get a diff when comparing two identical SFDX projects because the zip is built dynamically and the timestamps within zip files are different.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
