### PR TITLE
SALTO-5282: Complete support in Authorization Servers in Okta

### DIFF
--- a/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
+++ b/packages/okta-adapter/src/definitions/deploy/types/authorization_servers.ts
@@ -10,3 +10,10 @@ import { Change, getChangeData, InstanceElement } from '@salto-io/adapter-api'
 
 // System scopes are built-in default scopes that can't be added or removed.
 export const isSystemScope = (change: Change<InstanceElement>): boolean => getChangeData(change).value.system === true
+
+// "sub" is reserved claim name that can not be used by any other claim.
+export const SUB_CLAIM_NAME = 'sub'
+
+// A default claim that is created when the authorization server is created.
+export const isSubDefaultClaim = (change: Change<InstanceElement>): boolean =>
+  getChangeData(change).value.system === true && getChangeData(change).value.name === SUB_CLAIM_NAME

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1473,7 +1473,15 @@ const createCustomizations = ({
     },
   },
   OAuth2Claim: {
-    requests: [{ endpoint: { path: '/api/v1/authorizationServers/{id}/claims' } }],
+    requests: [
+      {
+        endpoint: {
+          path: '/api/v1/authorizationServers/{id}/claims',
+          // only include claims that are shown in Okta's Admin Console
+          queryArgs: { includeClaims: 'sub,custom' },
+        },
+      },
+    ],
     resource: { directFetch: false },
     element: {
       topLevel: { isTopLevel: true, elemID: { extendsParent: true } },

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -3771,7 +3771,7 @@ describe('adapter', () => {
         expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual('claim-fakeid')
         expect(nock.pendingMocks()).toHaveLength(0)
       })
-      it('should successfully add a default authorization server claim', async () => {
+      it('should successfully add a default authorization server claim with modifed values', async () => {
         loadMockReplies('authorization_server_default_claim_add.json')
         const defaultClaim = new InstanceElement(
           'sub',

--- a/packages/okta-adapter/test/adapter.test.ts
+++ b/packages/okta-adapter/test/adapter.test.ts
@@ -3771,6 +3771,37 @@ describe('adapter', () => {
         expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual('claim-fakeid')
         expect(nock.pendingMocks()).toHaveLength(0)
       })
+      it('should successfully add a default authorization server claim', async () => {
+        loadMockReplies('authorization_server_default_claim_add.json')
+        const defaultClaim = new InstanceElement(
+          'sub',
+          claimType,
+          {
+            name: 'sub',
+            status: 'ACTIVE',
+            claimType: 'RESOURCE',
+            valueType: 'EXPRESSION',
+            value: '(appuser != null) ? appuser.userName : app.name',
+            system: true,
+            alwaysIncludeInToken: true,
+          },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(authServerInstance.elemID, authServerInstance)],
+          },
+        )
+        const result = await operations.deploy({
+          changeGroup: {
+            groupID: defaultClaim.elemID.getFullName(),
+            changes: [toChange({ after: defaultClaim })],
+          },
+          progressReporter: nullProgressReporter,
+        })
+        expect(result.errors).toHaveLength(0)
+        expect(result.appliedChanges).toHaveLength(1)
+        expect(getChangeData(result.appliedChanges[0] as Change<InstanceElement>).value.id).toEqual('claim-fakeid')
+        expect(nock.pendingMocks()).toHaveLength(0)
+      })
       it('should successfully modify an authorization server claim', async () => {
         loadMockReplies('authorization_server_claim_modify.json')
         claimInstance.value.id = 'claim-fakeid'

--- a/packages/okta-adapter/test/mock_replies/authorization_server_default_claim_add.json
+++ b/packages/okta-adapter/test/mock_replies/authorization_server_default_claim_add.json
@@ -1,0 +1,73 @@
+[
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/claims?includeClaims=sub",
+    "scope": "",
+    "method": "GET",
+    "status": 200,
+    "response": [
+      {
+        "id": "claim-fakeid",
+        "name": "sub",
+        "status": "ACTIVE",
+        "claimType": "RESOURCE",
+        "valueType": "EXPRESSION",
+        "value": "(appuser != null) ? appuser.userName : app.clientId",
+        "conditions": {
+          "scopes": []
+        },
+        "system": true,
+        "alwaysIncludeInToken": true,
+        "apiResourceId": null
+      }
+    ],
+    "body": {
+      "name": "sub",
+      "status": "ACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "(appuser != null) ? appuser.userName : app.name",
+      "system": true,
+      "alwaysIncludeInToken": true
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "95",
+      "x-rate-limit-reset": "1735739033"
+    }
+  },
+  {
+    "path": "/api/v1/authorizationServers/authorizationserver-fakeid1/claims/claim-fakeid",
+    "scope": "",
+    "method": "PUT",
+    "status": 200,
+    "response": {
+      "id": "claim-fakeid",
+      "name": "sub",
+      "status": "ACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "(appuser != null) ? appuser.userName : app.name",
+      "conditions": {
+        "scopes": []
+      },
+      "system": true,
+      "alwaysIncludeInToken": true,
+      "apiResourceId": null
+    },
+    "body": {
+      "name": "sub",
+      "status": "ACTIVE",
+      "claimType": "RESOURCE",
+      "valueType": "EXPRESSION",
+      "value": "(appuser != null) ? appuser.userName : app.name",
+      "system": true,
+      "alwaysIncludeInToken": true,
+      "id": "claim-fakeid"
+    },
+    "reqHeaders": {
+      "x-rate-limit-limit": "100",
+      "x-rate-limit-remaining": "94",
+      "x-rate-limit-reset": "1735739033"
+    }
+  }
+]


### PR DESCRIPTION
In order to complete the support in Authorization servers in Okta, we need to handle deploy of new claims

---

_Additional context for reviewer_

This PR fixes leftovers remained from https://github.com/salto-io/salto/pull/6712
We need to allow creation of claims together with newly added auth server, for this, we need to handle "additions" of default claims, that are auto created when the auth server is created.

There are 2 types of default claims -
- The "sub" claim, which is auto created, visible in the UI, and can be modified after creation
- "SYSTEM" claims, that are auto created, are not visible in Okta UI, and can't be modified

This PR supports "additions" of the "sub" claim, and removes the "SYSTEM" claims entirely (from fetch as well), as there is no need to show objects that are not visible in the Okta admin console.

---
_Release Notes_: 

_Okta Adapter_:
- Support deployment of Authorization server with all of its claims

---
_User Notifications_: 

_Okta Adapter_:
- System claims that are not visible in the Okta Admin Console, will be deleted from the Salto workspace