### PR TITLE
SALTO-7241: Restore Jira types to original ones after deployment 

### DIFF
--- a/packages/jira-adapter/src/adapter.ts
+++ b/packages/jira-adapter/src/adapter.ts
@@ -200,7 +200,7 @@ import contextDefaultValueDeploymentFilter from './filters/fields/context_defaul
 import statusPropertiesReferencesFilter from './filters/workflowV2/status_properties_references'
 import enhancedSearchNoiseReductionFilter from './filters/script_runner/enhanced_search/enhanced_search_noise_filter'
 
-const { getAllElements, addRemainingTypes } = elementUtils.ducktype
+const { getAllElements, addRemainingTypes, restoreInstanceTypeFromDeploy } = elementUtils.ducktype
 const { findDataField } = elementUtils
 const { computeGetArgs } = fetchUtils.resource
 const { getAllInstances } = elementUtils.swagger
@@ -779,11 +779,16 @@ export default class JiraAdapter implements AdapterOperations {
       deployResult: { appliedChanges, errors },
     } = await runner.deploy(changesToDeploy)
 
-    const changesToReturn = [...appliedChanges]
+    const changesToReturn = Array.from(appliedChanges)
     await runner.onDeploy(changesToReturn)
 
-    return {
+    const changesWithRestoredTypes = restoreInstanceTypeFromDeploy({
       appliedChanges: changesToReturn,
+      originalInstanceChanges: changesToDeploy,
+    })
+
+    return {
+      appliedChanges: changesWithRestoredTypes,
       errors,
     }
   }

--- a/packages/jira-adapter/test/adapter.test.ts
+++ b/packages/jira-adapter/test/adapter.test.ts
@@ -65,6 +65,7 @@ jest.mock('@salto-io/adapter-components', () => {
         addRemainingTypes: jest.fn().mockImplementation(() => {
           throw new Error('addRemainingTypes called without a mock')
         }),
+        restoreInstanceTypeFromDeploy: jest.fn().mockImplementation(args => args.appliedChanges),
       },
     },
     openapi: {
@@ -233,6 +234,21 @@ describe('adapter', () => {
       })
 
       expect((getChangeData(appliedChanges[0]) as InstanceElement)?.value.id).toBeUndefined()
+    })
+    it('should restore changes to include their original type', async () => {
+      await adapter.deploy({
+        changeGroup: {
+          groupID: 'group',
+          changes: [
+            toChange({
+              before: new InstanceElement('inst1', fieldConfigurationIssueTypeItemType),
+              after: new InstanceElement('inst1', fieldConfigurationIssueTypeItemType),
+            }),
+          ],
+        },
+        progressReporter: nullProgressReporter,
+      })
+      expect(elements.ducktype.restoreInstanceTypeFromDeploy).toHaveBeenCalled()
     })
   })
   describe('deployModifiers', () => {


### PR DESCRIPTION
Fix a bug causing applied changes to return to core with incorrect types.

---

_Additional context for reviewer_

When deploying ducktype types, we override types for deployment, to make sure fields that are service ids defined this way, so we'll correctly assign the created internal id to the newly created element.
The types created for deployment should be ultimately restored, before returning the applied change to core, as this might cause pending changes, merge errors, and more.

The types creation is done in various of different filters, but I added the type restore in the end of flow of the adapter.

---
_Release Notes_: 

_Jira Adapter_:
- Fix a bug causing merge errors after deployments of new Request Types

---
_User Notifications_: 
None
