### PR TITLE
SALTO-7149: Fix deployment of array fields in adapters infra when there are references

### DIFF
--- a/packages/adapter-components/src/deployment/deploy/subresources.ts
+++ b/packages/adapter-components/src/deployment/deploy/subresources.ts
@@ -22,6 +22,7 @@ import {
   isAdditionOrModificationChange,
   isObjectType,
   getDeepInnerTypeSync,
+  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { applyFunctionToChangeDataSync, inspectValue, safeJsonStringify } from '@salto-io/adapter-utils'
 import { types, collections } from '@salto-io/lowerdash'
@@ -109,10 +110,13 @@ export const createChangesForSubResources = async <TOptions extends APIDefinitio
         getChangeData(change).elemID.getFullName(),
       )
     }
-    return fields
-      .map(({ fieldValue }) => fieldValue)
-      .map(String)
-      .join('_')
+    return (
+      fields
+        // if referenceResolution strategy is "on_demand", field value might be a reference expression
+        .map(({ fieldValue }) => (isReferenceExpression(fieldValue) ? fieldValue.elemID.getFullName() : fieldValue))
+        .map(String)
+        .join('_')
+    )
   }
 
   const createChangeFromSubResource = (

--- a/packages/adapter-components/test/deployment/deploy/subresources.test.ts
+++ b/packages/adapter-components/test/deployment/deploy/subresources.test.ts
@@ -312,4 +312,36 @@ describe('createChangesForSubResources', () => {
       expect(subChanges).toHaveLength(0)
     })
   })
+  describe('when change id fields are pointing a reference that is not yet resolved', () => {
+    it('should user reference getFullName as the field value', async () => {
+      const roleType = new ObjectType({ elemID: new ElemID('adapter', 'role') })
+      const role1 = new InstanceElement('role1', roleType, { name: 'role1' })
+      const role2 = new InstanceElement('role2', roleType, { name: 'role2' })
+      const afterInstance = instance.clone()
+      afterInstance.value.items = [
+        { name: 'name', role: new ReferenceExpression(role1.elemID, role1) },
+        { name: 'name', role: new ReferenceExpression(role2.elemID, role2) },
+      ]
+      const change = toChange({ after: afterInstance })
+      const subChanges = await createChangesForSubResources({
+        change,
+        definitions,
+        context: {
+          changeGroup: { groupID: 'testGroup', changes: [change] },
+          elementSource: buildElementsSourceFromElements([]),
+          sharedContext: {},
+        },
+      })
+      expect(subChanges).toHaveLength(2)
+      expect(subChanges.map(c => c.action)).toEqual(['add', 'add'])
+      expect(subChanges.map(c => getChangeData(c).elemID.name)).toEqual([
+        'name_adapter.role.instance.role1',
+        'name_adapter.role.instance.role2',
+      ])
+      expect(subChanges.map(c => getChangeData(c).value)).toEqual([
+        { name: 'name', role: new ReferenceExpression(role1.elemID, role1) },
+        { name: 'name', role: new ReferenceExpression(role2.elemID, role2) },
+      ])
+    })
+  })
 })


### PR DESCRIPTION
Fix a bug in `recurseIntoPath` that can happen when referenceResolution strategy is "on_demand"

---

_Additional context for reviewer_
(This has no affect on any current definitions)
This can happen when the references are resolved "late" in flow.

---
_Release Notes_: 
None

---
_User Notifications_: 
None