### PR TITLE
SALTO-7316 Allow empty arrays also for standalone instances

### DIFF
--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -125,7 +125,7 @@ const extractStandaloneInstancesFromField =
           toPath,
           defaultName: `${invertNaclCase(parent.elemID.name)}__unnamed_${index}`,
           parent: standaloneDef.addParentAnnotation !== false ? parent : undefined,
-          allowEmptyArrays: defQuery.query(standaloneDef.typeName)?.element?.topLevel?.allowEmptyArrays ?? false,
+          allowEmptyArrays: defQuery.query(standaloneDef.typeName)?.element?.topLevel?.allowEmptyArrays,
         }),
       )
       .filter(isDefined)

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -125,6 +125,7 @@ const extractStandaloneInstancesFromField =
           toPath,
           defaultName: `${invertNaclCase(parent.elemID.name)}__unnamed_${index}`,
           parent: standaloneDef.addParentAnnotation !== false ? parent : undefined,
+          allowEmptyArrays: defQuery.query(standaloneDef.typeName)?.element?.topLevel?.allowEmptyArrays ?? false,
         }),
       )
       .filter(isDefined)

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -125,6 +125,9 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
+    // We don't want to update the element, so we are permissive with the allowEmptyArrays and allowEmptyObjects
+    allowEmptyArrays: true,
+    allowEmptyObjects: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/adapter-components/test/filters/referenced_instance_names.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_names.test.ts
@@ -138,6 +138,7 @@ describe('referenced instances', () => {
       new InstanceElement('recipe123', recipeType, {
         name: 'recipe123',
         book_id: new ReferenceExpression(rootBook.elemID, rootBook),
+        ingredients: [],
       }),
       new InstanceElement('recipe456', recipeType, {
         name: 'recipe456',
@@ -388,6 +389,7 @@ describe('referenced instances', () => {
             element: {
               topLevel: {
                 isTopLevel: true,
+                allowEmptyArrays: true,
                 elemID: {
                   parts: [
                     {
@@ -916,6 +918,12 @@ describe('referenced instances', () => {
       expect(recipeWithNullBookRes.elemID.getFullName()).toEqual(
         'myAdapter.recipe.instance.recipe123_123_ROOT__recipeWithNullBook',
       )
+    })
+    it('should not remove empty arrays', async () => {
+      const result = (await addReferencesToInstanceNames(elements, defQuery)).filter(isInstanceElement)
+      const resultRecipe = result.find(e => e.elemID.name === 'recipe123_123_ROOT')
+      expect(resultRecipe).toBeDefined()
+      expect(resultRecipe?.value.ingredients).toEqual([])
     })
   })
 })


### PR DESCRIPTION
This PR fixes two issues, the first that when having a custom configuration where both the parent and the standalone child have `allowEmptyArrays: true` still removes empty arrays from the children. 
The second is for instances with references in their id that have `allowEmptyArrays: true` - these also still have their empty arrays removed..

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
