### PR TITLE
SALTO-6616: Support namespaced complex types in deploy

### DIFF
--- a/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
+++ b/packages/salesforce-adapter/test/transformers/xml_transformer.test.ts
@@ -284,7 +284,30 @@ describe('XML Transformer', () => {
           )
         })
       })
+      describe('namespaced LightningComponentBundle', () => {
+        beforeEach(async () => {
+          const mockLightningComponentBundleValues = _.clone(mockDefaultValues.LightningComponentBundle)
+          mockLightningComponentBundleValues.fullName = 'namespace__testLightningComponentBundle'
+          _.set(mockLightningComponentBundleValues.targetConfigs.targetConfig[0], 'property', [
+            {
+              name: 'testTrueProp',
+              default: 'true',
+            },
+            {
+              name: 'testFalseProp',
+              default: 'false',
+            },
+          ])
+          await pkg.add(createInstanceElement(mockLightningComponentBundleValues, mockTypes.LightningComponentBundle))
+          zipFiles = await getZipFiles(pkg)
+        })
+        it('should contain metadata xml without the namespace', () => {
+          const filePath = `${packageName}/lwc/testLightningComponentBundle/testLightningComponentBundle.js-meta.xml`
+          expect(zipFiles).toHaveProperty([filePath])
+        })
+      })
     })
+
     describe('with Settings types', () => {
       beforeEach(async () => {
         await pkg.add(createInstanceElement({ fullName: 'TestSettings', testField: true }, mockTypes.TestSettings))
@@ -306,6 +329,7 @@ describe('XML Transformer', () => {
         expect(manifest2.TestSettings.testField).toEqual(true)
       })
     })
+
     describe('content file name override for territory types', () => {
       describe('Territory2Model type', () => {
         beforeEach(async () => {


### PR DESCRIPTION
This is mainly meaningful for SFDX though it might also allow deploying some elements we couldn't before.

---

_Additional context for reviewer_
At least for LWC (though it's likely the case for other "complex types") the files are packaged such that in the file props there is a namespace prefix but in the zip it is not present.

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
