### PR TITLE
SALTO-7323 log when there is a different hash to the buffer in LazyStaticFile

### DIFF
--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -27,4 +27,5 @@ export const WORKSPACE_FLAGS = {
   // Killswitch for the new fetch diff computation logic. Activating this restores the old logic.
   // TODO(SALTO-6992): Remove this killswitch after 2025-01-30
   computePlanOnFetch: 'COMPUTE_PLAN_ON_FETCH',
+  verifyStaticFileContentHash: 'VERIFY_STATIC_FILE_CONTENT_HASH',
 } as const

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -222,9 +222,8 @@ export const buildStaticFilesSource = (
           args.isTemplate,
         )
       } catch (e) {
-        log.trace('failed to get file %s with error: %o', args.filepath, e)
+        log.trace('failed to get file %s (hash: %s) with error: %o', args.filepath, args.hash ?? 'not-given', e)
         if (args.hash !== undefined) {
-          log.trace('returning file %s without content (hash: %s)', args.filepath, args.hash)
           // We return a StaticFile in this case and not a MissingStaticFile to be able to differ
           // in the elements cache between a file that was really missing when the cache was
           // written, and a file that existed but was removed since the cache was written,

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -204,6 +204,15 @@ export const buildStaticFilesSource = (
             if (file.buffer === undefined) {
               log.warn('received file %s without buffer from static files dir store', args.filepath)
             }
+            const bufferHash = calculateStaticFileHash(file.buffer)
+            if (bufferHash !== staticFileData.hash) {
+              log.warn(
+                'received file %s with hash %s but expected hash to be %s',
+                args.filepath,
+                bufferHash,
+                staticFileData.hash,
+              )
+            }
             return file.buffer
           },
           args.encoding,


### PR DESCRIPTION
There's a possibility to have a mismatch in the StaticFile's hash and the hash of the StaticFile's content that was received from the staticFIlesDirStore.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
