### PR TITLE
SALTO-6396: Add missing reference from ApprovalProcess to WorkflowAction

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -143,6 +143,7 @@ import taskAndEventCustomFields from './filters/task_and_event_custom_fields'
 import picklistReferences from './filters/picklist_references'
 import addParentToInstancesWithinFolderFilter from './filters/add_parent_to_instances_within_folder'
 import addParentToRecordTriggeredFlows from './filters/add_parent_to_record_triggered_flows'
+import addParentToApprovalProcess from './filters/add_parent_to_approval_process'
 import { getConfigFromConfigChanges } from './config_change'
 import { Filter, FilterContext, FilterCreator, FilterResult } from './filter'
 import {
@@ -265,6 +266,7 @@ export const allFilters: Array<FilterCreator> = [
   valueToStaticFileFilter,
   // addParentToRecordTriggeredFlows should run before fieldReferenceFilter
   addParentToRecordTriggeredFlows,
+  addParentToApprovalProcess,
   fieldReferencesFilter,
   // should run after customObjectsInstancesFilter for now
   referenceAnnotationsFilter,

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -490,6 +490,7 @@ export const STATIC_RESOURCE_METADATA_TYPE = 'StaticResource'
 export const AURA_DEFINITION_BUNDLE_METADATA_TYPE = 'AuraDefinitionBundle'
 export const GEN_AI_FUNCTION_METADATA_TYPE = 'GenAiFunction'
 export const LIVE_CHAT_BUTTON = 'LiveChatButton'
+export const APPROVAL_PROCESS_METADATA_TYPE = 'ApprovalProcess'
 
 // Wave Metadata Types
 export const WAVE_RECIPE_METADATA_TYPE = 'WaveRecipe'

--- a/packages/salesforce-adapter/src/filters/add_parent_to_approval_process.ts
+++ b/packages/salesforce-adapter/src/filters/add_parent_to_approval_process.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { logger } from '@salto-io/logging'
+import _ from 'lodash'
+import { collections } from '@salto-io/lowerdash'
+import { Element } from '@salto-io/adapter-api'
+import { FilterCreator } from '../filter'
+import {
+  addElementParentReference,
+  apiNameSync,
+  buildElementsSourceForFetch,
+  isCustomObjectSync,
+  isInstanceOfTypeSync,
+} from './utils'
+import { APPROVAL_PROCESS_METADATA_TYPE } from '../constants'
+
+const log = logger(module)
+const { toArrayAsync } = collections.asynciterable
+
+const filter: FilterCreator = ({ config }) => ({
+  name: 'addParentToApprovalProcess',
+  onFetch: async (elements: Element[]) => {
+    const customObjectByName = _.keyBy(
+      (await toArrayAsync(await buildElementsSourceForFetch(elements, config).getAll())).filter(isCustomObjectSync),
+      objectType => apiNameSync(objectType) ?? '',
+    )
+    const createdReferencesCount: number = elements
+      .filter(isInstanceOfTypeSync(APPROVAL_PROCESS_METADATA_TYPE))
+      .reduce((acc, approvalProcess) => {
+        const apiName = apiNameSync(approvalProcess)
+        if (apiName !== undefined) {
+          const parent = customObjectByName[apiName.split('.')[0]]
+          if (parent !== undefined) {
+            addElementParentReference(approvalProcess, parent)
+            return acc + 1
+          }
+          log.warn(
+            'could not add parent reference to instance %s, the object %s is missing from the workspace',
+            approvalProcess.elemID.getFullName(),
+            apiName,
+          )
+        }
+        return acc
+      }, 0)
+    log.debug('filter created %d references in total', createdReferencesCount)
+  },
+})
+
+export default filter

--- a/packages/salesforce-adapter/test/filters/add_parent_to_approval_process.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_approval_process.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { CORE_ANNOTATIONS, Element, ReferenceExpression } from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { mockTypes } from '../mock_elements'
+import { createCustomObjectType, defaultFilterContext } from '../utils'
+import { FilterWith } from './mocks'
+import { createInstanceElement } from '../../src/transformers/transformer'
+import filterCreator from '../../src/filters/add_parent_to_approval_process'
+import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
+
+describe('addParentToApprovalProcess', () => {
+  describe('onFetch', () => {
+    let elements: Element[]
+    let elementsSource: Element[]
+    let accountApprovalProcess: Element
+    let leadApprovalProcess: Element
+    let account: Element
+    let lead: Element
+    let filter: FilterWith<'onFetch'>
+
+    describe('when all parents exist in the workspace', () => {
+      beforeEach(async () => {
+        account = mockTypes.Account
+        elementsSource = [account]
+        elements = [
+          (accountApprovalProcess = createInstanceElement(
+            { fullName: 'Account.AccountApporvalProcess' },
+            mockTypes.ApprovalProcess,
+          )),
+          (leadApprovalProcess = createInstanceElement(
+            { fullName: 'Lead.leadApprovalProcess' },
+            mockTypes.ApprovalProcess,
+          )),
+          (lead = createCustomObjectType('Lead', {})),
+        ]
+        filter = filterCreator({
+          config: {
+            ...defaultFilterContext,
+            fetchProfile: buildFetchProfile({
+              fetchParams: { target: [] },
+            }),
+            elementsSource: buildElementsSourceFromElements(elementsSource),
+          },
+        }) as FilterWith<'onFetch'>
+        await filter.onFetch(elements)
+      })
+      it('should add parent annotation when the parent was not fetched in the current partial fetch', async () => {
+        expect(accountApprovalProcess.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+          new ReferenceExpression(account.elemID, account),
+        )
+      })
+      it('should add parent annotation when the parent was fetched in the current partial fetch', async () => {
+        expect(leadApprovalProcess.annotations[CORE_ANNOTATIONS.PARENT][0]).toEqual(
+          new ReferenceExpression(lead.elemID, lead),
+        )
+      })
+    })
+    describe('when parent does not exist', () => {
+      beforeEach(async () => {
+        jest.clearAllMocks()
+        elementsSource = []
+        elements = [
+          (accountApprovalProcess = createInstanceElement(
+            { fullName: 'Account.AccountApporvalProcess' },
+            mockTypes.ApprovalProcess,
+          )),
+          (leadApprovalProcess = createInstanceElement(
+            { fullName: 'Lead.leadApprovalProcess' },
+            mockTypes.ApprovalProcess,
+          )),
+        ]
+        filter = filterCreator({
+          config: {
+            ...defaultFilterContext,
+            fetchProfile: buildFetchProfile({
+              fetchParams: { target: [] },
+            }),
+            elementsSource: buildElementsSourceFromElements(elementsSource),
+          },
+        }) as FilterWith<'onFetch'>
+        await filter.onFetch(elements)
+      })
+      it('should not create parent annotation', () => {
+        expect(accountApprovalProcess.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+        expect(leadApprovalProcess.annotations[CORE_ANNOTATIONS.PARENT]).toBeUndefined()
+      })
+    })
+  })
+})

--- a/packages/salesforce-adapter/test/filters/add_parent_to_approval_process.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_approval_process.test.ts
@@ -64,7 +64,6 @@ describe('addParentToApprovalProcess', () => {
     })
     describe('when parent does not exist', () => {
       beforeEach(async () => {
-        jest.clearAllMocks()
         elementsSource = []
         elements = [
           (accountApprovalProcess = createInstanceElement(

--- a/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
+++ b/packages/salesforce-adapter/test/filters/add_parent_to_record_triggered_flows.test.ts
@@ -16,15 +16,6 @@ import { FilterWith } from './mocks'
 import filterCreator from '../../src/filters/add_parent_to_record_triggered_flows'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 
-const mockLogError = jest.fn()
-jest.mock('@salto-io/logging', () => ({
-  ...jest.requireActual<{}>('@salto-io/logging'),
-  logger: jest.fn().mockReturnValue({
-    warn: jest.fn((...args) => mockLogError(...args)),
-    debug: jest.fn((...args) => mockLogError(...args)),
-  }),
-}))
-
 describe('addParentToRecordTriggeredFlows', () => {
   describe('onFetch', () => {
     let elements: Element[]
@@ -78,7 +69,6 @@ describe('addParentToRecordTriggeredFlows', () => {
     })
     describe('when parent does not exist', () => {
       beforeEach(async () => {
-        jest.clearAllMocks()
         elementsSource = []
         elements = [
           (updateOpportunityFlow = createInstanceElement(

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -62,6 +62,7 @@ import {
   FLOW_FIELD_TYPE_NAMES,
   ASSIGN_TO_REFERENCE,
   LIVE_CHAT_BUTTON,
+  APPROVAL_PROCESS_METADATA_TYPE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -877,6 +878,11 @@ export const mockTypes = {
       routingType: {
         refType: BuiltinTypes.STRING,
       },
+    },
+  }),
+  [APPROVAL_PROCESS_METADATA_TYPE]: createMetadataObjectType({
+    annotations: {
+      metadataType: APPROVAL_PROCESS_METADATA_TYPE,
     },
   }),
 }


### PR DESCRIPTION
SALTO-6396: Add missing reference from ApprovalProcess to workflowAction

---

Workspace Diff: https://github.com/salto-io/almog-sf/commit/438db584c6f41112b82dd06e7b0f37f22b1aef7d

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between ApprovalProcess and WorkflowAction.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from ApprovalProcess WorkflowAction.
- **_parent** annotation will be added to ApprovalProcess.
