### PR TITLE
SALTO-6998 Jira: omit webhookToken from Automation by default

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1629,6 +1629,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'schemaVersion' },
         { fieldName: 'idUuid' },
         { fieldName: 'tags' },
+        { fieldName: 'webhookToken' },
         // serviceDesk is referenced from the associated request type, so we don't need to keep it in the automation component
         { fieldName: 'serviceDesk' },
       ],


### PR DESCRIPTION
SALTO-6998 Jira: omit webhookToken from Automation by default

---

_Additional context for reviewer_
None

---
_Release Notes_: 

_Jira_adapter_:
- Remove webhookToken from Automations

---
_User Notifications_: 

_Jira_adapter_:
- Remove webhookToken from Automations
