### PR TITLE
SALTO-7198: Fix Brand template static files filter when Domain element is renamed

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -128,13 +128,13 @@ const DEFAULT_FILTERS = [
   addAliasFilter, // TODO SALTO-5607 - move to infra
   // should run after fieldReferencesFilter and userFilter
   unorderedListsFilter,
-  brandCustomizationsFilter, // must run after fieldReferencesFilter
   // should run before appDeploymentFilter and after userSchemaFilter
   serviceUrlFilter,
   appDeploymentFilter,
   profileMappingRemovalFilter,
   // should run after fieldReferences
   ...Object.values(commonFilters),
+  brandCustomizationsFilter, // must run after fieldReferencesFilter and referencedInstanceNames (SALTO-7314) filter
   // should run last
   privateApiDeployFilter,
   defaultDeployFilter,


### PR DESCRIPTION
until SALTO-7314 is implemented, we need to first rename domain elements (with `referencedInstanceNames`), and only then create the references

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
