### PR TITLE
SALTO-7351: add dependency for article translation modification to attachment

### DIFF
--- a/packages/zendesk-adapter/src/dependency_changers/article_attachment_and_translation.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/article_attachment_and_translation.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  Change,
+  dependencyChange,
+  DependencyChange,
+  DependencyChanger,
+  getChangeData,
+  InstanceElement,
+  isInstanceChange,
+  isModificationChange,
+  isReferenceExpression,
+  isStaticFile,
+} from '@salto-io/adapter-api'
+import { collections, values as lowerDashValues } from '@salto-io/lowerdash'
+import { deployment } from '@salto-io/adapter-components'
+import _ from 'lodash'
+import { parserUtils } from '@salto-io/parser'
+import { ARTICLE_ATTACHMENT_TYPE_NAME, ARTICLE_TRANSLATION_TYPE_NAME } from '../constants'
+
+const { isDefined } = lowerDashValues
+const { awu } = collections.asynciterable
+
+const getNameFromChange = (change: deployment.dependency.ChangeWithKey<Change<InstanceElement>>): string =>
+  getChangeData(change.change).elemID.getFullName()
+
+const getDependencies = async (
+  changes: deployment.dependency.ChangeWithKey<Change<InstanceElement>>[],
+): Promise<DependencyChange[]> => {
+  const articleTranslationModificationChanges = changes.filter(
+    change =>
+      getChangeData(change.change).elemID.typeName === ARTICLE_TRANSLATION_TYPE_NAME &&
+      isModificationChange(change.change),
+  )
+
+  const articleAttachmentModificationChanges = changes.filter(
+    change => getChangeData(change.change).elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME,
+  )
+
+  const articleTranslationFullNameToChange = _.keyBy(articleTranslationModificationChanges, getNameFromChange)
+  const articleAttachmentFullNameToChanges = _.keyBy(articleAttachmentModificationChanges, getNameFromChange)
+
+  const translationToAttachmentsList = await awu(Object.entries(articleTranslationFullNameToChange)).reduce<
+    Record<string, string[]>
+  >(async (currentRecord, [fullName, change]) => {
+    const data = getChangeData(change.change)
+    const { body } = data.value
+    if (isStaticFile(body) && body.isTemplate) {
+      const template = await parserUtils.staticFileToTemplateExpression(body)
+      const references = template?.parts
+        .filter(isReferenceExpression)
+        .filter(ref => ref.elemID.typeName === ARTICLE_ATTACHMENT_TYPE_NAME)
+        .map(ref => ref.elemID.getFullName())
+      if (references === undefined || _.isEmpty(references)) {
+        return currentRecord
+      }
+      return {
+        ...currentRecord,
+        [fullName]: references,
+      }
+    }
+    return currentRecord
+  }, {})
+
+  return articleTranslationModificationChanges
+    .flatMap(change => {
+      const attachmentList = translationToAttachmentsList[getNameFromChange(change)]
+      if (attachmentList === undefined) {
+        return undefined
+      }
+      return attachmentList.map(attachment => {
+        const attachmentChange = articleAttachmentFullNameToChanges[attachment]
+        if (attachmentChange) {
+          return dependencyChange('add', change.key, attachmentChange.key)
+        }
+        return undefined
+      })
+    })
+    .filter(isDefined)
+}
+
+/**
+ * This dependency changer is used to add dependency between article attachments and the translation that points them in the case
+ * where the article translation changes are modifications. This is because
+ * the modification of the translation doesn't work without the attachment changes happening first
+ */
+export const articleAttachmentAndTranslationDependencyChanger: DependencyChanger = async changes => {
+  const potentialChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter((change): change is deployment.dependency.ChangeWithKey<Change<InstanceElement>> =>
+      isInstanceChange(change.change),
+    )
+
+  return getDependencies(potentialChanges)
+}

--- a/packages/zendesk-adapter/src/dependency_changers/index.ts
+++ b/packages/zendesk-adapter/src/dependency_changers/index.ts
@@ -14,6 +14,7 @@ import { ticketFormDependencyChanger } from './ticket_form_change'
 import { articleAttachmentDependencyChanger } from './article_attachment_change'
 import { customObjectAndFieldDependencyChanger } from './custom_object_and_field_change'
 import { modifiedAndDeletedDependencyChanger } from './modified_and_deleted'
+import { articleAttachmentAndTranslationDependencyChanger } from './article_attachment_and_translation'
 
 const { awu } = collections.asynciterable
 
@@ -25,6 +26,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   articleAttachmentDependencyChanger,
   customObjectAndFieldDependencyChanger,
   modifiedAndDeletedDependencyChanger,
+  articleAttachmentAndTranslationDependencyChanger,
 ]
 
 export const dependencyChanger: DependencyChanger = async (changes, deps) =>

--- a/packages/zendesk-adapter/src/filters/article/article_body.ts
+++ b/packages/zendesk-adapter/src/filters/article/article_body.ts
@@ -26,6 +26,7 @@ import {
 } from '@salto-io/adapter-api'
 import {
   applyFunctionToChangeData,
+  createSaltoElementError,
   createTemplateExpression,
   ERROR_MESSAGES,
   extractTemplate,
@@ -247,9 +248,17 @@ const filterCreator: FilterCreator = ({ config }) => {
                 prepRef,
               )
             } catch (e) {
+              const message = `Error serializing article translation body in deployment: ${e}, stack: ${e.stack}`
               log.error(
                 `Error serializing article translation body in deployment for ${instance.elemID.getFullName()}: ${e}, stack: ${e.stack}`,
               )
+              throw createSaltoElementError({
+                // caught in adapter.ts
+                message,
+                detailedMessage: message,
+                severity: 'Error',
+                elemID: instance.elemID,
+              })
             }
             return instance
           })

--- a/packages/zendesk-adapter/test/dependency_changers/article_attachment_and_translation.test.ts
+++ b/packages/zendesk-adapter/test/dependency_changers/article_attachment_and_translation.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { InstanceElement, toChange, ReferenceExpression, ObjectType, ElemID, StaticFile } from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { createTemplateExpression } from '@salto-io/adapter-utils'
+import { parserUtils } from '@salto-io/parser'
+import {
+  ARTICLE_ATTACHMENT_TYPE_NAME,
+  ARTICLE_TRANSLATION_TYPE_NAME,
+  MACRO_TYPE_NAME,
+  ZENDESK,
+} from '../../src/constants'
+import { articleAttachmentAndTranslationDependencyChanger } from '../../src/dependency_changers/article_attachment_and_translation'
+
+describe('articleAttachmentAndTranslationDependencyChanger', () => {
+  const articleTranslationType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TRANSLATION_TYPE_NAME) })
+  const macroType = new ObjectType({ elemID: new ElemID(ZENDESK, MACRO_TYPE_NAME) })
+  const articleAttachmentType = new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_ATTACHMENT_TYPE_NAME) })
+  const macro = new InstanceElement('macro', macroType, {})
+  const articleAttachment = new InstanceElement('attachment1', articleAttachmentType, { id: 1 })
+  const articleAttachment2 = new InstanceElement('attachment2', articleAttachmentType, { id: 2 })
+  const articleTranslation = new InstanceElement('articleTranslation', articleTranslationType, {
+    body: parserUtils.templateExpressionToStaticFile(
+      createTemplateExpression({
+        parts: [
+          'hi',
+          new ReferenceExpression(articleAttachment.elemID),
+          'bye',
+          new ReferenceExpression(articleAttachment2.elemID),
+          'bla',
+          new ReferenceExpression(macro.elemID),
+        ],
+      }),
+      'test',
+    ),
+  })
+
+  it('should add dependency from translation to attachments', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: articleAttachment })],
+      [1, toChange({ before: articleAttachment2, after: articleAttachment2 })],
+      [2, toChange({ before: articleTranslation, after: articleTranslation })],
+      [3, toChange({ before: macro, after: macro })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+      [2, new Set()],
+      [3, new Set()],
+    ])
+
+    const dependencyChanges = [...(await articleAttachmentAndTranslationDependencyChanger(inputChanges, inputDeps))]
+    expect(dependencyChanges.length).toBe(2)
+    expect(dependencyChanges.every(change => change.action === 'add')).toBe(true)
+    expect(dependencyChanges[0].dependency).toMatchObject({ source: 2, target: 0 })
+    expect(dependencyChanges[1].dependency).toMatchObject({ source: 2, target: 1 })
+  })
+  it('should do nothing if translation body does not have references', async () => {
+    const afterTranslation = articleTranslation.clone()
+    afterTranslation.value.body = new StaticFile({ content: Buffer.from('hi'), filepath: 'test' })
+    const inputChanges = new Map([
+      [0, toChange({ after: articleAttachment })],
+      [1, toChange({ before: articleAttachment2, after: articleAttachment2 })],
+      [2, toChange({ before: articleTranslation, after: afterTranslation })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([
+      [0, new Set()],
+      [1, new Set()],
+      [2, new Set()],
+    ])
+
+    const dependencyChanges = [...(await articleAttachmentAndTranslationDependencyChanger(inputChanges, inputDeps))]
+    expect(dependencyChanges.length).toBe(0)
+  })
+})


### PR DESCRIPTION
add dependency for article translation modification to attachment

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
