### PR TITLE
SALTO-7352: Add inspect / serialize format options to element print

### DIFF
--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -756,7 +756,8 @@ const formatValue = async (value: Value, format: PrintElementArgs['format']): Pr
   }
   if (format === 'serialize') {
     const dumpedValue = await serialization.serialize([value])
-    return dumpedValue
+    // Slice off the [] around the value
+    return dumpedValue.slice(1, -1)
   }
   return 'unknown format'
 }

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -738,7 +738,7 @@ type PrintElementArgs = {
   selectors: string[]
   source: 'nacl' | 'state'
   onlyValue: boolean
-  format?: 'nacl' | 'inspect' | 'serialize'
+  format: 'nacl' | 'inspect' | 'serialize'
 } & EnvArg
 const formatValue = async (value: Value, format: PrintElementArgs['format']): Promise<string> => {
   if (format === undefined || format === 'nacl') {

--- a/packages/cli/src/commands/element.ts
+++ b/packages/cli/src/commands/element.ts
@@ -14,6 +14,7 @@ import {
   CORE_ANNOTATIONS,
   isModificationChange,
   ReferenceExpression,
+  Value,
 } from '@salto-io/adapter-api'
 import { adapterCreators } from '@salto-io/adapter-creators'
 import {
@@ -24,10 +25,11 @@ import {
   selectElementIdsByTraversal,
   nacl,
   staticFiles,
+  serialization,
 } from '@salto-io/workspace'
 import { parser } from '@salto-io/parser'
 import { getEnvsDeletionsDiff, RenameElementIdError, rename, fixElements, SelectorsError } from '@salto-io/core'
-import { getParents } from '@salto-io/adapter-utils'
+import { getParents, inspectValue } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { collections, promises } from '@salto-io/lowerdash'
 import { createCommandGroupDef, createWorkspaceCommand, WorkspaceCommandAction } from '../command_builder'
@@ -736,7 +738,28 @@ type PrintElementArgs = {
   selectors: string[]
   source: 'nacl' | 'state'
   onlyValue: boolean
+  format?: 'nacl' | 'inspect' | 'serialize'
 } & EnvArg
+const formatValue = async (value: Value, format: PrintElementArgs['format']): Promise<string> => {
+  if (format === undefined || format === 'nacl') {
+    // We build a new static files source each time to avoid having to keep
+    // all the static files loaded in memory
+    const functions = nacl.getFunctions(staticFiles.buildInMemStaticFilesSource())
+    const dumpedValue = isElement(value)
+      ? await parser.dumpElements([value], functions)
+      : await parser.dumpValues(value, functions)
+    return dumpedValue
+  }
+  if (format === 'inspect') {
+    const dumpedValue = inspectValue(value)
+    return dumpedValue
+  }
+  if (format === 'serialize') {
+    const dumpedValue = await serialization.serialize([value])
+    return dumpedValue
+  }
+  return 'unknown format'
+}
 export const printElementAction: WorkspaceCommandAction<PrintElementArgs> = async ({ workspace, input, output }) => {
   const { validSelectors, invalidSelectors } = createElementSelectors(input.selectors)
   if (!_.isEmpty(invalidSelectors)) {
@@ -755,12 +778,7 @@ export const printElementAction: WorkspaceCommandAction<PrintElementArgs> = asyn
 
   await awu(relevantIds).forEach(async id => {
     const value = await elementSource.get(id)
-    // We build a new static files source each time to avoid having to keep
-    // all the static files loaded in memory
-    const functions = nacl.getFunctions(staticFiles.buildInMemStaticFilesSource())
-    const dumpedValue = isElement(value)
-      ? await parser.dumpElements([value], functions)
-      : await parser.dumpValues(value, functions)
+    const dumpedValue = await formatValue(value, input.format)
     const outputStr = input.onlyValue ? dumpedValue : `${id.getFullName()}: ${dumpedValue}`
     outputLine(outputStr, output)
   })
@@ -786,6 +804,14 @@ const printElementDef = createWorkspaceCommand({
         type: 'boolean',
         default: false,
         description: 'Print only matching values without their ID',
+      },
+      {
+        name: 'format',
+        alias: 'r',
+        type: 'string',
+        default: 'nacl',
+        description: 'Format for the value',
+        choices: ['nacl', 'inspect', 'serialize'],
       },
       ENVIRONMENT_OPTION,
     ],

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1733,7 +1733,7 @@ Moving the specified elements to common.
         expect(result).toEqual(CliExitCode.Success)
       })
       it('should print the element in JSON like format', async () => {
-        const [parsed] = await serialization.deserialize(output.stdout.content)
+        const [parsed] = await serialization.deserialize(`[${output.stdout.content}]`)
         expect(parsed).toEqual(element)
       })
     })

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -1611,6 +1611,7 @@ Moving the specified elements to common.
             selectors: ['a.b.c.d'],
             source: 'nacl',
             onlyValue: false,
+            format: 'nacl',
           },
           workspace,
         })
@@ -1635,6 +1636,7 @@ Moving the specified elements to common.
             selectors: ['test.type'],
             source: 'nacl',
             onlyValue: false,
+            format: 'nacl',
           },
           workspace,
         })
@@ -1660,6 +1662,7 @@ Moving the specified elements to common.
             selectors: ['test.*'],
             source: 'state',
             onlyValue: true,
+            format: 'nacl',
           },
           workspace,
         })
@@ -1684,6 +1687,7 @@ Moving the specified elements to common.
             selectors: ['salto.*.field.*.label'],
             source: 'state',
             onlyValue: false,
+            format: 'nacl',
           },
           workspace,
         })

--- a/packages/cli/test/commands/element.test.ts
+++ b/packages/cli/test/commands/element.test.ts
@@ -16,7 +16,7 @@ import {
   isObjectType,
   ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { errors, UnresolvedElemIDs, createElementSelector } from '@salto-io/workspace'
+import { errors, UnresolvedElemIDs, createElementSelector, serialization } from '@salto-io/workspace'
 import { collections } from '@salto-io/lowerdash'
 import { SelectorsError, fixElements } from '@salto-io/core'
 import { CliExitCode } from '../../src/types'
@@ -1701,6 +1701,63 @@ Moving the specified elements to common.
           expect(output.stdout.content).toContain(field.elemID.createNestedID('label').getFullName())
           expect(output.stdout.content).toContain(field.annotations.label)
         })
+      })
+    })
+    describe('with serialize format', () => {
+      let result: CliExitCode
+      let output: mocks.MockCliOutput
+      let element: ObjectType
+      beforeEach(async () => {
+        const cliArgs = mocks.mockCliArgs()
+        output = cliArgs.output
+        const workspace = mocks.mockWorkspace({})
+        const elements = await workspace.elements()
+        element = new ObjectType({ elemID: new ElemID('test', 'type') })
+        await elements.set(element)
+        result = await printElementAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
+          input: {
+            selectors: ['test.type'],
+            source: 'nacl',
+            onlyValue: true,
+            format: 'serialize',
+          },
+          workspace,
+        })
+      })
+      it('should return success exit code', () => {
+        expect(result).toEqual(CliExitCode.Success)
+      })
+      it('should print the element in JSON like format', async () => {
+        const [parsed] = await serialization.deserialize(output.stdout.content)
+        expect(parsed).toEqual(element)
+      })
+    })
+    describe('with inspect format', () => {
+      let result: CliExitCode
+      let output: mocks.MockCliOutput
+      beforeEach(async () => {
+        const cliArgs = mocks.mockCliArgs()
+        output = cliArgs.output
+        const workspace = mocks.mockWorkspace({})
+        const elements = await workspace.elements()
+        await elements.set(new ObjectType({ elemID: new ElemID('test', 'type') }))
+        result = await printElementAction({
+          ...mocks.mockCliCommandArgs(commandName, cliArgs),
+          input: {
+            selectors: ['test.type'],
+            source: 'nacl',
+            onlyValue: true,
+            format: 'inspect',
+          },
+          workspace,
+        })
+      })
+      it('should return success exit code', () => {
+        expect(result).toEqual(CliExitCode.Success)
+      })
+      it('should print the element with the ID as a prefix', () => {
+        expect(output.stdout.content).toMatch(/^ObjectType \{.*ElemID\(test.type\).*/ms)
       })
     })
   })


### PR DESCRIPTION


---

_Additional context for reviewer_

---
_Release Notes_: 
CLI:
- Added different formatting options to `element print` command

---
_User Notifications_: 
_None_