### PR TITLE
SALTO-2737: Remove config suggestion to exclude user roles

### DIFF
--- a/packages/okta-adapter/src/adapter.ts
+++ b/packages/okta-adapter/src/adapter.ts
@@ -38,7 +38,7 @@ import { collections, objects } from '@salto-io/lowerdash'
 import OktaClient from './client/client'
 import changeValidator from './change_validators'
 import { CLIENT_CONFIG, FETCH_CONFIG, OLD_API_DEFINITIONS_CONFIG } from './config'
-import { configType, getExcludeUserRolesConfigSuggestion, OktaUserConfig, OktaUserFetchConfig } from './user_config'
+import { configType, OktaUserConfig } from './user_config'
 import fetchCriteria from './fetch_criteria'
 import { paginate } from './client/pagination'
 import { dependencyChanger } from './dependency_changers'
@@ -76,14 +76,7 @@ import groupPushFilter from './filters/group_push'
 import addImportantValues from './filters/add_important_values'
 import removedUserRoleAssignments from './filters/removed_user_roles_assignments'
 import brandCustomizationsFilter from './filters/brand_customizations'
-import {
-  APP_LOGO_TYPE_NAME,
-  BRAND_LOGO_TYPE_NAME,
-  FAV_ICON_TYPE_NAME,
-  OKTA,
-  USER_ROLES_TYPE_NAME,
-  USER_TYPE_NAME,
-} from './constants'
+import { APP_LOGO_TYPE_NAME, BRAND_LOGO_TYPE_NAME, FAV_ICON_TYPE_NAME, OKTA, USER_TYPE_NAME } from './constants'
 import { getLookUpNameCreator } from './reference_mapping'
 import { User, getUsers, getUsersFromInstances, shouldConvertUserIds } from './user_utils'
 import { isClassicEngineOrg, logUsersCount } from './utils'
@@ -150,25 +143,6 @@ const SKIP_RESOLVE_TYPE_NAMES = [
   ...POLICY_PRIORITY_TYPE_NAMES,
 ]
 
-/**
- * Temporary adjusment to support migration of UserRoles type into the exclude list
- */
-const createElementQueryWithExcludedUserRoles = (
-  fetchConfig: OktaUserFetchConfig,
-  criteria: Record<string, elementUtils.query.QueryCriterion>,
-): elementUtils.query.ElementQuery => {
-  const isUserRolesExcluded = fetchConfig.exclude.some(fetchEnrty => fetchEnrty.type === USER_ROLES_TYPE_NAME)
-  const isUserRolesIncluded = fetchConfig.include.some(fetchEntry => fetchEntry.type === USER_ROLES_TYPE_NAME)
-  const updatedConfig =
-    !isUserRolesExcluded && !isUserRolesIncluded
-      ? {
-          ...fetchConfig,
-          exclude: fetchConfig.exclude.concat({ type: USER_ROLES_TYPE_NAME }),
-        }
-      : fetchConfig
-  return elementUtils.query.createElementQuery(updatedConfig, criteria)
-}
-
 export interface OktaAdapterParams {
   filterCreators?: FilterCreator[]
   client: OktaClient
@@ -218,7 +192,7 @@ export default class OktaAdapter implements AdapterOperations {
       client: this.client,
       paginationFuncCreator: paginate,
     })
-    this.fetchQuery = createElementQueryWithExcludedUserRoles(this.userConfig.fetch, fetchCriteria)
+    this.fetchQuery = elementUtils.query.createElementQuery(this.userConfig.fetch, fetchCriteria)
     this.accountName = accountName
 
     const definitions = {
@@ -368,7 +342,6 @@ export default class OktaAdapter implements AdapterOperations {
     const configChanges = (getElementsConfigChanges ?? [])
       .concat(classicOrgConfigSuggestion ?? [])
       .concat(oauthConfigChange ?? [])
-      .concat(getExcludeUserRolesConfigSuggestion(this.configInstance) ?? [])
     const updatedConfig =
       !_.isEmpty(configChanges) && this.configInstance
         ? definitionsUtils.getUpdatedConfigFromConfigChanges({


### PR DESCRIPTION
Remove temporary config suggestion to migrate `UserRoles` into the exclude list introduced in https://github.com/salto-io/salto/pull/7007

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
