### PR TITLE
SALTO-7117: Add parent relationship to Record-Triggered Flows

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -140,6 +140,7 @@ import flowCoordinatesFilter from './filters/flow_coordinates'
 import taskAndEventCustomFields from './filters/task_and_event_custom_fields'
 import picklistReferences from './filters/picklist_references'
 import addParentToInstancesWithinFolderFilter from './filters/add_parent_to_instances_within_folder'
+import addParentToRecordTriggeredFlows from './filters/add_parent_to_record_triggered_flows'
 import { getConfigFromConfigChanges } from './config_change'
 import { Filter, FilterContext, FilterCreator, FilterResult } from './filter'
 import {
@@ -259,6 +260,8 @@ export const allFilters: Array<FilterCreator> = [
   // should run after convertListsFilter
   replaceFieldValuesFilter,
   valueToStaticFileFilter,
+  // addParentToRecordTriggeredFlows should run before fieldReferenceFilter
+  addParentToRecordTriggeredFlows,
   fieldReferencesFilter,
   // should run after customObjectsInstancesFilter for now
   referenceAnnotationsFilter,

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -21,6 +21,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   networkReferences: false,
   extendFetchTargets: false,
   addParentToInstancesWithinFolder: false,
+  addParentToRecordTriggeredFlows: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
@@ -56,7 +56,7 @@ const filter: FilterCreator = ({ config }) => ({
         }
         return acc
       }, 0)
-    log.debug('addParentToInstancesWithinFolderFilter created %d references in total', count)
+    log.debug('addParentToRecordTriggeredFlows created %d references in total', count)
   },
 })
 

--- a/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { logger } from '@salto-io/logging'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { Element, InstanceElement, isInstanceElement, TypeElement } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import { apiNameSync, buildElementsSourceForFetch, isInstanceOfTypeSync, addElementParentReference } from './utils'
+import { CUSTOM_OBJECT, FLOW_METADATA_TYPE } from '../constants'
+
+const { isDefined } = lowerDashValues
+const { toArrayAsync } = collections.asynciterable
+const log = logger(module)
+
+type RecordsIndex = Record<string, InstanceElement>
+
+const isRecordTriggeredFlow = (flow: InstanceElement): boolean => {
+  const flowStart: TypeElement = flow.getTypeSync()
+  return isDefined(flowStart) && isDefined(flowStart.fields.object)
+}
+
+const createFlowRecordIndex = (elements: Element[]): RecordsIndex => {
+  const recordsIndex: RecordsIndex = {}
+  elements
+    .filter(isInstanceElement)
+    .filter(isInstanceOfTypeSync(CUSTOM_OBJECT))
+    .forEach(instance => {
+      recordsIndex[apiNameSync(instance) ?? ''] = instance
+    })
+  return recordsIndex
+}
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'addParentToRecordTriggeredFlows',
+  onFetch: async (elements: Element[]) => {
+    if (!config.fetchProfile.isFeatureEnabled('addParentToRecordTriggeredFlows')) {
+      return
+    }
+    const recordsIndex = createFlowRecordIndex(
+      await toArrayAsync(await buildElementsSourceForFetch(elements, config).getAll()),
+    )
+    const count: number = elements
+      .filter(isInstanceElement)
+      .filter(isInstanceOfTypeSync(FLOW_METADATA_TYPE))
+      .filter(isRecordTriggeredFlow)
+      .reduce((acc, instance) => {
+        const parent = recordsIndex[apiNameSync(instance.getTypeSync().fields.object) ?? '']
+        if (isDefined(parent)) {
+          addElementParentReference(instance, parent)
+          return acc + 1
+        }
+        return acc
+      }, 0)
+    log.debug('addParentToInstancesWithinFolderFilter created %d references in total', count)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
@@ -53,7 +53,7 @@ const filter: FilterCreator = ({ config }) => ({
       }
       log.warn(
         'could not add parent reference to instance %s, the object %s is missing from the workspace',
-        flow,
+        flow.elemID.getFullName(),
         flow.value.start.object,
       )
       return acc

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -105,6 +105,7 @@ const OPTIONAL_FEATURES = [
   'networkReferences',
   'extendFetchTargets',
   'addParentToInstancesWithinFolder',
+  'addParentToRecordTriggeredFlows',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',

--- a/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { CORE_ANNOTATIONS, Element, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockTypes } from '../mock_elements'
+import { createCustomObjectType, defaultFilterContext } from '../utils'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { OPPORTUNITY_METADATA_TYPE } from '../../src/constants'
+import { FilterWith } from './mocks'
+import filterCreator from '../../src/filters/add_parent_to_record_triggered_flows'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+
+const mockLogError = jest.fn()
+jest.mock('@salto-io/logging', () => ({
+  ...jest.requireActual<{}>('@salto-io/logging'),
+  logger: jest.fn().mockReturnValue({
+    warn: jest.fn((...args) => mockLogError(...args)),
+    debug: jest.fn((...args) => mockLogError(...args)),
+  }),
+}))
+
+describe('addParentToRecordTriggeredFlows', () => {
+  describe('onFetch', () => {
+    let elements: Element[]
+    let elementsSource: Element[]
+    let updateOpportunityFlow: Element
+    let updateLeadFlow: Element
+    let opportunity: Element
+    let lead: Element
+
+    describe('when there are record triggered flows', () => {
+      describe('when addParentToRecordTriggeredFlows in Enabled', () => {
+        describe('when all objects that trigger flows exist in the workspace', () => {
+          beforeEach(async () => {
+            opportunity = createCustomObjectType(OPPORTUNITY_METADATA_TYPE, {})
+            elementsSource = [opportunity]
+            elements = [
+              (updateOpportunityFlow = createInstanceElement(
+                { fullName: 'UpdateOpportunity', start: { object: OPPORTUNITY_METADATA_TYPE } },
+                mockTypes.Flow,
+              )),
+              (updateLeadFlow = createInstanceElement(
+                { fullName: 'UpdateLead', start: { object: 'Lead' } },
+                mockTypes.Flow,
+              )),
+              (lead = createCustomObjectType('Lead', {})),
+            ]
+            const filter: FilterWith<'onFetch'> = filterCreator({
+              config: {
+                ...defaultFilterContext,
+                fetchProfile: buildFetchProfile({
+                  fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: true } },
+                }),
+                elementsSource: buildElementsSourceFromElements(elementsSource),
+              },
+            }) as FilterWith<'onFetch'>
+            await filter.onFetch(elements)
+          })
+          it('should add parent annotation to updateOpportunityFlow', async () => {
+            expect(updateOpportunityFlow.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+              new ReferenceExpression(opportunity.elemID, opportunity),
+            )
+          })
+          it('should add parent annotation to updateLeadFlow', async () => {
+            expect(updateLeadFlow.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+              new ReferenceExpression(lead.elemID, lead),
+            )
+          })
+        })
+        describe('when object that trigger Flow is missing from the workspace', () => {
+          beforeEach(async () => {
+            jest.clearAllMocks()
+            elementsSource = []
+            elements = [
+              (updateOpportunityFlow = createInstanceElement(
+                { fullName: 'UpdateOpportunity', start: { object: OPPORTUNITY_METADATA_TYPE } },
+                mockTypes.Flow,
+              )),
+              (updateLeadFlow = createInstanceElement(
+                { fullName: 'UpdateLead', start: { object: 'Lead' } },
+                mockTypes.Flow,
+              )),
+            ]
+            const filter: FilterWith<'onFetch'> = filterCreator({
+              config: {
+                ...defaultFilterContext,
+                fetchProfile: buildFetchProfile({
+                  fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: true } },
+                }),
+                elementsSource: buildElementsSourceFromElements(elementsSource),
+              },
+            }) as FilterWith<'onFetch'>
+            await filter.onFetch(elements)
+          })
+          it('should return warning that opportunity is missing from the workspace', () => {
+            expect(mockLogError).toHaveBeenCalledWith(
+              'could not add parent reference to instance %s, the object %s is missing from the workspace',
+              updateOpportunityFlow,
+              OPPORTUNITY_METADATA_TYPE,
+            )
+          })
+          it('should return warning that lead is missing from the workspace', () => {
+            expect(mockLogError).toHaveBeenCalledWith(
+              'could not add parent reference to instance %s, the object %s is missing from the workspace',
+              updateLeadFlow,
+              'Lead',
+            )
+          })
+        })
+      })
+      describe('when addParentToRecordTriggeredFlows in Disabled', () => {})
+    })
+  })
+})


### PR DESCRIPTION
SALTO-7117: Add parent relationship to Record-Triggered Flows

---
Workspace Diff: https://github.com/salto-io/almog-sf/commit/7587794e26f5e0b5c3aa65e0a72b689297c81edc

---
_Release Notes_: 
_Salesforce Adapter_:
- Add parent relationship to Record-Triggered Flows.

---
_User Notifications_: 
_Salesforce Adapter_:
- **_parent** annotation will be added to Record-Triggered Flows.
