### PR TITLE
SALTO-7322: add tests to e2e-test-utils

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -63,6 +63,7 @@
   },
   "devDependencies": {
     "@salto-io/e2e-credentials-store": "0.5.0",
+    "@salto-io/e2e-test-utils": "0.5.0",
     "@salto-io/element-test-utils": "0.5.0",
     "@salto-io/test-utils": "0.5.0",
     "@types/express": "^4.17.7",

--- a/packages/cli/test/command_builder.test.ts
+++ b/packages/cli/test/command_builder.test.ts
@@ -7,17 +7,18 @@
  */
 import { logger, LogLevel } from '@salto-io/logging'
 import { loadLocalWorkspace } from '@salto-io/local-workspace'
+import { MockWorkspace, mockWorkspace } from '@salto-io/e2e-test-utils'
 import { mockFunction } from '@salto-io/test-utils'
 import { adapterCreators } from '@salto-io/adapter-creators'
 import * as mocks from './mocks'
 import {
-  createPublicCommandDef,
-  CommandDefAction,
-  WorkspaceCommandAction,
-  createWorkspaceCommand,
   CommandDef,
+  CommandDefAction,
+  createPublicCommandDef,
+  createWorkspaceCommand,
+  WorkspaceCommandAction,
 } from '../src/command_builder'
-import { SpinnerCreator, CliExitCode, CliError } from '../src/types'
+import { CliError, CliExitCode, SpinnerCreator } from '../src/types'
 import {
   CONFIG_OVERRIDE_OPTION,
   ConfigOverrideArg,
@@ -230,10 +231,10 @@ describe('Command builder', () => {
     })
     describe('action', () => {
       let cliArgs: mocks.MockCliArgs
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       beforeEach(() => {
         cliArgs = mocks.mockCliArgs()
-        workspace = mocks.mockWorkspace({ uid: 'test' })
+        workspace = mockWorkspace({ uid: 'test' })
 
         const loadWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof loadLocalWorkspace>
         loadWorkspace.mockClear()
@@ -322,7 +323,7 @@ describe('Command builder', () => {
       }) as CommandDef<unknown>
 
       const cliArgs = mocks.mockCliArgs()
-      const workspace = mocks.mockWorkspace({ uid: 'test' })
+      const workspace = mockWorkspace({ uid: 'test' })
       const loadWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof loadLocalWorkspace>
       loadWorkspace.mockResolvedValue(workspace)
 

--- a/packages/cli/test/commands/account.test.ts
+++ b/packages/cli/test/commands/account.test.ts
@@ -5,18 +5,19 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { AdapterAuthentication, ObjectType, ElemID, BuiltinTypes } from '@salto-io/adapter-api'
-import { addAdapter, installAdapter, LoginStatus, verifyCredentials, updateCredentials } from '@salto-io/core'
+import { AdapterAuthentication, BuiltinTypes, ElemID, ObjectType } from '@salto-io/adapter-api'
+import { addAdapter, installAdapter, LoginStatus, updateCredentials, verifyCredentials } from '@salto-io/core'
 import { loadLocalWorkspace } from '@salto-io/local-workspace'
 import { Workspace } from '@salto-io/workspace'
+import { MockWorkspace, mockWorkspace } from '@salto-io/e2e-test-utils'
 import { getPrivateAdaptersNames } from '../../src/formatter'
 import {
   accountAddDef,
+  accountLoginDef,
   addAction,
+  createConfigFromLoginParameters,
   listAction,
   loginAction,
-  accountLoginDef,
-  createConfigFromLoginParameters,
 } from '../../src/commands/account'
 import { processOauthCredentials } from '../../src/cli_oauth_authenticator'
 import * as mocks from '../mocks'
@@ -103,7 +104,7 @@ jest.mock('@salto-io/adapter-creators', () => {
 describe('account command group', () => {
   let cliArgs: mocks.MockCliArgs
   let output: mocks.MockCliOutput
-  let workspace: mocks.MockWorkspace
+  let workspace: MockWorkspace
   const mockGetCredentialsFromUser = mocks.createMockGetCredentialsFromUser({
     username: 'test@test',
     password: 'test',
@@ -118,7 +119,7 @@ describe('account command group', () => {
   beforeEach(() => {
     cliArgs = mocks.mockCliArgs()
     output = cliArgs.output
-    workspace = mocks.mockWorkspace({ accounts: ['salesforce', 'netsuite', 'oauthAdapter'] })
+    workspace = mockWorkspace({ accounts: ['salesforce', 'netsuite', 'oauthAdapter'] })
   })
   describe('list command', () => {
     let cliCommandArgs: mocks.MockCommandArgs
@@ -197,7 +198,7 @@ describe('account command group', () => {
         telemetry = cliArgs.telemetry
 
         const loadWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof loadLocalWorkspace>
-        loadWorkspace.mockResolvedValue(mocks.mockWorkspace({ uid: 'test' }))
+        loadWorkspace.mockResolvedValue(mockWorkspace({ uid: 'test' }))
       })
 
       describe('when using correct parameters', () => {
@@ -681,7 +682,7 @@ describe('account command group', () => {
         telemetry = cliArgs.telemetry
 
         const loadWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof loadLocalWorkspace>
-        loadWorkspace.mockResolvedValue(mocks.mockWorkspace({ uid: 'test' }))
+        loadWorkspace.mockResolvedValue(mockWorkspace({ uid: 'test' }))
       })
 
       describe('when using correct parameters', () => {

--- a/packages/cli/test/commands/adapter_format.test.ts
+++ b/packages/cli/test/commands/adapter_format.test.ts
@@ -10,6 +10,7 @@ import { detailedCompare } from '@salto-io/adapter-utils'
 import { calculatePatch, initFolder, isInitializedFolder, syncWorkspaceToFolder } from '@salto-io/core'
 import { merger, updateElementsWithAlternativeAccount } from '@salto-io/workspace'
 import { loadLocalWorkspace } from '@salto-io/local-workspace'
+import { MockWorkspace, mockWorkspace, elements } from '@salto-io/e2e-test-utils'
 import * as mocks from '../mocks'
 import { applyPatchAction, syncWorkspaceToFolderAction } from '../../src/commands/adapter_format'
 import { CliExitCode } from '../../src/types'
@@ -41,18 +42,18 @@ const mockLoadLocalWorkspace = loadLocalWorkspace as jest.MockedFunction<typeof 
 
 describe('apply-patch command', () => {
   const commandName = 'apply-patch'
-  let workspace: mocks.MockWorkspace
+  let workspace: MockWorkspace
   let baseElements: Element[]
   let cliCommandArgs: mocks.MockCommandArgs
   beforeEach(async () => {
     jest.resetAllMocks()
 
-    baseElements = mocks.elements()
+    baseElements = elements()
     await updateElementsWithAlternativeAccount(baseElements, 'salesforce', 'salto')
 
     const cliArgs = mocks.mockCliArgs()
     cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-    workspace = mocks.mockWorkspace({
+    workspace = mockWorkspace({
       envs: ['env1', 'env2'],
       accounts: ['salesforce'],
       getElements: () => baseElements,
@@ -123,8 +124,8 @@ describe('apply-patch command', () => {
     let originalInstance: InstanceElement
     let updatedInstance: InstanceElement
     let newInstance: InstanceElement
-    let mockToWorkspace: mocks.MockWorkspace
-    let mockFromWorkspace: mocks.MockWorkspace
+    let mockToWorkspace: MockWorkspace
+    let mockFromWorkspace: MockWorkspace
 
     beforeEach(async () => {
       const type = baseElements[3] as ObjectType
@@ -151,8 +152,8 @@ describe('apply-patch command', () => {
         partiallyFetchedAccounts: new Set(['salesforce']),
       })
 
-      mockFromWorkspace = mocks.mockWorkspace({})
-      mockToWorkspace = mocks.mockWorkspace({})
+      mockFromWorkspace = mockWorkspace({})
+      mockToWorkspace = mockWorkspace({})
       mockLoadLocalWorkspace.mockResolvedValueOnce(mockToWorkspace).mockResolvedValueOnce(mockFromWorkspace)
 
       exitCode = await applyPatchAction({
@@ -199,7 +200,7 @@ describe('apply-patch command', () => {
       expect(workspace.flush).not.toHaveBeenCalled()
     })
     it('should fail if second workspace is invalid', async () => {
-      mockLoadLocalWorkspace.mockRejectedValueOnce(new Error('Error!')).mockResolvedValueOnce(mocks.mockWorkspace({}))
+      mockLoadLocalWorkspace.mockRejectedValueOnce(new Error('Error!')).mockResolvedValueOnce(mockWorkspace({}))
       const exitCode = await applyPatchAction({
         ...cliCommandArgs,
         input: {
@@ -346,13 +347,13 @@ describe('apply-patch command', () => {
 
 describe('sync-to-workspace command', () => {
   const commandName = 'sync-to-workspace'
-  let workspace: mocks.MockWorkspace
+  let workspace: MockWorkspace
   let cliCommandArgs: mocks.MockCommandArgs
 
   beforeEach(async () => {
     const cliArgs = mocks.mockCliArgs()
     cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-    workspace = mocks.mockWorkspace({
+    workspace = mockWorkspace({
       accounts: ['salesforce'],
     })
   })
@@ -490,7 +491,7 @@ describe('sync-to-workspace command', () => {
     let result: CliExitCode
     beforeEach(async () => {
       mockIsInitializedFolder.mockResolvedValueOnce({ result: true, errors: [] })
-      mockLoadLocalWorkspace.mockResolvedValueOnce(mocks.mockWorkspace({}))
+      mockLoadLocalWorkspace.mockResolvedValueOnce(mockWorkspace({}))
       mockSyncWorkspaceToFolder.mockResolvedValueOnce({ errors: [] })
       result = await syncWorkspaceToFolderAction({
         ...cliCommandArgs,

--- a/packages/cli/test/commands/cancel_task.test.ts
+++ b/packages/cli/test/commands/cancel_task.test.ts
@@ -6,8 +6,9 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import * as core from '@salto-io/core'
+import { mockWorkspace } from '@salto-io/e2e-test-utils'
 import { action, CancelTaskInput } from '../../src/commands/cancel_task'
-import { mockCliArgs, mockCliCommandArgs, mockWorkspace } from '../mocks'
+import { mockCliArgs, mockCliCommandArgs } from '../mocks'
 import { CliExitCode } from '../../src/types'
 import * as outputer from '../../src/outputer'
 import { WorkspaceCommandArgs } from '../../src/command_builder'

--- a/packages/cli/test/commands/commons.test.ts
+++ b/packages/cli/test/commands/commons.test.ts
@@ -6,13 +6,13 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { DetailedChange, ElemID, Value } from '@salto-io/adapter-api'
-import * as mocks from '../mocks'
+import { mockWorkspace as mockWorkspaceUtil, MockWorkspace } from '@salto-io/e2e-test-utils'
 import { getAndValidateActiveAccounts, getTagsForAccounts } from '../../src/commands/common/accounts'
 import { getConfigOverrideChanges } from '../../src/commands/common/config_override'
 
 describe('Commands commons tests', () => {
   describe('getAndValidateActiveAccounts with workspace with services', () => {
-    const mockWorkspace = mocks.mockWorkspace({ accounts: ['service1', 'service2', 'service3'] })
+    const mockWorkspace = mockWorkspaceUtil({ accounts: ['service1', 'service2', 'service3'] })
 
     it("Should return the workspaces' accounts if no input accounts provided", () => {
       const result = getAndValidateActiveAccounts(mockWorkspace, undefined)
@@ -37,7 +37,7 @@ describe('Commands commons tests', () => {
     })
   })
   describe('getAndValidateActiveAccounts with workspace with no accounts', () => {
-    const mockWorkspace = mocks.mockWorkspace({ accounts: [] })
+    const mockWorkspace = mockWorkspaceUtil({ accounts: [] })
     it('Should throw an error if no input accounts provided', () => {
       expect(() => getAndValidateActiveAccounts(mockWorkspace, undefined)).toThrow()
     })
@@ -47,10 +47,10 @@ describe('Commands commons tests', () => {
     })
   })
   describe('getTagsForAccounts', () => {
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
 
     beforeEach(() => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspaceUtil({})
       workspace.accounts = jest
         .fn()
         .mockImplementation((env?: string): string[] => (env ? ['workato'] : ['salesforce', 'netsuite']))

--- a/packages/cli/test/commands/deploy.test.ts
+++ b/packages/cli/test/commands/deploy.test.ts
@@ -5,8 +5,9 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { DeployResult, GroupProperties } from '@salto-io/core'
 import * as saltoCoreModule from '@salto-io/core'
+import { DeployResult, GroupProperties } from '@salto-io/core'
+import { MockWorkspace, mockWorkspace, mockErrors } from '@salto-io/e2e-test-utils'
 import { Workspace } from '@salto-io/workspace'
 import * as saltoFileModule from '@salto-io/file'
 import { Artifact, Change } from '@salto-io/adapter-api'
@@ -15,8 +16,8 @@ import Prompts from '../../src/prompts'
 import { CliExitCode } from '../../src/types'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import { action } from '../../src/commands/deploy'
 import * as deployModule from '../../src/commands/deploy'
+import { action } from '../../src/commands/deploy'
 
 const mockDeploy = mocks.deploy
 const mockPreview = mocks.preview
@@ -57,7 +58,7 @@ const mockedSaltoFile = jest.mocked(saltoFileModule)
 const commandName = 'deploy'
 
 describe('deploy command', () => {
-  let workspace: mocks.MockWorkspace
+  let workspace: MockWorkspace
   let output: mocks.MockCliOutput
   let cliCommandArgs: mocks.MockCommandArgs
   const accounts = ['salesforce']
@@ -70,7 +71,7 @@ describe('deploy command', () => {
     const cliArgs = mocks.mockCliArgs()
     cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
     output = cliArgs.output
-    workspace = mocks.mockWorkspace({})
+    workspace = mockWorkspace({})
     mockGetUserBooleanInput.mockReset()
     mockShouldCancel.mockReset()
     jest.spyOn(deployModule, 'shouldDeploy')
@@ -358,7 +359,7 @@ describe('deploy command', () => {
   describe('invalid deploy', () => {
     it('should fail gracefully', async () => {
       workspace.errors.mockResolvedValue(
-        mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+        mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
       )
       const result = await action({
         ...cliCommandArgs,
@@ -375,7 +376,7 @@ describe('deploy command', () => {
     })
     it('should allow the user to cancel when there are warnings', async () => {
       workspace.errors.mockResolvedValue(
-        mocks.mockErrors([{ severity: 'Warning', message: 'some warning', detailedMessage: 'some warning' }]),
+        mockErrors([{ severity: 'Warning', message: 'some warning', detailedMessage: 'some warning' }]),
       )
       mockGetUserBooleanInput.mockResolvedValue(false)
       const result = await action({
@@ -397,9 +398,7 @@ describe('deploy command', () => {
     beforeEach(() => {
       workspace.updateNaclFiles.mockImplementationOnce(async () => {
         // Make the workspace errored after the call to updateNaclFiles
-        workspace.errors.mockResolvedValueOnce(
-          mocks.mockErrors([{ severity: 'Error', message: '', detailedMessage: '' }]),
-        )
+        workspace.errors.mockResolvedValueOnce(mockErrors([{ severity: 'Error', message: '', detailedMessage: '' }]))
         return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
       })
       mockGetUserBooleanInput.mockReturnValue(true)

--- a/packages/cli/test/commands/diff.test.ts
+++ b/packages/cli/test/commands/diff.test.ts
@@ -6,6 +6,8 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { diff } from '@salto-io/core'
+import { MockWorkspace, mockWorkspace } from '@salto-io/e2e-test-utils'
+
 import { CliExitCode } from '../../src/types'
 import { diffAction } from '../../src/commands/env'
 import { expectElementSelector } from '../utils'
@@ -20,7 +22,7 @@ jest.mock('@salto-io/core', () => ({
 describe('diff command', () => {
   describe('with invalid source environment', () => {
     it('should throw Error', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       const result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -38,7 +40,7 @@ describe('diff command', () => {
 
   describe('with invalid destination environment', () => {
     it('should throw Error', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       const result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -56,9 +58,9 @@ describe('diff command', () => {
 
   describe('with valid workspace', () => {
     let result: CliExitCode
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     beforeAll(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -82,9 +84,9 @@ describe('diff command', () => {
 
   describe('with show hidden types flag', () => {
     let result: CliExitCode
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     beforeAll(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -108,9 +110,9 @@ describe('diff command', () => {
 
   describe('with state only flag', () => {
     let result: CliExitCode
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     beforeAll(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -134,10 +136,10 @@ describe('diff command', () => {
 
   describe('with id filters', () => {
     let result: CliExitCode
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     const regex = 'account.*'
     beforeAll(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {
@@ -170,10 +172,10 @@ describe('diff command', () => {
 
   describe('with invalid id filters', () => {
     let result: CliExitCode
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     const regex = '['
     beforeAll(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await diffAction({
         ...mocks.mockCliCommandArgs(commandName),
         input: {

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -7,35 +7,35 @@
  */
 import open from 'open'
 import {
+  CORE_ANNOTATIONS,
   Element,
   ElemID,
-  ObjectType,
-  CORE_ANNOTATIONS,
-  isInstanceElement,
   InstanceElement,
+  isInstanceElement,
   isObjectType,
+  ObjectType,
   ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { errors, UnresolvedElemIDs, createElementSelector } from '@salto-io/workspace'
+import { createElementSelector, errors, UnresolvedElemIDs } from '@salto-io/workspace'
+import { MockWorkspace, mockWorkspace, mockErrors, elements as elementsUtil } from '@salto-io/e2e-test-utils'
 import { collections } from '@salto-io/lowerdash'
-import { SelectorsError, fixElements } from '@salto-io/core'
+import { fixElements, SelectorsError } from '@salto-io/core'
 import { CliExitCode } from '../../src/types'
 import {
   cloneAction,
-  moveToEnvsAction,
-  moveToCommonAction,
-  listUnresolvedAction,
-  openAction,
-  listAction,
-  renameAction,
-  printElementAction,
   fixElementsAction,
+  listAction,
+  listUnresolvedAction,
+  moveToCommonAction,
+  moveToEnvsAction,
+  openAction,
+  printElementAction,
+  renameAction,
 } from '../../src/commands/element'
 import * as mocks from '../mocks'
 import * as callbacks from '../../src/callbacks'
 import Prompts from '../../src/prompts'
 import { formatTargetEnvRequired } from '../../src/formatter'
-import { MockWorkspace } from '../mocks'
 
 const { awu } = collections.asynciterable
 
@@ -62,9 +62,9 @@ describe('Element command group', () => {
     describe('with errored workspace', () => {
       let result: CliExitCode
       beforeAll(async () => {
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.errors.mockResolvedValue(
-          mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+          mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
         )
         result = await cloneAction({
           ...mocks.mockCliCommandArgs(cloneName),
@@ -90,7 +90,7 @@ describe('Element command group', () => {
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([new ElemID('salto', 'Account')]))
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.flush.mockRejectedValue(new Error('Oy Vey Zmir'))
@@ -118,14 +118,14 @@ describe('Element command group', () => {
 
     describe('with invalid element selectors', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let telemetry: mocks.MockTelemetry
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
         telemetry = cliArgs.telemetry
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await cloneAction({
           ...mocks.mockCliCommandArgs(cloneName, cliArgs),
           input: {
@@ -168,13 +168,13 @@ describe('Element command group', () => {
 
     describe('when user answer no', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       beforeAll(async () => {
         jest.spyOn(callbacks, 'getUserBooleanInput').mockImplementationOnce(() => Promise.resolve(false))
 
         const cliArgs = mocks.mockCliArgs()
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
         result = await cloneAction({
@@ -201,13 +201,13 @@ describe('Element command group', () => {
 
     describe('valid clone', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
         result = await cloneAction({
@@ -260,7 +260,7 @@ Cloning the specified elements to inactive.
             force: true,
             allowElementDeletions: false,
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         })
       })
 
@@ -289,7 +289,7 @@ Cloning the specified elements to inactive.
             force: true,
             allowElementDeletions: false,
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         })
       })
 
@@ -317,7 +317,7 @@ Cloning the specified elements to inactive.
             force: true,
             allowElementDeletions: false,
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         })
       })
 
@@ -345,7 +345,7 @@ Cloning the specified elements to inactive.
             force: true,
             allowElementDeletions: false,
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         })
       })
 
@@ -381,7 +381,7 @@ Cloning the specified elements to inactive.
             force: true,
             allowElementDeletions: false,
           },
-          workspace: workspace || mocks.mockWorkspace({}),
+          workspace: workspace || mockWorkspace({}),
         })
         return { result, output }
       }
@@ -403,7 +403,7 @@ Cloning the specified elements to inactive.
       })
 
       it('should fail running toAllEnvs with only current env', async () => {
-        const workspace = mocks.mockWorkspace({ envs: ['active'] })
+        const workspace = mockWorkspace({ envs: ['active'] })
         const { result, output } = await runClone({ toAllEnvs: true, workspace })
         expect(result).toBe(CliExitCode.UserInputError)
         expect(output.stderr.content).toContain('The target environments cannot be empty')
@@ -411,7 +411,7 @@ Cloning the specified elements to inactive.
 
       it('should succeed cloning to all envs', async () => {
         const envsToCloneTo = ['env1', 'env2', 'env3']
-        const workspace = mocks.mockWorkspace({ envs: ['active', ...envsToCloneTo] })
+        const workspace = mockWorkspace({ envs: ['active', ...envsToCloneTo] })
         const selector = new ElemID('salto', 'Account')
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
 
@@ -423,7 +423,7 @@ Cloning the specified elements to inactive.
 
     describe('allowElementDeletions', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let cliArgs: mocks.MockCliArgs
       let output: mocks.MockCliOutput
 
@@ -431,7 +431,7 @@ Cloning the specified elements to inactive.
       const elemToRemoveFromEnv2 = new ElemID('salto', 'elemToRemoveFromEnv2')
       const elemToRemoveFromEnv3 = new ElemID('salto', 'elemToRemoveFromEnv3')
       beforeEach(() => {
-        workspace = mocks.mockWorkspace({
+        workspace = mockWorkspace({
           envs: ['env1', 'env2', 'env3'],
         })
         cliArgs = mocks.mockCliArgs()
@@ -618,7 +618,7 @@ Nothing to do.
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([new ElemID('salto', 'Account')]))
         workspace.flush.mockRejectedValue(new Error('Oy Vey Zmir'))
         result = await moveToEnvsAction({
@@ -643,12 +643,12 @@ Nothing to do.
 
     describe('with invalid element selectors', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         result = await moveToEnvsAction({
           ...mocks.mockCliCommandArgs(moveToEnvsName, cliArgs),
@@ -679,12 +679,12 @@ Nothing to do.
 
     describe('when user answer no', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       beforeAll(async () => {
         jest.spyOn(callbacks, 'getUserBooleanInput').mockImplementationOnce(() => Promise.resolve(false))
         const cliArgs = mocks.mockCliArgs()
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors = jest.fn().mockResolvedValue([selector])
         result = await moveToEnvsAction({
@@ -709,13 +709,13 @@ Nothing to do.
 
     describe('valid move to envs', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors = jest.fn().mockResolvedValue([selector])
         result = await moveToEnvsAction({
@@ -759,7 +759,7 @@ Moving the specified elements to envs.
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([new ElemID('salto', 'Account')]))
         workspace.flush.mockRejectedValue(new Error('Oy Vey Zmir'))
@@ -785,12 +785,12 @@ Moving the specified elements to envs.
 
     describe('with invalid element selectors', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         result = await moveToCommonAction({
           ...mocks.mockCliCommandArgs(moveToCommonName, cliArgs),
@@ -821,13 +821,13 @@ Moving the specified elements to envs.
 
     describe('Without env option', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
         result = await moveToCommonAction({
@@ -859,13 +859,13 @@ Moving the specified elements to envs.
 
     describe('With env option', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const selector = new ElemID('salto', 'Account')
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([selector]))
         result = await moveToCommonAction({
@@ -903,7 +903,7 @@ Moving the specified elements to common.
 
     describe('allowElementDeletions', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const elemToAdd = new ElemID('salto', 'elemToAdd')
       const elemToRemoveFromEnv2 = new ElemID('salto', 'elemToRemoveFromEnv2')
       const elemToRemoveFromEnv3 = new ElemID('salto', 'elemToRemoveFromEnv3')
@@ -911,7 +911,7 @@ Moving the specified elements to common.
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({
+        workspace = mockWorkspace({
           envs: ['env1', 'env2', 'env3'],
         })
         workspace.getElementIdsBySelectors.mockResolvedValueOnce(awu([elemToAdd]))
@@ -971,7 +971,7 @@ Moving the specified elements to common.
 
     describe('success - all unresolved references are found in complete-from', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let userBooleanInput: jest.SpiedFunction<(typeof callbacks)['getUserBooleanInput']>
       let output: mocks.MockCliOutput
       beforeAll(async () => {
@@ -979,7 +979,7 @@ Moving the specified elements to common.
         output = cliArgs.output
         userBooleanInput = jest.spyOn(callbacks, 'getUserBooleanInput')
         userBooleanInput.mockRestore()
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         // Should ignore unresolved reference errors
         workspace.errors.mockResolvedValue(
@@ -1030,12 +1030,12 @@ Moving the specified elements to common.
 
     describe('success - no unresolved references', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementationOnce(() =>
           Promise.resolve({
             found: [],
@@ -1064,12 +1064,12 @@ Moving the specified elements to common.
 
     describe('success - some references do not exist', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementationOnce(() =>
           Promise.resolve({
             found: [new ElemID('salesforce', 'aaa'), new ElemID('salesforce', 'bbb', 'instance', 'ccc')],
@@ -1104,12 +1104,12 @@ Moving the specified elements to common.
 
     describe('failure - unexpected error', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementationOnce(() => {
           throw new Error('oh no')
         })
@@ -1143,7 +1143,7 @@ Moving the specified elements to common.
           input: {
             completeFrom: 'invalid',
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         })
       })
 
@@ -1155,9 +1155,9 @@ Moving the specified elements to common.
   describe('open command', () => {
     const commandName = 'open'
     const serviceUrlAccount = 'http://acme.com'
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     beforeEach(() => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
     })
 
     const getMockElement = (url?: string, parentElemIDs?: ElemID[]): ObjectType =>
@@ -1385,7 +1385,7 @@ Moving the specified elements to common.
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.listUnresolvedReferences.mockImplementation(mockedList)
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([new ElemID('salto', 'Account')]))
         workspace.errors.mockRejectedValue(new Error('Oy Vey Zmir'))
@@ -1410,12 +1410,12 @@ Moving the specified elements to common.
 
     describe('with invalid element selectors', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await listAction({
           ...mocks.mockCliCommandArgs(moveToCommonName, cliArgs),
           input: {
@@ -1440,7 +1440,7 @@ Moving the specified elements to common.
 
     describe('successful list cmd', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       const stringSelector = 'salto.Account'
       const elemID = new ElemID('salto', 'Account')
       let output: mocks.MockCliOutput
@@ -1448,7 +1448,7 @@ Moving the specified elements to common.
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.getElementIdsBySelectors.mockResolvedValue(awu([elemID]))
         result = await listAction({
           ...mocks.mockCliCommandArgs(moveToCommonName, cliArgs),
@@ -1479,9 +1479,9 @@ Moving the specified elements to common.
     describe('with errored workspace', () => {
       let result: CliExitCode
       beforeAll(async () => {
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.errors.mockResolvedValue(
-          mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+          mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
         )
         const cliArgs = mocks.mockCliArgs()
         result = await renameAction({
@@ -1500,12 +1500,12 @@ Moving the specified elements to common.
     })
     describe('with invalid element ids', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await renameAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
@@ -1522,12 +1522,12 @@ Moving the specified elements to common.
     })
     describe('when RenameElementIdError is throwen', () => {
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let output: mocks.MockCliOutput
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await renameAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
@@ -1543,11 +1543,11 @@ Moving the specified elements to common.
       })
     })
     describe('when other error throwen', () => {
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let cliArgs: mocks.MockCliArgs
       beforeAll(async () => {
         cliArgs = mocks.mockCliArgs()
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         workspace.getValue.mockRejectedValue(new Error('some error'))
       })
       it('should fail', async () =>
@@ -1565,14 +1565,14 @@ Moving the specified elements to common.
     describe('valid rename', () => {
       let output: mocks.MockCliOutput
       let result: CliExitCode
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let allElements: Element[]
       let sourceElement: InstanceElement
 
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
 
         allElements = await awu(await (await workspace.elements()).getAll()).toArray()
         sourceElement = allElements.find(isInstanceElement) as InstanceElement
@@ -1604,7 +1604,7 @@ Moving the specified elements to common.
       let result: CliExitCode
       beforeAll(async () => {
         const cliArgs = mocks.mockCliArgs()
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         result = await printElementAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
@@ -1626,7 +1626,7 @@ Moving the specified elements to common.
       beforeEach(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         const elements = await workspace.elements()
         await elements.set(new ObjectType({ elemID: new ElemID('test', 'type') }))
         result = await printElementAction({
@@ -1652,7 +1652,7 @@ Moving the specified elements to common.
       beforeEach(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         await workspace.state().set(new ObjectType({ elemID: new ElemID('test', 'type') }))
         result = await printElementAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
@@ -1677,7 +1677,7 @@ Moving the specified elements to common.
       beforeEach(async () => {
         const cliArgs = mocks.mockCliArgs()
         output = cliArgs.output
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         result = await printElementAction({
           ...mocks.mockCliCommandArgs(commandName, cliArgs),
           input: {
@@ -1692,8 +1692,7 @@ Moving the specified elements to common.
         expect(result).toEqual(CliExitCode.Success)
       })
       it('should print the element without the ID as a prefix', () => {
-        const fieldsWithLabel = mocks
-          .elements()
+        const fieldsWithLabel = elementsUtil()
           .filter(isObjectType)
           .flatMap(objType => Object.values(objType.fields))
           .filter(field => field.annotations.label !== undefined)
@@ -1717,7 +1716,7 @@ Moving the specified elements to common.
         elemID: new ElemID('salto', 'type'),
       })
       cliArgs = mocks.mockCliArgs()
-      workspace = mocks.mockWorkspace({ getElements: () => [type] })
+      workspace = mockWorkspace({ getElements: () => [type] })
       workspace.getValue.mockResolvedValue(type)
       fixElementsMock = fixElements as jest.Mock
       fixElementsMock.mockClear()

--- a/packages/cli/test/commands/env.test.ts
+++ b/packages/cli/test/commands/env.test.ts
@@ -6,9 +6,11 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { loadLocalWorkspace, locateWorkspaceRoot } from '@salto-io/local-workspace'
+import { MockWorkspace, mockWorkspace } from '@salto-io/e2e-test-utils'
+
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import { createAction, setAction, currentAction, listAction, deleteAction, renameAction } from '../../src/commands/env'
+import { createAction, currentAction, deleteAction, listAction, renameAction, setAction } from '../../src/commands/env'
 import { CliExitCode } from '../../src/types'
 
 jest.mock('@salto-io/local-workspace', () => ({
@@ -35,7 +37,7 @@ describe('env command group', () => {
   describe('create command', () => {
     const commandName = 'create'
     it('should create a new environment', async () => {
-      mockLoadLocalWorkspace.mockResolvedValue(mocks.mockWorkspace({}))
+      mockLoadLocalWorkspace.mockResolvedValue(mockWorkspace({}))
       await createAction({
         ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {
@@ -47,9 +49,9 @@ describe('env command group', () => {
     })
 
     describe('create multiple environments', () => {
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       beforeEach(() => {
-        workspace = mocks.mockWorkspace({ envs: ['me1'] })
+        workspace = mockWorkspace({ envs: ['me1'] })
         mockLoadLocalWorkspace.mockResolvedValue(workspace)
         jest.spyOn(callbacks, 'cliApproveIsolateBeforeMultiEnv').mockImplementation(() => Promise.resolve(false))
       })
@@ -158,7 +160,7 @@ describe('env command group', () => {
       })
 
       it('should not prompt on 3rd environment creation', async () => {
-        const newWorkspace = mocks.mockWorkspace({ envs: ['me1', 'me2'] })
+        const newWorkspace = mockWorkspace({ envs: ['me1', 'me2'] })
         mockLoadLocalWorkspace.mockResolvedValue(newWorkspace)
 
         await createAction({
@@ -183,7 +185,7 @@ describe('env command group', () => {
         input: {
           envName: 'active',
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
     })
@@ -195,7 +197,7 @@ describe('env command group', () => {
       await currentAction({
         ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {},
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
     })
@@ -207,7 +209,7 @@ describe('env command group', () => {
       await listAction({
         ...mocks.mockCliCommandArgs(commandName, cliArgs),
         input: {},
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(output.stdout.content.search('active')).toBeGreaterThan(0)
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)
@@ -222,7 +224,7 @@ describe('env command group', () => {
         input: {
           envName: 'inactive',
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)
     })
@@ -233,7 +235,7 @@ describe('env command group', () => {
           envName: 'inactive',
           keepNacls: true,
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)
     })
@@ -248,7 +250,7 @@ describe('env command group', () => {
           oldName: 'inactive',
           newName: 'new-inactive',
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(result).toBe(CliExitCode.Success)
       expect(output.stdout.content.search('inactive')).toBeGreaterThan(0)

--- a/packages/cli/test/commands/fetch.test.ts
+++ b/packages/cli/test/commands/fetch.test.ts
@@ -8,11 +8,12 @@
 import { EventEmitter } from 'pietile-eventemitter'
 import { InstanceElement } from '@salto-io/adapter-api'
 import { adapterCreators } from '@salto-io/adapter-creators'
-import { fetch, fetchFromWorkspace, FetchProgressEvents, StepEmitter, FetchFunc } from '@salto-io/core'
+import { MockWorkspace, mockWorkspace, elements, mockErrors } from '@salto-io/e2e-test-utils'
+import { fetch, fetchFromWorkspace, FetchFunc, FetchProgressEvents, StepEmitter } from '@salto-io/core'
 import { loadLocalWorkspace } from '@salto-io/local-workspace'
 import { createElementSelector, Workspace } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
-import { CliExitCode, CliTelemetry, CliError } from '../../src/types'
+import { CliError, CliExitCode, CliTelemetry } from '../../src/types'
 import { action, fetchCommand, FetchCommandArgs } from '../../src/commands/fetch'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
@@ -43,7 +44,7 @@ jest.mock('@salto-io/core', () => ({
 
 jest.mock('@salto-io/local-workspace', () => ({
   ...jest.requireActual<{}>('@salto-io/local-workspace'),
-  loadLocalWorkspace: jest.fn().mockImplementation(() => mocks.mockWorkspace({})),
+  loadLocalWorkspace: jest.fn().mockImplementation(() => mockWorkspace({})),
 }))
 describe('fetch command', () => {
   const accounts = ['salesforce']
@@ -65,9 +66,9 @@ describe('fetch command', () => {
     let result: number
     describe('with errored workspace', () => {
       beforeEach(async () => {
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         workspace.errors.mockResolvedValue(
-          mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some detailed error' }]),
+          mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some detailed error' }]),
         )
         result = await action({
           ...cliCommandArgs,
@@ -90,9 +91,9 @@ describe('fetch command', () => {
     })
 
     describe('with valid workspace and no changes', () => {
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       beforeEach(async () => {
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await action({
           ...cliCommandArgs,
           input: {
@@ -119,10 +120,10 @@ describe('fetch command', () => {
     })
 
     describe('when using implicit all accounts', () => {
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
 
       beforeEach(async () => {
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await action({
           ...cliCommandArgs,
           input: {
@@ -141,7 +142,7 @@ describe('fetch command', () => {
       })
     })
     describe('when passing regenerate salto ids for selectors', () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
 
       it('should exit with user error when regenerate salto ids flag is not passed', async () => {
         result = await action({
@@ -223,7 +224,7 @@ describe('fetch command', () => {
         )
         beforeEach(async () => {
           await fetchCommand({
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
             force: true,
             output,
             cliTelemetry,
@@ -254,7 +255,7 @@ describe('fetch command', () => {
       describe('with no upstream changes', () => {
         let workspace: Workspace
         beforeEach(async () => {
-          workspace = mocks.mockWorkspace({})
+          workspace = mockWorkspace({})
           await fetchCommand({
             workspace,
             force: true,
@@ -291,7 +292,7 @@ describe('fetch command', () => {
             mergeErrors: [],
             success: true,
           })
-          const workspace = mocks.mockWorkspace({})
+          const workspace = mockWorkspace({})
           fetchArgs = {
             workspace,
             force: false,
@@ -333,7 +334,7 @@ describe('fetch command', () => {
         describe('when called with force', () => {
           let workspace: Workspace
           beforeEach(async () => {
-            workspace = mocks.mockWorkspace({})
+            workspace = mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -361,7 +362,7 @@ describe('fetch command', () => {
         describe('when called with isolated', () => {
           let workspace: Workspace
           beforeEach(async () => {
-            workspace = mocks.mockWorkspace({})
+            workspace = mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -389,7 +390,7 @@ describe('fetch command', () => {
         describe('when called with align', () => {
           let workspace: Workspace
           beforeEach(async () => {
-            workspace = mocks.mockWorkspace({})
+            workspace = mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -417,7 +418,7 @@ describe('fetch command', () => {
         describe('when called with override', () => {
           let workspace: Workspace
           beforeEach(async () => {
-            workspace = mocks.mockWorkspace({})
+            workspace = mockWorkspace({})
             result = await fetchCommand({
               workspace,
               force: true,
@@ -447,7 +448,7 @@ describe('fetch command', () => {
             it('should throw an error', () =>
               expect(
                 fetchCommand({
-                  workspace: mocks.mockWorkspace({}),
+                  workspace: mockWorkspace({}),
                   force: true,
                   accounts,
                   cliTelemetry,
@@ -466,7 +467,7 @@ describe('fetch command', () => {
           describe('when state is updated', () => {
             let workspace: Workspace
             beforeEach(async () => {
-              workspace = mocks.mockWorkspace({})
+              workspace = mockWorkspace({})
               result = await fetchCommand({
                 workspace,
                 force: true,
@@ -495,9 +496,9 @@ describe('fetch command', () => {
             })
           })
           describe('when state failed to update', () => {
-            let workspace: mocks.MockWorkspace
+            let workspace: MockWorkspace
             beforeEach(async () => {
-              workspace = mocks.mockWorkspace({})
+              workspace = mockWorkspace({})
               workspace.flush.mockImplementation(() => {
                 throw new Error('failed to flush')
               })
@@ -523,9 +524,9 @@ describe('fetch command', () => {
           })
         })
         describe('when initial workspace is empty', () => {
-          let workspace: mocks.MockWorkspace
+          let workspace: MockWorkspace
           beforeEach(async () => {
-            workspace = mocks.mockWorkspace({})
+            workspace = mockWorkspace({})
             workspace.isEmpty.mockResolvedValue(true)
             await fetchCommand({
               workspace,
@@ -555,7 +556,7 @@ describe('fetch command', () => {
             const mockSingleChangeApprove = jest.fn().mockImplementation(cs => Promise.resolve([cs[0]]))
 
             it('should update workspace only with approved changes', async () => {
-              const workspace = mocks.mockWorkspace({})
+              const workspace = mockWorkspace({})
               await fetchCommand({
                 workspace,
                 force: false,
@@ -578,13 +579,11 @@ describe('fetch command', () => {
               const abortIfErrorCallback = jest.spyOn(callbacks, 'shouldAbortWorkspaceInCaseOfValidationError')
               abortIfErrorCallback.mockResolvedValue(true)
 
-              const workspace = mocks.mockWorkspace({})
+              const workspace = mockWorkspace({})
               workspace.updateNaclFiles.mockImplementation(async () => {
                 // Make the workspace errored after updateNaclFiles is called
                 workspace.errors.mockResolvedValue(
-                  mocks.mockErrors([
-                    { severity: 'Error', message: 'BLA Error', detailedMessage: 'detailed BLA Error' },
-                  ]),
+                  mockErrors([{ severity: 'Error', message: 'BLA Error', detailedMessage: 'detailed BLA Error' }]),
                 )
                 return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
@@ -610,13 +609,11 @@ describe('fetch command', () => {
               abortIfErrorCallback.mockRestore()
             })
             it('should not exit if warning identified in workspace after update', async () => {
-              const workspace = mocks.mockWorkspace({})
+              const workspace = mockWorkspace({})
               workspace.updateNaclFiles.mockImplementation(async () => {
                 // Make the workspace errored after updateNaclFiles is called
                 workspace.errors.mockResolvedValue(
-                  mocks.mockErrors([
-                    { severity: 'Warning', message: 'BLA Error', detailedMessage: 'detailed BLA Error' },
-                  ]),
+                  mockErrors([{ severity: 'Warning', message: 'BLA Error', detailedMessage: 'detailed BLA Error' }]),
                 )
                 return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
               })
@@ -648,9 +645,9 @@ describe('fetch command', () => {
           fetchErrors: [],
           mergeErrors: [
             {
-              elements: mocks.elements().slice(0, 2),
+              elements: elements().slice(0, 2),
               error: {
-                elemID: mocks.elements()[0].elemID,
+                elemID: elements()[0].elemID,
                 error: 'test',
                 message: 'test merge error',
                 detailedMessage: 'detailed test merge error',
@@ -663,7 +660,7 @@ describe('fetch command', () => {
           partiallyFetchedAccounts: new Set(['salesforce']),
         })
         beforeEach(async () => {
-          const workspace = mocks.mockWorkspace({})
+          const workspace = mockWorkspace({})
           result = await fetchCommand({
             workspace,
             force: true,
@@ -684,7 +681,7 @@ describe('fetch command', () => {
           expect(result).toBe(CliExitCode.Success)
         })
         it('should print merge errors', () => {
-          expect(output.stderr.content).toContain(mocks.elements()[0].elemID.getFullName())
+          expect(output.stderr.content).toContain(elements()[0].elemID.getFullName())
           expect(output.stderr.content).toContain('test merge error')
         })
       })
@@ -693,7 +690,7 @@ describe('fetch command', () => {
 
   describe('Verify using env command', () => {
     it('should use current env when env is not provided', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       await action({
         ...cliCommandArgs,
         input: {
@@ -709,7 +706,7 @@ describe('fetch command', () => {
       expect(workspace.setCurrentEnv).not.toHaveBeenCalled()
     })
     it('should use provided env', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       await action({
         ...cliCommandArgs,
         input: {
@@ -738,7 +735,7 @@ describe('fetch command', () => {
             env: 'envThatDoesNotExist',
             regenerateSaltoIds: false,
           },
-          workspace: mocks.mockWorkspace({}),
+          workspace: mockWorkspace({}),
         }),
       ).rejects.toThrow(new CliError(CliExitCode.AppError))
     })
@@ -761,8 +758,8 @@ describe('fetch command', () => {
     describe('success', () => {
       describe('when called with fromState false', () => {
         it('should invoke the fetch from workspace method with fromState false', async () => {
-          const workspace = mocks.mockWorkspace({ uid: 'target' })
-          const sourceWS = mocks.mockWorkspace({ uid: 'source' })
+          const workspace = mockWorkspace({ uid: 'target' })
+          const sourceWS = mockWorkspace({ uid: 'source' })
           const sourcePath = 'path/to/source'
           const env = 'sourceEnv'
           mockLoadLocalWorkspace.mockResolvedValueOnce(sourceWS)
@@ -793,8 +790,8 @@ describe('fetch command', () => {
 
       describe('when called with fromState true', () => {
         it('should invoke the fetch from workspace method with fromState false', async () => {
-          const workspace = mocks.mockWorkspace({ uid: 'target' })
-          const sourceWS = mocks.mockWorkspace({ uid: 'source' })
+          const workspace = mockWorkspace({ uid: 'target' })
+          const sourceWS = mockWorkspace({ uid: 'source' })
           const sourcePath = 'path/to/source'
           const env = 'sourceEnv'
           mockLoadLocalWorkspace.mockResolvedValueOnce(sourceWS)
@@ -828,7 +825,7 @@ describe('fetch command', () => {
       it('should throw an informative error if the workspace failed to load', async () => {
         const errMsg = 'All your base are belong to us'
         mockLoadLocalWorkspace.mockRejectedValueOnce(errMsg)
-        const workspace = mocks.mockWorkspace({ uid: 'target' })
+        const workspace = mockWorkspace({ uid: 'target' })
         await expect(() =>
           action({
             ...cliCommandArgs,
@@ -848,7 +845,7 @@ describe('fetch command', () => {
       })
 
       it('should return user input error if the from env argument is provided without the from workspace argument', async () => {
-        const workspace = mocks.mockWorkspace({ uid: 'target' })
+        const workspace = mockWorkspace({ uid: 'target' })
         const retValue = await action({
           ...cliCommandArgs,
           input: {
@@ -866,7 +863,7 @@ describe('fetch command', () => {
       })
 
       it('should return user input error if the from fromWorkspace argument is provided without the from fromEnv argument', async () => {
-        const workspace = mocks.mockWorkspace({ uid: 'target' })
+        const workspace = mockWorkspace({ uid: 'target' })
         const retValue = await action({
           ...cliCommandArgs,
           input: {

--- a/packages/cli/test/commands/restore.test.ts
+++ b/packages/cli/test/commands/restore.test.ts
@@ -7,6 +7,7 @@
  */
 import { restore, restorePaths } from '@salto-io/core'
 import { Workspace } from '@salto-io/workspace'
+import { mockWorkspace, mockErrors } from '@salto-io/e2e-test-utils'
 import { DetailedChangeWithBaseChange, ElemID, ModificationChange, StaticFile, Values } from '@salto-io/adapter-api'
 import { getUserBooleanInput } from '../../src/callbacks'
 import { CliExitCode } from '../../src/types'
@@ -63,9 +64,9 @@ describe('restore command', () => {
   describe('with errored workspace', () => {
     let result: number
     beforeEach(async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       workspace.errors.mockResolvedValue(
-        mocks.mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+        mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
       )
       result = await action({
         ...cliCommandArgs,
@@ -91,7 +92,7 @@ describe('restore command', () => {
     let result: number
     let workspace: Workspace
     beforeEach(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       jest.spyOn(workspace, 'updateNaclFiles').mockResolvedValue({
         naclFilesChangesCount: 2,
         stateOnlyChangesCount: 0,
@@ -143,7 +144,7 @@ describe('restore command', () => {
   })
   describe('Verify using env command', () => {
     it('should use current env when env is not provided', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       await action({
         ...cliCommandArgs,
         input: {
@@ -159,7 +160,7 @@ describe('restore command', () => {
       expect(workspace.setCurrentEnv).not.toHaveBeenCalled()
     })
     it('should use provided env', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       await action({
         ...cliCommandArgs,
         input: {
@@ -181,7 +182,7 @@ describe('restore command', () => {
     let result: number
     let workspace: Workspace
     beforeEach(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       result = await action({
         ...cliCommandArgs,
         input: {
@@ -217,7 +218,7 @@ describe('restore command', () => {
   describe('when prompting whether to perform the restore', () => {
     let workspace: Workspace
     beforeEach(async () => {
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
     })
 
     describe('when user input is y', () => {
@@ -333,10 +334,10 @@ describe('restore command', () => {
   })
 
   it('should return error when update workspace fails', async () => {
-    const workspace = mocks.mockWorkspace({})
+    const workspace = mockWorkspace({})
     workspace.updateNaclFiles.mockImplementation(async () => {
       workspace.errors.mockResolvedValue(
-        mocks.mockErrors([{ severity: 'Error', message: 'some error ', detailedMessage: 'some error ' }]),
+        mockErrors([{ severity: 'Error', message: 'some error ', detailedMessage: 'some error ' }]),
       )
       return { naclFilesChangesCount: 0, stateOnlyChangesCount: 0 }
     })
@@ -367,7 +368,7 @@ describe('restore command', () => {
           accounts,
           elementSelectors: ['++'],
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(result).toBe(CliExitCode.UserInputError)
     })
@@ -383,14 +384,14 @@ describe('restore command', () => {
           accounts,
           elementSelectors: ['salto.*'],
         },
-        workspace: mocks.mockWorkspace({}),
+        workspace: mockWorkspace({}),
       })
       expect(result).toBe(CliExitCode.Success)
     })
   })
   describe('restoring modified static files', () => {
     it('should not print about removal changes of static files', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       mockRestore.mockResolvedValueOnce([
         { change: mocks.staticFileChange('remove'), serviceChanges: [mocks.staticFileChange('add')] },
       ])
@@ -413,7 +414,7 @@ describe('restore command', () => {
     })
 
     it('should warn of unrestoring modified static files without content', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       mockRestore.mockResolvedValueOnce([
         { change: mocks.staticFileChange('modify'), serviceChanges: [mocks.staticFileChange('modify')] },
       ])
@@ -436,7 +437,7 @@ describe('restore command', () => {
     })
 
     it('should warn of inner unrestoring modified static files without content', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       const change: ModificationChange<Values> & DetailedChangeWithBaseChange = {
         data: {
           before: {
@@ -481,7 +482,7 @@ describe('restore command', () => {
     })
 
     it('should not warn about modified static files with content', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       mockRestore.mockResolvedValueOnce([
         { change: mocks.staticFileChange('modify', true), serviceChanges: [mocks.staticFileChange('modify', true)] },
       ])
@@ -504,7 +505,7 @@ describe('restore command', () => {
     })
 
     it('should warn of unrestoring added static files', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       mockRestore.mockResolvedValueOnce([
         { change: mocks.staticFileChange('add'), serviceChanges: [mocks.staticFileChange('remove')] },
       ])
@@ -527,7 +528,7 @@ describe('restore command', () => {
     })
 
     it('should not warn of added static files with content', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
       mockRestore.mockResolvedValueOnce([
         { change: mocks.staticFileChange('add', true), serviceChanges: [mocks.staticFileChange('remove', true)] },
       ])
@@ -552,7 +553,7 @@ describe('restore command', () => {
 
   describe('restore paths', () => {
     it('should call the restorePaths api', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
 
       const result = await action({
         ...cliCommandArgs,
@@ -577,7 +578,7 @@ describe('restore command', () => {
     })
 
     it('should fail when requesting to restore paths with specific selectors', async () => {
-      const workspace = mocks.mockWorkspace({})
+      const workspace = mockWorkspace({})
 
       const result = await action({
         ...cliCommandArgs,

--- a/packages/cli/test/commands/workspace.test.ts
+++ b/packages/cli/test/commands/workspace.test.ts
@@ -7,9 +7,10 @@
  */
 import * as core from '@salto-io/core'
 import { adapterCreators } from '@salto-io/adapter-creators'
+import { MockWorkspace, mockWorkspace } from '@salto-io/e2e-test-utils'
 import * as callbacks from '../../src/callbacks'
 import * as mocks from '../mocks'
-import { cleanAction, cacheUpdateAction, setStateProviderAction, wsValidateAction } from '../../src/commands/workspace'
+import { cacheUpdateAction, cleanAction, setStateProviderAction, wsValidateAction } from '../../src/commands/workspace'
 import { CliExitCode, Spinner } from '../../src/types'
 import * as workspaceFunctions from '../../src/workspace/workspace'
 
@@ -63,7 +64,7 @@ describe('workspace command group', () => {
               credentials: false,
               accountConfig: false,
             },
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
           }),
         ).toBe(CliExitCode.UserInputError)
         expect(output.stdout.content).toContain('Nothing to do.')
@@ -85,7 +86,7 @@ describe('workspace command group', () => {
               credentials: true,
               accountConfig: true,
             },
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
           }),
         ).toBe(CliExitCode.Success)
         expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
@@ -105,7 +106,7 @@ describe('workspace command group', () => {
               credentials: false,
               accountConfig: false,
             },
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
           }),
         ).toBe(CliExitCode.Success)
         expect(callbacks.getUserBooleanInput).toHaveBeenCalledWith('Do you want to perform these actions?')
@@ -124,7 +125,7 @@ describe('workspace command group', () => {
               credentials: true,
               accountConfig: true,
             },
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
           }),
         ).toBe(CliExitCode.UserInputError)
         expect(callbacks.getUserBooleanInput).not.toHaveBeenCalled()
@@ -134,7 +135,7 @@ describe('workspace command group', () => {
       })
 
       it('should prompt user and continue if yes', async () => {
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         expect(
           await cleanAction({
             ...cliCommandArgs,
@@ -183,7 +184,7 @@ describe('workspace command group', () => {
               credentials: true,
               accountConfig: true,
             },
-            workspace: mocks.mockWorkspace({}),
+            workspace: mockWorkspace({}),
           }),
         ).toBe(CliExitCode.AppError)
 
@@ -195,7 +196,7 @@ describe('workspace command group', () => {
     describe('with force flag', () => {
       it('should clean without prompting user', async () => {
         jest.spyOn(callbacks, 'getUserBooleanInput').mockImplementationOnce(() => Promise.resolve(false))
-        const workspace = mocks.mockWorkspace({})
+        const workspace = mockWorkspace({})
         expect(
           await cleanAction({
             ...cliCommandArgs,
@@ -234,12 +235,12 @@ describe('workspace command group', () => {
     describe('cache update command', () => {
       const commandName = 'update'
       let cliCommandArgs: mocks.MockCommandArgs
-      let workspace: mocks.MockWorkspace
+      let workspace: MockWorkspace
       let result: CliExitCode
 
       beforeEach(async () => {
         cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-        workspace = mocks.mockWorkspace({})
+        workspace = mockWorkspace({})
         result = await cacheUpdateAction({
           ...cliCommandArgs,
           input: {},
@@ -259,10 +260,10 @@ describe('workspace command group', () => {
   describe('set state provider', () => {
     const commandName = 'set-state-provider'
     let cliCommandArgs: mocks.MockCommandArgs
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     beforeEach(async () => {
       cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
     })
 
     describe('when provider is undefined', () => {
@@ -330,14 +331,14 @@ describe('workspace command group', () => {
   describe('validate command', () => {
     const commandName = 'validate'
     let cliCommandArgs: mocks.MockCommandArgs
-    let workspace: mocks.MockWorkspace
+    let workspace: MockWorkspace
     let spinner: Spinner
     let spinnerOutput: string[]
 
     beforeEach(() => {
       spinnerOutput = []
       cliCommandArgs = mocks.mockCliCommandArgs(commandName, cliArgs)
-      workspace = mocks.mockWorkspace({})
+      workspace = mockWorkspace({})
       spinner = {
         succeed: (text: string) => spinnerOutput.push(text),
         fail: (text: string) => spinnerOutput.push(text),

--- a/packages/cli/test/formatter.test.ts
+++ b/packages/cli/test/formatter.test.ts
@@ -17,6 +17,7 @@ import {
   StaticFile,
   ListType,
 } from '@salto-io/adapter-api'
+import { elements } from '@salto-io/e2e-test-utils'
 import { EOL } from 'os'
 import { DeployError, FetchChange } from '@salto-io/core'
 import { errors as wsErrors } from '@salto-io/workspace'
@@ -31,7 +32,7 @@ import {
   formatShouldChangeFetchModeToAlign,
   deployErrorsOutput,
 } from '../src/formatter'
-import { elements, preview, detailedChange } from './mocks'
+import { preview, detailedChange } from './mocks'
 import Prompts from '../src/prompts'
 
 describe('formatter', () => {

--- a/packages/cli/test/mocks.ts
+++ b/packages/cli/test/mocks.ts
@@ -9,51 +9,34 @@ import wu from 'wu'
 import _ from 'lodash'
 import { DataNodeMap, Group } from '@salto-io/dag'
 import {
+  AdapterAuthentication,
   BuiltinTypes,
   Change,
+  ChangeDataType,
+  ChangeError,
+  DetailedChange,
+  DetailedChangeWithBaseChange,
   Element,
   ElemID,
   getChangeData,
   InstanceElement,
-  ObjectType,
-  CORE_ANNOTATIONS,
-  SaltoError,
-  Values,
   ListType,
-  DetailedChange,
-  AdapterAuthentication,
-  OAuthRequestParameters,
   OauthAccessTokenResponse,
-  createRefToElmWithValue,
+  OAuthRequestParameters,
+  ObjectType,
   StaticFile,
-  ChangeError,
-  ChangeDataType,
-  DetailedChangeWithBaseChange,
+  Values,
 } from '@salto-io/adapter-api'
-import { Plan, PlanItem, DeployResult, DeployParams, deploy as coreDeploy } from '@salto-io/core'
-import {
-  Workspace,
-  errors as wsErrors,
-  state as wsState,
-  remoteMap,
-  elementSource,
-  pathIndex,
-  staticFiles,
-} from '@salto-io/workspace'
-import { Telemetry, CommandConfig } from '@salto-io/local-workspace'
-import { parser } from '@salto-io/parser'
+import { deploy as coreDeploy, DeployParams, DeployResult, Plan, PlanItem } from '@salto-io/core'
+import { CommandConfig, Telemetry } from '@salto-io/local-workspace'
 import { logger } from '@salto-io/logging'
-import { collections } from '@salto-io/lowerdash'
-import { MockInterface, mockFunction } from '@salto-io/test-utils'
+import { mockFunction } from '@salto-io/test-utils'
+import { elements } from '@salto-io/e2e-test-utils'
 import realCli from '../src/cli'
 import commandDefinitions from '../src/commands/index'
-import { CommandOrGroupDef, CommandArgs } from '../src/command_builder'
+import { CommandArgs, CommandOrGroupDef } from '../src/command_builder'
 import { Spinner, SpinnerCreator } from '../src/types'
 import { getCliTelemetry } from '../src/telemetry'
-
-const { InMemoryRemoteMap } = remoteMap
-const { createInMemoryElementSource } = elementSource
-const { awu } = collections.asynciterable
 
 export interface MockWriteStreamOpts {
   isTTY?: boolean
@@ -178,222 +161,8 @@ export const createMockGetCredentialsFromUser = (value: Values) =>
       new InstanceElement(ElemID.CONFIG_NAME, configObjType, value),
   )
 
-export const elements = (): Element[] => {
-  const addrElemID = new ElemID('salto', 'address')
-  const saltoAddr = new ObjectType({
-    elemID: addrElemID,
-    fields: {
-      country: { refType: BuiltinTypes.STRING },
-      city: { refType: BuiltinTypes.STRING },
-    },
-  })
-  saltoAddr.annotationRefTypes.label = createRefToElmWithValue(BuiltinTypes.STRING)
-
-  const officeElemID = new ElemID('salto', 'office')
-  const saltoOffice = new ObjectType({
-    elemID: officeElemID,
-    fields: {
-      name: { refType: BuiltinTypes.STRING },
-      location: {
-        refType: saltoAddr,
-        annotations: {
-          label: 'Office Location',
-          description: 'A location of an office',
-        },
-      },
-    },
-    annotations: {
-      description: 'Office type in salto',
-    },
-  })
-  saltoOffice.annotationRefTypes.label = createRefToElmWithValue(BuiltinTypes.STRING)
-
-  const employeeElemID = new ElemID('salto', 'employee')
-  const saltoEmployee = new ObjectType({
-    elemID: employeeElemID,
-    fields: {
-      name: {
-        refType: BuiltinTypes.STRING,
-        annotations: { _required: true },
-      },
-      nicknames: {
-        refType: new ListType(BuiltinTypes.STRING),
-        annotations: {},
-      },
-      company: {
-        refType: BuiltinTypes.STRING,
-        annotations: { _default: 'salto' },
-      },
-      office: {
-        refType: saltoOffice,
-        annotations: {
-          label: 'Based In',
-          name: {
-            [CORE_ANNOTATIONS.DEFAULT]: 'HQ',
-          },
-          location: {
-            country: {
-              [CORE_ANNOTATIONS.DEFAULT]: 'IL',
-            },
-            city: {
-              [CORE_ANNOTATIONS.DEFAULT]: 'Raanana',
-            },
-          },
-        },
-      },
-    },
-  })
-
-  const saltoEmployeeInstance = new InstanceElement('test', saltoEmployee, {
-    name: 'FirstEmployee',
-    nicknames: ['you', 'hi'],
-    office: { label: 'bla', name: 'foo' },
-  })
-  return [BuiltinTypes.STRING, saltoAddr, saltoOffice, saltoEmployee, saltoEmployeeInstance]
-}
-
-export const mockErrors = (errors: SaltoError[]): wsErrors.Errors =>
-  new wsErrors.Errors({
-    parse: [],
-    merge: [],
-    validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
-  })
-
-// Mock interface does not handle template functions well
-export type MockWorkspace = MockInterface<Omit<Workspace, 'transformToWorkspaceError'>> &
-  Pick<Workspace, 'transformToWorkspaceError'>
-
 export const withoutEnvironmentParam = 'active'
 export const withEnvironmentParam = 'inactive'
-
-type MockWorkspaceArgs = {
-  uid?: string
-  envs?: string[]
-  accounts?: string[]
-  getElements?: () => Element[]
-}
-
-export const mockStateStaticFilesSource = (): MockInterface<staticFiles.StateStaticFilesSource> => ({
-  persistStaticFile: mockFunction<staticFiles.StateStaticFilesSource['persistStaticFile']>(),
-  getStaticFile: mockFunction<staticFiles.StateStaticFilesSource['getStaticFile']>(),
-  clear: mockFunction<staticFiles.StateStaticFilesSource['clear']>(),
-  rename: mockFunction<staticFiles.StateStaticFilesSource['rename']>(),
-  delete: mockFunction<staticFiles.StateStaticFilesSource['delete']>(),
-  flush: mockFunction<staticFiles.StateStaticFilesSource['flush']>(),
-})
-
-export const mockWorkspace = ({
-  uid = '123',
-  envs = ['active', 'inactive'],
-  accounts = ['salesforce', 'netsuite'],
-  getElements = elements,
-}: MockWorkspaceArgs): MockWorkspace => {
-  const mockStateData = async (): Promise<wsState.StateData> => ({
-    elements: createInMemoryElementSource(getElements()),
-    pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
-    topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
-    accounts: new InMemoryRemoteMap([{ key: 'account_names', value: accounts }]),
-    saltoMetadata: new InMemoryRemoteMap(),
-    staticFilesSource: mockStateStaticFilesSource(),
-    deprecated: {
-      accountsUpdateDate: new InMemoryRemoteMap<Date>(),
-    },
-  })
-  const stateByEnv = Object.fromEntries(envs.map(env => [env, wsState.buildInMemState(mockStateData)]))
-  let currentEnv = envs[0]
-  return {
-    uid,
-    elements: mockFunction<Workspace['elements']>().mockResolvedValue(createInMemoryElementSource(getElements())),
-    state: mockFunction<Workspace['state']>().mockImplementation(env => stateByEnv[env ?? currentEnv]),
-    envs: mockFunction<Workspace['envs']>().mockReturnValue(envs),
-    currentEnv: mockFunction<Workspace['currentEnv']>().mockImplementation(() => currentEnv),
-    accounts: mockFunction<Workspace['accounts']>().mockReturnValue(accounts),
-    services: mockFunction<Workspace['services']>().mockReturnValue(accounts),
-    close: mockFunction<Workspace['close']>().mockResolvedValue(),
-    accountCredentials: mockFunction<Workspace['accountCredentials']>().mockResolvedValue({}),
-    servicesCredentials: mockFunction<Workspace['servicesCredentials']>().mockResolvedValue({}),
-    accountConfig: mockFunction<Workspace['accountConfig']>().mockResolvedValue(undefined),
-    serviceConfig: mockFunction<Workspace['serviceConfig']>().mockResolvedValue(undefined),
-    accountConfigPaths: mockFunction<Workspace['accountConfigPaths']>().mockResolvedValue([]),
-    serviceConfigPaths: mockFunction<Workspace['serviceConfigPaths']>().mockResolvedValue([]),
-    isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
-    hasElementsInAccounts: mockFunction<Workspace['hasElementsInAccounts']>().mockResolvedValue(true),
-    hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
-    hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),
-    envOfFile: mockFunction<Workspace['envOfFile']>().mockReturnValue(''),
-    hasErrors: mockFunction<Workspace['hasErrors']>().mockResolvedValue(false),
-    errors: mockFunction<Workspace['errors']>().mockResolvedValue(mockErrors([])),
-    transformToWorkspaceError: mockFunction<Workspace['transformToWorkspaceError']>().mockImplementation(
-      async error => ({ ...error, sourceLocations: [] }),
-    ) as Workspace['transformToWorkspaceError'],
-    transformError: mockFunction<Workspace['transformError']>().mockImplementation(async error => ({
-      ...error,
-      sourceLocations: [],
-    })),
-    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>().mockResolvedValue({
-      naclFilesChangesCount: 0,
-      stateOnlyChangesCount: 0,
-    }),
-    listNaclFiles: mockFunction<Workspace['listNaclFiles']>().mockResolvedValue([]),
-    getTotalSize: mockFunction<Workspace['getTotalSize']>().mockResolvedValue(0),
-    getNaclFile: mockFunction<Workspace['getNaclFile']>(),
-    setNaclFiles: mockFunction<Workspace['setNaclFiles']>(),
-    removeNaclFiles: mockFunction<Workspace['removeNaclFiles']>(),
-    getServiceFromAccountName: mockFunction<Workspace['getServiceFromAccountName']>().mockImplementation(
-      account => account,
-    ),
-    getSourceMap: mockFunction<Workspace['getSourceMap']>().mockResolvedValue(new parser.SourceMap()),
-    getSourceRanges: mockFunction<Workspace['getSourceRanges']>().mockResolvedValue([]),
-    getReferenceSourcesIndex: mockFunction<Workspace['getReferenceSourcesIndex']>(),
-    getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
-    getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
-    getElementIncomingReferenceInfos: mockFunction<Workspace['getElementIncomingReferenceInfos']>().mockResolvedValue(
-      [],
-    ),
-    getElementAuthorInformation: mockFunction<Workspace['getElementAuthorInformation']>().mockResolvedValue({}),
-    getElementsAuthorsById: mockFunction<Workspace['getElementsAuthorsById']>().mockResolvedValue({}),
-    getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
-    getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
-    getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),
-    flush: mockFunction<Workspace['flush']>(),
-    clone: mockFunction<Workspace['clone']>(),
-    clear: mockFunction<Workspace['clear']>(),
-    addAccount: mockFunction<Workspace['addAccount']>(),
-    addService: mockFunction<Workspace['addService']>(),
-    addEnvironment: mockFunction<Workspace['addEnvironment']>(),
-    deleteEnvironment: mockFunction<Workspace['deleteEnvironment']>(),
-    renameEnvironment: mockFunction<Workspace['renameEnvironment']>(),
-    setCurrentEnv: mockFunction<Workspace['setCurrentEnv']>().mockImplementation(async env => {
-      currentEnv = env
-    }),
-    updateAccountCredentials: mockFunction<Workspace['updateAccountCredentials']>(),
-    updateServiceCredentials: mockFunction<Workspace['updateServiceCredentials']>(),
-    updateAccountConfig: mockFunction<Workspace['updateAccountConfig']>(),
-    updateServiceConfig: mockFunction<Workspace['updateServiceConfig']>(),
-
-    getAllChangedByAuthors: mockFunction<Workspace['getAllChangedByAuthors']>(),
-    getChangedElementsByAuthors: mockFunction<Workspace['getChangedElementsByAuthors']>(),
-    promote: mockFunction<Workspace['promote']>(),
-    demote: mockFunction<Workspace['demote']>(),
-    demoteAll: mockFunction<Workspace['demoteAll']>(),
-    copyTo: mockFunction<Workspace['copyTo']>(),
-    sync: mockFunction<Workspace['sync']>(),
-    updateStateProvider: mockFunction<Workspace['updateStateProvider']>(),
-    getValue: mockFunction<Workspace['getValue']>(),
-    getSearchableNames: mockFunction<Workspace['getSearchableNames']>(),
-    getSearchableNamesOfEnv: mockFunction<Workspace['getSearchableNamesOfEnv']>(),
-    listUnresolvedReferences: mockFunction<Workspace['listUnresolvedReferences']>(),
-    getElementSourceOfPath: mockFunction<Workspace['getElementSourceOfPath']>(),
-    getFileEnvs: mockFunction<Workspace['getFileEnvs']>(),
-    getStaticFile: mockFunction<Workspace['getStaticFile']>(),
-    getElementFileNames: mockFunction<Workspace['getElementFileNames']>(),
-    getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
-    getAliases: mockFunction<Workspace['getAliases']>(),
-    getStaticFilePathsByElemIds: mockFunction<Workspace['getStaticFilePathsByElemIds']>(),
-    isChangedAtIndexEmpty: mockFunction<Workspace['isChangedAtIndexEmpty']>(),
-    getElemIdsByStaticFilePaths: mockFunction<Workspace['getElemIdsByStaticFilePaths']>(),
-  }
-}
 
 export const mockCredentialsType = (adapterName: string): AdapterAuthentication => {
   const configID = new ElemID(adapterName)

--- a/packages/cli/test/workspace/workspace.test.ts
+++ b/packages/cli/test/workspace/workspace.test.ts
@@ -10,6 +10,7 @@ import { FetchChange } from '@salto-io/core'
 import { Workspace, state } from '@salto-io/workspace'
 import { mockFunction } from '@salto-io/test-utils'
 import { EventEmitter } from 'pietile-eventemitter'
+import { mockErrors } from '@salto-io/e2e-test-utils'
 import {
   validateWorkspace,
   updateWorkspace,
@@ -17,7 +18,7 @@ import {
   updateStateOnly,
   applyChangesToWorkspace,
 } from '../../src/workspace/workspace'
-import { MockWriteStream, dummyChanges, detailedChange, mockErrors, getMockTelemetry } from '../mocks'
+import { MockWriteStream, dummyChanges, detailedChange, getMockTelemetry } from '../mocks'
 import { getCliTelemetry } from '../../src/telemetry'
 
 const mockWsFunctions = {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -26,6 +26,7 @@
     { "path": "../parser" },
     { "path": "../salesforce-adapter" },
     { "path": "../test-utils" },
+    { "path": "../e2e-test-utils" },
     { "path": "../workspace" }
   ]
 }

--- a/packages/e2e-test-utils/index.ts
+++ b/packages/e2e-test-utils/index.ts
@@ -6,3 +6,4 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export * from './src/e2e_utils'
+export * from './src/mocks'

--- a/packages/e2e-test-utils/jest.config.js
+++ b/packages/e2e-test-utils/jest.config.js
@@ -5,3 +5,20 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+const deepMerge = require('../../build_utils/deep_merge')
+
+module.exports = deepMerge(require('../../jest.base.config.js'), {
+  displayName: 'salto',
+  rootDir: `${__dirname}`,
+  collectCoverageFrom: ['!<rootDir>/index.ts'],
+  coverageThreshold: {
+    // Slowly start increasing here, never decrease!
+    global: {
+      branches: 58.33,
+      functions: 50,
+      lines: 77.45,
+      statements: 78.26,
+    },
+  },
+  setupFilesAfterEnv: ['jest-extended/all'],
+})

--- a/packages/e2e-test-utils/package.json
+++ b/packages/e2e-test-utils/package.json
@@ -36,6 +36,8 @@
     "@salto-io/file": "0.5.0",
     "@salto-io/local-workspace": "0.5.0",
     "@salto-io/lowerdash": "0.5.0",
+    "@salto-io/parser": "0.5.0",
+    "@salto-io/test-utils": "0.5.0",
     "@salto-io/workspace": "0.5.0",
     "@types/jest": "^29.5.12",
     "@types/lodash": "^4.14.168",

--- a/packages/e2e-test-utils/src/e2e_utils.ts
+++ b/packages/e2e-test-utils/src/e2e_utils.ts
@@ -37,7 +37,7 @@ import { rm } from '@salto-io/file'
 
 const { awu } = collections.asynciterable
 
-const updateConfig = async ({
+export const updateConfig = async ({
   workspace,
   adapterName,
   configOverride,

--- a/packages/e2e-test-utils/src/mocks.ts
+++ b/packages/e2e-test-utils/src/mocks.ts
@@ -1,0 +1,248 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  elementSource,
+  errors as wsErrors,
+  pathIndex,
+  remoteMap,
+  state as wsState,
+  staticFiles,
+  Workspace,
+} from '@salto-io/workspace'
+import { mockFunction, MockInterface } from '@salto-io/test-utils'
+import { parser } from '@salto-io/parser'
+import {
+  BuiltinTypes,
+  CORE_ANNOTATIONS,
+  createRefToElmWithValue,
+  Element,
+  ElemID,
+  InstanceElement,
+  ListType,
+  ObjectType,
+  SaltoError,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+
+const { InMemoryRemoteMap } = remoteMap
+const { createInMemoryElementSource } = elementSource
+const { awu } = collections.asynciterable
+
+type MockWorkspaceArgs = {
+  uid?: string
+  envs?: string[]
+  accounts?: string[]
+  getElements?: () => Element[]
+}
+
+export const elements = (): Element[] => {
+  const addrElemID = new ElemID('salto', 'address')
+  const saltoAddr = new ObjectType({
+    elemID: addrElemID,
+    fields: {
+      country: { refType: BuiltinTypes.STRING },
+      city: { refType: BuiltinTypes.STRING },
+    },
+  })
+  saltoAddr.annotationRefTypes.label = createRefToElmWithValue(BuiltinTypes.STRING)
+
+  const officeElemID = new ElemID('salto', 'office')
+  const saltoOffice = new ObjectType({
+    elemID: officeElemID,
+    fields: {
+      name: { refType: BuiltinTypes.STRING },
+      location: {
+        refType: saltoAddr,
+        annotations: {
+          label: 'Office Location',
+          description: 'A location of an office',
+        },
+      },
+    },
+    annotations: {
+      description: 'Office type in salto',
+    },
+  })
+  saltoOffice.annotationRefTypes.label = createRefToElmWithValue(BuiltinTypes.STRING)
+
+  const employeeElemID = new ElemID('salto', 'employee')
+  const saltoEmployee = new ObjectType({
+    elemID: employeeElemID,
+    fields: {
+      name: {
+        refType: BuiltinTypes.STRING,
+        annotations: { _required: true },
+      },
+      nicknames: {
+        refType: new ListType(BuiltinTypes.STRING),
+        annotations: {},
+      },
+      company: {
+        refType: BuiltinTypes.STRING,
+        annotations: { _default: 'salto' },
+      },
+      office: {
+        refType: saltoOffice,
+        annotations: {
+          label: 'Based In',
+          name: {
+            [CORE_ANNOTATIONS.DEFAULT]: 'HQ',
+          },
+          location: {
+            country: {
+              [CORE_ANNOTATIONS.DEFAULT]: 'IL',
+            },
+            city: {
+              [CORE_ANNOTATIONS.DEFAULT]: 'Raanana',
+            },
+          },
+        },
+      },
+    },
+  })
+
+  const saltoEmployeeInstance = new InstanceElement('test', saltoEmployee, {
+    name: 'FirstEmployee',
+    nicknames: ['you', 'hi'],
+    office: { label: 'bla', name: 'foo' },
+  })
+  return [BuiltinTypes.STRING, saltoAddr, saltoOffice, saltoEmployee, saltoEmployeeInstance]
+}
+
+// Mock interface does not handle template functions well
+export type MockWorkspace = MockInterface<Omit<Workspace, 'transformToWorkspaceError'>> &
+  Pick<Workspace, 'transformToWorkspaceError'>
+
+export const mockErrors = (errors: SaltoError[]): wsErrors.Errors =>
+  new wsErrors.Errors({
+    parse: [],
+    merge: [],
+    validation: errors.map(err => ({ elemID: new ElemID('test'), error: err.message, ...err })),
+  })
+
+export const mockStateStaticFilesSource = (): MockInterface<staticFiles.StateStaticFilesSource> => ({
+  persistStaticFile: mockFunction<staticFiles.StateStaticFilesSource['persistStaticFile']>(),
+  getStaticFile: mockFunction<staticFiles.StateStaticFilesSource['getStaticFile']>(),
+  clear: mockFunction<staticFiles.StateStaticFilesSource['clear']>(),
+  rename: mockFunction<staticFiles.StateStaticFilesSource['rename']>(),
+  delete: mockFunction<staticFiles.StateStaticFilesSource['delete']>(),
+  flush: mockFunction<staticFiles.StateStaticFilesSource['flush']>(),
+})
+
+export const mockWorkspace = ({
+  uid = '123',
+  envs = ['active', 'inactive'],
+  accounts = ['salesforce', 'netsuite'],
+  getElements = elements,
+}: MockWorkspaceArgs): MockWorkspace => {
+  const mockStateData = async (): Promise<wsState.StateData> => ({
+    elements: createInMemoryElementSource(getElements()),
+    pathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+    topLevelPathIndex: new InMemoryRemoteMap<pathIndex.Path[]>(),
+    accounts: new InMemoryRemoteMap([{ key: 'account_names', value: accounts }]),
+    saltoMetadata: new InMemoryRemoteMap(),
+    staticFilesSource: mockStateStaticFilesSource(),
+    deprecated: {
+      accountsUpdateDate: new InMemoryRemoteMap<Date>(),
+    },
+  })
+  const stateByEnv = Object.fromEntries(envs.map(env => [env, wsState.buildInMemState(mockStateData)]))
+  let currentEnv = envs[0]
+  return {
+    uid,
+    elements: mockFunction<Workspace['elements']>().mockResolvedValue(createInMemoryElementSource(getElements())),
+    state: mockFunction<Workspace['state']>().mockImplementation(env => stateByEnv[env ?? currentEnv]),
+    envs: mockFunction<Workspace['envs']>().mockReturnValue(envs),
+    currentEnv: mockFunction<Workspace['currentEnv']>().mockImplementation(() => currentEnv),
+    accounts: mockFunction<Workspace['accounts']>().mockReturnValue(accounts),
+    services: mockFunction<Workspace['services']>().mockReturnValue(accounts),
+    close: mockFunction<Workspace['close']>().mockResolvedValue(),
+    accountCredentials: mockFunction<Workspace['accountCredentials']>().mockResolvedValue({}),
+    servicesCredentials: mockFunction<Workspace['servicesCredentials']>().mockResolvedValue({}),
+    accountConfig: mockFunction<Workspace['accountConfig']>().mockResolvedValue(undefined),
+    serviceConfig: mockFunction<Workspace['serviceConfig']>().mockResolvedValue(undefined),
+    accountConfigPaths: mockFunction<Workspace['accountConfigPaths']>().mockResolvedValue([]),
+    serviceConfigPaths: mockFunction<Workspace['serviceConfigPaths']>().mockResolvedValue([]),
+    isEmpty: mockFunction<Workspace['isEmpty']>().mockResolvedValue(false),
+    hasElementsInAccounts: mockFunction<Workspace['hasElementsInAccounts']>().mockResolvedValue(true),
+    hasElementsInServices: mockFunction<Workspace['hasElementsInServices']>().mockResolvedValue(true),
+    hasElementsInEnv: mockFunction<Workspace['hasElementsInEnv']>().mockResolvedValue(false),
+    envOfFile: mockFunction<Workspace['envOfFile']>().mockReturnValue(''),
+    hasErrors: mockFunction<Workspace['hasErrors']>().mockResolvedValue(false),
+    errors: mockFunction<Workspace['errors']>().mockResolvedValue(mockErrors([])),
+    transformToWorkspaceError: mockFunction<Workspace['transformToWorkspaceError']>().mockImplementation(
+      async error => ({ ...error, sourceLocations: [] }),
+    ) as Workspace['transformToWorkspaceError'],
+    transformError: mockFunction<Workspace['transformError']>().mockImplementation(async error => ({
+      ...error,
+      sourceLocations: [],
+    })),
+    updateNaclFiles: mockFunction<Workspace['updateNaclFiles']>().mockResolvedValue({
+      naclFilesChangesCount: 0,
+      stateOnlyChangesCount: 0,
+    }),
+    listNaclFiles: mockFunction<Workspace['listNaclFiles']>().mockResolvedValue([]),
+    getTotalSize: mockFunction<Workspace['getTotalSize']>().mockResolvedValue(0),
+    getNaclFile: mockFunction<Workspace['getNaclFile']>(),
+    setNaclFiles: mockFunction<Workspace['setNaclFiles']>(),
+    removeNaclFiles: mockFunction<Workspace['removeNaclFiles']>(),
+    getServiceFromAccountName: mockFunction<Workspace['getServiceFromAccountName']>().mockImplementation(
+      account => account,
+    ),
+    getSourceMap: mockFunction<Workspace['getSourceMap']>().mockResolvedValue(new parser.SourceMap()),
+    getSourceRanges: mockFunction<Workspace['getSourceRanges']>().mockResolvedValue([]),
+    getReferenceSourcesIndex: mockFunction<Workspace['getReferenceSourcesIndex']>(),
+    getElementOutgoingReferences: mockFunction<Workspace['getElementOutgoingReferences']>().mockResolvedValue([]),
+    getElementIncomingReferences: mockFunction<Workspace['getElementIncomingReferences']>().mockResolvedValue([]),
+    getElementIncomingReferenceInfos: mockFunction<Workspace['getElementIncomingReferenceInfos']>().mockResolvedValue(
+      [],
+    ),
+    getElementAuthorInformation: mockFunction<Workspace['getElementAuthorInformation']>().mockResolvedValue({}),
+    getElementsAuthorsById: mockFunction<Workspace['getElementsAuthorsById']>().mockResolvedValue({}),
+    getElementNaclFiles: mockFunction<Workspace['getElementNaclFiles']>().mockResolvedValue([]),
+    getElementIdsBySelectors: mockFunction<Workspace['getElementIdsBySelectors']>().mockResolvedValue(awu([])),
+    getParsedNaclFile: mockFunction<Workspace['getParsedNaclFile']>(),
+    flush: mockFunction<Workspace['flush']>(),
+    clone: mockFunction<Workspace['clone']>(),
+    clear: mockFunction<Workspace['clear']>(),
+    addAccount: mockFunction<Workspace['addAccount']>(),
+    addService: mockFunction<Workspace['addService']>(),
+    addEnvironment: mockFunction<Workspace['addEnvironment']>(),
+    deleteEnvironment: mockFunction<Workspace['deleteEnvironment']>(),
+    renameEnvironment: mockFunction<Workspace['renameEnvironment']>(),
+    setCurrentEnv: mockFunction<Workspace['setCurrentEnv']>().mockImplementation(async env => {
+      currentEnv = env
+    }),
+    updateAccountCredentials: mockFunction<Workspace['updateAccountCredentials']>(),
+    updateServiceCredentials: mockFunction<Workspace['updateServiceCredentials']>(),
+    updateAccountConfig: mockFunction<Workspace['updateAccountConfig']>(),
+    updateServiceConfig: mockFunction<Workspace['updateServiceConfig']>(),
+
+    getAllChangedByAuthors: mockFunction<Workspace['getAllChangedByAuthors']>(),
+    getChangedElementsByAuthors: mockFunction<Workspace['getChangedElementsByAuthors']>(),
+    promote: mockFunction<Workspace['promote']>(),
+    demote: mockFunction<Workspace['demote']>(),
+    demoteAll: mockFunction<Workspace['demoteAll']>(),
+    copyTo: mockFunction<Workspace['copyTo']>(),
+    sync: mockFunction<Workspace['sync']>(),
+    updateStateProvider: mockFunction<Workspace['updateStateProvider']>(),
+    getValue: mockFunction<Workspace['getValue']>(),
+    getSearchableNames: mockFunction<Workspace['getSearchableNames']>(),
+    getSearchableNamesOfEnv: mockFunction<Workspace['getSearchableNamesOfEnv']>(),
+    listUnresolvedReferences: mockFunction<Workspace['listUnresolvedReferences']>(),
+    getElementSourceOfPath: mockFunction<Workspace['getElementSourceOfPath']>(),
+    getFileEnvs: mockFunction<Workspace['getFileEnvs']>(),
+    getStaticFile: mockFunction<Workspace['getStaticFile']>(),
+    getElementFileNames: mockFunction<Workspace['getElementFileNames']>(),
+    getChangedElementsBetween: mockFunction<Workspace['getChangedElementsBetween']>(),
+    getAliases: mockFunction<Workspace['getAliases']>(),
+    getStaticFilePathsByElemIds: mockFunction<Workspace['getStaticFilePathsByElemIds']>(),
+    isChangedAtIndexEmpty: mockFunction<Workspace['isChangedAtIndexEmpty']>(),
+    getElemIdsByStaticFilePaths: mockFunction<Workspace['getElemIdsByStaticFilePaths']>(),
+  }
+}

--- a/packages/e2e-test-utils/test/e2e_utils.test.ts
+++ b/packages/e2e-test-utils/test/e2e_utils.test.ts
@@ -1,0 +1,324 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  Adapter,
+  AdapterOperations,
+  BuiltinTypes,
+  ChangeError,
+  ChangeValidator,
+  DetailedChangeWithBaseChange,
+  ElemID,
+  FixElementsFunc,
+  GetAdditionalReferencesFunc,
+  InstanceElement,
+  ObjectType,
+} from '@salto-io/adapter-api'
+import { mockFunction } from '@salto-io/test-utils'
+import { deploy, DeployResult, fetch, fixElements, preview } from '@salto-io/core'
+import { createElementSelectors } from '@salto-io/workspace'
+import { e2eDeploy, fetchWorkspace, updateConfig } from '../src/e2e_utils'
+import { mockErrors, MockWorkspace, mockWorkspace } from '../src/mocks'
+
+const mockService = 'salto'
+// const emptyMockService = 'salto2'
+
+// const ACCOUNTS = [mockService, emptyMockService]
+
+const mockConfigType = new ObjectType({
+  elemID: new ElemID(mockService),
+  fields: {
+    username: { refType: BuiltinTypes.STRING },
+    password: { refType: BuiltinTypes.STRING },
+    token: { refType: BuiltinTypes.STRING },
+    sandbox: { refType: BuiltinTypes.BOOLEAN },
+  },
+})
+
+const mockAdapterOps = {
+  fetch: mockFunction<AdapterOperations['fetch']>().mockResolvedValue({ elements: [] }),
+  deploy: mockFunction<AdapterOperations['deploy']>().mockImplementation(({ changeGroup }) =>
+    Promise.resolve({ errors: [], appliedChanges: changeGroup.changes }),
+  ),
+  fixElements: mockFunction<FixElementsFunc>().mockResolvedValue({ fixedElements: [], errors: [] }),
+}
+
+const mockAdapter: Adapter = {
+  operations: mockFunction<Adapter['operations']>().mockReturnValue({
+    ...mockAdapterOps,
+    deployModifiers: { changeValidator: mockFunction<ChangeValidator>().mockResolvedValue([]) },
+  }),
+  authenticationMethods: { basic: { credentialsType: mockConfigType } },
+  validateCredentials: mockFunction<Adapter['validateCredentials']>().mockResolvedValue({
+    accountId: '',
+    accountType: 'Sandbox',
+    isProduction: false,
+  }),
+  getAdditionalReferences: mockFunction<GetAdditionalReferencesFunc>().mockResolvedValue([]),
+  configCreator: {
+    getConfig: mockFunction<NonNullable<Adapter['configCreator']>['getConfig']>().mockResolvedValue(
+      new InstanceElement(ElemID.CONFIG_NAME, mockConfigType, { val: 'bbb' }),
+    ),
+    optionsType: new ObjectType({
+      elemID: new ElemID('test'),
+    }),
+  },
+  configType: new ObjectType({
+    elemID: new ElemID('mockAdapter', ElemID.CONFIG_NAME),
+  }),
+}
+
+const mockAdapterCreator: Record<string, Adapter> = { [mockService]: mockAdapter }
+jest.mock('@salto-io/core', () => {
+  const actual = jest.requireActual('@salto-io/core')
+  return {
+    ...actual,
+    fetch: jest.fn().mockResolvedValue({ changes: [], mergeErrors: [], success: true }),
+    fixElements: jest.fn().mockResolvedValue({ changes: [], errors: [] }),
+    preview: jest.fn().mockResolvedValue({ changeErrors: [], size: 0 }),
+    deploy: jest.fn().mockResolvedValue({ errors: [], changes: [] }),
+  }
+})
+
+describe('e2e_utils', () => {
+  let workspace: MockWorkspace
+  let adapterCreators: Record<string, Adapter>
+  beforeEach(() => {
+    jest.clearAllMocks()
+    workspace = mockWorkspace({ accounts: [mockService] })
+    adapterCreators = mockAdapterCreator
+  })
+  describe('updateConfig', () => {
+    it('should update the config correctly', async () => {
+      const configOverride = { someKey: 'newValue' }
+
+      await updateConfig({ workspace, adapterName: mockService, configOverride, adapterCreators })
+      const newConfig = workspace.updateAccountConfig.mock.calls[0][1] as [InstanceElement]
+      expect(newConfig[0].value).toEqual({ someKey: 'newValue', val: 'bbb' })
+    })
+  })
+
+  describe('fetchWorkspace', () => {
+    it('should fail when fetch is not successful', async () => {
+      ;(fetch as jest.Mock).mockResolvedValueOnce({ changes: [], mergeErrors: [], success: false })
+      await expect(fetchWorkspace({ workspace, adapterCreators })).rejects.toThrow()
+    })
+
+    it('should fail if there are workspace errors', async () => {
+      workspace.errors.mockResolvedValueOnce(
+        mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+      )
+      await expect(fetchWorkspace({ workspace, adapterCreators })).rejects.toThrow()
+    })
+
+    it('it should not fail if there workspace validation errors are filtered using a validationFilter', async () => {
+      workspace.errors.mockResolvedValueOnce(
+        mockErrors([{ severity: 'Error', message: 'some error', detailedMessage: 'some error' }]),
+      )
+      await expect(
+        fetchWorkspace({ workspace, adapterCreators, validationFilter: e => !(e.message === 'some error') }),
+      ).resolves.not.toThrow()
+    })
+  })
+
+  describe('e2eDeploy', () => {
+    const envElemID = new ElemID('salto', 'env')
+    const envObject = new ObjectType({
+      elemID: envElemID,
+      fields: {
+        field: {
+          refType: BuiltinTypes.STRING,
+        },
+      },
+    })
+    const commonElemID = new ElemID('salto', 'common', 'instance', 'test', 'field')
+    const detailedChanges = [
+      {
+        action: 'remove',
+        data: { before: envObject },
+        baseChange: {
+          action: 'remove',
+          data: { before: envObject },
+        },
+        path: ['bla1'],
+        id: envElemID,
+      },
+      {
+        action: 'add',
+        data: { after: 'a' },
+        baseChange: {
+          action: 'add',
+          data: { after: 'a' },
+        },
+        path: ['bla1'],
+        id: commonElemID,
+      },
+    ] as DetailedChangeWithBaseChange[]
+
+    const error: ChangeError = {
+      message: 'err',
+      detailedMessage: 'err',
+      severity: 'Error',
+      elemID: new ElemID('test'),
+    }
+
+    it('make sure that fixElements runs with the correct arguments', async () => {
+      await e2eDeploy({
+        workspace,
+        detailedChanges,
+        adapterCreators,
+      })
+      const selectors = createElementSelectors(['salto.env', 'salto.common.instance.test'])
+      expect(fixElements).toHaveBeenCalledWith(workspace, selectors.validSelectors, mockAdapterCreator)
+    })
+
+    it('should not fail if expectedFixerErrors is defined and there are errors', async () => {
+      ;(fixElements as jest.Mock).mockResolvedValueOnce({ changes: [], errors: [error] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+          expectedFixerErrors: [error],
+        }),
+      ).resolves.not.toThrow()
+    })
+
+    it('should fail if expectedFixerErrors is not defined and there are errors', async () => {
+      ;(fixElements as jest.Mock).mockResolvedValueOnce({ changes: [], errors: [error] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should filter actionPlan errors correctly', async () => {
+      ;(preview as jest.Mock).mockResolvedValueOnce({ size: 0, changeErrors: [error] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+          changeErrorFilter: e => !(e.message === 'err'),
+        }),
+      ).resolves.not.toThrow()
+    })
+
+    it('should fail if changeErrorFilter is not defined and there are errors', async () => {
+      ;(preview as jest.Mock).mockResolvedValueOnce({ size: 0, changeErrors: [error] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should not fail if changeErrorFilter is defined and there are errors', async () => {
+      ;(preview as jest.Mock).mockResolvedValueOnce({ size: 0, changeErrors: [error] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+          expectedChangeErrors: [error],
+        }),
+      ).resolves.not.toThrow()
+    })
+
+    it('should not fail if expectedDeployErrors is defined and there are errors', async () => {
+      const deployResult: DeployResult = {
+        success: true,
+        errors: [{ ...error, groupId: '1' }],
+        changes: [],
+      }
+      ;(deploy as jest.Mock).mockResolvedValueOnce(deployResult)
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+          expectedDeployErrors: [{ ...error, groupId: '1' }],
+        }),
+      ).resolves.not.toThrow()
+    })
+
+    it('should fail if expectedDeployErrors is not defined and there are errors', async () => {
+      const deployResult: DeployResult = {
+        success: true,
+        errors: [{ ...error, groupId: '1' }],
+        changes: [],
+      }
+      ;(deploy as jest.Mock).mockResolvedValueOnce(deployResult)
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+        }),
+      ).rejects.toThrow()
+    })
+
+    it('should call updateWorkspace after deploy with the correct changes', async () => {
+      const deployResult: DeployResult = {
+        success: true,
+        errors: [],
+        changes: [
+          { change: detailedChanges[0], serviceChanges: detailedChanges },
+          { change: detailedChanges[1], serviceChanges: detailedChanges },
+        ],
+      }
+      ;(deploy as jest.Mock).mockResolvedValueOnce(deployResult)
+
+      await e2eDeploy({
+        workspace,
+        detailedChanges,
+        adapterCreators,
+      })
+      expect(workspace.updateNaclFiles).toHaveBeenCalledWith(detailedChanges)
+    })
+
+    it('should not fail if actionPlanAfterDeploySize is defined and the actionPlanAfterDeploy size is not 0', async () => {
+      ;(preview as jest.Mock)
+        .mockResolvedValueOnce({ size: 1, changeErrors: [] })
+        .mockResolvedValueOnce({ size: 1, changeErrors: [] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+          actionPlanAfterDeploySize: 1,
+        }),
+      ).resolves.not.toThrow()
+    })
+    it('should fail if actionPlanAfterDeploySize is not defined and the actionPlanAfterDeploy size is not 0', async () => {
+      ;(preview as jest.Mock)
+        .mockResolvedValueOnce({ size: 1, changeErrors: [] })
+        .mockResolvedValueOnce({ size: 1, changeErrors: [] })
+
+      await expect(
+        e2eDeploy({
+          workspace,
+          detailedChanges,
+          adapterCreators,
+        }),
+      ).rejects.toThrow()
+    })
+  })
+})

--- a/packages/e2e-test-utils/tsconfig.json
+++ b/packages/e2e-test-utils/tsconfig.json
@@ -15,6 +15,8 @@
     { "path": "../lowerdash" },
     { "path": "../file" },
     { "path": "../adapter-components" },
+    { "path": "../parser" },
+    { "path": "../test-utils" },
     { "path": "../workspace" }
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4153,6 +4153,7 @@ __metadata:
     "@salto-io/core": 0.5.0
     "@salto-io/dag": 0.5.0
     "@salto-io/e2e-credentials-store": 0.5.0
+    "@salto-io/e2e-test-utils": 0.5.0
     "@salto-io/element-test-utils": 0.5.0
     "@salto-io/file": 0.5.0
     "@salto-io/local-workspace": 0.5.0
@@ -4347,6 +4348,8 @@ __metadata:
     "@salto-io/file": 0.5.0
     "@salto-io/local-workspace": 0.5.0
     "@salto-io/lowerdash": 0.5.0
+    "@salto-io/parser": 0.5.0
+    "@salto-io/test-utils": 0.5.0
     "@salto-io/workspace": 0.5.0
     "@types/jest": ^29.5.12
     "@types/lodash": ^4.14.168


### PR DESCRIPTION
add tests to e2e-test-utils
---

_Additional context for reviewer_
had to move mock workspace function from cli to e2e-test-utils

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
