### PR TITLE
SALTO-7220: Support mixed mode in syncWorkspaceToFolder

### DIFF
--- a/packages/cli/src/commands/adapter_format.ts
+++ b/packages/cli/src/commands/adapter_format.ts
@@ -10,6 +10,7 @@ import { logger } from '@salto-io/logging'
 import { Workspace } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { calculatePatch, syncWorkspaceToFolder, initFolder, isInitializedFolder } from '@salto-io/core'
+import { loadLocalWorkspace } from '@salto-io/local-workspace'
 import { adapterCreators } from '@salto-io/adapter-creators'
 import { WorkspaceCommandAction, createWorkspaceCommand, createCommandGroupDef } from '../command_builder'
 import { outputLine, errorOutputLine } from '../outputer'
@@ -168,6 +169,7 @@ type SyncWorkspaceAdapters = (typeof SYNC_WORKSPACE_ADAPTERS)[number]
 
 type SyncWorkspaceToFolderArgs = {
   toDir: string
+  toWorkspaceDir?: string
   accountName: SyncWorkspaceAdapters
   force: boolean
 }
@@ -176,7 +178,7 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
   input,
   output,
 }) => {
-  const { accountName, toDir, force } = input
+  const { accountName, toDir, toWorkspaceDir, force } = input
   const adapterName = workspace.getServiceFromAccountName(accountName)
   const initializedResult = await isInitializedFolder({ adapterName, baseDir: toDir, adapterCreators })
   if (initializedResult.errors.length > 0) {
@@ -198,8 +200,31 @@ export const syncWorkspaceToFolderAction: WorkspaceCommandAction<SyncWorkspaceTo
     }
   }
 
+  let toWorkspace: Workspace | undefined
+  if (toWorkspaceDir) {
+    try {
+      toWorkspace = await loadLocalWorkspace({ path: toWorkspaceDir, adapterCreators })
+    } catch (e) {
+      log.debug('Failed to load target workspace: %o', e)
+      outputLine('Failed to load target workspace, aborting', output)
+      return CliExitCode.UserInputError
+    }
+  }
+
   outputLine(`Synchronizing content of workspace to folder at ${toDir}`, output)
-  const result = await syncWorkspaceToFolder({ workspace, accountName, baseDir: toDir, adapterCreators })
+  if (toWorkspace) {
+    outputLine(
+      `Using workspace at ${toWorkspace} for elements that cannot be represented in the adapter format`,
+      output,
+    )
+  }
+  const result = await syncWorkspaceToFolder({
+    workspace,
+    accountName,
+    baseDir: toDir,
+    toWorkspace,
+    adapterCreators,
+  })
   if (result.errors.length > 0) {
     outputLine(formatSyncToWorkspaceErrors(result.errors), output)
     return CliExitCode.AppError
@@ -219,6 +244,13 @@ const syncToWorkspaceCmd = createWorkspaceCommand({
         alias: 'd',
         description: 'The project folder to update',
         required: true,
+      },
+      {
+        name: 'toWorkspaceDir',
+        type: 'string',
+        alias: 'w',
+        description: 'Workspace for elements which cannot be represented in the adapter format',
+        required: false,
       },
       {
         name: 'accountName',

--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -20,6 +20,7 @@ import {
   SaltoError,
   toChange,
 } from '@salto-io/adapter-api'
+import { getDetailedChanges } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { merger, Workspace, ElementSelector, expressions, elementSource, hiddenValues } from '@salto-io/workspace'
@@ -60,6 +61,11 @@ const getAdapter = ({
   return { adapter: adapterCreators[adapterName], adapterName, error: undefined }
 }
 
+const getResolvedWorkspaceElements = async (workspace: Workspace): Promise<Element[]> => {
+  const workspaceElements = await workspace.elements()
+  return expressions.resolve(await awu(await workspaceElements.getAll()).toArray(), workspaceElements)
+}
+
 type GetAdapterAndContextArgs = {
   ignoreStateElemIdMapping?: boolean
   ignoreStateElemIdMappingForSelectors?: ElementSelector[]
@@ -83,11 +89,7 @@ const getAdapterAndContext = async ({
     throw new Error(error.message)
   }
 
-  const workspaceElements = await workspace.elements()
-  const resolvedElements = await expressions.resolve(
-    await awu(await workspaceElements.getAll()).toArray(),
-    workspaceElements,
-  )
+  const resolvedElements = await getResolvedWorkspaceElements(workspace)
   const { adaptersCreatorConfigs } = await getFetchAdapterAndServicesSetup({
     workspace,
     fetchAccounts: [accountName],
@@ -321,6 +323,7 @@ export const calculatePatch = async ({
 
 type SyncWorkspaceToFolderArgs = {
   baseDir: string
+  toWorkspace?: Workspace
 } & GetAdapterAndContextArgs
 
 export type SyncWorkspaceToFolderResult = {
@@ -331,6 +334,7 @@ export const syncWorkspaceToFolder = ({
   workspace,
   accountName,
   baseDir,
+  toWorkspace,
   ignoreStateElemIdMapping,
   ignoreStateElemIdMappingForSelectors,
   adapterCreators,
@@ -384,12 +388,14 @@ export const syncWorkspaceToFolder = ({
         }
       }
 
+      const toWorkspaceElements = toWorkspace ? await getResolvedWorkspaceElements(toWorkspace) : []
+
       // We know this is not accurate - we will get false modify changes here because we are directly comparing
       // salto elements to folder elements and we know salto elements have more information in them.
       // This should hopefully be ok because the effect of this incorrect comparison is that we will potentially
       // re-dump elements that are equal, so even though we do redundant work, the end result should be correct
       const plan = await getPlan({
-        before: elementSource.createInMemoryElementSource(folderElements),
+        before: elementSource.createInMemoryElementSource(folderElements.concat(toWorkspaceElements)),
         after: elementSource.createInMemoryElementSource(workspaceElements),
         dependencyChangers: [],
       })
@@ -404,11 +410,20 @@ export const syncWorkspaceToFolder = ({
         changes.length,
         changeCounts,
       )
-      return dumpElementsToFolder({
+
+      const { errors, unappliedChanges } = await dumpElementsToFolder({
         baseDir,
         changes: await filterHiddenChanges(changes, adapterContext.elementsSource),
         elementsSource: adapterContext.elementsSource,
       })
+
+      if (toWorkspace) {
+        log.debug('Updating nacl files with the %d unapplied changes', unappliedChanges.length)
+        await toWorkspace.updateNaclFiles(unappliedChanges.map(change => getDetailedChanges(change)).flat())
+        await toWorkspace.flush()
+      }
+
+      return { errors }
     },
     'syncWorkspaceToFolder %s',
     baseDir,


### PR DESCRIPTION
syncWorkspaceToFolder now gets an optional workspace which will function as storage for any changes which are not supported by dumpToFolder.

This current implementation does not deal with the case of elements which "move" between the folder & workspace.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
