### PR TITLE
SALTO-7084 validate singletonCustomRecords config

### DIFF
--- a/packages/netsuite-adapter/src/config/validations.ts
+++ b/packages/netsuite-adapter/src/config/validations.ts
@@ -361,7 +361,12 @@ const validateAdditionalDependencies = ({
   }
 }
 
-const validateFetchConfig = ({ include, exclude, fieldsToOmit }: Record<keyof FetchParams, unknown>): void => {
+const validateFetchConfig = ({
+  include,
+  exclude,
+  fieldsToOmit,
+  singletonCustomRecords,
+}: Record<keyof FetchParams, unknown>): void => {
   validateDefined(include, [CONFIG.fetch, FETCH_PARAMS.include])
   validatePlainObject(include, [CONFIG.fetch, FETCH_PARAMS.include])
   validateFetchParameters(include)
@@ -377,6 +382,11 @@ const validateFetchConfig = ({ include, exclude, fieldsToOmit }: Record<keyof Fe
 
   if (fieldsToOmit !== undefined) {
     validateFieldsToOmitConfig(fieldsToOmit)
+  }
+
+  if (singletonCustomRecords !== undefined) {
+    validateArrayOfStrings(singletonCustomRecords, [CONFIG.fetch, FETCH_PARAMS.singletonCustomRecords])
+    validateRegularExpressions(singletonCustomRecords, [CONFIG.fetch, FETCH_PARAMS.singletonCustomRecords])
   }
 }
 

--- a/packages/netsuite-adapter/test/config/validations.test.ts
+++ b/packages/netsuite-adapter/test/config/validations.test.ts
@@ -5,10 +5,11 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { Values } from '@salto-io/adapter-api'
+import { ElemID, ReferenceExpression, Values } from '@salto-io/adapter-api'
 import { fetchDefault } from '../../src/config/types'
 import { validateConfig } from '../../src/config/validations'
 import { getDefaultAdapterConfig } from '../utils'
+import { NETSUITE } from '../../src/constants'
 
 describe('netsuite config validations', () => {
   let config: Values
@@ -360,6 +361,26 @@ describe('netsuite config validations', () => {
         expect(() => validateConfig(config)).toThrow('The following regular expressions are invalid')
 
         config.fetch.fieldsToOmit = [{ type: 'aaa.*', subtype: 'cc(c.*', fields: ['bbb.*'] }]
+        expect(() => validateConfig(config)).toThrow('The following regular expressions are invalid')
+      })
+    })
+
+    describe('singletonCustomRecords', () => {
+      it('should not throw', () => {
+        config.fetch.singletonCustomRecords = ['customrecord_singleton']
+        expect(() => validateConfig(config)).not.toThrow()
+      })
+
+      it('should throw an error when it is not a list of strings', () => {
+        config.fetch.singletonCustomRecords = 'customrecord_singleton'
+        expect(() => validateConfig(config)).toThrow('fetch.singletonCustomRecords should be a list of strings')
+
+        config.fetch.singletonCustomRecords = [new ReferenceExpression(new ElemID(NETSUITE, 'customrecord_singleton'))]
+        expect(() => validateConfig(config)).toThrow('fetch.singletonCustomRecords should be a list of strings')
+      })
+
+      it('should throw an error when there is an invalid regex', () => {
+        config.fetch.singletonCustomRecords = ['customrecord_.*', 'customrecord[0-9]*', 'custom_record(.*']
         expect(() => validateConfig(config)).toThrow('The following regular expressions are invalid')
       })
     })


### PR DESCRIPTION
Validate that the `singletonCustomRecords` is a list of valid regexes.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None