### PR TITLE
[WIP] SALTO-7280: Fix parser bug causing template like strings to be identified as references

### DIFF
--- a/packages/parser/src/utils/template_static_file.ts
+++ b/packages/parser/src/utils/template_static_file.ts
@@ -23,7 +23,8 @@ const createSimpleStringValue = (_context: unknown, tokens: Required<Token>[]): 
 const parseBufferToTemplateExpression = (
   buffer: Buffer,
 ): { templateExpression: TemplateExpression; errors: string[] } => {
-  const tokens = stringLexerFromString(buffer.toString())
+  const contentWithUnescapedTemplates = unescapeTemplateMarker(buffer.toString())
+  const tokens = stringLexerFromString(contentWithUnescapedTemplates)
   const context = { errors: [] as ParseError[], filename: '' }
   const value = createStringValue(context, tokens, createSimpleStringValue)
   const errors = context.errors.map(err => err.detailedMessage)


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
