### PR TITLE
SALTO-6922: Map "Invalid dashboard Unique Name" deploy error to a link explaining that dashboards might be excluded

### DIFF
--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -10,6 +10,7 @@ import { DeployMessage } from '@salto-io/jsforce'
 import { decorators } from '@salto-io/lowerdash'
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
+import { inspectValue } from '@salto-io/adapter-utils'
 import {
   ENOTFOUND,
   ERROR_HTTP_502,
@@ -191,7 +192,11 @@ export const getUserFriendlyDeployMessage = (deployMessage: DeployMessage): Depl
     return deployMessage
   }
   if (matchedMapperNames.length > 1) {
-    log.error('The error %o matched on more than one mapper. Matcher mappers: %o', problem, matchedMapperNames)
+    log.error(
+      'The error %s matched on more than one mapper. Matcher mappers: %s',
+      problem,
+      inspectValue(matchedMapperNames),
+    )
     return deployMessage
   }
   const [mapperName, userFriendlyMessage] = Object.entries(userFriendlyMessageByMapperName)[0]

--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -161,9 +161,8 @@ export const MAX_METADATA_DEPLOY_LIMIT_MESSAGE =
   ' For more info you may refer to: https://help.salto.io/en/articles/8263355-the-metadata-deployment-exceeded-the-maximum-allowed-size-of-50mb'
 
 export const INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE =
-  ' This issue could be caused by unmanaged Dashboards in your environment.\n' +
-  ' To prevent this, ensure Dashboards are managed.\n' +
-  ' For more information, please refer to: https://help.salto.io/en/articles/7439350-supported-salesforce-types'
+  "Please make sure you're managing Dashboards in your Salto environment and that your deployment contains the referenced Dashboard instance.\n" +
+  'For more information, please refer to: https://help.salto.io/en/articles/7439350-supported-salesforce-types'
 
 export const DEPLOY_PROBLEM_MAPPER: DeployProblemMappers = {
   [SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS]: {

--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -69,7 +69,7 @@ export type ErrorMappers = {
   [SALESFORCE_ERRORS.INSUFFICIENT_ACCESS]: ErrorMapper<Error>
 }
 
-const withSalesforceError = (salesforceError: string, saltoErrorMessage: string): string =>
+export const withSalesforceError = (salesforceError: string, saltoErrorMessage: string): string =>
   `${saltoErrorMessage}\n\nUnderlying Error: ${salesforceError}`
 
 export const ERROR_MAPPERS: ErrorMappers = {

--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -139,9 +139,9 @@ export const mapToUserFriendlyErrorMessages = decorators.wrapMethodWith(async or
 
 // Deploy Problems Mapping
 
-type DeployProblemMapper = {
+export type DeployProblemMapper = {
   test: (problem: string) => boolean
-  map: (problem: DeployMessage) => string
+  map: (deployMessage: DeployMessage) => string
 }
 
 export type DeployProblemMappers = {

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -744,6 +744,13 @@ export const isSalesforceError = (error: Error): error is SalesforceError => {
   return _.isString(errorCode) && (Object.values(SALESFORCE_ERRORS) as ReadonlyArray<string>).includes(errorCode)
 }
 
+// Salesforce Deploy Problems
+export const SALESFORCE_DEPLOY_PROBLEMS = {
+  SCHEDULABLE_CLASS: 'This schedulable class has jobs pending or in progress',
+  MAX_METADATA_DEPLOY_LIMIT: 'Maximum size of request reached. Maximum size of request is 52428800 bytes.',
+  INVALID_DASHBOARD_UNIQUE_NAME: 'Invalid dashboard Unique Name',
+} as const
+
 // Artifacts
 export const SalesforceArtifacts = {
   DeployPackageXml: 'package.xml',

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -56,7 +56,6 @@ import {
 import { createElement, removeElement } from '../e2e_test/utils'
 import { mockTypes, mockDefaultValues } from './mock_elements'
 import { mockDeployResult, mockRunTestFailure, mockDeployResultComplete, mockRetrieveResult } from './connection'
-import { MAPPABLE_PROBLEM_TO_USER_FRIENDLY_MESSAGE, MappableSalesforceProblem } from '../src/client/user_facing_errors'
 import { GLOBAL_VALUE_SET } from '../src/filters/global_value_sets'
 import { apiNameSync, metadataTypeSync } from '../src/filters/utils'
 import { SalesforceArtifacts, INSTANCE_FULL_NAME_FIELD, ProgressReporterSuffix } from '../src/constants'
@@ -296,7 +295,7 @@ describe('SalesforceAdapter CRUD', () => {
       })
 
       describe('when the request fails with mappable problem', () => {
-        const MAPPABLE_PROBLEM: MappableSalesforceProblem = 'This schedulable class has jobs pending or in progress'
+        const MAPPABLE_PROBLEM: string = 'This schedulable class has jobs pending or in progress'
         let result: DeployResult
         beforeEach(async () => {
           const newInst = createInstanceElement(mockDefaultValues.Profile, mockTypes.Profile)
@@ -325,10 +324,8 @@ describe('SalesforceAdapter CRUD', () => {
 
         it('should return an error with user friendly message', () => {
           expect(result.errors).toHaveLength(1)
-          expect(result.errors[0].message).toContain(MAPPABLE_PROBLEM_TO_USER_FRIENDLY_MESSAGE[MAPPABLE_PROBLEM])
-          expect(result.errors[0].detailedMessage).toContain(
-            MAPPABLE_PROBLEM_TO_USER_FRIENDLY_MESSAGE[MAPPABLE_PROBLEM],
-          )
+          expect(result.errors[0].message).toContain(constants.SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS)
+          expect(result.errors[0].detailedMessage).toContain(constants.SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS)
         })
       })
 

--- a/packages/salesforce-adapter/test/adapter.crud.test.ts
+++ b/packages/salesforce-adapter/test/adapter.crud.test.ts
@@ -295,11 +295,9 @@ describe('SalesforceAdapter CRUD', () => {
       })
 
       describe('when the request fails with mappable problem', () => {
-        const MAPPABLE_PROBLEM: string = 'This schedulable class has jobs pending or in progress'
         let result: DeployResult
         beforeEach(async () => {
           const newInst = createInstanceElement(mockDefaultValues.Profile, mockTypes.Profile)
-
           connection.metadata.deploy.mockReturnValueOnce(
             mockDeployResult({
               success: false,
@@ -307,7 +305,7 @@ describe('SalesforceAdapter CRUD', () => {
                 {
                   fullName: await apiName(newInst),
                   componentType: await metadataType(newInst),
-                  problem: MAPPABLE_PROBLEM,
+                  problem: constants.SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS,
                 },
               ],
             }),

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -46,11 +46,8 @@ import {
   REQUEST_LIMIT_EXCEEDED_MESSAGE,
   DeployProblemMappers,
   DEPLOY_PROBLEM_MAPPER,
-  SCHEDULABLE_CLASS_MESSAGE,
-  MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
-  INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE,
   getUserFriendlyDeployMessage,
-  withSalesforceError,
+  DeployProblemMapper,
 } from '../src/client/user_facing_errors'
 
 const { array, asynciterable } = collections
@@ -535,8 +532,8 @@ describe('salesforce client', () => {
 
   describe('when deploy problem is mappable', () => {
     type TestInput = {
-      expectedMessage: string
       problem: string
+      expectedMapper: DeployProblemMapper
     }
 
     const mappableDeployProblemToTestInputs: Record<
@@ -544,19 +541,16 @@ describe('salesforce client', () => {
       types.NonEmptyArray<TestInput> | TestInput
     > = {
       [SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS]: {
-        expectedMessage: withSalesforceError(SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS, SCHEDULABLE_CLASS_MESSAGE),
         problem: SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS,
+        expectedMapper: DEPLOY_PROBLEM_MAPPER[SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS],
       },
       [SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT]: {
-        expectedMessage: withSalesforceError(
-          SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT,
-          MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
-        ),
         problem: SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT,
+        expectedMapper: DEPLOY_PROBLEM_MAPPER[SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT],
       },
       [SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME]: {
-        expectedMessage: `${SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME}\n${INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE}`,
         problem: SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME,
+        expectedMapper: DEPLOY_PROBLEM_MAPPER[SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME],
       },
     }
 
@@ -567,7 +561,7 @@ describe('salesforce client', () => {
         ...testInput,
       })
 
-      it.each(makeArray(testInputs).map(withTestName))('$name', ({ expectedMessage, problem }) => {
+      it.each(makeArray(testInputs).map(withTestName))('$name', ({ expectedMapper, problem }) => {
         const deployMessage: DeployMessage = {
           changed: true,
           columnNumber: 1,
@@ -585,7 +579,7 @@ describe('salesforce client', () => {
         }
         const expectedResult = {
           ...deployMessage,
-          problem: expectedMessage,
+          problem: expectedMapper.map(deployMessage),
         }
         expect(getUserFriendlyDeployMessage(deployMessage)).toEqual(expectedResult)
       })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -13,7 +13,7 @@ import { Values } from '@salto-io/adapter-api'
 import { collections, types, values } from '@salto-io/lowerdash'
 import { MockInterface } from '@salto-io/test-utils'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
-import { QueryResult } from '@salto-io/jsforce'
+import { QueryResult, DeployMessage } from '@salto-io/jsforce'
 import SalesforceClient, {
   API_VERSION,
   ApiLimitsTooLowError,
@@ -31,6 +31,7 @@ import {
   ErrorProperty,
   INVALID_GRANT,
   RATE_LIMIT_UNLIMITED_MAX_CONCURRENT_REQUESTS,
+  SALESFORCE_DEPLOY_PROBLEMS,
   SALESFORCE_ERRORS,
 } from '../src/constants'
 import { mockFileProperties, mockRetrieveLocator, mockRetrieveResult } from './connection'
@@ -43,6 +44,12 @@ import {
   INVALID_GRANT_MESSAGE,
   MAX_CONCURRENT_REQUESTS_MESSAGE,
   REQUEST_LIMIT_EXCEEDED_MESSAGE,
+  DeployProblemMappers,
+  DEPLOY_PROBLEM_MAPPER,
+  SCHEDULABLE_CLASS_MESSAGE,
+  MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
+  INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE,
+  getUserFriendlyDeployMessage,
 } from '../src/client/user_facing_errors'
 
 const { array, asynciterable } = collections
@@ -521,6 +528,58 @@ describe('salesforce client', () => {
       })
       it('should be mapped to user friendly message', async () => {
         await expect(testClient.listMetadataTypes()).rejects.toThrow(INVALID_GRANT_MESSAGE)
+      })
+    })
+  })
+
+  describe('when deploy problem is mappable', () => {
+    type TestInput = {
+      expectedMessage: string
+      problem: string
+    }
+
+    const mappableDeployProblemToTestInputs: Record<
+      keyof DeployProblemMappers,
+      types.NonEmptyArray<TestInput> | TestInput
+    > = {
+      [SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS]: {
+        expectedMessage: SCHEDULABLE_CLASS_MESSAGE,
+        problem: SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS,
+      },
+      [SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT]: {
+        expectedMessage: MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
+        problem: SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT,
+      },
+      [SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME]: {
+        expectedMessage: INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE,
+        problem: SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME,
+      },
+    }
+
+    describe.each(Object.keys(DEPLOY_PROBLEM_MAPPER))('%p', mappableDeployProblem => {
+      const testInputs = mappableDeployProblemToTestInputs[mappableDeployProblem as keyof DeployProblemMappers]
+      const withTestName = (testInput: TestInput): TestInput & { name: string } => ({
+        name: isDefined(testInput.problem) ? safeJsonStringify(testInput.problem) : 'should replace problem message',
+        ...testInput,
+      })
+
+      it.each(makeArray(testInputs).map(withTestName))('$name', ({ expectedMessage, problem }) => {
+        const deployMessage: DeployMessage = {
+          changed: true,
+          columnNumber: 1,
+          componentType: 'TestType',
+          created: false,
+          createdDate: '01.01.2000',
+          deleted: false,
+          fileName: 'TestFile',
+          fullName: 'Test',
+          id: 'TestId',
+          lineNumber: 1,
+          problem,
+          problemType: 'TestType',
+          success: false,
+        }
+        expect(getUserFriendlyDeployMessage(deployMessage).problem).toContain(expectedMessage)
       })
     })
   })

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -50,6 +50,7 @@ import {
   MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
   INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE,
   getUserFriendlyDeployMessage,
+  withSalesforceError,
 } from '../src/client/user_facing_errors'
 
 const { array, asynciterable } = collections
@@ -543,15 +544,18 @@ describe('salesforce client', () => {
       types.NonEmptyArray<TestInput> | TestInput
     > = {
       [SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS]: {
-        expectedMessage: SCHEDULABLE_CLASS_MESSAGE,
+        expectedMessage: withSalesforceError(SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS, SCHEDULABLE_CLASS_MESSAGE),
         problem: SALESFORCE_DEPLOY_PROBLEMS.SCHEDULABLE_CLASS,
       },
       [SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT]: {
-        expectedMessage: MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
+        expectedMessage: withSalesforceError(
+          SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT,
+          MAX_METADATA_DEPLOY_LIMIT_MESSAGE,
+        ),
         problem: SALESFORCE_DEPLOY_PROBLEMS.MAX_METADATA_DEPLOY_LIMIT,
       },
       [SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME]: {
-        expectedMessage: INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE,
+        expectedMessage: `${SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME}\n${INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE}`,
         problem: SALESFORCE_DEPLOY_PROBLEMS.INVALID_DASHBOARD_UNIQUE_NAME,
       },
     }
@@ -579,7 +583,11 @@ describe('salesforce client', () => {
           problemType: 'TestType',
           success: false,
         }
-        expect(getUserFriendlyDeployMessage(deployMessage).problem).toContain(expectedMessage)
+        const expectedResult = {
+          ...deployMessage,
+          problem: expectedMessage,
+        }
+        expect(getUserFriendlyDeployMessage(deployMessage)).toEqual(expectedResult)
       })
     })
   })


### PR DESCRIPTION
SALTO-6922: Map "Invalid dashboard Unique Name" deploy error to a link explaining that dashboards might be excluded

---

_Additional context for reviewer_:
New error message:
<img width="1447" alt="image" src="https://github.com/user-attachments/assets/da974254-4c7f-416c-bd5b-34a8e4b9e46f" />

---
_Release Notes_: 
None

---
_User Notifications_: 
None
