### PR TITLE
SALTO-7104 Kanban board backlog

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/board.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/board.ts
@@ -19,6 +19,9 @@ export const createKanbanBoardValues = (name: string, allElements: Element[]): V
   columnConfig: {
     columns: [
       {
+        name: 'Backlog',
+      },
+      {
         name: 'first',
       },
       {

--- a/packages/jira-adapter/e2e_test/instances/datacenter/board.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/board.ts
@@ -16,6 +16,9 @@ export const createKanbanBoardValues = (name: string, allElements: Element[]): V
   columnConfig: {
     columns: [
       {
+        name: 'Backlog',
+      },
+      {
         name: 'first',
       },
       {

--- a/packages/jira-adapter/src/change_validators/boards/board_column_config.ts
+++ b/packages/jira-adapter/src/change_validators/boards/board_column_config.ts
@@ -17,7 +17,7 @@ import {
 import Joi from 'joi'
 import { createSchemeGuard } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { BOARD_TYPE_NAME } from '../constants'
+import { BOARD_TYPE_NAME } from '../../constants'
 
 type BoardColumn = {
   name: string

--- a/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
+++ b/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ChangeValidator,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  SeverityLevel,
+} from '@salto-io/adapter-api'
+import Joi from 'joi'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import { BOARD_TYPE_NAME, KANBAN_TYPE } from '../../constants'
+
+const BACKLOG = 'Backlog'
+type BoardColumn = {
+  name: string
+}
+
+type BoardColumnConfig = {
+  columns: BoardColumn[]
+}
+
+const COLUMN_CONFIG_SCHEME = Joi.object({
+  columns: Joi.array()
+    .items(
+      Joi.object({
+        name: Joi.string().required(),
+      }).unknown(true),
+    )
+    .min(1)
+    .required(),
+})
+  .required()
+  .unknown(true)
+
+const isBoardColumnConfig = createSchemeGuard<BoardColumnConfig>(COLUMN_CONFIG_SCHEME)
+
+export const kanbanBoardBacklogValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === BOARD_TYPE_NAME)
+    .filter(instance => instance.value.type === KANBAN_TYPE)
+    .filter(
+      instance =>
+        !isBoardColumnConfig(instance.value.columnConfig) || instance.value.columnConfig.columns[0].name !== BACKLOG,
+    )
+    .map(instance => ({
+      elemID: instance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Unable to deploy a Kanban Board When the first column is not named "Backlog"',
+      detailedMessage:
+        // Change this message in 1 month, the fetch part is relevant only for deployments before the fix
+        'A Kanban board must have a first column named Backlog. If you did not edit the board manually please fetch both envs and try again',
+    }))

--- a/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
+++ b/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
@@ -17,8 +17,11 @@ import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { BOARD_TYPE_NAME, KANBAN_TYPE } from '../../constants'
 
 const BACKLOG = 'Backlog'
-type BoardColumn = {
+export type BoardColumn = {
   name: string
+  min?: number
+  max?: number
+  statuses?: string[]
 }
 
 type BoardColumnConfig = {

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -26,6 +26,7 @@ import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { permissionTypeValidator } from './permission_type'
 import { boardColumnConfigValidator } from './boards/board_column_config'
+import { kanbanBoardBacklogValidator } from './boards/kanban_board_backlog'
 import { maskingValidator } from './masking'
 import { automationsValidator } from './automation/automations'
 import { lockedFieldsValidator } from './locked_fields'
@@ -156,6 +157,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     enhancedSearchDeployment: enhancedSearchDeploymentValidator,
     emptyProjectScopedContext: emptyProjectScopedContextValidator,
     field: fieldValidator,
+    kanbanBoardBacklog: kanbanBoardBacklogValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -25,7 +25,7 @@ import { inboundTransitionChangeValidator } from './workflowsV2/inbound_transiti
 import { dashboardGadgetsValidator } from './dashboard_gadgets'
 import { dashboardLayoutValidator } from './dashboard_layout'
 import { permissionTypeValidator } from './permission_type'
-import { boardColumnConfigValidator } from './board_culomn_config'
+import { boardColumnConfigValidator } from './boards/board_column_config'
 import { maskingValidator } from './masking'
 import { automationsValidator } from './automation/automations'
 import { lockedFieldsValidator } from './locked_fields'

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -296,6 +296,7 @@ const CHANGE_VALIDATOR_NAMES = [
   'fieldContext',
   'emptyProjectScopedContext',
   'filter',
+  'kanbanBoardBacklog',
 ]
 
 export type ChangeValidatorName = (typeof CHANGE_VALIDATOR_NAMES)[number]

--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -154,6 +154,7 @@ export const SLA_CONDITIONS_START_TYPE = 'SLA__config__definition__start'
 export const SHARE_PERMISSION_FIELDS = ['sharePermissions', 'editPermissions']
 export const CONTENT_TYPE_HEADER = 'Content-Type'
 export const JSON_CONTENT_TYPE = 'application/json'
+export const KANBAN_TYPE = 'kanban'
 // almost constant functions
 export const fetchFailedWarnings = (name: string): string =>
   `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/test/change_validators/boards/board_column_config.test.ts
+++ b/packages/jira-adapter/test/change_validators/boards/board_column_config.test.ts
@@ -6,9 +6,9 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { toChange, InstanceElement } from '@salto-io/adapter-api'
-import { boardColumnConfigValidator } from '../../src/change_validators/board_culomn_config'
-import { BOARD_TYPE_NAME } from '../../src/constants'
-import { createEmptyType } from '../utils'
+import { boardColumnConfigValidator } from '../../../src/change_validators/boards/board_column_config'
+import { BOARD_TYPE_NAME } from '../../../src/constants'
+import { createEmptyType } from '../../utils'
 
 describe('boardColumnConfigValidator', () => {
   let instance: InstanceElement

--- a/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
+++ b/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { toChange, InstanceElement } from '@salto-io/adapter-api'
+import { kanbanBoardBacklogValidator } from '../../../src/change_validators/boards/kanban_board_backlog'
+import { BOARD_TYPE_NAME } from '../../../src/constants'
+import { createEmptyType } from '../../utils'
+
+const ERROR_TITLE = 'Unable to deploy a Kanban Board When the first column is not named "Backlog"'
+const ERROR_MESSAGE =
+  'A Kanban board must have a first column named Backlog. If you did not edit the board manually please fetch both envs and try again'
+describe('kanbanBoardBacklogValidator', () => {
+  let instance: InstanceElement
+  let instance2: InstanceElement
+  let noErrorInstance: InstanceElement
+
+  beforeEach(() => {
+    instance = new InstanceElement('instance', createEmptyType(BOARD_TYPE_NAME), {
+      type: 'kanban',
+      columnConfig: {
+        columns: [
+          {
+            name: 'column1',
+          },
+          {
+            name: 'Backlog',
+          },
+        ],
+      },
+    })
+    instance2 = new InstanceElement('instance2', createEmptyType(BOARD_TYPE_NAME), {
+      type: 'scrum',
+      columnConfig: {
+        columns: [
+          {
+            name: 'column1',
+          },
+        ],
+      },
+    })
+    noErrorInstance = new InstanceElement('noErrorInstance', createEmptyType(BOARD_TYPE_NAME), {
+      type: 'kanban',
+      columnConfig: {
+        columns: [
+          {
+            name: 'Backlog',
+          },
+          {
+            name: 'column2',
+          },
+        ],
+      },
+    })
+  })
+
+  it('should return an error when there is no column', async () => {
+    instance.value.columnConfig.columns = []
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: instance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: ERROR_TITLE,
+        detailedMessage: ERROR_MESSAGE,
+      },
+    ])
+  })
+
+  it('should return an error when there is no column config', async () => {
+    instance.value.columnConfig = undefined
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: instance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: ERROR_TITLE,
+        detailedMessage: ERROR_MESSAGE,
+      },
+    ])
+  })
+
+  it('should return an error when the first column is not Backlog', async () => {
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: instance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: ERROR_TITLE,
+        detailedMessage: ERROR_MESSAGE,
+      },
+    ])
+  })
+
+  it('should not return an error if the first column is Backlog', async () => {
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: noErrorInstance,
+        }),
+      ]),
+    ).toEqual([])
+  })
+  it('should not return an error if the board is not kanban', async () => {
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: instance2,
+        }),
+      ]),
+    ).toEqual([])
+  })
+  it('it should return several errors if they exist', async () => {
+    expect(
+      await kanbanBoardBacklogValidator([
+        toChange({
+          after: instance,
+        }),
+        toChange({
+          before: instance,
+          after: instance2,
+        }),
+        toChange({
+          after: noErrorInstance,
+        }),
+      ]),
+    ).toEqual([
+      {
+        elemID: instance.elemID,
+        severity: 'Error',
+        message: ERROR_TITLE,
+        detailedMessage: ERROR_MESSAGE,
+      },
+    ])
+  })
+})

--- a/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
+++ b/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
@@ -17,9 +17,10 @@ describe('kanbanBoardBacklogValidator', () => {
   let instance: InstanceElement
   let instance2: InstanceElement
   let noErrorInstance: InstanceElement
+  const boardType = createEmptyType(BOARD_TYPE_NAME)
 
   beforeEach(() => {
-    instance = new InstanceElement('instance', createEmptyType(BOARD_TYPE_NAME), {
+    instance = new InstanceElement('instance', boardType, {
       type: 'kanban',
       columnConfig: {
         columns: [
@@ -32,7 +33,7 @@ describe('kanbanBoardBacklogValidator', () => {
         ],
       },
     })
-    instance2 = new InstanceElement('instance2', createEmptyType(BOARD_TYPE_NAME), {
+    instance2 = new InstanceElement('instance2', boardType, {
       type: 'scrum',
       columnConfig: {
         columns: [
@@ -42,7 +43,7 @@ describe('kanbanBoardBacklogValidator', () => {
         ],
       },
     })
-    noErrorInstance = new InstanceElement('noErrorInstance', createEmptyType(BOARD_TYPE_NAME), {
+    noErrorInstance = new InstanceElement('noErrorInstance', boardType, {
       type: 'kanban',
       columnConfig: {
         columns: [
@@ -129,6 +130,16 @@ describe('kanbanBoardBacklogValidator', () => {
     ).toEqual([])
   })
   it('it should return several errors if they exist', async () => {
+    const faultInstance = new InstanceElement('faultInstance', boardType, {
+      type: 'kanban',
+      columnConfig: {
+        columns: [
+          {
+            name: 'column1',
+          },
+        ],
+      },
+    })
     expect(
       await kanbanBoardBacklogValidator([
         toChange({
@@ -141,10 +152,19 @@ describe('kanbanBoardBacklogValidator', () => {
         toChange({
           after: noErrorInstance,
         }),
+        toChange({
+          after: faultInstance,
+        }),
       ]),
     ).toEqual([
       {
         elemID: instance.elemID,
+        severity: 'Error',
+        message: ERROR_TITLE,
+        detailedMessage: ERROR_MESSAGE,
+      },
+      {
+        elemID: faultInstance.elemID,
         severity: 'Error',
         message: ERROR_TITLE,
         detailedMessage: ERROR_MESSAGE,

--- a/packages/jira-adapter/test/filters/board/board_columns.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_columns.test.ts
@@ -79,7 +79,7 @@ describe('boardColumnsFilter', () => {
       expect(instance.value.config[COLUMNS_CONFIG_FIELD]).toBeUndefined()
     })
 
-    it('should not remove first column if kanban', async () => {
+    it('should not remove columns', async () => {
       await filter.onFetch([instance])
       expect(instance.value[COLUMNS_CONFIG_FIELD]).toEqual({
         columns: [
@@ -95,7 +95,7 @@ describe('boardColumnsFilter', () => {
       })
     })
 
-    it('should not remove first column if scrum', async () => {
+    it('should not remove columns if scrum', async () => {
       instance.value.type = 'scrum'
       await filter.onFetch([instance])
       expect(instance.value[COLUMNS_CONFIG_FIELD]).toEqual({

--- a/packages/jira-adapter/test/filters/board/board_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/board/board_deployment.test.ts
@@ -206,6 +206,7 @@ describe('boardDeploymentFilter', () => {
             mappedColumns: [
               {
                 name: 'someColumn',
+                isKanPlanColumn: false,
                 mappedStatuses: [{ id: '4' }],
                 min: 2,
                 max: 4,
@@ -362,6 +363,7 @@ describe('boardDeploymentFilter', () => {
             rapidViewId: '1',
             mappedColumns: [
               {
+                isKanPlanColumn: false,
                 name: 'someColumn2',
                 mappedStatuses: [],
                 min: '',
@@ -384,7 +386,7 @@ describe('boardDeploymentFilter', () => {
             [COLUMNS_CONFIG_FIELD]: {
               columns: [
                 {
-                  name: 'backlog',
+                  name: 'Backlog',
                 },
                 {
                   name: 'someColumn2',
@@ -396,6 +398,9 @@ describe('boardDeploymentFilter', () => {
 
         instance.value[COLUMNS_CONFIG_FIELD] = {
           columns: [
+            {
+              name: 'Backlog',
+            },
             {
               name: 'someColumn2',
             },
@@ -415,6 +420,14 @@ describe('boardDeploymentFilter', () => {
             rapidViewId: '1',
             mappedColumns: [
               {
+                isKanPlanColumn: true,
+                name: 'Backlog',
+                mappedStatuses: [],
+                min: '',
+                max: '',
+              },
+              {
+                isKanPlanColumn: false,
                 name: 'someColumn2',
                 mappedStatuses: [],
                 min: '',
@@ -489,6 +502,7 @@ describe('boardDeploymentFilter', () => {
             mappedColumns: [
               {
                 name: 'someColumn2',
+                isKanPlanColumn: false,
                 mappedStatuses: [],
                 min: '',
                 max: '',
@@ -501,6 +515,82 @@ describe('boardDeploymentFilter', () => {
         )
 
         expect(connection.put).toHaveBeenCalledTimes(3)
+      })
+      it('should properly deploy second Backlog column', async () => {
+        connection.get.mockResolvedValue({
+          status: 200,
+          data: {
+            [COLUMNS_CONFIG_FIELD]: {
+              columns: [
+                {
+                  name: 'Backlog',
+                },
+                {
+                  name: 'someColumn2',
+                },
+                {
+                  name: 'Backlog',
+                },
+              ],
+            },
+          },
+        })
+
+        instance.value[COLUMNS_CONFIG_FIELD] = {
+          columns: [
+            {
+              name: 'Backlog',
+            },
+            {
+              name: 'someColumn2',
+            },
+            {
+              name: 'Backlog',
+            },
+          ],
+        }
+
+        instance.value.type = 'kanban'
+
+        await filter.deploy([change])
+
+        expect(connection.put).toHaveBeenCalledWith(
+          '/rest/greenhopper/1.0/rapidviewconfig/columns',
+          {
+            currentStatisticsField: {
+              id: 'none_',
+            },
+            rapidViewId: '1',
+            mappedColumns: [
+              {
+                isKanPlanColumn: true,
+                name: 'Backlog',
+                mappedStatuses: [],
+                min: '',
+                max: '',
+              },
+              {
+                isKanPlanColumn: false,
+                name: 'someColumn2',
+                mappedStatuses: [],
+                min: '',
+                max: '',
+              },
+              {
+                isKanPlanColumn: false,
+                name: 'Backlog',
+                mappedStatuses: [],
+                min: '',
+                max: '',
+              },
+            ],
+          },
+          {
+            headers: PRIVATE_API_HEADERS,
+          },
+        )
+
+        expect(connection.put).toHaveBeenCalledOnce()
       })
 
       it('should throw if deploy columns does not change the columns', async () => {


### PR DESCRIPTION
Fixed a bug in which we used to delete the backlog column of boards

---

This PR is split to 2 commits, the first one is relocation for some functions.

In kanban boards there are columns. They have a special built-in column called `Backlog` that is always the first column. Unfortunately, you can also add another column called the same way. 
The bug here resulted from a wrong bug fix in the past.
Fetch for Boards is the official API, but modify is private API.  As part of the private API there is a field called `isKanPlanColumn`, which is true for the built-in Backlog, and false for the rest (from what I saw).
If you deploy without `isKanPlanColumn` you will deploy that Backlog column as a user added `Backlog` column.
In the past we did that and created unwanted columns for users. The fix removed the backlog column altogether.
Other than to remove useful information this behavior caused deployment failures. The deployment fails only if during the put command the build-in `Backlog` column have some statuses, and that is why our tests did not fail.

* I have tested DC, the behavior and API there are the same (and that is a very surprising result. If I had to change the DC adapter for that I might have ran to Syria), and it works
* I have added a CV. It will also protect us from users who deploy from the old version (no backlog column in the start of the array)

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug with some Board Deployments. Also, Board will now include also the Backlog built-in column

---
_User Notifications_: 
Jira Adapter:
* Board NaCls will now include also the built-in backlog column