### PR TITLE
SALTO-7101-salesforce - fixed bug of defaultRules CV catches permission Sets

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/default_rules.ts
+++ b/packages/salesforce-adapter/src/change_validators/default_rules.ts
@@ -240,7 +240,7 @@ const getInstancesMultipleDefaultsErrors = async (after: InstanceElement): Promi
             return [createInstanceChangeError(field, defaultsContexts, after)]
           }
           const typesToCheck = FIELD_NAME_TO_INNER_CONTEXT_FIELD[fieldPath].types
-          if (typesToCheck !== undefined && typesToCheck.some(type => isInstanceOfTypeSync(type)(after))) {
+          if (typesToCheck !== undefined && isInstanceOfTypeSync(...typesToCheck)(after)) {
             if (defaultsCount === 1) {
               const singleDefaultIsValid = findNotVisibleDefault(innerValue, startLevelType)
               if (singleDefaultIsValid !== undefined) {

--- a/packages/salesforce-adapter/test/change_validators/default_rules.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/default_rules.test.ts
@@ -620,50 +620,33 @@ describe('default rules change validator', () => {
     })
     describe('PermissionSet', () => {
       describe('has no defaults', () => {
-        const createAfterInstance = (
-          beforeInstance: InstanceElement,
-          changedDefaultValue: boolean = true,
-        ): InstanceElement => {
-          const afterInstance = beforeInstance.clone()
-          afterInstance.value.recordTypeVisibilities.test1.testRecordType1.visible = changedDefaultValue
-          return afterInstance
-        }
-        const type = new ObjectType({
-          elemID: new ElemID(SALESFORCE, PERMISSION_SET_METADATA_TYPE),
-          fields: {
-            applicationVisibilities: {
-              refType: new MapType(
-                new ObjectType({
-                  elemID: new ElemID(SALESFORCE, 'ProfileApplicationVisibility'),
-                  fields: { default: { refType: BuiltinTypes.BOOLEAN } },
-                  annotations: {
-                    [METADATA_TYPE]: 'ProfileApplicationVisibility',
-                  },
-                }),
-              ),
-            },
-            recordTypeVisibilities: {
-              refType: new MapType(
-                new MapType(
-                  new ObjectType({
-                    elemID: new ElemID(SALESFORCE, 'ProfileRecordTypeVisibility'),
-                    fields: { default: { refType: BuiltinTypes.BOOLEAN } },
-                    annotations: {
-                      [METADATA_TYPE]: 'ProfileRecordTypeVisibility',
-                    },
-                  }),
+        let beforeInstance: InstanceElement
+        let afterInstance: InstanceElement
+        beforeEach(() => {
+          const type = new ObjectType({
+            elemID: new ElemID(SALESFORCE, PERMISSION_SET_METADATA_TYPE),
+            fields: {
+              recordTypeVisibilities: {
+                refType: new MapType(
+                  new MapType(
+                    new ObjectType({
+                      elemID: new ElemID(SALESFORCE, 'PermissionSetRecordTypeVisibility'),
+                      fields: { default: { refType: BuiltinTypes.BOOLEAN } },
+                      annotations: {
+                        [METADATA_TYPE]: 'PermissionSetRecordTypeVisibility',
+                      },
+                    }),
+                  ),
                 ),
-              ),
+              },
             },
-          },
-          annotations: {
-            [METADATA_TYPE]: PERMISSION_SET_METADATA_TYPE,
-          },
-        })
-        it('should not raise errors', async () => {
-          const beforeInstance = createInstanceElement(
+            annotations: {
+              [METADATA_TYPE]: PERMISSION_SET_METADATA_TYPE,
+            },
+          })
+          beforeInstance = createInstanceElement(
             {
-              fullName: 'ProfileInstance',
+              fullName: 'PermissionSetInstance',
               recordTypeVisibilities: {
                 test1: {
                   testRecordType1: {
@@ -682,9 +665,12 @@ describe('default rules change validator', () => {
             },
             type,
           )
-          const afterInstance = createAfterInstance(beforeInstance)
+          afterInstance = beforeInstance.clone()
+          afterInstance.value.recordTypeVisibilities.test1.testRecordType1.visible = true
+        })
+        it('should not create errors', async () => {
           const changeErrors = await runChangeValidatorOnUpdate(beforeInstance, afterInstance)
-          expect(changeErrors).toHaveLength(0)
+          expect(changeErrors).toBeEmpty()
         })
       })
     })


### PR DESCRIPTION
fixed bug of defaultRules CV catches permission Sets

---

validating metadata types that have no defaults in their recordTypeVisibilities raised errors by defaultRules CV, now fixed to check only recordTypeVisibilities of Profiles

---
_Release Notes_: 
none

---
_User Notifications_: 
none