### PR TITLE
SALTO-7048: Core: Hidden Values: Add side effects for existing field values where field annotation is added or removed completely

### DIFF
--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -233,12 +233,12 @@ const isAttributeChangeToNotHidden = (change: DetailedChange, hiddenValue: boole
   isRemovalOrModificationChange(change) &&
   change.data.before === true
 
-const isFieldAnnotationWithHiddenValueAdded = (change: DetailedChange): boolean =>
+const isFieldAdditionWithHiddenValue = (change: DetailedChange): boolean =>
   isFieldChange(change) &&
   isAdditionChange(change) &&
   change.data.after?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
 
-const isFieldAnnotationWithHiddenValueRemoved = (change: DetailedChange): boolean =>
+const isFieldRemovalWithHiddenValue = (change: DetailedChange): boolean =>
   isFieldChange(change) &&
   isRemovalChange(change) &&
   change.data.before?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
@@ -248,12 +248,15 @@ const isHiddenAttributeChange = (change: DetailedChange, hiddenValue: boolean): 
   change.id.nestingLevel === 1 &&
   (isAttributeChangeToHidden(change, hiddenValue) || isAttributeChangeToNotHidden(change, hiddenValue))
 
+const isFieldModificationWithHiddenValue = (change: DetailedChange): boolean =>
+  change.id.idType === 'field' &&
+  change.id.nestingLevel === 2 &&
+  (isAttributeChangeToHidden(change, true) || isAttributeChangeToNotHidden(change, true))
+
 const isHiddenChangeOnField = (change: DetailedChange): boolean =>
-  (change.id.idType === 'field' &&
-    change.id.nestingLevel === 2 &&
-    (isAttributeChangeToHidden(change, true) || isAttributeChangeToNotHidden(change, true))) ||
-  isFieldAnnotationWithHiddenValueAdded(change) ||
-  isFieldAnnotationWithHiddenValueRemoved(change)
+  isFieldModificationWithHiddenValue(change) ||
+  isFieldAdditionWithHiddenValue(change) ||
+  isFieldRemovalWithHiddenValue(change)
 
 const isTopLevelModificationWithHiddenChange = <T>(
   change: DetailedChange<T>,
@@ -391,7 +394,7 @@ const groupAnnotationIdsByParentAndName = (ids: ElemID[]): Record<string, Set<st
 const getChangeParentIdsByHideAction = (changes: DetailedChange[]): { hide: Set<string>; unhide: Set<string> } => {
   const [hideChanges, unhideChanges] = _.partition(
     changes,
-    c => isAttributeChangeToHidden(c, true) || isFieldAnnotationWithHiddenValueAdded(c),
+    c => isAttributeChangeToHidden(c, true) || isFieldAdditionWithHiddenValue(c),
   )
   return {
     hide: new Set(

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -52,6 +52,8 @@ import {
   isTypeReference,
   DetailedChangeWithBaseChange,
   toChange,
+  isAdditionChange,
+  isFieldChange,
 } from '@salto-io/adapter-api'
 import { mergeElements, MergeResult } from '../merger'
 import { State } from './state'
@@ -231,15 +233,27 @@ const isAttributeChangeToNotHidden = (change: DetailedChange, hiddenValue: boole
   isRemovalOrModificationChange(change) &&
   change.data.before === true
 
+const isFieldAnnotationWithHiddenValueAdded = (change: DetailedChange): boolean =>
+  isFieldChange(change) &&
+  isAdditionChange(change) &&
+  change.data.after?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+
+const isFieldAnnotationWithHiddenValueRemoved = (change: DetailedChange): boolean =>
+  isFieldChange(change) &&
+  isRemovalChange(change) &&
+  change.data.before?.annotations?.[CORE_ANNOTATIONS.HIDDEN_VALUE] === true
+
 const isHiddenAttributeChange = (change: DetailedChange, hiddenValue: boolean): boolean =>
   change.id.idType === 'attr' &&
   change.id.nestingLevel === 1 &&
   (isAttributeChangeToHidden(change, hiddenValue) || isAttributeChangeToNotHidden(change, hiddenValue))
 
 const isHiddenChangeOnField = (change: DetailedChange): boolean =>
-  change.id.idType === 'field' &&
-  change.id.nestingLevel === 2 &&
-  (isAttributeChangeToHidden(change, true) || isAttributeChangeToNotHidden(change, true))
+  (change.id.idType === 'field' &&
+    change.id.nestingLevel === 2 &&
+    (isAttributeChangeToHidden(change, true) || isAttributeChangeToNotHidden(change, true))) ||
+  isFieldAnnotationWithHiddenValueAdded(change) ||
+  isFieldAnnotationWithHiddenValueRemoved(change)
 
 const isTopLevelModificationWithHiddenChange = <T>(
   change: DetailedChange<T>,
@@ -375,10 +389,27 @@ const groupAnnotationIdsByParentAndName = (ids: ElemID[]): Record<string, Set<st
   )
 
 const getChangeParentIdsByHideAction = (changes: DetailedChange[]): { hide: Set<string>; unhide: Set<string> } => {
-  const [hideChanges, unhideChanges] = _.partition(changes, c => isAttributeChangeToHidden(c, true))
+  const [hideChanges, unhideChanges] = _.partition(
+    changes,
+    c => isAttributeChangeToHidden(c, true) || isFieldAnnotationWithHiddenValueAdded(c),
+  )
   return {
-    hide: new Set(hideChanges.map(change => change.id.createParentID().getFullName())),
-    unhide: new Set(unhideChanges.map(change => change.id.createParentID().getFullName())),
+    hide: new Set(
+      hideChanges.map(change => {
+        if (isAttributeChangeToHidden(change, true)) {
+          return change.id.createParentID().getFullName()
+        }
+        return change.id.getFullName()
+      }),
+    ),
+    unhide: new Set(
+      unhideChanges.map(change => {
+        if (isAttributeChangeToNotHidden(change, true)) {
+          return change.id.createParentID().getFullName()
+        }
+        return change.id.getFullName()
+      }),
+    ),
   }
 }
 
@@ -404,6 +435,7 @@ const getHiddenFieldAndAnnotationValueChanges = async (
   const { hide: hideFieldIds, unhide: unhideFieldIds } = getChangeParentIdsByHideAction(
     changes.filter(isHiddenChangeOnField),
   )
+
   const { hide: hideTypeIds, unhide: unhideTypeIds } = getChangeParentIdsByHideAction(
     changes.filter(c => isHiddenAttributeChange(c, true)),
   )

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -318,8 +318,8 @@ describe('handleHiddenChanges', () => {
     })
   })
 
-  describe('When a field is added with hidden value annotation', () => {
-    it('should hide existing field values when their added field definition marks them as hidden', async () => {
+  describe('when a field with hidden value annotation is added', () => {
+    it('should hide existing field values', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),
         fields: {},
@@ -356,7 +356,7 @@ describe('handleHiddenChanges', () => {
   })
 
   describe('when a field with hidden value annotation is removed', () => {
-    it('should unhide existing field values when their field definition is removed and marked them as hidden', async () => {
+    it('should unhide existing field values', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),
         fields: {

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -318,7 +318,7 @@ describe('handleHiddenChanges', () => {
     })
   })
 
-  describe('Field annotation added for existing field', () => {
+  describe('When a field is added with hidden value annotation', () => {
     it('should hide existing field values when their added field definition marks them as hidden', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),
@@ -355,7 +355,7 @@ describe('handleHiddenChanges', () => {
     })
   })
 
-  describe('Field annotation removed for existing field', () => {
+  describe('when a field with hidden value annotation is removed', () => {
     it('should unhide existing field values when their field definition is removed and marked them as hidden', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -319,7 +319,7 @@ describe('handleHiddenChanges', () => {
   })
 
   describe('Field annotation added for existing field', () => {
-    it('should hide existing fields when their added annotation defines them as hidden', async () => {
+    it('should hide existing field values when their added field definition marks them as hidden', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),
         fields: {},
@@ -356,7 +356,7 @@ describe('handleHiddenChanges', () => {
   })
 
   describe('Field annotation removed for existing field', () => {
-    it('should unhide existing fields when their field annotation is removed and defined them as hidden', async () => {
+    it('should unhide existing field values when their field definition is removed and marked them as hidden', async () => {
       const objectTypeBefore = new ObjectType({
         elemID: new ElemID('test', 'type'),
         fields: {


### PR DESCRIPTION
Current side effect changes were added if a field annotations' `_hidden_value` was _modified_. This PR handles cases where the entire field annotation is added (as hidden) or removed (and was hidden before removal).

---

_Additional context for reviewer_:
Manually tested with the reproduction steps detailed in SALTO-7048. Note that this PR only addresses the first issue in that ticket.

---
_Release Notes_: 
- Bugfix: added or removed field annotations now have correct side effects for hiding or unhiding instance field values. 

---
_User Notifications_: 
None
