### PR TITLE
SALTO-7275: limit static file name in automations

### DIFF
--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -21,7 +21,7 @@ import {
 import _ from 'lodash'
 import { logger } from '@salto-io/logging'
 import { fetch as fetchUtils, client as clientUtils } from '@salto-io/adapter-components'
-import { collections } from '@salto-io/lowerdash'
+import { collections, hash as hashUtils } from '@salto-io/lowerdash'
 import { createSchemeGuard, fileNameFromNaclCase } from '@salto-io/adapter-utils'
 import Joi from 'joi'
 import { JiraConfig, JspUrls } from './config/config'
@@ -270,6 +270,11 @@ const HTML_RESPONSE_SCHEME = Joi.object({
 
 export const getHTMLStaticFileName = (path: ElemID): string => {
   const pathName = fileNameFromNaclCase(path.getFullName()).split('instance.')
+  const fileName = pathName[1]
+  if (fileName !== undefined && fileName.length > 200) {
+    // the file name has a 255 character limit, and there are some additional chars added by the static file
+    return fileName.substring(0, 160).concat(hashUtils.sizedHash({ input: fileName, evenOutputLength: 40 }))
+  }
   return pathName[1]
 }
 

--- a/packages/jira-adapter/src/utils.ts
+++ b/packages/jira-adapter/src/utils.ts
@@ -268,12 +268,15 @@ const HTML_RESPONSE_SCHEME = Joi.object({
   data: Joi.string().required(),
 }).unknown(true)
 
-export const getHTMLStaticFileName = (path: ElemID): string => {
+export const getHTMLStaticFileName = (path: ElemID): string | undefined => {
   const pathName = fileNameFromNaclCase(path.getFullName()).split('instance.')
+  if (pathName.length < 2 || pathName[1] === undefined) {
+    return undefined
+  }
   const fileName = pathName[1]
-  if (fileName !== undefined && fileName.length > 200) {
+  if (fileName.length > 200) {
     // the file name has a 255 character limit, and there are some additional chars added by the static file
-    return fileName.substring(0, 160).concat(hashUtils.sizedHash({ input: fileName, evenOutputLength: 40 }))
+    return fileName.substring(0, 160).concat(hashUtils.toSha1(fileName.substring(160)))
   }
   return pathName[1]
 }

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -306,6 +306,14 @@ describe('automationStructureFilter', () => {
       expect(instance.value.components[9].value.body.filepath).toBe('jira/Automation/.html')
       expect(instance.value.components[9].value.body.internalContent).toBe(HTML_BODY_TEST)
     })
+    it('static file name for html content should not be size limited', async () => {
+      const longString = 'a'.repeat(3000)
+      const longNamedInstance = new InstanceElement(longString, type)
+      longNamedInstance.value = instance.value
+      await filter.onFetch([longNamedInstance])
+      expect(longNamedInstance.value.components[9].value.body).toBeInstanceOf(StaticFile)
+      expect(longNamedInstance.value.components[9].value.body.filepath.length).toBeLessThan(255)
+    })
 
     it('should not throw if wrong structure', async () => {
       const exceptionInstance = new InstanceElement('instance', type, {

--- a/packages/lowerdash/src/hash.ts
+++ b/packages/lowerdash/src/hash.ts
@@ -9,12 +9,4 @@ import { createHash } from 'crypto'
 
 export const toMD5 = (buffer: Buffer | string): string => createHash('md5').update(buffer).digest('hex')
 
-// evenOutputLength must be even
-export const sizedHash = ({ input, evenOutputLength }: { input: string; evenOutputLength: number }): string => {
-  if (evenOutputLength % 2 !== 0) {
-    throw new Error('Output length must be even')
-  }
-  return createHash('shake256', { outputLength: evenOutputLength / 2 })
-    .update(input)
-    .digest('hex')
-}
+export const toSha1 = (input: string): string => createHash('sha1').update(input).digest('hex')

--- a/packages/lowerdash/src/hash.ts
+++ b/packages/lowerdash/src/hash.ts
@@ -8,3 +8,13 @@
 import { createHash } from 'crypto'
 
 export const toMD5 = (buffer: Buffer | string): string => createHash('md5').update(buffer).digest('hex')
+
+// evenOutputLength must be even
+export const sizedHash = ({ input, evenOutputLength }: { input: string; evenOutputLength: number }): string => {
+  if (evenOutputLength % 2 !== 0) {
+    throw new Error('Output length must be even')
+  }
+  return createHash('shake256', { outputLength: evenOutputLength / 2 })
+    .update(input)
+    .digest('hex')
+}

--- a/packages/lowerdash/test/hash.test.ts
+++ b/packages/lowerdash/test/hash.test.ts
@@ -6,9 +6,13 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { toMD5 } from '../src/hash'
+import { sizedHash, toMD5 } from '../src/hash'
 
 describe('Hash', () => {
   it('should calculate MD5 from buffer', () =>
     expect(toMD5(Buffer.from('ZOMG'))).toEqual('4dc55a74daa147a028360ee5687389d7'))
+  it('should properly create a sized hash', () =>
+    expect(sizedHash({ input: 'Text for hashing', evenOutputLength: 4 })).toEqual('3fc5'))
+  it('should throw an error when output length is not even', () =>
+    expect(() => sizedHash({ input: 'Text for hashing', evenOutputLength: 5 })).toThrow())
 })

--- a/packages/lowerdash/test/hash.test.ts
+++ b/packages/lowerdash/test/hash.test.ts
@@ -6,13 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { sizedHash, toMD5 } from '../src/hash'
+import { toMD5, toSha1 } from '../src/hash'
 
 describe('Hash', () => {
   it('should calculate MD5 from buffer', () =>
     expect(toMD5(Buffer.from('ZOMG'))).toEqual('4dc55a74daa147a028360ee5687389d7'))
-  it('should properly create a sized hash', () =>
-    expect(sizedHash({ input: 'Text for hashing', evenOutputLength: 4 })).toEqual('3fc5'))
-  it('should throw an error when output length is not even', () =>
-    expect(() => sizedHash({ input: 'Text for hashing', evenOutputLength: 5 })).toThrow())
+  it('should calculate sha1 from string', () =>
+    expect(toSha1('Text for hashing')).toEqual('a412b9956ea4e3688ec59fd1a07b568eb9b4b6af'))
 })


### PR DESCRIPTION
Fixed a limitation on the file size name
---

The proper fix should be done IMO in the static file code, but doing this for speed, might remove it later on

---
_Release Notes_: 
Jira Adapter: 
* Fixed a bug that caused fetch failures for envs with automations that are connected to many projects

---
_User Notifications_: 
Jira Adapter:
* for some users the path of static files for HTML automation content might change
