### PR TITLE
SALTO-7278:  (Bug-fix) Salesforce CBF won't detect modifications of sub-instances and CustomFields

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -600,11 +600,11 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
     const fetchParams = this.userConfig.fetch ?? {}
     this.initializeCustomListFunctions(withChangesDetection)
     const baseQuery = buildMetadataQuery({ fetchParams })
-    const metadataTypeInfosPromise = this.listMetadataTypes(baseQuery)
+    const metadataTypeInfos = await this.client.listMetadataTypes()
     const lastChangeDateOfTypesWithNestedInstances = await getLastChangeDateOfTypesWithNestedInstances({
       client: this.client,
       metadataQuery: buildFilePropsMetadataQuery(baseQuery),
-      metadataTypeInfos: await metadataTypeInfosPromise,
+      metadataTypeInfos,
     })
     const targetedFetchInclude = fetchParams.target
       ? await getMetadataIncludeFromFetchTargets(fetchParams.target, this.elementsSource)
@@ -638,7 +638,9 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
         .filter((namedType): namedType is [string, TypeElement] => namedType[0] !== undefined),
     )
     const metadataMetaType = fetchProfile.isFeatureEnabled('metaTypes') ? MetadataMetaType : undefined
-
+    const metadataTypeInfosPromise = Promise.resolve(
+      metadataTypeInfos.filter(typeInfo => metadataQuery.isTypeMatch(typeInfo.xmlName)),
+    )
     progressReporter.reportProgress({ message: 'Fetching types' })
     const metadataTypes = await this.fetchTypes({
       metadataQuery,
@@ -827,10 +829,6 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
 
   async cancelServiceAsyncTask(input: CancelServiceAsyncTaskInput): Promise<CancelServiceAsyncTaskResult> {
     return this.client.cancelMetadataValidateOrDeployTask(input)
-  }
-
-  private async listMetadataTypes(metadataQuery: MetadataQuery): Promise<MetadataObject[]> {
-    return (await this.client.listMetadataTypes()).filter(info => metadataQuery.isTypeMatch(info.xmlName))
   }
 
   private async fetchTypes({

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -697,6 +697,7 @@ export default class SalesforceClient implements ISalesforceClient {
   @requiresLogin()
   public async listMetadataTypes(): Promise<MetadataObject[]> {
     const describeResult = await this.retryOnBadResponse(() => this.conn.metadata.describe())
+    log.trace('listMetadataTypes result: %s', inspectValue(describeResult, { maxArrayLength: null }))
     this.orgNamespace = describeResult.organizationNamespace
     log.debug('org namespace: %s', this.orgNamespace)
     return flatValues(describeResult.metadataObjects)

--- a/packages/salesforce-adapter/src/last_change_date_of_types_with_nested_instances.ts
+++ b/packages/salesforce-adapter/src/last_change_date_of_types_with_nested_instances.ts
@@ -81,7 +81,9 @@ export const getLastChangeDateOfTypesWithNestedInstances = async ({
   metadataQuery,
   metadataTypeInfos,
 }: GetLastChangeDateOfTypesWithNestedInstancesParams): Promise<LastChangeDateOfTypesWithNestedInstances> => {
-  const knownTypes: Set<string> = new Set(metadataTypeInfos.map(({ xmlName }) => xmlName))
+  const knownTypes: Set<string> = new Set(
+    metadataTypeInfos.flatMap(({ xmlName, childXmlNames }) => (childXmlNames ?? []).concat(xmlName)),
+  )
   const lastChangeDateOfTypeWithNestedInstancesPerParent = async (
     type: TypeWithNestedInstancesPerParent,
     relatedTypes: types.NonEmptyArray<string>,

--- a/packages/salesforce-adapter/test/last_change_data_of_types_with_nested_instances.test.ts
+++ b/packages/salesforce-adapter/test/last_change_data_of_types_with_nested_instances.test.ts
@@ -237,7 +237,7 @@ describe('getLastChangeDateOfTypesWithNestedInstances', () => {
         metadataQuery,
         metadataTypeInfos: [{ xmlName: CUSTOM_OBJECT, childXmlNames: [...CUSTOM_OBJECT_FIELDS, CUSTOM_FIELD] }],
       })
-      expect(listedTypes).toContainValues([...CUSTOM_OBJECT_FIELDS, CUSTOM_FIELD])
+      expect(listedTypes).toContainValues([CUSTOM_OBJECT, ...CUSTOM_OBJECT_FIELDS, CUSTOM_FIELD])
     })
   })
 })

--- a/packages/salesforce-adapter/test/last_change_data_of_types_with_nested_instances.test.ts
+++ b/packages/salesforce-adapter/test/last_change_data_of_types_with_nested_instances.test.ts
@@ -16,6 +16,7 @@ import { mockFileProperties } from './connection'
 import { getLastChangeDateOfTypesWithNestedInstances } from '../src/last_change_date_of_types_with_nested_instances'
 import { buildFilePropsMetadataQuery, buildMetadataQuery } from '../src/fetch_profile/metadata_query'
 import { LastChangeDateOfTypesWithNestedInstances, MetadataQuery } from '../src/types'
+import { CUSTOM_OBJECT_FIELDS } from '../src/fetch_profile/metadata_types'
 
 const { makeArray } = collections.array
 
@@ -229,6 +230,14 @@ describe('getLastChangeDateOfTypesWithNestedInstances', () => {
         Workflow: {},
       }
       expect(lastChangeDateOfTypesWithNestedInstances).toEqual(expected)
+    })
+    it('should list children types', async () => {
+      await getLastChangeDateOfTypesWithNestedInstances({
+        client,
+        metadataQuery,
+        metadataTypeInfos: [{ xmlName: CUSTOM_OBJECT, childXmlNames: [...CUSTOM_OBJECT_FIELDS, CUSTOM_FIELD] }],
+      })
+      expect(listedTypes).toContainValues([...CUSTOM_OBJECT_FIELDS, CUSTOM_FIELD])
     })
   })
 })


### PR DESCRIPTION
Salesforce CBF won't detect modifications of sub-instances and CustomFields

---

This is a regression from https://github.com/salto-io/salto/pull/7024.
1. We didn't take into consideration the `childXmlNames`.
2. The `metadataTypeInfos` input shouldn't be filtered by the MetadataQuery.

---
_Release Notes_: 
_Salesforce Adapter_:
- (Bug-fix) Change Based Fetch won't detect modifications of sub-instances and CustomFields

---
_User Notifications_: 
_None_
