### PR TITLE
SALTO-7134: Calculate Salesforce Data Instances service URL before creating collision warnings

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -226,6 +226,8 @@ export const allFilters: Array<FilterCreator> = [
   // convertMapsFilter should run before profile fieldReferencesFilter
   convertMapsFilter,
   flowFilter,
+  elementsUrlFilter,
+  // customObjectInstanceReferencesFilter should run after elementsUrlFilter
   customObjectInstanceReferencesFilter,
   cpqReferencableFieldReferencesFilter,
   cpqCustomScriptFilter,
@@ -240,7 +242,6 @@ export const allFilters: Array<FilterCreator> = [
   extendTriggersMetadataFilter,
   profilePathsFilter,
   territoryFilter,
-  elementsUrlFilter,
   nestedInstancesAuthorInformation,
   customObjectAuthorFilter,
   dataInstancesAuthorFilter,


### PR DESCRIPTION
Calculate Salesforce Data Instances service URL before creating collision warnings

---

Simply reordered the filters.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
