### PR TITLE
PROD-390: Salesforce noisy features

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -15,8 +15,8 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   extendedCustomFieldInformation: false,
   hideTypesFolder: true,
   metaTypes: false,
-  picklistsAsMaps: false,
-  retrieveSettings: false,
+  picklistsAsMaps: true,
+  retrieveSettings: true,
   genAiReferences: true,
   networkReferences: false,
   extendFetchTargets: false,
@@ -24,7 +24,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   addParentToInstancesWithinFolder: false,
   packageVersionReference: false,
   omitTotalTrustedRequestsUsageField: false,
-  disablePermissionsOmissions: false,
+  disablePermissionsOmissions: true,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -992,6 +992,7 @@ describe('SalesforceAdapter fetch', () => {
           2 /* ChangedAtSingleton type & instance */ +
           1 /* ProfilesAndPermissionSetsBrokenPaths */ +
           1 /* FetchTargets */ +
+          1 /* OrderedMapOfvalueSet */ +
           1 /* FieldPermissionEnum */,
       )
 

--- a/packages/salesforce-adapter/test/filters/field_permissions_enum.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_permissions_enum.test.ts
@@ -26,6 +26,7 @@ import fieldPermissionsEnumFilter, {
 import { generateProfileType, defaultFilterContext, buildFilterContext } from '../utils'
 import { API_NAME, CUSTOM_OBJECT, METADATA_TYPE, PERMISSION_SET_METADATA_TYPE, SALESFORCE } from '../../src/constants'
 import { FilterWith } from './mocks'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 
 const { awu } = collections.asynciterable
 
@@ -205,7 +206,16 @@ describe('FieldPermissionsEnum filter', () => {
       describe('with disablePermissionsOmissions false', () => {
         beforeAll(async () => {
           filter = fieldPermissionsEnumFilter({
-            config: defaultFilterContext,
+            config: {
+              ...defaultFilterContext,
+              fetchProfile: buildFetchProfile({
+                fetchParams: {
+                  optionalFeatures: {
+                    disablePermissionsOmissions: false,
+                  },
+                },
+              }),
+            },
           }) as FilterWith<'onFetch' | 'onDeploy' | 'preDeploy'>
           profileInstanceClone = profileInstance.clone()
           profileObjectClone = profileObj.clone()


### PR DESCRIPTION
PROD-390: Salesforce noisy features

---

Workspace Diff: TBD

---
_Release Notes_: 
_Salesforce Adapter_:
- Remodeled Picklist values as Maps instead of arrays (GlobalValueSet, StandardValueSet, and Picklist fields)
- Retrieve Settings Instances instead of using Read API for correct Metadata values.
- Fixed an issue where we've previously omitted values from PermissionSet and Profile instances.

---
_User Notifications_: 
_Salesforce_:
- Expect changes to nacls of the following types:
  - Settings instances.
  - GlobalValueSet.
  - StandardValueSet.
  - Picklist fields
