### PR TITLE
SALTO-7160 Change to more robust alias field

### DIFF
--- a/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/zendesk-adapter/src/definitions/fetch/fetch.ts
@@ -496,7 +496,7 @@ const createCustomizations = (): Record<
         isTopLevel: true,
         elemID: { parts: [{ fieldName: 'value' }], extendsParent: true },
         path: { pathParts: [{ parts: [{ fieldName: 'value' }], extendsParent: true }] },
-        alias: { aliasComponents: [{ fieldName: 'raw_name' }] },
+        alias: { aliasComponents: [{ fieldName: 'value' }] },
       },
       fieldCustomizations: {
         id: { hide: true, fieldType: 'number' },
@@ -555,7 +555,7 @@ const createCustomizations = (): Record<
         isTopLevel: true,
         elemID: { parts: [{ fieldName: 'value' }], extendsParent: true },
         path: { pathParts: [{ parts: [{ fieldName: 'value' }], extendsParent: true }] },
-        alias: { aliasComponents: [{ fieldName: 'raw_name' }] },
+        alias: { aliasComponents: [{ fieldName: 'value' }] },
       },
       fieldCustomizations: {
         id: { hide: true, fieldType: 'number' },
@@ -609,7 +609,7 @@ const createCustomizations = (): Record<
         isTopLevel: true,
         elemID: { parts: [{ fieldName: 'value' }], extendsParent: true },
         path: { pathParts: [{ parts: [{ fieldName: 'value' }], extendsParent: true }] },
-        alias: { aliasComponents: [{ fieldName: 'raw_name' }] },
+        alias: { aliasComponents: [{ fieldName: 'value' }] },
       },
       fieldCustomizations: {
         id: { hide: true, fieldType: 'number' },

--- a/packages/zendesk-adapter/src/filters/add_alias.ts
+++ b/packages/zendesk-adapter/src/filters/add_alias.ts
@@ -197,7 +197,7 @@ export const aliasMap: Record<string, AliasData> = {
   organization_field__custom_field_options: {
     aliasComponents: [
       {
-        fieldName: 'raw_name',
+        fieldName: 'value',
       },
     ],
   },
@@ -253,7 +253,7 @@ export const aliasMap: Record<string, AliasData> = {
   [TICKET_FIELD_CUSTOM_FIELD_OPTION]: {
     aliasComponents: [
       {
-        fieldName: 'raw_name',
+        fieldName: 'value',
       },
     ],
   },
@@ -288,7 +288,7 @@ export const aliasMap: Record<string, AliasData> = {
   user_field__custom_field_options: {
     aliasComponents: [
       {
-        fieldName: 'raw_name',
+        fieldName: 'value',
       },
     ],
   },


### PR DESCRIPTION
As a result of cases where the raw_name is a dynamic content, the `raw_name` field is not a good fit for alias.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
