### PR TITLE
SALTO-7095: replace markdown links in id collision message

### DIFF
--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -120,18 +120,17 @@ ${getInstancesDetailsMsg(instanceDetails, baseUrl, maxBreakdownDetailsElements)}
   return collisionMessages
 }
 
-const createMarkdownLinkOrText = ({ text, url }: { text: string; url?: string }): string =>
-  url !== undefined ? `[${text}](${url})` : text
+const getTextWithLinkToService = ({ instanceName, url }: { instanceName: string; url?: string }): string =>
+  url !== undefined ? `${instanceName}, view in the service - ${url}` : instanceName
 
-const getInstancesMarkdownLinks = (instances: InstanceElement[]): string =>
-  instances
-    .map(instance =>
-      createMarkdownLinkOrText({
-        text: instance.annotations[CORE_ANNOTATIONS.ALIAS] ?? instance.elemID.name,
-        url: instance.annotations[CORE_ANNOTATIONS.SERVICE_URL],
-      }),
-    )
-    .join(', ')
+const getInstancesWithLinksToService = (instances: InstanceElement[]): string =>
+  instances.map(instance =>
+    getTextWithLinkToService({
+      instanceName: instance.annotations[CORE_ANNOTATIONS.ALIAS] ?? instance.elemID.name,
+      url: instance.annotations[CORE_ANNOTATIONS.SERVICE_URL],
+    }),
+  ).join(`,
+`)
 
 const createWarningMessages = ({
   elemIDtoInstances,
@@ -147,10 +146,10 @@ const createWarningMessages = ({
       elemId,
       collideInstances,
     ]) => `${collideInstances.length} ${adapterName} elements ${addChildrenMessage ? 'and their child elements ' : ''}were not fetched, as they were mapped to a single ID ${elemId}:
-${getInstancesMarkdownLinks(collideInstances)}
+${getInstancesWithLinksToService(collideInstances)}.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-${createMarkdownLinkOrText({ text: 'Learn about additional ways to resolve this issue', url: 'https://help.salto.io/en/articles/6927157-salto-id-collisions' })}`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
   )
 
 // after SALTO-7088 is done, this function will replace getAndLogCollisionWarnings

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -171,7 +171,7 @@ export const getCollisionWarnings = ({
   if (instances.length === 0) {
     return []
   }
-  const adapterName = _.capitalize(instances[0].elemID.adapter)
+  const adapterName = _.upperFirst(instances[0].elemID.adapter)
   const elemIDtoInstances = _.pickBy(
     _.groupBy(instances, instance => instance.elemID.getFullName()),
     collideInstances => collideInstances.length > 1,

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -120,13 +120,21 @@ ${getInstancesDetailsMsg(instanceDetails, baseUrl, maxBreakdownDetailsElements)}
   return collisionMessages
 }
 
-const getTextWithLinkToService = ({ instanceName, url }: { instanceName: string; url?: string }): string =>
-  url !== undefined ? `${instanceName}, view in the service - ${url}` : instanceName
+const getTextWithLinkToService = ({
+  instanceName,
+  adapterName,
+  url,
+}: {
+  instanceName: string
+  adapterName: string
+  url?: string
+}): string => (url !== undefined ? `${instanceName} - open in ${adapterName}: ${url}` : instanceName)
 
-const getInstancesWithLinksToService = (instances: InstanceElement[]): string =>
+const getInstancesWithLinksToService = (instances: InstanceElement[], adapterName: string): string =>
   instances.map(instance =>
     getTextWithLinkToService({
       instanceName: instance.annotations[CORE_ANNOTATIONS.ALIAS] ?? instance.elemID.name,
+      adapterName,
       url: instance.annotations[CORE_ANNOTATIONS.SERVICE_URL],
     }),
   ).join(`,
@@ -146,7 +154,7 @@ const createWarningMessages = ({
       elemId,
       collideInstances,
     ]) => `${collideInstances.length} ${adapterName} elements ${addChildrenMessage ? 'and their child elements ' : ''}were not fetched, as they were mapped to a single ID ${elemId}:
-${getInstancesWithLinksToService(collideInstances)}.
+${getInstancesWithLinksToService(collideInstances, adapterName)}.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
@@ -163,7 +171,7 @@ export const getCollisionWarnings = ({
   if (instances.length === 0) {
     return []
   }
-  const adapterName = instances[0].elemID.adapter
+  const adapterName = _.capitalize(instances[0].elemID.adapter)
   const elemIDtoInstances = _.pickBy(
     _.groupBy(instances, instance => instance.elemID.getFullName()),
     collideInstances => collideInstances.length > 1,

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -163,15 +163,16 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 // after SALTO-7088 is done, this function will replace getAndLogCollisionWarnings
 export const getCollisionWarnings = ({
   instances,
+  adapterName,
   addChildrenMessage,
 }: {
   instances: InstanceElement[]
+  adapterName: string
   addChildrenMessage?: boolean
 }): SaltoError[] => {
   if (instances.length === 0) {
     return []
   }
-  const adapterName = _.upperFirst(instances[0].elemID.adapter)
   const elemIDtoInstances = _.pickBy(
     _.groupBy(instances, instance => instance.elemID.getFullName()),
     collideInstances => collideInstances.length > 1,

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -154,10 +154,11 @@ Alternatively, you can exclude obj from the default configuration in salto.nacl`
   describe('getAndLogCollisionWarningsV2', () => {
     it('should return the correct warning messages', async () => {
       const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-[aliasName](someUrl), [QuackAliasName](QuackUrl)
+aliasName, view in the service - someUrl,
+QuackAliasName, view in the service - QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -172,10 +173,11 @@ Usually, this happens because of duplicate configuration names in the service. M
 
     it('should add children message when addChildrenMessage is true', async () => {
       const detailedMessage = `2 salto elements and their child elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-[aliasName](someUrl), [QuackAliasName](QuackUrl)
+aliasName, view in the service - someUrl,
+QuackAliasName, view in the service - QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -192,10 +194,11 @@ Usually, this happens because of duplicate configuration names in the service. M
     it('should use the elemID name when alias is not defined', async () => {
       instance.annotations[CORE_ANNOTATIONS.ALIAS] = undefined
       const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-[test](someUrl), [QuackAliasName](QuackUrl)
+test, view in the service - someUrl,
+QuackAliasName, view in the service - QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -213,10 +216,11 @@ Usually, this happens because of duplicate configuration names in the service. M
       collidedInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = undefined
 
       const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-aliasName, QuackAliasName
+aliasName,
+QuackAliasName.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -236,16 +240,19 @@ Usually, this happens because of duplicate configuration names in the service. M
     })
     it('should return a message for each duplicated elemID', async () => {
       const firstDetailedMessage = `3 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-[aliasName](someUrl), [aliasName](someUrl), [QuackAliasName](QuackUrl)
+aliasName, view in the service - someUrl,
+aliasName, view in the service - someUrl,
+QuackAliasName, view in the service - QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const secondDetailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test1:
-[anotherAliasName](anotherUrl), [anotherAliasName](anotherUrl)
+anotherAliasName, view in the service - anotherUrl,
+anotherAliasName, view in the service - anotherUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-[Learn about additional ways to resolve this issue](https://help.salto.io/en/articles/6927157-salto-id-collisions)`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
       const errors = getCollisionWarnings({
         instances: [instance, instance.clone(), collidedInstance.clone(), differentInstance, differentInstance.clone()],

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -153,9 +153,9 @@ Alternatively, you can exclude obj from the default configuration in salto.nacl`
   })
   describe('getAndLogCollisionWarningsV2', () => {
     it('should return the correct warning messages', async () => {
-      const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-aliasName, view in the service - someUrl,
-QuackAliasName, view in the service - QuackUrl.
+      const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
+aliasName - open in Salto: someUrl,
+QuackAliasName - open in Salto: QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
@@ -172,9 +172,9 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
     })
 
     it('should add children message when addChildrenMessage is true', async () => {
-      const detailedMessage = `2 salto elements and their child elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-aliasName, view in the service - someUrl,
-QuackAliasName, view in the service - QuackUrl.
+      const detailedMessage = `2 Salto elements and their child elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
+aliasName - open in Salto: someUrl,
+QuackAliasName - open in Salto: QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
@@ -193,9 +193,9 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
     it('should use the elemID name when alias is not defined', async () => {
       instance.annotations[CORE_ANNOTATIONS.ALIAS] = undefined
-      const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-test, view in the service - someUrl,
-QuackAliasName, view in the service - QuackUrl.
+      const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
+test - open in Salto: someUrl,
+QuackAliasName - open in Salto: QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
@@ -215,7 +215,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
       instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = undefined
       collidedInstance.annotations[CORE_ANNOTATIONS.SERVICE_URL] = undefined
 
-      const detailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
+      const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName,
 QuackAliasName.
 
@@ -239,17 +239,17 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
       expect(errors).toHaveLength(0)
     })
     it('should return a message for each duplicated elemID', async () => {
-      const firstDetailedMessage = `3 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
-aliasName, view in the service - someUrl,
-aliasName, view in the service - someUrl,
-QuackAliasName, view in the service - QuackUrl.
+      const firstDetailedMessage = `3 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
+aliasName - open in Salto: someUrl,
+aliasName - open in Salto: someUrl,
+QuackAliasName - open in Salto: QuackUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
 
-      const secondDetailedMessage = `2 salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test1:
-anotherAliasName, view in the service - anotherUrl,
-anotherAliasName, view in the service - anotherUrl.
+      const secondDetailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test1:
+anotherAliasName - open in Salto: anotherUrl,
+anotherAliasName - open in Salto: anotherUrl.
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -162,6 +162,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
+        adapterName: 'Salto',
       })
       expect(errors).toHaveLength(1)
       expect(errors[0]).toEqual({
@@ -181,6 +182,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
+        adapterName: 'Salto',
         addChildrenMessage: true,
       })
       expect(errors).toHaveLength(1)
@@ -202,6 +204,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
+        adapterName: 'Salto',
       })
       expect(errors).toHaveLength(1)
       expect(errors[0]).toEqual({
@@ -224,6 +227,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
+        adapterName: 'Salto',
       })
       expect(errors).toHaveLength(1)
       expect(errors[0]).toEqual({
@@ -235,6 +239,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
     it('should return no errors when there are no collided instances', async () => {
       const errors = getCollisionWarnings({
         instances: [instance, differentInstance],
+        adapterName: 'Salto',
       })
       expect(errors).toHaveLength(0)
     })
@@ -256,6 +261,7 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const errors = getCollisionWarnings({
         instances: [instance, instance.clone(), collidedInstance.clone(), differentInstance, differentInstance.clone()],
+        adapterName: 'Salto',
       })
       expect(errors).toHaveLength(2)
       expect(errors[0]).toEqual({


### PR DESCRIPTION
_replace markdown links in id collision message_

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
