### PR TITLE
SALTO-7188: Setting flow author info from selected version

### DIFF
--- a/packages/salesforce-adapter/src/filters/flows_filter.ts
+++ b/packages/salesforce-adapter/src/filters/flows_filter.ts
@@ -139,8 +139,9 @@ const getFlowVersionsByApiName = async ({
 }
 
 type versionSelector = (versions: FlowVersionProperties[]) => FlowVersionProperties | undefined
-const selectActiveVersion: versionSelector = versions => versions.find(version => version.status === 'Active')
 const selectLatestVersion: versionSelector = versions => _.maxBy(versions, 'version')
+const selectActiveVersion: versionSelector = versions =>
+  versions.find(version => version.status === 'Active') ?? selectLatestVersion(versions)
 
 const createSelectedVersionFileProperties = async ({
   flowsFileProps,


### PR DESCRIPTION
Currently the author info is derived from the flow object which is not necessarily what users expect. Creation info is for when the entire flow was created and change info is for the last time a version was created or activated.
Now, the author information for the selected version (latest or active, depending on user preference) is used. Creation info is from when the version was created and change info is from one second later or when the version was activated (this is SF behavior).
Also, no longer hiding the FlowDefinition type because that's covered by the hide types folder filter.

---

_Additional context for reviewer_
See the Flow tooling api documentation: https://developer.salesforce.com/docs/atlas.en-us.api_tooling.meta/api_tooling/tooling_api_objects_flow.htm

---

_Release Notes_: 
_Salesforce_:
* Flow author information (created by, created at, changed by, changed at) now match the selected version (latest or active, depending on user preferences).

---

_User Notifications_: 
_Salesforce_:
* For environments where the `hideTypes` optional feature is disabled, the `FlowDefinition` type will no longer be hidden.
