### PR TITLE
SALTO-7240: remove noisy log from AssetsObjectFieldConfigurationReferencesFilter

### DIFF
--- a/packages/jira-adapter/src/filters/assets/assets_object_field_configuration_references.ts
+++ b/packages/jira-adapter/src/filters/assets/assets_object_field_configuration_references.ts
@@ -38,7 +38,6 @@ const ASSETS_OBJECT_FIELD_CONFIGURATION_SCHEME = Joi.object({
 
 const isAssetsObjectFieldConfiguration = createSchemeGuard<assetObjectFieldConfiguration>(
   ASSETS_OBJECT_FIELD_CONFIGURATION_SCHEME,
-  'Received an invalid assets object field configuration',
 )
 
 const getObjectTypeAttributeReferences = (


### PR DESCRIPTION
_remove noisy logs from AssetsObjectFieldConfigurationReferencesFilter_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
