### PR TITLE
SALTO-6988: Salesforce adapter config documentation saltoIdSettings overrides example is misleading

### DIFF
--- a/packages/salesforce-adapter/config_doc.md
+++ b/packages/salesforce-adapter/config_doc.md
@@ -95,8 +95,8 @@ salesforce {
     }
     data = {
       includeObjects = [
-        ".*SBQQ__CustomAction__c.*",
-        ".*PricebookEntry.*",
+        "SBQQ__CustomAction__c",
+        "PricebookEntry",
       ]
       saltoManagementFieldSettings = {
         defaultFieldName = "ManagedBySalto__c"
@@ -117,14 +117,14 @@ salesforce {
         ]
         overrides = [
           {
-            objectsRegex = ".*pricebookEntryName.*"
+            objectsRegex = "PricebookEntry"
             idFields = [
               "Pricebook2Id",
               "Name",
             ]
           },
           {
-            objectsRegex = ".*SBQQCustomActionName.*"
+            objectsRegex = "SBQQ__CustomAction__c"
             idFields = [
               "SBQQ__Location__c",
               "SBQQ__DisplayOrder__c",


### PR DESCRIPTION
SALTO-6988: Salesforce adapter config documentation saltoIdSettings overrides example is misleading

---
_Release Notes_: 
None

---
_User Notifications_: 
None
