### PR TITLE
SALTO-7104: Remove kanban CV temp message

### DIFF
--- a/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
+++ b/packages/jira-adapter/src/change_validators/boards/kanban_board_backlog.ts
@@ -58,7 +58,5 @@ export const kanbanBoardBacklogValidator: ChangeValidator = async changes =>
       elemID: instance.elemID,
       severity: 'Error' as SeverityLevel,
       message: 'Unable to deploy a Kanban Board When the first column is not named "Backlog"',
-      detailedMessage:
-        // Change this message in 1 month, the fetch part is relevant only for deployments before the fix
-        'A Kanban board must have a first column named Backlog. If you did not edit the board manually please fetch both envs and try again',
+      detailedMessage: 'A Kanban board must have a first column named Backlog. Please fix the NaCl accordingly.',
     }))

--- a/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
+++ b/packages/jira-adapter/test/change_validators/boards/kanban_board_backlog.test.ts
@@ -11,8 +11,7 @@ import { BOARD_TYPE_NAME } from '../../../src/constants'
 import { createEmptyType } from '../../utils'
 
 const ERROR_TITLE = 'Unable to deploy a Kanban Board When the first column is not named "Backlog"'
-const ERROR_MESSAGE =
-  'A Kanban board must have a first column named Backlog. If you did not edit the board manually please fetch both envs and try again'
+const ERROR_MESSAGE = 'A Kanban board must have a first column named Backlog. Please fix the NaCl accordingly.'
 describe('kanbanBoardBacklogValidator', () => {
   let instance: InstanceElement
   let instance2: InstanceElement


### PR DESCRIPTION
The original message was for users who deployed without fetching, not likely anymore

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
