### PR TITLE
SALTO-5299: New properties added to JSM request form 

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -36,7 +36,7 @@ const REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME = Joi.object({
   .unknown(true)
   .required()
 
-const requestTypeRequestFormItemComponent = createSchemeGuard<requestTypeRequestFormItemComponent>(
+const isRequestTypeRequestFormItemComponent = createSchemeGuard<requestTypeRequestFormItemComponent>(
   REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME,
 )
 
@@ -54,12 +54,14 @@ const deleteEmptyProperties = (fields: requestTypeRequestFormData[]): void => {
 const filterEmptyProperties = (elements: Element[]): void => {
   elements
     .filter(e => e.elemID.typeName === REQUEST_FORM_TYPE)
-    .filter(isInstanceElement)
+    .filter(isInstanceElement) 
     .forEach(instance => {
       if (Array.isArray(instance.value.issueLayoutConfig?.items)) {
-        deleteEmptyProperties(
-          instance.value.issueLayoutConfig.items.map((item: requestTypeRequestFormItemComponent) => item.data ?? {}),
-        )
+        instance.value.issueLayoutConfig.items
+          .filter(isRequestTypeRequestFormItemComponent) 
+          .forEach(item => {
+            deleteEmptyProperties([item.data])
+          })
       }
     })
 }

--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -6,19 +6,46 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { Element, isInstanceElement, Value, Values } from '@salto-io/adapter-api'
+import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
+import Joi from 'joi'
 import { ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { fetchRequestTypeDetails } from './layout_service_operations'
 
-const deleteEmptyProperties = (fields: Values[]): void => {
+type requestTypeRequestFormData = {
+  properties?: Record<string, string>
+}
+
+type requestTypeRequestFormItemComponent = {
+  data: requestTypeRequestFormData
+}
+
+const REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME = Joi.object({
+  data: Joi.object({
+    properties: Joi.array()
+      .items(
+        Joi.object({
+          key: Joi.string().required(),
+          value: Joi.string().required(),
+        }),
+      )
+      .required(),
+  }).unknown(true),
+})
+  .unknown(true)
+  .required()
+
+const requestTypeRequestFormItemComponent = createSchemeGuard<requestTypeRequestFormItemComponent>(
+  REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME,
+)
+
+const deleteEmptyProperties = (fields: requestTypeRequestFormData[]): void => {
   fields.forEach(field => {
-    if (field.properties !== undefined) {
-      field.properties = Object.entries(field.properties).filter(([_key, value]) => value !== '')
-      if (field.properties.length === 0) {
+    if (field.properties) {
+      field.properties = Object.fromEntries(Object.entries(field.properties).filter(([_key, value]) => value !== ''))
+      if (Object.keys(field.properties).length === 0) {
         delete field.properties
-      } else {
-        field.properties = Object.fromEntries(field.properties)
       }
     }
   })
@@ -30,7 +57,9 @@ const filterEmptyProperties = (elements: Element[]): void => {
     .filter(isInstanceElement)
     .forEach(instance => {
       if (Array.isArray(instance.value.issueLayoutConfig?.items)) {
-        deleteEmptyProperties(instance.value.issueLayoutConfig.items.map((item: Value) => item.data ?? {}))
+        deleteEmptyProperties(
+          instance.value.issueLayoutConfig.items.map((item: requestTypeRequestFormItemComponent) => item.data ?? {}),
+        )
       }
     })
 }

--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -38,24 +38,22 @@ const isRequestTypeRequestFormItemsComponent = createSchemeGuard<requestTypeRequ
   'invalid request form items component',
 )
 
-const deleteEmptyProperties = (data: requestTypeRequestFormData): void => {
-  if (data.properties) {
-    data.properties = Object.fromEntries(Object.entries(data.properties).filter(([_key, value]) => value !== ''))
-    if (Object.keys(data.properties).length === 0) {
-      delete data.properties
-    }
-  }
-}
-
-const filterEmptyProperties = (elements: Element[]): void => {
+const removePropertiesWithEmptyValues = (elements: Element[]): void => {
   elements
     .filter(e => e.elemID.typeName === REQUEST_FORM_TYPE)
     .filter(isInstanceElement)
     .forEach(instance => {
       const items = instance.value.issueLayoutConfig?.items
       if (isRequestTypeRequestFormItemsComponent(items)) {
-        items.forEach(item => {
-          deleteEmptyProperties(item.data)
+        items.forEach(({ data }) => {
+          if (data.properties) {
+            data.properties = Object.fromEntries(
+              Object.entries(data.properties).filter(([_key, value]) => value !== ''),
+            )
+            if (Object.keys(data.properties).length === 0) {
+              delete data.properties
+            }
+          }
         })
       }
     })
@@ -72,7 +70,9 @@ const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) =>
       getElemIdFunc,
       typeName: REQUEST_FORM_TYPE,
     })
-    filterEmptyProperties(elements)
+
+    removePropertiesWithEmptyValues(elements)
+
     await fetchRequestTypeDetails({
       elements,
       client,

--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -7,7 +7,6 @@
  */
 
 import { Element, isInstanceElement, Value, Values } from '@salto-io/adapter-api'
-import _ from 'lodash'
 import { ISSUE_VIEW_TYPE, REQUEST_FORM_TYPE } from '../../constants'
 import { FilterCreator } from '../../filter'
 import { fetchRequestTypeDetails } from './layout_service_operations'
@@ -25,16 +24,15 @@ const deleteEmptyProperties = (fields: Values[]): void => {
   })
 }
 
-const filterEmptyProperties = (elements: Element[]): Element[] => {
+const filterEmptyProperties = (elements: Element[]): void => {
   elements
     .filter(e => e.elemID.typeName === REQUEST_FORM_TYPE)
     .filter(isInstanceElement)
     .forEach(instance => {
-      if (instance.value.issueLayoutConfig?.items !== undefined && _.isArray(instance.value.issueLayoutConfig.items)) {
+      if (Array.isArray(instance.value.issueLayoutConfig?.items)) {
         deleteEmptyProperties(instance.value.issueLayoutConfig.items.map((item: Value) => item.data ?? {}))
       }
     })
-  return elements
 }
 
 const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) => ({
@@ -48,6 +46,7 @@ const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) =>
       getElemIdFunc,
       typeName: REQUEST_FORM_TYPE,
     })
+    filterEmptyProperties(elements)
     await fetchRequestTypeDetails({
       elements,
       client,
@@ -56,7 +55,6 @@ const filter: FilterCreator = ({ client, config, fetchQuery, getElemIdFunc }) =>
       getElemIdFunc,
       typeName: ISSUE_VIEW_TYPE,
     })
-    filterEmptyProperties(elements)
   },
 })
 

--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -21,47 +21,42 @@ type requestTypeRequestFormItemComponent = {
   data: requestTypeRequestFormData
 }
 
-const REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME = Joi.object({
-  data: Joi.object({
-    properties: Joi.array()
-      .items(
-        Joi.object({
-          key: Joi.string().required(),
-          value: Joi.string().required(),
-        }),
-      )
+const REQUEST_TYPE_REQUEST_FORM_ITEMS_COMPONENT_SCHEME = Joi.array().items(
+  Joi.object({
+    data: Joi.object({
+      properties: Joi.object().pattern(Joi.string(), Joi.string().allow('')).required(),
+    })
+      .unknown(true)
       .required(),
-  }).unknown(true),
-})
-  .unknown(true)
-  .required()
-
-const isRequestTypeRequestFormItemComponent = createSchemeGuard<requestTypeRequestFormItemComponent>(
-  REQUEST_TYPE_REQUEST_FORM_ITEM_COMPONENT_SCHEME,
+  })
+    .unknown(true)
+    .required(),
 )
 
-const deleteEmptyProperties = (fields: requestTypeRequestFormData[]): void => {
-  fields.forEach(field => {
-    if (field.properties) {
-      field.properties = Object.fromEntries(Object.entries(field.properties).filter(([_key, value]) => value !== ''))
-      if (Object.keys(field.properties).length === 0) {
-        delete field.properties
-      }
+const isRequestTypeRequestFormItemsComponent = createSchemeGuard<requestTypeRequestFormItemComponent[]>(
+  REQUEST_TYPE_REQUEST_FORM_ITEMS_COMPONENT_SCHEME,
+  'invalid request form items component',
+)
+
+const deleteEmptyProperties = (data: requestTypeRequestFormData): void => {
+  if (data.properties) {
+    data.properties = Object.fromEntries(Object.entries(data.properties).filter(([_key, value]) => value !== ''))
+    if (Object.keys(data.properties).length === 0) {
+      delete data.properties
     }
-  })
+  }
 }
 
 const filterEmptyProperties = (elements: Element[]): void => {
   elements
     .filter(e => e.elemID.typeName === REQUEST_FORM_TYPE)
-    .filter(isInstanceElement) 
+    .filter(isInstanceElement)
     .forEach(instance => {
-      if (Array.isArray(instance.value.issueLayoutConfig?.items)) {
-        instance.value.issueLayoutConfig.items
-          .filter(isRequestTypeRequestFormItemComponent) 
-          .forEach(item => {
-            deleteEmptyProperties([item.data])
-          })
+      const items = instance.value.issueLayoutConfig?.items
+      if (isRequestTypeRequestFormItemsComponent(items)) {
+        items.forEach(item => {
+          deleteEmptyProperties(item.data)
+        })
       }
     })
 }

--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -13,7 +13,7 @@ import { fetchRequestTypeDetails } from './layout_service_operations'
 
 const deleteEmptyProperties = (fields: Values[]): void => {
   fields.forEach(field => {
-    if (field.properties != null) {
+    if (field.properties !== undefined) {
       field.properties = Object.entries(field.properties).filter(([_key, value]) => value !== '')
       if (field.properties.length === 0) {
         delete field.properties

--- a/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
@@ -532,9 +532,8 @@ describe('requestTypeLayoutsFilter', () => {
       await filter.onFetch(elements)
       const instances = elements.filter(isInstanceElement)
       const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
-      expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].data.properties[0]).toEqual({
-        key: 'jsd.field.helpText',
-        value: 'someText',
+      expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].data.properties).toEqual({
+        'jsd.field.helpText': 'someText',
       })
     })
     it('should remove properties field from request forms if all properties values are empty', async () => {

--- a/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
+++ b/packages/jira-adapter/test/filters/layouts/request_type_request_form.test.ts
@@ -489,5 +489,98 @@ describe('requestTypeLayoutsFilter', () => {
       expect(issueLayoutInstance?.value.issueLayoutConfig.items[1].key).toEqual('innerContentDefaultFieldItemId')
       expect(issueLayoutInstance?.value.issueLayoutConfig.items).toHaveLength(2)
     })
+    it('should remove empty objects in properties if their value is empty', async () => {
+      mockGet.mockImplementation(params => {
+        if (params.url === GQL_BASE_URL_GIRA) {
+          return {
+            data: {
+              issueLayoutConfiguration: {
+                issueLayoutResult: {
+                  id: '3',
+                  name: 'Default Issue Layout',
+                  containers: [
+                    {
+                      containerType: 'REQUEST',
+                      items: {
+                        nodes: [
+                          {
+                            fieldItemId: 'testField1',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                          properties: { 'jsd.field.displayName': '', 'jsd.field.helpText': 'someText' },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          }
+        }
+        throw new Error('Err')
+      })
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
+      expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].data.properties[0]).toEqual({
+        key: 'jsd.field.helpText',
+        value: 'someText',
+      })
+    })
+    it('should remove properties field from request forms if all properties values are empty', async () => {
+      mockGet.mockImplementation(params => {
+        if (params.url === GQL_BASE_URL_GIRA) {
+          return {
+            data: {
+              issueLayoutConfiguration: {
+                issueLayoutResult: {
+                  id: '4',
+                  name: 'Default Issue Layout',
+                  containers: [
+                    {
+                      containerType: 'REQUEST',
+                      items: {
+                        nodes: [
+                          {
+                            fieldItemId: 'testField1',
+                          },
+                        ],
+                      },
+                    },
+                  ],
+                },
+                metadata: {
+                  configuration: {
+                    items: {
+                      nodes: [
+                        {
+                          fieldItemId: 'testField1',
+                          properties: { 'jsd.field.displayName': '', 'jsd.field.helpText': null },
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          }
+        }
+        throw new Error('Err')
+      })
+      await filter.onFetch(elements)
+      const instances = elements.filter(isInstanceElement)
+      const issueLayoutInstance = instances.find(e => e.elemID.typeName === REQUEST_FORM_TYPE)
+      expect(issueLayoutInstance?.value.issueLayoutConfig.items[0].data).not.toHaveProperty('properties')
+    })
   })
 })


### PR DESCRIPTION
Added a new filter to remove empty properties in request forms

---

_Additional context for reviewer_

---
_Release Notes_: 
_Jira_adapter_:
- Added a filter to remove empty properties in request forms in Jira
---
_User Notifications_: 
_Jira_adapter_:
- Upon user next fetch, all empty properties will be removed from the requestType instances