### PR TITLE
SALTO-5481: add reference to support address

### DIFF
--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -217,7 +217,6 @@ export const DEFAULT_FILTERS = [
   organizationsFilter,
   tagsFilter,
   localeFilter,
-
   customStatus,
   guideAddBrandToArticleTranslation,
   macroFilter,

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -217,8 +217,7 @@ export const DEFAULT_FILTERS = [
   organizationsFilter,
   tagsFilter,
   localeFilter,
-  // supportAddress should run before referencedIdFieldsFilter
-  supportAddress,
+
   customStatus,
   guideAddBrandToArticleTranslation,
   macroFilter,
@@ -249,6 +248,8 @@ export const DEFAULT_FILTERS = [
   // fieldReferencesFilter should be after:
   // usersFilter, macroAttachmentsFilter, tagsFilter, guideLocalesFilter, customObjectFilter, customObjectFieldFilter
   fieldReferencesFilter,
+  // supportAddress should run before referencedIdFieldsFilter and after fieldReferencesFilter
+  supportAddress,
   // listValuesMissingReferencesFilter should be after fieldReferencesFilter
   listValuesMissingReferencesFilter,
   appInstallationsFilter,

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { Element, isInstanceElement, isReferenceExpression, isTemplateExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
@@ -251,7 +251,15 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
     lookupIndexName: 'value',
   },
   email: {
-    serialize: ({ ref }) => (isInstanceElement(ref.value) ? ref.value.value.email : ref.value),
+    serialize: ({ ref }) => {
+      if (isInstanceElement(ref.value)) {
+        const val = ref.value.value.email
+        return isTemplateExpression(val)
+          ? val.parts.map(part => (isReferenceExpression(part) ? part.value : part)).join('')
+          : val
+      }
+      return ref.value
+    },
     lookup: val => val,
     lookupIndexName: 'email',
   },

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { Element, isInstanceElement, isReferenceExpression, isTemplateExpression } from '@salto-io/adapter-api'
+import { Element, isInstanceElement, isTemplateExpression } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import { GetLookupNameFunc } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../filter'
@@ -47,6 +47,7 @@ import {
   ZendeskMissingReferenceStrategyName,
 } from './references/missing_references'
 import { ZendeskUserConfig } from '../user_config'
+import { replaceIfReferenceExpression } from './support_address'
 
 const { neighborContextGetter } = referenceUtils
 
@@ -253,10 +254,9 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
   email: {
     serialize: ({ ref }) => {
       if (isInstanceElement(ref.value)) {
+        // the email in the support address is turned to a template expression, we need to serialize this too.
         const val = ref.value.value.email
-        return isTemplateExpression(val)
-          ? val.parts.map(part => (isReferenceExpression(part) ? part.value : part)).join('')
-          : val
+        return isTemplateExpression(val) ? val.parts.map(replaceIfReferenceExpression).join('') : val
       }
       return ref.value
     },

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -297,7 +297,7 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
 
 export type ReferenceContextStrategyName =
   | 'neighborField'
-  | 'allowlistedNeighborField'
+  | 'allowListedNeighborField'
   | 'allowlistedNeighborSubject'
   | 'neighborType'
   | 'parentSubject'
@@ -314,7 +314,7 @@ export const contextStrategyLookup: Record<ReferenceContextStrategyName, referen
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
   // We use allow lists because there are types we don't support (such as organization or requester)
   // and they'll end up being false positives
-  allowlistedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: allowListLookupType }),
+  allowListedNeighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: allowListLookupType }),
   allowlistedNeighborSubject: neighborContextFunc({
     contextFieldName: 'subject',
     contextValueMapper: allowListLookupType,
@@ -957,7 +957,7 @@ const firstIterationFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[
       parentTypes: ['trigger__conditions__all', 'trigger__conditions__any'],
     },
     serializationStrategy: 'email',
-    target: { typeContext: 'allowlistedNeighborField' },
+    target: { typeContext: 'allowListedNeighborField' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
 ]
@@ -985,7 +985,7 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
       parentTypes: ['trigger__actions'],
     },
     serializationStrategy: 'idString',
-    target: { typeContext: 'allowlistedNeighborField' },
+    target: { typeContext: 'allowListedNeighborField' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
 
@@ -1038,7 +1038,7 @@ const commonFieldNameToTypeMappingDefs: ZendeskFieldReferenceDefinition[] = [
         'queue__definition__any',
       ],
     },
-    target: { typeContext: 'allowlistedNeighborField' },
+    target: { typeContext: 'allowListedNeighborField' },
     zendeskMissingRefStrategy: 'typeAndValue',
   },
   {

--- a/packages/zendesk-adapter/src/filters/support_address.ts
+++ b/packages/zendesk-adapter/src/filters/support_address.ts
@@ -75,7 +75,8 @@ const turnEmailToTemplateExpression = ({
   )
 }
 
-const replaceIfReferenceExpression = (part: TemplatePart): string => (isReferenceExpression(part) ? part.value : part)
+export const replaceIfReferenceExpression = (part: TemplatePart): string =>
+  isReferenceExpression(part) ? part.value : part
 
 const templateToEmail = (
   change: Change<InstanceElement>,


### PR DESCRIPTION
add reference to support address

---

_Additional context for reviewer_

---
_Release Notes_: 
zendesk: 
* add references to `support_address` in triggers.

---
_User Notifications_: 
zendesk: 
* add references to `support_address` in triggers.