### PR TITLE
SALTO-5055: Salesforce cleanup outdated TopicForObjects read error suppression

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -844,10 +844,7 @@ export default class SalesforceClient implements ISalesforceClient {
         // This seems to happen with actions that relate to sending emails - these are disabled in
         // some way on sandboxes and for some reason this causes the SF API to fail reading
         (this.credentials.isSandbox && type === 'QuickAction' && error.message === 'targetObject is invalid') ||
-        error.name === 'sf:INSUFFICIENT_ACCESS' ||
-        // Seems that reading TopicsForObjects for Problem, Incident and ChangeRequest fails.
-        // Unclear why this happens, might be a SF API bug, suppressing as this seems unimportant
-        (type === 'TopicsForObjects' && error.name === 'sf:INVALID_TYPE_FOR_OPERATION'),
+        error.name === 'sf:INSUFFICIENT_ACCESS',
       isUnhandledError,
     })
   }

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -401,24 +401,6 @@ describe('salesforce client', () => {
       expect(result).toHaveLength(1)
       expect(dodoScope.isDone()).toBeTruthy()
     })
-
-    it('should return non error responses for valid TopicsForObjects', async () => {
-      const dodoScope = nock(`http://dodo22/servies/Soap/m/${API_VERSION}`)
-        .post(/.*/)
-        .times(2) // Once for the chunk and once for item
-        .reply(
-          500,
-          '<?xml version="1.0" encoding="UTF-8"?><soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:sf="http://soap.sforce.com/2006/04/metadata"><soapenv:Body><soapenv:Fault><faultcode>sf:INVALID_TYPE_FOR_OPERATION</faultcode><faultstring>INVALID_TYPE_FOR_OPERATION: Topics cant be enabled for this entityName: aaa</faultstring></soapenv:Fault></soapenv:Body></soapenv:Envelope>',
-          { 'content-type': 'text/xml' },
-        )
-        .post(/.*/)
-        .times(1)
-        .reply(200, workingReadReplay)
-
-      const { result } = await client.readMetadata('TopicsForObjects', ['aaa', 'bbb'])
-      expect(result).toHaveLength(1)
-      expect(dodoScope.isDone()).toBeTruthy()
-    })
   })
 
   describe('when client throws mappable error', () => {


### PR DESCRIPTION
SALTO-5055: Salesforce cleanup outdated TopicForObjects read error suppression

---
_Release Notes_: 
None

---
_User Notifications_: 
None
