### PR TITLE
SALTO-7105: Support multipleDefaults CV config

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ChangeValidator } from '@salto-io/adapter-api'
+import { ChangeError, ChangeValidator } from '@salto-io/adapter-api'
 import { buildLazyShallowTypeResolverElementsSource, GetLookupNameFunc } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { deployment } from '@salto-io/adapter-components'
@@ -70,6 +70,8 @@ export const defaultChangeValidatorsValidateConfig: Record<string, boolean> = {
   dataChange: false,
 }
 
+const nopValidator = async (): Promise<ReadonlyArray<ChangeError>> => []
+
 export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreator> = {
   managedPackage: () => packageValidator,
   picklistStandardField: () => picklistStandardFieldValidator,
@@ -110,6 +112,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   orderedMaps: ({ fetchProfile }) => orderedMaps(fetchProfile),
   layoutDuplicateFields: () => layoutDuplicateFields,
   customApplications: () => customApplications,
+  multipleDefaults: () => nopValidator,
   ..._.mapValues(getDefaultChangeValidators(), validator => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -182,6 +182,7 @@ export type ChangeValidatorName =
   | 'orderedMaps'
   | 'layoutDuplicateFields'
   | 'customApplications'
+  | 'multipleDefaults'
 
 type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
 
@@ -872,6 +873,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     orderedMaps: { refType: BuiltinTypes.BOOLEAN },
     layoutDuplicateFields: { refType: BuiltinTypes.BOOLEAN },
     customApplications: { refType: BuiltinTypes.BOOLEAN },
+    multipleDefaults: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,


### PR DESCRIPTION
Changing the name of the CV was a breaking change, this will allow support for configs which specify it.

---

_Additional context for reviewer_

---

_Release Notes_: 
_Salesforce_:
* Fixed a bug when explicitly configuring the multipleDefaults CV.

---

_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
