### PR TITLE
SALTO-5932: change split options in Fields to default true

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -43,7 +43,11 @@ import { findInstance } from './utils'
 import { getLookUpName } from '../src/reference_mapping'
 import { getDefaultConfig } from '../src/config/config'
 import { BEHAVIOR_TYPE } from '../src/constants'
-import { FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from '../src/filters/fields/constants'
+import {
+  FIELD_CONTEXT_OPTION_TYPE_NAME,
+  FIELD_CONTEXT_TYPE_NAME,
+  FIELD_TYPE_NAME,
+} from '../src/filters/fields/constants'
 
 const { awu } = collections.asynciterable
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
@@ -299,6 +303,7 @@ each([
             instance.elemID.typeName !== FIELD_CONTEXT_TYPE_NAME ||
             instance.annotations[CORE_ANNOTATIONS.PARENT]?.[0].value.isLocked === false,
         ) // do not delete contexts of locked fields
+        .filter(instance => instance.elemID.typeName !== FIELD_CONTEXT_OPTION_TYPE_NAME) // do not delete options, they will be deleted with their contexts
         .map(instance => toChange({ before: instance }))
 
       if (!isDataCenter) {

--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -33,7 +33,7 @@ export const createOptionsAndOrders = ({
   optionsType: ObjectType
   orderType: ObjectType
   contextInstance: InstanceElement
-}): InstanceElement[] => {
+}): { contextOptions: InstanceElement[]; contextOrders: InstanceElement[] } => {
   const createOptionInstance = (value: string, parent: InstanceElement, disabled = false): InstanceElement =>
     new InstanceElement(
       createOptionName(parent.elemID.name, value),
@@ -65,18 +65,22 @@ export const createOptionsAndOrders = ({
   const optionP3 = createOptionInstance('p3', contextInstance, true)
   const optionP4 = createOptionInstance('p4', contextInstance)
 
-  return [
-    cascadingOptionP1,
-    cascadingOptionP1C11,
-    cascadingOptionP1C12,
-    cascadingOptionP2,
-    cascadingOptionP2C22,
-    optionP3,
-    optionP4,
-    createOrderInstance(contextInstance, [cascadingOptionP1, cascadingOptionP2, optionP3, optionP4]),
-    createOrderInstance(cascadingOptionP1, [cascadingOptionP1C11, cascadingOptionP1C12]),
-    createOrderInstance(cascadingOptionP2, [cascadingOptionP2C22]),
-  ]
+  return {
+    contextOptions: [
+      cascadingOptionP1,
+      cascadingOptionP1C11,
+      cascadingOptionP1C12,
+      cascadingOptionP2,
+      cascadingOptionP2C22,
+      optionP3,
+      optionP4,
+    ],
+    contextOrders: [
+      createOrderInstance(contextInstance, [cascadingOptionP1, cascadingOptionP2, optionP3, optionP4]),
+      createOrderInstance(cascadingOptionP1, [cascadingOptionP1C11, cascadingOptionP1C12]),
+      createOrderInstance(cascadingOptionP2, [cascadingOptionP2C22]),
+    ],
+  }
 }
 
 export const createFieldValues = (name: string): Values => ({

--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -5,26 +5,78 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ElemID, Values, Element } from '@salto-io/adapter-api'
+import {
+  ElemID,
+  Values,
+  Element,
+  InstanceElement,
+  ObjectType,
+  CORE_ANNOTATIONS,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { invertNaclCase } from '@salto-io/adapter-utils'
 import { createReference } from '../utils'
 import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
+import { ORDER_INSTANCE_SUFFIX } from '../../src/filters/fields/constants'
 
-const p1Option = {
-  value: 'p1',
-  disabled: false,
-  cascadingOptions: {
-    c11: {
-      value: 'c11',
-      disabled: false,
-      position: 0,
-    },
-    c12: {
-      value: 'c12',
-      disabled: false,
-      position: 1,
-    },
-  },
-  position: 1,
+const createOptionName = (parentName: string, optionValue: string): string =>
+  `${invertNaclCase(parentName)}_${optionValue}`
+
+const createOrderName = (parent: InstanceElement): string =>
+  `${invertNaclCase(parent.elemID.name)}_${ORDER_INSTANCE_SUFFIX}`
+
+export const createOptionsAndOrders = ({
+  optionsType,
+  orderType,
+  contextInstance,
+}: {
+  optionsType: ObjectType
+  orderType: ObjectType
+  contextInstance: InstanceElement
+}): InstanceElement[] => {
+  const createOptionInstance = (value: string, parent: InstanceElement, disabled = false): InstanceElement =>
+    new InstanceElement(
+      createOptionName(parent.elemID.name, value),
+      optionsType,
+      {
+        value,
+        disabled,
+      },
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
+    )
+
+  const createOrderInstance = (parent: InstanceElement, options: InstanceElement[]): InstanceElement =>
+    new InstanceElement(
+      createOrderName(parent),
+      orderType,
+      {
+        options: options.map(option => new ReferenceExpression(option.elemID, option)),
+      },
+      undefined,
+      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
+    )
+
+  const cascadingOptionP1 = createOptionInstance('p1', contextInstance)
+  const cascadingOptionP2 = createOptionInstance('p2', contextInstance)
+  const cascadingOptionP1C11 = createOptionInstance('c11', cascadingOptionP1)
+  const cascadingOptionP1C12 = createOptionInstance('c12', cascadingOptionP1)
+  const cascadingOptionP2C22 = createOptionInstance('c22', cascadingOptionP2)
+  const optionP3 = createOptionInstance('p3', contextInstance, true)
+  const optionP4 = createOptionInstance('p4', contextInstance)
+
+  return [
+    cascadingOptionP1,
+    cascadingOptionP1C11,
+    cascadingOptionP1C12,
+    cascadingOptionP2,
+    cascadingOptionP2C22,
+    optionP3,
+    optionP4,
+    createOrderInstance(contextInstance, [cascadingOptionP1, cascadingOptionP2, optionP3, optionP4]),
+    createOrderInstance(cascadingOptionP1, [cascadingOptionP1C11, cascadingOptionP1C12]),
+    createOrderInstance(cascadingOptionP2, [cascadingOptionP2C22]),
+  ]
 }
 
 export const createFieldValues = (name: string): Values => ({
@@ -36,31 +88,6 @@ export const createFieldValues = (name: string): Values => ({
 
 export const createContextValues = (name: string, allElements: Element[]): Values => ({
   name,
-  options: {
-    p1: p1Option,
-    p2: {
-      value: 'p2',
-      disabled: false,
-      cascadingOptions: {
-        c22: {
-          value: 'c22',
-          disabled: false,
-          position: 0,
-        },
-      },
-      position: 2,
-    },
-    p3: {
-      value: 'p3',
-      disabled: true,
-      position: 3,
-    },
-    p4: {
-      value: 'p4',
-      disabled: false,
-      position: 4,
-    },
-  },
   issueTypeIds: [
     createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Epic'), allElements),
     createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Story'), allElements),

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -18,7 +18,7 @@ import { naclCase } from '@salto-io/adapter-utils'
 import { CUSTOM_FIELDS_SUFFIX } from '../../src/filters/fields/field_name_filter'
 import { JIRA, WEBHOOK_TYPE, STATUS_TYPE_NAME } from '../../src/constants'
 import { createReference, findType } from '../utils'
-import { createContextValues, createFieldValues } from './field'
+import { createContextValues, createFieldValues, createOptionsAndOrders } from './field'
 import { createFieldConfigurationSchemeValues } from './fieldConfigurationScheme'
 import { createIssueTypeScreenSchemeValues } from './issueTypeScreenScheme'
 import { createScreenValues } from './screen'
@@ -45,6 +45,12 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     undefined,
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)] },
   )
+
+  const fieldContextOptionsAndOrders = createOptionsAndOrders({
+    optionsType: findType('CustomFieldContextOption', fetchedElements),
+    orderType: findType('FieldContextOptionsOrder', fetchedElements),
+    contextInstance: fieldContext,
+  })
 
   const screen = new InstanceElement(
     randomString,
@@ -108,7 +114,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
       ? createDataCenterInstances(randomString, fetchedElements)
       : createCloudInstances(randomString, uuid, fetchedElements)),
     [field],
-    [fieldContext],
+    fieldContextOptionsAndOrders,
     [screen],
     [screenScheme],
     [issueTypeScreenScheme],

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -117,8 +117,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
       ? createDataCenterInstances(randomString, fetchedElements)
       : createCloudInstances(randomString, uuid, fetchedElements)),
     [field],
-    [fieldContext],
-    contextOptions,
+    [fieldContext, ...contextOptions],
     contextOrders,
     [screen],
     [screenScheme],

--- a/packages/jira-adapter/e2e_test/instances/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/index.ts
@@ -49,7 +49,7 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
     { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)] },
   )
 
-  const fieldContextOptionsAndOrders = createOptionsAndOrders({
+  const { contextOptions, contextOrders } = createOptionsAndOrders({
     optionsType: findType('CustomFieldContextOption', fetchedElements),
     orderType: findType('FieldContextOptionsOrder', fetchedElements),
     contextInstance: fieldContext,
@@ -118,7 +118,8 @@ export const createInstances = (fetchedElements: Element[], isDataCenter: boolea
       : createCloudInstances(randomString, uuid, fetchedElements)),
     [field],
     [fieldContext],
-    fieldContextOptionsAndOrders,
+    contextOptions,
+    contextOrders,
     [screen],
     [screenScheme],
     [issueTypeScreenScheme],

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -187,6 +187,7 @@ export const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     allowUserCallFailure: false,
     enableAssetsObjectFieldConfiguration: true,
     removeFieldConfigurationDefaultValues: false,
+    splitFieldContextOptions: true,
   },
   deploy: {
     forceDelete: false,

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -71,27 +71,23 @@ export const scriptRunnerAuditSetter = (instance: InstanceElement, response: cli
   }
 }
 
-const updatePropertyIfExist = (
-  instance: InstanceElement,
-  property: string,
-  response: clientUtils.ResponseValue,
-): void => {
-  if (Object.prototype.hasOwnProperty.call(response, property)) {
-    instance.value[property] = response[property]
+const updatePropertyIfExist = (instanceValue: Value, property: string, responseValue: Value): void => {
+  if (responseValue[property] != null) {
+    // not undefined or null
+    instanceValue[property] = responseValue[property]
   }
 }
 
-export const scriptRunnerIdAndAuditSetter = (
-  instance: InstanceElement,
-  serviceIdField: string,
-  response: clientUtils.ResponseValue,
-): void => {
-  instance.value[serviceIdField] = response[serviceIdField]
-  if (AUDIT_SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName)) {
-    updatePropertyIfExist(instance, 'auditData', response)
+export const scriptRunnerAuditSetter = (instance: InstanceElement, response: clientUtils.ResponseValue): void => {
+  if (AUDIT_SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName) && response.auditData != null) {
+    if (instance.value.auditData === undefined) {
+      instance.value.auditData = {}
+    }
+    updatePropertyIfExist(instance.value.auditData, 'createdTimestamp', response.auditData)
+    updatePropertyIfExist(instance.value.auditData, 'updatedTimestamp', response.auditData)
   } else if (instance.elemID.typeName === SCRIPT_RUNNER_LISTENER_TYPE) {
-    updatePropertyIfExist(instance, 'createdTimestamp', response)
-    updatePropertyIfExist(instance, 'updatedTimestamp', response)
+    updatePropertyIfExist(instance.value, 'createdTimestamp', response)
+    updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
   }
 }
 

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -57,8 +57,8 @@ const updatePropertyIfExist = (instanceValue: Value, property: string, responseV
 }
 
 export const listenersAuditSetter = (instance: InstanceElement, response: Value): void => {
-  updatePropertyIfExist(instance.value, 'createdTimestamp', response)
-  updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
+  updatePropertyIfExist(instance.value, CREATED_TIMESTAMP, response)
+  updatePropertyIfExist(instance.value, UPDATED_TIMESTAMP, response)
 }
 
 export const scriptRunnerAuditSetter = (instance: InstanceElement, response: clientUtils.ResponseValue): void => {
@@ -66,8 +66,8 @@ export const scriptRunnerAuditSetter = (instance: InstanceElement, response: cli
     if (instance.value.auditData === undefined) {
       instance.value.auditData = {}
     }
-    updatePropertyIfExist(instance.value.auditData, 'createdTimestamp', response.auditData)
-    updatePropertyIfExist(instance.value.auditData, 'updatedTimestamp', response.auditData)
+    updatePropertyIfExist(instance.value.auditData, CREATED_TIMESTAMP, response.auditData)
+    updatePropertyIfExist(instance.value.auditData, UPDATED_TIMESTAMP, response.auditData)
   }
 }
 

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -57,28 +57,6 @@ const updatePropertyIfExist = (instanceValue: Value, property: string, responseV
 }
 
 export const listenersAuditSetter = (instance: InstanceElement, response: Value): void => {
-  updatePropertyIfExist(instance.value, CREATED_TIMESTAMP, response)
-  updatePropertyIfExist(instance.value, UPDATED_TIMESTAMP, response)
-}
-
-export const scriptRunnerAuditSetter = (instance: InstanceElement, response: clientUtils.ResponseValue): void => {
-  if (AUDIT_SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName) && response.auditData != null) {
-    if (instance.value.auditData === undefined) {
-      instance.value.auditData = {}
-    }
-    updatePropertyIfExist(instance.value.auditData, CREATED_TIMESTAMP, response.auditData)
-    updatePropertyIfExist(instance.value.auditData, UPDATED_TIMESTAMP, response.auditData)
-  }
-}
-
-const updatePropertyIfExist = (instanceValue: Value, property: string, responseValue: Value): void => {
-  if (responseValue[property] != null) {
-    // not undefined or null
-    instanceValue[property] = responseValue[property]
-  }
-}
-
-export const listenersAuditSetter = (instance: InstanceElement, response: Value): void => {
   updatePropertyIfExist(instance.value, 'createdTimestamp', response)
   updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
 }

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -78,6 +78,11 @@ const updatePropertyIfExist = (instanceValue: Value, property: string, responseV
   }
 }
 
+export const listenersAuditSetter = (instance: InstanceElement, response: Value): void => {
+  updatePropertyIfExist(instance.value, 'createdTimestamp', response)
+  updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
+}
+
 export const scriptRunnerAuditSetter = (instance: InstanceElement, response: clientUtils.ResponseValue): void => {
   if (AUDIT_SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName) && response.auditData != null) {
     if (instance.value.auditData === undefined) {
@@ -85,9 +90,6 @@ export const scriptRunnerAuditSetter = (instance: InstanceElement, response: cli
     }
     updatePropertyIfExist(instance.value.auditData, 'createdTimestamp', response.auditData)
     updatePropertyIfExist(instance.value.auditData, 'updatedTimestamp', response.auditData)
-  } else if (instance.elemID.typeName === SCRIPT_RUNNER_LISTENER_TYPE) {
-    updatePropertyIfExist(instance.value, 'createdTimestamp', response)
-    updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
   }
 }
 

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -71,6 +71,30 @@ export const scriptRunnerAuditSetter = (instance: InstanceElement, response: cli
   }
 }
 
+const updatePropertyIfExist = (
+  instance: InstanceElement,
+  property: string,
+  response: clientUtils.ResponseValue,
+): void => {
+  if (Object.prototype.hasOwnProperty.call(response, property)) {
+    instance.value[property] = response[property]
+  }
+}
+
+export const scriptRunnerIdAndAuditSetter = (
+  instance: InstanceElement,
+  serviceIdField: string,
+  response: clientUtils.ResponseValue,
+): void => {
+  instance.value[serviceIdField] = response[serviceIdField]
+  if (AUDIT_SCRIPT_RUNNER_TYPES.includes(instance.elemID.typeName)) {
+    updatePropertyIfExist(instance, 'auditData', response)
+  } else if (instance.elemID.typeName === SCRIPT_RUNNER_LISTENER_TYPE) {
+    updatePropertyIfExist(instance, 'createdTimestamp', response)
+    updatePropertyIfExist(instance, 'updatedTimestamp', response)
+  }
+}
+
 // This filter is used to:
 // * make script runner types deployable
 // * make script runner settings only updatable

--- a/packages/jira-adapter/test/change_validators/field_contexts/custom_field_with_10K_options.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/custom_field_with_10K_options.test.ts
@@ -56,9 +56,11 @@ describe('customFieldsWith10KOptionValidator', () => {
       },
     )
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
-    config.fetch.splitFieldContextOptions = false
   })
   describe('without splitFieldContextOptions', () => {
+    beforeEach(() => {
+      config.fetch.splitFieldContextOptions = false
+    })
     it('should return info message when context has more than 10K options', async () => {
       const largeOptionsObject = tenKOptions
       contextInstance.value.options = largeOptionsObject

--- a/packages/jira-adapter/test/change_validators/field_contexts/custom_field_with_10K_options.test.ts
+++ b/packages/jira-adapter/test/change_validators/field_contexts/custom_field_with_10K_options.test.ts
@@ -56,6 +56,7 @@ describe('customFieldsWith10KOptionValidator', () => {
       },
     )
     config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+    config.fetch.splitFieldContextOptions = false
   })
   describe('without splitFieldContextOptions', () => {
     it('should return info message when context has more than 10K options', async () => {

--- a/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
@@ -13,6 +13,7 @@ import {
   getChangeData,
   InstanceElement,
   isAdditionChange,
+  isRemovalChange,
   isSaltoElementError,
   ReadOnlyElementsSource,
   ReferenceExpression,
@@ -309,6 +310,19 @@ describe('ContextOptionsDeployment', () => {
     expect(isSaltoElementError(result.deployResult.errors[0])).toBeTruthy()
     expect(result.deployResult.errors[0]).toHaveProperty('elemID', getChangeData(changes[0]).elemID)
     expect(result.deployResult.appliedChanges).toHaveLength(0)
+  })
+  it('should not issue an error if a removal fails with 404', async () => {
+    connection.delete.mockImplementation(async () => {
+      throw new clientUtils.HTTPError('message', {
+        status: 404,
+        data: {},
+      })
+    })
+    const removalChanges = changes.filter(isRemovalChange)
+    const result = await filter.deploy(removalChanges)
+    expect(result.leftoverChanges).toHaveLength(0)
+    expect(result.deployResult.errors).toHaveLength(0)
+    expect(result.deployResult.appliedChanges).toHaveLength(2)
   })
   describe('add cascading options', () => {
     beforeEach(() => {

--- a/packages/jira-adapter/test/filters/fields/default_values.test.ts
+++ b/packages/jira-adapter/test/filters/fields/default_values.test.ts
@@ -39,6 +39,7 @@ describe('default values', () => {
         patch: mockFunction<clientUtils.HTTPWriteClientInterface['patch']>(),
       }
       config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+      config.fetch.splitFieldContextOptions = false
       type = new ObjectType({ elemID: new ElemID(JIRA, FIELD_CONTEXT_TYPE_NAME) })
     })
 


### PR DESCRIPTION
None

---

[Noise reduction](https://github.com/salto-io/salto_private/pull/10145)

---
_Release Notes_: 
Jira Adapter:
* Options in Fields will now be a separate element. It allows modifying options without changing their IDs

---
_User Notifications_: 
Jira Adapter:
* Field contexts will now have a list of references to their options, options will now be in standalone elements
