### PR TITLE
SALTO-5096: Bug in duplicateRulesSortOrder Change Validator in Salesforce

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
+++ b/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
@@ -59,8 +59,10 @@ const createSortOrderError = (instance: DuplicateRuleInstance, objectName: strin
 /**
  * Validates the values in the array are in sequential order starting from 1.
  */
+const compareFn = (a: number, b: number): number => a - b
+
 const isInvalidSortOrder = (sortOrders: number[]): boolean =>
-  sortOrders.sort().some((sortOrder, index) => sortOrder !== index + 1)
+  sortOrders.sort(compareFn).some((sortOrder, index) => sortOrder !== index + 1)
 
 const changeValidator: ChangeValidator = async (changes, elementsSource) => {
   if (elementsSource === undefined) {
@@ -93,7 +95,7 @@ const changeValidator: ChangeValidator = async (changes, elementsSource) => {
 
   const invalidSortOrderByObjectName = _.pickBy(
     _.mapValues(relevantDuplicateRuleInstancesByObjectName, instances =>
-      instances.map(instance => instance.value.sortOrder).sort(),
+      instances.map(instance => instance.value.sortOrder),
     ),
     isInvalidSortOrder,
   )

--- a/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
+++ b/packages/salesforce-adapter/src/change_validators/duplicate_rules_sort_order.ts
@@ -59,10 +59,9 @@ const createSortOrderError = (instance: DuplicateRuleInstance, objectName: strin
 /**
  * Validates the values in the array are in sequential order starting from 1.
  */
-const compareFn = (a: number, b: number): number => a - b
 
 const isInvalidSortOrder = (sortOrders: number[]): boolean =>
-  sortOrders.sort(compareFn).some((sortOrder, index) => sortOrder !== index + 1)
+  sortOrders.sort((a: number, b: number): number => a - b).some((sortOrder, index) => sortOrder !== index + 1)
 
 const changeValidator: ChangeValidator = async (changes, elementsSource) => {
   if (elementsSource === undefined) {

--- a/packages/salesforce-adapter/test/change_validators/duplicate_rules_sort_order.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/duplicate_rules_sort_order.test.ts
@@ -122,6 +122,56 @@ describe('duplicateRulesSortOrder', () => {
           objectName: MODIFICATION_OBJECT_NAME,
           sortOrder: 2,
         }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule3',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 3,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule4',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 4,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule5',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 5,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule6',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 6,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule7',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 7,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule8',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 8,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule9',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 9,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule10',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 10,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule11',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 11,
+        }),
+        createDuplicateRuleInstance({
+          instanceName: 'existingDuplicateRule12',
+          objectName: MODIFICATION_OBJECT_NAME,
+          sortOrder: 12,
+        }),
       ]
       const changes = [additionChange, modificationChange]
       changedInstances = changes.map(getChangeData)


### PR DESCRIPTION
SALTO-5096: Bug in duplicateRulesSortOrder Change Validator in Salesforce

---
_Release Notes_: 
None

---
_User Notifications_: 
None