### PR TITLE
SALTO-7091: Change noisy SF warn log severity to trace

### DIFF
--- a/packages/salesforce-adapter/src/filters/picklist_references.ts
+++ b/packages/salesforce-adapter/src/filters/picklist_references.ts
@@ -122,7 +122,7 @@ const createReferencesForRecordType = (
       if (ref) {
         _.set(value, 'fullName', ref)
       } else {
-        log.warn('Failed to resolve picklist value %s in field %s', value.fullName, field.elemID.getFullName())
+        log.trace('Failed to resolve picklist value %s in field %s', value.fullName, field.elemID.getFullName())
       }
     })
   })


### PR DESCRIPTION
Change noisy SF warn log severity to trace

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
