### PR TITLE
SALTO-7169: Fix Entra app roles addition results in pending changes on the app role id

### DIFF
--- a/packages/microsoft-security-adapter/src/filters/entra/app_role.ts
+++ b/packages/microsoft-security-adapter/src/filters/entra/app_role.ts
@@ -130,7 +130,7 @@ const groupAppRolesByParent = async (
 ): Promise<Record<string, InstanceElement[]>> =>
   _.groupBy(
     (await getInstancesFromElementSource(elementSource, [APP_ROLE_TYPE_NAME])).map(appRole =>
-      addAppRoleIdToAppRole(appRole, appRoleNameToInternalId),
+      addAppRoleIdToAppRole(appRole.clone(), appRoleNameToInternalId),
     ),
     // If no parent is found & the app role is not part of the received changes, we will just skip it
     elem => getParents(elem)[0]?.elemID.getFullName(),


### PR DESCRIPTION
We should clone the instances received from the `elementSource` before we apply any changes on them.

---
_Release Notes_: 
_Microsoft Security adapter:_
* Fix pending changes on the app role id post addition

---
_User Notifications_: 
None
