### PR TITLE
SALTO-7063 Resolve ASVs for referenced builtin field types

### DIFF
--- a/packages/netsuite-adapter/src/constants.ts
+++ b/packages/netsuite-adapter/src/constants.ts
@@ -60,6 +60,7 @@ export const TAX_SCHEDULE = 'taxSchedule'
 export const PROJECT_EXPENSE_TYPE = 'projectExpenseType'
 export const ALLOCATION_TYPE = 'allocationType'
 export const SUPPORT_CASE_PROFILE = 'supportCaseProfile'
+export const FIELD_TYPE = 'fieldType'
 
 // Type Annotations
 export const SOURCE = 'source'

--- a/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
+++ b/packages/netsuite-adapter/src/data_elements/suiteql_table_elements.ts
@@ -20,7 +20,14 @@ import {
 } from '@salto-io/adapter-api'
 import NetsuiteClient from '../client/client'
 import { NetsuiteConfig, SuiteQLTableQueryParams } from '../config/types'
-import { ALLOCATION_TYPE, NETSUITE, PROJECT_EXPENSE_TYPE, SUPPORT_CASE_PROFILE, TAX_SCHEDULE } from '../constants'
+import {
+  ALLOCATION_TYPE,
+  FIELD_TYPE,
+  NETSUITE,
+  PROJECT_EXPENSE_TYPE,
+  SUPPORT_CASE_PROFILE,
+  TAX_SCHEDULE,
+} from '../constants'
 import { SuiteQLTableName } from './types'
 
 const log = logger(module)
@@ -41,6 +48,7 @@ export type AdditionalQueryName =
   | typeof PROJECT_EXPENSE_TYPE
   | typeof ALLOCATION_TYPE
   | typeof SUPPORT_CASE_PROFILE
+  | typeof FIELD_TYPE
 
 type InternalIdsMap = Record<string, { name: string }>
 
@@ -539,11 +547,37 @@ const getSavedSearchInternalIdsMapFromColumn =
     return internalIdsMap
   }
 
+const getFieldTypeStaticInternalIdsMap = async (): Promise<InternalIdsMap> => ({
+  '1': { name: 'Free-Form Text' },
+  '2': { name: 'Email Address' },
+  '3': { name: 'Phone Number' },
+  '4': { name: 'Date' },
+  '6': { name: 'Currency' },
+  '8': { name: 'Decimal Number' },
+  '10': { name: 'Integer Number' },
+  '11': { name: 'Check Box' },
+  '12': { name: 'List/Record' },
+  '13': { name: 'Hyperlink' },
+  '14': { name: 'Time Of Day' },
+  '15': { name: 'Text Area' },
+  '16': { name: 'Multiple Select' },
+  '17': { name: 'Image' },
+  '18': { name: 'Document' },
+  '20': { name: 'Password' },
+  '23': { name: 'Help' },
+  '24': { name: 'Rich Text' },
+  '28': { name: 'Percent' },
+  '35': { name: 'Long Text' },
+  '40': { name: 'Inline HTML' },
+  '46': { name: 'Date/Time' },
+})
+
 export const ADDITIONAL_QUERIES: Record<AdditionalQueryName, ReturnType<typeof getSavedSearchInternalIdsMap>> = {
   [TAX_SCHEDULE]: getSavedSearchInternalIdsMap(TAX_SCHEDULE),
   [PROJECT_EXPENSE_TYPE]: getSavedSearchInternalIdsMap(PROJECT_EXPENSE_TYPE),
   [ALLOCATION_TYPE]: getSavedSearchInternalIdsMapFromColumn('resourceAllocation', ALLOCATION_TYPE),
   [SUPPORT_CASE_PROFILE]: getSavedSearchInternalIdsMapFromColumn('supportCase', 'profile'),
+  [FIELD_TYPE]: getFieldTypeStaticInternalIdsMap,
 }
 
 export const getQueriesByTableName = (config: NetsuiteConfig): Record<string, SuiteQLTableQueryParams | undefined> => {

--- a/packages/netsuite-adapter/src/filters/analytics_definition_handle.ts
+++ b/packages/netsuite-adapter/src/filters/analytics_definition_handle.ts
@@ -29,7 +29,7 @@ import { XMLBuilder, XMLParser } from 'fast-xml-parser'
 import he from 'he'
 import { collections, strings } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { DATASET, REAL_VALUE_KEY, SCRIPT_ID, SOAP_SCRIPT_ID, WORKBOOK } from '../constants'
+import { DATASET, FIELD_TYPE, REAL_VALUE_KEY, SCRIPT_ID, SOAP_SCRIPT_ID, WORKBOOK } from '../constants'
 import { LocalFilterCreator } from '../filter'
 import { CDATA_TAG_NAME } from '../client/constants'
 import { parsedWorkbookType, workbookDefinitionFields } from '../type_parsers/analytics_parsers/parsed_workbook'
@@ -46,7 +46,6 @@ import {
   EXPRESSION_VALUE_VALUE_REGEX,
   FALSE,
   FIELD_DEFINITION,
-  FIELD_TYPE,
   fieldsToOmitFromDefinition,
   fieldsToOmitFromOriginal,
   FieldWithType,

--- a/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
+++ b/packages/netsuite-adapter/src/type_parsers/analytics_parsers/analytics_constants.ts
@@ -18,7 +18,6 @@ export const IGNORE_T_VALUE = 'ignore_t_value'
 // xml fields
 export const FIELD_DEFINITION = '_T_'
 export const TYPE = '@_type'
-export const FIELD_TYPE = 'fieldType'
 
 // const strings
 export const ROOT = 'root'

--- a/packages/netsuite-adapter/test/filters/analytics_tests_constants.ts
+++ b/packages/netsuite-adapter/test/filters/analytics_tests_constants.ts
@@ -17,7 +17,6 @@ import {
   DATA_VIEWS,
   DATA_VIEW_IDS,
   FIELD_DEFINITION,
-  FIELD_TYPE,
   PIVOTS,
   PIVOT_IDS,
 } from '../../src/type_parsers/analytics_parsers/analytics_constants'
@@ -209,7 +208,7 @@ export const parsedUnknownDatasetValue = {
     isPublic: true,
   },
   strangeAttribute: {
-    [FIELD_TYPE]: 'type',
+    [constants.FIELD_TYPE]: 'type',
     num: '0.5',
   },
 }
@@ -218,12 +217,12 @@ export const parsedUnknownDatasetValueForFetch = {
   name: unknownDatasetValue.name,
   scriptid: unknownDatasetValue.scriptid,
   audience: {
-    [FIELD_TYPE]: 'audience',
+    [constants.FIELD_TYPE]: 'audience',
     Stam_Field: true,
     isPublic: true,
   },
   strangeAttribute: {
-    [FIELD_TYPE]: 'type',
+    [constants.FIELD_TYPE]: 'type',
     num: '0.5',
   },
 }


### PR DESCRIPTION
Builtin fields can be referenced in data instances & custom record instances. They are referenced by their internalID, but I couldn’t find the SuiteQL table to query them from. Instead, it looks like their internalIDs are static and the same across accounts, so we can add a static mapping for them.

In order to resolve them, the user need to add the following to their adapter config:
```
netsuite {
  ...
  suiteAppClient = {
     additionalSuiteQLTables = [
        ...
        {
           name = "fieldType"
           typeId = "-213"
        },
     ]
  }
}
```

Resolving it automatically will be done in a future PR, in order to make it less noisy.

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Resolve ASVs for referenced builtin field types

---
_User Notifications_: 
Netsuite Adapter:
- Resolve ASVs for referenced builtin field types using the following config:
```
netsuite {
  ...
  suiteAppClient = {
     additionalSuiteQLTables = [
        ...
        {
           name = "fieldType"
           typeId = "-213"
        },
     ]
  }
}
```
