### PR TITLE
SALTO-7286: add objectTypeAttribute references rule

### DIFF
--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1352,6 +1352,16 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: OBJECT_TYPE_TYPE },
   },
+  // target is empty because this rule is only for resolving
+  {
+    src: { field: 'attributesIncludedInAutoCompleteSearch', parentTypes: ['AssetsObjectFieldConfiguration'] },
+    serializationStrategy: 'name',
+  },
+  // target is empty because this rule is only for resolving
+  {
+    src: { field: 'attributesDisplayedOnIssue', parentTypes: ['AssetsObjectFieldConfiguration'] },
+    serializationStrategy: 'name',
+  },
   {
     src: { field: 'schemaId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'id',


### PR DESCRIPTION
_add objectTypeAttribute references rule_

---

_Additional context for reviewer_
* I added the rules that I removed in this [pr](https://github.com/salto-io/salto/pull/7099/files#diff-ef0b7e0d708b8a1d16e805a734d3527fac5248a64958ad1c20cdf9783bacd7fbL1363).
* I omit the `target` section because these rules should be applied only for resolving, because we create the references in a filter. 

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
