### PR TITLE
SALTO-7144: Stop removing flow coordinates on deploy which were not added pre deploy

### DIFF
--- a/packages/salesforce-adapter/src/filters/flow_coordinates.ts
+++ b/packages/salesforce-adapter/src/filters/flow_coordinates.ts
@@ -44,22 +44,24 @@ const isInCanvasAutoLayoutMode = (instance: InstanceElement): boolean => {
   return canvasMode?.value?.stringValue === 'AUTO_LAYOUT_CANVAS'
 }
 
-const removeCoordinatesFromAllSections: TransformFuncSync = ({ value, field }) => {
-  if (!field) {
+const removeCoordinatesFromAllSections: (removeOnlyZeros?: boolean) => TransformFuncSync =
+  (removeOnlyZeros: boolean = false) =>
+  ({ value, field }) => {
+    if (!field) {
+      return value
+    }
+    const typeName = apiNameSync(field.parent)
+    if (!typeName || !TYPES_WITH_COORDINATES.includes(typeName)) {
+      return value
+    }
+
+    if (['locationX', 'locationY'].includes(field.name) && (!removeOnlyZeros || value === 0)) {
+      log.trace('Removing field %s', field.elemID.getFullName())
+      return undefined
+    }
+
     return value
   }
-  const typeName = apiNameSync(field.parent)
-  if (!typeName || !TYPES_WITH_COORDINATES.includes(typeName)) {
-    return value
-  }
-
-  if (['locationX', 'locationY'].includes(field.name)) {
-    log.debug('Removing field %s', field.elemID.getFullName())
-    return undefined
-  }
-
-  return value
-}
 
 const addZeroCoordinatesToAllSections: TransformFuncSync = ({ value, field }) => {
   if (!field) {
@@ -70,7 +72,7 @@ const addZeroCoordinatesToAllSections: TransformFuncSync = ({ value, field }) =>
     return value
   }
 
-  log.debug('Adding field %s.{locationX,locationY}', field.elemID.getFullName())
+  log.trace('Adding field %s.{locationX,locationY}', field.elemID.getFullName())
 
   value.locationX = value.locationX ?? 0
   value.locationY = value.locationY ?? 0
@@ -91,7 +93,7 @@ const filter: FilterCreator = ({ config }) => ({
           instance.value = transformValuesSync({
             values: instance.value,
             type: instance.getTypeSync(),
-            transformFunc: removeCoordinatesFromAllSections,
+            transformFunc: removeCoordinatesFromAllSections(),
           })
         })
     },
@@ -119,7 +121,7 @@ const filter: FilterCreator = ({ config }) => ({
         instance.value = transformValuesSync({
           values: instance.value,
           type: instance.getTypeSync(),
-          transformFunc: removeCoordinatesFromAllSections,
+          transformFunc: removeCoordinatesFromAllSections(true),
         })
       })
   },

--- a/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
+++ b/packages/salesforce-adapter/test/filters/flow_coordinates.test.ts
@@ -358,7 +358,7 @@ describe('flow coordinates filter', () => {
         )
       })
     })
-    describe('when a flow is in auto-layout mode', () => {
+    describe('when a flow is in auto-layout mode with zero coordinates', () => {
       const instance = new InstanceElement('flowInstance', flowType, {
         assignments: [
           {
@@ -386,6 +386,37 @@ describe('flow coordinates filter', () => {
         const instanceAfterTest = getChangeData(changes[0]) as InstanceElement
         expect(instanceAfterTest.value.assignments[0]).not.toHaveProperty('locationX')
         expect(instanceAfterTest.value.assignments[0]).not.toHaveProperty('locationX')
+      })
+    })
+    describe('when a flow is in auto-layout mode with nonzero coordinates', () => {
+      const instance = new InstanceElement('flowInstance', flowType, {
+        assignments: [
+          {
+            label: 'SomeAssignment',
+            locationX: 123,
+            locationY: 456,
+          },
+        ],
+        processMetadataValues: [
+          {
+            name: 'CanvasMode',
+            value: {
+              stringValue: 'AUTO_LAYOUT_CANVAS',
+            },
+          },
+        ],
+      })
+
+      beforeEach(async () => {
+        changes = [instance].map(e => toChange({ after: e.clone() }))
+        await filter.onDeploy(changes)
+      })
+
+      it('should not modify anything', () => {
+        expect((getChangeData(changes[0]) as InstanceElement).value).toHaveProperty(
+          'assignments',
+          instance.value.assignments,
+        )
       })
     })
   })


### PR DESCRIPTION
This will also drop preexisting coordinates if they were 0 before but that should basically never happen.

---

_Additional context for reviewer_

---

_Release Notes_: 
_Salesforce_:
* Preserve coordinates in Flows with auto-canvas layout when deploying.

---

_User Notifications_: 
None.
