### PR TITLE
SALTO-7087: keep statusMigrations when deploying workflowScheme

### DIFF
--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -14,6 +14,7 @@ import {
   Field,
   getChangeData,
   InstanceElement,
+  isAdditionChange,
   isInstanceChange,
   isInstanceElement,
   isModificationChange,
@@ -270,8 +271,9 @@ export const deployWorkflowScheme = async (
     fieldsToIgnore: ['items'],
     elementsSource,
   })
-
-  if (isModificationChange(resolvedChange) && !Array.isArray(response) && response?.draft) {
+  if (isAdditionChange(resolvedChange)) {
+    getChangeData(change).value.id = getChangeData(resolvedChange).value.id
+  } else if (isModificationChange(resolvedChange) && !Array.isArray(response) && response?.draft) {
     try {
       await publishDraft(resolvedChange, client, config, statusMigrations)
     } catch (err) {

--- a/packages/jira-adapter/src/filters/workflow_scheme.ts
+++ b/packages/jira-adapter/src/filters/workflow_scheme.ts
@@ -30,6 +30,7 @@ import {
   client as clientUtils,
   config as configUtils,
   resolveValues,
+  resolveChangeElement,
 } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
@@ -253,27 +254,26 @@ export const deployWorkflowScheme = async (
   config: JiraConfig,
   elementsSource: ReadOnlyElementsSource,
 ): Promise<void> => {
-  const instance = getChangeData(change)
-
   if (isRemovalOrModificationChange(change)) {
     // For some reason sometime the id is changed after publishing the draft
     await updateSchemeId(change, client, paginator, config)
   }
-
-  const { statusMigrations } = (await resolveValues(instance, getLookUpName, elementsSource)).value
-  delete instance.value.statusMigrations
+  const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues, elementsSource)
+  const resolvedInstance = getChangeData(resolvedChange)
+  const { statusMigrations } = resolvedInstance.value
+  delete resolvedInstance.value.statusMigrations
 
   const response = await defaultDeployChange({
-    change,
+    change: resolvedChange,
     client,
     apiDefinitions: config.apiDefinitions,
     fieldsToIgnore: ['items'],
     elementsSource,
   })
 
-  if (isModificationChange(change) && !Array.isArray(response) && response?.draft) {
+  if (isModificationChange(resolvedChange) && !Array.isArray(response) && response?.draft) {
     try {
-      await publishDraft(change, client, config, statusMigrations)
+      await publishDraft(resolvedChange, client, config, statusMigrations)
     } catch (err) {
       if (shouldThrowError(err)) {
         throw err
@@ -285,13 +285,9 @@ export const deployWorkflowScheme = async (
           elementsSource,
         )
         handleDeploymentError(err)
-        log.warn(
-          `failed to publish draft for workflow scheme ${getChangeData(change).elemID.name}, error: ${err.message}`,
-        )
+        log.warn(`failed to publish draft for workflow scheme ${resolvedInstance.elemID.name}, error: ${err.message}`)
       } catch {
-        log.warn(
-          `failed to reformat the workflow scheme ${getChangeData(change).elemID.getFullName()} migration error `,
-        )
+        log.warn(`failed to reformat the workflow scheme ${resolvedInstance.elemID.getFullName()} migration error `)
       }
     }
   }

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -711,6 +711,26 @@ describe('workflowScheme', () => {
         },
       ])
     })
+
+    it('should update the id after addition', async () => {
+      const instance = new InstanceElement('instance', workflowSchemeType, {
+        name: 'name',
+        items: [
+          {
+            issueType: 1234,
+            workflow: 'workflow name',
+          },
+        ],
+      })
+
+      deployChangeMock.mockResolvedValueOnce({
+        id: '1',
+      })
+
+      await filter.deploy?.([toChange({ after: instance })])
+
+      expect(instance.value.id).toBe('1')
+    })
   })
 
   describe('onDeploy', () => {

--- a/packages/jira-adapter/test/filters/workflow_scheme.test.ts
+++ b/packages/jira-adapter/test/filters/workflow_scheme.test.ts
@@ -248,8 +248,10 @@ describe('workflowScheme', () => {
       instanceBefore.value.description = 'desc'
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
+      const noMigrationInstance = instance.clone()
+      delete noMigrationInstance.value.statusMigrations
       expect(deployChangeMock).toHaveBeenCalledWith({
-        change: toChange({ before: instanceBefore, after: instance }),
+        change: toChange({ before: instanceBefore, after: noMigrationInstance }),
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.WorkflowScheme.deployRequests,
         fieldsToIgnore: ['items'],
@@ -271,8 +273,6 @@ describe('workflowScheme', () => {
       )
 
       expect(connection.get).toHaveBeenCalledWith('taskUrl', undefined)
-
-      expect(instance.value.statusMigrations).toBeUndefined()
     })
 
     it('should update the id if changed', async () => {
@@ -321,9 +321,10 @@ describe('workflowScheme', () => {
       const instanceBefore = instance.clone()
       instanceBefore.value.description = 'desc'
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
-
+      const noMigrationInstance = instance.clone()
+      delete noMigrationInstance.value.statusMigrations
       expect(deployChangeMock).toHaveBeenCalledWith({
-        change: toChange({ before: instanceBefore, after: instance }),
+        change: toChange({ before: instanceBefore, after: noMigrationInstance }),
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.WorkflowScheme.deployRequests,
         fieldsToIgnore: ['items'],
@@ -338,7 +339,6 @@ describe('workflowScheme', () => {
         responseType: undefined,
       })
 
-      expect(instance.value.statusMigrations).toBeUndefined()
       expect(instance.value.id).toBe('2')
     })
 
@@ -375,10 +375,12 @@ describe('workflowScheme', () => {
 
       const instanceBefore = instance.clone()
       instanceBefore.value.description = 'desc'
+      const noMigrationInstance = instance.clone()
+      delete noMigrationInstance.value.statusMigrations
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(deployChangeMock).toHaveBeenCalledWith({
-        change: toChange({ before: instanceBefore, after: instance }),
+        change: toChange({ before: instanceBefore, after: noMigrationInstance }),
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.WorkflowScheme.deployRequests,
         fieldsToIgnore: ['items'],
@@ -389,7 +391,6 @@ describe('workflowScheme', () => {
 
       expect(connection.get).not.toHaveBeenCalledWith('/rest/api/3/workflowscheme', undefined)
 
-      expect(instance.value.statusMigrations).toBeUndefined()
       expect(instance.value.id).toBe('1')
     })
 
@@ -433,17 +434,18 @@ describe('workflowScheme', () => {
 
       const instanceBefore = instance.clone()
       instanceBefore.value.description = 'desc'
+      const noMigrationInstance = instance.clone()
+      delete noMigrationInstance.value.statusMigrations
       await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
 
       expect(deployChangeMock).toHaveBeenCalledWith({
-        change: toChange({ before: instanceBefore, after: instance }),
+        change: toChange({ before: instanceBefore, after: noMigrationInstance }),
         client,
         endpointDetails: getDefaultConfig({ isDataCenter: false }).apiDefinitions.types.WorkflowScheme.deployRequests,
         fieldsToIgnore: ['items'],
         elementsSource,
       })
 
-      expect(instance.value.statusMigrations).toBeUndefined()
       expect(instance.value.id).toBe('1')
     })
 
@@ -678,6 +680,36 @@ describe('workflowScheme', () => {
       expect(logErrorSpy).toHaveBeenCalledWith(
         'failed to publish draft for workflow scheme workflowSchemeInstance, error: Failed to publish draft with error: . Issue type with name issueInstance is missing the mappings required for statuses with names ID 7',
       )
+    })
+
+    it('should not delete the statusMigration field', async () => {
+      const instance = new InstanceElement('instance', workflowSchemeType, {
+        id: '1',
+        items: [
+          {
+            issueType: 1234,
+            workflow: 'workflow name',
+          },
+        ],
+        statusMigrations: [
+          {
+            issueTypeId: '1',
+            statusId: '2',
+            newStatusId: '3',
+          },
+        ],
+      })
+
+      const instanceBefore = instance.clone()
+      instanceBefore.value.description = 'desc'
+      await filter.deploy?.([toChange({ before: instanceBefore, after: instance })])
+      expect(instance.value.statusMigrations).toEqual([
+        {
+          issueTypeId: '1',
+          statusId: '2',
+          newStatusId: '3',
+        },
+      ])
     })
   })
 


### PR DESCRIPTION
Current situation creates partial success for deployments and triggers an incident

---

I decided to do the long way, and properly clone the change before deployment. That is the correct behavior and the one used in the deployment function, and I think it reduces future potential issues
[Noise reduction](https://github.com/salto-io/salto_private/pull/10078)

---
_Release Notes_: 
Jira Adapter:
* Deployments of Workflow Schemes with migration will not end in partial success

---
_User Notifications_: 
None
