### PR TITLE
SALTO-7145 Add theme settings and guide theme dependency

### DIFF
--- a/packages/zendesk-adapter/src/dependency_changers/modified_and_deleted.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/modified_and_deleted.ts
@@ -21,7 +21,14 @@ import {
 import { values as lowerDashValues } from '@salto-io/lowerdash'
 import { deployment, references as referencesUtils } from '@salto-io/adapter-components'
 import _, { isArray } from 'lodash'
-import { MACRO_TYPE_NAME, TICKET_FIELD_TYPE_NAME, TRIGGER_CATEGORY_TYPE_NAME, TRIGGER_TYPE_NAME } from '../constants'
+import {
+  GUIDE_THEME_TYPE_NAME,
+  MACRO_TYPE_NAME,
+  THEME_SETTINGS_TYPE_NAME,
+  TICKET_FIELD_TYPE_NAME,
+  TRIGGER_CATEGORY_TYPE_NAME,
+  TRIGGER_TYPE_NAME,
+} from '../constants'
 
 const { isDefined } = lowerDashValues
 const { MISSING_REF_PREFIX } = referencesUtils
@@ -91,6 +98,15 @@ const dependencyTuple: Record<string, DeletedDependency[]> = {
     {
       typeName: TICKET_FIELD_TYPE_NAME,
       getDeletedTypeFullNameFromModificationChangeFunc: getFieldsFromTrigger,
+    },
+  ],
+  [THEME_SETTINGS_TYPE_NAME]: [
+    {
+      typeName: GUIDE_THEME_TYPE_NAME,
+      getDeletedTypeFullNameFromModificationChangeFunc: (change, type) => {
+        const data = change.data[type]
+        return [data.value?.liveTheme?.elemID.getFullName()].filter(isDefined)
+      },
     },
   ],
 }


### PR DESCRIPTION
I created a new faulty theme, changed `live_theme` to point there and deleted the current live theme.
Before I got the errors:
```
Errors:
  ○ zendesk.theme.instance.SeroussiTest_Copenhagen: InvalidTemplates - Template(s) with syntax error(s)

  ○ zendesk.theme.instance.SeroussiTest_Copenhagen2: Error: Failed to delete /api/v2/guide/theming/themes/50b3cc11-5c0a-4142-86e8-927288956c84 with error: Request failed with status code 400
  {
    "errors": [
      {
        "title": "Cannot delete live theme",
        "code": "LiveThemeDeleted",
        "status": "400",
        "meta": {}
      }
    ]
  }

  ○ zendesk.theme_settings.instance.SeroussiTest_settings: Element was not deployed, as it depends on theme which failed to deploy
```

After I got the errors:
```
Errors:
  ○ zendesk.theme.instance.SeroussiTest_Copenhagen: InvalidTemplates - Template(s) with syntax error(s)

  ○ zendesk.theme_settings.instance.SeroussiTest_settings: Element was not deployed, as it depends on theme-1 which failed to deploy

  ○ zendesk.theme.instance.SeroussiTest_Copenhagen2: Element was not deployed, as it depends on theme_settings which failed to deploy
```

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
