### PR TITLE
SALTO-7105: Supporting deprecated CVs in config

### DIFF
--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -44,7 +44,7 @@ import {
 import { validateFetchParameters } from './fetch_profile/fetch_profile'
 import { ConfigValidationError } from './config_validation'
 import { updateDeprecatedConfiguration } from './deprecated_config'
-import createChangeValidator, { changeValidators } from './change_validator'
+import createChangeValidator from './change_validator'
 import { getChangeGroupIds } from './group_changes'
 import { ConfigChange } from './config_change'
 import { configCreator } from './config_creator'
@@ -136,26 +136,20 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   }
 
   const validateValidatorsConfig = (validators: ValidatorsActivationConfig | undefined): void => {
-    if (validators !== undefined && !_.isPlainObject(validators)) {
+    if (validators === undefined) {
+      return
+    }
+    if (!_.isPlainObject(validators)) {
       throw new ConfigValidationError(
         ['validators'],
         'Enabled validators configuration must be an object if it is defined',
       )
     }
-    if (_.isPlainObject(validators)) {
-      const validValidatorsNames = Object.keys(changeValidators)
-      Object.entries(validators as {}).forEach(([key, value]) => {
-        if (!validValidatorsNames.includes(key)) {
-          throw new ConfigValidationError(
-            ['validators', key],
-            `Validator ${key} does not exist, expected one of ${validValidatorsNames.join(',')}`,
-          )
-        }
-        if (!_.isBoolean(value)) {
-          throw new ConfigValidationError(['validators', key], 'Value must be true or false')
-        }
-      })
-    }
+    Object.entries(validators as {}).forEach(([key, value]) => {
+      if (!_.isBoolean(value)) {
+        throw new ConfigValidationError(['validators', key], 'Value must be true or false')
+      }
+    })
   }
 
   const validateEnumFieldPermissions = (enumFieldPermissions: boolean | undefined): void => {

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -145,7 +145,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
         'Enabled validators configuration must be an object if it is defined',
       )
     }
-    Object.entries(validators as {}).forEach(([key, value]) => {
+    Object.entries(validators).forEach(([key, value]) => {
       if (!_.isBoolean(value)) {
         throw new ConfigValidationError(['validators', key], 'Value must be true or false')
       }

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -142,48 +142,49 @@ export type OptionalFeatures = {
   [key in (typeof OPTIONAL_FEATURES)[number]]?: boolean
 }
 
-export type ChangeValidatorName =
-  | 'managedPackage'
-  | 'picklistStandardField'
-  | 'customObjectInstances'
-  | 'customFieldType'
-  | 'standardFieldLabel'
-  | 'mapKeys'
-  | 'defaultRules'
-  | 'picklistPromote'
-  | 'cpqValidator'
-  | 'recordTypeDeletion'
-  | 'flowsValidator'
-  | 'fullNameChangedValidator'
-  | 'invalidListViewFilterScope'
-  | 'caseAssignmentRulesValidator'
-  | 'omitData'
-  | 'unknownUser'
-  | 'animationRuleRecordType'
-  | 'currencyIsoCodes'
-  | 'dataChange'
-  | 'duplicateRulesSortOrder'
-  | 'lastLayoutRemoval'
-  | 'accountSettings'
-  | 'unknownPicklistValues'
-  | 'installedPackages'
-  | 'dataCategoryGroup'
-  | 'standardFieldOrObjectAdditionsOrDeletions'
-  | 'deletedNonQueryableFields'
-  | 'instanceWithUnknownType'
-  | 'artificialTypes'
-  | 'metadataTypes'
-  | 'taskOrEventFieldsModifications'
-  | 'newFieldsAndObjectsFLS'
-  | 'elementApiVersion'
-  | 'cpqBillingStartDate'
-  | 'cpqBillingTriggers'
-  | 'managedApexComponent'
-  | 'orderedMaps'
-  | 'layoutDuplicateFields'
-  | 'customApplications'
-
-type ChangeValidatorConfig = Partial<Record<ChangeValidatorName, boolean>>
+const CHANGE_VALIDATORS = [
+  'managedPackage',
+  'picklistStandardField',
+  'customObjectInstances',
+  'customFieldType',
+  'standardFieldLabel',
+  'mapKeys',
+  'defaultRules',
+  'picklistPromote',
+  'cpqValidator',
+  'recordTypeDeletion',
+  'flowsValidator',
+  'fullNameChangedValidator',
+  'invalidListViewFilterScope',
+  'caseAssignmentRulesValidator',
+  'omitData',
+  'unknownUser',
+  'animationRuleRecordType',
+  'currencyIsoCodes',
+  'dataChange',
+  'duplicateRulesSortOrder',
+  'lastLayoutRemoval',
+  'accountSettings',
+  'unknownPicklistValues',
+  'installedPackages',
+  'dataCategoryGroup',
+  'standardFieldOrObjectAdditionsOrDeletions',
+  'deletedNonQueryableFields',
+  'instanceWithUnknownType',
+  'artificialTypes',
+  'metadataTypes',
+  'taskOrEventFieldsModifications',
+  'newFieldsAndObjectsFLS',
+  'elementApiVersion',
+  'cpqBillingStartDate',
+  'cpqBillingTriggers',
+  'managedApexComponent',
+  'orderedMaps',
+  'layoutDuplicateFields',
+  'customApplications',
+] as const
+const DEPRECATED_CHANGE_VALIDATORS = ['multipleDefaults'] as const
+export type ChangeValidatorName = (typeof CHANGE_VALIDATORS)[number]
 
 type ObjectIdSettings = {
   objectsRegex: string
@@ -828,51 +829,13 @@ const optionalFeaturesType = new ObjectType({
   },
 })
 
-const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig>({
+const changeValidatorConfigType = new ObjectType({
   elemID: new ElemID(constants.SALESFORCE, 'changeValidatorConfig'),
-  fields: {
-    managedPackage: { refType: BuiltinTypes.BOOLEAN },
-    picklistStandardField: { refType: BuiltinTypes.BOOLEAN },
-    customObjectInstances: { refType: BuiltinTypes.BOOLEAN },
-    customFieldType: { refType: BuiltinTypes.BOOLEAN },
-    standardFieldLabel: { refType: BuiltinTypes.BOOLEAN },
-    mapKeys: { refType: BuiltinTypes.BOOLEAN },
-    defaultRules: { refType: BuiltinTypes.BOOLEAN },
-    picklistPromote: { refType: BuiltinTypes.BOOLEAN },
-    cpqValidator: { refType: BuiltinTypes.BOOLEAN },
-    recordTypeDeletion: { refType: BuiltinTypes.BOOLEAN },
-    flowsValidator: { refType: BuiltinTypes.BOOLEAN },
-    fullNameChangedValidator: { refType: BuiltinTypes.BOOLEAN },
-    invalidListViewFilterScope: { refType: BuiltinTypes.BOOLEAN },
-    caseAssignmentRulesValidator: { refType: BuiltinTypes.BOOLEAN },
-    omitData: { refType: BuiltinTypes.BOOLEAN },
-    dataChange: { refType: BuiltinTypes.BOOLEAN },
-    unknownUser: { refType: BuiltinTypes.BOOLEAN },
-    animationRuleRecordType: { refType: BuiltinTypes.BOOLEAN },
-    currencyIsoCodes: { refType: BuiltinTypes.BOOLEAN },
-    duplicateRulesSortOrder: { refType: BuiltinTypes.BOOLEAN },
-    lastLayoutRemoval: { refType: BuiltinTypes.BOOLEAN },
-    accountSettings: { refType: BuiltinTypes.BOOLEAN },
-    unknownPicklistValues: { refType: BuiltinTypes.BOOLEAN },
-    dataCategoryGroup: { refType: BuiltinTypes.BOOLEAN },
-    installedPackages: { refType: BuiltinTypes.BOOLEAN },
-    standardFieldOrObjectAdditionsOrDeletions: {
-      refType: BuiltinTypes.BOOLEAN,
-    },
-    deletedNonQueryableFields: { refType: BuiltinTypes.BOOLEAN },
-    instanceWithUnknownType: { refType: BuiltinTypes.BOOLEAN },
-    artificialTypes: { refType: BuiltinTypes.BOOLEAN },
-    metadataTypes: { refType: BuiltinTypes.BOOLEAN },
-    taskOrEventFieldsModifications: { refType: BuiltinTypes.BOOLEAN },
-    newFieldsAndObjectsFLS: { refType: BuiltinTypes.BOOLEAN },
-    elementApiVersion: { refType: BuiltinTypes.BOOLEAN },
-    cpqBillingStartDate: { refType: BuiltinTypes.BOOLEAN },
-    cpqBillingTriggers: { refType: BuiltinTypes.BOOLEAN },
-    managedApexComponent: { refType: BuiltinTypes.BOOLEAN },
-    orderedMaps: { refType: BuiltinTypes.BOOLEAN },
-    layoutDuplicateFields: { refType: BuiltinTypes.BOOLEAN },
-    customApplications: { refType: BuiltinTypes.BOOLEAN },
-  },
+  fields: Object.fromEntries(
+    (CHANGE_VALIDATORS as readonly string[])
+      .concat(DEPRECATED_CHANGE_VALIDATORS)
+      .map(name => [name, { refType: BuiltinTypes.BOOLEAN }]),
+  ),
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
   },


### PR DESCRIPTION
This also reduces the severity of listing a CV that doesn't exist from an error to a warning.

---

_Additional context for reviewer_

---

_Release Notes_: 
_Salesforce_:
* Added support for listing deprecated CVs in deploy config.
* Reduced the severity of listing a CV that doesn't exist in the delpoy config from an error to a warning.

---

_User Notifications_: 
None.
