### PR TITLE
SALTO-7176: Omit Entra application's credentials fields

### DIFF
--- a/packages/microsoft-security-adapter/src/change_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validator.ts
@@ -7,10 +7,10 @@
  */
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
-import { builtInInstancesValidator, readOnlyFieldsValidator, requiredFieldsValidator } from './change_validators'
 import { createDeployDefinitions } from './definitions'
 import { entraConstants } from './constants'
 import { Options } from './definitions/types'
+import changeValidators from './change_validators'
 
 export default (): Record<string, ChangeValidator> => ({
   createCheckDeploymentBasedOnDefinitions:
@@ -18,7 +18,5 @@ export default (): Record<string, ChangeValidator> => ({
       deployDefinitions: createDeployDefinitions(),
       typesDeployedViaParent: [entraConstants.APP_ROLE_TYPE_NAME],
     }),
-  builtInInstances: builtInInstancesValidator,
-  requiredFields: requiredFieldsValidator,
-  readOnlyFields: readOnlyFieldsValidator,
+  ...changeValidators(),
 })

--- a/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  ChangeError,
+  ChangeValidator,
+  InstanceElement,
+  getChangeData,
+  isAdditionChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { entraConstants } from '../../constants'
+
+const { APPLICATION_TYPE_NAME, SERVICE_PRINCIPAL_TYPE_NAME } = entraConstants
+
+const createApplicationSetupMessage = (instance: InstanceElement): ChangeError => {
+  const appType = instance.elemID.typeName === SERVICE_PRINCIPAL_TYPE_NAME ? 'app registration' : 'application'
+  return {
+    elemID: instance.elemID,
+    severity: 'Info',
+    message: `Credentials setup may be required for the new ${appType}`,
+    detailedMessage: `The newly created ${appType} may require additional credentials setup.`,
+    deployActions: {
+      postAction: {
+        title: `Complete the ${appType} setup`,
+        description: `The new ${appType} (${instance.value.displayName}) currently lacks credentials. If needed, please configure credentials in the Entra admin center.`,
+        showOnFailure: false,
+        subActions: [],
+      },
+    },
+  }
+}
+/**
+ * Ensures that a service provider application integrates with Okta using the SAML 2.0 protocol.
+ */
+export const applicationSetupValidator: ChangeValidator = async changes =>
+  changes
+    .filter(isAdditionChange)
+    .filter(isInstanceChange)
+    .map(getChangeData)
+    .filter(instance => [APPLICATION_TYPE_NAME, SERVICE_PRINCIPAL_TYPE_NAME].includes(instance.elemID.typeName))
+    .map(instance => createApplicationSetupMessage(instance))

--- a/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
@@ -36,7 +36,8 @@ const createApplicationSetupMessage = (instance: InstanceElement): ChangeError =
   }
 }
 /**
- * Ensures that a service provider application integrates with Okta using the SAML 2.0 protocol.
+ * This validator will return a message for each new application or service principal instance,
+ * suggesting to complete the credentials setup in the Entra admin center.
  */
 export const applicationSetupValidator: ChangeValidator = async changes =>
   changes

--- a/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/application_setup_validator.ts
@@ -19,7 +19,7 @@ import { entraConstants } from '../../constants'
 const { APPLICATION_TYPE_NAME, SERVICE_PRINCIPAL_TYPE_NAME } = entraConstants
 
 const createApplicationSetupMessage = (instance: InstanceElement): ChangeError => {
-  const appType = instance.elemID.typeName === SERVICE_PRINCIPAL_TYPE_NAME ? 'app registration' : 'application'
+  const appType = instance.elemID.typeName === APPLICATION_TYPE_NAME ? 'app registration' : 'application'
   return {
     elemID: instance.elemID,
     severity: 'Info',

--- a/packages/microsoft-security-adapter/src/change_validators/entra/index.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/index.ts
@@ -7,10 +7,8 @@
  */
 
 import { ChangeValidator } from '@salto-io/adapter-api'
-import sharedChangeValidators from './shared'
-import entraChangeValidators from './entra'
+import { applicationSetupValidator } from './application_setup_validator'
 
 export default (): Record<string, ChangeValidator> => ({
-  ...sharedChangeValidators(),
-  ...entraChangeValidators(),
+  applicationSetup: applicationSetupValidator,
 })

--- a/packages/microsoft-security-adapter/src/change_validators/shared/index.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/shared/index.ts
@@ -7,10 +7,17 @@
  */
 
 import { ChangeValidator } from '@salto-io/adapter-api'
-import sharedChangeValidators from './shared'
-import entraChangeValidators from './entra'
+import { builtInInstancesValidator } from './built_in_instances_validator'
+import { requiredFieldsValidator } from './required_fields_validator'
+import { readOnlyFieldsValidator } from './read_only_fields_validator'
+
+export {
+  TYPE_NAME_TO_READ_ONLY_FIELDS_MODIFICATION,
+  TYPE_NAME_TO_READ_ONLY_FIELDS_ADDITION,
+} from './read_only_fields_validator'
 
 export default (): Record<string, ChangeValidator> => ({
-  ...sharedChangeValidators(),
-  ...entraChangeValidators(),
+  builtInInstances: builtInInstancesValidator,
+  requiredFields: requiredFieldsValidator,
+  readOnlyFields: readOnlyFieldsValidator,
 })

--- a/packages/microsoft-security-adapter/src/definitions/deploy/shared/utils/read_only_fields.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/shared/utils/read_only_fields.ts
@@ -12,7 +12,7 @@ import { isAdditionChange, isRemovalChange } from '@salto-io/adapter-api'
 import {
   TYPE_NAME_TO_READ_ONLY_FIELDS_ADDITION,
   TYPE_NAME_TO_READ_ONLY_FIELDS_MODIFICATION,
-} from '../../../../change_validators'
+} from '../../../../change_validators/shared'
 import { AdjustFunctionSingle as AdjustFunctionSingleWithContext } from '../types'
 
 /*

--- a/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/entra/fetch.ts
@@ -244,6 +244,7 @@ const graphV1Customizations: FetchCustomizations = {
         },
         transformation: {
           ...DEFAULT_TRANSFORMATION,
+          omit: ['keyCredentials', 'passwordCredentials', 'tokenEncryptionKeyId'],
           adjust: adjustApplication,
         },
       },
@@ -282,7 +283,9 @@ const graphV1Customizations: FetchCustomizations = {
             'homepage',
             'info',
             'oauth2PermissionScopes',
+            'keyCredentials',
             'passwordCredentials',
+            'tokenEncryptionKeyId',
             'preferredSingleSignOnMode',
             'preferredTokenSigningKeyThumbprint',
             'resourceSpecificApplicationPermissions',

--- a/packages/microsoft-security-adapter/test/change_validators/entra/application_setup_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/entra/application_setup_validator.test.ts
@@ -27,15 +27,15 @@ describe(applicationSetupValidator.name, () => {
         const res = await applicationSetupValidator(changes)
         expect(res).toEqual([
           {
-            elemID: applicationInstance.elemID,
             severity: 'Info',
-            message: 'Credentials setup may be required for the new application',
-            detailedMessage: 'The newly created application may require additional credentials setup.',
+            message: 'Credentials setup may be required for the new app registration',
+            detailedMessage: 'The newly created app registration may require additional credentials setup.',
+            elemID: applicationInstance.elemID,
             deployActions: {
               postAction: {
-                title: 'Complete the application setup',
+                title: 'Complete the app registration setup',
                 description:
-                  'The new application (testApplication) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
+                  'The new app registration (testApplication) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
                 showOnFailure: false,
                 subActions: [],
               },
@@ -89,15 +89,15 @@ describe(applicationSetupValidator.name, () => {
         const res = await applicationSetupValidator(changes)
         expect(res).toEqual([
           {
-            severity: 'Info',
-            message: 'Credentials setup may be required for the new app registration',
-            detailedMessage: 'The newly created app registration may require additional credentials setup.',
             elemID: servicePrincipalInstance.elemID,
+            severity: 'Info',
+            message: 'Credentials setup may be required for the new application',
+            detailedMessage: 'The newly created application may require additional credentials setup.',
             deployActions: {
               postAction: {
-                title: 'Complete the app registration setup',
+                title: 'Complete the application setup',
                 description:
-                  'The new app registration (testServicePrincipal) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
+                  'The new application (testServicePrincipal) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
                 showOnFailure: false,
                 subActions: [],
               },

--- a/packages/microsoft-security-adapter/test/change_validators/entra/application_setup_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/entra/application_setup_validator.test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ADAPTER_NAME, entraConstants } from '../../../src/constants'
+import { applicationSetupValidator } from '../../../src/change_validators/entra/application_setup_validator'
+
+describe(applicationSetupValidator.name, () => {
+  describe('when the changes include an application instance', () => {
+    const applicationType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, entraConstants.APPLICATION_TYPE_NAME) })
+    const applicationInstance = new InstanceElement('testApplication', applicationType, {
+      displayName: 'testApplication',
+    })
+
+    describe('when the change is an addition', () => {
+      it('should return a change error for the application instance', async () => {
+        const changes = [
+          toChange({
+            after: applicationInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toEqual([
+          {
+            elemID: applicationInstance.elemID,
+            severity: 'Info',
+            message: 'Credentials setup may be required for the new application',
+            detailedMessage: 'The newly created application may require additional credentials setup.',
+            deployActions: {
+              postAction: {
+                title: 'Complete the application setup',
+                description:
+                  'The new application (testApplication) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
+                showOnFailure: false,
+                subActions: [],
+              },
+            },
+          },
+        ])
+      })
+    })
+
+    describe('when the change is a modification', () => {
+      it('should not return a change error for the application instance', async () => {
+        const changes = [
+          toChange({
+            before: applicationInstance.clone(),
+            after: applicationInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toEqual([])
+      })
+    })
+
+    describe('when the change is a removal', () => {
+      it('should not return a change error for the application instance', async () => {
+        const changes = [
+          toChange({
+            before: applicationInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toEqual([])
+      })
+    })
+  })
+
+  describe('when the changes include a service principal instance', () => {
+    const servicePrincipalType = new ObjectType({
+      elemID: new ElemID(ADAPTER_NAME, entraConstants.SERVICE_PRINCIPAL_TYPE_NAME),
+    })
+    const servicePrincipalInstance = new InstanceElement('testServicePrincipal', servicePrincipalType, {
+      displayName: 'testServicePrincipal',
+    })
+
+    describe('when the change is an addition', () => {
+      it('should return a change error for the service principal instance', async () => {
+        const changes = [
+          toChange({
+            after: servicePrincipalInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toEqual([
+          {
+            severity: 'Info',
+            message: 'Credentials setup may be required for the new app registration',
+            detailedMessage: 'The newly created app registration may require additional credentials setup.',
+            elemID: servicePrincipalInstance.elemID,
+            deployActions: {
+              postAction: {
+                title: 'Complete the app registration setup',
+                description:
+                  'The new app registration (testServicePrincipal) currently lacks credentials. If needed, please configure credentials in the Entra admin center.',
+                showOnFailure: false,
+                subActions: [],
+              },
+            },
+          },
+        ])
+      })
+    })
+
+    describe('when the change is a modification', () => {
+      it('should not return a change error for the service principal instance', async () => {
+        const changes = [
+          toChange({
+            before: servicePrincipalInstance.clone(),
+            after: servicePrincipalInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toEqual([])
+      })
+    })
+
+    describe('when the change is a removal', () => {
+      it('should not return a change error for the service principal instance', async () => {
+        const changes = [
+          toChange({
+            before: servicePrincipalInstance.clone(),
+          }),
+        ]
+        const res = await applicationSetupValidator(changes)
+        expect(res).toHaveLength(0)
+      })
+    })
+  })
+
+  describe('when the changes do not include an application or service principal instance', () => {
+    const randomType = new ObjectType({ elemID: new ElemID(ADAPTER_NAME, 'randomType') })
+    const randomInstance = new InstanceElement('randomInstance', randomType, {
+      displayName: 'randomInstance',
+    })
+
+    it('should not return a change error', async () => {
+      const changes = [
+        toChange({
+          after: randomInstance.clone(),
+        }),
+      ]
+      const res = await applicationSetupValidator(changes)
+      expect(res).toEqual([])
+    })
+  })
+})

--- a/packages/microsoft-security-adapter/test/change_validators/shared/built_in_instances_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/shared/built_in_instances_validator.test.ts
@@ -8,7 +8,7 @@
 
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { ADAPTER_NAME, entraConstants } from '../../../src/constants'
-import { builtInInstancesValidator } from '../../../src/change_validators'
+import { builtInInstancesValidator } from '../../../src/change_validators/shared/built_in_instances_validator'
 
 describe(`${builtInInstancesValidator.name}`, () => {
   describe(entraConstants.AUTHENTICATION_STRENGTH_POLICY_TYPE_NAME, () => {

--- a/packages/microsoft-security-adapter/test/change_validators/shared/read_only_fields_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/shared/read_only_fields_validator.test.ts
@@ -8,7 +8,7 @@
 
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { ADAPTER_NAME, entraConstants } from '../../../src/constants'
-import { readOnlyFieldsValidator } from '../../../src/change_validators'
+import { readOnlyFieldsValidator } from '../../../src/change_validators/shared/read_only_fields_validator'
 
 // Please notice that only a subset of the types are being tested here, since the logic is the same for all of them.
 describe(`${readOnlyFieldsValidator.name}`, () => {

--- a/packages/microsoft-security-adapter/test/change_validators/shared/required_fields_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/shared/required_fields_validator.test.ts
@@ -8,7 +8,7 @@
 
 import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
 import { ADAPTER_NAME, entraConstants, ODATA_TYPE_FIELD_NACL_CASE } from '../../../src/constants'
-import { requiredFieldsValidator } from '../../../src/change_validators'
+import { requiredFieldsValidator } from '../../../src/change_validators/shared/required_fields_validator'
 
 describe(`${requiredFieldsValidator.name}`, () => {
   describe.each(['addition', 'modification'])(

--- a/packages/microsoft-security-adapter/test/definitions/deploy/shared/utils/read_only_fields.test.ts
+++ b/packages/microsoft-security-adapter/test/definitions/deploy/shared/utils/read_only_fields.test.ts
@@ -9,7 +9,7 @@
 import {
   TYPE_NAME_TO_READ_ONLY_FIELDS_ADDITION,
   TYPE_NAME_TO_READ_ONLY_FIELDS_MODIFICATION,
-} from '../../../../../src/change_validators'
+} from '../../../../../src/change_validators/shared'
 import { omitReadOnlyFields } from '../../../../../src/definitions/deploy/shared/utils'
 import { contextMock, modificationChangeMock, removalChangeMock } from '../../../../mocks'
 


### PR DESCRIPTION
1. Omit the following fields from Entra Application & Service Principal: `keyCredentials`, `passwordCredentials`, `tokenEncryptionKeyId`.
2. Return a change error with deploy actions reminding the user to manually set credentials if needed.

---

_Additional context for reviewer_
The above credential fields are not easily deployable using MS Graph. For now, we omit them and instruct users to manually configure these fields for newly created applications.
Omitting these fields will not cause them to be removed during modification changes, as we use the PATCH request method.

---
_Release Notes_: 
_Microsoft Security adapter:_
* Omit credential fields (`keyCredentials`, `passwordCredentials`, `tokenEncryptionKeyId`) from Entra Application & Service Principal.

---
_User Notifications_: 
_Microsoft Security adapter:_
* The following fields will no longer be fetched for Entra Application & Service Principal instances: `keyCredentials`, `passwordCredentials`, `tokenEncryptionKeyId`.
