### PR TITLE
SALTO-7268: Fix deployment for contextOption in forms

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -253,7 +253,6 @@ export const DEFAULT_FILTERS = [
   workflowDeployFilter,
   workflowModificationFilter,
   emptyValidatorWorkflowFilter, // must run after workflowFilter
-  formsFilter, // must run before fieldReferencesFilter
   objectTypeIconFilter,
   groupNameFilter,
   workflowGroupsFilter,
@@ -311,6 +310,8 @@ export const DEFAULT_FILTERS = [
   contextDeploymentFilter, // must run after fieldDeploymentFilter
   avatarsFilter, // This must run after contextDeploymentFilter
   jqlReferencesFilter, // must run after assetsObjectFieldConfigurationFilter
+  fieldContextOptionsSplitFilter,
+  formsFilter, // must run before fieldReferencesFilter and after fieldContextOptionsSplitFilter
   fieldReferencesFilter,
   addJsmTypesAsFieldsFilter, // Must run after fieldReferencesFilter
   issueLayoutFilter,
@@ -321,7 +322,6 @@ export const DEFAULT_FILTERS = [
   createReferencesIssueLayoutFilter,
   requestTypelayoutsToValuesFilter, // Must run after createReferencesIssueLayoutFilter
   projectFieldContextOrder,
-  fieldContextOptionsSplitFilter,
   fieldConfigurationDeployment,
   fieldConfigurationDependenciesFilter, // Must run after fieldConfigurationSplitFilter
   missingFieldDescriptionsFilter, // Must run after fieldReferencesFilter

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -157,6 +157,37 @@ export const createFormType = (): {
       },
     },
   })
+
+  const cIdsType = new ObjectType({
+    elemID: new ElemID(JIRA, 'CIds'),
+    fields: {
+      key: {
+        refType: BuiltinTypes.STRING,
+      },
+      value: {
+        refType: new ListType(BuiltinTypes.STRING),
+      },
+    },
+  })
+
+  const coType = new ObjectType({
+    elemID: new ElemID(JIRA, 'Co'),
+    fields: {
+      cIds: {
+        refType: new ListType(cIdsType),
+      },
+    },
+  })
+
+  const conditionType = new ObjectType({
+    elemID: new ElemID(JIRA, 'Condition'),
+    fields: {
+      i: {
+        refType: new MapType(coType),
+      },
+    },
+  })
+
   const formDesignType = new ObjectType({
     elemID: new ElemID(JIRA, 'FormDesign'),
     fields: {
@@ -167,7 +198,7 @@ export const createFormType = (): {
         refType: new ListType(formLayoutItemType),
       },
       conditions: {
-        refType: BuiltinTypes.UNKNOWN,
+        refType: new MapType(conditionType),
       },
       sections: {
         refType: BuiltinTypes.UNKNOWN,
@@ -226,6 +257,9 @@ export const createFormType = (): {
       contentLayoutType,
       formPortalType,
       formPublishType,
+      conditionType,
+      coType,
+      cIdsType,
     ],
   }
 }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -78,7 +78,7 @@ import {
 } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
-import { FIELD_TYPE_NAME } from './filters/fields/constants'
+import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_TYPE_NAME } from './filters/fields/constants'
 import {
   gadgetValuesContextFunc,
   gadgetValueSerialize,
@@ -1306,6 +1306,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: FIELD_TYPE_NAME },
   },
   {
+    src: { field: 'value', parentTypes: ['CIds'] },
+    serializationStrategy: 'id',
+    target: { type: FIELD_CONTEXT_OPTION_TYPE_NAME },
+  },
+  {
     src: { field: 'parentObjectTypeId', parentTypes: [OBJECT_TYPE_TYPE] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',
@@ -1426,8 +1431,19 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   },
 ]
 
+/* Due to changes in the form structure during preDeploy and the resolution of references occurring during deploy,
+ * the resolved reference definitions are unavailable. As a result, we need to explicitly specify the serialization strategy.
+ */
+export const getConditionsLookUpName: GetLookupNameFunc = ({ ref, path }) => {
+  if (path !== undefined && path.typeName === 'Form' && path.getFullName().includes('cIds')) {
+    return ref.value.value.id
+  }
+  return ref
+}
+
 const lookupNameFuncs: GetLookupNameFunc[] = [
   getFieldsLookUpName,
+  getConditionsLookUpName,
   // The second param is needed to resolve references by serializationStrategy
   referenceUtils.generateLookupFunc(referencesRules, defs => new JiraFieldReferenceResolver(defs)),
 ]

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -47,6 +47,7 @@ describe('forms filter', () => {
     beforeEach(async () => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
+      config.fetch.splitFieldContextOptions = true
       const { client: cli } = mockClient(false)
       client = cli
       filter = formsFilter(getFilterParams({ config, client })) as typeof filter

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -24,6 +24,7 @@ import formsFilter from '../../../src/filters/forms/forms'
 import { createEmptyType, getFilterParams, mockClient } from '../../utils'
 import { FORM_TYPE, JIRA, PROJECT_TYPE, REQUEST_TYPE_NAME } from '../../../src/constants'
 import JiraClient from '../../../src/client/client'
+import { FIELD_CONTEXT_OPTION_TYPE_NAME } from '../../../src/filters/fields/constants'
 
 describe('forms filter', () => {
   type FilterType = filterUtils.FilterWith<'onFetch' | 'deploy' | 'onDeploy' | 'preDeploy', FilterResult>
@@ -32,6 +33,11 @@ describe('forms filter', () => {
   let mockAtlassianApiPost: jest.SpyInstance
   let client: JiraClient
   const projectType = createEmptyType(PROJECT_TYPE)
+  const CustomFieldContextOptionType = createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME)
+  const CustomFieldContextOptionInstance = new InstanceElement('project1', CustomFieldContextOptionType, {
+    id: '123456',
+    name: 'project1',
+  })
   let projectInstance: InstanceElement
   let elements: Element[]
   afterEach(() => {
@@ -96,7 +102,17 @@ describe('forms filter', () => {
                 ],
               },
             ],
-            conditions: {},
+            conditions: {
+              8: {
+                i: {
+                  co: {
+                    cIds: {
+                      3: ['123456'],
+                    },
+                  },
+                },
+              },
+            },
             sections: {
               36: {
                 t: 'sh',
@@ -170,7 +186,20 @@ describe('forms filter', () => {
               ],
             },
           ],
-          conditions: {},
+          conditions: {
+            '8@': {
+              i: {
+                co: {
+                  cIds: [
+                    {
+                      key: '3',
+                      value: ['123456'],
+                    },
+                  ],
+                },
+              },
+            },
+          },
           sections: {
             '36@': {
               t: 'sh',
@@ -608,7 +637,12 @@ describe('forms filter', () => {
                 i: {
                   co: {
                     cIds: {
-                      2: ['2'],
+                      2: [
+                        new ReferenceExpression(
+                          CustomFieldContextOptionInstance.elemID,
+                          CustomFieldContextOptionInstance,
+                        ),
+                      ],
                     },
                   },
                 },
@@ -672,6 +706,30 @@ describe('forms filter', () => {
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
       expect(mockAtlassianApiPost).toHaveBeenCalledTimes(1)
+      // Check that it resolved the reference inside conditions
+      expect(mockAtlassianApiPost).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            design: expect.objectContaining({
+              conditions: {
+                '10': {
+                  i: {
+                    co: {
+                      cIds: {
+                        '2': ['123456'],
+                      },
+                    },
+                  },
+                  o: {
+                    sIds: ['1'],
+                  },
+                  t: 'sh',
+                },
+              },
+            }),
+          }),
+        }),
+      )
     })
     it('should modify form', async () => {
       const mockAtlassianApiPut = jest.spyOn(client, 'atlassianApiPut')
@@ -682,6 +740,30 @@ describe('forms filter', () => {
       expect(res.deployResult.errors).toHaveLength(0)
       expect(res.deployResult.appliedChanges).toHaveLength(1)
       expect(mockAtlassianApiPut).toHaveBeenCalledTimes(1)
+      // Check that it resolved the reference inside conditions
+      expect(mockAtlassianApiPut).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            design: expect.objectContaining({
+              conditions: {
+                '10': {
+                  i: {
+                    co: {
+                      cIds: {
+                        '2': ['123456'],
+                      },
+                    },
+                  },
+                  o: {
+                    sIds: ['1'],
+                  },
+                  t: 'sh',
+                },
+              },
+            }),
+          }),
+        }),
+      )
     })
     it('should delete form', async () => {
       const mockAtlassianApiDelete = jest.spyOn(client, 'atlassianApiDelete')
@@ -784,14 +866,20 @@ describe('forms filter', () => {
                 t: 'sh',
                 i: {
                   co: {
-                    cIds: {
-                      2: ['2'],
-                    },
+                    cIds: [
+                      {
+                        key: '3',
+                        value: ['123456'],
+                      },
+                    ],
                   },
                 },
-                o: {
-                  sIds: ['1'],
-                },
+                o: [
+                  {
+                    key: 'sIds',
+                    value: ['1'],
+                  },
+                ],
               },
             },
             sections: {
@@ -837,6 +925,24 @@ describe('forms filter', () => {
       const updatedTime = new Date(formInstance.value.updated)
       const isBetween = updatedTime >= timeBeforeFilter && updatedTime <= timeAfterFilter
       expect(isBetween).toBeTruthy()
+    })
+    it('should return the conditions field to its original structure', async () => {
+      await filter.preDeploy([{ action: 'add', data: { after: formInstance } }])
+      expect(formInstance.value.design.conditions).toEqual({
+        10: {
+          t: 'sh',
+          i: {
+            co: {
+              cIds: {
+                3: ['123456'],
+              },
+            },
+          },
+          o: {
+            sIds: ['1'],
+          },
+        },
+      })
     })
   })
   describe('onDeploy', () => {
@@ -943,6 +1049,12 @@ describe('forms filter', () => {
     it('should delete updated field', async () => {
       await filter.onDeploy([{ action: 'add', data: { after: formInstance } }])
       expect(formInstance.value.updated).toBeUndefined()
+    })
+    it('should return the conditions field to its modified structure', async () => {
+      await filter.onDeploy([{ action: 'add', data: { after: formInstance } }])
+      expect(formInstance.value.design.conditions).toEqual({
+        '10': { i: { co: { cIds: [{ key: '2', value: ['2'] }] } }, o: [{ key: 'sIds', value: ['1'] }], t: 'sh' },
+      })
     })
   })
 })

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -951,6 +951,7 @@ describe('forms filter', () => {
     beforeEach(async () => {
       const config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
       config.fetch.enableJSM = true
+      config.fetch.splitFieldContextOptions = true
       const { client: cli } = mockClient(false)
       client = cli
       filter = formsFilter(getFilterParams({ config, client })) as typeof filter


### PR DESCRIPTION
In this PR I fixed the deployment of forms.

---

_Additional context for reviewer_
We encountered an issue where the absence of a reference to contextOption in forms prevented proper deployment. 2. Additionally, the reference infrastructure didn't support adding references to lists within maps. To resolve this, I made the following changes:

1. Fetch: Adjusted the structure of forms during the fetch process to allow adding references.
2. PreDeploy: Reverted the forms back to their original structure before deployment.
3. OnDeploy: Restored the modified structure.

Adding noise reduction now. 

---
_Release Notes_: 
_jira Adapter_:
* Users can now deploy forms that include contextOption.

---
_User Notifications_: 
_Jira Adapter_:
* The conditions field in the forms NACL has been updated. It has been changed from a map of objects as values to a list of key-value objects. Where possible, IDs have been converted to references.
```
Before:  
    conditions = {  
      "8@" = {  
        i = {  
          co = {  
            cIds = {  
              "2@" = [  
                "61756",  
              ]  
            }  
          }  
        }  
      }  
    }  

After:  
    conditions = {  
      "8@" = {  
        i = {  
          co = {  
            cIds = [  
              {  
                key = "2@"  
                value = [  new ReferenceExpression(...)]  
              },  
            ]  
          }  
        }  
      }  
    }  
```