### PR TITLE
SALTO-7223: clean leftover usages of error messages

### DIFF
--- a/packages/cli/e2e_test/helpers/salesforce.ts
+++ b/packages/cli/e2e_test/helpers/salesforce.ts
@@ -114,7 +114,7 @@ export const nullProgressReporter: DeployProgressReporter = {
 }
 
 const errorToString = (error: SaltoError | SaltoElementError): string =>
-  `[${error.severity}] ${error.message}${isSaltoElementError(error) ? error.elemID.getFullName() : ''}`
+  `[${error.severity}] ${error.detailedMessage}${isSaltoElementError(error) ? error.elemID.getFullName() : ''}`
 
 export const addElements = async <T extends InstanceElement | ObjectType>(
   client: SalesforceClient,

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -985,7 +985,7 @@ const createFetchChanges = async ({
 
   const errorMessages = await awu(configsMerge.errors.entries())
     .flatMap(err => err.value)
-    .map(err => err.message)
+    .map(err => err.detailedMessage)
     .toArray()
   if (errorMessages.length !== 0) {
     throw new Error(`Received configuration merge errors: ${errorMessages.join(', ')}`)

--- a/packages/lang-server/src/diagnostics.ts
+++ b/packages/lang-server/src/diagnostics.ts
@@ -44,7 +44,7 @@ export const getDiagnostics = async (workspace: EditorWorkspace): Promise<Worksp
           return {
             filename: range.filename,
             severity: err.severity,
-            msg: err.message,
+            msg: err.detailedMessage,
             range: {
               start: range.start,
               end: range.end,

--- a/packages/lang-server/test/workspace.ts
+++ b/packages/lang-server/test/workspace.ts
@@ -50,7 +50,7 @@ export const mockErrors = (errors: SaltoError[], parseErrors: parser.ParseError[
   merge: [],
   parse: parseErrors,
   validation: errors.map(err => ({ elemID: new ElemID('test'), error: '', ...err })),
-  strings: () => errors.map(err => err.message),
+  strings: () => errors.map(err => err.detailedMessage),
 })
 
 const mockDirStore = <T extends dirStore.ContentType>(files: Record<string, T> = {}): dirStore.DirectoryStore<T> => {

--- a/packages/parser/src/parser/functions.ts
+++ b/packages/parser/src/parser/functions.ts
@@ -31,7 +31,7 @@ export class MissingFunctionError implements SaltoError {
   }
 
   toString(): string {
-    return this.message
+    return this.detailedMessage
   }
 }
 

--- a/packages/parser/test/parser/functions.test.ts
+++ b/packages/parser/test/parser/functions.test.ts
@@ -12,8 +12,9 @@ describe('Functions', () => {
     it('should show correct message and severity', () => {
       const missus = new MissingFunctionError('ZOMG')
       expect(missus.message).toEqual('Element has invalid NaCl content')
+      expect(missus.detailedMessage).toEqual("Invalid function name 'ZOMG'")
       expect(missus.severity).toEqual('Error')
-      expect(missus.toString()).toEqual(missus.message)
+      expect(missus.toString()).toEqual(missus.detailedMessage)
     })
   })
   describe('Factory', () => {

--- a/packages/workspace/src/merger/index.ts
+++ b/packages/workspace/src/merger/index.ts
@@ -79,7 +79,7 @@ export const mergeElements = async (elements: AsyncIterable<Element>): Promise<M
     log.warn(
       `All merge errors:\n${(
         await awu(errors.values())
-          .flatMap(elemErrs => elemErrs.map(e => e.message))
+          .flatMap(elemErrs => elemErrs.map(e => e.detailedMessage))
           .toArray()
       ).join('\n')}`,
     )
@@ -93,14 +93,14 @@ export const mergeSingleElement = async <T extends Element>(elementParts: T[]): 
 
   const errorMessages = await awu(mergeRes.errors.entries())
     .flatMap(err => err.value)
-    .map(err => err.message)
+    .map(err => err.detailedMessage)
     .toArray()
   if (errorMessages.length !== 0) {
     throw new Error(`Received merge errors: ${errorMessages.join(', ')}`)
   }
   const [error] = await awu(mergeRes.errors.entries()).toArray()
   if (error !== undefined) {
-    throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.message).join(', ')}`)
+    throw new Error(`Received merge errors: ${error.key}: ${error.value.map(err => err.detailedMessage).join(', ')}`)
   }
 
   const mergedElements = await awu(mergeRes.merged.values()).toArray()

--- a/packages/workspace/src/merger/internal/common.ts
+++ b/packages/workspace/src/merger/internal/common.ts
@@ -28,7 +28,7 @@ export abstract class MergeError
   public severity: SeverityLevel = 'Error'
 
   toString(): string {
-    return this.message
+    return this.detailedMessage
   }
 }
 

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -72,7 +72,7 @@ export abstract class ValidationError
   }
 
   toString(): string {
-    return this.message
+    return this.detailedMessage
   }
 }
 

--- a/packages/workspace/test/merger.test.ts
+++ b/packages/workspace/test/merger.test.ts
@@ -229,7 +229,7 @@ describe('merger', () => {
       expect(errors[0].message).toEqual('Element has invalid NaCl content')
       expect(errors[0].detailedMessage).toContain(BuiltinTypes.STRING.elemID.getFullName())
       expect(errors[0].detailedMessage).toContain(BuiltinTypes.NUMBER.elemID.getFullName())
-      expect(String(errors[0])).toEqual(errors[0].message)
+      expect(String(errors[0])).toEqual(errors[0].detailedMessage)
     })
 
     it('returns an error when meta types have conflicting types', async () => {
@@ -239,7 +239,7 @@ describe('merger', () => {
         .toArray()
       expect(errors).toHaveLength(1)
       expect(errors[0]).toBeInstanceOf(ConflictingMetaTypeError)
-      expect(String(errors[0])).toEqual(errors[0].message)
+      expect(String(errors[0])).toEqual(errors[0].detailedMessage)
     })
   })
 


### PR DESCRIPTION
_clean leftover usages of error messages_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
