### PR TITLE
SALTO-5299: New properties added to JSM request form fix - remove log error message

### DIFF
--- a/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
+++ b/packages/jira-adapter/src/filters/layouts/request_type_request_form.ts
@@ -35,7 +35,6 @@ const REQUEST_TYPE_REQUEST_FORM_ITEMS_COMPONENT_SCHEME = Joi.array().items(
 
 const isRequestTypeRequestFormItemsComponent = createSchemeGuard<requestTypeRequestFormItemComponent[]>(
   REQUEST_TYPE_REQUEST_FORM_ITEMS_COMPONENT_SCHEME,
-  'invalid request form items component',
 )
 
 const removePropertiesWithEmptyValues = (elements: Element[]): void => {


### PR DESCRIPTION
Removed the scheme guard log error message as it made a lot of unnecessary noise, as there are also valid objects without 'properties' field.

---


---
_Release Notes_: 

---
_User Notifications_: 

