### PR TITLE
SALTO-6781 make locked custom record types visible

### DIFF
--- a/packages/netsuite-adapter/src/change_validator.ts
+++ b/packages/netsuite-adapter/src/change_validator.ts
@@ -54,6 +54,7 @@ import unreferencedDatasetsValidator from './change_validators/check_referenced_
 import analyticsSilentFailureValidator from './change_validators/analytics_post_deploy_notification'
 import bundleChangesValidator from './change_validators/bundle_changes'
 import customRecordEmptyPermissionListValidator from './change_validators/custom_record_empty_permission_list'
+import lockedCustomRecordTypesValidator from './change_validators/locked_custom_record_types'
 import NetsuiteClient from './client/client'
 import {
   AdditionalDependencies,
@@ -104,6 +105,7 @@ const netsuiteChangeValidators: Record<NetsuiteValidatorName, NetsuiteChangeVali
   analyticsSilentFailure: analyticsSilentFailureValidator,
   undeployableBundleChanges: bundleChangesValidator,
   customRecordEmptyPermissionList: customRecordEmptyPermissionListValidator,
+  lockedCustomRecordTypes: lockedCustomRecordTypesValidator,
 }
 
 const nonSuiteAppValidators: Record<NonSuiteAppValidatorName, NetsuiteChangeValidator> = {

--- a/packages/netsuite-adapter/src/change_validators/bundle_changes.ts
+++ b/packages/netsuite-adapter/src/change_validators/bundle_changes.ts
@@ -30,7 +30,7 @@ const getBundlesChangeError = (change: Change): ChangeError | undefined => {
       severity: 'Error',
       elemID: changeData.elemID,
       detailedMessage:
-        'Cannot create, modify or remove bundles.To manage bundles, please manually install or update them in the target account.' +
+        'Cannot create, modify or remove bundles. To manage bundles, please manually install or update them in the target account.' +
         ' Follow these steps: Customization > SuiteBundler > Search & Install Bundles.' +
         ' Learn more at https://help.salto.io/en/articles/8963376-enhancing-the-visibility-of-bundles-in-netsuite-with-salto-s-suiteapp',
     }

--- a/packages/netsuite-adapter/src/change_validators/locked_custom_record_types.ts
+++ b/packages/netsuite-adapter/src/change_validators/locked_custom_record_types.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ChangeError, getChangeData, isObjectType } from '@salto-io/adapter-api'
+import { IS_LOCKED } from '../constants'
+import { getElementValueOrAnnotations, isCustomRecordType } from '../types'
+import { NetsuiteChangeValidator } from './types'
+
+const changeValidator: NetsuiteChangeValidator = async changes =>
+  changes
+    .filter(change => Object.values(change.data).some(element => getElementValueOrAnnotations(element)[IS_LOCKED]))
+    .map(getChangeData)
+    .filter(isObjectType)
+    .filter(isCustomRecordType)
+    .map(
+      ({ elemID }): ChangeError => ({
+        elemID,
+        severity: 'Error',
+        message: 'Cannot add, modify, or remove locked custom record types',
+        detailedMessage:
+          'Cannot create, modify or remove locked custom record types.' +
+          ' To manage locked objects, please manually install or update their bundle in the target account.',
+      }),
+    )
+
+export default changeValidator

--- a/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
+++ b/packages/netsuite-adapter/src/change_validators/remove_sdf_elements.ts
@@ -19,6 +19,7 @@ import { values, collections } from '@salto-io/lowerdash'
 import { isCustomRecordType, isStandardType, hasInternalId } from '../types'
 import { NetsuiteChangeValidator } from './types'
 import { isSupportedInstance } from '../filters/internal_ids/sdf_internal_ids'
+import { IS_LOCKED } from '../constants'
 
 const { isDefined } = values
 const { awu } = collections.asynciterable
@@ -44,7 +45,7 @@ const validateRemovableChange = async (
         detailedMessage: `Can't remove this ${element.elemID.typeName}. Try fetching and deploying again, or remove it in Netsuite UI`,
       }
     }
-  } else if (isObjectType(element) && isCustomRecordType(element)) {
+  } else if (isObjectType(element) && isCustomRecordType(element) && !element.annotations[IS_LOCKED]) {
     if (!hasInternalId(element)) {
       return {
         elemID: element.elemID,

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -107,6 +107,7 @@ export type FetchParams = {
   fieldsToOmit?: FieldToOmitParams[]
   findReferencesInFilesWithExtension?: string[]
   singletonCustomRecords?: string[]
+  visibleLockedCustomRecordTypes?: boolean
 } & LockedElementsConfig['fetch']
 
 export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
@@ -118,6 +119,7 @@ export const FETCH_PARAMS: lowerdashTypes.TypeKeysEnum<FetchParams> = {
   fieldsToOmit: 'fieldsToOmit',
   findReferencesInFilesWithExtension: 'findReferencesInFilesWithExtension',
   singletonCustomRecords: 'singletonCustomRecords',
+  visibleLockedCustomRecordTypes: 'visibleLockedCustomRecordTypes',
 }
 
 export type AdditionalSdfDeployDependencies = {
@@ -276,6 +278,7 @@ export type NetsuiteValidatorName =
   | 'undeployableBundleChanges'
   | 'removeListItemWithoutScriptID'
   | 'customRecordEmptyPermissionList'
+  | 'lockedCustomRecordTypes'
 
 export type NonSuiteAppValidatorName = 'removeFileCabinet' | 'removeStandardTypes'
 
@@ -615,6 +618,7 @@ const fetchConfigType = createMatchingObjectType<FetchParams>({
     fieldsToOmit: { refType: new ListType(fieldsToOmitConfig) },
     findReferencesInFilesWithExtension: { refType: new ListType(BuiltinTypes.STRING) },
     singletonCustomRecords: { refType: new ListType(BuiltinTypes.STRING) },
+    visibleLockedCustomRecordTypes: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
@@ -680,6 +684,7 @@ const changeValidatorConfigType = createMatchingObjectType<ChangeValidatorConfig
     undeployableBundleChanges: { refType: BuiltinTypes.BOOLEAN },
     removeListItemWithoutScriptID: { refType: BuiltinTypes.BOOLEAN },
     customRecordEmptyPermissionList: { refType: BuiltinTypes.BOOLEAN },
+    lockedCustomRecordTypes: { refType: BuiltinTypes.BOOLEAN },
   },
   annotations: {
     [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,

--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -64,6 +64,7 @@ export const SUPPORT_CASE_PROFILE = 'supportCaseProfile'
 // Type Annotations
 export const SOURCE = 'source'
 export const METADATA_TYPE = 'metadataType'
+export const IS_LOCKED = 'isLocked'
 
 // Fields
 export const SCRIPT_ID = 'scriptid'

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -49,6 +49,7 @@ import {
   METADATA_TYPE,
   CUSTOM_RECORD_TYPE,
   CUSTOM_RECORDS_PATH,
+  IS_LOCKED,
 } from '../src/constants'
 import { createInstanceElement, toCustomizationInfo } from '../src/transformer'
 import { LocalFilterCreator } from '../src/filter'
@@ -775,82 +776,73 @@ describe('Adapter', () => {
       })
     })
 
-    it('should create locked custom record type elements', async () => {
-      const adapter = new NetsuiteAdapter({
-        client: new NetsuiteClient(client),
-        elementsSource: buildElementsSourceFromElements([]),
-        filtersCreators: [firstDummyFilter, secondDummyFilter],
-        config: {
-          ...config,
-          fetch: {
-            ...config.fetch,
-            lockedElementsToExclude: {
-              types: [
-                {
-                  name: 'customrecordtype',
-                  ids: ['customrecord_locked2', 'customrecord_locked3'],
-                },
-              ],
-              fileCabinet: [],
+    describe.each([false, true])('visibleLockedCustomRecordTypes %s', visibleLockedCustomRecordTypes => {
+      it('should create locked custom record type elements', async () => {
+        const adapter = new NetsuiteAdapter({
+          client: new NetsuiteClient(client),
+          elementsSource: buildElementsSourceFromElements([]),
+          filtersCreators: [firstDummyFilter, secondDummyFilter],
+          config: {
+            ...config,
+            fetch: {
+              ...config.fetch,
+              lockedElementsToExclude: {
+                types: [
+                  {
+                    name: 'customrecordtype',
+                    ids: ['customrecord_locked2', 'customrecord_locked3'],
+                  },
+                ],
+                fileCabinet: [],
+              },
+              visibleLockedCustomRecordTypes,
             },
           },
-        },
-        originalConfig: config,
-        getElemIdFunc: mockGetElemIdFunc,
+          originalConfig: config,
+          getElemIdFunc: mockGetElemIdFunc,
+        })
+        client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
+          elements: [],
+          instancesIds: [
+            { type: 'customrecordtype', instanceId: 'customrecord_locked1' },
+            { type: 'customrecordtype', instanceId: 'customrecord_locked2' },
+          ],
+          failedToFetchAllAtOnce: true,
+          failedTypes: {
+            lockedError: { customrecordtype: ['customrecord_locked1'] },
+            unexpectedError: {},
+            excludedTypes: [],
+          },
+        })
+        const fetchResult = await adapter.fetch(mockFetchOpts)
+        const lockedCustomRecordTypes = fetchResult.elements
+          .filter(isObjectType)
+          .filter(isCustomRecordType)
+          .filter(e =>
+            visibleLockedCustomRecordTypes ? e.annotations[IS_LOCKED] : e.annotations[CORE_ANNOTATIONS.HIDDEN],
+          )
+        expect(lockedCustomRecordTypes).toHaveLength(2)
+        const lockedCustomRecordType1 = lockedCustomRecordTypes.find(
+          type => type.elemID.name === 'customrecord_locked1',
+        ) as ObjectType
+        expect(lockedCustomRecordType1.annotations).toEqual({
+          scriptid: 'customrecord_locked1',
+          source: 'soap',
+          [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+          ...(visibleLockedCustomRecordTypes ? { [IS_LOCKED]: true } : { [CORE_ANNOTATIONS.HIDDEN]: true }),
+        })
+        expect(lockedCustomRecordType1.path).toEqual([NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord_locked1'])
+        const lockedCustomRecordType2 = lockedCustomRecordTypes.find(
+          type => type.elemID.name === 'customrecord_locked2',
+        ) as ObjectType
+        expect(lockedCustomRecordType2.annotations).toEqual({
+          scriptid: 'customrecord_locked2',
+          source: 'soap',
+          [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+          ...(visibleLockedCustomRecordTypes ? { [IS_LOCKED]: true } : { [CORE_ANNOTATIONS.HIDDEN]: true }),
+        })
+        expect(lockedCustomRecordType2.path).toEqual([NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord_locked2'])
       })
-      client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
-        elements: [],
-        instancesIds: [
-          { type: 'customrecordtype', instanceId: 'customrecord_locked1' },
-          { type: 'customrecordtype', instanceId: 'customrecord_locked2' },
-        ],
-        failedToFetchAllAtOnce: true,
-        failedTypes: {
-          lockedError: { customrecordtype: ['customrecord_locked1'] },
-          unexpectedError: {},
-          excludedTypes: [],
-        },
-      })
-      const fetchResult = await adapter.fetch(mockFetchOpts)
-      const lockedCustomRecordTypes = fetchResult.elements
-        .filter(isObjectType)
-        .filter(isCustomRecordType)
-        .filter(e => e.annotations[CORE_ANNOTATIONS.HIDDEN])
-      expect(lockedCustomRecordTypes).toHaveLength(2)
-      expect(lockedCustomRecordTypes).toEqual(
-        expect.arrayContaining([
-          new ObjectType({
-            elemID: new ElemID(NETSUITE, 'customrecord_locked1'),
-            fields: {
-              scriptid: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.REQUIRED]: true } },
-              internalId: { refType: BuiltinTypes.SERVICE_ID, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
-            },
-            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING, internalId: BuiltinTypes.HIDDEN_STRING },
-            annotations: {
-              scriptid: 'customrecord_locked1',
-              source: 'soap',
-              [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
-              [CORE_ANNOTATIONS.HIDDEN]: true,
-            },
-            path: [NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord_locked1'],
-          }),
-          new ObjectType({
-            elemID: new ElemID(NETSUITE, 'customrecord_locked2'),
-            fields: {
-              scriptid: { refType: BuiltinTypes.STRING, annotations: { [CORE_ANNOTATIONS.REQUIRED]: true } },
-              internalId: { refType: BuiltinTypes.SERVICE_ID, annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true } },
-            },
-            annotationRefsOrTypes: { source: BuiltinTypes.HIDDEN_STRING, internalId: BuiltinTypes.HIDDEN_STRING },
-            annotations: {
-              scriptid: 'customrecord_locked2',
-              source: 'soap',
-              [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
-              [CORE_ANNOTATIONS.HIDDEN]: true,
-            },
-            path: [NETSUITE, CUSTOM_RECORDS_PATH, 'customrecord_locked2'],
-          }),
-        ]),
-      )
     })
   })
 

--- a/packages/netsuite-adapter/test/change_validators/bundle_changes.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/bundle_changes.test.ts
@@ -45,7 +45,7 @@ describe('bundle changes', () => {
       severity: 'Error',
       elemID: bundleInstanceAfter.elemID,
       detailedMessage:
-        'Cannot create, modify or remove bundles.To manage bundles, please manually install or update them in the target account. Follow these steps: Customization > SuiteBundler > Search & Install Bundles. Learn more at https://help.salto.io/en/articles/8963376-enhancing-the-visibility-of-bundles-in-netsuite-with-salto-s-suiteapp',
+        'Cannot create, modify or remove bundles. To manage bundles, please manually install or update them in the target account. Follow these steps: Customization > SuiteBundler > Search & Install Bundles. Learn more at https://help.salto.io/en/articles/8963376-enhancing-the-visibility-of-bundles-in-netsuite-with-salto-s-suiteapp',
     })
   })
 

--- a/packages/netsuite-adapter/test/change_validators/locked_custom_record_types.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/locked_custom_record_types.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ElemID, ObjectType, toChange } from '@salto-io/adapter-api'
+import lockedCustomRecordTypesValidator from '../../src/change_validators/locked_custom_record_types'
+import { CUSTOM_RECORD_TYPE, IS_LOCKED, METADATA_TYPE, NETSUITE } from '../../src/constants'
+import { mockChangeValidatorParams } from '../utils'
+
+describe('remove sdf object change validator', () => {
+  const customRecordType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1'),
+    annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE },
+  })
+  const lockedCustomRecordType = new ObjectType({
+    elemID: new ElemID(NETSUITE, 'customrecord1_locked'),
+    annotations: { [METADATA_TYPE]: CUSTOM_RECORD_TYPE, [IS_LOCKED]: true },
+  })
+
+  it('should have a change error for added locked custom record type', async () => {
+    const changeErrors = await lockedCustomRecordTypesValidator(
+      [toChange({ after: lockedCustomRecordType })],
+      mockChangeValidatorParams(),
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: lockedCustomRecordType.elemID,
+      severity: 'Error',
+      message: 'Cannot add, modify, or remove locked custom record types',
+      detailedMessage:
+        'Cannot create, modify or remove locked custom record types.' +
+        ' To manage locked objects, please manually install or update their bundle in the target account.',
+    })
+  })
+
+  it('should have a change error for removed locked custom record type', async () => {
+    const changeErrors = await lockedCustomRecordTypesValidator(
+      [toChange({ before: lockedCustomRecordType })],
+      mockChangeValidatorParams(),
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: lockedCustomRecordType.elemID,
+      severity: 'Error',
+      message: 'Cannot add, modify, or remove locked custom record types',
+      detailedMessage:
+        'Cannot create, modify or remove locked custom record types.' +
+        ' To manage locked objects, please manually install or update their bundle in the target account.',
+    })
+  })
+
+  it('should have a change error for modified locked custom record type', async () => {
+    const afterLockedCustomRecordType = lockedCustomRecordType.clone()
+    delete afterLockedCustomRecordType.annotations[IS_LOCKED]
+    const changeErrors = await lockedCustomRecordTypesValidator(
+      [toChange({ before: lockedCustomRecordType, after: afterLockedCustomRecordType })],
+      mockChangeValidatorParams(),
+    )
+    expect(changeErrors).toHaveLength(1)
+    expect(changeErrors[0]).toEqual({
+      elemID: lockedCustomRecordType.elemID,
+      severity: 'Error',
+      message: 'Cannot add, modify, or remove locked custom record types',
+      detailedMessage:
+        'Cannot create, modify or remove locked custom record types.' +
+        ' To manage locked objects, please manually install or update their bundle in the target account.',
+    })
+  })
+
+  it('should not have a change error for non locked custom record type', async () => {
+    const changeErrors = await lockedCustomRecordTypesValidator(
+      [toChange({ after: customRecordType })],
+      mockChangeValidatorParams(),
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
+})

--- a/packages/netsuite-adapter/test/filters/add_important_values.test.ts
+++ b/packages/netsuite-adapter/test/filters/add_important_values.test.ts
@@ -10,7 +10,7 @@ import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import { addBundleFieldToType } from '../../src/transformer'
 import { LazyElementsSourceIndexes } from '../../src/elements_source_index/types'
 import { getDefaultAdapterConfig } from '../utils'
-import { CUSTOM_RECORD_TYPE, METADATA_TYPE, NETSUITE } from '../../src/constants'
+import { CUSTOM_RECORD_TYPE, IS_LOCKED, METADATA_TYPE, NETSUITE } from '../../src/constants'
 import filterCreator from '../../src/filters/add_important_values'
 import { LocalFilterOpts } from '../../src/filter'
 import { customrecordtypeType } from '../../src/autogen/types/standard_types/customrecordtype'
@@ -26,6 +26,7 @@ describe('add important values filter', () => {
   let formType: ObjectType
   let standardCustomRecordType: ObjectType
   let userCustomRecordType: ObjectType
+  let lockedCustomRecordType: ObjectType
   let types: ObjectType[]
 
   let defaultOpts: LocalFilterOpts
@@ -44,8 +45,18 @@ describe('add important values filter', () => {
         [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
       },
     })
+    lockedCustomRecordType = new ObjectType({
+      elemID: new ElemID(NETSUITE, 'customrecord1_locked'),
+      fields: {
+        scriptid: { refType: BuiltinTypes.SERVICE_ID },
+      },
+      annotations: {
+        [IS_LOCKED]: true,
+        [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+      },
+    })
 
-    types = [workflow, formType, standardCustomRecordType, userCustomRecordType, innerType]
+    types = [workflow, formType, standardCustomRecordType, userCustomRecordType, lockedCustomRecordType, innerType]
 
     types.forEach(type => addBundleFieldToType(type, bundleType().type))
 
@@ -183,6 +194,60 @@ describe('add important values filter', () => {
           indexed: true,
         },
       ],
+      [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
+    })
+
+    expect(lockedCustomRecordType.annotations).toEqual({
+      _important_values: [
+        {
+          value: 'name',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isInactive',
+          highlighted: true,
+          indexed: true,
+        },
+        {
+          value: 'bundle',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+      _self_important_values: [
+        {
+          value: 'description',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'scriptid',
+          highlighted: true,
+          indexed: false,
+        },
+        {
+          value: 'isinactive',
+          highlighted: true,
+          indexed: true,
+        },
+        {
+          value: 'bundle',
+          highlighted: true,
+          indexed: true,
+        },
+        {
+          value: 'isLocked',
+          highlighted: true,
+          indexed: true,
+        },
+      ],
+      [IS_LOCKED]: true,
       [METADATA_TYPE]: CUSTOM_RECORD_TYPE,
     })
 


### PR DESCRIPTION
Make locked custom record types visible (with adapter config `visibleLockedCustomRecordTypes`). the locked custom record types will have the `isLocked` annotation, and there's a CV that prevents deploying any changes to them.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- make locked custom record types visible (with adapter config `visibleLockedCustomRecordTypes`).

---
_User Notifications_: 
Netsuite Adapter:
- with the adapter config `visibleLockedCustomRecordTypes`, locked custom record types will be visible in the workspace, with the `isLocked = true` annotation.

