### PR TITLE
SALTO-7155: solve context deletion options bugs

### DIFF
--- a/packages/jira-adapter/src/filters/fields/README.md
+++ b/packages/jira-adapter/src/filters/fields/README.md
@@ -1,0 +1,33 @@
+Field Context options guide
+
+references:
+https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-options#api-group-issue-custom-field-options
+
+https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-custom-field-contexts/#api-rest-api-3-field-fieldid-context-defaultvalue-put
+
+The Field Context Options logic has several API limitations that should be addressed:
+
+1. Options API
+2. Options order API
+3. Cascade options limitations
+4. Default Values API
+5. 10K options limitation
+
+API constraints:
+
+- Options should be added after the context is added, as they need its id
+- Cascade options should be added after their parents, as they their ids
+- Options API support batch operations for add and modify (with a 1K limitation)
+- Options API limits the amount of options to 10K. we use private (slower, one by one) API for more than 10K options
+- Default Values should be deployed after the options deployment as they use the option's id
+- Cascade options should be deleted before their parents options
+
+In addition options usually have different ids in different environments. As a result we are creating them as instances. If we add them as a map inside the context we lose the inter-environment id connection when an option is changed.
+
+Following the API limitations we are using the following design:
+
+- We group Contexts and Options together, as we need the following order in addition: add context => add options => set default value. The default value is a field in the context (making it something else will be counterintuitive for the users), so we must group them
+- We group options orders with the context and options on removal. The reason is that without it a circle of dependency is created (parent dependencies are kept on removal, others are reversed, so the order references the context as parent and the options reference it, causing a circle) and the group is broken.
+- We sort the removal cascade options to be the first options removed
+- We count the amount of options and use private API for options over 10K
+- We do not call removal of options with a removed context parent

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -18,12 +18,7 @@ import { hasValidParent } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
 import { deployContextChange, setContextDeploymentAnnotations } from './contexts'
 import { deployChanges } from '../../deployment/standard_deployment'
-import {
-  FIELD_CONTEXT_OPTION_TYPE_NAME,
-  FIELD_CONTEXT_TYPE_NAME,
-  FIELD_TYPE_NAME,
-  OPTIONS_ORDER_TYPE_NAME,
-} from './constants'
+import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME, FIELD_TYPE_NAME } from './constants'
 import { findObject, setFieldDeploymentAnnotations } from '../../utils'
 import { getContextParent } from '../../common/fields'
 
@@ -64,9 +59,7 @@ const filter: FilterCreator = ({ client, config, paginator, elementsSource }) =>
           leftoverChanges
             .map(getChangeData)
             .filter(isInstanceElement)
-            .filter(relevantInstance =>
-              [FIELD_CONTEXT_OPTION_TYPE_NAME, OPTIONS_ORDER_TYPE_NAME].includes(relevantInstance.elemID.typeName),
-            )
+            .filter(relevantInstance => relevantInstance.elemID.typeName === FIELD_CONTEXT_OPTION_TYPE_NAME)
             .forEach(relevantInstance => {
               getContextParent(relevantInstance).value.id = instance.value.id
             })

--- a/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
@@ -13,15 +13,13 @@ import {
   getChangeData,
   isAdditionChange,
   isInstanceChange,
-  isInstanceElement,
   isModificationChange,
 } from '@salto-io/adapter-api'
 import { logger } from '@salto-io/logging'
-import { collections } from '@salto-io/lowerdash'
 import _ from 'lodash'
-import { inspectValue, isResolvedReferenceExpression } from '@salto-io/adapter-utils'
+import { inspectValue } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
-import { FIELD_CONTEXT_OPTION_TYPE_NAME, OPTIONS_ORDER_TYPE_NAME } from './constants'
+import { FIELD_CONTEXT_OPTION_TYPE_NAME } from './constants'
 import { setContextOptionsSplitted } from './context_options_splitted'
 import { getContextAndFieldIds } from '../../common/fields'
 
@@ -84,21 +82,6 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
         elementsSource,
         paginator,
       })
-      // update the ids of added options
-      const addedOptionFullNameToId = _.fromPairs(
-        addChanges.map(getChangeData).map(option => [option.elemID.getFullName(), option.value.id]),
-      )
-      leftoverChanges
-        .map(getChangeData)
-        .filter(isInstanceElement)
-        .filter(relevantInstance => relevantInstance.elemID.typeName === OPTIONS_ORDER_TYPE_NAME)
-        .flatMap(orderInstance => collections.array.makeArray(orderInstance.value.options))
-        .filter(isResolvedReferenceExpression)
-        .forEach(optionRef => {
-          if (addedOptionFullNameToId[optionRef.elemID.getFullName()] !== undefined) {
-            optionRef.value.value.id = addedOptionFullNameToId[optionRef.elemID.getFullName()]
-          }
-        })
     } catch (err) {
       log.error('An error occurred during deployment of custom field context options: %o', err)
       const message = inspectValue(err)

--- a/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
@@ -198,6 +198,14 @@ const countOptionsInContext = async (contextId: string, elementsSource: ReadOnly
   )
 }
 
+const sortAllCascadeFirst = (options: InstanceElement[]): void => {
+  options.sort((a, b) => {
+    if (isCascadeOption(a) && !isCascadeOption(b)) return -1
+    if (!isCascadeOption(a) && isCascadeOption(b)) return 1
+    return 0
+  })
+}
+
 export const setContextOptionsSplitted = async ({
   contextId,
   fieldId,
@@ -218,6 +226,9 @@ export const setContextOptionsSplitted = async ({
   paginator?: clientUtils.Paginator
 }): Promise<void> => {
   const [addedCascade, addedSimple] = _.partition(added, isCascadeOption)
+
+  // we need the cascade options to be first in delete due to API limitations
+  sortAllCascadeFirst(removed)
 
   setCascadeOptions(modified.filter(isCascadeOption))
   setCascadeOptions(addedCascade)
@@ -248,7 +259,5 @@ export const setContextOptionsSplitted = async ({
     isCascade: true,
     optionsCount,
   })
-  unsetOptions(added)
-  unsetOptions(modified)
-  unsetOptions(removed)
+  ;[added, modified, removed].forEach(unsetOptions)
 }

--- a/packages/jira-adapter/src/group_change.ts
+++ b/packages/jira-adapter/src/group_change.ts
@@ -68,7 +68,10 @@ const getFieldContextGroup: deployment.grouping.ChangeIdFunction = async change 
   const instance = getChangeData(change)
 
   return isInstanceElement(instance) &&
-    [FIELD_CONTEXT_OPTION_TYPE_NAME, OPTIONS_ORDER_TYPE_NAME].includes(instance.elemID.typeName)
+    (instance.elemID.typeName === FIELD_CONTEXT_OPTION_TYPE_NAME ||
+      // we group the order only when it is a removal change. We want it separate for id updates,
+      // but on removal it breaks the grouping due to dependency changes
+      (instance.elemID.typeName === OPTIONS_ORDER_TYPE_NAME && isRemovalChange(change)))
     ? getContextParent(instance).elemID.getFullName()
     : undefined
 }

--- a/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
@@ -254,41 +254,7 @@ describe('ContextOptionsDeployment', () => {
     expect(result.deployResult.errors).toHaveLength(0)
     expect(result.deployResult.appliedChanges).toHaveLength(6)
   })
-  it('should update the ids of order instances references', async () => {
-    connection.post.mockResolvedValueOnce({
-      status: 200,
-      data: {
-        options: [
-          {
-            id: '4',
-            value: 'p1',
-          },
-          {
-            id: '5',
-            value: 'p2',
-          },
-        ],
-      },
-    })
-    const orderType = createEmptyType(OPTIONS_ORDER_TYPE_NAME)
-    const orderInstance1 = new InstanceElement('order1', orderType, {
-      options: [
-        new ReferenceExpression(getChangeData(changes[0]).elemID, _.cloneDeep(getChangeData(changes[0]))),
-        new ReferenceExpression(getChangeData(changes[1]).elemID, _.cloneDeep(getChangeData(changes[1]))),
-      ],
-    })
-    const orderInstance2 = new InstanceElement('order2', orderType, {
-      options: [
-        new ReferenceExpression(getChangeData(changes[2]).elemID, _.cloneDeep(getChangeData(changes[2]))),
-        new ReferenceExpression(getChangeData(changes[3]).elemID, _.cloneDeep(getChangeData(changes[3]))),
-      ],
-    })
-    await filter.deploy(changes.concat([toChange({ after: orderInstance1 }), toChange({ after: orderInstance2 })]))
-    expect(orderInstance1.value.options[0].value.value.id).toEqual('4')
-    expect(orderInstance1.value.options[1].value.value.id).toEqual('5')
-    expect(orderInstance2.value.options[0].value.value.id).toEqual('2option')
-    expect(orderInstance2.value.options[1].value.value.id).toEqual('3option')
-  })
+
   it('should properly handle salto errors', async () => {
     connection.post.mockRejectedValueOnce({
       message: 'error message',
@@ -544,13 +510,6 @@ describe('ContextOptionsDeployment', () => {
       expect(result.leftoverChanges).toHaveLength(5)
       expect(result.deployResult.errors).toHaveLength(0)
       expect(result.deployResult.appliedChanges).toHaveLength(10)
-    })
-    it('should update the ids of order instances references', async () => {
-      await filter.deploy(changes)
-      expect(getChangeData(changes[13]).value.options[0].value.value.id).toEqual('10')
-      expect(getChangeData(changes[13]).value.options[1].value.value.id).toEqual('11')
-      expect(getChangeData(changes[14]).value.options[0].value.value.id).toEqual('20')
-      expect(getChangeData(changes[14]).value.options[1].value.value.id).toEqual('22')
     })
     it('should add id to additions', async () => {
       await filter.deploy(changes)

--- a/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
@@ -248,6 +248,39 @@ describe('ContextOptionsDeployment', () => {
       undefined,
     )
   })
+  it('should remove cascading options before their parents', async () => {
+    addOption1.value.id = '1option'
+    addOption2.value.id = '2option'
+    const cascadeInstance = new InstanceElement(
+      'cascadeOption',
+      createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME),
+      { id: 'cascadeOption' },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(addOption1.elemID, addOption1),
+      },
+    )
+    changes = [
+      toChange({ before: addOption1 }),
+      toChange({ before: cascadeInstance }),
+      toChange({ before: addOption2 }),
+    ]
+    await filter.deploy(changes)
+    expect(connection.delete).toHaveBeenCalledTimes(3)
+    expect(connection.delete).toHaveBeenNthCalledWith(
+      1,
+      '/rest/api/3/field/1field/context/1context/option/cascadeOption',
+      undefined,
+    )
+    expect(connection.delete).toHaveBeenCalledWith(
+      '/rest/api/3/field/1field/context/1context/option/1option',
+      undefined,
+    )
+    expect(connection.delete).toHaveBeenCalledWith(
+      '/rest/api/3/field/1field/context/1context/option/2option',
+      undefined,
+    )
+  })
   it('should return a correct deployment result', async () => {
     const result = await filter.deploy(changes)
     expect(result.leftoverChanges).toHaveLength(1)

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -263,13 +263,36 @@ describe('fieldContextDeployment', () => {
       expect(leftoverChanges).toHaveLength(changes.length)
     })
     it('should mark options of deleted contexts as applied', async () => {
+      const secondOptionInstance = new InstanceElement('option2', optionType, {}, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(contextInstance.elemID, _.cloneDeep(contextInstance)),
+      })
+      const secondCascadeInstance = new InstanceElement('cascade2', optionType, {}, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(
+          secondOptionInstance.elemID,
+          _.cloneDeep(secondOptionInstance),
+        ),
+      })
+      const thirdCascadeInstance = new InstanceElement('cascade3', optionType, {}, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(
+          secondOptionInstance.elemID,
+          _.cloneDeep(secondOptionInstance),
+        ),
+      })
+      const thirdOptionInstance = new InstanceElement('option3', optionType, {}, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(contextInstance.elemID, _.cloneDeep(contextInstance)),
+      })
+
       changes = [
         toChange({ before: optionInstance }),
         toChange({ before: cascadeInstance }),
         toChange({ before: contextInstance }),
+        toChange({ before: secondOptionInstance }),
+        toChange({ before: secondCascadeInstance }),
+        toChange({ before: thirdOptionInstance }),
+        toChange({ before: thirdCascadeInstance }),
       ]
       const { deployResult, leftoverChanges } = await filter.deploy(changes)
-      expect(deployResult.appliedChanges).toHaveLength(2)
+      expect(deployResult.appliedChanges).toHaveLength(changes.length - 1)
       expect(
         every(
           deployResult.appliedChanges,

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -252,7 +252,6 @@ describe('fieldContextDeployment', () => {
       expect(getParent(optionInstance).value.id).toEqual('newIdcontext')
       expect(getParent(cascadeInstance).value.id).toBeUndefined()
       expect(getParent(getParent(cascadeInstance)).value.id).toEqual('newIdcontext')
-      expect(getParent(orderInstance).value.id).toEqual('newIdcontext')
     })
     it('should keep context changes in leftoverChanges', async () => {
       const { leftoverChanges } = await filter.deploy(changes)

--- a/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_context_deployment.test.ts
@@ -20,14 +20,18 @@ import {
 } from '@salto-io/adapter-api'
 import { filterUtils, client as clientUtils } from '@salto-io/adapter-components'
 import { getParent } from '@salto-io/adapter-utils'
-import _ from 'lodash'
+import _, { every } from 'lodash'
 import { createEmptyType, getFilterParams, mockClient } from '../../utils'
 import { getDefaultConfig } from '../../../src/config/config'
 import { JIRA } from '../../../src/constants'
 import contextDeploymentFilter from '../../../src/filters/fields/context_deployment_filter'
 import JiraClient from '../../../src/client/client'
 import * as contexts from '../../../src/filters/fields/contexts'
-import { FIELD_CONTEXT_TYPE_NAME, OPTIONS_ORDER_TYPE_NAME } from '../../../src/filters/fields/constants'
+import {
+  FIELD_CONTEXT_OPTION_TYPE_NAME,
+  FIELD_CONTEXT_TYPE_NAME,
+  OPTIONS_ORDER_TYPE_NAME,
+} from '../../../src/filters/fields/constants'
 
 describe('fieldContextDeployment', () => {
   let filter: filterUtils.FilterWith<'onFetch' | 'deploy'>
@@ -214,6 +218,7 @@ describe('fieldContextDeployment', () => {
     let orderInstance: InstanceElement
     let optionInstance: InstanceElement
     let cascadeInstance: InstanceElement
+    let contextInstance: InstanceElement
     beforeEach(() => {
       const config = getDefaultConfig({ isDataCenter: false })
       config.fetch.splitFieldContextOptions = true
@@ -224,7 +229,7 @@ describe('fieldContextDeployment', () => {
           config,
         }),
       ) as typeof filter
-      const contextInstance = new InstanceElement('context', contextType, {})
+      contextInstance = new InstanceElement('context', contextType, {})
       orderInstance = new InstanceElement('order', createEmptyType(OPTIONS_ORDER_TYPE_NAME), {}, undefined, {
         [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(contextInstance.elemID, _.cloneDeep(contextInstance)),
       })
@@ -256,6 +261,34 @@ describe('fieldContextDeployment', () => {
     it('should keep context changes in leftoverChanges', async () => {
       const { leftoverChanges } = await filter.deploy(changes)
       expect(leftoverChanges).toHaveLength(changes.length)
+    })
+    it('should mark options of deleted contexts as applied', async () => {
+      changes = [
+        toChange({ before: optionInstance }),
+        toChange({ before: cascadeInstance }),
+        toChange({ before: contextInstance }),
+      ]
+      const { deployResult, leftoverChanges } = await filter.deploy(changes)
+      expect(deployResult.appliedChanges).toHaveLength(2)
+      expect(
+        every(
+          deployResult.appliedChanges,
+          change => getChangeData(change).elemID.typeName === FIELD_CONTEXT_OPTION_TYPE_NAME,
+        ),
+      ).toBeTruthy()
+      expect(leftoverChanges).toHaveLength(1)
+      expect(getChangeData(leftoverChanges[0]).elemID.typeName).toEqual(FIELD_CONTEXT_TYPE_NAME)
+    })
+    it('should not mark removal options as applied if parent is not deleted', async () => {
+      const afterContext = contextInstance.clone()
+      afterContext.value.description = 'newIdcontext'
+      changes = [toChange({ before: optionInstance }), toChange({ before: contextInstance, after: afterContext })]
+      const { deployResult, leftoverChanges } = await filter.deploy(changes)
+      expect(deployResult.appliedChanges).toHaveLength(0)
+      expect(leftoverChanges).toHaveLength(2)
+      expect(
+        leftoverChanges.find(change => getChangeData(change).elemID.typeName === FIELD_CONTEXT_OPTION_TYPE_NAME),
+      ).toBeDefined()
     })
   })
 })

--- a/packages/jira-adapter/test/group_change.test.ts
+++ b/packages/jira-adapter/test/group_change.test.ts
@@ -29,7 +29,11 @@ import {
   SLA_TYPE_NAME,
   WORKFLOW_TYPE_NAME,
 } from '../src/constants'
-import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME } from '../src/filters/fields/constants'
+import {
+  FIELD_CONTEXT_OPTION_TYPE_NAME,
+  FIELD_CONTEXT_TYPE_NAME,
+  OPTIONS_ORDER_TYPE_NAME,
+} from '../src/filters/fields/constants'
 import { createEmptyType } from './utils'
 
 describe('group change', () => {
@@ -56,6 +60,7 @@ describe('group change', () => {
   let fieldContextOptionInstance1: InstanceElement
   let fieldContextOptionInstance2: InstanceElement
   let fieldContextOptionInstance3: InstanceElement
+  let fieldContextOptionOrderInstance: InstanceElement
   let fieldContextInstance1: InstanceElement
   let fieldContextInstance2: InstanceElement
 
@@ -154,6 +159,16 @@ describe('group change', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(fieldContextInstance2.elemID, fieldContextInstance2)],
+      },
+    )
+
+    fieldContextOptionOrderInstance = new InstanceElement(
+      'fieldContextOptionOrderInstance',
+      createEmptyType(OPTIONS_ORDER_TYPE_NAME),
+      {},
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(fieldContextInstance1.elemID, fieldContextInstance1)],
       },
     )
 
@@ -343,7 +358,7 @@ describe('group change', () => {
       ),
     ).rejects.toThrow()
   })
-  it('should group field context options', async () => {
+  it('should group field context options but not orders', async () => {
     const changeGroupIds = (
       await getChangeGroupIds(
         new Map<string, Change>([
@@ -365,6 +380,12 @@ describe('group change', () => {
               after: fieldContextOptionInstance3,
             }),
           ],
+          [
+            fieldContextOptionOrderInstance.elemID.getFullName(),
+            toChange({
+              after: fieldContextOptionOrderInstance,
+            }),
+          ],
         ]),
       )
     ).changeGroupIdMap
@@ -377,6 +398,26 @@ describe('group change', () => {
     )
     expect(changeGroupIds.get(fieldContextOptionInstance3.elemID.getFullName())).toEqual(
       'jira.CustomFieldContext.instance.parent2',
+    )
+    expect(changeGroupIds.get(fieldContextOptionOrderInstance.elemID.getFullName())).toEqual(
+      fieldContextOptionOrderInstance.elemID.getFullName(),
+    )
+  })
+  it('should group field context options and orders on removal', async () => {
+    const changeGroupIds = (
+      await getChangeGroupIds(
+        new Map<string, Change>([
+          [
+            fieldContextOptionOrderInstance.elemID.getFullName(),
+            toChange({
+              before: fieldContextOptionOrderInstance,
+            }),
+          ],
+        ]),
+      )
+    ).changeGroupIdMap
+    expect(changeGroupIds.get(fieldContextOptionOrderInstance.elemID.getFullName())).toEqual(
+      'jira.CustomFieldContext.instance.parent1',
     )
   })
   it('should group queue type additions', async () => {


### PR DESCRIPTION
Solved two deletion bugs, and reduced code complexity by removing the options order from the context group

---

This PR has 2 commits
* The first one is to simplify the code. The context options order used to be part of a change group that contained the context and the options. Because of that we had to manually add ids of options in addition flow. I removed it from the group and deleted the id update code. It is still part of the group in removal- it does not matter for anything as orders are not really deleted, and without it the group would have been broken by dependency problems (in removal we change the directions of dependencies but not for parents. It causes a circle (the options point to the order after reversal, and the order points to the context which is in the group with the options) and in that case the core breaks the group.

* In the second one I resolved two deletion bugs. The first one was that deleting context with all its options caused 404 error as deleting the context already deleted the options. I fixed it properly (🥳) by marking all the options as deleted in such a case. The second one exists also in the old flow (I did not bother fixing it)- if a user deletes an option with its cascading options we fail as we try to delete first the parent option, and the API requires to delete the cascade option first. The solution for that was surprisingly short....

I will add E2E in the [flag-on PR](https://github.com/salto-io/salto/pull/7002)

I also added a README to hopefully reduce the time to rump-up next time we touch this area

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug in removal of context options when split flag is on

---
_User Notifications_: 
None
