### PR TITLE
SALTO-7095: use the new id collision message in the adapters

### DIFF
--- a/packages/adapter-components/test/filters/omit_collisions.test.ts
+++ b/packages/adapter-components/test/filters/omit_collisions.test.ts
@@ -52,10 +52,13 @@ describe('omitCollisionsFilter', () => {
       errors: [
         {
           severity: 'Warning',
-          detailedMessage: expect.stringContaining(
-            'Omitted 2 instances and all their child instances of t1 due to Salto ID collisions.\nCurrent Salto ID configuration for t1 is defined as [name, status].',
-          ),
           message: 'Some elements were not fetched due to Salto ID collisions',
+          detailedMessage: `2 myAdapter elements and their child elements were not fetched, as they were mapped to a single ID myAdapter.t1.instance.A:
+A,
+A.
+
+Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
         },
       ],
     })
@@ -74,10 +77,13 @@ describe('omitCollisionsFilter', () => {
       errors: [
         {
           severity: 'Warning',
-          detailedMessage: expect.stringContaining(
-            'Omitted 2 instances and all their child instances of t1 due to Salto ID collisions.\nCurrent Salto ID configuration for t1 is defined as [name, status].',
-          ),
           message: expect.stringContaining('Some elements were not fetched due to Salto ID collisions'),
+          detailedMessage: `2 myAdapter elements and their child elements were not fetched, as they were mapped to a single ID myAdapter.t1.instance.A:
+A,
+A.
+
+Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
         },
       ],
     })

--- a/packages/adapter-components/test/filters/omit_collisions.test.ts
+++ b/packages/adapter-components/test/filters/omit_collisions.test.ts
@@ -55,10 +55,10 @@ describe('omitCollisionsFilter', () => {
           message: 'Some elements were not fetched due to Salto ID collisions',
           detailedMessage: `2 myAdapter elements and their child elements were not fetched, as they were mapped to a single ID myAdapter.t1.instance.A:
 A,
-A.
+A .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`,
         },
       ],
     })
@@ -80,10 +80,10 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
           message: expect.stringContaining('Some elements were not fetched due to Salto ID collisions'),
           detailedMessage: `2 myAdapter elements and their child elements were not fetched, as they were mapped to a single ID myAdapter.t1.instance.A:
 A,
-A.
+A .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`,
         },
       ],
     })

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -6,17 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, ElemID, InstanceElement, SaltoError } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, InstanceElement, SaltoError } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { logger } from '@salto-io/logging'
-import { inspectValue } from './utils'
 import { ERROR_MESSAGES } from './errors'
 
 const { groupByAsync } = collections.asynciterable
-const log = logger(module)
-
-const MAX_BREAKDOWN_ELEMENTS = 10
-const MAX_BREAKDOWN_DETAILS_ELEMENTS = 3
 
 type InstanceDetail = {
   name: string
@@ -51,74 +45,10 @@ const getInstanceDescWithServiceUrl = (instanceDetail: InstanceDetail, baseUrl?:
 export const getInstanceDesc = (instanceId: string, baseUrl?: string): string =>
   getInstanceDescWithServiceUrl({ name: instanceId }, baseUrl)
 
-const getCollisionBreakdownTitle = (collidingInstanceName: string): string =>
-  collidingInstanceName === ElemID.CONFIG_NAME
-    ? 'Instances with empty name (Due to no values in any of the provided ID fields)'
-    : collidingInstanceName
-
-const getInstancesDetailsMsg = (
-  instanceDetails: InstanceDetail[],
-  baseUrl?: string,
-  maxBreakdownDetailsElements = MAX_BREAKDOWN_DETAILS_ELEMENTS,
-): string => {
-  const instancesToPrint = instanceDetails.slice(0, maxBreakdownDetailsElements)
-  const instancesMsgs = instancesToPrint.map(instanceDetail => getInstanceDescWithServiceUrl(instanceDetail, baseUrl))
-  const overFlowSize = instanceDetails.length - maxBreakdownDetailsElements
-  const overFlowMsg = overFlowSize > 0 ? [`${overFlowSize} more instances`] : []
-  return [...instancesMsgs, ...overFlowMsg].map(msg => `\t* ${msg}`).join('\n')
-}
-
 export const getInstancesWithCollidingElemID = (instances: InstanceElement[]): InstanceElement[] =>
   Object.values(_.groupBy(instances, instance => instance.elemID.getFullName()))
     .filter(groupedInstances => groupedInstances.length > 1)
     .flat()
-
-const logInstancesWithCollidingElemID = async (
-  typeToElemIDtoInstances: Record<string, Record<string, InstanceElement[]>>,
-): Promise<void> => {
-  Object.entries(typeToElemIDtoInstances).forEach(([type, elemIDtoInstances]) => {
-    const instancesCount = Object.values(elemIDtoInstances).flat().length
-    log.debug(`Omitted ${instancesCount} instances of type ${type} due to Salto ID collisions`)
-    Object.entries(elemIDtoInstances).forEach(([elemID, elemIDInstances]) => {
-      const relevantInstanceValues = elemIDInstances.map(instance => _.pickBy(instance.value, val => val != null))
-      const relevantInstanceValuesStr = relevantInstanceValues.map(instValues => inspectValue(instValues)).join('\n')
-      log.debug(`Omitted instances of type ${type} with colliding ElemID ${elemID} with values - 
-  ${relevantInstanceValuesStr}`)
-    })
-  })
-}
-
-const getCollisionMessages = async ({
-  elemIDtoInstances,
-  getInstanceName,
-  baseUrl,
-  maxBreakdownElements,
-  maxBreakdownDetailsElements,
-}: {
-  elemIDtoInstances: Record<string, InstanceElement[]>
-  getInstanceName: (instance: InstanceElement) => Promise<string>
-  baseUrl?: string
-  maxBreakdownElements: number
-  maxBreakdownDetailsElements: number
-}): Promise<string[]> => {
-  const collisionsToDisplay = Object.entries(elemIDtoInstances).slice(0, maxBreakdownElements)
-  const collisionMessages = await Promise.all(
-    collisionsToDisplay.map(async ([elemID, collisionInstances]) => {
-      const instanceDetails = await Promise.all(
-        collisionInstances.map(async instance => ({
-          name: await getInstanceName(instance),
-          serviceUrl:
-            typeof instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] === 'string'
-              ? instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]
-              : undefined,
-        })),
-      )
-      return `- ${getCollisionBreakdownTitle(elemID)}:
-${getInstancesDetailsMsg(instanceDetails, baseUrl, maxBreakdownDetailsElements)}`
-    }),
-  )
-  return collisionMessages
-}
 
 const getTextWithLinkToService = ({
   instanceName,
@@ -186,80 +116,6 @@ export const getCollisionWarnings = ({
     createWarningFromMsg({
       message: ERROR_MESSAGES.ID_COLLISION,
       detailedMessage: warningMessage,
-    }),
-  )
-}
-
-export const getAndLogCollisionWarnings = async ({
-  instances,
-  getTypeName,
-  getInstanceName,
-  getIdFieldsByType,
-  adapterName,
-  configurationName,
-  idFieldsName,
-  maxBreakdownElements = MAX_BREAKDOWN_ELEMENTS,
-  maxBreakdownDetailsElements = MAX_BREAKDOWN_DETAILS_ELEMENTS,
-  baseUrl,
-  docsUrl,
-  addChildrenMessage,
-}: {
-  instances: InstanceElement[]
-  getTypeName: (instance: InstanceElement) => Promise<string>
-  getInstanceName: (instance: InstanceElement) => Promise<string>
-  getIdFieldsByType: (type: string) => string[]
-  adapterName: string
-  configurationName: string
-  idFieldsName: string
-  maxBreakdownElements?: number
-  maxBreakdownDetailsElements?: number
-  baseUrl?: string
-  docsUrl?: string
-  addChildrenMessage?: boolean
-}): Promise<SaltoError[]> => {
-  const typeToElemIDtoInstances = await groupInstancesByTypeAndElemID(instances, getTypeName)
-  await logInstancesWithCollidingElemID(typeToElemIDtoInstances)
-  return Promise.all(
-    Object.entries(typeToElemIDtoInstances).map(async ([type, elemIDtoInstances]) => {
-      const childMessage = addChildrenMessage === true ? 'and all their child instances ' : ''
-      const numInstances = Object.values(elemIDtoInstances).flat().length
-      const header = `Omitted ${numInstances} instances ${childMessage}of ${type} due to Salto ID collisions.
-Current Salto ID configuration for ${type} is defined as [${getIdFieldsByType(type).join(', ')}].`
-
-      const collisionsHeader = 'Breakdown per colliding Salto ID:'
-      const collisionMessages = await getCollisionMessages({
-        elemIDtoInstances,
-        getInstanceName,
-        baseUrl,
-        maxBreakdownElements,
-        maxBreakdownDetailsElements,
-      })
-      const epilogue = `To resolve these collisions please take one of the following actions and fetch again:
-\t1. Change ${type}'s ${idFieldsName} to include all fields that uniquely identify the type's instances.
-\t2. Delete duplicate instances from your ${adapterName} account.
-
-Alternatively, you can exclude ${type} from the ${configurationName} configuration in ${adapterName}.nacl`
-      const elemIDCount = Object.keys(elemIDtoInstances).length
-      const overflowMsg =
-        elemIDCount > maxBreakdownElements
-          ? ['', `And ${elemIDCount - maxBreakdownElements} more colliding Salto IDs`]
-          : []
-      const linkToDocsMsg = docsUrl ? ['', `Learn more at: ${docsUrl}`] : []
-      const detailedMessage = [
-        header,
-        '',
-        collisionsHeader,
-        ...collisionMessages,
-        ...overflowMsg,
-        '',
-        epilogue,
-        ...linkToDocsMsg,
-      ].join('\n')
-
-      return createWarningFromMsg({
-        message: ERROR_MESSAGES.ID_COLLISION,
-        detailedMessage,
-      })
     }),
   )
 }

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -90,7 +90,6 @@ Usually, this happens because of duplicate configuration names in the service. M
 Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
   )
 
-// after SALTO-7088 is done, this function will replace getAndLogCollisionWarnings
 export const getCollisionWarnings = ({
   instances,
   adapterName,

--- a/packages/adapter-utils/src/collisions.ts
+++ b/packages/adapter-utils/src/collisions.ts
@@ -84,10 +84,10 @@ const createWarningMessages = ({
       elemId,
       collideInstances,
     ]) => `${collideInstances.length} ${adapterName} elements ${addChildrenMessage ? 'and their child elements ' : ''}were not fetched, as they were mapped to a single ID ${elemId}:
-${getInstancesWithLinksToService(collideInstances, adapterName)}.
+${getInstancesWithLinksToService(collideInstances, adapterName)} .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`,
   )
 
 export const getCollisionWarnings = ({

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -56,10 +56,10 @@ describe('collisions', () => {
     it('should return the correct warning messages', async () => {
       const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName - open in Salto: someUrl,
-QuackAliasName - open in Salto: QuackUrl.
+QuackAliasName - open in Salto: QuackUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -76,10 +76,10 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
     it('should add children message when addChildrenMessage is true', async () => {
       const detailedMessage = `2 Salto elements and their child elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName - open in Salto: someUrl,
-QuackAliasName - open in Salto: QuackUrl.
+QuackAliasName - open in Salto: QuackUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -98,10 +98,10 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
       instance.annotations[CORE_ANNOTATIONS.ALIAS] = undefined
       const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 test - open in Salto: someUrl,
-QuackAliasName - open in Salto: QuackUrl.
+QuackAliasName - open in Salto: QuackUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -121,10 +121,10 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
 
       const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName,
-QuackAliasName.
+QuackAliasName .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const errors = getCollisionWarnings({
         instances: [instance, collidedInstance],
@@ -148,17 +148,17 @@ Learn about additional ways to resolve this issue at https://help.salto.io/en/ar
       const firstDetailedMessage = `3 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName - open in Salto: someUrl,
 aliasName - open in Salto: someUrl,
-QuackAliasName - open in Salto: QuackUrl.
+QuackAliasName - open in Salto: QuackUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const secondDetailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test1:
 anotherAliasName - open in Salto: anotherUrl,
-anotherAliasName - open in Salto: anotherUrl.
+anotherAliasName - open in Salto: anotherUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`
 
       const errors = getCollisionWarnings({
         instances: [instance, instance.clone(), collidedInstance.clone(), differentInstance, differentInstance.clone()],

--- a/packages/adapter-utils/test/collisions.test.ts
+++ b/packages/adapter-utils/test/collisions.test.ts
@@ -52,7 +52,7 @@ describe('collisions', () => {
       expect(collidedElements).toEqual([instance, collidedInstance])
     })
   })
-  describe('getAndLogCollisionWarningsV2', () => {
+  describe('getCollisionWarnings', () => {
     it('should return the correct warning messages', async () => {
       const detailedMessage = `2 Salto elements were not fetched, as they were mapped to a single ID salto.obj.instance.test:
 aliasName - open in Salto: someUrl,

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -6,10 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
-import { CORE_ANNOTATIONS, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
-import { naclCase, inspectValue, ERROR_MESSAGES } from '@salto-io/adapter-utils'
+import { InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
+import { naclCase, inspectValue, ERROR_MESSAGES, getCollisionWarnings } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
+import { JIRA } from '../constants'
 
 const log = logger(module)
 
@@ -43,7 +44,7 @@ const filter: FilterCreator = ({ config }) => ({
       elements,
       element =>
         duplicateIds.has(element.elemID.getFullName()) && isInstanceElement(element) && element.value.id !== undefined,
-    )
+    ).filter(isInstanceElement)
 
     duplicateInstances.filter(isInstanceElement).forEach(instance => {
       log.debug(
@@ -51,32 +52,15 @@ const filter: FilterCreator = ({ config }) => ({
       )
     })
 
-    const getServiceUrl = (instance: InstanceElement): string =>
-      instance.annotations[CORE_ANNOTATIONS.SERVICE_URL] !== undefined
-        ? `. View in the service - ${instance.annotations[CORE_ANNOTATIONS.SERVICE_URL]}`
-        : ''
-    const prettifiesName = (instance: InstanceElement): string =>
-      instance.annotations[CORE_ANNOTATIONS.ALIAS] !== undefined
-        ? instance.annotations[CORE_ANNOTATIONS.ALIAS]
-        : instance.elemID.name
-    const duplicateInstanceNames = _.uniq(
-      duplicateInstances
-        .filter(isInstanceElement)
-        .flatMap(
-          instance => `${prettifiesName(instance)} (${instance.elemID.getFullName()})${getServiceUrl(instance)}`,
-        ),
-    )
+    const duplicateWarnings = getCollisionWarnings({
+      instances: duplicateInstances,
+      addChildrenMessage: true,
+      adapterName: _.upperFirst(JIRA),
+    })
+
     if (!config.fetch.fallbackToInternalId) {
       return {
-        errors: [
-          {
-            message: ERROR_MESSAGES.ID_COLLISION,
-            detailedMessage: `The following elements had duplicate names in Jira. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
-If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions
-${duplicateInstanceNames.join(',\n')}`,
-            severity: 'Warning',
-          },
-        ],
+        errors: duplicateWarnings,
       }
     }
 

--- a/packages/jira-adapter/src/filters/duplicate_ids.ts
+++ b/packages/jira-adapter/src/filters/duplicate_ids.ts
@@ -44,7 +44,7 @@ const filter: FilterCreator = ({ config }) => ({
       elements,
       element =>
         duplicateIds.has(element.elemID.getFullName()) && isInstanceElement(element) && element.value.id !== undefined,
-    ).filter(isInstanceElement)
+    ) as InstanceElement[]
 
     duplicateInstances.filter(isInstanceElement).forEach(instance => {
       log.debug(
@@ -52,13 +52,11 @@ const filter: FilterCreator = ({ config }) => ({
       )
     })
 
-    const duplicateWarnings = getCollisionWarnings({
-      instances: duplicateInstances,
-      addChildrenMessage: true,
-      adapterName: _.upperFirst(JIRA),
-    })
-
     if (!config.fetch.fallbackToInternalId) {
+      const duplicateWarnings = getCollisionWarnings({
+        instances: duplicateInstances,
+        adapterName: _.upperFirst(JIRA),
+      })
       return {
         errors: duplicateWarnings,
       }

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -161,10 +161,10 @@ dup,
 dup,
 instance alias - open in Jira: https://dup_1_someurl.com,
 another instance alias - open in Jira: https://dup_2_someurl.com,
-instance alias.
+instance alias .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`,
           severity: 'Warning',
         },
       ],

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -156,7 +156,7 @@ describe('duplicateIdsFilter', () => {
       errors: [
         {
           message: 'Some elements were not fetched due to Salto ID collisions',
-          detailedMessage: `5 Jira elements and their child elements were not fetched, as they were mapped to a single ID jira.Status.instance.dup:
+          detailedMessage: `5 Jira elements were not fetched, as they were mapped to a single ID jira.Status.instance.dup:
 dup,
 dup,
 instance alias - open in Jira: https://dup_1_someurl.com,

--- a/packages/jira-adapter/test/filters/duplicate_ids.test.ts
+++ b/packages/jira-adapter/test/filters/duplicate_ids.test.ts
@@ -156,12 +156,15 @@ describe('duplicateIdsFilter', () => {
       errors: [
         {
           message: 'Some elements were not fetched due to Salto ID collisions',
-          detailedMessage: `The following elements had duplicate names in Jira. It is strongly recommended to rename these instances so they are unique in Jira, then re-fetch.
-If changing the names is not possible, you can add the fetch.fallbackToInternalId option to the configuration file; that will add their internal ID to their names and fetch them. Read more here: https://help.salto.io/en/articles/6927157-salto-id-collisions
-dup (jira.Status.instance.dup),
-instance alias (jira.Status.instance.dup). View in the service - https://dup_1_someurl.com,
-another instance alias (jira.Status.instance.dup). View in the service - https://dup_2_someurl.com,
-instance alias (jira.Status.instance.dup)`,
+          detailedMessage: `5 Jira elements and their child elements were not fetched, as they were mapped to a single ID jira.Status.instance.dup:
+dup,
+dup,
+instance alias - open in Jira: https://dup_1_someurl.com,
+another instance alias - open in Jira: https://dup_2_someurl.com,
+instance alias.
+
+Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
           severity: 'Warning',
         },
       ],

--- a/packages/okta-adapter/src/filters/common.ts
+++ b/packages/okta-adapter/src/filters/common.ts
@@ -5,6 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+import _ from 'lodash'
 import { filters } from '@salto-io/adapter-components'
 import { FilterCreator } from '../filter'
 import { OKTA } from '../constants'
@@ -18,7 +19,7 @@ const filterCreators: Record<string, FilterCreator> = {
   addAlias: filters.addAliasFilterCreator(),
   query: filters.queryFilterCreator({}),
   sortLists: filters.sortListsFilterCreator(),
-  omitCollitions: filters.omitCollisionsFilterCreator(OKTA),
+  omitCollitions: filters.omitCollisionsFilterCreator(_.upperFirst(OKTA)),
 }
 
 export default filterCreators

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -10,13 +10,13 @@ import { collections, values as lowerdashValues, promises } from '@salto-io/lowe
 import {
   transformValues,
   TransformFunc,
-  getAndLogCollisionWarnings,
   getInstanceDesc,
   createWarningFromMsg,
   getInstancesWithCollidingElemID,
   safeJsonStringify,
   inspectValue,
   ERROR_MESSAGES,
+  getCollisionWarnings,
 } from '@salto-io/adapter-utils'
 import { references } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
@@ -144,16 +144,9 @@ const createWarnings = async (
     })
   }
 
-  const collisionWarnings = await getAndLogCollisionWarnings({
-    adapterName: SALESFORCE,
-    baseUrl,
+  const collisionWarnings = getCollisionWarnings({
     instances: instancesWithCollidingElemID,
-    configurationName: 'data management',
-    getIdFieldsByType: dataManagement.getObjectIdsFields,
-    getTypeName: async instance => apiName(await instance.getType(), true),
-    idFieldsName: 'saltoIDSettings',
-    getInstanceName: instance => apiName(instance),
-    docsUrl: 'https://help.salto.io/en/articles/6927217-salto-for-salesforce-cpq-support',
+    adapterName: _.upperFirst(SALESFORCE),
   })
   const instanceWithEmptyIdWarnings = await awu(instancesWithEmptyIds)
     // In case of collisions, there's already a warning on the Element

--- a/packages/zendesk-adapter/src/filters/omit_collision.ts
+++ b/packages/zendesk-adapter/src/filters/omit_collision.ts
@@ -6,35 +6,25 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { isInstanceElement, Element } from '@salto-io/adapter-api'
-import { config as configUtils, filters } from '@salto-io/adapter-components'
-import { getAndLogCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
+import { filters } from '@salto-io/adapter-components'
+import { getCollisionWarnings, getInstancesWithCollidingElemID } from '@salto-io/adapter-utils'
 import _ from 'lodash'
-import { FilterCreator } from '../filter'
 import { ZENDESK } from '../constants'
+import { FilterCreator } from '../filter'
 
 /**
  * Adds collision warnings and remove colliding elements and their children
  */
-const filterCreator: FilterCreator = ({ oldApiDefinitions }) => ({
+const filterCreator: FilterCreator = () => ({
   name: 'omitCollisionsFilter',
   onFetch: async (elements: Element[]) => {
     const collidingElements = getInstancesWithCollidingElemID(elements.filter(isInstanceElement))
     const collidingElemIds = new Set(collidingElements.map(elem => elem.elemID.getFullName()))
     filters.removeChildElements(elements, collidingElements)
-    const collisionWarnings = await getAndLogCollisionWarnings({
-      adapterName: ZENDESK,
-      configurationName: 'service',
+    const collisionWarnings = getCollisionWarnings({
       instances: collidingElements,
-      getTypeName: async instance => instance.elemID.typeName,
-      getInstanceName: async instance => instance.elemID.name,
-      getIdFieldsByType: typeName =>
-        configUtils.getConfigWithDefault(
-          oldApiDefinitions.types[typeName]?.transformation,
-          oldApiDefinitions.typeDefaults.transformation,
-        ).idFields,
-      idFieldsName: 'idFields',
-      docsUrl: 'https://help.salto.io/en/articles/6927157-salto-id-collisions',
       addChildrenMessage: true,
+      adapterName: _.upperFirst(ZENDESK),
     })
     _.remove(elements, e => collidingElemIds.has(e.elemID.getFullName()))
     return { errors: collisionWarnings }

--- a/packages/zendesk-adapter/test/adapter.test.ts
+++ b/packages/zendesk-adapter/test/adapter.test.ts
@@ -2486,20 +2486,30 @@ describe('adapter', () => {
           })
           .fetch({ progressReporter: { reportProgress: () => null } })
         expect(errors).toBeDefined()
-        expect(errors?.length).toEqual(3)
+        expect(errors?.length).toEqual(4)
         expect(errors?.[0]).toEqual({
           severity: 'Info',
           message: 'Other issues',
           detailedMessage:
             "Salto could not access the custom_status resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource",
         })
-        expect(errors?.[1].message.split('.')[0]).toEqual('Some elements were not fetched due to Salto ID collisions')
-        expect(errors?.[1].detailedMessage.split('.')[0]).toEqual(
-          'Omitted 2 instances and all their child instances of ticket_field due to Salto ID collisions',
+        expect(errors?.[1].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(errors?.[1].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field.instance.Product_components_multiselect@su',
+          ),
         )
-        expect(errors?.[2].message.split('.')[0]).toEqual('Some elements were not fetched due to Salto ID collisions')
-        expect(errors?.[2].detailedMessage.split('.')[0]).toEqual(
-          'Omitted 4 instances and all their child instances of ticket_field__custom_field_options due to Salto ID collisions',
+        expect(errors?.[2].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(errors?.[2].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect__component_b@suuuu',
+          ),
+        )
+        expect(errors?.[3].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(errors?.[3].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect__component_a@suuuu',
+          ),
         )
         const elementsNames = elements.map(e => e.elemID.getFullName())
         expect(elementsNames).not.toContain(
@@ -2622,25 +2632,33 @@ describe('adapter', () => {
             elementsSource: buildElementsSourceFromElements([]),
           })
           .fetch({ progressReporter: { reportProgress: () => null } })
-        expect(fetchRes.errors?.length).toEqual(3)
+        expect(fetchRes.errors?.length).toEqual(4)
         expect(fetchRes.errors?.[0]).toEqual({
           severity: 'Warning',
           message: 'Other issues',
           detailedMessage:
             'Could not find any brands matching the included patterns: [BestBrand]. Please update the configuration under fetch.guide.brands in the configuration file',
         })
-        expect(fetchRes.errors?.[1].message.split('.')[0]).toEqual(
-          'Some elements were not fetched due to Salto ID collisions',
+
+        expect(fetchRes.errors?.[1].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(fetchRes.errors?.[1].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field.instance.Product_components_multiselect@su',
+          ),
         )
-        expect(fetchRes.errors?.[1].detailedMessage.split('.')[0]).toEqual(
-          'Omitted 2 instances and all their child instances of ticket_field due to Salto ID collisions',
+        expect(fetchRes.errors?.[2].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(fetchRes.errors?.[2].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect__component_b@suuuu',
+          ),
         )
-        expect(fetchRes.errors?.[2].message.split('.')[0]).toEqual(
-          'Some elements were not fetched due to Salto ID collisions',
+        expect(fetchRes.errors?.[3].message).toEqual('Some elements were not fetched due to Salto ID collisions')
+        expect(fetchRes.errors?.[3].detailedMessage).toEqual(
+          expect.stringContaining(
+            '2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.ticket_field__custom_field_options.instance.Product_components_multiselect__component_a@suuuu',
+          ),
         )
-        expect(fetchRes.errors?.[2].detailedMessage.split('.')[0]).toEqual(
-          'Omitted 4 instances and all their child instances of ticket_field__custom_field_options due to Salto ID collisions',
-        )
+
         expect(fetchRes.elements.filter(isInstanceElement).find(e => e.elemID.typeName === 'article')).not.toBeDefined()
         expect(fetchRes.elements.filter(isObjectType).find(e => e.elemID.typeName === 'article')).toBeDefined()
       })

--- a/packages/zendesk-adapter/test/filters/omit_collision.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_collision.test.ts
@@ -40,21 +40,12 @@ describe('collision errors', () => {
       expect(filterResult.errors?.[0]).toEqual({
         severity: 'Warning',
         message: 'Some elements were not fetched due to Salto ID collisions',
-        detailedMessage: `Omitted 2 instances and all their child instances of obj due to Salto ID collisions.
-Current Salto ID configuration for obj is defined as [name].
+        detailedMessage: `2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.obj.instance.inst1:
+inst1,
+inst1 - open in Zendesk: someUrl.
 
-Breakdown per colliding Salto ID:
-- inst1:
-\t* Instance with Id - inst1
-\t* Instance with Id - inst1. View in the service - someUrl
-
-To resolve these collisions please take one of the following actions and fetch again:
-\t1. Change obj's idFields to include all fields that uniquely identify the type's instances.
-\t2. Delete duplicate instances from your zendesk account.
-
-Alternatively, you can exclude obj from the service configuration in zendesk.nacl
-
-Learn more at: https://help.salto.io/en/articles/6927157-salto-id-collisions`,
+Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
       })
     })
     it('should return no errors if there were no collisions', async () => {

--- a/packages/zendesk-adapter/test/filters/omit_collision.test.ts
+++ b/packages/zendesk-adapter/test/filters/omit_collision.test.ts
@@ -42,10 +42,10 @@ describe('collision errors', () => {
         message: 'Some elements were not fetched due to Salto ID collisions',
         detailedMessage: `2 Zendesk elements and their child elements were not fetched, as they were mapped to a single ID zendesk.obj.instance.inst1:
 inst1,
-inst1 - open in Zendesk: someUrl.
+inst1 - open in Zendesk: someUrl .
 
 Usually, this happens because of duplicate configuration names in the service. Make sure these element names are unique, and try fetching again.
-Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions.`,
+Learn about additional ways to resolve this issue at https://help.salto.io/en/articles/6927157-salto-id-collisions .`,
       })
     })
     it('should return no errors if there were no collisions', async () => {


### PR DESCRIPTION
_use the new id collision message in the adapters_

---

_Additional context for reviewer_
* in this pr I changed the usage of `getAndLogCollisionWarnings` to use `getCollisionWarnings`, and delete the old function

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_
