### PR TITLE
SALTO-6868: CV for LiveChatButton with routingType "Omni-Channel"

### DIFF
--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -54,6 +54,7 @@ import { getLookUpName } from './transformers/reference_mapping'
 import layoutDuplicateFields from './change_validators/layout_duplicate_fields'
 import customApplications from './change_validators/custom_applications'
 import flowReferencedElements from './change_validators/flow_referenced_elements'
+import liveChatButtonRoutingType from './change_validators/live_chat_button_routing_type'
 
 const { createChangeValidator, getDefaultChangeValidators } = deployment.changeValidators
 
@@ -114,6 +115,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   layoutDuplicateFields: () => layoutDuplicateFields,
   customApplications: () => customApplications,
   flowReferencedElements: () => flowReferencedElements,
+  liveChatButtonRoutingType: () => liveChatButtonRoutingType,
   ..._.mapValues(getDefaultChangeValidators(), validator => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -20,8 +20,8 @@ import { LIVE_CHAT_BUTTON } from '../constants'
 
 const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement =>
   isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
-  _.isUndefined(_.get(element.value, 'routingType')) &&
-  _.isUndefined(_.get(element.value, 'skills'))
+  _.get(element.value, 'routingType') === undefined &&
+  _.get(element.value, 'skills') === undefined
 
 const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -5,3 +5,32 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+
+import _ from 'lodash'
+import {
+  ChangeValidator,
+  InstanceElement,
+  Element,
+  getChangeData,
+  ChangeError,
+  CORE_ANNOTATIONS,
+} from '@salto-io/adapter-api'
+import { isInstanceOfTypeSync } from '../filters/utils'
+import { LIVE_CHAT_BUTTON } from '../constants'
+
+const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement =>
+  isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
+  _.isUndefined(_.get(element.value, 'routingType')) &&
+  _.isUndefined(_.get(element.value, 'skills'))
+
+const createChangeError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Warning',
+  message: 'Salesforce does not support LiveChatButton with routingType "Omni-Channel"',
+  detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because Salesforce does not support them: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API. To proceed with deployment, update the routingType to a value other than "Omni-Channel" before deploying, here:${instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]}. After deployment, you can change it back to "Omni-Channel" if required.`,
+})
+
+const changeValidator: ChangeValidator = async changes =>
+  changes.map(getChangeData).filter(isOmniChannelRoutedLiveChatButton).map(createChangeError)
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -18,13 +18,10 @@ import {
 import { isInstanceOfTypeSync } from '../filters/utils'
 import { LIVE_CHAT_BUTTON } from '../constants'
 
-const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement => {
-  const bool =
-    isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
-    _.isUndefined(_.get(element.value, 'routingType')) &&
-    _.isUndefined(_.get(element.value, 'skills'))
-  return bool
-}
+const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement =>
+  isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
+  _.isUndefined(_.get(element.value, 'routingType')) &&
+  _.isUndefined(_.get(element.value, 'skills'))
 
 const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -18,10 +18,13 @@ import {
 import { isInstanceOfTypeSync } from '../filters/utils'
 import { LIVE_CHAT_BUTTON } from '../constants'
 
-const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement =>
-  isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
-  _.isUndefined(_.get(element.value, 'routingType')) &&
-  _.isUndefined(_.get(element.value, 'skills'))
+const isOmniChannelRoutedLiveChatButton = (element: Element): element is InstanceElement => {
+  const bool =
+    isInstanceOfTypeSync(LIVE_CHAT_BUTTON)(element) &&
+    _.isUndefined(_.get(element.value, 'routingType')) &&
+    _.isUndefined(_.get(element.value, 'skills'))
+  return bool
+}
 
 const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,

--- a/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
+++ b/packages/salesforce-adapter/src/change_validators/live_chat_button_routing_type.ts
@@ -30,7 +30,7 @@ const createChangeError = (instance: InstanceElement): ChangeError => ({
   elemID: instance.elemID,
   severity: 'Warning',
   message: 'Salesforce does not support LiveChatButton with routingType "Omni-Channel"',
-  detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because Salesforce does not support them: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API. To proceed with deployment, update the routingType to a value other than "Omni-Channel" before deploying, here:${instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]}. After deployment, you can change it back to "Omni-Channel" if required.`,
+  detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because [Salesforce does not support them](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API). To proceed with deployment, before deploying change the routingType to a value other than "Omni-Channel", [here](${instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]}). After deployment, you can change it back to "Omni-Channel" if required.`,
 })
 
 const changeValidator: ChangeValidator = async changes =>

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -462,6 +462,7 @@ export const CANVAS_METADATA_TYPE = 'CanvasMetadata'
 export const STATIC_RESOURCE_METADATA_TYPE = 'StaticResource'
 export const AURA_DEFINITION_BUNDLE_METADATA_TYPE = 'AuraDefinitionBundle'
 export const GEN_AI_FUNCTION_METADATA_TYPE = 'GenAiFunction'
+export const LIVE_CHAT_BUTTON = 'LiveChatButton'
 
 // Wave Metadata Types
 export const WAVE_RECIPE_METADATA_TYPE = 'WaveRecipe'

--- a/packages/salesforce-adapter/src/transformers/missing_fields.json
+++ b/packages/salesforce-adapter/src/transformers/missing_fields.json
@@ -2023,5 +2023,14 @@
         "type": "STRING"
       }
     ]
+  },
+  {
+    "id": "LiveChatButton",
+    "fields": [
+      {
+        "name": "routingType",
+        "type": "STRING"
+      }
+    ]
   }
 ]

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -187,6 +187,7 @@ const CHANGE_VALIDATORS = [
   'layoutDuplicateFields',
   'customApplications',
   'flowReferencedElements',
+  'liveChatButtonRoutingType',
 ] as const
 const DEPRECATED_CHANGE_VALIDATORS = ['multipleDefaults'] as const
 export type ChangeValidatorName = (typeof CHANGE_VALIDATORS)[number]

--- a/packages/salesforce-adapter/test/change_validators/live_chat_button_routing_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/live_chat_button_routing_type.test.ts
@@ -48,7 +48,7 @@ describe('live chat button routing type change validator', () => {
         elemID: liveChatButton.elemID,
         severity: 'Warning',
         message: 'Salesforce does not support LiveChatButton with routingType "Omni-Channel"',
-        detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because Salesforce does not support them: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API. To proceed with deployment, update the routingType to a value other than "Omni-Channel" before deploying, here:${liveChatButton.annotations[CORE_ANNOTATIONS.SERVICE_URL]}. After deployment, you can change it back to "Omni-Channel" if required.`,
+        detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because [Salesforce does not support them](https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API). To proceed with deployment, before deploying change the routingType to a value other than "Omni-Channel", [here](${liveChatButton.annotations[CORE_ANNOTATIONS.SERVICE_URL]}). After deployment, you can change it back to "Omni-Channel" if required.`,
       }
       expect(errors[0]).toEqual(expected)
     })

--- a/packages/salesforce-adapter/test/change_validators/live_chat_button_routing_type.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/live_chat_button_routing_type.test.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { Change, CORE_ANNOTATIONS, InstanceElement, toChange } from '@salto-io/adapter-api'
+import liveChatButtonRoutingType from '../../src/change_validators/live_chat_button_routing_type'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import { mockTypes } from '../mock_elements'
+
+describe('live chat button routing type change validator', () => {
+  let liveChatButton: InstanceElement
+  let liveChatButtonChange: Change
+  describe('when there are no LiveChatButton instances with routingType Omni-Channel', () => {
+    beforeEach(() => {
+      liveChatButton = createInstanceElement(
+        {
+          fullName: 'Test liveChatButton',
+          skills: 'skill',
+          routingType: 'Choice',
+        },
+        mockTypes.LiveChatButton,
+      )
+      liveChatButtonChange = toChange({ after: liveChatButton })
+    })
+    it('should not return any errors', async () => {
+      const errors = await liveChatButtonRoutingType([liveChatButtonChange])
+      expect(errors).toBeEmpty()
+    })
+  })
+  describe('when there are LiveChatButton instances with routingType Omni-Channel', () => {
+    beforeEach(() => {
+      liveChatButton = createInstanceElement(
+        {
+          fullName: 'Test liveChatButton',
+          values: {},
+        },
+        mockTypes.LiveChatButton,
+      )
+      liveChatButtonChange = toChange({ after: liveChatButton })
+    })
+    it('should return warning', async () => {
+      const errors = await liveChatButtonRoutingType([liveChatButtonChange])
+      const expected = {
+        elemID: liveChatButton.elemID,
+        severity: 'Warning',
+        message: 'Salesforce does not support LiveChatButton with routingType "Omni-Channel"',
+        detailedMessage: `Cannot deploy LiveChatButton with routingType set to "Omni-Channel" because Salesforce does not support them: https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_livechatbutton.htm?_ga=2.198568300.2106099414.1736670790-665087354.1736070429#:~:text=Chats%20routed%20with%20Omni%2DChannel%20aren%E2%80%99t%20supported%20in%20the%20Metadata%20API. To proceed with deployment, update the routingType to a value other than "Omni-Channel" before deploying, here:${liveChatButton.annotations[CORE_ANNOTATIONS.SERVICE_URL]}. After deployment, you can change it back to "Omni-Channel" if required.`,
+      }
+      expect(errors[0]).toEqual(expected)
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -61,6 +61,7 @@ import {
   OPPORTUNITY_METADATA_TYPE,
   FLOW_FIELD_TYPE_NAMES,
   ASSIGN_TO_REFERENCE,
+  LIVE_CHAT_BUTTON,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -863,6 +864,19 @@ export const mockTypes = {
     },
     fields: {
       fieldItem: { refType: BuiltinTypes.STRING },
+    },
+  }),
+  [LIVE_CHAT_BUTTON]: createMetadataObjectType({
+    annotations: {
+      metadataType: LIVE_CHAT_BUTTON,
+    },
+    fields: {
+      skills: {
+        refType: BuiltinTypes.STRING,
+      },
+      routingType: {
+        refType: BuiltinTypes.STRING,
+      },
     },
   }),
 }


### PR DESCRIPTION
SALTO-6868: CV for LiveChatButton with routingType "Omni-Channel"

---

_Additional context for reviewer_:
Error message format:
<img width="1568" alt="image" src="https://github.com/user-attachments/assets/20e15c3f-0034-4511-866f-123928704f09" />
Error message in Markdown preview:
<img width="828" alt="image" src="https://github.com/user-attachments/assets/41de98e0-4568-4c1b-a52e-eef6264724f5" />

---
_Release Notes_: 
None

---
_User Notifications_: 
None
