### PR TITLE
SALTO-7359: temporary disable Okta E2e

### DIFF
--- a/packages/okta-adapter/e2e_test/adapter.test.ts
+++ b/packages/okta-adapter/e2e_test/adapter.test.ts
@@ -762,7 +762,8 @@ const getDomain = (url: string): string => {
   return match ? match[1] : ''
 }
 
-describe('Okta adapter E2E', () => {
+// eslint-disable-next-line jest/no-disabled-tests
+describe.skip('Okta adapter E2E', () => {
   describe('fetch and deploy', () => {
     let credLease: CredsLease<Credentials>
     let adapterAttr: Reals


### PR DESCRIPTION
Per the request of @shir-reifenberg as the E2E is blocking deployment
---

None
---
_Release Notes_: 
None
---
_User Notifications_: 
None
