### PR TITLE
SALTO-7148: Change toActionNames to be async, so it can work with element source

### DIFF
--- a/packages/adapter-components/src/definitions/system/deploy/deploy.ts
+++ b/packages/adapter-components/src/definitions/system/deploy/deploy.ts
@@ -100,7 +100,11 @@ export type InstanceDeployApiDefinitions<AdditionalAction extends string, Client
   // changes will be marked as applied if at least one action succeeded, but will include errors from all changes (TODO may revisit in SALTO-5557).
   // Note: in most cases, customizing the actions goes hand in hand with customizing dependencies
   // (e.g. defining that all activate actions come after all add actions)
-  toActionNames?: ({ change, changeGroup, elementSource }: ChangeAndContext) => (ActionName | AdditionalAction)[]
+  toActionNames?: ({
+    change,
+    changeGroup,
+    elementSource,
+  }: ChangeAndContext) => Promise<(ActionName | AdditionalAction)[]>
 
   // by default, all actions for a type are run in parallel.
   // if the order is important (e.g. removals before additions), it can be controlled here

--- a/packages/adapter-components/src/deployment/deploy/deploy.ts
+++ b/packages/adapter-components/src/deployment/deploy/deploy.ts
@@ -113,7 +113,7 @@ export const deployChanges = async <TOptions extends APIDefinitionsOptions>({
     change => getChangeData(change).elemID,
   )
 
-  const graph = createDependencyGraph({
+  const graph = await createDependencyGraph({
     defQuery,
     dependencies,
     changes: changes.concat(Object.values(subResourceChangesByChangeID).flat()),

--- a/packages/adapter-components/test/deployment/deploy/deploy.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/deploy.test.ts
@@ -90,7 +90,7 @@ describe('deployChanges', () => {
               requestsByAction: {
                 customizations: {},
               },
-              toActionNames: ({ change }) => {
+              toActionNames: async ({ change }) => {
                 if (change.action === 'add') {
                   return ['add', 'activate']
                 }

--- a/packages/adapter-components/test/deployment/deploy/graph.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/graph.test.ts
@@ -64,8 +64,8 @@ describe('createDependencyGraph', () => {
 
   describe('without action or dependency customizations', () => {
     let graph: DAG<NodeType<never>>
-    beforeEach(() => {
-      graph = createDependencyGraph({
+    beforeEach(async () => {
+      graph = await createDependencyGraph({
         defQuery: queryWithDefault<InstanceDeployApiDefinitions<never, 'main'>>(
           (deployDef as DeployApiDefinitions<never, 'main'>).instances,
         ),
@@ -95,11 +95,11 @@ describe('createDependencyGraph', () => {
 
   describe('with custom actions and dependencies', () => {
     let graph: DAG<NodeType<'activate' | 'deactivate'>>
-    beforeEach(() => {
+    beforeEach(async () => {
       if (!deployDef.instances.customizations) {
         deployDef.instances.customizations = {}
       }
-      deployDef.instances.customizations.typeB.toActionNames = ({ change }) => {
+      deployDef.instances.customizations.typeB.toActionNames = async ({ change }) => {
         if (change.action === 'add') {
           return ['add', 'activate']
         }
@@ -117,7 +117,7 @@ describe('createDependencyGraph', () => {
         { first: { type: 'typeC' }, second: { type: 'typeB' } },
         { first: { type: 'unavailable1' }, second: { type: 'typeB' } },
       ]
-      graph = createDependencyGraph({
+      graph = await createDependencyGraph({
         defQuery: queryWithDefault<InstanceDeployApiDefinitions<'activate' | 'deactivate', 'main'>>(
           deployDef.instances,
         ),
@@ -173,13 +173,13 @@ describe('createDependencyGraph', () => {
 
   describe('with a dependency cycle', () => {
     let graph: DAG<NodeType<'activate' | 'deactivate'>>
-    beforeEach(() => {
+    beforeEach(async () => {
       deployDef.dependencies = [
         { first: { type: 'typeA', action: 'add' }, second: { type: 'typeB' } },
         { first: { type: 'typeB' }, second: { type: 'typeC' } },
         { first: { type: 'typeC', action: 'remove' }, second: { type: 'typeA', action: 'add' } },
       ]
-      graph = createDependencyGraph({
+      graph = await createDependencyGraph({
         defQuery: queryWithDefault<InstanceDeployApiDefinitions<'activate' | 'deactivate', 'main'>>(
           deployDef.instances,
         ),
@@ -241,8 +241,8 @@ describe('createDependencyGraph', () => {
     describe('without action or dependency customizations', () => {
       let graph: DAG<NodeType<never>>
 
-      beforeEach(() => {
-        graph = createDependencyGraph({
+      beforeEach(async () => {
+        graph = await createDependencyGraph({
           defQuery: queryWithDefault<InstanceDeployApiDefinitions<never, 'main'>>(
             (deployDef as DeployApiDefinitions<never, 'main'>).instances,
           ),
@@ -264,7 +264,7 @@ describe('createDependencyGraph', () => {
     })
     describe('with additional action and dependency customizations', () => {
       let graph: DAG<NodeType<never>>
-      beforeEach(() => {
+      beforeEach(async () => {
         if (!deployDef.instances.customizations) {
           deployDef.instances.customizations = {}
         }
@@ -272,7 +272,7 @@ describe('createDependencyGraph', () => {
         deployDef.dependencies = [
           { first: { type: 'typeA', action: 'modify' }, second: { type: 'typeAItems', action: 'modify' } },
         ]
-        graph = createDependencyGraph({
+        graph = await createDependencyGraph({
           defQuery: queryWithDefault<InstanceDeployApiDefinitions<never, 'main'>>(
             (deployDef as DeployApiDefinitions<never, 'main'>).instances,
           ),

--- a/packages/confluence-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/confluence-adapter/src/definitions/deploy/deploy.ts
@@ -305,7 +305,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
       },
     },
     [SPACE_SETTINGS_TYPE_NAME]: {
-      toActionNames: ({ change }) => {
+      toActionNames: async ({ change }) => {
         if (isAdditionOrModificationChange(change)) {
           return ['modify']
         }

--- a/packages/confluence-adapter/src/definitions/utils/page.ts
+++ b/packages/confluence-adapter/src/definitions/utils/page.ts
@@ -33,7 +33,10 @@ export const homepageAdditionToModification: ({
   change,
   changeGroup,
   elementSource,
-}: definitions.deploy.ChangeAndContext) => (ActionName | AdditionalAction)[] = ({ change, changeGroup }) => {
+}: definitions.deploy.ChangeAndContext) => Promise<(ActionName | AdditionalAction)[]> = async ({
+  change,
+  changeGroup,
+}) => {
   const spaceChange = changeGroup.changes.find(c => getChangeData(c).elemID.typeName === SPACE_TYPE_NAME)
   if (isAdditionChange(change) && spaceChange !== undefined && isInstanceChange(spaceChange)) {
     const changeData = getChangeData(change)

--- a/packages/confluence-adapter/test/definitions/utils/page.test.ts
+++ b/packages/confluence-adapter/test/definitions/utils/page.test.ts
@@ -129,7 +129,7 @@ describe('page definitions utils', () => {
         spaceId: new ReferenceExpression(getChangeData(spaceChange).elemID),
       }),
     })
-    it('should return the original action when there is no space change in the change group', () => {
+    it('should return the original action when there is no space change in the change group', async () => {
       const args = {
         change: pageChange,
         changeGroup: {
@@ -139,9 +139,9 @@ describe('page definitions utils', () => {
         elementSource: buildElementsSourceFromElements([]),
         sharedContext: {},
       }
-      expect(homepageAdditionToModification(args)).toEqual([pageChange.action])
+      await expect(homepageAdditionToModification(args)).resolves.toEqual([pageChange.action])
     })
-    it('should return the original action if page is not pointing to space change', () => {
+    it('should return the original action if page is not pointing to space change', async () => {
       const args = {
         change: pageChange,
         changeGroup: {
@@ -151,9 +151,9 @@ describe('page definitions utils', () => {
         elementSource: buildElementsSourceFromElements([]),
         sharedContext: {},
       }
-      expect(homepageAdditionToModification(args)).toEqual([pageChange.action])
+      await expect(homepageAdditionToModification(args)).resolves.toEqual([pageChange.action])
     })
-    it('should return the original action if page is pointing to a different space instance', () => {
+    it('should return the original action if page is pointing to a different space instance', async () => {
       const args = {
         change: pageChangeWithRefToDifferentSpace,
         changeGroup: {
@@ -163,9 +163,9 @@ describe('page definitions utils', () => {
         elementSource: buildElementsSourceFromElements([]),
         sharedContext: {},
       }
-      expect(homepageAdditionToModification(args)).toEqual([pageChangeWithRefToDifferentSpace.action])
+      await expect(homepageAdditionToModification(args)).resolves.toEqual([pageChangeWithRefToDifferentSpace.action])
     })
-    it('should return the original action if page change is not addition', () => {
+    it('should return the original action if page change is not addition', async () => {
       const pageNotAdditionChange = toChange({ before: getChangeData(pageChangeWithRefToSpace) })
       const args = {
         change: pageNotAdditionChange,
@@ -176,9 +176,9 @@ describe('page definitions utils', () => {
         elementSource: buildElementsSourceFromElements([]),
         sharedContext: {},
       }
-      expect(homepageAdditionToModification(args)).toEqual([pageNotAdditionChange.action])
+      await expect(homepageAdditionToModification(args)).resolves.toEqual([pageNotAdditionChange.action])
     })
-    it('should return the "modify" action', () => {
+    it('should return the "modify" action', async () => {
       const args = {
         change: pageChangeWithRefToSpace,
         changeGroup: {
@@ -188,7 +188,7 @@ describe('page definitions utils', () => {
         elementSource: buildElementsSourceFromElements([]),
         sharedContext: {},
       }
-      expect(homepageAdditionToModification(args)).toEqual(['modify'])
+      await expect(homepageAdditionToModification(args)).resolves.toEqual(['modify'])
     })
   })
   describe('putHomepageIdInAdditionContext', () => {

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -142,7 +142,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
+      toActionNames: async ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
       actionDependencies: [
         {
           first: 'add',
@@ -303,7 +303,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: changeContext => {
+      toActionNames: async changeContext => {
         const { change } = changeContext
         if (isRemovalChange(change) && getChangeData(change).value.status !== INACTIVE_STATUS) {
           return ['deactivate', 'remove']
@@ -394,7 +394,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: changeContext => {
+      toActionNames: async changeContext => {
         // NetworkZone works like other "simple status" types, except it must
         // be deactivated before removal.
         const { change } = changeContext
@@ -604,7 +604,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           changeIdFields: GRANTS_CHANGE_ID_FIELDS,
         },
       ],
-      toActionNames: ({ change }) => {
+      toActionNames: async ({ change }) => {
         if (isRemovalChange(change)) {
           return ['deactivate', 'remove']
         }
@@ -666,7 +666,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => {
+      toActionNames: async ({ change }) => {
         if (isAdditionChange(change)) {
           return ['add', 'modify']
         }
@@ -705,7 +705,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => {
+      toActionNames: async ({ change }) => {
         if (isAdditionChange(change)) {
           return ['add', 'modify']
         }
@@ -755,7 +755,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => {
+      toActionNames: async ({ change }) => {
         if (isAdditionChange(change)) {
           return ['add', 'modify']
         }
@@ -884,7 +884,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
+      toActionNames: async ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
     [SIGN_IN_PAGE_TYPE_NAME]: {
@@ -1413,7 +1413,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) =>
+      toActionNames: async ({ change }) =>
         isAdditionChange(change) && isSystemScope(change) ? ['add', 'modify'] : [change.action],
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
@@ -1474,7 +1474,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change }) =>
+      toActionNames: async ({ change }) =>
         isAdditionChange(change) && isSubDefaultClaim(change) ? ['add', 'modify'] : [change.action],
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
@@ -1527,7 +1527,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           remove: [{ request: { earlySuccess: true } }],
         },
       },
-      toActionNames: ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
+      toActionNames: async ({ change }) => (isAdditionChange(change) ? ['add', 'modify'] : [change.action]),
       actionDependencies: [{ first: 'add', second: 'modify' }],
     },
     [EMAIL_CUSTOMIZATION_TYPE_NAME]: {
@@ -1701,7 +1701,7 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           ],
         },
       },
-      toActionNames: ({ change, changeGroup }) => {
+      toActionNames: async ({ change, changeGroup }) => {
         if (isAdditionChange(change) && isPermissionChangeOfAddedRole(change, changeGroup)) {
           return ['modify']
         }

--- a/packages/okta-adapter/src/definitions/deploy/utils/simple_status.ts
+++ b/packages/okta-adapter/src/definitions/deploy/utils/simple_status.ts
@@ -57,7 +57,7 @@ export const modificationCondition: definitionUtils.deploy.DeployRequestConditio
 
 export const toActionNames: ({
   change,
-}: definitionUtils.deploy.ChangeAndContext) => (ActionName | AdditionalAction)[] = ({ change }) => {
+}: definitionUtils.deploy.ChangeAndContext) => Promise<(ActionName | AdditionalAction)[]> = async ({ change }) => {
   if (isAdditionChange(change)) {
     // Conditions inside 'activate' and 'deactivate' will determine which one to run, based on the service
     // response to the 'add' action.

--- a/packages/okta-adapter/test/definitions/deploy/utils/simple_status.test.ts
+++ b/packages/okta-adapter/test/definitions/deploy/utils/simple_status.test.ts
@@ -21,70 +21,70 @@ describe('simple_status', () => {
   describe('toActionNames', () => {
     describe('addition change', () => {
       const additionChange = toChange({ after: activeInst })
-      it('should return the correct action names', () => {
-        expect(
+      it('should return the correct action names', async () => {
+        await expect(
           toActionNames({
             change: additionChange,
             sharedContext: {},
             changeGroup: { groupID: 'groupID', changes: [additionChange] },
             elementSource: buildElementsSourceFromElements([]),
           }),
-        ).toEqual(['add', 'deactivate', 'activate'])
+        ).resolves.toEqual(['add', 'deactivate', 'activate'])
       })
     })
 
     describe('modification change', () => {
       describe('activation change', () => {
         const activationChange = toChange({ before: inactiveInst, after: activeInst })
-        it('should return the correct action names', () => {
-          expect(
+        it('should return the correct action names', async () => {
+          await expect(
             toActionNames({
               change: activationChange,
               sharedContext: {},
               changeGroup: { groupID: 'groupID', changes: [activationChange] },
               elementSource: buildElementsSourceFromElements([]),
             }),
-          ).toEqual(['modify', 'activate'])
+          ).resolves.toEqual(['modify', 'activate'])
         })
       })
       describe('deactivation change', () => {
         const deactivationChange = toChange({ before: activeInst, after: inactiveInst })
-        it('should return the correct action names', () => {
-          expect(
+        it('should return the correct action names', async () => {
+          await expect(
             toActionNames({
               change: deactivationChange,
               sharedContext: {},
               changeGroup: { groupID: 'groupID', changes: [deactivationChange] },
               elementSource: buildElementsSourceFromElements([]),
             }),
-          ).toEqual(['deactivate', 'modify'])
+          ).resolves.toEqual(['deactivate', 'modify'])
         })
       })
       describe('no status change', () => {
         const change = toChange({ before: activeInst, after: activeInst })
-        it('should return the correct action names', () => {
-          expect(
+        it('should return the correct action names', async () => {
+          await expect(
             toActionNames({
               change,
               sharedContext: {},
               changeGroup: { groupID: 'groupID', changes: [change] },
               elementSource: buildElementsSourceFromElements([]),
             }),
-          ).toEqual(['modify'])
+          ).resolves.toEqual(['modify'])
         })
       })
     })
     describe('removal change', () => {
       const removalChange = toChange({ before: activeInst })
-      it('should return the correct action names', () => {
-        expect(
+      it('should return the correct action names', async () => {
+        await expect(
           toActionNames({
             change: removalChange,
             sharedContext: {},
             changeGroup: { groupID: 'groupID', changes: [removalChange] },
             elementSource: buildElementsSourceFromElements([]),
           }),
-        ).toEqual(['remove'])
+        ).resolves.toEqual(['remove'])
       })
     })
   })


### PR DESCRIPTION
The function was sync which made element source useless

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
