### PR TITLE
Avoid failing workspace.close() when bulidWorkspaceState throws an ex…

### DIFF
--- a/packages/workspace/src/workspace/workspace.ts
+++ b/packages/workspace/src/workspace/workspace.ts
@@ -1279,7 +1279,11 @@ export async function loadWorkspace(params: LoadWorkspaceParams): Promise<Worksp
       if (workspaceState !== undefined) {
         // in case that `workspaceState` is currently being built, we'd like to wait until it finishes.
         log.debug('waiting for workspaceState to finish building before closing the workspace')
-        await workspaceState
+        try {
+          await workspaceState
+        } catch (error) {
+          log.warn('failed waiting for workspaceState to finish building with error: %o', error)
+        }
       }
       log.debug('closing the workspace')
       await remoteMapCreator.close()

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -3275,6 +3275,16 @@ salesforce.staticFile staticFileInstance {
 
           await elementsPromise
         })
+
+        it('should close remoteMapCreator even if workspaceState throws', async () => {
+          mockCreate.mockRejectedValue(new Error('error in workspaceState'))
+          await expect(workspace.elements()).rejects.toThrow('error in workspaceState')
+
+          mockCreate.mockClear()
+          await workspace.close()
+          expect(mockCreate).not.toHaveBeenCalled()
+          expect(mockClose).toHaveBeenCalled()
+        })
       })
     })
   })


### PR DESCRIPTION
…ception

Inside `workspace.close()` we do `await workspaceState` , and it should be wrapped with a `try catch` so we will close the remote maps even if the promise of `workspaceState` rejects.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Avoid failing workspace.close() when bulidWorkspaceState throws an exception

---
_User Notifications_: 
None
