### PR TITLE
SALTO-6286, SALTO-7280: Fix escaping of template expressions

### DIFF
--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -64,7 +64,7 @@ const createSimpleStringValue = (
 ): string => {
   try {
     return JSON.parse(
-      `"${unescapeTemplateMarker(tokens.map(token => token.text).join(''), { unescapeLeadingBackslashes: false })}"`,
+      `"${unescapeTemplateMarker(tokens.map(token => token.text).join(''), { unescapeStrategy: 'markerOnly' })}"`,
     )
   } catch (e) {
     context.errors.push(

--- a/packages/parser/src/parser/internal/native/helpers.ts
+++ b/packages/parser/src/parser/internal/native/helpers.ts
@@ -58,8 +58,6 @@ export const createReferenceExpression = (ref: string): ReferenceExpression | Il
   }
 }
 
-export const unescapeTemplateMarker = (text: string): string => text.replace(/\\\$\{/gi, '${')
-
 export const registerRange = (context: ParseContext, id: ElemID, range: Omit<SourceRange, 'filename'>): void => {
   if (context.calcSourceMap) {
     context.sourceMap.push(id.getFullName(), { ...range, filename: context.filename })

--- a/packages/parser/src/parser/internal/utils.ts
+++ b/packages/parser/src/parser/internal/utils.ts
@@ -5,4 +5,40 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-export const escapeTemplateMarker = (prim: string): string => prim.replace(/\$\{/gi, '\\${')
+type EscapeTemplateMarkerOptions = {
+  isLastPart?: boolean
+}
+
+export const escapeTemplateMarker = (
+  prim: string,
+  { isLastPart = true }: EscapeTemplateMarkerOptions | undefined = {},
+): string =>
+  prim.replace(
+    // In the last part we don't need to escape a \ at the end
+    isLastPart ? /(\\*)(\$\{)/g : /(\\*)(\$\{|$)/g,
+    (_, backslashes, ending) =>
+      // Double all leading backslashes and escape the ${
+      `${backslashes.replace(/\\/g, '\\\\')}${ending === '' ? '' : '\\${'}`,
+  )
+
+type UnescapeTemplateMarkerOptions = EscapeTemplateMarkerOptions & {
+  // The use case where we don't need to unescape the leading backslashes:
+  // When we dump a single line string we call
+  //  1. escapeTemplateMarker - which escapes the leading backslashes and the ${
+  //  2. stringify which escapes all backslashes
+  //  3. fixDoubleTemplateMarkerEscaping when unescapes the leading backslashes from 1
+  // This means that when we want to parse back a single line string, we only need to undo the escaping of the ${
+  unescapeLeadingBackslashes?: boolean
+}
+
+export const unescapeTemplateMarker = (
+  text: string,
+  { isLastPart = true, unescapeLeadingBackslashes = true }: UnescapeTemplateMarkerOptions | undefined = {},
+): string =>
+  text.replace(
+    // In the last part we don't need to unescape \ at the end
+    isLastPart ? /(\\*)(\\\$\{)/g : /(\\*)(\\\$\{|$)/g,
+    (_, backslashes, ending) =>
+      // Halve the leading backslashes (if needed) and unescape the ${
+      `${unescapeLeadingBackslashes ? backslashes.replace(/\\\\/g, '\\') : backslashes}${ending === '' ? '' : '${'}`,
+  )

--- a/packages/parser/src/parser/internal/utils.ts
+++ b/packages/parser/src/parser/internal/utils.ts
@@ -5,6 +5,20 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
+
+// Template marker escaping logic:
+//
+// In normal strings we need to escape everything that JSON.stringify would escape, and also the template marker (${)
+// In multi line strings we only need to escape the multi line string terminator (''') and the template marker (${)
+// In template static files we only need to escape the template marker
+//
+// The code below deals with the escaping of the template marker.
+// The first rule is that we replace ${ -> \${
+// This leads to an ambiguous case where if we had \${ in the string or a \ followed by a real reference, both cases would end up being \\${
+// Given this, we must escape \ as well, but just the ones that come immediately before a ${ or a reference
+// So for example a string with \${ will be escaped to \\\${
+// A string with \ followed by a reference will be \\${
+// and so on...
 type EscapeTemplateMarkerOptions = {
   isLastPart?: boolean
 }
@@ -22,23 +36,37 @@ export const escapeTemplateMarker = (
   )
 
 type UnescapeTemplateMarkerOptions = EscapeTemplateMarkerOptions & {
-  // The use case where we don't need to unescape the leading backslashes:
+  // The use case where we unescape only leading backslashes or only marker:
   // When we dump a single line string we call
-  //  1. escapeTemplateMarker - which escapes the leading backslashes and the ${
-  //  2. stringify which escapes all backslashes
-  //  3. fixDoubleTemplateMarkerEscaping when unescapes the leading backslashes from 1
-  // This means that when we want to parse back a single line string, we only need to undo the escaping of the ${
-  unescapeLeadingBackslashes?: boolean
+  //  1. escapeTemplateMarker - which escapes the leading backslashes and the marker
+  //  2. stringify which escapes all backslashes, not just the leading backslashes (so the leading backslashes are escaped twice at this point)
+  //  3. In order to fix the double escaping, we unescape leadingBackslashOnly as part of the dump code
+
+  // When we parse a single ine string we call
+  //  1. JSON.parse which unescapes all backslashes
+  //  2. Since we already unescaped the leading backslashes in part 3 of the dump process, we unescape markerOnly
+  unescapeStrategy?: 'all' | 'leadingBackslashOnly' | 'markerOnly'
 }
 
 export const unescapeTemplateMarker = (
   text: string,
-  { isLastPart = true, unescapeLeadingBackslashes = true }: UnescapeTemplateMarkerOptions | undefined = {},
-): string =>
-  text.replace(
+  { isLastPart = true, unescapeStrategy = 'all' }: UnescapeTemplateMarkerOptions | undefined = {},
+): string => {
+  if (unescapeStrategy === 'leadingBackslashOnly') {
+    return text.replace(/(\\*)(\\\\\$\{)/g, (_match, backslashes, ending) =>
+      // Halve the leading backslashes before the escaped ${
+      `${backslashes}${ending}`.replace(/\\\\/g, '\\'),
+    )
+  }
+  return text.replace(
     // In the last part we don't need to unescape \ at the end
     isLastPart ? /(\\*)(\\\$\{)/g : /(\\*)(\\\$\{|$)/g,
-    (_, backslashes, ending) =>
-      // Halve the leading backslashes (if needed) and unescape the ${
-      `${unescapeLeadingBackslashes ? backslashes.replace(/\\\\/g, '\\') : backslashes}${ending === '' ? '' : '${'}`,
+    (_, backslashes, ending) => {
+      const leadingBackslashes = unescapeStrategy === 'markerOnly' ? backslashes : backslashes.replace(/\\\\/g, '\\')
+      if (ending === '') {
+        return leadingBackslashes
+      }
+      return `${leadingBackslashes}\${`
+    },
   )
+}

--- a/packages/parser/src/utils/template_static_file.ts
+++ b/packages/parser/src/utils/template_static_file.ts
@@ -9,16 +9,15 @@ import { isReferenceExpression, StaticFile, TemplateExpression } from '@salto-io
 import { logger } from '@salto-io/logging'
 import type { Token } from 'moo'
 import { createTemplateExpression } from '@salto-io/adapter-utils'
-import { escapeTemplateMarker } from '../parser/internal/utils'
-import { unescapeTemplateMarker } from '../parser/internal/native/helpers'
+import { escapeTemplateMarker, unescapeTemplateMarker } from '../parser/internal/utils'
 import { stringLexerFromString } from '../parser/internal/native/lexer'
 import { createStringValue } from '../parser/internal/native/consumers/values'
-import type { ParseError } from '../parser'
+import { ParseError } from '../parser'
 
 const log = logger(module)
 
-const createSimpleStringValue = (_context: unknown, tokens: Required<Token>[]): string =>
-  unescapeTemplateMarker(tokens.map(token => token.text).join(''))
+const createSimpleStringValue = (_context: unknown, tokens: Required<Token>[], isLastPart?: boolean): string =>
+  unescapeTemplateMarker(tokens.map(token => token.text).join(''), { isLastPart })
 
 const parseBufferToTemplateExpression = (
   buffer: Buffer,
@@ -39,7 +38,11 @@ const parseBufferToTemplateExpression = (
 
 export const templateExpressionToStaticFile = (expression: TemplateExpression, filepath: string): StaticFile => {
   const string = expression.parts
-    .map(part => (isReferenceExpression(part) ? `\${ ${[part.elemID.getFullName()]} }` : escapeTemplateMarker(part)))
+    .map((part, idx) =>
+      isReferenceExpression(part)
+        ? `\${ ${[part.elemID.getFullName()]} }`
+        : escapeTemplateMarker(part, { isLastPart: idx === expression.parts.length - 1 }),
+    )
     .join('')
   return new StaticFile({ filepath, content: Buffer.from(string), isTemplate: true, encoding: 'utf8' })
 }

--- a/packages/parser/test/parser/dump.test.ts
+++ b/packages/parser/test/parser/dump.test.ts
@@ -156,6 +156,26 @@ describe('Salto Dump', () => {
     template: new TemplateExpression({ parts: ['Hello ', new ReferenceExpression(new ElemID('salto', 'ref'))] }),
   })
 
+  const instanceWithEscapedTemplateExpression = new InstanceElement('escaped_template_inst', model, {
+    template: new TemplateExpression({
+      parts: [
+        // eslint-disable-next-line no-template-curly-in-string
+        'Hello \\${ not.reference } and \n line with escaped ref \\',
+        new ReferenceExpression(new ElemID('salto', 'ref')),
+        '\n and another line\\',
+      ],
+    }),
+    doubleEscapedTemplate: new TemplateExpression({
+      parts: ['double escaped ref \\\\\\', new ReferenceExpression(new ElemID('salto', 'ref'))],
+    }),
+    singleLineNonTemplate:
+      // eslint-disable-next-line no-template-curly-in-string
+      'string with two backslashes before template marker \\\\${ not.reference } and after \\',
+    multiLineNonTemplate:
+      // eslint-disable-next-line no-template-curly-in-string
+      'multi line string\nwith two \\ before template marker \\\\${ not.reference } \\\n and one at the end \\',
+  })
+
   describe('dump elements', () => {
     let body: string
 
@@ -175,6 +195,7 @@ describe('Salto Dump', () => {
           instanceWithArray,
           instanceWithTemplateExpression,
           unknownType,
+          instanceWithEscapedTemplateExpression,
         ],
         functions,
       )
@@ -263,6 +284,39 @@ describe('Salto Dump', () => {
       })
     })
 
+    describe('dumped escaped multi line template expression', () => {
+      it('should escape backslashes that appear before a reference', () => {
+        expect(body).toMatch(/line with escaped ref \\\\\$\{ salto.ref \}/m)
+      })
+      it('should escape backslashes that appear before a non reference ${', () => {
+        expect(body).toMatch(/Hello \\\\\\\$\{ not.reference \}/m)
+      })
+      it('should not escape backslashes that do not appear before ${', () => {
+        expect(body).toMatch(/and another line\\\n\s*'''/m)
+      })
+    })
+
+    describe('dumped multi line string with escaped template marker', () => {
+      it('should escape the template marker and all leading backslashes before it', () => {
+        expect(body).toMatch(
+          /multi line string\nwith two \\ before template marker \\\\\\\\\\\$\{ not.reference \} \\\n and one at the end \\/m,
+        )
+      })
+    })
+
+    describe('dumped escaped single line template expression', () => {
+      it('should escape all leading backslashes before a reference', () => {
+        // Original string had 3 backslashes before the reference, so we expect there to be 6 backslashes in the output
+        expect(body).toMatch(/"double escaped ref \\\\\\\\\\\\\$\{ salto.ref \}"/)
+      })
+      it('should escape all leading backslashes before an escaped reference marker in a string that is not a reference', () => {
+        // Original string had 2 backslashes, and the ${ should also be escaped, so we expect a total of 5 backslashes before the $
+        expect(body).toMatch(
+          /"string with two backslashes before template marker \\\\\\\\\\\$\{ not.reference \} and after \\\\"/,
+        )
+      })
+    })
+
     describe('indentation', () => {
       it('should indent attributes', () => {
         expect(body).toMatch(/LeadConvertSettings = {\s*\n {4}account = \[\s*\n {6}{\s*\n {8}input/m)
@@ -318,7 +372,7 @@ describe('Salto Dump', () => {
       const { elements, errors } = result
       const [listTypes, nonListElements] = _.partition(elements, e => isContainerType(e))
       expect(errors).toHaveLength(0)
-      expect(elements).toHaveLength(15)
+      expect(elements).toHaveLength(16)
       expect(nonListElements[0]).toEqual(strType)
       expect(nonListElements[1]).toEqual(numType)
       expect(nonListElements[2]).toEqual(boolType)
@@ -333,6 +387,7 @@ describe('Salto Dump', () => {
       expectInstancesToMatch(nonListElements[10] as InstanceElement, instanceWithArray)
       expectInstancesToMatch(nonListElements[11] as InstanceElement, instanceWithTemplateExpression)
       expect(nonListElements[12]).toEqual(unknownType)
+      expectInstancesToMatch(nonListElements[13] as InstanceElement, instanceWithEscapedTemplateExpression)
     })
   })
   describe('dump field', () => {


### PR DESCRIPTION
This fixes an issue where it was impossible to tell the difference between an escaped reference marker \${ and a real reference that had a \ before it. The effect of this change is that all `\` leading up to a template marker will now be escaped (turned into `\\`)

---

_Additional context for reviewer_
A few examples of the old behavior vs the new behavior, marking reference expressions in the actual value as "(ref)" so it will be possible to see where a real reference is supposed to be (the table below shows multi line NaCl, the behavior in single line strings is slightly different)

Value  |  Nacl (old) |  Nacl (new)
------ | ---------- | -----------
`bla \(ref)` | `"bla \${ ref }"` | `"bla \\${ ref }"`
`bla ${ not.ref }` | `"bla \${ not.ref }"` | `"bla \${ not.ref }"`
`bla \\(ref)` | `"bla \\${ ref }"` | `"bla \\\\${ ref }"`
`bla \${ not.ref }` | `"bla \\${ not.ref }"` | `"bla \\\${ not.ref }"`


We also tested backwards compatibility of parsing - the only difference with parsing NaCl that was generated by the old code for the examples above is for the case in line 3 of the table where the old code would parse `\\${ ref }` as two backslashes and then a reference whereas the new code would parse it as a single backslash and then a reference


The effect of this on a "live" workspace should be that:

For template strings in the NaCl:
- nothing will change if the value does not change, no new pending changes will be created (existing pending changes will remain)
- running `salto restore` would write correctly formatted values to the NaCl and fix the pending changes on the strings
- if the value changes, the change will be considered a conflict (if there were pending changes), once the change is applied, the whole string will be formatted correctly


For template static files:
- before the first fetch, no new pending changes will be created
- running `salto restore` will not fix the file's content
- The content of the file will be fixed on the first fetch with the new code (even if the content did not change)

---
_Release Notes_: 
Core:
- Fixed issue where template expressions / static files that contained \${ would be parsed incorrectly

---
_User Notifications_: 
Core:
- Additional `\` characters may be added to strings and static files that contain references the next time they change