### PR TITLE
SALTO-7217: Fix Confluence e2e

### DIFF
--- a/packages/confluence-adapter/e2e_test/adapter.test.ts
+++ b/packages/confluence-adapter/e2e_test/adapter.test.ts
@@ -53,7 +53,15 @@ const log = logger(module)
 jest.setTimeout(1000 * 60 * 10)
 
 const fieldsToOmitOnComparisonPerType: Record<string, string[]> = {
-  [SPACE_TYPE_NAME]: ['permissionInternalIdMap', 'homepageId', 'permissions', 'authorId', 'createdAt', 'id'],
+  [SPACE_TYPE_NAME]: [
+    'permissionInternalIdMap',
+    'homepageId',
+    'permissions',
+    'authorId',
+    'createdAt',
+    'id',
+    'currentActiveAlias',
+  ],
   [PAGE_TYPE_NAME]: ['version', 'createdAt', 'parentId', 'spaceId', 'ownerId', 'authorId'],
   [TEMPLATE_TYPE_NAME]: [],
 }


### PR DESCRIPTION
Looks like they added unexpected field `currentActiveAlias` to their API response when fetching Spaces.
The API should be stable AFAICT, so this may be a bug on their side. For the meantime, in order to unblock us, we will simply omit this field when comparing the fetched value vs the deployed value.

```
2025-01-08T22:51:15.226Z error confluence-adapter/e2e_test/adapter.test Received unexpected result when deploying instance: confluence.space.instance.Testspace4359b24f. Deployed value: {
  key: 'Testspace4359b24f',
  name: 'Testspace4359b24f',
  type: 'global',
  status: 'current',
  description: { plain: { value: 'some description', representation: 'plain' } }
} , Received value after fetch: {
  description: { plain: { representation: 'plain', value: 'some description' } },
  status: 'current',
  name: 'Testspace4359b24f',
  key: 'Testspace4359b24f',
  type: 'global',
  currentActiveAlias: 'Testspace4359b24f'
}
```

---
_Release Notes_: 
None

---
_User Notifications_: 
None
