### PR TITLE
SAAS-12444 Jira: add service Url in collision msg

### DIFF
--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -51,6 +51,10 @@ const filter: FilterCreator = ({ config }) => ({
       )
     })
 
+    const getServiceUrl = (instance: InstanceElement): string =>
+      instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] !== undefined
+        ? `. View in the service - ${instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]}`
+        : ''
     const prettifiesName = (instance: InstanceElement): string =>
       instance.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined
         ? instance.annotations[CORE_ANNOTATIONS.ALIAS]
@@ -58,7 +62,9 @@ const filter: FilterCreator = ({ config }) => ({
     const duplicateInstanceNames = _.uniq(
       duplicateInstances
         .filter(isInstanceElement)
-        .flatMap(instance => `${prettifiesName(instance)} (${instance.elemID.getFullName()})`),
+        .flatMap(
+          instance => `${prettifiesName(instance)} (${instance.elemID.getFullName()})${getServiceUrl(instance)}`,
+        ),
     )
     if (!config.fetch.fallbackToInternalId) {
       const message = `The following elements had duplicate names in Jira. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -114,6 +114,7 @@ describe('duplicateIdsFilter', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.ALIAS]: ['instance alias'],
+        [CORE_ANNOTATIONS.SERVICE_URL]: ['https://dup_1_someurl.com'],
       },
     )
     const instanceWithAliasDuplicatedName = new InstanceElement(
@@ -126,6 +127,7 @@ describe('duplicateIdsFilter', () => {
       undefined,
       {
         [CORE_ANNOTATIONS.ALIAS]: ['another instance alias'],
+        [CORE_ANNOTATIONS.SERVICE_URL]: ['https://dup_2_someurl.com'],
       },
     )
     const instanceWithAliasDuplicatedNameDuplicateAlias = new InstanceElement(
@@ -157,13 +159,15 @@ describe('duplicateIdsFilter', () => {
           message: `The following elements had duplicate names in Jira. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
 If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions
 dup (jira.Status.instance.dup),
-instance alias (jira.Status.instance.dup),
-another instance alias (jira.Status.instance.dup)`,
+instance alias (jira.Status.instance.dup). View in the service - https://dup_1_someurl.com,
+another instance alias (jira.Status.instance.dup). View in the service - https://dup_2_someurl.com,
+instance alias (jira.Status.instance.dup)`,
           detailedMessage: `The following elements had duplicate names in Jira. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
 If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions
 dup (jira.Status.instance.dup),
-instance alias (jira.Status.instance.dup),
-another instance alias (jira.Status.instance.dup)`,
+instance alias (jira.Status.instance.dup). View in the service - https://dup_1_someurl.com,
+another instance alias (jira.Status.instance.dup). View in the service - https://dup_2_someurl.com,
+instance alias (jira.Status.instance.dup)`,
           severity: 'Warning',
         },
       ],


### PR DESCRIPTION
SAAS-12444 Jira: add service Url in collision msg

---

_Additional context for reviewer_
Put back https://github.com/salto-io/salto/pull/6928

---
_Release Notes_: 
Add in-app links to duplicated instances in collision error

---
_User Notifications_: 
None
