### PR TITLE
SALTO-2737: Support User Roles in Okta

### DIFF
--- a/packages/adapter-components/src/definitions/system/index.ts
+++ b/packages/adapter-components/src/definitions/system/index.ts
@@ -33,6 +33,7 @@ export {
   AdjustFunctionMulti,
   ContextParams,
   GeneratedItem,
+  ExtractionParams,
 } from './shared'
 export { RequiredDefinitions } from './types'
 export { mergeDefinitionsWithOverrides } from './overrides'

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -38,7 +38,7 @@ import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
 import { CLIENT_CONFIG, FETCH_CONFIG, OLD_API_DEFINITIONS_CONFIG } from './config'
-import { configType, OktaUserConfig } from './user_config'
+import { configType, getExcludeUserRolesConfigSuggestion, OktaUserConfig, OktaUserFetchConfig } from './user_config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -73,7 +73,15 @@ import policyPrioritiesFilter, {
 } from './filters/policy_priority'
 import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
-import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA, USER_TYPE_NAME } from './constants'
+import removedUserRoleAssignments from './filters/removed_user_roles_assignments'
+import {
+  APP_LOGO_TYPE_NAME,
+  BRAND_LOGO_TYPE_NAME,
+  FAV_ICON_TYPE_NAME,
+  OKTA,
+  USER_ROLES_TYPE_NAME,
+  USER_TYPE_NAME,
+} from './constants'
 import { getLookUpNameCreator } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances, shouldConvertUserIds } from './user_utils'
 import { isClassicEngineOrg, logUsersCount } from './utils'
@@ -95,6 +103,8 @@ const DEFAULT_FILTERS = [
   standardRolesFilter, // TODO SALTO-5607 - move to infra
   userSchemaFilter,
   authorizationRuleFilter,
+  // must run before userFilter
+  removedUserRoleAssignments,
   // should run before fieldReferencesFilter
   userFilter,
   groupPushFilter,
@@ -135,6 +145,25 @@ const SKIP_RESOLVE_TYPE_NAMES = [
   ...POLICY_RULE_PRIORITY_TYPE_NAMES,
   ...POLICY_PRIORITY_TYPE_NAMES,
 ]
+
+/**
+ * Temporary adjusment to support migration of UserRoles type into the exclude list
+ */
+const createElementQueryWithExcludedUserRoles = (
+  fetchConfig: OktaUserFetchConfig,
+  criteria: Record<string, elementUtils.query.QueryCriterion>,
+): elementUtils.query.ElementQuery => {
+  const isUserRolesExcluded = fetchConfig.exclude.find(fetchEnrty => fetchEnrty.type === USER_ROLES_TYPE_NAME)
+  const isUserRolesIncluded = fetchConfig.include.find(fetchEntry => fetchEntry.type === USER_ROLES_TYPE_NAME)
+  const updatedConfig =
+    !isUserRolesExcluded && !isUserRolesIncluded
+      ? {
+          ...fetchConfig,
+          exclude: fetchConfig.exclude.concat({ type: USER_ROLES_TYPE_NAME }),
+        }
+      : fetchConfig
+  return elementUtils.query.createElementQuery(updatedConfig, criteria)
+}
 
 export interface OktaAdapterParams {
   filterCreators?: FilterCreator[]
@@ -183,7 +212,7 @@ export default class OktaAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: paginate,
     })
-    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig.fetch, fetchCriteria)
+    this.fetchQuery = createElementQueryWithExcludedUserRoles(this.userConfig.fetch, fetchCriteria)
     this.accountName = accountName
 
     const definitions = {
@@ -334,6 +363,7 @@ export default class OktaAdapter implements AdapterOperations {
     const configChanges = (getElementsConfigChanges ?? [])
       .concat(classicOrgConfigSuggestion ?? [])
       .concat(oauthConfigChange ?? [])
+      .concat(getExcludeUserRolesConfigSuggestion(this.configInstance) ?? [])
     const updatedConfig =
       !_.isEmpty(configChanges) && this.configInstance
         ? definitionsUtils.getUpdatedConfigFromConfigChanges({

--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -153,8 +153,8 @@ const createElementQueryWithExcludedUserRoles = (
   fetchConfig: OktaUserFetchConfig,
   criteria: Record<string, elementUtils.query.QueryCriterion>,
 ): elementUtils.query.ElementQuery => {
-  const isUserRolesExcluded = fetchConfig.exclude.find(fetchEnrty => fetchEnrty.type === USER_ROLES_TYPE_NAME)
-  const isUserRolesIncluded = fetchConfig.include.find(fetchEntry => fetchEntry.type === USER_ROLES_TYPE_NAME)
+  const isUserRolesExcluded = fetchConfig.exclude.some(fetchEnrty => fetchEnrty.type === USER_ROLES_TYPE_NAME)
+  const isUserRolesIncluded = fetchConfig.include.some(fetchEntry => fetchEntry.type === USER_ROLES_TYPE_NAME)
   const updatedConfig =
     !isUserRolesExcluded && !isUserRolesIncluded
       ? {

--- a/packages/okta-adapter/src/constants.ts
+++ b/packages/okta-adapter/src/constants.ts
@@ -92,6 +92,7 @@ export const GROUP_PUSH_TYPE_NAME = 'GroupPush'
 export const GROUP_PUSH_RULE_TYPE_NAME = 'GroupPushRule'
 export const DOMAIN_TYPE_NAME = 'Domain'
 export const USER_TYPE_NAME = 'User'
+export const USER_ROLES_TYPE_NAME = 'UserRoles'
 export const SMS_TEMPLATE_TYPE_NAME = 'SmsTemplate'
 export const SCHEMA_TYPES = [GROUP_SCHEMA_TYPE_NAME, APP_USER_SCHEMA_TYPE_NAME, USER_SCHEMA_TYPE_NAME]
 export const EMAIL_DOMAIN_TYPE_NAME = 'EmailDomain'

--- a/packages/okta-adapter/src/definitions/deploy/types/user_roles.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/user_roles.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import _ from 'lodash'
+import { logger } from '@salto-io/logging'
+import { definitions } from '@salto-io/adapter-components'
+import { getParents, naclCase, safeJsonStringify } from '@salto-io/adapter-utils'
+import { Values, getChangeData, isReferenceExpression } from '@salto-io/adapter-api'
+
+const log = logger(module)
+
+export const USER_ROLE_CHANGE_ID_FIELDS = ['type', 'resource-set', 'role']
+
+export const getRoleId = (values: Values, naclCaseFields = false): string =>
+  Object.values(
+    _.pick(
+      values,
+      USER_ROLE_CHANGE_ID_FIELDS.map(f => (naclCaseFields ? naclCase(f) : f)),
+    ),
+  )
+    .filter(v => _.isString(v))
+    .join('_')
+
+// Extract removed roles ids from shared context, assigned by removedUserRoleAssignments filter
+export const getRoleIdFromSharedContext: definitions.ExtractionParams<
+  definitions.deploy.ChangeAndExtendedContext,
+  definitions.deploy.ChangeAndExtendedContext
+>['context'] = {
+  custom:
+    () =>
+    ({ change, sharedContext }) => {
+      const parent = getParents(getChangeData(change))[0]
+      if (!isReferenceExpression(parent)) {
+        log.error(
+          'failed to get context for request, expected parent to be reference, got %s',
+          safeJsonStringify(parent),
+        )
+        return {}
+      }
+      const changeId = getRoleId(getChangeData(change).value, true)
+      const roleId = _.get(sharedContext, [parent.elemID.getFullName(), changeId])
+      return { id: roleId, userId: parent.value.user }
+    },
+}

--- a/packages/okta-adapter/src/filters/removed_user_roles_assignments.ts
+++ b/packages/okta-adapter/src/filters/removed_user_roles_assignments.ts
@@ -20,7 +20,7 @@ const log = logger(module)
 const { awu } = collections.asynciterable
 
 /**
- * When removing user roles, the removed role id must be provided.
+ * When removing a user role, the removed role id must be provided.
  * As the role id is not persisted on the element, we make an API request to get the current roles,
  * and keeps a mapping between the user roles to thier ids in the shared context, to be used during deploy.
  */
@@ -38,8 +38,8 @@ const filterCreator: FilterCreator = ({ definitions, sharedContext }) => ({
     await awu(changes)
       .filter(isInstanceChange)
       .filter(isRemovalOrModificationChange)
-      .filter(change => getChangeData(change).elemID.typeName === USER_ROLES_TYPE_NAME)
       .map(change => getChangeData(change))
+      .filter(instance => instance.elemID.typeName === USER_ROLES_TYPE_NAME)
       .forEach(async instance => {
         const { user } = instance.value
         try {
@@ -47,7 +47,7 @@ const filterCreator: FilterCreator = ({ definitions, sharedContext }) => ({
             callerIdentifier: { typeName: 'UserRole' },
             contextPossibleArgs: { id: [user] },
           })
-          const roles = response.map(res => res.value).map(val => ({ [getRoleId(val)]: _.get(val, 'id') }))
+          const roles = response.map(({ value }) => ({ [getRoleId(value)]: _.get(value, 'id') }))
           _.assign(sharedContext, { [instance.elemID.getFullName()]: _.merge({}, ...roles) })
         } catch (e) {
           log.error(

--- a/packages/okta-adapter/src/filters/removed_user_roles_assignments.ts
+++ b/packages/okta-adapter/src/filters/removed_user_roles_assignments.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import _ from 'lodash'
+import { isInstanceChange, getChangeData, isRemovalOrModificationChange } from '@salto-io/adapter-api'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
+import { collections } from '@salto-io/lowerdash'
+import { definitions as definitionsUtils, fetch as fetchUtils } from '@salto-io/adapter-components'
+import { logger } from '@salto-io/logging'
+import { OKTA, USER_ROLES_TYPE_NAME } from '../constants'
+import { FilterCreator } from '../filter'
+import { OktaOptions } from '../definitions/types'
+import { getRoleId } from '../definitions/deploy/types/user_roles'
+
+const log = logger(module)
+const { awu } = collections.asynciterable
+
+/**
+ * When removing user roles, the removed role id must be provided.
+ * As the role id is not persisted on the element, we make an API request to get the current roles,
+ * and keeps a mapping between the user roles to thier ids in the shared context, to be used during deploy.
+ */
+const filterCreator: FilterCreator = ({ definitions, sharedContext }) => ({
+  name: 'removedUserRoleAssignments',
+  preDeploy: async changes => {
+    const requester = fetchUtils.request.getRequester<OktaOptions>({
+      adapterName: OKTA,
+      clients: definitions.clients,
+      pagination: definitions.pagination,
+      requestDefQuery: definitionsUtils.queryWithDefault(
+        definitionsUtils.getNestedWithDefault(definitions.fetch?.instances ?? {}, 'requests'),
+      ),
+    })
+    await awu(changes)
+      .filter(isInstanceChange)
+      .filter(isRemovalOrModificationChange)
+      .filter(change => getChangeData(change).elemID.typeName === USER_ROLES_TYPE_NAME)
+      .map(change => getChangeData(change))
+      .forEach(async instance => {
+        const { user } = instance.value
+        try {
+          const response = await requester.requestAllForResource({
+            callerIdentifier: { typeName: 'UserRole' },
+            contextPossibleArgs: { id: [user] },
+          })
+          const roles = response.map(res => res.value).map(val => ({ [getRoleId(val)]: _.get(val, 'id') }))
+          _.assign(sharedContext, { [instance.elemID.getFullName()]: _.merge({}, ...roles) })
+        } catch (e) {
+          log.error(
+            'Failed to fetch user roles for %s: %s',
+            instance.elemID.getFullName(),
+            safeJsonStringify(e.message),
+          )
+        }
+      })
+  },
+})
+
+export default filterCreator

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -308,11 +308,13 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
   {
     src: { field: 'role', parentTypes: ['UserRole'] },
     serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'Role' },
   },
   {
     src: { field: naclCase('resource-set'), parentTypes: ['UserRole'] },
     serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
     target: { type: 'ResourceSet' },
   },
 ]

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -8,7 +8,7 @@
 import _ from 'lodash'
 import { isReferenceExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
-import { GetLookupNameFunc } from '@salto-io/adapter-utils'
+import { GetLookupNameFunc, naclCase } from '@salto-io/adapter-utils'
 import { collections } from '@salto-io/lowerdash'
 import {
   APPLICATION_TYPE_NAME,
@@ -29,6 +29,7 @@ import {
   USER_TYPE_NAME,
   GROUP_MEMBERSHIP_TYPE_NAME,
   JWK_TYPE_NAME,
+  USER_ROLES_TYPE_NAME,
 } from './constants'
 import { resolveUserSchemaRef } from './filters/expression_language'
 
@@ -304,6 +305,16 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     serializationStrategy: 'credentials.oauthClient.client_id',
     target: { type: APPLICATION_TYPE_NAME },
   },
+  {
+    src: { field: 'role', parentTypes: ['UserRole'] },
+    serializationStrategy: 'id',
+    target: { type: 'Role' },
+  },
+  {
+    src: { field: naclCase('resource-set'), parentTypes: ['UserRole'] },
+    serializationStrategy: 'id',
+    target: { type: 'ResourceSet' },
+  },
 ]
 
 const userReferenceRules: OktaFieldReferenceDefinition[] = [
@@ -331,6 +342,11 @@ const userReferenceRules: OktaFieldReferenceDefinition[] = [
     src: { field: 'id', parentTypes: ['UserTypeRef'] },
     serializationStrategy: 'id',
     target: { type: USERTYPE_TYPE_NAME },
+  },
+  {
+    src: { field: 'user', parentTypes: [USER_ROLES_TYPE_NAME] },
+    serializationStrategy: 'id',
+    target: { type: USER_TYPE_NAME },
   },
 ]
 

--- a/packages/okta-adapter/src/user_config.ts
+++ b/packages/okta-adapter/src/user_config.ts
@@ -144,14 +144,14 @@ export const getExcludeUserRolesConfigSuggestion = (
     )
     return undefined
   }
-  const isUserRolesExcluded = typesToExclude.find(fetchEnty => fetchEnty?.type === USER_ROLES_TYPE_NAME)
-  const isUserRolesIncluded = typesToInclude.find(fetchEnty => fetchEnty?.type === USER_ROLES_TYPE_NAME)
+  const isUserRolesExcluded = typesToExclude.some(fetchEntry => fetchEntry?.type === USER_ROLES_TYPE_NAME)
+  const isUserRolesIncluded = typesToInclude.some(fetchEntry => fetchEntry?.type === USER_ROLES_TYPE_NAME)
   if (!isUserRolesExcluded && !isUserRolesIncluded) {
     return {
       type: 'typeToExclude',
       value: USER_ROLES_TYPE_NAME,
       reason:
-        'UserRoles type is excluded by default. To include it, explicitly add "JsonWebKey" type into the include list.',
+        'UserRoles type is excluded by default. To include it, explicitly add "UserRoles" type into the include list.',
     }
   }
   return undefined

--- a/packages/okta-adapter/src/user_utils.ts
+++ b/packages/okta-adapter/src/user_utils.ts
@@ -20,6 +20,7 @@ import {
   MFA_RULE_TYPE_NAME,
   PASSWORD_RULE_TYPE_NAME,
   SIGN_ON_RULE_TYPE_NAME,
+  USER_ROLES_TYPE_NAME,
   USER_TYPE_NAME,
 } from './constants'
 import { DEFAULT_CONVERT_USERS_IDS_VALUE, OktaUserConfig } from './user_config'
@@ -74,6 +75,7 @@ export const USER_MAPPING: Record<string, string[][]> = {
   [MFA_RULE_TYPE_NAME]: [EXCLUDE_USERS_PATH],
   [AUTHORIZATION_POLICY_RULE]: [INCLUDE_USERS_PATH],
   [GROUP_MEMBERSHIP_TYPE_NAME]: [['members']],
+  [USER_ROLES_TYPE_NAME]: [['user']],
   EndUserSupport: [['technicalContactId']],
 }
 

--- a/packages/okta-adapter/test/filters/removed_user_roles_assignments.test.ts
+++ b/packages/okta-adapter/test/filters/removed_user_roles_assignments.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { filterUtils } from '@salto-io/adapter-components'
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import removedUserRoleAssignments from '../../src/filters/removed_user_roles_assignments'
+import { OKTA, USER_ROLES_TYPE_NAME } from '../../src/constants'
+import { getFilterParams } from '../utils'
+
+const mockRequestAllForResource = jest.fn()
+
+jest.mock('@salto-io/adapter-components', () => {
+  const actual = jest.requireActual('@salto-io/adapter-components')
+  return {
+    ...actual,
+    fetch: {
+      ...actual.fetch,
+      request: {
+        ...actual.fetch.request,
+        getRequester: jest.fn(() => ({
+          requestAllForResource: mockRequestAllForResource,
+        })),
+      },
+    },
+  }
+})
+
+describe('removedUserRoleAssignments', () => {
+  type FilterType = filterUtils.FilterWith<'preDeploy'>
+  let filter: FilterType
+  let userRolesType: ObjectType
+  const sharedContext = {}
+  beforeEach(() => {
+    mockRequestAllForResource
+      .mockResolvedValueOnce([
+        {
+          value: { id: '1', type: 'CUSTOM', role: 'role', 'resource-set': 'resource' },
+        },
+        { value: { id: '2', type: 'ADMIN' } },
+      ])
+      .mockResolvedValueOnce([
+        {
+          value: { id: '3', type: 'ADMIN' },
+        },
+      ])
+    filter = removedUserRoleAssignments(getFilterParams({ sharedContext })) as typeof filter
+    userRolesType = new ObjectType({ elemID: new ElemID(OKTA, USER_ROLES_TYPE_NAME) })
+  })
+
+  it('should assign current role ids to the shared context', async () => {
+    const instA = new InstanceElement('a', userRolesType, { user: 'a' })
+    const instB = new InstanceElement('b', userRolesType, { user: 'b' })
+    const changes = [toChange({ before: instA }), toChange({ before: instB, after: instB })]
+    await filter.preDeploy(changes)
+    expect(sharedContext).toEqual({
+      [instA.elemID.getFullName()]: {
+        CUSTOM_resource_role: '1',
+        ADMIN: '2',
+      },
+      [instB.elemID.getFullName()]: {
+        ADMIN: '3',
+      },
+    })
+  })
+})

--- a/packages/okta-adapter/test/mock_replies/user_role_add.json
+++ b/packages/okta-adapter/test/mock_replies/user_role_add.json
@@ -1,0 +1,52 @@
+[
+  {
+    "path": "/api/v1/users/userId/roles",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "userRoleId1",
+      "label": "easy to deploy",
+      "type": "CUSTOM",
+      "status": "ACTIVE",
+      "created": "2024-12-27T07:25:39.000Z",
+      "lastUpdated": "2024-12-27T07:25:39.000Z",
+      "assignmentType": "USER",
+      "resource-set": "resourceSetId",
+      "role": "roleId"
+    },
+    "body": {
+      "type": "CUSTOM",
+      "resource-set": "resourceSetId",
+      "role": "customRoleId"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "299",
+      "x-rate-limit-reset": "1735284399"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "userRoleId2",
+      "label": "Report Administrator",
+      "type": "REPORT_ADMIN",
+      "status": "ACTIVE",
+      "created": "2024-12-27T07:25:39.000Z",
+      "lastUpdated": "2024-12-27T07:25:39.000Z",
+      "assignmentType": "USER"
+    },
+    "body": {
+      "type": "REPORT_ADMIN"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "298",
+      "x-rate-limit-reset": "1735284399"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/user_role_modify.json
+++ b/packages/okta-adapter/test/mock_replies/user_role_modify.json
@@ -1,0 +1,82 @@
+[
+  {
+    "path": "/api/v1/users/userId/roles",
+    "scope": "",
+    "method": "GET",
+    "status": 200,
+    "response": [
+      {
+        "id": "userRoleId2",
+        "label": "Report Administrator",
+        "type": "REPORT_ADMIN",
+        "status": "ACTIVE",
+        "created": "2024-12-28T12:11:10.000Z",
+        "lastUpdated": "2024-12-28T12:11:10.000Z",
+        "assignmentType": "USER"
+      },
+      {
+        "id": "userRoleId1",
+        "label": "test",
+        "type": "CUSTOM",
+        "status": "ACTIVE",
+        "created": "2024-12-28T12:11:10.000Z",
+        "lastUpdated": "2024-12-28T12:11:10.000Z",
+        "assignmentType": "USER",
+        "resource-set": "resourceSetId",
+        "role": "customRoleId"
+      }
+    ],
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "297",
+      "x-rate-limit-reset": "1735388340"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles",
+    "scope": "",
+    "method": "POST",
+    "status": 201,
+    "response": {
+      "id": "userRoleId3",
+      "label": "Group Membership Administrator",
+      "type": "GROUP_MEMBERSHIP_ADMIN",
+      "status": "ACTIVE",
+      "created": "2024-12-28T12:18:23.000Z",
+      "lastUpdated": "2024-12-28T12:18:23.000Z",
+      "assignmentType": "USER"
+    },
+    "body": {
+      "type": "GROUP_MEMBERSHIP_ADMIN"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "296",
+      "x-rate-limit-reset": "1735388340"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles/userRoleId1",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "295",
+      "x-rate-limit-reset": "1735388340"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles/userRoleId2",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "294",
+      "x-rate-limit-reset": "1735388340"
+    }
+  }
+]

--- a/packages/okta-adapter/test/mock_replies/user_role_remove.json
+++ b/packages/okta-adapter/test/mock_replies/user_role_remove.json
@@ -1,0 +1,59 @@
+[
+  {
+    "path": "/api/v1/users/userId/roles",
+    "scope": "",
+    "method": "GET",
+    "status": 200,
+    "response": [
+      {
+        "id": "userRoleId2",
+        "label": "Report Administrator",
+        "type": "REPORT_ADMIN",
+        "status": "ACTIVE",
+        "created": "2024-12-27T07:25:39.000Z",
+        "lastUpdated": "2024-12-27T07:25:39.000Z",
+        "assignmentType": "USER"
+      },
+      {
+        "id": "userRoleId1",
+        "label": "test",
+        "type": "CUSTOM",
+        "status": "ACTIVE",
+        "created": "2024-12-27T07:25:39.000Z",
+        "lastUpdated": "2024-12-27T07:25:39.000Z",
+        "assignmentType": "USER",
+        "resource-set": "resourceSetId",
+        "role": "customRoleId"
+      }
+    ],
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "299",
+      "x-rate-limit-reset": "1735309544"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles/userRoleId1",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "298",
+      "x-rate-limit-reset": "1735309544"
+    }
+  },
+  {
+    "path": "/api/v1/users/userId/roles/userRoleId2",
+    "scope": "",
+    "method": "DELETE",
+    "status": 204,
+    "response": "",
+    "reqHeaders": {
+      "x-rate-limit-limit": "300",
+      "x-rate-limit-remaining": "297",
+      "x-rate-limit-reset": "1735309544"
+    }
+  }
+]


### PR DESCRIPTION
Add support in user-role assignments in Okta

---

_Additional context for reviewer_
- `UserRoles` is an instance listing all roles of a single user
- As users are excluded by default, `UserRoles` will be excluded by default as well. I created a migration to add the type into the exclude list, the migration should be deleted once all exiting environments were fetched.
- On fetch:
  - Instead of iterating all users and getting their roles, we call an endpoint that returns only users with assigned roles
  - Then for each returned user, we make a request to get its roles
  - Each assignment has an assignment id which is omitted, cause hidden values are not supported in lists.

- On deploy:
  - in order to remove user-role assignment, we must specify the assignment id. As we don't keep the ids on the nacl, we make a single call during deploy to get the current roles ids
  - deploy is done with `recurseIntoPath` as each assignment has its own request (only additions and removals are supported)

- UserRoles works in both mode - when `User` is an instance, or in "emails mode"

---
_Release Notes_: 

_Okta adapter_:
- Add support in `UserRoles` type, which includes all admin roles assigned to a user.

---
_User Notifications_: 

_Okta adapter_:
- On the next fetch, a config change will exclude `UserRoles` type. To include to, explicitly add an entry in the adapter nacl file:
```
okta {
   fetch = {
       include = [
          { type = ".*" },
          { type = "UserRoles" }
       ]
   }
}
```