### PR TITLE
SALTO-7137: Fix assignment fields handler - array fields

### DIFF
--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -16,7 +16,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
     global: {
       statements: 97.8,
       branches: 88.06,
-      functions: 92.6,
+      functions: 92.31,
       lines: 97.6,
     },
   },

--- a/packages/microsoft-security-adapter/src/config/assignment_fields.ts
+++ b/packages/microsoft-security-adapter/src/config/assignment_fields.ts
@@ -27,8 +27,9 @@ export type AssignmentFieldRuleWithFallback =
       fallbackValue: unknown
     }
 
+export type IntuneAssignmentsField = typeof intuneConstants.ASSIGNMENTS_FIELD_NAME
 export type IntuneAssignmentsFieldNamesConfig = Partial<
-  Record<typeof intuneConstants.ASSIGNMENTS_FIELD_NAME, AssignmentFieldRuleWithoutFallback>
+  Record<IntuneAssignmentsField, AssignmentFieldRuleWithoutFallback>
 >
 export type ConditionalAccessPolicyAssignmentFieldNamesConfig = Partial<
   Record<ConditionalAccessPolicyAssignmentField, AssignmentFieldRuleWithFallback>

--- a/packages/microsoft-security-adapter/src/config/index.ts
+++ b/packages/microsoft-security-adapter/src/config/index.ts
@@ -12,5 +12,6 @@ export {
   AssignmentFieldsConfig,
   ConditionalAccessPolicyAssignmentField,
   ConditionalAccessPolicyAssignmentFieldNamesConfig,
+  IntuneAssignmentsField,
   IntuneAssignmentsFieldNamesConfig,
 } from './assignment_fields'

--- a/packages/microsoft-security-adapter/test/fix_elements/assignment_fields_handler.test.ts
+++ b/packages/microsoft-security-adapter/test/fix_elements/assignment_fields_handler.test.ts
@@ -50,29 +50,32 @@ describe('replaceGroupsDomainHandler', () => {
           },
         }
       })
-      describe.each([undefined, []])('when the instance assignments field equals %s', assignments => {
+
+      describe('when the instance assignments field equals []', () => {
         it('should do nothing', async () => {
           const clonedInstance = intuneApplicationInstance.clone()
-          clonedInstance.value.assignments = assignments
+          clonedInstance.value.assignments = []
           const result = await handler([clonedInstance])
           expect(result).toEqual({ fixedElements: [], errors: [] })
         })
       })
 
       describe('when the instance assignments field is not empty', () => {
-        it('should omit the assignments field', async () => {
+        it('should replace the field value with an empty array', async () => {
           const clonedInstance = intuneApplicationInstance.clone()
           clonedInstance.value.assignments = [{ id: 'testAssignment' }]
+          const expectedInstance = intuneApplicationInstance.clone()
+          expectedInstance.value.assignments = []
           const result = await handler([clonedInstance])
           expect(result).toEqual({
-            fixedElements: [intuneApplicationInstance],
+            fixedElements: [expectedInstance],
             errors: [
               {
                 elemID: intuneApplicationInstance.elemID,
                 severity: 'Info',
                 message: 'Changes were made to assignment-related fields',
                 detailedMessage:
-                  'Changes were made to assignment-related fields according to the assignmentFieldsStrategy configuration:\n — Field "assignments" was omitted',
+                  'Changes were made to assignment-related fields according to the assignmentFieldsStrategy configuration:\n — Field "assignments" was replaced with []',
               },
             ],
           })
@@ -167,22 +170,33 @@ describe('replaceGroupsDomainHandler', () => {
             }
           })
 
-          it('should omit the field', async () => {
-            const expectedInstance = entraConditionalAccessPolicy.clone()
-            delete expectedInstance.value.conditions.applications.excludeApplications
+          describe.each([undefined, []])('when the field value is %o', value => {
+            it('should do nothing', async () => {
+              const clonedInstance = entraConditionalAccessPolicy.clone()
+              clonedInstance.value.conditions.applications.excludeApplications = value
+              const result = await handler([clonedInstance])
+              expect(result).toEqual({ fixedElements: [], errors: [] })
+            })
+          })
 
-            const result = await handler([entraConditionalAccessPolicy])
-            expect(result).toEqual({
-              fixedElements: [expectedInstance],
-              errors: [
-                {
-                  elemID: entraConditionalAccessPolicy.elemID,
-                  severity: 'Info',
-                  message: 'Changes were made to assignment-related fields',
-                  detailedMessage:
-                    'Changes were made to assignment-related fields according to the assignmentFieldsStrategy configuration:\n — Field "conditions.applications.excludeApplications" was omitted',
-                },
-              ],
+          describe('when the specified field is not empty', () => {
+            it('should omit the field', async () => {
+              const expectedInstance = entraConditionalAccessPolicy.clone()
+              delete expectedInstance.value.conditions.applications.excludeApplications
+
+              const result = await handler([entraConditionalAccessPolicy])
+              expect(result).toEqual({
+                fixedElements: [expectedInstance],
+                errors: [
+                  {
+                    elemID: entraConditionalAccessPolicy.elemID,
+                    severity: 'Info',
+                    message: 'Changes were made to assignment-related fields',
+                    detailedMessage:
+                      'Changes were made to assignment-related fields according to the assignmentFieldsStrategy configuration:\n — Field "conditions.applications.excludeApplications" was omitted',
+                  },
+                ],
+              })
             })
           })
         })


### PR DESCRIPTION
There's a bug in the assignment fields handler for Intune types **on modification**:
The fixer simply deletes the `assignments` fields, which is considered as a modification to that field (when we match it against our [deploy condition for Intune assignments](https://github.com/salto-io/salto/blob/2a6890d7ddae3b682b165a95727f320be58fd776/packages/microsoft-security-adapter/src/definitions/deploy/intune/utils/assignments.ts#L40) field). Therefore, we try to deploy the `assignments` field with an undefined value - which results in an error.

This PR specifically set an `emptyValue` of [] for intune assignments.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
