### PR TITLE
SALTO-7089 wait for workspaceState to finish building in workspace.cl…

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1212,9 +1212,11 @@ export const loadWorkspace = async (
     state,
     close: async () => {
       if (workspaceState !== undefined) {
-        // in case that `workspaceState` is currently beind built, we'd like to wait until it finishes.
+        // in case that `workspaceState` is currently being built, we'd like to wait until it finishes.
+        log.debug('waiting for workspaceState to finish building before closing the workspace')
         await workspaceState
       }
+      log.debug('closing the workspace')
       await remoteMapCreator.close()
     },
     envs,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -880,7 +880,7 @@ export const loadWorkspace = async (
     }, 'buildWorkspaceState')
 
   const getWorkspaceState = async (): Promise<WorkspaceState> => {
-    if (_.isUndefined(workspaceState)) {
+    if (workspaceState === undefined) {
       workspaceState = buildWorkspaceState({})
     }
     return workspaceState
@@ -1211,6 +1211,10 @@ export const loadWorkspace = async (
     elements: elementsImpl,
     state,
     close: async () => {
+      if (workspaceState !== undefined) {
+        // in case that `workspaceState` is currently beind built, we'd like to wait until it finishes.
+        await workspaceState
+      }
       await remoteMapCreator.close()
     },
     envs,


### PR DESCRIPTION
…ose()

When we run a workspace method that rebuilds the workspaceState (e.g updateNaclFiles), we need to wait for the workspaceState to finish rebuilding before calling remoteMapCreator.close() , else the remote map calls in the building process will fail on closed connection.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- prevent a future bug of closing a workspace while a workspaceState is being built, causing to remoteMap calls to fail on closed connections.

---
_User Notifications_: 
None