### PR TITLE
SALTO-7340: remove generated version files

### DIFF
--- a/packages/cli/generate.sh
+++ b/packages/cli/generate.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
-GENERATED_DIR=./src/generated
+SCRIPT_DIR=$(dirname "$(realpath "$0")")
+GENERATED_DIR="${SCRIPT_DIR}/src/generated"
 
-rm -rf ${GENERATED_DIR}
-mkdir -p ${GENERATED_DIR}
-. ./version_json.sh > ./src/generated/version.json
+rm -rf "${GENERATED_DIR}"
+mkdir -p "${GENERATED_DIR}"
+. "${SCRIPT_DIR}/version_json.sh" > "${GENERATED_DIR}/version.json"

--- a/packages/core/src/generated/version.json
+++ b/packages/core/src/generated/version.json
@@ -1,5 +1,0 @@
-{
-  "version": "0.4.6",
-  "branch": "SAAS-12693",
-  "hash": "daf98a36a"
-}

--- a/packages/local-workspace/src/generated/version.json
+++ b/packages/local-workspace/src/generated/version.json
@@ -1,5 +1,0 @@
-{
-  "version": "0.4.6",
-  "branch": "SAAS-12693",
-  "hash": "daf98a36a"
-}


### PR DESCRIPTION
The version files should not have been pushed to git.
Also, fixed the script that created them to make sure it creates the generated folder in the right location no matter where it is run from

---

_Additional context for reviewer_

---
_Release Notes_: 
_None_

---
_User Notifications_: 
_None_