### PR TITLE
SALTO-7313: E2E fixes

### DIFF
--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -13,6 +13,7 @@ import {
   getChangeData,
   InstanceElement,
   isAdditionChange,
+  isAdditionOrModificationChange,
   isEqualValues,
   isModificationChange,
   isSaltoError,
@@ -45,6 +46,7 @@ type DeployChangeParam = {
   elementsSource?: ReadOnlyElementsSource
   allowedStatusCodesOnRemoval?: number[]
   serviceIdSetter?: (instance: InstanceElement, serviceIdField: string, response: clientUtils.ResponseValue) => void
+  hiddenFieldsSetter?: (instance: InstanceElement, response: clientUtils.ResponseValue) => void
 }
 
 const invertKeysNames = (instance: Record<string, unknown>): void => {
@@ -84,6 +86,7 @@ export const defaultDeployChange = async ({
   elementsSource,
   allowedStatusCodesOnRemoval,
   serviceIdSetter = defaultServiceIdSetter,
+  hiddenFieldsSetter,
 }: DeployChangeParam): Promise<clientUtils.ResponseValue | clientUtils.ResponseValue[] | undefined> => {
   const resolvedChange = await resolveChangeElement(change, getLookUpName, resolveValues, elementsSource)
   invertKeysNames(getChangeData(resolvedChange).value)
@@ -122,6 +125,14 @@ export const defaultDeployChange = async ({
     } else {
       log.warn('Received unexpected response from deployChange: %o', response)
     }
+  }
+  if (
+    isAdditionOrModificationChange(change) &&
+    response !== undefined &&
+    !Array.isArray(response) &&
+    hiddenFieldsSetter !== undefined
+  ) {
+    hiddenFieldsSetter(change.data.after, response)
   }
   return response
 }

--- a/packages/jira-adapter/src/deployment/standard_deployment.ts
+++ b/packages/jira-adapter/src/deployment/standard_deployment.ts
@@ -64,6 +64,14 @@ export const defaultServiceIdSetter = (
   instance.value[serviceIdField] = response[serviceIdField]
 }
 
+export const toNumberServiceIdSetter = (
+  instance: InstanceElement,
+  serviceIdField: string,
+  response: clientUtils.ResponseValue,
+): void => {
+  instance.value[serviceIdField] = Number(response[serviceIdField])
+}
+
 /**
  * Deploy change with the standard "add", "modify", "remove" endpoints
  */

--- a/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
+++ b/packages/jira-adapter/src/filters/notification_scheme/notification_scheme_deployment.ts
@@ -23,7 +23,7 @@ import { collections } from '@salto-io/lowerdash'
 import { findObject, setFieldDeploymentAnnotations, setTypeDeploymentAnnotations } from '../../utils'
 import { FilterCreator } from '../../filter'
 import { NOTIFICATION_EVENT_TYPE_NAME, NOTIFICATION_SCHEME_TYPE_NAME } from '../../constants'
-import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
+import { defaultDeployChange, deployChanges, toNumberServiceIdSetter } from '../../deployment/standard_deployment'
 import JiraClient from '../../client/client'
 import {
   getEventChangesToDeploy,
@@ -159,6 +159,7 @@ const filter: FilterCreator = ({ client, config }) => {
           change,
           client,
           apiDefinitions: config.apiDefinitions,
+          serviceIdSetter: toNumberServiceIdSetter,
         })
         if (isModificationChange(change)) {
           const eventChanges = getEventChangesToDeploy(change)

--- a/packages/jira-adapter/src/filters/screen/screen.ts
+++ b/packages/jira-adapter/src/filters/screen/screen.ts
@@ -199,10 +199,6 @@ const filter: FilterCreator = ({ config, client }) => ({
                 isReferenceExpression(refOrFieldId) ? refOrFieldId.value.value.id : refOrFieldId,
               ),
             }
-          } else {
-            tab.originalFieldsIds = {
-              ids: [],
-            }
           }
         })
       })

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_filter.ts
@@ -36,15 +36,17 @@ const getTimeNowAsSeconds = (): number => Math.floor(Date.now() / 1000)
 const AUDIT_SCRIPT_RUNNER_TYPES = SCRIPT_RUNNER_TYPES.filter(
   type => ![SCRIPT_RUNNER_LISTENER_TYPE, SCRIPT_FRAGMENT_TYPE].includes(type),
 )
+const CREATED_TIMESTAMP = 'createdTimestamp'
+const UPDATED_TIMESTAMP = 'updatedTimestamp'
 
 const addCreatedChanges = (value: Value, currentUserInfo: UserInfo | undefined, timeStampAsString: boolean): void => {
   value.createdByAccountId = currentUserInfo?.userId ?? ''
-  value.createdTimestamp = timeStampAsString ? getTimeNowAsSeconds().toString() : getTimeNowAsSeconds()
+  value[CREATED_TIMESTAMP] = timeStampAsString ? getTimeNowAsSeconds().toString() : getTimeNowAsSeconds()
 }
 
 const addUpdatedChanges = (value: Value, currentUserInfo: UserInfo | undefined, timeStampAsString: boolean): void => {
   value.updatedByAccountId = currentUserInfo?.userId ?? ''
-  value.updatedTimestamp = timeStampAsString ? getTimeNowAsSeconds().toString() : getTimeNowAsSeconds()
+  value[UPDATED_TIMESTAMP] = timeStampAsString ? getTimeNowAsSeconds().toString() : getTimeNowAsSeconds()
 }
 
 const updatePropertyIfExist = (instanceValue: Value, property: string, responseValue: Value): void => {
@@ -55,8 +57,8 @@ const updatePropertyIfExist = (instanceValue: Value, property: string, responseV
 }
 
 export const listenersAuditSetter = (instance: InstanceElement, response: Value): void => {
-  updatePropertyIfExist(instance.value, 'createdTimestamp', response)
-  updatePropertyIfExist(instance.value, 'updatedTimestamp', response)
+  updatePropertyIfExist(instance.value, CREATED_TIMESTAMP, response)
+  updatePropertyIfExist(instance.value, UPDATED_TIMESTAMP, response)
 }
 
 export const scriptRunnerAuditSetter = (instance: InstanceElement, response: clientUtils.ResponseValue): void => {
@@ -64,8 +66,8 @@ export const scriptRunnerAuditSetter = (instance: InstanceElement, response: cli
     if (instance.value.auditData === undefined) {
       instance.value.auditData = {}
     }
-    updatePropertyIfExist(instance.value.auditData, 'createdTimestamp', response.auditData)
-    updatePropertyIfExist(instance.value.auditData, 'updatedTimestamp', response.auditData)
+    updatePropertyIfExist(instance.value.auditData, CREATED_TIMESTAMP, response.auditData)
+    updatePropertyIfExist(instance.value.auditData, UPDATED_TIMESTAMP, response.auditData)
   }
 }
 

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_instances_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_instances_deploy.ts
@@ -10,6 +10,7 @@ import { Change, InstanceElement, getChangeData, isInstanceChange } from '@salto
 import _ from 'lodash'
 import { defaultDeployChange, deployChanges } from '../../deployment/standard_deployment'
 import { FilterCreator } from '../../filter'
+import { scriptRunnerAuditSetter } from './script_runner_filter'
 
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
@@ -51,6 +52,7 @@ const filter: FilterCreator = ({ scriptRunnerClient, config }) => ({
         change,
         client: scriptRunnerClient,
         apiDefinitions: scriptRunnerApiDefinitions,
+        hiddenFieldsSetter: scriptRunnerAuditSetter, // the time stamps might differ between the request and the response
       })
     })
     return { deployResult, leftoverChanges }

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
@@ -27,6 +27,7 @@ import { FilterCreator } from '../../filter'
 import { SCRIPT_RUNNER_LISTENER_TYPE } from '../../constants'
 import { getLookUpName } from '../../reference_mapping'
 import { JiraDuckTypeConfig } from '../../config/api_config'
+import { listenersAuditSetter } from './script_runner_filter'
 
 const { replaceInstanceTypeForDeploy } = elementUtils.ducktype
 
@@ -47,6 +48,18 @@ const isListenersResponse = createSchemeGuard<ListenersResponse>(
   LISTENERS_RESPONSE_SCHEME,
   'Received an invalid script runner listeners response',
 )
+
+const updateAuditData = (changes: Change<InstanceElement>[], response: ListenersResponse): void => {
+  const uuidToResponse = Object.fromEntries(
+    response.values
+      .filter(value => Object.prototype.hasOwnProperty.call(value, 'uuid'))
+      .map(value => [value.uuid, value]),
+  )
+  changes
+    .map(getChangeData)
+    .filter(instance => uuidToResponse[instance.value.uuid] !== undefined)
+    .forEach(instance => listenersAuditSetter(instance, uuidToResponse[instance.value.uuid]))
+}
 
 // this function rebuilds the type inside the instance based on the instance's fields
 const fixType = (
@@ -204,10 +217,13 @@ const filter: FilterCreator = ({ scriptRunnerClient, config }) => ({
       scriptRunnerApiDefinitions,
     })
     try {
-      await scriptRunnerClient.put({
+      const response = await scriptRunnerClient.put({
         url: '/sr-dispatcher/jira/admin/token/scriptevents',
         data: valuesToDeploy,
       })
+      if (isListenersResponse(response.data)) {
+        updateAuditData(relevantChanges.filter(isInstanceChange), response.data)
+      }
     } catch (e) {
       const errorMessage = e instanceof Error ? e.message : e
       log.error(`Failed to put script runner listeners with the error: ${errorMessage}`)

--- a/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_runner_listeners_deploy.ts
@@ -51,9 +51,7 @@ const isListenersResponse = createSchemeGuard<ListenersResponse>(
 
 const updateAuditData = (changes: Change<InstanceElement>[], response: ListenersResponse): void => {
   const uuidToResponse = Object.fromEntries(
-    response.values
-      .filter(value => Object.prototype.hasOwnProperty.call(value, 'uuid'))
-      .map(value => [value.uuid, value]),
+    response.values.filter(value => value.uuid !== undefined).map(value => [value.uuid, value]),
   )
   changes
     .map(getChangeData)

--- a/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/notification_scheme/notification_scheme_deployment.test.ts
@@ -305,7 +305,7 @@ describe('notificationSchemeDeploymentFilter', () => {
         expect(deployResult.appliedChanges).toHaveLength(1)
         expect(deployResult.errors).toHaveLength(0)
         const inst = getChangeData(deployResult.appliedChanges[0]) as InstanceElement
-        expect(inst.value.id).toEqual('1')
+        expect(inst.value.id).toEqual(1)
         expect(inst.value.notificationIds['3-EmailAddress-email']).toEqual('123')
       })
       it('should throw if recived unexpected response when trying to set notificaitonIds', async () => {

--- a/packages/jira-adapter/test/filters/screen/screen.test.ts
+++ b/packages/jira-adapter/test/filters/screen/screen.test.ts
@@ -309,5 +309,16 @@ describe('screenFilter', () => {
         },
       })
     })
+    it('should not fail when deploying a screen with an empty tab', async () => {
+      screenInstance.value.tabs.tab2 = {
+        name: 'tab2',
+        position: 1,
+      }
+      await filter.onDeploy?.([toChange({ after: screenInstance })])
+      expect(screenInstance.value.tabs.tab2).toEqual({
+        name: 'tab2',
+        position: 1,
+      })
+    })
   })
 })

--- a/packages/jira-adapter/test/filters/script_runner/script_runner_listeners_deploy.test.ts
+++ b/packages/jira-adapter/test/filters/script_runner/script_runner_listeners_deploy.test.ts
@@ -288,6 +288,46 @@ describe('script_runner_listeners_deploy', () => {
       ],
     })
   })
+  it('should update the creation and update time from the response', async () => {
+    mockPut.mockResolvedValueOnce({
+      status: 200,
+      data: {
+        values: [
+          {
+            uuid: '5',
+            name: 'n5',
+            createdTimestamp: '100',
+            updatedTimestamp: '110',
+          },
+          {
+            uuid: '6',
+            name: 'n6',
+            createdTimestamp: '106',
+            updatedTimestamp: '116',
+          },
+          {
+            uuid: '7',
+            name: 'n7',
+            createdTimestamp: '107',
+            updatedTimestamp: '117',
+          },
+        ],
+      },
+    })
+    const scriptInstanceAdd2 = new InstanceElement('instance22', type, {
+      uuid: '7',
+      name: 'n7',
+      createdTimestamp: '-1',
+      updatedTimestamp: '-11',
+    })
+    const res = await filter.deploy([toChange({ after: scriptInstanceAdd }), toChange({ after: scriptInstanceAdd2 })])
+    expect(res.deployResult.errors).toEqual([])
+    expect(res.leftoverChanges).toEqual([])
+    expect(scriptInstanceAdd.value.createdTimestamp).toEqual('100')
+    expect(scriptInstanceAdd.value.updatedTimestamp).toEqual('110')
+    expect(scriptInstanceAdd2.value.createdTimestamp).toEqual('107')
+    expect(scriptInstanceAdd2.value.updatedTimestamp).toEqual('117')
+  })
   it('should return the proper error if put fails', async () => {
     mockPut.mockReset()
     mockPut.mockRejectedValueOnce(new Error('error'))


### PR DESCRIPTION
Fixed a problem in the E2E- it did not apply changes to the instances

---

In the core we apply changes after a deployment of a change group on the instances, so references will have the valid values (for instance IDs). In the E2E we only copied the value of the ids for parents.
Following the change, which is in the first commit, a few bug were revealed. Each is fixed in a separate commit.
In the last commit I added another fix for the E2E, to perform the delete in the same groups of the additions as sometimes the order is important

---
_Release Notes_: 
Jira Adapter:
* Improvements to the E2E and related bug fixes (mostly in hidden fields)

---
_User Notifications_: 
None
