### PR TITLE
SALTO-7358: Change locateWorkspaceRoot to named params

### DIFF
--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -32,7 +32,7 @@ export const action: CommandDefAction<InitArgs> = async ({
   cliTelemetry.start()
   try {
     const baseDir = path.resolve(workspacePath)
-    const existingWorkspacePath = await locateWorkspaceRoot(baseDir)
+    const existingWorkspacePath = await locateWorkspaceRoot({ lookupDir: baseDir })
     if (existingWorkspacePath !== undefined) {
       errorOutputLine(Prompts.initFailed(`existing salto workspace in ${existingWorkspacePath}`), output)
       return CliExitCode.AppError

--- a/packages/local-workspace/test/workspace.test.ts
+++ b/packages/local-workspace/test/workspace.test.ts
@@ -127,23 +127,28 @@ describe('local workspace', () => {
   describe('locateWorkspaceRoot', () => {
     it('should return undefined if no workspaceRoot exists in path', async () => {
       mockExists.mockResolvedValue(false)
-      const workspacePath = await locateWorkspaceRoot('/some/path')
+      const workspacePath = await locateWorkspaceRoot({ lookupDir: '/some/path' })
       expect(workspacePath).toEqual(undefined)
     })
     it('should return current folder if salto.config exists in it', async () => {
       mockExists.mockResolvedValue(true)
-      const workspacePath = await locateWorkspaceRoot('/some/path')
+      const workspacePath = await locateWorkspaceRoot({ lookupDir: '/some/path' })
       expect(workspacePath).toEqual('/some/path')
     })
     it('should find the corret folder in which salto.config exists in path', async () => {
       mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
-      const workspacePath = await locateWorkspaceRoot('/some/path')
+      const workspacePath = await locateWorkspaceRoot({ lookupDir: '/some/path' })
       expect(workspacePath).toEqual('/some')
     })
     it('should only check the provided path if allowWorkspaceRootLookup is false', async () => {
       mockExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true)
-      const workspacePath = await locateWorkspaceRoot('/some/path', false)
+      const workspacePath = await locateWorkspaceRoot({ lookupDir: '/some/path', allowWorkspaceRootLookup: false })
       expect(workspacePath).toEqual(undefined)
+    })
+    it('should support deprecated string argument', async () => {
+      mockExists.mockResolvedValue(true)
+      const workspacePath = await locateWorkspaceRoot('/some/path')
+      expect(workspacePath).toEqual('/some/path')
     })
   })
 


### PR DESCRIPTION
This is a follow up of https://github.com/salto-io/salto/pull/7164 

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
