### PR TITLE
SALTO-7333: Add missing Entra scope

### DIFF
--- a/packages/microsoft-security-adapter/src/auth.ts
+++ b/packages/microsoft-security-adapter/src/auth.ts
@@ -30,6 +30,7 @@ export const SCOPE_MAPPING: Record<AvailableMicrosoftSecurityServices, string[]>
   Entra: [
     'AdministrativeUnit.ReadWrite.All',
     'Application.ReadWrite.All',
+    'AppRoleAssignment.ReadWrite.All',
     'CustomSecAttributeDefinition.ReadWrite.All',
     'Directory.ReadWrite.All',
     'Domain.ReadWrite.All',


### PR DESCRIPTION
This scope is sometimes required to assign App Roles to a Service Principal

---
_Release Notes_: 
_Microsoft Security adapter:_
* Add missing Entra scope, to allow assigning App Roles to Service Principals.

---
_User Notifications_: 
None
