### PR TITLE
SALTO-7316 Allow empty arrays fix

### DIFF
--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -125,6 +125,7 @@ const extractStandaloneInstancesFromField =
           toPath,
           defaultName: `${invertNaclCase(parent.elemID.name)}__unnamed_${index}`,
           parent: standaloneDef.addParentAnnotation !== false ? parent : undefined,
+          allowEmptyArrays: defQuery.query(standaloneDef.typeName)?.element?.topLevel?.allowEmptyArrays,
         }),
       )
       .filter(isDefined)

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -125,6 +125,9 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
+    // We don't want to update the element, so we are permissive with the allowEmptyArrays and allowEmptyObjects
+    allowEmptyArrays: true,
+    allowEmptyObjects: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/adapter-components/test/filters/referenced_instance_names.test.ts
+++ b/packages/adapter-components/test/filters/referenced_instance_names.test.ts
@@ -138,6 +138,7 @@ describe('referenced instances', () => {
       new InstanceElement('recipe123', recipeType, {
         name: 'recipe123',
         book_id: new ReferenceExpression(rootBook.elemID, rootBook),
+        ingredients: [],
       }),
       new InstanceElement('recipe456', recipeType, {
         name: 'recipe456',
@@ -388,6 +389,7 @@ describe('referenced instances', () => {
             element: {
               topLevel: {
                 isTopLevel: true,
+                allowEmptyArrays: true,
                 elemID: {
                   parts: [
                     {
@@ -916,6 +918,12 @@ describe('referenced instances', () => {
       expect(recipeWithNullBookRes.elemID.getFullName()).toEqual(
         'myAdapter.recipe.instance.recipe123_123_ROOT__recipeWithNullBook',
       )
+    })
+    it('should not remove empty arrays', async () => {
+      const result = (await addReferencesToInstanceNames(elements, defQuery)).filter(isInstanceElement)
+      const resultRecipe = result.find(e => e.elemID.name === 'recipe123_123_ROOT')
+      expect(resultRecipe).toBeDefined()
+      expect(resultRecipe?.value.ingredients).toEqual([])
     })
   })
 })

--- a/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
+++ b/packages/workato-adapter/src/filters/cross_service/jira/project_issuetypes.ts
@@ -15,6 +15,7 @@ import {
 } from '@salto-io/adapter-api'
 import { createSchemeGuard, walkOnElement, WALK_NEXT_STEP } from '@salto-io/adapter-utils'
 import Joi from 'joi'
+import { isEmpty } from 'lodash'
 import { CROSS_SERVICE_SUPPORTED_APPS, JIRA, RECIPE_CODE_TYPE, RECIPE_TYPE } from '../../../constants'
 import { FilterCreator } from '../../../filter'
 import { BlockBase } from '../recipe_block_types'
@@ -122,6 +123,9 @@ const splitAllProjectAndIssueType = (inst: InstanceElement): void =>
       ) {
         splitProjectAndIssueType(objValues, PROJECT_ISSUETYPE, PROJECT_KEY, ISSUE_TYPE)
         splitProjectAndIssueType(objValues, SAMPLE_PROJECT_ISSUETYPE, SAMPLE_PROJECT_KEY, SAMPLE_ISSUE_TYPE)
+        if (isEmpty(objValues.dynamicPickListSelection)) {
+          delete objValues.dynamicPickListSelection
+        }
       }
       return WALK_NEXT_STEP.RECURSE
     },

--- a/packages/workato-adapter/test/filters/project_issuetypes.test.ts
+++ b/packages/workato-adapter/test/filters/project_issuetypes.test.ts
@@ -248,7 +248,7 @@ describe('projectIssuetype filter', () => {
       await filter.onFetch(elements)
 
       expect(recipeCode.value.block[0].block[0].dynamicPickListSelection.project_issuetype).toBeUndefined()
-      expect(recipeCode.value.block[1].dynamicPickListSelection.project_issuetype).toBeUndefined()
+      expect(recipeCode.value.block[1].dynamicPickListSelection).toBeUndefined()
     })
 
     it("should remove 'sample_project_issuetype' from dynamicPickListSelection", async () => {

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import _ from 'lodash'
+import _, { isEmpty } from 'lodash'
 import { logger } from '@salto-io/logging'
 import { collections, strings, promises } from '@salto-io/lowerdash'
 import {
@@ -470,6 +470,9 @@ const filterCreator: FilterCreator = ({ config, oldApiDefinitions, client, eleme
           (attachment: ReferenceExpression) => getInline(attachmentByName[attachment.elemID.name]),
         ])
         article.value.attachments = sortedAttachments
+        if (isEmpty(article.value.attachments)) {
+          delete article.value.attachments
+        }
       })
       return { errors: attachmentErrors }
     },

--- a/packages/zendesk-adapter/src/filters/guide_order/article_order.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/article_order.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import _ from 'lodash'
+import _, { isEmpty } from 'lodash'
 import { Change, Element, getChangeData, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { FilterCreator } from '../../filter'
 import { ARTICLE_TYPE_NAME, SECTION_TYPE_NAME, ARTICLES_FIELD, ARTICLE_ORDER_TYPE_NAME } from '../../constants'
@@ -40,11 +40,13 @@ const filterCreator: FilterCreator = ({ client, config, oldApiDefinitions }) => 
         orderType,
       })
 
-      // Promoted articles are first
-      articleOrderElements.value[ARTICLES_FIELD] = _.sortBy(
-        articleOrderElements.value[ARTICLES_FIELD],
-        a => !a.value.value.promoted,
-      )
+      if (!isEmpty(articleOrderElements.value[ARTICLES_FIELD])) {
+        // Promoted articles are first
+        articleOrderElements.value[ARTICLES_FIELD] = _.sortBy(
+          articleOrderElements.value[ARTICLES_FIELD],
+          a => !a.value.value.promoted,
+        )
+      }
 
       elements.push(articleOrderElements)
     })

--- a/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
+++ b/packages/zendesk-adapter/src/filters/guide_order/guide_order_utils.ts
@@ -99,16 +99,19 @@ export const createOrderInstance = ({
     ['asc', 'desc', 'desc'],
   )
 
+  const brand = // for category_order parent is brand
+    parent.elemID.typeName !== BRAND_TYPE_NAME ? parent.value.brand : new ReferenceExpression(parent.elemID, parent)
+  const value = _.isEmpty(parentsChildren)
+    ? { brand }
+    : {
+        [orderField]: parentsChildren.map(c => new ReferenceExpression(c.elemID, c)),
+        brand,
+      }
+
   return new InstanceElement(
     parent.elemID.name,
     orderType,
-    {
-      [orderField]: parentsChildren.map(c => new ReferenceExpression(c.elemID, c)),
-      brand:
-        parent.elemID.typeName !== BRAND_TYPE_NAME
-          ? parent.value.brand
-          : new ReferenceExpression(parent.elemID, parent), // for category_order parent is brand
-    },
+    value,
     // The same directory as it's parent
     parent.path !== undefined ? [...parent.path.slice(0, -1), orderType.elemID.typeName] : undefined,
     {

--- a/packages/zendesk-adapter/test/filters/guide_order/guide_order_utils.test.ts
+++ b/packages/zendesk-adapter/test/filters/guide_order/guide_order_utils.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { ElemID, InstanceElement, ObjectType, ReferenceExpression } from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import { ZENDESK } from '../../../src/constants'
+import { createOrderInstance } from '../../../src/filters/guide_order/guide_order_utils'
+
+describe('guide_order_utils', () => {
+  describe('createOrderInstance', () => {
+    const childType = new ObjectType({ elemID: new ElemID(ZENDESK, 'child') })
+    const parent = new InstanceElement('parent', new ObjectType({ elemID: new ElemID(ZENDESK, 'parent') }), {
+      parent_id: 'parent_id',
+      brand: 'brandRef',
+    })
+    const parentField = 'parent_id'
+    const orderField = 'children'
+    it('should create an instance element with the correct values', () => {
+      const childrenElements = [
+        new InstanceElement('child1', childType, {
+          order_field: 1,
+        }),
+        new InstanceElement('child2', childType, {
+          order_field: 2,
+        }),
+      ]
+      const orderType = new ObjectType({ elemID: new ElemID(ZENDESK, 'order_type') })
+      const instance = createOrderInstance({
+        parent,
+        parentField,
+        orderField,
+        childrenElements,
+        orderType,
+      })
+      expect(instance.elemID.name).toEqual('parent')
+      expect(instance.value.brand).toEqual('brandRef')
+      expect(instance.value[orderField]).toEqual(
+        childrenElements.map(child => new ReferenceExpression(child.elemID, child)),
+      )
+      expect(getParent(instance)).toEqual(parent)
+    })
+    it('should create an instance element with the correct values when there are no children', () => {
+      const childrenElements: InstanceElement[] = []
+      const orderType = new ObjectType({ elemID: new ElemID(ZENDESK, 'order_type') })
+      const instance = createOrderInstance({
+        parent,
+        parentField,
+        orderField,
+        childrenElements,
+        orderType,
+      })
+      expect(instance.elemID.name).toEqual('parent')
+      expect(instance.value.brand).toEqual('brandRef')
+      expect(instance.value[orderField]).toBeUndefined()
+      expect(getParent(instance)).toEqual(parent)
+    })
+    it('should create an instance element with the correct values when the parent is a brand', () => {
+      const childrenElements = [
+        new InstanceElement('child1', childType, {
+          order_field: 1,
+        }),
+        new InstanceElement('child2', childType, {
+          order_field: 2,
+        }),
+      ]
+      const orderType = new ObjectType({ elemID: new ElemID(ZENDESK, 'order_type') })
+      const brand = new InstanceElement('brand', new ObjectType({ elemID: new ElemID(ZENDESK, 'brand') }), {
+        brand_id: 'brand_id',
+      })
+      const instance = createOrderInstance({
+        parent: brand,
+        parentField,
+        orderField,
+        childrenElements,
+        orderType,
+      })
+      expect(instance.elemID.name).toEqual('brand')
+      expect(instance.value.brand).toEqual(new ReferenceExpression(brand.elemID, brand))
+      expect(instance.value[orderField]).toEqual(
+        childrenElements.map(child => new ReferenceExpression(child.elemID, child)),
+      )
+      expect(getParent(instance)).toEqual(brand)
+    })
+  })
+})


### PR DESCRIPTION
Reverting the revert and updating the filters that created empty arrays.

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
