### PR TITLE
SALTO-7309: Allow users to disable Salesforce   `omitStandardFieldsNonDeployableValues` optional feature

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -25,6 +25,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   packageVersionReference: false,
   omitTotalTrustedRequestsUsageField: false,
   disablePermissionsOmissions: true,
+  omitStandardFieldsNonDeployableValues: true,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/filters/omit_standard_fields_non_deployable_values.ts
+++ b/packages/salesforce-adapter/src/filters/omit_standard_fields_non_deployable_values.ts
@@ -14,6 +14,7 @@ const filterCreator: FilterCreator = ({ config }) => ({
   name: 'omitStandardFieldsNonDeployableValues',
   onFetch: ensureSafeFilterFetch({
     config,
+    filterName: 'omitStandardFieldsNonDeployableValues',
     warningMessage: 'Error occurred when attempting to omit standard fields non deployable values',
     fetchFilterFunc: async elements =>
       elements

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -108,6 +108,7 @@ const OPTIONAL_FEATURES = [
   'packageVersionReference',
   'omitTotalTrustedRequestsUsageField',
   'disablePermissionsOmissions',
+  'omitStandardFieldsNonDeployableValues',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',
@@ -129,7 +130,6 @@ const DEPRECATED_OPTIONAL_FEATURES = [
   'indexedEmailTemplateAttachments',
   'lightningPageFieldItemReference',
   'logDiffsFromParsingXmlNumbers',
-  'omitStandardFieldsNonDeployableValues',
   'profilePaths',
   'removeReferenceFromFilterItemToRecordType',
   'sharingRulesMaps',


### PR DESCRIPTION
Allow users to disable Salesforce   `omitStandardFieldsNonDeployableValues` optional feature

---

Un-deprecated the optional feature.

---
_Release Notes_: 
_Salesforce Adapter_:
- Add the ability to disable  `omitStandardFieldsNonDeployableValues` optional feature.

---
_User Notifications_: 
_None_
