### PR TITLE
SALTO-2490 deprecate closeRemoteMapsOfLocation

### DIFF
--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -261,6 +261,9 @@ const closeTmpConnection = async (
   log.debug('closed temporary connection to %s', tmpLocation)
 }
 
+/**
+ * @deprecated use `workspace.close()` instead.
+ */
 export const closeRemoteMapsOfLocation = async (location: string): Promise<boolean> =>
   log.timeDebug(
     async () => {

--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -836,7 +836,9 @@ export const createRemoteMapCreator = (
         close: async (): Promise<void> => {
           // Do nothing - we can not close the connection here
           //  because we share the connection across multiple namespaces
-          log.warn('cannot close connection of remote map with close method - use `workspace.close()` / `remoteMapCreator.close()` instead.')
+          log.warn(
+            'cannot close connection of remote map with close method - use `workspace.close()` / `remoteMapCreator.close()` instead.',
+          )
         },
         isEmpty: async (): Promise<boolean> => {
           if (isNamespaceEmpty === undefined) {

--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -262,7 +262,7 @@ const closeTmpConnection = async (
 }
 
 /**
- * @deprecated use `workspace.close()` instead.
+ * @deprecated use `workspace.close()` / `remoteMapCreator.close()` instead.
  */
 export const closeRemoteMapsOfLocation = async (location: string): Promise<boolean> =>
   log.timeDebug(
@@ -836,7 +836,7 @@ export const createRemoteMapCreator = (
         close: async (): Promise<void> => {
           // Do nothing - we can not close the connection here
           //  because we share the connection across multiple namespaces
-          log.warn('cannot close connection of remote map with close method - use closeRemoteMapsOfLocation')
+          log.warn('cannot close connection of remote map with close method - use `workspace.close()` / `remoteMapCreator.close()` instead.')
         },
         isEmpty: async (): Promise<boolean> => {
           if (isNamespaceEmpty === undefined) {


### PR DESCRIPTION
Deprecating `closeRemoteMapsOfLocation` in favor of `workspace.close()`.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Deprecating `closeRemoteMapsOfLocation` in favor of `workspace.close()`. The deprecated function will be removed from the package's exports on the next release (0.5.1).

---
_User Notifications_: 
None
