### PR TITLE
SALTO-7248: Support Automation Deployment with trigger eventFilters

### DIFF
--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -1632,6 +1632,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
         { fieldName: 'webhookToken' },
         // serviceDesk is referenced from the associated request type, so we don't need to keep it in the automation component
         { fieldName: 'serviceDesk' },
+        { fieldName: 'eventFilters' },
       ],
       serviceUrl: '/jira/settings/automation#/rule/{id}',
       idFields: ['name', PROJECTS_FIELD], // idFields is handled separately in automation filter.

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -151,14 +151,13 @@ const generateRuleScopesResources = (instance: InstanceElement, cloudId: string)
   })
 }
 
-const generateRuleScopes = (
-  instance: InstanceElement,
-  cloudId: string | undefined,
-): {
+type RuleScope = {
   ruleScope?: {
     resources: string[]
   }
-} =>
+}
+
+const generateRuleScopes = (instance: InstanceElement, cloudId: string | undefined): RuleScope =>
   cloudId !== undefined
     ? {
         ruleScope: {
@@ -166,6 +165,12 @@ const generateRuleScopes = (
         },
       }
     : {}
+
+const updateTriggerEventFilters = (instance: InstanceElement, cloudId: string | undefined): void => {
+  if (cloudId !== undefined && instance.value.trigger?.value !== undefined) {
+    instance.value.trigger.value.eventFilters = generateRuleScopesResources(instance, cloudId)
+  }
+}
 
 const getUrlPrefix = (cloudId: string | undefined): string =>
   cloudId === undefined
@@ -212,15 +217,24 @@ const awaitSuccessfulImport = async ({
   })
 }
 
+const createAutomationDeploymentInstances = async (
+  instance: InstanceElement,
+  cloudId: string | undefined,
+): Promise<{ resolvedInstance: InstanceElement; ruleScopes: RuleScope }> => {
+  const resolvedInstance = await resolveValues(instance, getLookUpName, undefined, true)
+  // we are currently doing this for all triggers, even though some do not require it. We know create issue and modify issue do, and delete issue does not.
+  updateTriggerEventFilters(resolvedInstance, cloudId)
+  const ruleScopes = generateRuleScopes(resolvedInstance, cloudId)
+  return { resolvedInstance, ruleScopes }
+}
+
 const importAutomation = async (
   instance: InstanceElement,
   client: JiraClient,
   cloudId: string | undefined,
   config: JiraConfig,
 ): Promise<boolean> => {
-  const resolvedInstance = await resolveValues(instance, getLookUpName, undefined, true)
-
-  const ruleScopes = generateRuleScopes(resolvedInstance, cloudId)
+  const { resolvedInstance, ruleScopes } = await createAutomationDeploymentInstances(instance, cloudId)
 
   const data = {
     rules: [
@@ -425,9 +439,7 @@ const updateAutomation = async (
   client: JiraClient,
   cloudId: string | undefined,
 ): Promise<void> => {
-  const resolvedInstance = await resolveValues(instance, getLookUpName, undefined, true)
-
-  const ruleScopes = generateRuleScopes(resolvedInstance, cloudId)
+  const { resolvedInstance, ruleScopes } = await createAutomationDeploymentInstances(instance, cloudId)
 
   const data = !client.isDataCenter
     ? {

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -33,6 +33,7 @@ describe('automationDeploymentFilter', () => {
   let config: JiraConfig
   let client: JiraClient
   let connection: MockInterface<clientUtils.APIConnection>
+  let deploymentTriggerSegment: Value
   const objectSchemaType = new ObjectType({
     elemID: new ElemID(JIRA, OBJECT_SCHEMA_TYPE),
     fields: {
@@ -117,12 +118,41 @@ describe('automationDeploymentFilter', () => {
     instance = new InstanceElement('instance', type, {
       name: 'someName',
       state: 'ENABLED',
+      trigger: {
+        component: 'ACTION',
+        schemaVersion: 1,
+        value: {
+          objectTypeId: new ReferenceExpression(objectTypeInstance.elemID, objectTypeInstance),
+          schemaId: new ReferenceExpression(objectSchemaInstance.elemID, objectSchemaInstance),
+        },
+        children: [],
+        conditions: [],
+      },
       projects: [
         {
           projectId: '1',
         },
       ],
     })
+    deploymentTriggerSegment = {
+      trigger: {
+        component: 'ACTION',
+        schemaVersion: 1,
+        value: {
+          objectTypeId: {
+            id: '35',
+            name: 'objectTypeName',
+          },
+          schemaId: {
+            id: '25',
+            name: 'schemaName',
+            workspaceId: 'w11',
+          },
+        },
+        children: [],
+        conditions: [],
+      },
+    }
   })
 
   describe('onFetch', () => {
@@ -207,11 +237,13 @@ describe('automationDeploymentFilter', () => {
       expect(instance.value.id).toBe(3)
       expect(instance.value.created).toBe(1)
 
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira:cloudId:project/1']
       expect(connection.post).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/import',
         {
           rules: [
             {
+              ...deploymentTriggerSegment,
               name: 'someName',
               state: 'ENABLED',
               projects: [
@@ -229,7 +261,7 @@ describe('automationDeploymentFilter', () => {
           headers: PRIVATE_API_HEADERS,
         },
       )
-
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira:cloudId:project/1']
       expect(connection.put).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/3',
         {
@@ -238,6 +270,7 @@ describe('automationDeploymentFilter', () => {
             created: 1,
             name: 'someName',
             state: 'ENABLED',
+            ...deploymentTriggerSegment,
             projects: [
               {
                 projectId: '1',
@@ -420,6 +453,7 @@ describe('automationDeploymentFilter', () => {
             {
               name: 'someName',
               state: 'ENABLED',
+              ...deploymentTriggerSegment,
               projects: [
                 {
                   projectId: '1',
@@ -440,6 +474,7 @@ describe('automationDeploymentFilter', () => {
           created: 1,
           name: 'someName',
           state: 'ENABLED',
+          ...deploymentTriggerSegment,
           projects: [
             {
               projectId: '1',
@@ -457,7 +492,7 @@ describe('automationDeploymentFilter', () => {
       await filter.deploy([toChange({ after: instance })])
 
       expect(instance.value.id).toBe(3)
-
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira:cloudId:project/1']
       expect(connection.post).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/import',
         {
@@ -465,6 +500,7 @@ describe('automationDeploymentFilter', () => {
             {
               name: 'someName',
               state: 'DISABLED',
+              ...deploymentTriggerSegment,
               projects: [
                 {
                   projectId: '1',
@@ -489,7 +525,7 @@ describe('automationDeploymentFilter', () => {
       connection.post.mockClear()
       connection.post.mockImplementation(async url => createPostMockResponse([])(url))
       await filter.deploy([toChange({ after: instance })])
-
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira::site/cloudId']
       expect(connection.post).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/import',
         {
@@ -497,6 +533,7 @@ describe('automationDeploymentFilter', () => {
             {
               name: 'someName',
               state: 'ENABLED',
+              ...deploymentTriggerSegment,
               ruleScope: {
                 resources: ['ari:cloud:jira::site/cloudId'],
               },
@@ -524,7 +561,7 @@ describe('automationDeploymentFilter', () => {
         ])(url),
       )
       await filter.deploy([toChange({ after: instance })])
-
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira-core::site/cloudId']
       expect(connection.post).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/import',
         {
@@ -532,6 +569,7 @@ describe('automationDeploymentFilter', () => {
             {
               name: 'someName',
               state: 'ENABLED',
+              ...deploymentTriggerSegment,
               projects: [
                 {
                   projectTypeKey: 'business',
@@ -640,7 +678,7 @@ describe('automationDeploymentFilter', () => {
       instance.value.id = 3
       instance.value.created = 1
       await filter.deploy([toChange({ before: instance, after: instance })])
-
+      deploymentTriggerSegment.trigger.value.eventFilters = ['ari:cloud:jira:cloudId:project/1']
       expect(connection.put).toHaveBeenCalledWith(
         '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/3',
         {
@@ -649,6 +687,7 @@ describe('automationDeploymentFilter', () => {
             created: 1,
             name: 'someName',
             state: 'ENABLED',
+            ...deploymentTriggerSegment,
             projects: [
               {
                 projectId: '1',


### PR DESCRIPTION
See jira ticket

---

[Noise reduction](https://github.com/salto-io/salto_private/pull/10304)

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug in automation deployments that prevented them from being triggered

---
_User Notifications_: 
Jira Adapter:
* Removed the eventFilter field in automations' triggers 
