### PR TITLE
SALTO-7106: [MS Security] Block the creation of on-prem groups

### DIFF
--- a/packages/microsoft-security-adapter/src/change_validators/entra/index.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/index.ts
@@ -8,7 +8,9 @@
 
 import { ChangeValidator } from '@salto-io/adapter-api'
 import { applicationSetupValidator } from './application_setup_validator'
+import { onPremGroupAdditionValidator } from './on_prem_group_addition_validator'
 
 export default (): Record<string, ChangeValidator> => ({
   applicationSetup: applicationSetupValidator,
+  onPremGroupAddition: onPremGroupAdditionValidator,
 })

--- a/packages/microsoft-security-adapter/src/change_validators/entra/on_prem_group_addition_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/on_prem_group_addition_validator.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import _ from 'lodash'
+import { ChangeValidator, getChangeData, isAdditionChange, isInstanceElement } from '@salto-io/adapter-api'
+import { entraConstants } from '../../constants'
+
+/*
+ * Validates that on-premises groups are not created. Returns an error for each new group with onPremisesSyncEnabled set.
+ */
+export const onPremGroupAdditionValidator: ChangeValidator = async changes => {
+  const onPremGroupAdditions = changes
+    .filter(isAdditionChange)
+    .map(getChangeData)
+    .filter(isInstanceElement)
+    .filter(instance => instance.elemID.typeName === entraConstants.GROUP_TYPE_NAME)
+    // If onPremisesSyncEnabled is set to false it means this group was originally synced from an on-premises directory but is no longer synced.
+    // We still block the creation of such groups, as the created group will still differ from the original on-premises group.
+    .filter(instance => _.get(instance.value, 'onPremisesSyncEnabled') !== undefined)
+
+  return onPremGroupAdditions.map(instance => ({
+    elemID: instance.elemID,
+    severity: 'Error',
+    message: 'Creation of on-premises groups is not supported',
+    detailedMessage:
+      'Creation of on-premises groups is not supported. Please use the Entra admin center to sync on-premises groups.',
+  }))
+}

--- a/packages/microsoft-security-adapter/src/change_validators/entra/on_prem_group_addition_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/entra/on_prem_group_addition_validator.ts
@@ -12,6 +12,7 @@ import { entraConstants } from '../../constants'
 
 /*
  * Validates that on-premises groups are not created. Returns an error for each new group with onPremisesSyncEnabled set.
+ * The MS Graph API does not support creating on-premises groups, so we block the creation of such groups in advance.
  */
 export const onPremGroupAdditionValidator: ChangeValidator = async changes => {
   const onPremGroupAdditions = changes

--- a/packages/microsoft-security-adapter/src/change_validators/shared/read_only_fields_validator.ts
+++ b/packages/microsoft-security-adapter/src/change_validators/shared/read_only_fields_validator.ts
@@ -62,9 +62,14 @@ const TYPE_NAME_TO_READ_ONLY_FIELDS: Record<string, ReadOnlyFieldDefinition[]> =
   [entraConstants.GROUP_TYPE_NAME]: [
     { fieldName: 'mail', verifyAdditionChanges: true },
     { fieldName: 'assignedLicenses', verifyAdditionChanges: true },
-    { fieldName: 'onPremisesProvisioningErrors', verifyAdditionChanges: true },
     { fieldName: 'proxyAddresses', verifyAdditionChanges: true },
     { fieldName: 'uniqueName', verifyAdditionChanges: true },
+    { fieldName: 'onPremisesDomainName' },
+    { fieldName: 'onPremisesNetBiosName' },
+    { fieldName: 'onPremisesProvisioningErrors' },
+    { fieldName: 'onPremisesSamAccountName' },
+    { fieldName: 'onPremisesSecurityIdentifier' },
+    { fieldName: 'onPremisesSyncEnabled' },
   ],
 
   /* Intune instances */

--- a/packages/microsoft-security-adapter/test/change_validators/entra/on_prem_group_addition_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/entra/on_prem_group_addition_validator.test.ts
@@ -43,7 +43,7 @@ describe(onPremGroupAdditionValidator.name, () => {
           const groupType = new ObjectType({
             elemID: new ElemID(ADAPTER_NAME, entraConstants.GROUP_TYPE_NAME),
           })
-          const group = new InstanceElement('testGroup', groupType, { onPremisesSyncEnabled: true })
+          const group = new InstanceElement('testGroup', groupType, { onPremisesSyncEnabled })
           const changes =
             changeType === 'modification'
               ? [

--- a/packages/microsoft-security-adapter/test/change_validators/entra/on_prem_group_addition_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/entra/on_prem_group_addition_validator.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2024 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter-api'
+import { ADAPTER_NAME, entraConstants } from '../../../src/constants'
+import { onPremGroupAdditionValidator } from '../../../src/change_validators/entra/on_prem_group_addition_validator'
+
+describe(onPremGroupAdditionValidator.name, () => {
+  describe('when the change is a group change', () => {
+    describe.each([true, false])('when the group has onPremisesSyncEnabled set to %s', onPremisesSyncEnabled => {
+      describe('when the change is an addition change', () => {
+        it('should return an error', async () => {
+          const groupType = new ObjectType({
+            elemID: new ElemID(ADAPTER_NAME, entraConstants.GROUP_TYPE_NAME),
+          })
+          const group = new InstanceElement('testGroup', groupType, { onPremisesSyncEnabled })
+          const changes = [
+            toChange({
+              after: group.clone(),
+            }),
+          ]
+          const res = await onPremGroupAdditionValidator(changes)
+          expect(res).toHaveLength(1)
+          expect(res).toEqual([
+            {
+              elemID: group.elemID,
+              severity: 'Error',
+              message: 'Creation of on-premises groups is not supported',
+              detailedMessage:
+                'Creation of on-premises groups is not supported. Please use the Entra admin center to sync on-premises groups.',
+            },
+          ])
+        })
+      })
+
+      describe.each(['modification', 'removal'])('when the change is a %s change', changeType => {
+        it('should not return an error', async () => {
+          const groupType = new ObjectType({
+            elemID: new ElemID(ADAPTER_NAME, entraConstants.GROUP_TYPE_NAME),
+          })
+          const group = new InstanceElement('testGroup', groupType, { onPremisesSyncEnabled: true })
+          const changes =
+            changeType === 'modification'
+              ? [
+                  toChange({
+                    before: group.clone(),
+                    after: group.clone(),
+                  }),
+                ]
+              : [
+                  toChange({
+                    before: group.clone(),
+                  }),
+                ]
+          const res = await onPremGroupAdditionValidator(changes)
+          expect(res).toEqual([])
+        })
+      })
+    })
+
+    describe('when the group does not have onPremisesSyncEnabled set', () => {
+      it('should not return an error', async () => {
+        const groupType = new ObjectType({
+          elemID: new ElemID(ADAPTER_NAME, entraConstants.GROUP_TYPE_NAME),
+        })
+        const group = new InstanceElement('testGroup', groupType, { someField: 'someValue' })
+        const changes = [
+          toChange({
+            after: group.clone(),
+          }),
+        ]
+        const res = await onPremGroupAdditionValidator(changes)
+        expect(res).toEqual([])
+      })
+    })
+  })
+
+  describe('when the change is not a group change', () => {
+    it('should not return an error', async () => {
+      const objectType = new ObjectType({
+        elemID: new ElemID(ADAPTER_NAME, 'someType'),
+      })
+      const instance = new InstanceElement('testInstance', objectType, { onPremisesSyncEnabled: true })
+      const changes = [
+        toChange({
+          after: instance.clone(),
+        }),
+      ]
+      const res = await onPremGroupAdditionValidator(changes)
+      expect(res).toEqual([])
+    })
+  })
+})

--- a/packages/microsoft-security-adapter/test/change_validators/shared/built_in_instances_validator.test.ts
+++ b/packages/microsoft-security-adapter/test/change_validators/shared/built_in_instances_validator.test.ts
@@ -10,7 +10,7 @@ import { ElemID, InstanceElement, ObjectType, toChange } from '@salto-io/adapter
 import { ADAPTER_NAME, entraConstants } from '../../../src/constants'
 import { builtInInstancesValidator } from '../../../src/change_validators/shared/built_in_instances_validator'
 
-describe(`${builtInInstancesValidator.name}`, () => {
+describe(builtInInstancesValidator.name, () => {
   describe(entraConstants.AUTHENTICATION_STRENGTH_POLICY_TYPE_NAME, () => {
     it('should return change error for built-in authentication strength policy', async () => {
       const authenticationStrengthPolicyType = new ObjectType({


### PR DESCRIPTION
It's not possible to create on-premises groups using MS Graph. 
This PR:
*  introduces a change validator to block additions of on-prem groups
* Set on-prem related fields as read-only, to prevent their modification on modification changes (which are not blocked).

---
_Release Notes_: 
_Microsoft Security adapter:_
* Block the creation of on-prem groups.

---
_User Notifications_: 
None
