### PR TITLE
SALTO-7006: move functions between packages

### DIFF
--- a/packages/core/src/core/adapters/adapters.ts
+++ b/packages/core/src/core/adapters/adapters.ts
@@ -31,11 +31,11 @@ import {
   merger,
   updateElementsWithAlternativeAccount,
   elementSource as workspaceElementSource,
+  getAdaptersConfigTypesMap as getAdaptersConfigTypesMapImplementation,
 } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 // for backward comptability
 import { adapterCreators as allAdapterCreators } from '@salto-io/adapter-creators'
-import { getAdaptersConfigTypesMap as getAdaptersConfigTypesMapImplementation } from '@salto-io/local-workspace'
 
 const { awu } = collections.asynciterable
 const { buildContainerType } = workspaceElementSource

--- a/packages/core/test/core/adapters/adapters.test.ts
+++ b/packages/core/test/core/adapters/adapters.test.ts
@@ -29,13 +29,12 @@ import { buildElementsSourceFromElements, createDefaultInstanceFromType } from '
 import { collections } from '@salto-io/lowerdash'
 import { mockFunction } from '@salto-io/test-utils'
 import _ from 'lodash'
-import { expressions } from '@salto-io/workspace'
+import { expressions, getAdaptersConfigTypesMap } from '@salto-io/workspace'
 import {
   initAdapters,
   getAdaptersCredentialsTypes,
   getAdaptersCreatorConfigs,
   getDefaultAdapterConfig,
-  getAdaptersConfigTypesMap,
   createResolvedTypesElementsSource,
 } from '../../../src/core/adapters'
 import { createMockAdapter } from '../../common/helpers'

--- a/packages/local-workspace/index.ts
+++ b/packages/local-workspace/index.ts
@@ -13,7 +13,6 @@ export {
   STATES_DIR_NAME,
   locateWorkspaceRoot,
   createEnvironmentSource,
-  getAdaptersConfigTypesMap,
 } from './src/workspace'
 export {
   workspaceConfigSource as localWorkspaceConfigSource,

--- a/packages/local-workspace/src/workspace.ts
+++ b/packages/local-workspace/src/workspace.ts
@@ -29,9 +29,9 @@ import {
   getBaseDirFromEnvName,
   getStaticFileCacheName,
   WorkspaceGetCustomReferencesFunc,
+  getAdaptersConfigTypesMap,
 } from '@salto-io/workspace'
 import { logger } from '@salto-io/logging'
-import { getSubtypes } from '@salto-io/adapter-utils'
 import { localDirectoryStore, createExtensionFileFilter } from './dir_store'
 import { CONFIG_DIR_NAME, getLocalStoragePath } from './app_config'
 import { loadState } from './state'
@@ -315,15 +315,6 @@ export async function loadLocalWorkspace({
     throw e
   }
 }
-
-export const getAdaptersConfigTypesMap = (adapterCreators: Record<string, Adapter>): Record<string, ObjectType[]> =>
-  Object.fromEntries(
-    Object.entries(
-      _.mapValues(adapterCreators, adapterCreator =>
-        adapterCreator.configType ? [adapterCreator.configType, ...getSubtypes([adapterCreator.configType], true)] : [],
-      ),
-    ).filter(entry => entry[1].length > 0),
-  )
 
 type InitLocalWorkspaceParams = {
   baseDir: string

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -25,7 +25,6 @@ import {
   listElementsDependenciesInWorkspace,
   WorkspaceGetCustomReferencesFunc,
   COMMON_ENV_PREFIX,
-  loadWorkspaceParams,
 } from './src/workspace/workspace'
 import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
@@ -45,7 +44,6 @@ import * as staticFiles from './src/workspace/static_files'
 import * as merger from './src/merger'
 import * as expressions from './src/expressions'
 import * as serialization from './src/serializer/elements'
-import { getAdaptersConfigTypesMap, getAdapterConfigsPerAccount } from './src/workspace/index_utils'
 import * as pathIndex from './src/workspace/path_index'
 import * as flags from './src/flags'
 import { Author } from './src/workspace/changed_by_index'
@@ -73,9 +71,9 @@ import { State } from './src/workspace/state'
 import { PathIndex, splitElementByPath, getElementsPathHints, filterByPathHint } from './src/workspace/path_index'
 import { createPathIndexForElement } from './src/path_index_fallbacks'
 import { ReferenceIndexEntry } from './src/workspace/reference_indexes'
+import { getAdapterConfigsPerAccount, getAdaptersConfigTypesMap } from './src/workspace/adapters_config_source'
 
 export {
-  loadWorkspaceParams,
   getAdaptersConfigTypesMap,
   getAdapterConfigsPerAccount,
   errors,

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -44,6 +44,7 @@ import * as staticFiles from './src/workspace/static_files'
 import * as merger from './src/merger'
 import * as expressions from './src/expressions'
 import * as serialization from './src/serializer/elements'
+import { getAdaptersConfigTypesMap, getAdapterConfigsPerAccount } from './src/workspace/index_utils'
 import * as pathIndex from './src/workspace/path_index'
 import * as flags from './src/flags'
 import { Author } from './src/workspace/changed_by_index'
@@ -73,6 +74,8 @@ import { createPathIndexForElement } from './src/path_index_fallbacks'
 import { ReferenceIndexEntry } from './src/workspace/reference_indexes'
 
 export {
+  getAdaptersConfigTypesMap,
+  getAdapterConfigsPerAccount,
   errors,
   hiddenValues,
   serialization,

--- a/packages/workspace/index.ts
+++ b/packages/workspace/index.ts
@@ -25,6 +25,7 @@ import {
   listElementsDependenciesInWorkspace,
   WorkspaceGetCustomReferencesFunc,
   COMMON_ENV_PREFIX,
+  loadWorkspaceParams,
 } from './src/workspace/workspace'
 import * as hiddenValues from './src/workspace/hidden_values'
 import * as configSource from './src/workspace/config_source'
@@ -74,6 +75,7 @@ import { createPathIndexForElement } from './src/path_index_fallbacks'
 import { ReferenceIndexEntry } from './src/workspace/reference_indexes'
 
 export {
+  loadWorkspaceParams,
   getAdaptersConfigTypesMap,
   getAdapterConfigsPerAccount,
   errors,

--- a/packages/workspace/src/workspace/index_utils.ts
+++ b/packages/workspace/src/workspace/index_utils.ts
@@ -7,16 +7,16 @@
  */
 import { logger } from '@salto-io/logging'
 import {
-  Change,
+  ReadOnlyElementsSource,
   Element,
-  Field,
+  Change,
+  toChange,
+  isObjectTypeChange,
+  isAdditionOrRemovalChange,
   getChangeData,
   isAdditionChange,
-  isAdditionOrRemovalChange,
-  isObjectTypeChange,
   ObjectType,
-  ReadOnlyElementsSource,
-  toChange,
+  Field,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { RemoteMap } from './remote_map'

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -538,8 +538,7 @@ export const getCustomReferencesImplementation = (
   }
 }
 
-// export is kept for backward compatibility
-export type loadWorkspaceParams = {
+type LoadWorkspaceParams = {
   config: WorkspaceConfigSource
   adaptersConfig: AdaptersConfigSource
   credentials: ConfigSource
@@ -552,7 +551,7 @@ export type loadWorkspaceParams = {
 }
 
 const getLoadWorkspaceParams: (
-  configOrArgs: WorkspaceConfigSource | loadWorkspaceParams,
+  configOrArgs: WorkspaceConfigSource | LoadWorkspaceParams,
   adaptersConfig?: AdaptersConfigSource,
   credentials?: ConfigSource,
   environmentsSources?: EnvironmentsSources,
@@ -561,7 +560,7 @@ const getLoadWorkspaceParams: (
   persistent?: boolean,
   mergedRecoveryMode?: MergedRecoveryMode,
   getCustomReferences?: WorkspaceGetCustomReferencesFunc,
-) => loadWorkspaceParams & { getCustomReferences?: WorkspaceGetCustomReferencesFunc } = (
+) => LoadWorkspaceParams & { getCustomReferences?: WorkspaceGetCustomReferencesFunc } = (
   configOrArgs,
   adaptersConfig,
   credentials,
@@ -597,7 +596,7 @@ const getLoadWorkspaceParams: (
   }
 }
 // As a transitionary step, we support both a string WorkspaceConfigSource and an argument object
-export function loadWorkspace(args: loadWorkspaceParams): Promise<Workspace>
+export function loadWorkspace(args: LoadWorkspaceParams): Promise<Workspace>
 // @deprecated
 export function loadWorkspace(
   config: WorkspaceConfigSource,
@@ -612,7 +611,7 @@ export function loadWorkspace(
 ): Promise<Workspace>
 
 export async function loadWorkspace(
-  inputConfig: WorkspaceConfigSource | loadWorkspaceParams,
+  inputConfig: WorkspaceConfigSource | LoadWorkspaceParams,
   inputAdaptersConfig?: AdaptersConfigSource,
   inputCredentials?: ConfigSource,
   inputEnvironmentsSources?: EnvironmentsSources,

--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -538,7 +538,8 @@ export const getCustomReferencesImplementation = (
   }
 }
 
-type loadWorkspaceParams = {
+// export is kept for backward compatibility
+export type loadWorkspaceParams = {
   config: WorkspaceConfigSource
   adaptersConfig: AdaptersConfigSource
   credentials: ConfigSource


### PR DESCRIPTION
move functions between packages 
`getAdaptersConfigTypesMap` and `getAdapterConfigsPerAccount` are moved to workspace package instead of being in core

---

_Additional context for reviewer_


---
_Release Notes_: 


---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
