### PR TITLE
SALTO-7342: assets reference in automation

### DIFF
--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -187,6 +187,7 @@ export const createAutomationTypes = (): {
       objectTypeId: { refType: BuiltinTypes.STRING },
       templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
+      cmdbField: { refType: BuiltinTypes.UNKNOWN },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1381,6 +1381,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: REQUEST_TYPE_NAME },
   },
   {
+    src: { field: 'cmdbField', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: FIELD_TYPE_NAME },
+  },
+  {
     src: { field: 'portalRequestTypeIds', parentTypes: ['FormPortal'] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',


### PR DESCRIPTION
None

---

Noise reduction will follow
---
_Release Notes_: 
Jira Adapter:
* Added support for references in automation's `edit asset fields atrributes`
---
_User Notifications_: 
Jira Adapter:
* Automation's `edit asset fields atrributes` will become references
