### PR TITLE
SALTO-7283: protecting StaticFile from errors of long file path

### DIFF
--- a/packages/adapter-api/package.json
+++ b/packages/adapter-api/package.json
@@ -32,7 +32,8 @@
     "@salto-io/dag": "0.5.0",
     "@salto-io/logging": "0.5.0",
     "@salto-io/lowerdash": "0.5.0",
-    "lodash": "^4.17.21"
+    "lodash": "^4.17.21",
+    "truncate-utf8-bytes": "^1.0.2"
   },
   "devDependencies": {
     "@jest/expect-utils": "^29.7.0",

--- a/packages/adapter-api/src/values.ts
+++ b/packages/adapter-api/src/values.ts
@@ -13,6 +13,7 @@ import { hash as hashUtils } from '@salto-io/lowerdash'
 import { ElemID } from './element_id'
 // There is a real cycle here and alternatively elements.ts should be defined in the same file
 import { Element, ReadOnlyElementsSource, PlaceholderObjectType, TypeElement, isVariable } from './elements'
+import { normalizeFilePathPart } from './utils'
 
 export type PrimitiveValue = string | boolean | number | null | undefined
 
@@ -55,7 +56,8 @@ export class StaticFile {
   private internalContent?: Buffer
   constructor(params: StaticFileParameters) {
     this.isTemplate = params.isTemplate
-    this.filepath = path.normalize(params.filepath)
+    const filePathParts = path.parse(params.filepath)
+    this.filepath = path.normalize(`${filePathParts.dir}/${normalizeFilePathPart(filePathParts.base)}`)
     this.encoding = params.encoding ?? DEFAULT_STATIC_FILE_ENCODING
     if (this.isTemplate === true && params.encoding !== 'utf8') {
       this.encoding = 'utf8'

--- a/packages/adapter-api/test/values.test.ts
+++ b/packages/adapter-api/test/values.test.ts
@@ -158,6 +158,18 @@ describe('Values', () => {
         const SFile = new StaticFile({ filepath: 'some//path.ext', content: Buffer.from('VERY SURPRISING DATA') })
         expect(SFile.filepath).toEqual('some/path.ext')
       })
+      it('should shorten names that are too long', () => {
+        const SFile = new StaticFile({
+          filepath: `some/path/${'a'.repeat(300)}.html`,
+          content: Buffer.from('VERY SURPRISING DATA'),
+        })
+        const filePathParts = SFile.filepath.split('/')
+        expect(filePathParts.length).toEqual(3)
+        expect(filePathParts[0]).toEqual('some')
+        expect(filePathParts[1]).toEqual('path')
+        expect(filePathParts[2].length).toBeLessThanOrEqual(255)
+        expect(filePathParts[2].endsWith('.html')).toBeTruthy()
+      })
       it('should override encoding for templates', () => {
         const SFile = new StaticFile({
           filepath: 'some/path.ext',

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -40,7 +40,6 @@
     "joi": "^17.4.0",
     "lodash": "^4.17.21",
     "object-hash": "^3.0.0",
-    "truncate-utf8-bytes": "^1.0.2",
     "wu": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/adapter-utils/package.json
+++ b/packages/adapter-utils/package.json
@@ -48,7 +48,6 @@
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",
     "@types/object-hash": "^3.0.0",
-    "@types/truncate-utf8-bytes": "^1.0.0",
     "@types/wu": "^2.1.40",
     "eslint": "^9.16.0",
     "jest": "^29.7.0",

--- a/packages/adapter-utils/src/nacl_case_utils.ts
+++ b/packages/adapter-utils/src/nacl_case_utils.ts
@@ -5,19 +5,11 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import path from 'path'
-import truncate from 'truncate-utf8-bytes'
 import invert from 'lodash/invert'
-import { hash as hashUtils } from '@salto-io/lowerdash'
+import { MAX_PATH_LENGTH } from '@salto-io/adapter-api'
 
 const NACL_ESCAPING_SUFFIX_SEPARATOR = '@'
 const NACL_CUSTOM_MAPPING_PREFIX = '_'
-// Windows has the lowest known limit, of 255
-// This can have an effect at a time we add a ~15 chars suffix
-// So we are taking an extra buffer and limit it to 200
-const MAX_PATH_LENGTH = 200
-const MAX_PATH_EXTENSION_LENGTH = 20
-
 const allCapsRegex = /^[A-Z]+$/
 const camelCaseRegex = /[a-z][A-Z]/g
 const allCapsCamelCaseRegex = /[A-Z]([A-Z][a-z])/g
@@ -25,22 +17,6 @@ const allCapsCamelCaseRegex = /[A-Z]([A-Z][a-z])/g
 export const pathNaclCase = (name?: string): string =>
   (name ? name.split(NACL_ESCAPING_SUFFIX_SEPARATOR)[0] : '').slice(0, MAX_PATH_LENGTH)
 
-// Trim part of a file name to comply with filesystem restrictions
-// This assumes the filesystem does not allow path parts to be over
-// MAX_PATH_LENGTH long in byte length
-export const normalizeFilePathPart = (name: string): string => {
-  if (Buffer.byteLength(name) <= MAX_PATH_LENGTH) {
-    return name
-  }
-  const nameHash = hashUtils.toMD5(name)
-  let extension = path.extname(name)
-  if (extension.length > MAX_PATH_EXTENSION_LENGTH || Buffer.byteLength(extension) !== extension.length) {
-    // Heuristic guess - a valid extension must be short and ascii
-    extension = ''
-  }
-  const suffix = `_${nameHash}${extension}`
-  return truncate(name, MAX_PATH_LENGTH - suffix.length).concat(suffix)
-}
 // Current values in this mapping should not be changed
 // Values in the map should be unique
 // Adding more values should be with a leading z as an indication the value has more than one letter

--- a/packages/adapter-utils/test/nacl_case_utils.test.ts
+++ b/packages/adapter-utils/test/nacl_case_utils.test.ts
@@ -11,7 +11,6 @@ import {
   fileNameFromUniqueName,
   invertNaclCase,
   naclCase,
-  normalizeFilePathPart,
   pathNaclCase,
   prettifyName,
 } from '../src/nacl_case_utils'
@@ -144,51 +143,6 @@ describe('naclCase utils', () => {
       })
     })
   })
-
-  describe(`${normalizeFilePathPart.name} func`, () => {
-    describe('With a short path', () => {
-      const shortPaths = ['lalala.txt', 'aבגדe.טקסט', 'noExtension']
-      it('Should remain the same', () => {
-        shortPaths.forEach(path => expect(normalizeFilePathPart(path)).toEqual(path))
-      })
-    })
-    describe('With a very long path', () => {
-      const longPathPrefix = new Array(17).fill('123456שבע0_').join('')
-      const extension = '.extension'
-      const longString = longPathPrefix.concat(extension)
-      const anotherLongString = longPathPrefix.concat('a').concat(extension)
-      it('Should return at exactly 200 chars or less', () => {
-        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength).toBeLessThanOrEqual(200)
-      })
-      it('Should contain the full file extension', () => {
-        expect(normalizeFilePathPart(longString)).toContain(extension)
-      })
-      it('Should maintain difference between different strings', () => {
-        expect(normalizeFilePathPart(longString)).not.toEqual(normalizeFilePathPart(anotherLongString))
-      })
-    })
-    describe('With a very long extension', () => {
-      const extension = new Array(17).fill('1234חמש890_').join('')
-      const longString = 'aaa.'.concat(extension)
-      it('Should return 200 chars or less', () => {
-        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength).toBeLessThanOrEqual(200)
-      })
-      it('Should not contain the full file extension', () => {
-        expect(normalizeFilePathPart(longString)).not.toContain(extension)
-      })
-    })
-    describe('With a short non ascii extension', () => {
-      const extension = '.סיומת'
-      const longString = new Array(17).fill('1234חמש890_').join('').concat(extension)
-      it('Should return 200 chars or less', () => {
-        expect(Buffer.from(normalizeFilePathPart(longString)).byteLength).toBeLessThanOrEqual(200)
-      })
-      it('Should not contain the full file extension', () => {
-        expect(normalizeFilePathPart(longString)).not.toContain(extension)
-      })
-    })
-  })
-
   describe(`${fileNameFromNaclCase.name} func`, () => {
     it('should return empty string for empty input', () => {
       expect(fileNameFromNaclCase('')).toEqual('')

--- a/packages/okta-adapter/src/filters/brand_customizations.ts
+++ b/packages/okta-adapter/src/filters/brand_customizations.ts
@@ -14,6 +14,7 @@ import {
   isReferenceExpression,
   ReferenceExpression,
   StaticFile,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import {
   TemplateExtractionFunc,
@@ -22,7 +23,6 @@ import {
   getParent,
   inspectValue,
   mergeDistinctReferences,
-  normalizeFilePathPart,
   parseTagsFromHtml,
 } from '@salto-io/adapter-utils'
 import { parserUtils } from '@salto-io/parser'

--- a/packages/okta-adapter/src/logo.ts
+++ b/packages/okta-adapter/src/logo.ts
@@ -20,16 +20,11 @@ import {
   isAdditionOrModificationChange,
   isRemovalChange,
   isStaticFile,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import FormData from 'form-data'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import {
-  getParent,
-  getParents,
-  fileNameFromNaclCase,
-  normalizeFilePathPart,
-  pathNaclCase,
-} from '@salto-io/adapter-utils'
+import { getParent, getParents, fileNameFromNaclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import OktaClient from './client/client'
 import { getOktaError } from './deprecated_deployment'
 import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA } from './constants'

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -23,6 +23,7 @@ import {
   StaticFile,
   TemplateExpression,
   TemplatePart,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import {
   applyFunctionToChangeData,
@@ -30,7 +31,6 @@ import {
   ERROR_MESSAGES,
   extractTemplate,
   getParent,
-  normalizeFilePathPart,
   replaceTemplatesWithValues,
   resolveTemplates,
 } from '@salto-io/adapter-utils'

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -13,7 +13,6 @@ import { resolveValues } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
 import {
   getParent,
-  normalizeFilePathPart,
   replaceTemplatesWithValues,
   safeJsonStringify,
   inspectValue,
@@ -38,6 +37,7 @@ import {
   TemplatePart,
   UnresolvedReference,
   Values,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import ZendeskClient from '../../client/client'
 import { BRAND_TYPE_NAME, ZENDESK } from '../../constants'

--- a/packages/zendesk-adapter/src/filters/brand_logo.ts
+++ b/packages/zendesk-adapter/src/filters/brand_logo.ts
@@ -22,16 +22,10 @@ import {
   SaltoError,
   StaticFile,
   isObjectType,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import { elements as elementsUtils, fetch as fetchUtils, client as clientUtils } from '@salto-io/adapter-components'
-import {
-  naclCase,
-  safeJsonStringify,
-  getParent,
-  normalizeFilePathPart,
-  pathNaclCase,
-  inspectValue,
-} from '@salto-io/adapter-utils'
+import { naclCase, safeJsonStringify, getParent, pathNaclCase, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import FormData from 'form-data'
 import { collections } from '@salto-io/lowerdash'

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -13,10 +13,11 @@ import {
   ReferenceExpression,
   isStaticFile,
   StaticFile,
+  normalizeFilePathPart,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { elements as elementsUtils } from '@salto-io/adapter-components'
-import { getParent, naclCase, normalizeFilePathPart, pathNaclCase } from '@salto-io/adapter-utils'
+import { getParent, naclCase, pathNaclCase } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { DAG } from '@salto-io/dag'
 import { collections } from '@salto-io/lowerdash'

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -25,7 +25,13 @@ import {
   StaticFile,
   normalizeFilePathPart,
 } from '@salto-io/adapter-api'
-import { naclCase, safeJsonStringify, pathNaclCase, references, inspectValue   createSaltoElementError,
+import {
+  naclCase,
+  safeJsonStringify,
+  pathNaclCase,
+  references,
+  inspectValue,
+  createSaltoElementError,
   ERROR_MESSAGES,
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'

--- a/packages/zendesk-adapter/src/filters/macro_attachments.ts
+++ b/packages/zendesk-adapter/src/filters/macro_attachments.ts
@@ -23,15 +23,9 @@ import {
   ReferenceExpression,
   SaltoElementError,
   StaticFile,
-} from '@salto-io/adapter-api'
-import {
   normalizeFilePathPart,
-  naclCase,
-  safeJsonStringify,
-  pathNaclCase,
-  references,
-  inspectValue,
-  createSaltoElementError,
+} from '@salto-io/adapter-api'
+import { naclCase, safeJsonStringify, pathNaclCase, references, inspectValue   createSaltoElementError,
   ERROR_MESSAGES,
 } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'

--- a/yarn.lock
+++ b/yarn.lock
@@ -4103,7 +4103,6 @@ __metadata:
     "@types/jest": ^29.5.12
     "@types/lodash": ^4.14.168
     "@types/object-hash": ^3.0.0
-    "@types/truncate-utf8-bytes": ^1.0.0
     "@types/wu": ^2.1.40
     domhandler: ^4.2.2
     eslint: ^9.16.0
@@ -6146,13 +6145,6 @@ __metadata:
   version: 4.0.0
   resolution: "@types/tough-cookie@npm:4.0.0"
   checksum: 454fa8d4d64532992274ebf2ff5ea0061b0dd32a2282255a3e793f04a8b64a9c4c1f9e0f4ed83c514c852b7b604d69336c66c80de4a857cb41a81e9572981e7f
-  languageName: node
-  linkType: hard
-
-"@types/truncate-utf8-bytes@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "@types/truncate-utf8-bytes@npm:1.0.0"
-  checksum: df4d452de2f0c9c0811dfd965f2a2e2ed463a3a9836d5504cad766308a40f5e9d6fa14281ab0d960690d1ff2a16dd04b6bdd78b7ff2cb99febfe71cec900d391
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4003,6 +4003,7 @@ __metadata:
     jest: ^29.7.0
     lodash: ^4.17.21
     prettier: 3.2.5
+    truncate-utf8-bytes: ^1.0.2
     ts-jest: ^29.2.0
     tsc-watch: ^2.2.1
     turbo: ^2.0.6
@@ -4114,7 +4115,6 @@ __metadata:
     lodash: ^4.17.21
     object-hash: ^3.0.0
     prettier: 3.2.5
-    truncate-utf8-bytes: ^1.0.2
     ts-jest: ^29.2.0
     tsc-watch: ^2.2.1
     turbo: ^2.0.6


### PR DESCRIPTION
Added protection for StaticFile. Sometimes, the file name provided was too long, and the file creation would have failed (there is a max limit on file name).

---

I used an existing function that adds a hash to maintain uniqueness.

I split the PR into two commits- the first one is for moving a call from adapter-utils to adapter-api, the second one is the actual fix 

The existing implementation set the limit to 200. Though a good practice I wonder if it should be set to 255 to avoid noise of changing existing files

---
_Release Notes_: 
Adapters Infra:
* StaticFile will no longer fail due to a long file path

---
_User Notifications_: 
All adapters:
* static files with file name longer than 200 chars will be changed