### PR TITLE
SALTO-6690 limit the allowed amount of files in a FileCabinet folder

### DIFF
--- a/packages/netsuite-adapter/config_doc.md
+++ b/packages/netsuite-adapter/config_doc.md
@@ -54,6 +54,12 @@ netsuite {
     maxItemsInImportObjectsRequest = 40
     sdfConcurrencyLimit = 4
     maxFileCabinetSizeInGB = 3
+    maxFilesPerFileCabinetFolder = [
+      {
+        folderPath = "/SuiteScripts.*"
+        limit = 2000
+      },
+    ]
   }
   suiteAppClient = {
    suiteAppConcurrencyLimit = 4
@@ -137,6 +143,7 @@ netsuite {
 | installedSuiteApps             | []                     | The SuiteApps ids to deploy and fetch elements from                                                                                     |
 | maxInstancesPerType            | 5000                   | Limits the amount of instances per type                                                                                                 |
 | maxFileCabinetSizeInGB         | 3                      | Limits the max size in GB of the fileCabinet size                                                                                       |
+| maxFilesPerFileCabinetFolder   | 1000                   | Limits the max files allowed in a single fileCabinet folder                                                                             |
 
 ### Salto SuiteApp client configuration options
 

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -535,7 +535,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       .concat(serverTimeElements)
       .concat(scriptIdListElements)
 
-    const fetchErrors = ([] as SaltoError[]).concat(errors).concat(deletedElementErrors)
+    const fetchErrors = errors.concat(deletedElementErrors)
 
     await this.createFiltersRunner({
       operation: 'fetch',

--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -25,7 +25,6 @@ import {
   TypeElement,
   ChangeDataType,
   FixElementsFunc,
-  SaltoElementError,
   SaltoError,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
@@ -130,6 +129,7 @@ import { SystemInformation } from './client/suiteapp_client/types'
 import { getOrCreateObjectIdListElements } from './scriptid_list'
 import { getUpdatedSuiteQLNameToInternalIdsMap } from './account_specific_values_resolver'
 import { getTypesToInternalId } from './data_elements/types'
+import { createLargeFilesCountFolderFetchWarnings } from './client/file_cabinet_utils'
 
 const { makeArray } = collections.array
 const { awu } = collections.asynciterable
@@ -373,11 +373,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
 
     const importFileCabinetContent = async (): Promise<ImportFileCabinetResult> => {
       progressReporter.reportProgress({ message: 'Fetching file cabinet items' })
-      const result = await this.client.importFileCabinetContent(
-        updatedFetchQuery,
-        this.config.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
-        this.config.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
-      )
+      const result = await this.client.importFileCabinetContent({
+        query: updatedFetchQuery,
+        maxFileCabinetSizeInGB: this.config.client?.maxFileCabinetSizeInGB ?? DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
+        extensionsToExclude: this.config.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
+        maxFilesPerFileCabinetFolder: this.config.client?.maxFilesPerFileCabinetFolder ?? [],
+      })
       progressReporter.reportProgress({ message: 'Fetching instances' })
       return result
     }
@@ -421,12 +422,12 @@ export default class NetsuiteAdapter implements AdapterOperations {
       customRecordTypes: ObjectType[]
       lockedCustomRecordTypes: ObjectType[]
       customRecords: InstanceElement[]
-      customRecordErrors: SaltoElementError[]
+      errors: SaltoError[]
       instancesIds: ObjectID[]
-      failures: Omit<FetchByQueryFailures, 'largeSuiteQLTables'>
+      failures: FetchByQueryFailures
     }> => {
       const [
-        { elements: fileCabinetContent, failedPaths: failedFilePaths },
+        { elements: fileCabinetContent, failedPaths: failedFilePaths, largeFilesCountFolderWarnings },
         { elements: customObjects, instancesIds, failedToFetchAllAtOnce, failedTypes },
       ] = await Promise.all([
         importFileCabinetContent(),
@@ -461,13 +462,17 @@ export default class NetsuiteAdapter implements AdapterOperations {
         this.config.fetch.singletonCustomRecords ?? [],
         this.getElemIdFunc,
       )
+      const largeFilesCountFolderFetchWarnings = createLargeFilesCountFolderFetchWarnings(
+        standardInstances,
+        largeFilesCountFolderWarnings,
+      )
       return {
         standardInstances,
         standardTypes: [...standardTypes, ...otherTypes],
         customRecordTypes,
         lockedCustomRecordTypes,
         customRecords,
-        customRecordErrors,
+        errors: largeFilesCountFolderFetchWarnings.concat(customRecordErrors),
         instancesIds,
         failures: { failedCustomRecords, failedFilePaths, failedToFetchAllAtOnce, failedTypes },
       }
@@ -480,7 +485,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         customRecordTypes,
         lockedCustomRecordTypes,
         customRecords,
-        customRecordErrors,
+        errors,
         instancesIds,
         failures,
       },
@@ -530,7 +535,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
       .concat(serverTimeElements)
       .concat(scriptIdListElements)
 
-    const fetchErrors = ([] as SaltoError[]).concat(customRecordErrors).concat(deletedElementErrors)
+    const fetchErrors = ([] as SaltoError[]).concat(errors).concat(deletedElementErrors)
 
     await this.createFiltersRunner({
       operation: 'fetch',

--- a/packages/netsuite-adapter/src/client/client.ts
+++ b/packages/netsuite-adapter/src/client/client.ts
@@ -23,11 +23,15 @@ import { decorators, collections, values } from '@salto-io/lowerdash'
 import { soap } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { captureServiceIdInfo } from '../service_id_info'
-import { NetsuiteFetchQueries, NetsuiteQuery } from '../config/query'
+import { NetsuiteFetchQueries } from '../config/query'
 import { Credentials, isSuiteAppCredentials, toUrlAccountId } from './credentials'
 import SdfClient from './sdf_client'
 import SuiteAppClient from './suiteapp_client/suiteapp_client'
-import { deployFileCabinetInstances, importFileCabinet } from './suiteapp_client/suiteapp_file_cabinet'
+import {
+  deployFileCabinetInstances,
+  importFileCabinet,
+  ImportFileCabinetParams,
+} from './suiteapp_client/suiteapp_file_cabinet'
 import {
   ConfigRecord,
   EnvType,
@@ -223,16 +227,12 @@ export default class NetsuiteClient {
   }
 
   @logDecorator
-  async importFileCabinetContent(
-    query: NetsuiteQuery,
-    maxFileCabinetSizeInGB: number,
-    extensionsToExclude: string[],
-  ): Promise<ImportFileCabinetResult> {
+  async importFileCabinetContent(params: ImportFileCabinetParams): Promise<ImportFileCabinetResult> {
     if (this.suiteAppClient !== undefined) {
-      return importFileCabinet(this.suiteAppClient, query, maxFileCabinetSizeInGB, extensionsToExclude)
+      return importFileCabinet(this.suiteAppClient, params)
     }
 
-    return this.sdfClient.importFileCabinetContent(query, maxFileCabinetSizeInGB)
+    return this.sdfClient.importFileCabinetContent(params.query, params.maxFileCabinetSizeInGB)
   }
 
   private static async getSDFObjectGraphNodes(changes: DeployableChange[]): Promise<GraphNode<SDFObjectNode>[]> {

--- a/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
+++ b/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
@@ -13,7 +13,7 @@ import { ERROR_MESSAGES } from '@salto-io/adapter-utils'
 import { InstanceElement, SaltoElementError, SaltoError } from '@salto-io/adapter-api'
 import { FOLDER, PATH, FILE_CABINET_PATH_SEPARATOR as sep } from '../constants'
 import { WARNING_MAX_FILE_CABINET_SIZE_IN_GB } from '../config/constants'
-import { MaxFilesPerFileCabinetFolder } from '../config/types'
+import { LargeFilesCountFolderWarning } from './types'
 
 const log = logger(module)
 
@@ -139,18 +139,19 @@ export const filterFolderPathsInFolders = <T extends { path: string[] }>(files: 
 
 export const createLargeFilesCountFolderFetchWarnings = (
   instances: InstanceElement[],
-  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[],
+  largeFilesCountFolderWarnings: LargeFilesCountFolderWarning[],
 ): (SaltoError | SaltoElementError)[] => {
   const folderInstances = _.keyBy(
     instances.filter(instance => instance.elemID.typeName === FOLDER),
     instance => instance.value[PATH] as string,
   )
-  return largeFilesCountFolderWarnings.map(({ folderPath, limit }) => {
+  return largeFilesCountFolderWarnings.map(({ folderPath, limit, current }) => {
     const severity = 'Warning'
     const message = ERROR_MESSAGES.OTHER_ISSUES
     const detailedMessage =
-      `The File Cabinet folder "${folderPath}" is close to exceed the limit of allowed amount of files in a folder, which is ${limit} files.` +
-      ' The folder will be automatically excluded in case of reaching that limit.' +
+      `The File Cabinet folder "${folderPath}" is close to exceed the limit of allowed amount of files in a folder.` +
+      ` There are currently ${current} files in the folder and the limit for this folder is ${limit} files.` +
+      ' It will be automatically excluded in case of reaching that limit.' +
       ' In order to keep managing this folder in Salto, add it to the `client.maxFilesPerFileCabinetFolder` config with a matching limit.' +
       ' To learn more visit https://github.com/salto-io/salto/blob/main/packages/netsuite-adapter/config_doc.md'
 

--- a/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
+++ b/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
@@ -141,6 +141,9 @@ export const createLargeFilesCountFolderFetchWarnings = (
   instances: InstanceElement[],
   largeFilesCountFolderWarnings: LargeFilesCountFolderWarning[],
 ): (SaltoError | SaltoElementError)[] => {
+  if (largeFilesCountFolderWarnings.length === 0) {
+    return []
+  }
   const folderInstances = _.keyBy(
     instances.filter(instance => instance.elemID.typeName === FOLDER),
     instance => instance.value[PATH] as string,

--- a/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
+++ b/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
@@ -149,7 +149,7 @@ export const createLargeFilesCountFolderFetchWarnings = (
     const severity = 'Warning'
     const message = ERROR_MESSAGES.OTHER_ISSUES
     const detailedMessage =
-      `The File Cabinet folder "${folderPath}" is closed to exceed the limit of allowed amount of files in a folder, which is ${limit} files.` +
+      `The File Cabinet folder "${folderPath}" is close to exceed the limit of allowed amount of files in a folder, which is ${limit} files.` +
       ' The folder will be automatically excluded in case of reaching that limit.' +
       ' In order to keep managing this folder in Salto, add it to the `client.maxFilesPerFileCabinetFolder` config with a matching limit.' +
       ' To learn more visit https://github.com/salto-io/salto/blob/main/packages/netsuite-adapter/config_doc.md'

--- a/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
+++ b/packages/netsuite-adapter/src/client/file_cabinet_utils.ts
@@ -9,8 +9,11 @@ import _ from 'lodash'
 import { posix } from 'path'
 import { strings } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
-import { FILE_CABINET_PATH_SEPARATOR as sep } from '../constants'
+import { ERROR_MESSAGES } from '@salto-io/adapter-utils'
+import { InstanceElement, SaltoElementError, SaltoError } from '@salto-io/adapter-api'
+import { FOLDER, PATH, FILE_CABINET_PATH_SEPARATOR as sep } from '../constants'
 import { WARNING_MAX_FILE_CABINET_SIZE_IN_GB } from '../config/constants'
+import { MaxFilesPerFileCabinetFolder } from '../config/types'
 
 const log = logger(module)
 
@@ -133,3 +136,32 @@ export const filterFilePathsInFolders = <T extends { path: string[] }>(files: T[
 
 export const filterFolderPathsInFolders = <T extends { path: string[] }>(files: T[], folders: string[]): T[] =>
   filterPathsInFoldersByFunc(files, folders, file => `${sep}${file.path.join(sep)}${sep}`)
+
+export const createLargeFilesCountFolderFetchWarnings = (
+  instances: InstanceElement[],
+  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[],
+): (SaltoError | SaltoElementError)[] => {
+  const folderInstances = _.keyBy(
+    instances.filter(instance => instance.elemID.typeName === FOLDER),
+    instance => instance.value[PATH] as string,
+  )
+  return largeFilesCountFolderWarnings.map(({ folderPath, limit }) => {
+    const severity = 'Warning'
+    const message = ERROR_MESSAGES.OTHER_ISSUES
+    const detailedMessage =
+      `The File Cabinet folder "${folderPath}" is closed to exceed the limit of allowed amount of files in a folder, which is ${limit} files.` +
+      ' The folder will be automatically excluded in case of reaching that limit.' +
+      ' In order to keep managing this folder in Salto, add it to the `client.maxFilesPerFileCabinetFolder` config with a matching limit.' +
+      ' To learn more visit https://github.com/salto-io/salto/blob/main/packages/netsuite-adapter/config_doc.md'
+
+    const folderInstance = folderInstances[folderPath]
+    if (folderInstance === undefined) {
+      log.warn(
+        'missing folder instance with path %s . returning LargeFilesCountFolderFetchWarning without instance elemID.',
+        folderPath,
+      )
+      return { severity, message, detailedMessage }
+    }
+    return { severity, message, detailedMessage, elemID: folderInstance.elemID }
+  })
+}

--- a/packages/netsuite-adapter/src/client/sdf_parser.ts
+++ b/packages/netsuite-adapter/src/client/sdf_parser.ts
@@ -150,6 +150,7 @@ const convertToFileCustomizationInfo = ({
   fileContent: Buffer
 }): FileCustomizationInfo => ({
   ...convertToCustomizationInfo(xmlContent),
+  typeName: 'file',
   path,
   fileContent,
 })
@@ -162,6 +163,7 @@ const convertToFolderCustomizationInfo = ({
   path: string[]
 }): FolderCustomizationInfo => ({
   ...convertToCustomizationInfo(xmlContent),
+  typeName: 'folder',
   path,
 })
 

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -321,11 +321,7 @@ const querySubFolders = async (
   topLevelFolders: FolderResult[],
   isSuiteBundlesEnabled: boolean,
 ): Promise<FolderResult[]> => {
-  const subFolderCriteria = "istoplevel = 'F'"
-  const whereQuery =
-    topLevelFolders.length > 0
-      ? `${subFolderCriteria} AND (${topLevelFolders.map(folder => `appfolder LIKE '${folder.name}%'`).join(' OR ')})`
-      : subFolderCriteria
+  const whereQuery = `istoplevel = 'F' AND (${topLevelFolders.map(folder => `appfolder LIKE '${folder.name}%'`).join(' OR ')})`
   const { results } = await queryFolders(suiteAppClient, whereQuery, isSuiteBundlesEnabled)
   return results
 }
@@ -644,11 +640,15 @@ const queryFileCabinet = async (
     }
   }
 
-  const filesCountsPerFolder = await queryFilesCountPerFolder(suiteAppClient, {
-    folderIdsToQuery: foldersToIncludeByPath.map(folder => folder.id),
-    isSuiteBundlesEnabled,
-    extensionsToExclude,
-  })
+  const filesCountsPerFolder =
+    // TODO: remove this condition
+    maxFilesPerFileCabinetFolder.length > 0
+      ? await queryFilesCountPerFolder(suiteAppClient, {
+          folderIdsToQuery: foldersToIncludeByPath.map(folder => folder.id),
+          isSuiteBundlesEnabled,
+          extensionsToExclude,
+        })
+      : {}
 
   const { foldersResults, largeFilesCountFoldersError, largeFilesCountFolderWarnings } = filterFoldersByFilesCount({
     filesCountsPerFolder,

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -38,6 +38,7 @@ import {
   FileCustomizationInfo,
   FolderCustomizationInfo,
   ImportFileCabinetResult,
+  LargeFilesCountFolderWarning,
 } from '../types'
 import { FILE_CABINET_PATH_SEPARATOR, INTERNAL_ID, PARENT, PATH } from '../../constants'
 import { FileCabinetDeployGroup } from '../../group_changes'
@@ -178,7 +179,7 @@ type FileCabinetResults = {
   filesResults: ExtendedFileResult[]
   foldersResults: ExtendedFolderResult[]
   largeFilesCountFoldersError: string[]
-  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
+  largeFilesCountFolderWarnings: LargeFilesCountFolderWarning[]
 }
 
 type FilesQueryParams = {
@@ -490,7 +491,7 @@ const getFolderMaxFilesPerFolderInfo = ({
   filesCountsPerFolder: Record<string, number>
   maxFilesPerFileCabinetFolder: MaxFilesPerFileCabinetFolder[]
   level: 'error' | 'warn'
-}): MaxFilesPerFileCabinetFolder | undefined => {
+}): LargeFilesCountFolderWarning | undefined => {
   const folderPath = fullPath(folder.path)
   const filesInFolder = filesCountsPerFolder[folder.id] ?? 0
 
@@ -505,7 +506,7 @@ const getFolderMaxFilesPerFolderInfo = ({
   }
 
   if (filesInFolder > maxFilesCountAllowedByLevel[level]) {
-    return { folderPath, limit }
+    return { folderPath, limit, current: filesInFolder }
   }
 
   return undefined
@@ -522,7 +523,7 @@ const filterFoldersByFilesCount = ({
 }): {
   foldersResults: ExtendedFolderResult[]
   largeFilesCountFoldersError: string[]
-  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
+  largeFilesCountFolderWarnings: LargeFilesCountFolderWarning[]
 } => {
   // TODO: remove this condition
   if (maxFilesPerFileCabinetFolder.length === 0) {

--- a/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
+++ b/packages/netsuite-adapter/src/client/suiteapp_client/suiteapp_file_cabinet.ts
@@ -21,7 +21,7 @@ import {
 } from '@salto-io/adapter-api'
 import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
-import { chunks, promises, values } from '@salto-io/lowerdash'
+import { chunks, promises, regex } from '@salto-io/lowerdash'
 import Ajv from 'ajv'
 import _ from 'lodash'
 import path from 'path'
@@ -33,7 +33,12 @@ import {
 } from './errors'
 import SuiteAppClient from './suiteapp_client'
 import { ExistingFileCabinetInstanceDetails, FileCabinetInstanceDetails } from './types'
-import { ImportFileCabinetResult } from '../types'
+import {
+  FileCabinetCustomizationInfo,
+  FileCustomizationInfo,
+  FolderCustomizationInfo,
+  ImportFileCabinetResult,
+} from '../types'
 import { FILE_CABINET_PATH_SEPARATOR, INTERNAL_ID, PARENT, PATH } from '../../constants'
 import { FileCabinetDeployGroup } from '../../group_changes'
 import { NetsuiteQuery } from '../../config/query'
@@ -41,6 +46,8 @@ import { isFileCabinetType, isFileInstance } from '../../types'
 import { filterFilePathsInFolders, filterFolderPathsInFolders, largeFoldersToExclude } from '../file_cabinet_utils'
 import { getDeployResultFromSuiteAppResult, toElementError, toError } from '../utils'
 import { SoapDeployResult } from './soap_client/types'
+import { MaxFilesPerFileCabinetFolder } from '../../config/types'
+import { DEFAULT_MAX_FILES_PER_FOLDER_VALUE } from '../../config/constants'
 
 const log = logger(module)
 
@@ -130,6 +137,18 @@ const FILES_SCHEMA = {
   },
 }
 
+const FILES_COUNT_SCHEMA = {
+  type: 'array',
+  items: {
+    type: 'object',
+    properties: {
+      folder: { type: 'string' },
+      count: { type: 'string' },
+    },
+    required: ['folder', 'count'],
+  },
+}
+
 type FileResult = {
   name: string
   id: string
@@ -145,12 +164,34 @@ type FileResult = {
   folder: string
 }
 
+type FileCustomizationInfoWithoutContent = { size: number; id: string } & Omit<FileCustomizationInfo, 'fileContent'>
+
+type FilesCountResult = {
+  folder: string
+  count: string
+}
+
 type ExtendedFolderResult = FolderResult & { path: string[] }
 type ExtendedFileResult = FileResult & { path: string[] }
 
 type FileCabinetResults = {
   filesResults: ExtendedFileResult[]
   foldersResults: ExtendedFolderResult[]
+  largeFilesCountFoldersError: string[]
+  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
+}
+
+type FilesQueryParams = {
+  folderIdsToQuery: string[]
+  isSuiteBundlesEnabled: boolean
+  extensionsToExclude: string[]
+}
+
+export type ImportFileCabinetParams = {
+  query: NetsuiteQuery
+  maxFileCabinetSizeInGB: number
+  extensionsToExclude: string[]
+  maxFilesPerFileCabinetFolder: MaxFilesPerFileCabinetFolder[]
 }
 
 const FILES_CHUNK_SIZE = 5 * 1024 * 1024
@@ -158,6 +199,7 @@ const MAX_FILES_IN_READ_REQUEST = 10000
 const MAX_DEPLOYABLE_FILE_SIZE = 10 * 1024 * 1024
 const DEPLOY_CHUNK_SIZE = 50
 const MAX_ITEMS_IN_WHERE_QUERY = 200
+const MAX_FILES_PER_FOLDER_WARNING_THRESHOLD = 0.9
 const BUNDLEABLE = ', bundleable'
 export const SUITEBUNDLES_DISABLED_ERROR =
   'Failed to list folders. Please verify that the "Create bundles with SuiteBundler" feature is enabled in the account.'
@@ -244,7 +286,7 @@ const queryFolders = (
   suiteAppClient: SuiteAppClient,
   whereQuery: string,
   isSuiteBundlesEnabled = true,
-): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
+): Promise<{ results: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
   retryOnRetryableError(async () => {
     const foldersQuery = {
       select: `id, name${isSuiteBundlesEnabled ? BUNDLEABLE : ''}, isinactive, isprivate, description, parent`,
@@ -253,16 +295,16 @@ const queryFolders = (
       orderBy: 'id',
     }
     try {
-      const folderResults = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
-      assertFoldersResults(folderResults)
-      return { folderResults, isSuiteBundlesEnabled: true }
+      const results = await suiteAppClient.runSuiteQL(foldersQuery, THROW_ON_MISSING_FEATURE_ERROR)
+      assertFoldersResults(results)
+      return { results, isSuiteBundlesEnabled: true }
     } catch (e) {
       if (toError(e).message === SUITEBUNDLES_DISABLED_ERROR && isSuiteBundlesEnabled) {
         log.debug("SuiteBundles not enabled in the account, removing 'bundleable' from query")
         const noBundleableQuery = { ...foldersQuery, select: foldersQuery.select.replace(BUNDLEABLE, '') }
-        const folderResults = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)
-        assertFoldersResults(folderResults)
-        return { folderResults, isSuiteBundlesEnabled: false }
+        const results = await suiteAppClient.runSuiteQL(noBundleableQuery, THROW_ON_MISSING_FEATURE_ERROR)
+        assertFoldersResults(results)
+        return { results, isSuiteBundlesEnabled: false }
       }
       throw e
     }
@@ -270,7 +312,7 @@ const queryFolders = (
 
 const queryTopLevelFolders = async (
   suiteAppClient: SuiteAppClient,
-): Promise<{ folderResults: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
+): Promise<{ results: FolderResult[]; isSuiteBundlesEnabled: boolean }> =>
   queryFolders(suiteAppClient, "istoplevel = 'T'")
 
 const querySubFolders = async (
@@ -283,25 +325,30 @@ const querySubFolders = async (
     topLevelFolders.length > 0
       ? `${subFolderCriteria} AND (${topLevelFolders.map(folder => `appfolder LIKE '${folder.name}%'`).join(' OR ')})`
       : subFolderCriteria
-  return (await queryFolders(suiteAppClient, whereQuery, isSuiteBundlesEnabled)).folderResults
+  const { results } = await queryFolders(suiteAppClient, whereQuery, isSuiteBundlesEnabled)
+  return results
 }
 
-const queryFiles = (
-  suiteAppClient: SuiteAppClient,
-  folderIdsToQuery: string[],
-  isSuiteBundlesEnabled: boolean,
-  extensionsToExclude: string[],
-): Promise<FileResult[]> =>
+const getFilesWhereQueries = ({
+  folderIdsToQuery,
+  isSuiteBundlesEnabled,
+  extensionsToExclude,
+}: FilesQueryParams): string[] => {
+  const whereNotHideInBundle = isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''
+  const whereNotExtension = extensionsToExclude.map(reg => `NOT REGEXP_LIKE(name, '${reg}') AND `).join('')
+  const whereQueries = _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(
+    foldersToQueryChunk => `${whereNotExtension}${whereNotHideInBundle}folder IN (${foldersToQueryChunk.join(', ')})`,
+  )
+  return whereQueries
+}
+
+const queryFiles = (suiteAppClient: SuiteAppClient, params: FilesQueryParams): Promise<FileResult[]> =>
   retryOnRetryableError(async () => {
-    const whereNotHideInBundle = isSuiteBundlesEnabled ? "hideinbundle = 'F' AND " : ''
-    const whereNotExtension = extensionsToExclude.map(reg => `NOT REGEXP_LIKE(name, '${reg}') AND `).join('')
-    const whereQueries = _.chunk(folderIdsToQuery, MAX_ITEMS_IN_WHERE_QUERY).map(
-      foldersToQueryChunk => `${whereNotExtension}${whereNotHideInBundle}folder IN (${foldersToQueryChunk.join(', ')})`,
-    )
+    const whereQueries = getFilesWhereQueries(params)
     const results = await Promise.all(
       whereQueries.map(async whereQuery => {
         const filesResults = await suiteAppClient.runSuiteQL({
-          select: `id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url${isSuiteBundlesEnabled ? ', bundleable, hideinbundle' : ''}`,
+          select: `id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url${params.isSuiteBundlesEnabled ? ', bundleable, hideinbundle' : ''}`,
           from: 'file',
           where: whereQuery,
           orderBy: 'id',
@@ -321,6 +368,38 @@ const queryFiles = (
     )
 
     return results.flat()
+  })
+
+const queryFilesCountPerFolder = (
+  suiteAppClient: SuiteAppClient,
+  params: FilesQueryParams,
+): Promise<Record<string, number>> =>
+  retryOnRetryableError(async () => {
+    const whereQueries = getFilesWhereQueries(params)
+    const results = await Promise.all(
+      whereQueries.map(async whereQuery => {
+        const filesCountResults = await suiteAppClient.runSuiteQL({
+          select: 'folder, count(*) as count',
+          from: 'file',
+          where: whereQuery,
+          orderBy: 'folder',
+          groupBy: 'folder',
+        })
+
+        if (filesCountResults === undefined) {
+          throw new RetryableError(new Error('Failed to list files'))
+        }
+
+        const ajv = new Ajv({ allErrors: true, strict: false })
+        if (!ajv.validate<FilesCountResult[]>(FILES_COUNT_SCHEMA, filesCountResults)) {
+          log.error('Got invalid results from files count query - %s: %o', ajv.errorsText(), filesCountResults)
+          throw new RetryableError(new Error('Failed to list files'))
+        }
+        return filesCountResults
+      }),
+    )
+
+    return Object.fromEntries(results.flat().map(({ folder, count }) => [folder, parseInt(count, 10)]))
   })
 
 const removeResultsWithoutParentFolder = (foldersResults: FolderResult[]): FolderResult[] => {
@@ -344,9 +423,9 @@ const removeResultsWithoutParentFolder = (foldersResults: FolderResult[]): Folde
 
 const removeFilesWithoutParentFolder = (
   filesResults: FileResult[],
-  filteredFolderResults: ExtendedFolderResult[],
+  foldersResults: ExtendedFolderResult[],
 ): FileResult[] => {
-  const folderIdsSet = new Set(filteredFolderResults.map(folder => folder.id))
+  const folderIdsSet = new Set(foldersResults.map(folder => folder.id))
   return filesResults.filter(file => {
     if (!folderIdsSet.has(file.folder)) {
       log.warn("file's folder does not exist: %o", file)
@@ -370,45 +449,179 @@ const fullPathParts = (folder: FolderResult, idToFolder: Record<string, FolderRe
 const fullPath = (fileParts: string[]): string =>
   `${FILE_CABINET_PATH_SEPARATOR}${fileParts.join(FILE_CABINET_PATH_SEPARATOR)}`
 
-// SALTO-6690 this is for logging only. the code for removal should be done using a `groupBy` in the SuiteQL query
-const logLargeFolders = (filesResults: ExtendedFileResult[]): void => {
-  const filesByFolder = _.groupBy(filesResults, file => fullPath(file.path.slice(0, -1)))
-  const firstLargeFoldersLevel = Object.keys(_.pickBy(filesByFolder, files => files.length > 1000))
-  if (firstLargeFoldersLevel.length === 0) {
-    return
-  }
-  log.debug(
-    'There are %d folders with more than 1000 files in them: %o',
-    firstLargeFoldersLevel.length,
-    firstLargeFoldersLevel,
-  )
-  const secondLargeFoldersLevel = Object.entries(_.pickBy(filesByFolder, files => files.length > 10000)).map(
-    ([folderPath, files]) => {
-      const fileSamples = _.chunk(files.map(file => file.name).sort(), 2000).map(chunk => chunk[0])
-      return { path: folderPath, count: files.length, fileSamples }
-    },
-  )
-  if (secondLargeFoldersLevel.length === 0) {
-    return
-  }
-  log.debug(
-    'There are %d folders with more than 10000 files in them: %o',
-    secondLargeFoldersLevel.length,
-    secondLargeFoldersLevel,
-  )
+const toFoldersWithPaths = ({
+  queriedFolders,
+  idToFolder,
+}: {
+  queriedFolders: FolderResult[]
+  idToFolder: Record<string, FolderResult>
+}): ExtendedFolderResult[] => {
+  const foldersWithParent = removeResultsWithoutParentFolder(queriedFolders)
+  return foldersWithParent.map(folder => ({ path: fullPathParts(folder, idToFolder), ...folder }))
 }
+
+const filterFoldersByPath = ({
+  foldersWithPath,
+  query,
+}: {
+  foldersWithPath: ExtendedFolderResult[]
+  query: NetsuiteQuery
+}): ExtendedFolderResult[] => {
+  const [foldersToInclude, removedFolders] = _.partition(foldersWithPath, folder =>
+    query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
+  )
+  if (removedFolders.length > 0) {
+    log.debug(
+      'removed the following %d folders before querying files counts: %o',
+      removedFolders.length,
+      removedFolders.map(folder => folder.path),
+    )
+  }
+  return foldersToInclude
+}
+
+const getFolderMaxFilesPerFolderInfo = ({
+  folder,
+  filesCountsPerFolder,
+  maxFilesPerFileCabinetFolder,
+  level,
+}: {
+  folder: ExtendedFolderResult
+  filesCountsPerFolder: Record<string, number>
+  maxFilesPerFileCabinetFolder: MaxFilesPerFileCabinetFolder[]
+  level: 'error' | 'warn'
+}): MaxFilesPerFileCabinetFolder | undefined => {
+  const folderPath = fullPath(folder.path)
+  const filesInFolder = filesCountsPerFolder[folder.id] ?? 0
+
+  const limit = maxFilesPerFileCabinetFolder
+    .filter(row => regex.isFullRegexMatch(folderPath, row.folderPath))
+    .map(row => row.limit)
+    .reduce((max, next) => Math.max(max, next), DEFAULT_MAX_FILES_PER_FOLDER_VALUE)
+
+  const maxFilesCountAllowedByLevel = {
+    error: limit,
+    warn: limit * MAX_FILES_PER_FOLDER_WARNING_THRESHOLD,
+  }
+
+  if (filesInFolder > maxFilesCountAllowedByLevel[level]) {
+    return { folderPath, limit }
+  }
+
+  return undefined
+}
+
+const filterFoldersByFilesCount = ({
+  filesCountsPerFolder,
+  foldersToIncludeByPath,
+  maxFilesPerFileCabinetFolder,
+}: {
+  foldersToIncludeByPath: ExtendedFolderResult[]
+  filesCountsPerFolder: Record<string, number>
+  maxFilesPerFileCabinetFolder: MaxFilesPerFileCabinetFolder[]
+}): {
+  foldersResults: ExtendedFolderResult[]
+  largeFilesCountFoldersError: string[]
+  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
+} => {
+  // TODO: remove this condition
+  if (maxFilesPerFileCabinetFolder.length === 0) {
+    return {
+      foldersResults: foldersToIncludeByPath,
+      largeFilesCountFoldersError: [],
+      largeFilesCountFolderWarnings: [],
+    }
+  }
+
+  const [foldersToInclude, removedFolders] = _.partition(
+    foldersToIncludeByPath,
+    folder =>
+      getFolderMaxFilesPerFolderInfo({
+        folder,
+        filesCountsPerFolder,
+        maxFilesPerFileCabinetFolder,
+        level: 'error',
+      }) === undefined,
+  )
+
+  const largeFilesCountFoldersError = removedFolders.map(
+    folder => `${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`,
+  )
+  const foldersResults = filterFolderPathsInFolders(foldersToInclude, largeFilesCountFoldersError)
+  const largeFilesCountFolderWarnings = foldersResults.flatMap(
+    folder =>
+      getFolderMaxFilesPerFolderInfo({
+        folder,
+        filesCountsPerFolder,
+        maxFilesPerFileCabinetFolder,
+        level: 'warn',
+      }) ?? [],
+  )
+
+  return { foldersResults, largeFilesCountFoldersError, largeFilesCountFolderWarnings }
+}
+
+const filterFoldersBySize = (
+  unfilteredFilesCustomizationInfos: FileCustomizationInfoWithoutContent[],
+  unfilteredFoldersCustomizationInfo: FolderCustomizationInfo[],
+  { maxFileCabinetSizeInGB }: ImportFileCabinetParams,
+): {
+  foldersCustomizationInfos: FolderCustomizationInfo[]
+  filesWithoutContent: FileCustomizationInfoWithoutContent[]
+  largeSizeFoldersError: string[]
+} => {
+  const filesSize = unfilteredFilesCustomizationInfos.map(file => ({
+    path: fullPath(file.path),
+    size: file.size,
+  }))
+  const largeSizeFoldersError = largeFoldersToExclude(filesSize, maxFileCabinetSizeInGB)
+  const filesWithoutContent = filterFilePathsInFolders(unfilteredFilesCustomizationInfos, largeSizeFoldersError)
+  const foldersCustomizationInfos = filterFolderPathsInFolders(
+    unfilteredFoldersCustomizationInfo,
+    largeSizeFoldersError,
+  )
+  return { filesWithoutContent, foldersCustomizationInfos, largeSizeFoldersError }
+}
+
+const toFilesWithPaths = ({
+  queriedFiles,
+  foldersResults,
+  idToFolder,
+}: {
+  queriedFiles: FileResult[]
+  foldersResults: ExtendedFolderResult[]
+  idToFolder: Record<string, FolderResult>
+}): ExtendedFileResult[] => {
+  const filesWithParent = removeFilesWithoutParentFolder(queriedFiles, foldersResults)
+  return filesWithParent.map(file => ({
+    path: [...fullPathParts(idToFolder[file.folder], idToFolder), file.name],
+    ...file,
+  }))
+}
+
+const filterFilesByPath = ({
+  filesWithPath,
+  query,
+}: {
+  filesWithPath: ExtendedFileResult[]
+  query: NetsuiteQuery
+}): ExtendedFileResult[] => filesWithPath.filter(file => query.isFileMatch(fullPath(file.path)))
 
 const queryFileCabinet = async (
   suiteAppClient: SuiteAppClient,
-  query: NetsuiteQuery,
-  extensionsToExclude: string[],
+  { query, extensionsToExclude, maxFilesPerFileCabinetFolder }: ImportFileCabinetParams,
 ): Promise<FileCabinetResults> => {
-  const { folderResults, isSuiteBundlesEnabled } = await queryTopLevelFolders(suiteAppClient)
-  const topLevelFoldersResults = folderResults.filter(folder => query.isParentFolderMatch(`/${folder.name}`))
+  const { results: topLevelFolders, isSuiteBundlesEnabled } = await queryTopLevelFolders(suiteAppClient)
+  const topLevelFoldersResults = topLevelFolders.filter(folder => query.isParentFolderMatch(`/${folder.name}`))
 
   if (topLevelFoldersResults.length === 0) {
     log.warn("No top level folder matched the adapter's query. returning empty result")
-    return { foldersResults: [], filesResults: [] }
+    return {
+      foldersResults: [],
+      filesResults: [],
+      largeFilesCountFoldersError: [],
+      largeFilesCountFolderWarnings: [],
+    }
   }
   log.debug(
     'the following top level folders have been queried: %o',
@@ -416,50 +629,154 @@ const queryFileCabinet = async (
   )
 
   const subFoldersResults = await querySubFolders(suiteAppClient, topLevelFoldersResults, isSuiteBundlesEnabled)
-  const foldersResults = topLevelFoldersResults.concat(subFoldersResults)
-  const idToFolder = _.keyBy(foldersResults, folder => folder.id)
-  const [filteredFolderResults, removedFolders] = _.partition(
-    removeResultsWithoutParentFolder(foldersResults).map(folder => ({
-      path: fullPathParts(folder, idToFolder),
-      ...folder,
-    })),
-    // remove excluded folders before creating the files query
-    folder => query.isFileMatch(`${fullPath(folder.path)}${FILE_CABINET_PATH_SEPARATOR}`),
-  )
-  log.debug('removed the following %d folder before querying files: %o', removedFolders.length, removedFolders)
+  const queriedFolders = topLevelFoldersResults.concat(subFoldersResults)
+  const idToFolder = _.keyBy(queriedFolders, folder => folder.id)
 
-  const filesResults =
-    filteredFolderResults.length > 0
-      ? await queryFiles(
-          suiteAppClient,
-          filteredFolderResults.map(folder => folder.id),
-          isSuiteBundlesEnabled,
-          extensionsToExclude,
-        )
-      : []
-  const filteredFilesResults = removeFilesWithoutParentFolder(filesResults, filteredFolderResults)
-    .map(file => ({ path: [...fullPathParts(idToFolder[file.folder], idToFolder), file.name], ...file }))
-    .filter(file => query.isFileMatch(fullPath(file.path)))
-  return { filesResults: filteredFilesResults, foldersResults: filteredFolderResults }
+  const foldersWithPath = toFoldersWithPaths({ queriedFolders, idToFolder })
+  const foldersToIncludeByPath = filterFoldersByPath({ foldersWithPath, query })
+  if (foldersToIncludeByPath.length === 0) {
+    return {
+      filesResults: [],
+      foldersResults: [],
+      largeFilesCountFoldersError: [],
+      largeFilesCountFolderWarnings: [],
+    }
+  }
+
+  const filesCountsPerFolder = await queryFilesCountPerFolder(suiteAppClient, {
+    folderIdsToQuery: foldersToIncludeByPath.map(folder => folder.id),
+    isSuiteBundlesEnabled,
+    extensionsToExclude,
+  })
+
+  const { foldersResults, largeFilesCountFoldersError, largeFilesCountFolderWarnings } = filterFoldersByFilesCount({
+    filesCountsPerFolder,
+    foldersToIncludeByPath,
+    maxFilesPerFileCabinetFolder,
+  })
+
+  if (foldersResults.length === 0) {
+    return {
+      filesResults: [],
+      foldersResults: [],
+      largeFilesCountFoldersError,
+      largeFilesCountFolderWarnings,
+    }
+  }
+
+  const queriedFiles = await queryFiles(suiteAppClient, {
+    folderIdsToQuery: foldersResults.map(folder => folder.id),
+    isSuiteBundlesEnabled,
+    extensionsToExclude,
+  })
+
+  const filesWithPath = toFilesWithPaths({ queriedFiles, foldersResults, idToFolder })
+  const filesResults = filterFilesByPath({ filesWithPath, query })
+
+  return {
+    filesResults,
+    foldersResults,
+    largeFilesCountFoldersError,
+    largeFilesCountFolderWarnings,
+  }
+}
+
+const queryFilesContent = async (
+  suiteAppClient: SuiteAppClient,
+  filesWithoutContent: FileCustomizationInfoWithoutContent[],
+): Promise<{
+  filesCustomizationInfos: FileCustomizationInfo[]
+  otherError: string[]
+  lockedError: string[]
+}> => {
+  const fileChunks = chunks.weightedChunks(
+    filesWithoutContent,
+    FILES_CHUNK_SIZE,
+    file => file.size,
+    MAX_FILES_IN_READ_REQUEST,
+  )
+
+  const contents = await Promise.all(
+    fileChunks.map(async (fileChunk, i) => {
+      if (fileChunk[0].size > FILES_CHUNK_SIZE) {
+        const id = parseInt(fileChunk[0].id, 10)
+        log.debug(`File with id ${id} is too big to fetch via Restlet (${fileChunk[0].size}), using SOAP API`)
+        return suiteAppClient.readLargeFile(id)
+      }
+
+      const results = await retryOnRetryableError(async () => {
+        const res = await suiteAppClient.readFiles(fileChunk.map(f => parseInt(f.id, 10)))
+        if (res === undefined) {
+          throw new RetryableError(new Error('Request for reading files from the file cabinet failed'))
+        }
+        return res
+      })
+
+      log.debug(`Finished Reading files chunk ${i + 1}/${fileChunks.length} with ${fileChunk.length} files`)
+
+      return Promise.all(
+        results.map(async (content, index) => {
+          if (content instanceof ReadFileEncodingError) {
+            const id = parseInt(fileChunk[index].id, 10)
+            log.debug(`Received file encoding error for id ${id}. Fallback to SOAP request`)
+            return suiteAppClient.readLargeFile(id)
+          }
+          return content
+        }),
+      )
+    }),
+  )
+
+  const filesContent: (Buffer | Error)[] = contents.flat()
+
+  const otherError: string[] = []
+  const lockedError: string[] = []
+
+  const filesCustomizationInfos = filesWithoutContent.flatMap((file, index) => {
+    const fileContent = filesContent[index]
+    if (fileContent instanceof Buffer) {
+      return {
+        path: file.path,
+        typeName: 'file' as const,
+        fileContent,
+        values: file.values,
+      }
+    }
+    log.warn(`Failed reading file ${fullPath(file.path)} with id ${file.id}`)
+    if (fileContent instanceof ReadFileInsufficientPermissionError) {
+      lockedError.push(fullPath(file.path))
+    } else {
+      otherError.push(fullPath(file.path))
+    }
+    return []
+  })
+
+  return { filesCustomizationInfos, otherError, lockedError }
 }
 
 export const importFileCabinet = async (
   suiteAppClient: SuiteAppClient,
-  query: NetsuiteQuery,
-  maxFileCabinetSizeInGB: number,
-  extensionsToExclude: string[],
+  params: ImportFileCabinetParams,
 ): Promise<ImportFileCabinetResult> => {
-  if (!query.areSomeFilesMatch()) {
-    return { elements: [], failedPaths: { lockedError: [], otherError: [], largeFolderError: [] } }
+  if (!params.query.areSomeFilesMatch()) {
+    return {
+      elements: [],
+      failedPaths: {
+        lockedError: [],
+        otherError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+      },
+      largeFilesCountFolderWarnings: [],
+    }
   }
 
-  const { foldersResults, filesResults } = await queryFileCabinet(suiteAppClient, query, extensionsToExclude)
-
-  logLargeFolders(filesResults)
+  const { foldersResults, filesResults, largeFilesCountFoldersError, largeFilesCountFolderWarnings } =
+    await queryFileCabinet(suiteAppClient, params)
 
   const unfilteredFoldersCustomizationInfo = foldersResults.map(folder => ({
     path: folder.path,
-    typeName: 'folder',
+    typeName: 'folder' as const,
     values: {
       description: folder.description ?? '',
       bundleable: folder.bundleable ?? 'F',
@@ -471,7 +788,7 @@ export const importFileCabinet = async (
 
   const filesCustomizations = filesResults.map(file => ({
     path: file.path,
-    typeName: 'file',
+    typeName: 'file' as const,
     values: {
       description: file.description ?? '',
       bundleable: file.bundleable ?? 'F',
@@ -486,102 +803,40 @@ export const importFileCabinet = async (
     size: parseInt(file.filesize, 10),
   }))
 
-  const [unfilteredFilesCustomizationWithoutContent, filesCustomizationsLinks] = _.partition(
+  const [unfilteredFilesCustomizationWithoutContent, linksCustomlizations] = _.partition(
     filesCustomizations,
     file => file.values.link === undefined,
   )
 
-  const filesSize = unfilteredFilesCustomizationWithoutContent.map(file => ({
-    path: fullPath(file.path),
-    size: file.size,
+  const linksCustomizationInfos = linksCustomlizations.map(file => ({
+    path: file.path,
+    typeName: 'file' as const,
+    values: file.values,
   }))
-  const largeFolders = largeFoldersToExclude(filesSize, maxFileCabinetSizeInGB)
-  const filesCustomizationWithoutContent = filterFilePathsInFolders(
+
+  const { filesWithoutContent, foldersCustomizationInfos, largeSizeFoldersError } = filterFoldersBySize(
     unfilteredFilesCustomizationWithoutContent,
-    largeFolders,
-  )
-  const foldersCustomizationInfo = filterFolderPathsInFolders(unfilteredFoldersCustomizationInfo, largeFolders)
-
-  const fileChunks = chunks.weightedChunks(
-    filesCustomizationWithoutContent,
-    FILES_CHUNK_SIZE,
-    file => file.size,
-    MAX_FILES_IN_READ_REQUEST,
+    unfilteredFoldersCustomizationInfo,
+    params,
   )
 
-  const filesContent = (
-    await Promise.all(
-      fileChunks.map(async (fileChunk, i) => {
-        if (fileChunk[0].size > FILES_CHUNK_SIZE) {
-          const id = parseInt(fileChunk[0].id, 10)
-          log.debug(`File with id ${id} is too big to fetch via Restlet (${fileChunk[0].size}), using SOAP API`)
-          return suiteAppClient.readLargeFile(id)
-        }
-
-        const results = await retryOnRetryableError(async () => {
-          const res = await suiteAppClient.readFiles(fileChunk.map(f => parseInt(f.id, 10)))
-          if (res === undefined) {
-            throw new RetryableError(new Error('Request for reading files from the file cabinet failed'))
-          }
-          return res
-        })
-        log.debug(`Finished Reading files chunk ${i + 1}/${fileChunks.length} with ${fileChunk.length} files`)
-
-        return (
-          results &&
-          Promise.all(
-            results.map(async (content, index) => {
-              if (!(content instanceof ReadFileEncodingError)) {
-                return content
-              }
-
-              const id = parseInt(fileChunk[index].id, 10)
-              log.debug(`Received file encoding error for id ${id}. Fallback to SOAP request`)
-              return suiteAppClient.readLargeFile(id)
-            }),
-          )
-        )
-      }),
-    )
-  ).flat()
-
-  const failedPaths: string[][] = []
-  const lockedPaths: string[][] = []
-  const filesCustomizationWithContent = filesCustomizationWithoutContent
-    .map((file, index) => {
-      if (!(filesContent[index] instanceof Buffer)) {
-        log.warn(`Failed reading file ${fullPath(file.path)} with id ${file.id}`)
-        if (filesContent[index] instanceof ReadFileInsufficientPermissionError) {
-          lockedPaths.push(file.path)
-        } else {
-          failedPaths.push(file.path)
-        }
-        return undefined
-      }
-      return {
-        path: file.path,
-        typeName: 'file',
-        fileContent: filesContent[index],
-        values: file.values,
-      }
-    })
-    .filter(values.isDefined)
+  const { filesCustomizationInfos, otherError, lockedError } = await queryFilesContent(
+    suiteAppClient,
+    filesWithoutContent,
+  )
 
   return {
-    elements: [
-      ...foldersCustomizationInfo,
-      ...filesCustomizationWithContent,
-      ...filesCustomizationsLinks.map(file => ({
-        path: file.path,
-        typeName: 'file',
-        values: file.values,
-      })),
-    ],
+    elements: ([] as FileCabinetCustomizationInfo[])
+      .concat(foldersCustomizationInfos)
+      .concat(filesCustomizationInfos)
+      .concat(linksCustomizationInfos),
     failedPaths: {
-      otherError: failedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
-      lockedError: lockedPaths.map(fileCabinetPath => fullPath(fileCabinetPath)),
-      largeFolderError: largeFolders,
+      otherError,
+      lockedError,
+      largeSizeFoldersError,
+      largeFilesCountFoldersError,
     },
+    largeFilesCountFolderWarnings,
   }
 }
 

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -20,7 +20,12 @@ import {
   Values,
 } from '@salto-io/adapter-api'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
-import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, ObjectID } from '../config/types'
+import {
+  MaxFilesPerFileCabinetFolder,
+  NetsuiteFilePathsQueryParams,
+  NetsuiteTypesQueryParams,
+  ObjectID,
+} from '../config/types'
 
 export interface CustomizationInfo {
   typeName: string
@@ -37,11 +42,13 @@ export interface TemplateCustomTypeInfo extends CustomTypeInfo {
 }
 
 export interface FileCustomizationInfo extends CustomizationInfo {
+  typeName: 'file'
   path: string[]
-  fileContent: Buffer
+  fileContent?: Buffer
 }
 
 export interface FolderCustomizationInfo extends CustomizationInfo {
+  typeName: 'folder'
   path: string[]
 }
 
@@ -63,12 +70,14 @@ export type GetCustomObjectsResult = {
 export type FailedFiles = {
   lockedError: NetsuiteFilePathsQueryParams
   otherError: NetsuiteFilePathsQueryParams
-  largeFolderError: NetsuiteFilePathsQueryParams
+  largeSizeFoldersError: NetsuiteFilePathsQueryParams
+  largeFilesCountFoldersError: NetsuiteFilePathsQueryParams
 }
 
 export type ImportFileCabinetResult = {
   elements: FileCabinetCustomizationInfo[]
   failedPaths: FailedFiles
+  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
 }
 
 export type FailedImport = {

--- a/packages/netsuite-adapter/src/client/types.ts
+++ b/packages/netsuite-adapter/src/client/types.ts
@@ -20,12 +20,7 @@ import {
   Values,
 } from '@salto-io/adapter-api'
 import { toCustomRecordTypeInstance } from '../custom_records/custom_record_type'
-import {
-  MaxFilesPerFileCabinetFolder,
-  NetsuiteFilePathsQueryParams,
-  NetsuiteTypesQueryParams,
-  ObjectID,
-} from '../config/types'
+import { NetsuiteFilePathsQueryParams, NetsuiteTypesQueryParams, ObjectID } from '../config/types'
 
 export interface CustomizationInfo {
   typeName: string
@@ -74,10 +69,16 @@ export type FailedFiles = {
   largeFilesCountFoldersError: NetsuiteFilePathsQueryParams
 }
 
+export type LargeFilesCountFolderWarning = {
+  folderPath: string
+  limit: number
+  current: number
+}
+
 export type ImportFileCabinetResult = {
   elements: FileCabinetCustomizationInfo[]
   failedPaths: FailedFiles
-  largeFilesCountFolderWarnings: MaxFilesPerFileCabinetFolder[]
+  largeFilesCountFolderWarnings: LargeFilesCountFolderWarning[]
 }
 
 export type FailedImport = {

--- a/packages/netsuite-adapter/src/config/constants.ts
+++ b/packages/netsuite-adapter/src/config/constants.ts
@@ -18,6 +18,7 @@ export const DEFAULT_DEPLOY_REFERENCED_ELEMENTS = false
 export const DEFAULT_WARN_STALE_DATA = false
 export const DEFAULT_VALIDATE = true
 export const DEFAULT_MAX_INSTANCES_VALUE = 5000
+export const DEFAULT_MAX_FILES_PER_FOLDER_VALUE = 1000
 export const DEFAULT_MAX_INSTANCES_PER_TYPE = [
   { name: `${CUSTOM_RECORD_TYPE_NAME_PREFIX}.*`, limit: 10_000 },
   { name: SAVED_SEARCH, limit: 20_000 },

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -168,9 +168,15 @@ type SdfClientConfig = {
   installedSuiteApps?: string[]
 }
 
+export type MaxFilesPerFileCabinetFolder = {
+  folderPath: string
+  limit: number
+}
+
 export type ClientConfig = SdfClientConfig & {
   maxInstancesPerType?: MaxInstancesPerType[]
   maxFileCabinetSizeInGB?: number
+  maxFilesPerFileCabinetFolder?: MaxFilesPerFileCabinetFolder[]
 }
 
 export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
@@ -181,6 +187,7 @@ export const CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<ClientConfig> = {
   installedSuiteApps: 'installedSuiteApps',
   maxInstancesPerType: 'maxInstancesPerType',
   maxFileCabinetSizeInGB: 'maxFileCabinetSizeInGB',
+  maxFilesPerFileCabinetFolder: 'maxFilesPerFileCabinetFolder',
 }
 
 export type SuiteQLTableQueryParams = {
@@ -305,6 +312,23 @@ const maxInstancesPerConfigType = createMatchingObjectType<MaxInstancesPerType>(
   },
 })
 
+const maxFilesPerFileCabinetFolderType = createMatchingObjectType<MaxFilesPerFileCabinetFolder>({
+  elemID: new ElemID(NETSUITE, 'maxFilesPerFileCabinetFolder'),
+  fields: {
+    folderPath: {
+      refType: BuiltinTypes.STRING,
+      annotations: { _required: true },
+    },
+    limit: {
+      refType: BuiltinTypes.NUMBER,
+      annotations: { _required: true },
+    },
+  },
+  annotations: {
+    [CORE_ANNOTATIONS.ADDITIONAL_PROPERTIES]: false,
+  },
+})
+
 const clientConfigType = createMatchingObjectType<ClientConfig>({
   elemID: new ElemID(NETSUITE, 'clientConfig'),
   fields: {
@@ -355,6 +379,9 @@ const clientConfigType = createMatchingObjectType<ClientConfig>({
       annotations: {
         [CORE_ANNOTATIONS.DEFAULT]: DEFAULT_MAX_FILE_CABINET_SIZE_IN_GB,
       },
+    },
+    maxFilesPerFileCabinetFolder: {
+      refType: new ListType(maxFilesPerFileCabinetFolderType),
     },
   },
   annotations: {

--- a/packages/netsuite-adapter/test/adapter.test.ts
+++ b/packages/netsuite-adapter/test/adapter.test.ts
@@ -63,6 +63,7 @@ import {
   CustomTypeInfo,
   FileCustomizationInfo,
   FolderCustomizationInfo,
+  ImportFileCabinetResult,
   SDFObjectNode,
 } from '../src/client/types'
 import * as changesDetector from '../src/changes_detector/changes_detector'
@@ -208,10 +209,16 @@ describe('Adapter', () => {
     })
     client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
       elements: [],
-      failedPaths: { lockedError: [], otherError: [], largeFolderError: [] },
+      failedPaths: { lockedError: [], otherError: [], largeSizeFoldersError: [], largeFilesCountFoldersError: [] },
+      largeFilesCountFolderWarnings: [],
     })
 
-    suiteAppImportFileCabinetMock.mockResolvedValue({ elements: [], failedPaths: [] })
+    const suiteAppImportFileCabinetResult: ImportFileCabinetResult = {
+      elements: [],
+      failedPaths: { lockedError: [], otherError: [], largeFilesCountFoldersError: [], largeSizeFoldersError: [] },
+      largeFilesCountFolderWarnings: [],
+    }
+    suiteAppImportFileCabinetMock.mockResolvedValue(suiteAppImportFileCabinetResult)
   })
 
   describe('fetch', () => {
@@ -248,7 +255,8 @@ describe('Adapter', () => {
 
       client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [folderCustomizationInfo, fileCustomizationInfo],
-        failedPaths: { lockedError: [], otherError: [], largeFolderError: [] },
+        failedPaths: { lockedError: [], otherError: [], largeSizeFoldersError: [], largeFilesCountFoldersError: [] },
+        largeFilesCountFolderWarnings: [],
       })
       client.getCustomObjects = mockFunction<SdfClient['getCustomObjects']>().mockResolvedValue({
         elements: [customTypeInfo, featuresCustomTypeInfo],
@@ -458,14 +466,25 @@ describe('Adapter', () => {
     it('should filter large file cabinet folders', async () => {
       client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [],
-        failedPaths: { lockedError: [], otherError: [], largeFolderError: ['largeFolder'] },
+        failedPaths: {
+          lockedError: [],
+          otherError: [],
+          largeSizeFoldersError: ['largeFolder'],
+          largeFilesCountFoldersError: [],
+        },
+        largeFilesCountFolderWarnings: [],
       })
 
       await netsuiteAdapter.fetch(mockFetchOpts)
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: ['largeFolder'] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: ['largeFolder'],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: expect.anything(),
           failedCustomRecords: expect.anything(),
         },
@@ -486,7 +505,12 @@ describe('Adapter', () => {
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: ['excludedTypeTest'] },
           failedCustomRecords: [],
         },
@@ -553,7 +577,12 @@ describe('Adapter', () => {
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
         },
@@ -565,7 +594,13 @@ describe('Adapter', () => {
     it('should call getConfigFromConfigChanges with failed file paths', async () => {
       client.importFileCabinetContent = mockFunction<SdfClient['importFileCabinetContent']>().mockResolvedValue({
         elements: [],
-        failedPaths: { lockedError: [], otherError: ['/path/to/file'], largeFolderError: [] },
+        failedPaths: {
+          lockedError: [],
+          otherError: ['/path/to/file'],
+          largeSizeFoldersError: [],
+          largeFilesCountFoldersError: [],
+        },
+        largeFilesCountFolderWarnings: [],
       })
       const getConfigFromConfigChangesMock = getConfigFromConfigChanges as jest.Mock
       const updatedConfig = new InstanceElement(ElemID.CONFIG_NAME, configType)
@@ -574,7 +609,12 @@ describe('Adapter', () => {
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: ['/path/to/file'], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: ['/path/to/file'],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
         },
@@ -598,7 +638,12 @@ describe('Adapter', () => {
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: failedTypeToInstances, excludedTypes: [] },
           failedCustomRecords: [],
         },
@@ -621,7 +666,12 @@ describe('Adapter', () => {
       expect(getConfigFromConfigChanges).toHaveBeenCalledWith(
         {
           failedToFetchAllAtOnce: true,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
         },
@@ -1346,9 +1396,12 @@ describe('Adapter', () => {
 
     it('should use suiteAppFileCabinet importFileCabinet and pass it the right params', async () => {
       await adapter.fetch(mockFetchOpts)
-      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(suiteAppClient, expect.anything(), 3, [
-        '.*\\.(csv|pdf|png)',
-      ])
+      expect(suiteAppImportFileCabinetMock).toHaveBeenCalledWith(suiteAppClient, {
+        query: expect.anything(),
+        maxFileCabinetSizeInGB: 3,
+        extensionsToExclude: ['.*\\.(csv|pdf|png)'],
+        maxFilesPerFileCabinetFolder: [],
+      })
     })
 
     it('should not create serverTime elements when getSystemInformation returns undefined', async () => {

--- a/packages/netsuite-adapter/test/change_validator.test.ts
+++ b/packages/netsuite-adapter/test/change_validator.test.ts
@@ -67,7 +67,12 @@ describe('change validator', () => {
         Promise.resolve({
           failures: {
             failedToFetchAllAtOnce: false,
-            failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+            failedFilePaths: {
+              lockedError: [],
+              otherError: [],
+              largeSizeFoldersError: [],
+              largeFilesCountFoldersError: [],
+            },
             failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
             failedCustomRecords: [],
             largeSuiteQLTables: [],
@@ -151,7 +156,12 @@ describe('change validator', () => {
         Promise.resolve({
           failures: {
             failedToFetchAllAtOnce: false,
-            failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+            failedFilePaths: {
+              lockedError: [],
+              otherError: [],
+              largeSizeFoldersError: [],
+              largeFilesCountFoldersError: [],
+            },
             failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
             failedCustomRecords: [],
             largeSuiteQLTables: [],

--- a/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
+++ b/packages/netsuite-adapter/test/change_validators/safe_deploy.test.ts
@@ -29,7 +29,7 @@ import { NetsuiteConfig } from '../../src/config/types'
 const EMPTY_FETCH_RESULT: FetchByQueryReturnType = {
   failures: {
     failedToFetchAllAtOnce: false,
-    failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+    failedFilePaths: { lockedError: [], otherError: [], largeSizeFoldersError: [], largeFilesCountFoldersError: [] },
     failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
     failedCustomRecords: [],
   },
@@ -146,7 +146,12 @@ describe('safe deploy change validator', () => {
             Promise.resolve({
               failures: {
                 failedToFetchAllAtOnce: false,
-                failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+                failedFilePaths: {
+                  lockedError: [],
+                  otherError: [],
+                  largeSizeFoldersError: [],
+                  largeFilesCountFoldersError: [],
+                },
                 failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
                 failedCustomRecords: [],
                 largeSuiteQLTables: [],
@@ -190,7 +195,12 @@ describe('safe deploy change validator', () => {
             Promise.resolve({
               failures: {
                 failedToFetchAllAtOnce: false,
-                failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+                failedFilePaths: {
+                  lockedError: [],
+                  otherError: [],
+                  largeSizeFoldersError: [],
+                  largeFilesCountFoldersError: [],
+                },
                 failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
                 failedCustomRecords: [],
                 largeSuiteQLTables: [],

--- a/packages/netsuite-adapter/test/client/file_cabinet_utils.test.ts
+++ b/packages/netsuite-adapter/test/client/file_cabinet_utils.test.ts
@@ -7,27 +7,93 @@
  */
 
 import { logger } from '@salto-io/logging'
+import { ElemID, InstanceElement, ObjectType, SaltoElementError, SaltoError } from '@salto-io/adapter-api'
+import { ERROR_MESSAGES } from '@salto-io/adapter-utils'
 import {
+  createLargeFilesCountFolderFetchWarnings,
   filterFilePathsInFolders,
   filterFilesInFolders,
   filterFolderPathsInFolders,
   largeFoldersToExclude,
 } from '../../src/client/file_cabinet_utils'
+import { folderType } from '../../src/types/file_cabinet_types'
+import { NETSUITE, PATH } from '../../src/constants'
 
 const logging = logger('netsuite-adapter/src/client/file_cabinet_utils')
 
-describe('excludeLargeFolders', () => {
-  it('should not exclude any folders if there is no size overflow', () => {
-    const filesToSize = [
-      { path: '/folder/path1', size: 500_000 },
-      { path: '/folder/path2', size: 500_000 },
-    ]
-    const largeFolders = largeFoldersToExclude(filesToSize, 1)
-    expect(largeFolders).toEqual([])
+describe('file cabinet utils', () => {
+  describe('excludeLargeFolders', () => {
+    it('should not exclude any folders if there is no size overflow', () => {
+      const filesToSize = [
+        { path: '/folder/path1', size: 500_000 },
+        { path: '/folder/path2', size: 500_000 },
+      ]
+      const largeFolders = largeFoldersToExclude(filesToSize, 1)
+      expect(largeFolders).toEqual([])
+    })
+
+    describe('when there is a size overflow', () => {
+      it('should exclude the last largest folder if there is a larger than overflow top level folder', () => {
+        const filesToSize = [
+          { path: '/largeTopFolder/largeFolder/path1', size: 1_000_000 },
+          { path: '/largeTopFolder/largeFolder/path2', size: 1_000_000 },
+          { path: '/largeTopFolder/smallFolder/path2', size: 500_000 },
+          { path: '/smallTopFolder/path1', size: 500_000 },
+        ]
+        const largeFolders = largeFoldersToExclude(filesToSize, 0.002)
+        expect(largeFolders).toEqual(['/largeTopFolder/largeFolder/'])
+      })
+
+      it('should exclude multiple largest top level folders if there are no larger than overflow top level folders', () => {
+        const filesToSize = [
+          { path: '/firstTopFolder/path1', size: 1_700_000 },
+          { path: '/thirdTopFolder/path2', size: 1_500_000 },
+          { path: '/secondTopFolder/path2', size: 1_600_000 },
+          { path: '/fourthTopFolder/path2', size: 1_400_000 },
+        ]
+        const largeFolders = largeFoldersToExclude(filesToSize, 0.004)
+        expect(largeFolders).toEqual(['/firstTopFolder/', '/secondTopFolder/'])
+      })
+    })
+
+    it('should create a log when there is a warning overflow (1GB hardcoded), but no size overflow', () => {
+      const log = jest.spyOn(logging, 'info')
+      const filesToSize = [{ path: '/firstTopFolder/path1', size: 1_500_000_000 }]
+      const largeFolders = largeFoldersToExclude(filesToSize, 2)
+      expect(largeFolders).toEqual([])
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('1.40 GB'))
+    })
   })
 
-  describe('when there is a size overflow', () => {
-    it('should exclude the last largest folder if there is a larger than overflow top level folder', () => {
+  describe('filterFilePathsInFolders', () => {
+    it('filters out files that appear in one of the folders', () => {
+      const files = [{ path: ['a', 'b', 'c.ts'] }, { path: ['a', 'b', 'd.ts'] }, { path: ['a', 'z', 'w.ts'] }]
+      const folders = ['/a/b/']
+      const result = filterFilePathsInFolders(files, folders)
+      expect(result).toEqual([{ path: ['a', 'z', 'w.ts'] }])
+    })
+  })
+
+  describe('filterFolderPathsInFolders', () => {
+    it('filters out folders that appear in one of the folders', () => {
+      const files = [{ path: ['a', 'b'] }, { path: ['a', 'b', 'd'] }, { path: ['a', 'z'] }]
+      const folders = ['/a/b/']
+      const result = filterFolderPathsInFolders(files, folders)
+      expect(result).toEqual([{ path: ['a', 'z'] }])
+    })
+  })
+
+  describe('filterFilesInFolders', () => {
+    it('filters out files or subfolders that appear in one of the folders', () => {
+      const files = ['a/b/c.ts', 'a/b/d', 'a/z/w.ts']
+      const folders = ['a/b/']
+      const result = filterFilesInFolders(files, folders)
+      expect(result).toEqual(['a/z/w.ts'])
+    })
+  })
+
+  describe('exclude and filter', () => {
+    it('works together when excluding files', () => {
       const filesToSize = [
         { path: '/largeTopFolder/largeFolder/path1', size: 1_000_000 },
         { path: '/largeTopFolder/largeFolder/path2', size: 1_000_000 },
@@ -35,86 +101,106 @@ describe('excludeLargeFolders', () => {
         { path: '/smallTopFolder/path1', size: 500_000 },
       ]
       const largeFolders = largeFoldersToExclude(filesToSize, 0.002)
-      expect(largeFolders).toEqual(['/largeTopFolder/largeFolder/'])
+      const result = filterFilesInFolders(
+        filesToSize.map(({ path }) => path),
+        largeFolders,
+      )
+      expect(result).toEqual(['/largeTopFolder/smallFolder/path2', '/smallTopFolder/path1'])
     })
 
-    it('should exclude multiple largest top level folders if there are no larger than overflow top level folders', () => {
-      const filesToSize = [
-        { path: '/firstTopFolder/path1', size: 1_700_000 },
-        { path: '/thirdTopFolder/path2', size: 1_500_000 },
-        { path: '/secondTopFolder/path2', size: 1_600_000 },
-        { path: '/fourthTopFolder/path2', size: 1_400_000 },
+    it('works together when excluding file paths', () => {
+      const filesPathsSize = [
+        { path: ['largeTopFolder', 'largeFolder', 'path1'], size: 1_000_000 },
+        { path: ['largeTopFolder', 'largeFolder', 'path2'], size: 1_000_000 },
+        { path: ['largeTopFolder', 'smallFolder', 'path2'], size: 500_000 },
+        { path: ['smallTopFolder', 'path1'], size: 500_000 },
       ]
-      const largeFolders = largeFoldersToExclude(filesToSize, 0.004)
-      expect(largeFolders).toEqual(['/firstTopFolder/', '/secondTopFolder/'])
+      const filesToSize = filesPathsSize.map(({ path, size }) => ({ path: `/${path.join('/')}`, size }))
+      const largeFolders = largeFoldersToExclude(filesToSize, 0.002)
+      const result = filterFilePathsInFolders(filesPathsSize, largeFolders)
+      expect(result).toEqual([
+        { path: ['largeTopFolder', 'smallFolder', 'path2'], size: 500_000 },
+        { path: ['smallTopFolder', 'path1'], size: 500_000 },
+      ])
     })
   })
 
-  it('should create a log when there is a warning overflow (1GB hardcoded), but no size overflow', () => {
-    const log = jest.spyOn(logging, 'info')
-    const filesToSize = [{ path: '/firstTopFolder/path1', size: 1_500_000_000 }]
-    const largeFolders = largeFoldersToExclude(filesToSize, 2)
-    expect(largeFolders).toEqual([])
-    expect(log).toHaveBeenCalledWith(expect.stringContaining('1.40 GB'))
-  })
-})
+  describe('create large files count folder fetch warnings', () => {
+    let folderInstance1: InstanceElement
+    let folderInstance2: InstanceElement
+    let otherInstance: InstanceElement
+    let fetchWarnings: (SaltoError | SaltoElementError)[]
 
-describe('filterFilePathsInFolders', () => {
-  it('filters out files that appear in one of the folders', () => {
-    const files = [{ path: ['a', 'b', 'c.ts'] }, { path: ['a', 'b', 'd.ts'] }, { path: ['a', 'z', 'w.ts'] }]
-    const folders = ['/a/b/']
-    const result = filterFilePathsInFolders(files, folders)
-    expect(result).toEqual([{ path: ['a', 'z', 'w.ts'] }])
-  })
-})
+    beforeEach(() => {
+      const folder = folderType()
+      const otherType = new ObjectType({ elemID: new ElemID(NETSUITE, 'type') })
+      folderInstance1 = new InstanceElement('folder1', folder, { [PATH]: '/SuiteScripts/folder1' })
+      folderInstance2 = new InstanceElement('folder2', folder, { [PATH]: '/SuiteScripts/folder2' })
+      otherInstance = new InstanceElement('instance', otherType, { [PATH]: 'other' })
+    })
 
-describe('filterFolderPathsInFolders', () => {
-  it('filters out folders that appear in one of the folders', () => {
-    const files = [{ path: ['a', 'b'] }, { path: ['a', 'b', 'd'] }, { path: ['a', 'z'] }]
-    const folders = ['/a/b/']
-    const result = filterFolderPathsInFolders(files, folders)
-    expect(result).toEqual([{ path: ['a', 'z'] }])
-  })
-})
+    describe('when there are no large files count folder warnings', () => {
+      beforeEach(() => {
+        fetchWarnings = createLargeFilesCountFolderFetchWarnings([folderInstance1, folderInstance2, otherInstance], [])
+      })
 
-describe('filterFilesInFolders', () => {
-  it('filters out files or subfolders that appear in one of the folders', () => {
-    const files = ['a/b/c.ts', 'a/b/d', 'a/z/w.ts']
-    const folders = ['a/b/']
-    const result = filterFilesInFolders(files, folders)
-    expect(result).toEqual(['a/z/w.ts'])
-  })
-})
+      it('should not return fetch warnings', () => {
+        expect(fetchWarnings).toHaveLength(0)
+      })
+    })
 
-describe('exclude and filter', () => {
-  it('works together when excluding files', () => {
-    const filesToSize = [
-      { path: '/largeTopFolder/largeFolder/path1', size: 1_000_000 },
-      { path: '/largeTopFolder/largeFolder/path2', size: 1_000_000 },
-      { path: '/largeTopFolder/smallFolder/path2', size: 500_000 },
-      { path: '/smallTopFolder/path1', size: 500_000 },
-    ]
-    const largeFolders = largeFoldersToExclude(filesToSize, 0.002)
-    const result = filterFilesInFolders(
-      filesToSize.map(({ path }) => path),
-      largeFolders,
-    )
-    expect(result).toEqual(['/largeTopFolder/smallFolder/path2', '/smallTopFolder/path1'])
-  })
+    describe('when there are large files count folder warnings', () => {
+      beforeEach(() => {
+        fetchWarnings = createLargeFilesCountFolderFetchWarnings(
+          [folderInstance1, folderInstance2, otherInstance],
+          [
+            { folderPath: '/SuiteScripts/folder1', limit: 1000, current: 1100 },
+            { folderPath: '/SuiteScripts/folder2', limit: 2000, current: 2200 },
+          ],
+        )
+      })
 
-  it('works together when excluding file paths', () => {
-    const filesPathsSize = [
-      { path: ['largeTopFolder', 'largeFolder', 'path1'], size: 1_000_000 },
-      { path: ['largeTopFolder', 'largeFolder', 'path2'], size: 1_000_000 },
-      { path: ['largeTopFolder', 'smallFolder', 'path2'], size: 500_000 },
-      { path: ['smallTopFolder', 'path1'], size: 500_000 },
-    ]
-    const filesToSize = filesPathsSize.map(({ path, size }) => ({ path: `/${path.join('/')}`, size }))
-    const largeFolders = largeFoldersToExclude(filesToSize, 0.002)
-    const result = filterFilePathsInFolders(filesPathsSize, largeFolders)
-    expect(result).toEqual([
-      { path: ['largeTopFolder', 'smallFolder', 'path2'], size: 500_000 },
-      { path: ['smallTopFolder', 'path1'], size: 500_000 },
-    ])
+      it('should return fetch warnings', () => {
+        expect(fetchWarnings).toEqual([
+          {
+            elemID: folderInstance1.elemID,
+            severity: 'Warning',
+            message: ERROR_MESSAGES.OTHER_ISSUES,
+            detailedMessage: expect.stringContaining(
+              'The File Cabinet folder "/SuiteScripts/folder1" is close to exceed the limit of allowed amount of files in a folder. There are currently 1100 files in the folder and the limit for this folder is 1000 files.',
+            ),
+          },
+          {
+            elemID: folderInstance2.elemID,
+            severity: 'Warning',
+            message: ERROR_MESSAGES.OTHER_ISSUES,
+            detailedMessage: expect.stringContaining(
+              'The File Cabinet folder "/SuiteScripts/folder2" is close to exceed the limit of allowed amount of files in a folder. There are currently 2200 files in the folder and the limit for this folder is 2000 files.',
+            ),
+          },
+        ])
+      })
+    })
+
+    describe('when there are large files count folder warnings that do not match any folder instance', () => {
+      beforeEach(() => {
+        fetchWarnings = createLargeFilesCountFolderFetchWarnings(
+          [folderInstance1, folderInstance2, otherInstance],
+          [{ folderPath: 'other', limit: 1000, current: 1100 }],
+        )
+      })
+
+      it('should return fetch warning without elemID', () => {
+        expect(fetchWarnings).toEqual([
+          {
+            severity: 'Warning',
+            message: ERROR_MESSAGES.OTHER_ISSUES,
+            detailedMessage: expect.stringContaining(
+              'The File Cabinet folder "other" is close to exceed the limit of allowed amount of files in a folder. There are currently 1100 files in the folder and the limit for this folder is 1000 files.',
+            ),
+          },
+        ])
+      })
+    })
   })
 })

--- a/packages/netsuite-adapter/test/client/sdf_client.test.ts
+++ b/packages/netsuite-adapter/test/client/sdf_client.test.ts
@@ -1065,7 +1065,8 @@ describe.each([
       expect(elements).toHaveLength(0)
       expect(failedPaths).toEqual({
         lockedError: [],
-        largeFolderError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
         otherError: fileCabinetTopLevelFolders.map(folderPath => `^${folderPath}.*`),
       })
     })
@@ -1107,7 +1108,12 @@ describe.each([
       expect(mockExecuteAction).toHaveBeenNthCalledWith(5, listFilesCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(6, deleteAuthIdCommandMatcher)
       expect(elements).toHaveLength(0)
-      expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+        otherError: [],
+      })
     })
 
     it('should fail to importFiles when failing to import a certain file', async () => {
@@ -1249,7 +1255,12 @@ describe.each([
           path: ['Templates', 'E-mail Templates'],
         },
       ])
-      expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+        otherError: [],
+      })
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(3, listFilesCommandMatcher)
@@ -1280,7 +1291,12 @@ describe.each([
       const { elements, failedPaths } = await client.importFileCabinetContent(query, maxFileCabinetSizeInGB)
       expect(readFileMock).toHaveBeenCalledTimes(0)
       expect(elements).toHaveLength(0)
-      expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+        otherError: [],
+      })
       expect(mockExecuteAction).toHaveBeenCalledTimes(6)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(1, createProjectCommandMatcher)
       expect(mockExecuteAction).toHaveBeenNthCalledWith(2, saveTokenCommandMatcher)
@@ -1299,7 +1315,12 @@ describe.each([
       )
 
       expect(elements).toHaveLength(0)
-      expect(failedPaths).toEqual({ lockedError: [], otherError: [], largeFolderError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        otherError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+      })
       expect(mockExecuteAction).not.toHaveBeenCalled()
     })
 
@@ -1350,7 +1371,12 @@ describe.each([
           path: ['Templates', 'E-mail Templates', 'InnerFolder'],
         },
       ])
-      expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [], otherError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+        otherError: [],
+      })
       expect(rmMock).toHaveBeenCalledTimes(withOAuth ? 2 : 1)
     })
 
@@ -1400,7 +1426,12 @@ describe.each([
         maxFileCabinetSizeInGB,
       )
       expect(elements).toHaveLength(0)
-      expect(failedPaths).toEqual({ lockedError: [], largeFolderError: [MOCK_FOLDER_PATH], otherError: [] })
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        largeSizeFoldersError: [MOCK_FOLDER_PATH],
+        largeFilesCountFoldersError: [],
+        otherError: [],
+      })
     })
   })
 

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -10,7 +10,7 @@ import { InstanceElement, ElemID } from '@salto-io/adapter-api'
 import { formatConfigSuggestionsReasons } from '@salto-io/adapter-utils'
 import { fullFetchConfig, fullQueryParams } from '../../src/config/config_creator'
 import {
-  toLargeFoldersExcludedMessage,
+  toLargeSizeFoldersExcludedMessage,
   toLargeTypesExcludedMessage,
   STOP_MANAGING_ITEMS_MSG,
   getConfigFromConfigChanges,
@@ -66,7 +66,12 @@ describe('netsuite config suggestions', () => {
       getConfigFromConfigChanges(
         {
           failedToFetchAllAtOnce: false,
-          failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+          failedFilePaths: {
+            lockedError: [],
+            otherError: [],
+            largeSizeFoldersError: [],
+            largeFilesCountFoldersError: [],
+          },
           failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
           failedCustomRecords: [],
         },
@@ -81,7 +86,12 @@ describe('netsuite config suggestions', () => {
     const configFromConfigChanges = getConfigFromConfigChanges(
       {
         failedToFetchAllAtOnce: true,
-        failedFilePaths: { lockedError: lockedFiles, otherError: [newFailedFilePath], largeFolderError: [] },
+        failedFilePaths: {
+          lockedError: lockedFiles,
+          otherError: [newFailedFilePath],
+          largeSizeFoldersError: [],
+          largeFilesCountFoldersError: [],
+        },
         failedTypes: { lockedError: lockedTypes, unexpectedError: suggestedSkipListTypes, excludedTypes: [] },
         failedCustomRecords: [],
       },
@@ -137,7 +147,12 @@ describe('netsuite config suggestions', () => {
     const configChange = getConfigFromConfigChanges(
       {
         failedToFetchAllAtOnce: true,
-        failedFilePaths: { lockedError: [], otherError: [newFailedFilePath], largeFolderError: [newLargeFolderPath] },
+        failedFilePaths: {
+          lockedError: [],
+          otherError: [newFailedFilePath],
+          largeSizeFoldersError: [newLargeFolderPath],
+          largeFilesCountFoldersError: [],
+        },
         failedTypes: { lockedError: {}, unexpectedError: suggestedSkipListTypes, excludedTypes: ['excludedTypeTest'] },
         failedCustomRecords: ['excludedCustomRecord'],
       },
@@ -163,7 +178,7 @@ describe('netsuite config suggestions', () => {
     expect(configChange?.message).toBe(
       formatConfigSuggestionsReasons([
         STOP_MANAGING_ITEMS_MSG,
-        toLargeFoldersExcludedMessage([newLargeFolderPath]),
+        toLargeSizeFoldersExcludedMessage([newLargeFolderPath]),
         toLargeTypesExcludedMessage(['excludedTypeTest', 'excludedCustomRecord']),
       ]),
     )
@@ -186,7 +201,12 @@ describe('netsuite config suggestions', () => {
     const configChange = getConfigFromConfigChanges(
       {
         failedToFetchAllAtOnce: false,
-        failedFilePaths: { lockedError: [], otherError: [newFailedFilePath], largeFolderError: [newLargeFolderPath] },
+        failedFilePaths: {
+          lockedError: [],
+          otherError: [newFailedFilePath],
+          largeSizeFoldersError: [newLargeFolderPath],
+          largeFilesCountFoldersError: [],
+        },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
       },
@@ -194,7 +214,10 @@ describe('netsuite config suggestions', () => {
     )
 
     expect(configChange?.message).toBe(
-      formatConfigSuggestionsReasons([STOP_MANAGING_ITEMS_MSG, toLargeFoldersExcludedMessage([newLargeFolderPath])]),
+      formatConfigSuggestionsReasons([
+        STOP_MANAGING_ITEMS_MSG,
+        toLargeSizeFoldersExcludedMessage([newLargeFolderPath]),
+      ]),
     )
   })
 
@@ -211,7 +234,12 @@ describe('netsuite config suggestions', () => {
     const configChange = getConfigFromConfigChanges(
       {
         failedToFetchAllAtOnce: false,
-        failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+        failedFilePaths: {
+          lockedError: [],
+          otherError: [],
+          largeSizeFoldersError: [],
+          largeFilesCountFoldersError: [],
+        },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
       },
@@ -248,7 +276,12 @@ describe('netsuite config suggestions', () => {
     const configChange = getConfigFromConfigChanges(
       {
         failedToFetchAllAtOnce: false,
-        failedFilePaths: { lockedError: [], otherError: [], largeFolderError: [] },
+        failedFilePaths: {
+          lockedError: [],
+          otherError: [],
+          largeSizeFoldersError: [],
+          largeFilesCountFoldersError: [],
+        },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
       },

--- a/packages/netsuite-adapter/test/config/suggestions.test.ts
+++ b/packages/netsuite-adapter/test/config/suggestions.test.ts
@@ -16,6 +16,7 @@ import {
   getConfigFromConfigChanges,
   ALIGNED_INACTIVE_CRITERIAS,
   toRemovedDeprecatedConfigsMessage,
+  toLargeFilesCountFoldersExcludedMessage,
 } from '../../src/config/suggestions'
 import { NetsuiteQueryParameters, fetchDefault, configType, NetsuiteConfig } from '../../src/config/types'
 import { INACTIVE_FIELDS } from '../../src/constants'
@@ -56,6 +57,11 @@ describe('netsuite config suggestions', () => {
     },
   }
   const newFailedFilePath = '/path/to/file'
+  const newLargeFolderPath = '/largeFolder/'
+  const newLargeFilesCountFolderPath = '/largeFilesCountFolder/'
+  const newLargeFolderExclusion = `^${newLargeFolderPath}.*`
+  const newLargeFilesCountFolderExclusion = `^${newLargeFilesCountFolderPath}.*`
+
   const suggestedSkipListTypes = {
     testExistingPartial: ['scriptid3', 'scriptid4'],
     testNew: ['scriptid5', 'scriptid6'],
@@ -131,8 +137,6 @@ describe('netsuite config suggestions', () => {
   })
 
   it('should return updated currentConfig when having suggestions and the currentConfig has values', () => {
-    const newLargeFolderPath = '/largeFolder/'
-    const newLargeFolderExclusion = `^${newLargeFolderPath}.*`
     const newExclude = {
       types: [
         { name: 'testAll', ids: ['.*'] },
@@ -141,7 +145,12 @@ describe('netsuite config suggestions', () => {
         { name: 'testNew', ids: ['scriptid5', 'scriptid6'] },
         { name: 'excludedTypeTest' },
       ],
-      fileCabinet: ['SomeRegex', _.escapeRegExp(newFailedFilePath), newLargeFolderExclusion],
+      fileCabinet: [
+        'SomeRegex',
+        _.escapeRegExp(newFailedFilePath),
+        newLargeFolderExclusion,
+        newLargeFilesCountFolderExclusion,
+      ],
       customRecords: [{ name: 'excludedCustomRecord' }],
     }
     const configChange = getConfigFromConfigChanges(
@@ -151,7 +160,7 @@ describe('netsuite config suggestions', () => {
           lockedError: [],
           otherError: [newFailedFilePath],
           largeSizeFoldersError: [newLargeFolderPath],
-          largeFilesCountFoldersError: [],
+          largeFilesCountFoldersError: [newLargeFilesCountFolderPath],
         },
         failedTypes: { lockedError: {}, unexpectedError: suggestedSkipListTypes, excludedTypes: ['excludedTypeTest'] },
         failedCustomRecords: ['excludedCustomRecord'],
@@ -179,14 +188,13 @@ describe('netsuite config suggestions', () => {
       formatConfigSuggestionsReasons([
         STOP_MANAGING_ITEMS_MSG,
         toLargeSizeFoldersExcludedMessage([newLargeFolderPath]),
+        toLargeFilesCountFoldersExcludedMessage([newLargeFilesCountFolderPath]),
         toLargeTypesExcludedMessage(['excludedTypeTest', 'excludedCustomRecord']),
       ]),
     )
   })
 
   it('should combine configuration messages when needed', () => {
-    const newLargeFolderPath = '/largeFolder/'
-    const newLargeFolderExclusion = `^${newLargeFolderPath}.*`
     const newSkipList = _.cloneDeep(skipList)
     newSkipList.types = { ...newSkipList.types, someType: ['.*'] }
     newSkipList.filePaths?.push('.*someRegex.*')
@@ -205,7 +213,7 @@ describe('netsuite config suggestions', () => {
           lockedError: [],
           otherError: [newFailedFilePath],
           largeSizeFoldersError: [newLargeFolderPath],
-          largeFilesCountFoldersError: [],
+          largeFilesCountFoldersError: [newLargeFilesCountFolderPath],
         },
         failedTypes: { lockedError: {}, unexpectedError: {}, excludedTypes: [] },
         failedCustomRecords: [],
@@ -217,6 +225,7 @@ describe('netsuite config suggestions', () => {
       formatConfigSuggestionsReasons([
         STOP_MANAGING_ITEMS_MSG,
         toLargeSizeFoldersExcludedMessage([newLargeFolderPath]),
+        toLargeFilesCountFoldersExcludedMessage([newLargeFilesCountFolderPath]),
       ]),
     )
   })

--- a/packages/netsuite-adapter/test/config/validations.test.ts
+++ b/packages/netsuite-adapter/test/config/validations.test.ts
@@ -416,6 +416,33 @@ describe('netsuite config validations', () => {
         expect(() => validateConfig(config)).toThrow()
       })
     })
+
+    describe('validate maxFilesPerFileCabinetFolder', () => {
+      it('should validate maxFilesPerFileCabinetFolder is the correct object with valid regex', () => {
+        config.client = {
+          maxFilesPerFileCabinetFolder: [{ folderPath: '/SuiteScripts.*', limit: 2000 }],
+        }
+        expect(() => validateConfig(config)).not.toThrow()
+      })
+
+      it('should throw if maxFilesPerFileCabinetFolder is the wrong object', () => {
+        config.client = {
+          maxFilesPerFileCabinetFolder: [{ name: '/SuiteScripts.*', limit: 2000 }],
+        }
+        expect(() => validateConfig(config)).toThrow(
+          'Expected maxFilesPerFileCabinetFolder to be a list of { folderPath: string, limit: number }',
+        )
+      })
+
+      it('should throw if maxFilesPerFileCabinetFolder is the correct object with invalid regex', () => {
+        config.client = {
+          maxFilesPerFileCabinetFolder: [{ folderPath: '/SuiteScripts(.*', limit: 2000 }],
+        }
+        expect(() => validateConfig(config)).toThrow(
+          'The following regular expressions in maxFilesPerFileCabinetFolder are invalid',
+        )
+      })
+    })
   })
 
   describe('suiteAppClient config', () => {


### PR DESCRIPTION
Exclude FileCabinet folders (and all in them) that have more then the allowed amount of files for a single folder.
The limit is configurable using the `maxFilesPerFileCabinetFolder` config (see config_doc.md).
In case that a folder has reached 90% of the allowed amount, a fetch warning will be returned.

---

_Additional context for reviewer_

TODO:
- [x] add tests

---
_Release Notes_: 
Netsuite Adapter:
- Limit the allowed amount of files in a FileCabinet folder (using the `client.maxFilesPerFileCabinetFolder` config)

---
_User Notifications_: 
Netsuite Adapter:
- When `client.maxFilesPerFileCabinetFolder` is given, FileCabinet folder that have more than the allowed amount of files will be excluded.
