### PR TITLE
SALTO-7925: (Bug-fix) Salesforce picklistReferences crashes when fullName is a non resolved Element

### DIFF
--- a/packages/salesforce-adapter/test/filters/picklist_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/picklist_references.test.ts
@@ -47,6 +47,7 @@ describe('picklistReferences filter', () => {
   })
   describe('RecordType instances', () => {
     const highCustomObject = createCustomObjectType('High', {})
+    const veryHighCustomObject = createCustomObjectType('VeryHigh', {})
 
     const accountObjectType = new ObjectType({
       elemID: new ElemID('salesforce', 'Account'),
@@ -73,6 +74,10 @@ describe('picklistReferences filter', () => {
                   fullName: new ReferenceExpression(highCustomObject.elemID, highCustomObject),
                   default: false,
                   label: 'High',
+                },
+                VeryHigh: {
+                  // Make sure we support the case where fullName is unresolved reference
+                  fullName: new ReferenceExpression(veryHighCustomObject.elemID),
                 },
                 Low: {
                   fullName: 'Low',
@@ -148,11 +153,13 @@ describe('picklistReferences filter', () => {
               ),
               values: [
                 { fullName: 'High', default: false },
+                { fullName: 'VeryHigh', default: false },
                 { fullName: 'Low', default: false },
                 { fullName: 'High %26 Low', default: false },
                 // Make sure the filter does not crash violently when trying to decode this URI value.
                 // See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/decodeURIComponent#catching_errors
                 { fullName: 'Non %% Decode-able', default: false },
+                // Make sure we handle the use-case where
               ],
             },
             // Field in old format
@@ -226,6 +233,10 @@ describe('picklistReferences filter', () => {
               accountObjectType.fields.priority__c.elemID.createNestedID('valueSet', 'values', 'High', 'fullName'),
               'High',
             ),
+            default: false,
+          },
+          {
+            fullName: 'VeryHigh',
             default: false,
           },
           {


### PR DESCRIPTION
(Bug-fix) Salesforce picklistReferences crashes when fullName is a non resolved Element

---

Reproduces on CPQ account and CBF that modifies RecordTypes.

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_