### PR TITLE
SALTO-7279: Change elements_cache mergeManager to flush remote maps sequentially

### DIFF
--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -788,7 +788,7 @@ export const createRemoteMapCreator = (
             throw new Error('can not flush a non persistent remote map')
           }
 
-          log.debug('flushing %s', namespace, { wasClearCalled })
+          log.debug('flushing %s, wasClearCalled=%s', namespace, wasClearCalled)
           if (wasClearCalled) {
             await clearImpl(persistentDB, keyPrefix)
             log.debug('cleared persistent db %s', namespace)
@@ -798,7 +798,7 @@ export const createRemoteMapCreator = (
             awu(aggregatedIterable([createTempIterator({ keys: true, values: true })])),
             false,
           )
-          log.debug('finished writing to persistent db %s', namespace)
+          log.debug('finished writing to persistent db %s, writeRes=%s', namespace, writeRes)
           await clearImpl(tmpDB, tempKeyPrefix)
           log.debug('cleared temp db %s', namespace)
           const deleteRes = await batchUpdate(

--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -788,15 +788,19 @@ export const createRemoteMapCreator = (
             throw new Error('can not flush a non persistent remote map')
           }
 
+          log.debug('flushing %s', namespace, { wasClearCalled })
           if (wasClearCalled) {
             await clearImpl(persistentDB, keyPrefix)
+            log.debug('cleared persistent db %s', namespace)
           }
 
           const writeRes = await batchUpdate(
             awu(aggregatedIterable([createTempIterator({ keys: true, values: true })])),
             false,
           )
+          log.debug('finished writing to persistent db %s', namespace)
           await clearImpl(tmpDB, tempKeyPrefix)
+          log.debug('cleared temp db %s', namespace)
           const deleteRes = await batchUpdate(
             awu(delKeys.keys()).map(async key => ({ key, value: key })),
             false,

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -455,9 +455,10 @@ export const createMergeManager = async (
         log.debug(`Started flushing hashes under namespace ${namespace}.`)
         await hashes.set(MERGER_LOCK, FLUSH_IN_PROGRESS)
         await hashes.flush()
-        const hasChanged = (await Promise.all(flushables.map(async f => f.flush()))).some(
-          b => typeof b !== 'boolean' || b,
-        )
+        const hasChanged = await awu(flushables)
+          .map(async f => f.flush())
+          .some(b => typeof b !== 'boolean' || b)
+
         await hashes.delete(MERGER_LOCK)
         await hashes.flush()
         log.debug(`Successfully flushed hashes under namespace ${namespace}.`)

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -462,23 +462,22 @@ export const createMergeManager = async (
             )
 
             try {
-              log.debug(`Started flushing hashes under namespace ${namespace}.`)
               await hashes.set(MERGER_LOCK, FLUSH_IN_PROGRESS)
               await hashes.flush()
               const flushResults = await awu(flushables)
-                .map(async f => f.flush())
+                .map(f => f.flush())
                 .toArray()
               const hasChanged = flushResults.some(b => typeof b !== 'boolean' || b)
 
               await hashes.delete(MERGER_LOCK)
               await hashes.flush()
-              log.debug(`Successfully flushed hashes under namespace ${namespace}.`)
               return hasChanged
             } finally {
               clearTimeout(timeoutId)
             }
           }),
-        `flush ${namespace}`,
+        'mergeManager.flush %s',
+        namespace,
       ),
     ),
     mergeComponents: ensureInitiated(async (cacheUpdate: CacheChangeSetUpdate) =>

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -450,9 +450,9 @@ export const createMergeManager = async (
 
   const mergeManager: ElementMergeManager = {
     clear: ensureInitiated(() => lock.acquire(MERGER_LOCK, clearImpl)),
-    flush: ensureInitiated(
+    flush: ensureInitiated(() =>
       log.timeDebug(
-        () => async () =>
+        () =>
           lock.acquire(MERGER_LOCK, async () => {
             const timeoutId = setTimeout(
               () => {

--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -465,9 +465,10 @@ export const createMergeManager = async (
               log.debug(`Started flushing hashes under namespace ${namespace}.`)
               await hashes.set(MERGER_LOCK, FLUSH_IN_PROGRESS)
               await hashes.flush()
-              const hasChanged = await awu(flushables)
+              const flushResults = await awu(flushables)
                 .map(async f => f.flush())
-                .some(b => typeof b !== 'boolean' || b)
+                .toArray()
+              const hasChanged = flushResults.some(b => typeof b !== 'boolean' || b)
 
               await hashes.delete(MERGER_LOCK)
               await hashes.flush()


### PR DESCRIPTION
* Flush `mergeManager` remote maps sequentially.
* Add logs: timeDebug, a conditional log (triggered if more than 10 minutes have passed), and debug logs during each flushable flush operation

---
_Release Notes_: 
None

---
_User Notifications_: 
None
