### PR TITLE
SALTO-7337: fix guide_arrange_path filter

### DIFF
--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -295,7 +295,11 @@ const filterCreator: FilterCreator = () => ({
     // articles
     const articles = guideGrouped[ARTICLE_TYPE_NAME] ?? []
     articles.forEach(instance => {
-      const parentId = nameByIdParents[instance.value.section_id?.elemID.getFullName()]
+      const sectionName = instance.value.section_id?.elemID?.getFullName()
+      if (sectionName === undefined) {
+        log.warn(`article ${instance.elemID.getFullName()} does not have a section_id, cannot determine path`)
+      }
+      const parentId = nameByIdParents[sectionName]
       instance.path = pathForOtherLevels({
         instance,
         needTypeDirectory: true,

--- a/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/guide_arrange_paths.ts
@@ -297,6 +297,7 @@ const filterCreator: FilterCreator = () => ({
     articles.forEach(instance => {
       const sectionName = instance.value.section_id?.elemID?.getFullName()
       if (sectionName === undefined) {
+        // this shouldn't happen if it does we should understand why an article doesn't have a section_id
         log.warn(`article ${instance.elemID.getFullName()} does not have a section_id, cannot determine path`)
       }
       const parentId = nameByIdParents[sectionName]


### PR DESCRIPTION
fix guide_arrange_path filter

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
