### PR TITLE
SALTO-7110: Improving SBQQ__ProductOption__c alias

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/data_management.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/data_management.ts
@@ -21,6 +21,7 @@ const ALIAS_FIELDS_BY_TYPE: Record<string, types.NonEmptyArray<string>> = {
   SBQQ__LineColumn__c: [DETECTS_PARENTS_INDICATOR, 'SBQQ__FieldName__c', 'Name'],
   SBQQ__LookupQuery__c: [DETECTS_PARENTS_INDICATOR, 'SBQQ__PriceRule2__c', 'Name'],
   SBQQ__Dimension__c: [DETECTS_PARENTS_INDICATOR, 'SBQQ__Product__c', 'Name'],
+  SBQQ__ProductOption__c: [DETECTS_PARENTS_INDICATOR, 'SBQQ__OptionalSKU__c', 'SBQQ__ConfiguredSKU__c'],
   PricebookEntry: ['Pricebook2Id', 'Name'],
   Product2: ['ProductCode', 'Family', 'Name'],
   sbaa__ApprovalCondition__c: ['sbaa__ApprovalRule__c', 'sbaa__Index__c'],


### PR DESCRIPTION
Now uses SBQQ__OptionalSKU__c and SBQQ__ConfiguredSKU__c.

---

WS diff: https://github.com/salto-io/ariel-sf/commit/1c148edc8c6e6e58adc22ba6c3e21109272a4371

---

_Release Notes_: 
_Salesforce_:
* Improve SBQQ__ProductOption__c alias.

---

_User Notifications_: 
_Salesforce_:
* Tha alias for SBQQ__ProductOption__c instances will change.
