### PR TITLE
Remove warnings from SDF error message

### DIFF
--- a/packages/netsuite-adapter/src/client/sdf_client.ts
+++ b/packages/netsuite-adapter/src/client/sdf_client.ts
@@ -171,7 +171,7 @@ const ALL = 'ALL'
 export const ALL_FEATURES = 'FEATURES:ALL_FEATURES'
 
 // e.g. *** ERREUR ***
-const fatalErrorMessageRegex = RegExp('^\\*\\*\\*.+\\*\\*\\*$')
+const fatalErrorMessageRegex = RegExp('^\\*\\*\\*.+\\*\\*\\*$', 'm')
 
 export const MINUTE_IN_MILLISECONDS = 1000 * 60
 const SINGLE_OBJECT_RETRIES = 3
@@ -1016,7 +1016,10 @@ export default class SdfClient {
     const allDeployedObjects = getGroupItemFromRegex(error.message, deployedObjectRegex, OBJECT_ID)
     if (allDeployedObjects.length > 0) {
       const errorMessages = sliceMessagesByRegex(messages, deployedObjectRegex, false)
-      const message = errorMessages.length > 0 ? errorMessages.join(os.EOL) : error.message
+      const joinedErrorMessage = errorMessages.length > 0 ? errorMessages.join(os.EOL) : undefined
+      const messageAfterFatalError = joinedErrorMessage?.split(fatalErrorMessageRegex).slice(-1)[0]?.trimStart()
+
+      const message = messageAfterFatalError ?? joinedErrorMessage ?? error.message
       // the last object in the error message is the one that failed the deploy
       const errorsMap = new Map([[allDeployedObjects.slice(-1)[0], [{ message }]]])
       return new ObjectsDeployError(error.message, errorsMap)

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1924,6 +1924,13 @@ Update object -- customrecord_flo_customization.custrecord_flo_description (cust
 Update object -- customrecord_flo_customization.custrecord_sp_personal_data (customrecordcustomfield)
 Update object -- customrecord_flo_customization.custrecord_flo_help (customrecordcustomfield)
 Update object -- customrecord_flo_customization.custrecord_flo_custz_link (customrecordcustomfield)
+Validate for circular dependencies -- Success
+
+WARNING -- One or more potential issues were found during custom object validation. (customrecord_flo_customization)
+File: ~/Objects/customrecord_flo_customization.xml
+
+WARNING -- One or more potential issues were found during custom object validation. (customrecord_flo_customization)
+File: ~/Objects/customrecord_flo_customization.xml
 *** ERROR ***
 
 An error occurred during custom object update.


### PR DESCRIPTION
Return a cleaner SDF error message - without warnings that aren't part of the error.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Remove warnings from SDF error message

---
_User Notifications_: 
None
