### PR TITLE
SALTO-6375: Removed from optional features, reference from FlowAssignmentItem (Flows) to CustomField

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -22,7 +22,6 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   extendFetchTargets: false,
   shouldPopulateInternalIdAfterDeploy: true,
   addParentToInstancesWithinFolder: false,
-  addParentToRecordTriggeredFlows: false,
   packageVersionReference: false,
 }
 

--- a/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_record_triggered_flows.ts
@@ -38,9 +38,6 @@ const isRecordTriggeredFlowInstance = (element: Element): element is RecordTrigg
 const filter: FilterCreator = ({ config }) => ({
   name: 'addParentToRecordTriggeredFlows',
   onFetch: async (elements: Element[]) => {
-    if (!config.fetchProfile.isFeatureEnabled('addParentToRecordTriggeredFlows')) {
-      return
-    }
     const customObjectByName = _.keyBy(
       (await toArrayAsync(await buildElementsSourceForFetch(elements, config).getAll())).filter(isCustomObjectSync),
       objectType => apiNameSync(objectType) ?? '',

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -275,15 +275,6 @@ const NETWORK_REFERENCES_DEF: FieldReferenceDefinition[] = [
   },
 ]
 
-const FLOW_ASSIGNMENT_ITEM_REFERENCE_DEF: FieldReferenceDefinition = {
-  src: {
-    field: ASSIGN_TO_REFERENCE,
-    parentTypes: Object.values(FLOW_FIELD_TYPE_NAMES),
-  },
-  serializationStrategy: 'assignToReferenceField',
-  target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
-}
-
 /**
  * The rules for finding and resolving values into (and back from) reference expressions.
  * Overlaps between rules are allowed, and the first successful conversion wins.
@@ -1000,6 +991,14 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'recordField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
+  {
+    src: {
+      field: ASSIGN_TO_REFERENCE,
+      parentTypes: Object.values(FLOW_FIELD_TYPE_NAMES),
+    },
+    serializationStrategy: 'assignToReferenceField',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>
@@ -1147,7 +1146,6 @@ export const getDefsFromFetchProfile = (fetchProfile: FetchProfile): FieldRefere
   fieldNameToTypeMappingDefs
     .concat(fetchProfile.isFeatureEnabled('genAiReferences') ? GEN_AI_REFERENCES_DEF : [])
     .concat(fetchProfile.isFeatureEnabled('networkReferences') ? NETWORK_REFERENCES_DEF : [])
-    .concat(fetchProfile.isFeatureEnabled('addParentToRecordTriggeredFlows') ? FLOW_ASSIGNMENT_ITEM_REFERENCE_DEF : [])
     .concat(fetchProfile.isFeatureEnabled('packageVersionReference') ? PACKAGE_VERSION_REFERENCE_DEF : [])
 
 /**

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -105,7 +105,6 @@ const OPTIONAL_FEATURES = [
   'networkReferences',
   'extendFetchTargets',
   'addParentToInstancesWithinFolder',
-  'addParentToRecordTriggeredFlows',
   'shouldPopulateInternalIdAfterDeploy',
   'packageVersionReference',
 ] as const

--- a/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
@@ -57,7 +57,7 @@ describe('addParentToRecordTriggeredFlows', () => {
             config: {
               ...defaultFilterContext,
               fetchProfile: buildFetchProfile({
-                fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: true } },
+                fetchParams: { target: [] },
               }),
               elementsSource: buildElementsSourceFromElements(elementsSource),
             },
@@ -73,24 +73,6 @@ describe('addParentToRecordTriggeredFlows', () => {
           expect(updateLeadFlow.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
             new ReferenceExpression(lead.elemID, lead),
           )
-        })
-      })
-      describe('when addParentToRecordTriggeredFlows in Disabled', () => {
-        beforeEach(async () => {
-          filter = filterCreator({
-            config: {
-              ...defaultFilterContext,
-              fetchProfile: buildFetchProfile({
-                fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: false } },
-              }),
-              elementsSource: buildElementsSourceFromElements(elementsSource),
-            },
-          }) as FilterWith<'onFetch'>
-          await filter.onFetch(elements)
-        })
-        it('should not create parent annotation', async () => {
-          expect(updateOpportunityFlow.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
-          expect(updateLeadFlow.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
         })
       })
     })
@@ -112,7 +94,7 @@ describe('addParentToRecordTriggeredFlows', () => {
           config: {
             ...defaultFilterContext,
             fetchProfile: buildFetchProfile({
-              fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: true } },
+              fetchParams: { target: [] },
             }),
             elementsSource: buildElementsSourceFromElements(elementsSource),
           },

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -841,7 +841,7 @@ describe('Serialization Strategies', () => {
         config: {
           ...defaultFilterContext,
           fetchProfile: buildFetchProfile({
-            fetchParams: { target: [], optionalFeatures: { addParentToRecordTriggeredFlows: true } },
+            fetchParams: { target: [] },
           }),
         },
       }) as FilterWith<'onFetch'>


### PR DESCRIPTION
SALTO-6375: Removed from optional features, reference from FlowAssignmentItem (Flows) to CustomField

---

Workspace Diff: https://github.com/salto-io/almog-sf/commit/d454106f2ae78cd0c9169bbbdfee6a886b4d0d68

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between Flows and CustomFields.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from FlowAssignmentItem (Flows) to CustomField.
- **_parent** annotation will be added to Record-Triggered Flows.
- **_generated_dependencies** will be removed from Record-Triggered Flows.