### PR TITLE
SALTO-7338: Omit Intune scopeTag.permissions field on fetch

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/fetch/intune/fetch.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/intune/fetch.ts
@@ -319,7 +319,10 @@ const graphBetaCustomizations: FetchCustomizations = {
         endpoint: {
           path: '/deviceManagement/roleScopeTags',
         },
-        transformation: DEFAULT_TRANSFORMATION,
+        transformation: {
+          ...DEFAULT_TRANSFORMATION,
+          omit: ['permissions'],
+        },
       },
     ],
     resource: {


### PR DESCRIPTION
This is a newly added field in their beta API response.

ATM there’s no documentation available for it, and it doesn’t seem to appear in the Intune admin center (based on my attempts).
Currently, it causes deployment failures. Until we gain more clarity, we will omit this field.

---
_Release Notes_: 
_Microsoft Security:_
* Omit Intune scopeTag.permissions field on fetch

---
_User Notifications_: 
_Microsoft Security:_
* The field `permissions` will be omitted from Intune Scope Tags elements starting from the next fetch.
