### PR TITLE
SALTO-7294 bug in IssueLayout filter with length on undefined

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/issue_layout.ts
+++ b/packages/jira-adapter/src/filters/layouts/issue_layout.ts
@@ -132,7 +132,7 @@ const getProjectToScreenMappingUnresolved = (elements: Element[]): Record<string
                     issueTypeScreenSchemesToiIssueTypeMappings[
                       project.value.issueTypeScreenScheme.issueTypeScreenScheme.id
                     ].length,
-                    issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme.issueTypeScheme.id].length,
+                    issueTypeSchemesToIssueTypeList[project.value.issueTypeScheme?.issueTypeScheme.id]?.length ?? 0,
                   ),
                 )
                 .map(


### PR DESCRIPTION
SALTO-7294 bug in IssueLayout filter with length on undefined

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
