### PR TITLE
SALTO-7099: Enable Salesforce Profiles & PS elements fixer by default 

### DIFF
--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -34,7 +34,7 @@ const defaultCustomReferencesConfiguration: Required<CustomReferencesSettings> =
 }
 
 const defaultFixElementsConfiguration: Required<FixElementsSettings> = {
-  profilesAndPermissionSets: false,
+  profilesAndPermissionSets: true,
   managedElements: true,
   formulaRefs: false,
 }


### PR DESCRIPTION
Enable Salesforce Profiles & PS elements fixer by default

---

_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
