### PR TITLE
SALTO-7376: Cleanup `SALTO_COMPUTE_PLAN_ON_FETCH` flag.

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -83,7 +83,6 @@ import {
   isElementIdMatchSelectors,
   updateElementsWithAlternativeAccount,
   Workspace,
-  flags,
 } from '@salto-io/workspace'
 import { collections, promises, types, values } from '@salto-io/lowerdash'
 import { StepEvents } from './deploy'
@@ -100,7 +99,6 @@ const { mapValuesAsync } = promises.object
 const { withLimitedConcurrency } = promises.array
 const { mergeElements } = merger
 const { isTypeOfOrUndefined } = types
-const { getSaltoFlagBool, WORKSPACE_FLAGS } = flags
 const log = logger(module)
 
 const MAX_SPLIT_CONCURRENCY = 2000
@@ -143,21 +141,6 @@ export const getDetailedChanges = async (
   after: ReadOnlyElementsSource,
   topLevelFilters: IDFilter[],
 ): Promise<DetailedChangeWithBaseChange[]> => {
-  if (getSaltoFlagBool(WORKSPACE_FLAGS.computePlanOnFetch)) {
-    return wu(
-      (
-        await getPlan({
-          before,
-          after,
-          dependencyChangers: [],
-          topLevelFilters,
-        })
-      ).itemsByEvalOrder(),
-    )
-      .map(item => item.detailedChanges())
-      .flatten()
-      .toArray()
-  }
   const changes = await calculateDiff({ before, after, topLevelFilters })
   return awu(changes)
     .map(change => getDetailedChangesFromChange(change))
@@ -403,7 +386,7 @@ const toFetchChanges = (
       // When there are no pending changes, the state and workspace are already aligned, so we can reuse service changes
       // as workspace changes. We are guaranteed no conflicts, so we can return early here. This reuse relies on the
       // assumption that reference expressions in the state element source used to compute the diff are *not* resolved.
-      if (!getSaltoFlagBool(WORKSPACE_FLAGS.computePlanOnFetch) && pendingChanges.length === 0) {
+      if (pendingChanges.length === 0) {
         return serviceChanges.map(change => ({ change, serviceChanges, pendingChanges: [] }))
       }
 
@@ -916,11 +899,7 @@ export const calcFetchChanges = async ({
           [
             accountFetchFilter,
             partialFetchFilter,
-            // Computing a plan for fetch operations results in reference expressions being resolved, which doesn't
-            // allow us to use service-state diff to calculate workspace-service diff (as resolved values would be
-            // wrong), so we can't limit the diff to pending changes here if the flag is turned on.
-            // TODO: Remove when the new plan computation is stable in production.
-            getSaltoFlagBool(WORKSPACE_FLAGS.computePlanOnFetch) ? serviceChangeIdsFilter : pendingChangeIdsFilter,
+            pendingChangeIdsFilter,
           ],
           'service',
         ),

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -896,11 +896,7 @@ export const calcFetchChanges = async ({
         getDetailedChangeTree(
           workspaceElements,
           partialFetchElementSource,
-          [
-            accountFetchFilter,
-            partialFetchFilter,
-            pendingChangeIdsFilter,
-          ],
+          [accountFetchFilter, partialFetchFilter, pendingChangeIdsFilter],
           'service',
         ),
       'calculate service-workspace changes',

--- a/packages/workspace/src/flags.ts
+++ b/packages/workspace/src/flags.ts
@@ -24,8 +24,5 @@ export const getSaltoFlagBool = (flagName: string): boolean => {
 export const WORKSPACE_FLAGS = {
   createFilenamesToElementIdsMapping: 'CREATE_FILENAMES_TO_ELEMENT_IDS_MAPPING',
   useSplitSourceMapInUpdate: 'USE_SPLIT_SOURCE_MAP_IN_UPDATE',
-  // Killswitch for the new fetch diff computation logic. Activating this restores the old logic.
-  // TODO(SALTO-6992): Remove this killswitch after 2025-01-30
-  computePlanOnFetch: 'COMPUTE_PLAN_ON_FETCH',
   skipStaticFilesCacheUpdate: 'SKIP_STATIC_FILES_CACHE_UPDATE',
 } as const


### PR DESCRIPTION
This feature is already rolled out, so the killswitch flag can be removed.

---

_Additional context for reviewer_:
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
