### PR TITLE
SALTO-7095: add getAndLogCollisionWarningsV2

### DIFF
--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -173,7 +173,6 @@ ${getInstancesMarkdownLinks(collideInstances)}
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 ${createMarkdownLink({ text: 'Learn about additional ways to resolve this issue', url: 'https://help.salto.io/en/articles/6927157-salto-id-collisions' })}`,
   )
-  console.log(warningMessages[0])
   return warningMessages.map(warningMessage =>
     createWarningFromMsg({
       message: 'Some elements were not fetched due to Salto ID collisions',

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -86,6 +86,24 @@ const logInstancesWithCollidingElemID = async (
     })
   })
 }
+// after SALTO-7088 is done, this function will replace logInstancesWithCollidingElemID
+const logInstancesWithCollidingElemIDV2 = async (
+  elemIDtoInstances: Record<string, InstanceElement[]>,
+): Promise<void> => {
+  Object.entries(elemIDtoInstances).forEach(([elemID, collideInstances]) => {
+    if (collideInstances.length <= 1) {
+      log.error('Collide instances length is less than or equal to 1 for elemID %s', elemID)
+      return
+    }
+    const type = collideInstances[0].elemID.typeName
+    const instancesCount = collideInstances.length
+    log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
+    const relevantInstanceValues = collideInstances.map(instance => _.pickBy(instance.value, val => val != null))
+    const relevantInstanceValuesStr = relevantInstanceValues.map(instValues => inspectValue(instValues)).join('\n')
+    log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
+  ${relevantInstanceValuesStr}`)
+  })
+}
 
 const getCollisionMessages = async ({
   elemIDtoInstances,
@@ -117,6 +135,51 @@ ${getInstancesDetailsMsg(instanceDetails, baseUrl, maxBreakdownDetailsElements)}
     }),
   )
   return collisionMessages
+}
+
+const createMarkdownLink = ({ text, url }: { text: string; url: string }): string => `[${text}](${url})`
+
+const getInstancesMarkdownLinks = (instances: InstanceElement[]): string =>
+  instances
+    .map(instance =>
+      createMarkdownLink({
+        text: instance.annotations[CORE_ANNOTATIONS.ALIAS] ?? instance.elemID.name,
+        url: instance.annotations[CORE_ANNOTATIONS.SERVICE_URL],
+      }),
+    )
+    .join(', ')
+
+// after SALTO-7088 is done, this function will replace getAndLogCollisionWarnings
+export const getAndLogCollisionWarningsV2 = async ({
+  instances,
+  addChildrenMessage,
+}: {
+  instances: InstanceElement[]
+  addChildrenMessage?: boolean
+}): Promise<SaltoError[]> => {
+  if (instances.length === 0) {
+    return []
+  }
+  const adapterName = instances[0].elemID.adapter
+  const elemIDtoInstances = _.groupBy(instances, instance => instance.elemID.getFullName())
+  await logInstancesWithCollidingElemIDV2(elemIDtoInstances)
+  const warningMessages = Object.entries(elemIDtoInstances).map(
+    ([
+      elemId,
+      collideInstances,
+    ]) => `${collideInstances.length} ${adapterName} elements ${addChildrenMessage ? 'and their child elements ' : ''}were not fetched, as they were mapped to a single ID ${elemId}:
+${getInstancesMarkdownLinks(collideInstances)}
+
+Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
+${createMarkdownLink({ text: 'Learn about additional ways to resolve this issue', url: 'https://help.salto.io/en/articles/6927157-salto-id-collisions' })}`,
+  )
+  console.log(warningMessages[0])
+  return warningMessages.map(warningMessage =>
+    createWarningFromMsg({
+      message: 'Some elements were not fetched due to Salto ID collisions',
+      detailedMessage: warningMessage,
+    }),
+  )
 }
 
 export const getAndLogCollisionWarnings = async ({

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -169,7 +169,7 @@ Alternatively, you can exclude obj from the default configuration in salto.nacl`
 ${instancesLinks}
 ${usuallyThisHappens}
 ${learnMore}`
-      const errors = await getAndLogCollisionWarningsV2({
+      const errors = getAndLogCollisionWarningsV2({
         instances: [instance, instance.clone()],
       })
       expect(errors).toHaveLength(1)
@@ -186,7 +186,7 @@ ${learnMore}`
 ${instancesLinks}
 ${usuallyThisHappens}
 ${learnMore}`
-      const errors = await getAndLogCollisionWarningsV2({
+      const errors = getAndLogCollisionWarningsV2({
         instances: [instance, instance.clone()],
         addChildrenMessage: true,
       })
@@ -205,7 +205,25 @@ ${learnMore}`
 ${instancesLinks}
 ${usuallyThisHappens}
 ${learnMore}`
-      const errors = await getAndLogCollisionWarningsV2({
+      const errors = getAndLogCollisionWarningsV2({
+        instances: [instance, instance.clone()],
+      })
+      expect(errors).toHaveLength(1)
+      expect(errors[0]).toEqual({
+        severity: 'Warning',
+        message: COLLISION_MESSAGE,
+        detailedMessage,
+      })
+    })
+
+    it('should not create links when serviceUrl is not defined', async () => {
+      instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = undefined
+      const instancesLinks = 'aliasName, aliasName\n'
+      const detailedMessage = `${prefix('2')}${wereNotFetched(instance.elemID.getFullName())}
+${instancesLinks}
+${usuallyThisHappens}
+${learnMore}`
+      const errors = getAndLogCollisionWarningsV2({
         instances: [instance, instance.clone()],
       })
       expect(errors).toHaveLength(1)
@@ -216,12 +234,12 @@ ${learnMore}`
       })
     })
     it('should return no errors when there are no collided instances', async () => {
-      const errors = await getAndLogCollisionWarningsV2({
+      const errors = getAndLogCollisionWarningsV2({
         instances: [],
       })
       expect(errors).toHaveLength(0)
     })
-    it('should return a message each duplicated elemID', async () => {
+    it('should return a message for each duplicated elemID', async () => {
       const firstInstancesLinks = '[aliasName](someUrl), [aliasName](someUrl), [aliasName](someUrl)\n'
       const firstDetailedMessage = `${prefix('3')}${wereNotFetched(instance.elemID.getFullName())}
 ${firstInstancesLinks}
@@ -233,7 +251,7 @@ ${secondInstancesLinks}
 ${usuallyThisHappens}
 ${learnMore}`
 
-      const errors = await getAndLogCollisionWarningsV2({
+      const errors = getAndLogCollisionWarningsV2({
         instances: [instance, instance.clone(), instance.clone(), differentInstance, differentInstance.clone()],
       })
       expect(errors).toHaveLength(2)


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_
an example of the new detailedMessage: 
```
    2 salto elements and their child elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
    [aliasName](someUrl), [aliasName](someUrl)
    
    Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
    [Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)
```

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
