### PR TITLE
SALTO-7332: Add optional base url for Workato

### DIFF
--- a/packages/workato-adapter/specific-cli-options.md
+++ b/packages/workato-adapter/specific-cli-options.md
@@ -4,7 +4,8 @@
 
 Supprted parameters are:
 
-- `username`
+- `username` (optional)
+- `baseUrl` (optional)
 - `token`
 
 ### Example

--- a/packages/workato-adapter/src/auth.ts
+++ b/packages/workato-adapter/src/auth.ts
@@ -5,12 +5,22 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ElemID, BuiltinTypes } from '@salto-io/adapter-api'
+import { ElemID, BuiltinTypes, CORE_ANNOTATIONS, createRestriction } from '@salto-io/adapter-api'
 import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import * as constants from './constants'
 
+// base URL options are documented in https://docs.workato.com/workato-api.html#base-url
+export const workatoBaseUrlOptions = [
+  'https://www.workato.com',
+  'https://app.eu.workato.com',
+  'https://app.jp.workato.com',
+  'https://app.sg.workato.com',
+  'https://app.au.workato.com',
+]
+
 export type UsernameTokenCredentials = {
   username?: string
+  baseUrl?: string
   token: string
 }
 
@@ -21,6 +31,14 @@ export const usernameTokenCredentialsType = createMatchingObjectType<UsernameTok
       refType: BuiltinTypes.STRING,
       annotations: {
         message: 'username (optional) - keep empty if using token-based authentication',
+      },
+    },
+    baseUrl: {
+      refType: BuiltinTypes.STRING,
+      annotations: {
+        _required: false,
+        [CORE_ANNOTATIONS.RESTRICTION]: createRestriction({ values: workatoBaseUrlOptions }),
+        message: 'base URL (optional) - only fill in if your account is not under Workato US (https://www.workato.com)',
       },
     },
     token: {

--- a/packages/workato-adapter/src/client/connection.ts
+++ b/packages/workato-adapter/src/client/connection.ts
@@ -6,11 +6,15 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import _ from 'lodash'
+import { logger } from '@salto-io/logging'
 import { AccountInfo, CredentialError } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
+import { safeJsonStringify } from '@salto-io/adapter-utils'
 import { Credentials } from '../auth'
 
-const BASE_URL = 'https://www.workato.com/api'
+const log = logger(module)
+
+const DEFAULT_BASE_URL = 'https://www.workato.com'
 
 export const validateCredentials = async ({
   connection,
@@ -22,6 +26,11 @@ export const validateCredentials = async ({
     // there is no good stable account id in workato, so we default to empty string
     return { accountId: '' }
   } catch (error) {
+    log.error(
+      'Failed to validate credentials, error: %s, stack: %s',
+      safeJsonStringify({ data: error?.response?.data, status: error?.response?.status }),
+      error.stack,
+    )
     if (error.response?.status === 401) {
       throw new CredentialError('Invalid Credentials')
     }
@@ -43,7 +52,7 @@ export const createConnection: clientUtils.ConnectionCreator<Credentials> = (ret
               'x-user-token': token,
             },
     }),
-    baseURLFunc: async () => BASE_URL,
+    baseURLFunc: async ({ baseUrl }) => `${baseUrl ?? DEFAULT_BASE_URL}/api/`,
     credValidateFunc: validateCredentials,
     timeout,
   })

--- a/packages/workato-adapter/test/adapter_creator.test.ts
+++ b/packages/workato-adapter/test/adapter_creator.test.ts
@@ -29,7 +29,7 @@ describe('adapter creator', () => {
     const config = adapter.configType as ObjectType
     expect(Object.keys(config?.fields)).toEqual(Object.keys(configType.fields))
   })
-  it('should use username+token as the basic auth method', () => {
+  it('should use username+token+baseUrl as the basic auth method', () => {
     expect(Object.keys(adapter.authenticationMethods.basic.credentialsType.fields)).toEqual(
       Object.keys(usernameTokenCredentialsType.fields),
     )

--- a/packages/workato-adapter/test/client/connection.test.ts
+++ b/packages/workato-adapter/test/client/connection.test.ts
@@ -110,5 +110,37 @@ describe('client connection', () => {
       expect(res.status).toEqual(200)
       expect(mockAxiosAdapter.history.get.length).toBe(2)
     })
+
+    it('should make get requests with correct params when provided with base URL', async () => {
+      const conn = createConnection({ retries: 3 })
+      mockAxiosAdapter
+        .onGet('/users/me')
+        .reply(200, {
+          id: 'user123',
+        })
+        .onGet('/a/b')
+        .reply(200, {
+          something: 'bla',
+        })
+      const apiConn = await conn.login({ token: 'token123', baseUrl: 'https://app.eu.workato.com' })
+      expect(apiConn.accountInfo).toEqual({ accountId: '' })
+      expect(mockAxiosAdapter.history.get.length).toBe(1)
+      expect(mockAxiosAdapter.history.get[0]).toEqual(
+        expect.objectContaining({
+          baseURL: 'https://app.eu.workato.com/api/',
+        }),
+      )
+
+      const getRes = apiConn.get('/a/b')
+      const res = await getRes
+      expect(res.data).toEqual({ something: 'bla' })
+      expect(res.status).toEqual(200)
+      expect(mockAxiosAdapter.history.get.length).toBe(2)
+      expect(mockAxiosAdapter.history.get[1]).toEqual(
+        expect.objectContaining({
+          baseURL: 'https://app.eu.workato.com/api/',
+        }),
+      )
+    })
   })
 })


### PR DESCRIPTION
Allow providing optional base URL for workato, with a fallback value to the default Workato based URL we used until now.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Workato Adapter_:
- Support authenticating Workato adapter with non US based Workato account (see https://docs.workato.com/workato-api.html#base-url)


---
_User Notifications_: 
None
