### PR TITLE
SALTO-7315: Order Okta application features list to avoid noise

### DIFF
--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -609,6 +609,7 @@ const createCustomizations = ({
         settings: { fieldType: 'unknown' },
         profileEnrollment: { fieldType: 'string' },
         accessPolicy: { fieldType: 'string' },
+        features: { sort: { properties: [] } },
         ApplicationGroupAssignment: {
           standalone: {
             typeName: 'ApplicationGroupAssignment',


### PR DESCRIPTION
Order application `features` field (list of strings)
 
---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta Adapter_:
- Fix a bug causing items in application features list to be re ordered between fetches.

---
_User Notifications_: 

_Okta Adapter_:
- For application with `features` configured, feature items might be re-ordered
