### PR TITLE
SALTO-7108: NS - ReportDefinition scriptId regex is too restrictive

### DIFF
--- a/packages/netsuite-adapter/scripts/types_generation/types_generator.py
+++ b/packages/netsuite-adapter/scripts/types_generation/types_generator.py
@@ -708,7 +708,7 @@ type_name_to_special_script_id_prefix = {
     'emailtemplate': 'standardemailtemplate|standardpaymentlinktransactionemailtemplate|^custemailtmpl[0-9a-z_]+', # The standardemailtemplate scriptid appeared to a certain customer's account & standardpaymentlinktransactionemailtemplate appeared when fetching from 2021.2 release preview
     'role': '^customrole[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
     'savedsearch': '^customsearch[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
-    'reportdefinition': '^customreport[0-9a-z_]*', # https://salto-io.atlassian.net/browse/SALTO-7054
+    'reportdefinition': '^[0-9a-z_]+', # https://salto-io.atlassian.net/browse/SALTO-7054 & https://salto-io.atlassian.net/browse/SALTO-7108
 }
 
 fields_to_create = {

--- a/packages/netsuite-adapter/src/autogen/types/standard_types/reportdefinition.ts
+++ b/packages/netsuite-adapter/src/autogen/types/standard_types/reportdefinition.ts
@@ -121,7 +121,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
         annotations: {
           [CORE_ANNOTATIONS.REQUIRED]: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]*' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^[0-9a-z_]+' }),
         },
       } /* Original description: This attribute value can be up to 40 characters long.   The default value is ‘customreport’. */,
       name: {

--- a/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
+++ b/packages/netsuite-adapter/src/type_parsers/report_definition_parsing/parsed_report_definition.ts
@@ -469,7 +469,7 @@ export const reportdefinitionType = (): TypeAndInnerTypes => {
         annotations: {
           _required: true,
           [constants.IS_ATTRIBUTE]: true,
-          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^customreport[0-9a-z_]*' }),
+          [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ regex: '^[0-9a-z_]+' }),
         },
       },
       definition: {


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
SALTO-7108:  Modify ReportDefinition scriptId regex is to be less restrictive

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
