### PR TITLE
SALTO-7223: CLI shows WS error message instead of detailedMessage

### DIFF
--- a/packages/cli/src/formatter.ts
+++ b/packages/cli/src/formatter.ts
@@ -72,7 +72,8 @@ export const emptyLine = (): string => ''
 
 const planItemName = (step: PlanItem): string => step.groupKey
 
-const formatError = (err: { message: string }): string => header(err.message)
+const formatErrorDetailedMessage = (err: { detailedMessage: string }): string => header(err.detailedMessage)
+const formatErrorMessage = (err: { message: string }): string => header(err.message)
 
 export const formatWordsSeries = (words: string[]): string =>
   words.length > 1 ? `${words.slice(0, -1).join(', ')} and ${_.last(words)}` : words[0]
@@ -87,9 +88,14 @@ const formatSourceLocation = (sl: Readonly<SourceLocation>): string =>
 const formatSourceLocations = (sourceLocations: ReadonlyArray<SourceLocation>): string =>
   `${sourceLocations.map(formatSourceLocation).join(EOL)}`
 
-export const formatWorkspaceError = (we: Readonly<errors.WorkspaceError<SaltoError>>): string => {
+export const formatWorkspaceErrorMessage = (we: Readonly<errors.WorkspaceError<SaltoError>>): string => {
   const possibleEOL = we.sourceLocations.length > 0 ? EOL : ''
-  return `${formatError(we)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
+  return `${formatErrorMessage(we)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
+}
+
+export const formatWorkspaceErrorDetailedMessage = (we: Readonly<errors.WorkspaceError<SaltoError>>): string => {
+  const possibleEOL = we.sourceLocations.length > 0 ? EOL : ''
+  return `${formatErrorDetailedMessage(we)}${possibleEOL}${formatSourceLocations(we.sourceLocations)}`
 }
 
 const indent = (text: string, level: number): string => {
@@ -266,8 +272,8 @@ type ChangeWorkspaceError = errors.WorkspaceError<ChangeError>
 export const formatChangeErrors = (wsChangeErrors: ReadonlyArray<ChangeWorkspaceError>, detailed = false): string => {
   const errorsIndent = 2
   const formatSingleChangeError = (changeError: ChangeWorkspaceError): string => {
-    const formattedError = formatWorkspaceError(changeError)
-    return indent(`${formattedError}${EOL}${changeError.severity}: ${changeError.detailedMessage}`, errorsIndent)
+    const formattedErrorMessage = formatWorkspaceErrorMessage(changeError)
+    return indent(`${formattedErrorMessage}${EOL}${changeError.severity}: ${changeError.detailedMessage}`, errorsIndent)
   }
   const formatElement = (changeError: ChangeWorkspaceError): string => {
     const possibleDetailed: string = detailed
@@ -285,7 +291,7 @@ export const formatChangeErrors = (wsChangeErrors: ReadonlyArray<ChangeWorkspace
     }
 
     const resultMessages: string = [
-      indent(`${firstErr.severity}: ${formatError(firstErr)} in the following elements:`, errorsIndent),
+      indent(`${firstErr.severity}: ${formatErrorMessage(firstErr)} in the following elements:`, errorsIndent),
     ]
       .concat(groupedChangeErrors.map(formatElement))
       .join(EOL)
@@ -540,7 +546,10 @@ export const formatFetchFinish = (): string => [emptyLine(), Prompts.FETCH_SUCCE
 
 export const formatMergeErrors = (mergeErrors: FetchResult['mergeErrors']): string =>
   `${Prompts.FETCH_MERGE_ERRORS}\n${mergeErrors
-    .map(me => `${formatError(me.error)}, dropped elements: ${me.elements.map(e => e.elemID.getFullName()).join(', ')}`)
+    .map(
+      me =>
+        `${formatErrorDetailedMessage(me.error)}, dropped elements: ${me.elements.map(e => e.elemID.getFullName()).join(', ')}`,
+    )
     .join('\n')}`
 
 export const formatFetchWarnings = (warnings: string[]): string =>

--- a/packages/cli/src/workspace/workspace.ts
+++ b/packages/cli/src/workspace/workspace.ts
@@ -13,11 +13,11 @@ import { logger } from '@salto-io/logging'
 import { Workspace, nacl, validator as wsValidator } from '@salto-io/workspace'
 import { EventEmitter } from 'pietile-eventemitter'
 import {
-  formatWorkspaceError,
   formatWorkspaceLoadFailed,
   formatDetailedChanges,
   formatFinishedLoading,
   formatWorkspaceAbort,
+  formatWorkspaceErrorDetailedMessage,
 } from '../formatter'
 import { CliOutput, SpinnerCreator, CliTelemetry } from '../types'
 import { shouldContinueInCaseOfWarnings, shouldAbortWorkspaceInCaseOfValidationError } from '../callbacks'
@@ -96,7 +96,7 @@ export const formatWorkspaceErrors = async (workspace: Workspace, errors: Iterab
       wu(errors)
         .slice(0, MAX_WORKSPACE_ERRORS_TO_LOG)
         .map(err => workspace.transformError(err))
-        .map(async err => formatWorkspaceError(await err)),
+        .map(async err => formatWorkspaceErrorDetailedMessage(await err)),
     )
   ).join(EOL)
 

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -25,7 +25,7 @@ import {
   formatExecutionPlan,
   formatChange,
   formatFetchChangeForApproval,
-  formatWorkspaceError,
+  formatWorkspaceErrorDetailedMessage,
   formatChangeErrors,
   formatConfigChangeNeeded,
   formatShouldChangeFetchModeToAlign,
@@ -577,7 +577,7 @@ describe('formatter', () => {
   describe('workspace error format with source fragments', () => {
     let formattedErrors: string
     beforeEach(() => {
-      formattedErrors = formatWorkspaceError(workspaceErrorWithSourceLocations)
+      formattedErrors = formatWorkspaceErrorDetailedMessage(workspaceErrorWithSourceLocations)
     })
     it('should print the start line', () => {
       expect(formattedErrors).toContain('2')
@@ -589,7 +589,7 @@ describe('formatter', () => {
   describe('workspace error format without source fragments', () => {
     let formattedErrors: string
     beforeEach(() => {
-      formattedErrors = formatWorkspaceError(workspaceErrorWithoutSourceFragments)
+      formattedErrors = formatWorkspaceErrorDetailedMessage(workspaceErrorWithoutSourceFragments)
     })
     it('should print the error', () => {
       expect(formattedErrors).toContain('This is my error')


### PR DESCRIPTION
_CLI shows WS error message instead of detailedMessage_

---

_Additional context for reviewer_
* WS errors should be shown with their detailedMessage. The CLI used the same function for WS and change errors, so I split `formatWorkspaceError` into two for both usages


---
_Release Notes_: 
_CLI_
* bug fix: show WS errors detailedMessage instead of message

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
