### PR TITLE
SALTO-7179: CV that blocks Automation with issueTypes that are out of scope

### DIFF
--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -20,7 +20,7 @@ import { AUTOMATION_TYPE } from '../../constants'
 import { JiraConfig } from '../../config/config'
 
 const { isDefined } = values
-export type Component = {
+type Component = {
   component: string
   schemaVersion: number
   type: string

--- a/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automation_to_assets.ts
@@ -20,7 +20,7 @@ import { AUTOMATION_TYPE } from '../../constants'
 import { JiraConfig } from '../../config/config'
 
 const { isDefined } = values
-type Component = {
+export type Component = {
   component: string
   schemaVersion: number
   type: string

--- a/packages/jira-adapter/src/change_validators/automation/automations_issue_types.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automations_issue_types.ts
@@ -106,13 +106,10 @@ const isInstanceWithInvalidIssueType = (
         _.isPlainObject(value) &&
         _.isPlainObject(value.value) &&
         value.component === 'ACTION' &&
-        value.type === 'jira.issue.create'
+        value.type === 'jira.issue.create' &&
+        Array.isArray(value.value.operations)
       ) {
-        const operations = Array.isArray(value.value.operations) ? value.value.operations : undefined
-        if (operations === undefined) {
-          return WALK_NEXT_STEP.SKIP
-        }
-
+        const { operations } = value.value
         const projectOperation = getOperations(operations, PROJECT_FIELD)
         const issueTypeOperation = getOperations(operations, ISSUE_TYPE_FIELD)
 

--- a/packages/jira-adapter/src/change_validators/automation/automations_issue_types.ts
+++ b/packages/jira-adapter/src/change_validators/automation/automations_issue_types.ts
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ChangeValidator,
+  ElemID,
+  getChangeData,
+  InstanceElement,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+  isReferenceExpression,
+  ReferenceExpression,
+  SeverityLevel,
+} from '@salto-io/adapter-api'
+import { createSchemeGuard, getInstancesFromElementSource, WALK_NEXT_STEP, walkOnValue } from '@salto-io/adapter-utils'
+import Joi from 'joi'
+import { ISSUE_TYPE_FIELD, PROJECT_FIELD } from '@atlassianlabs/jql-ast'
+import { collections } from '@salto-io/lowerdash'
+import { AUTOMATION_TYPE, PROJECT_TYPE } from '../../constants'
+
+const { awu } = collections.asynciterable
+
+type Component = {
+  component: string
+  type: string
+}
+
+type IssueTypeObject = {
+  fieldType: string
+  value: ReferenceExpression
+}
+
+const AUTOMATION_ISSUE_TYPE_OBJECT_SCHEME = Joi.object({
+  fieldType: Joi.string().required(),
+  value: Joi.object({
+    type: Joi.string().required(),
+    value: Joi.any().required(),
+  })
+    .unknown(true)
+    .required(),
+})
+  .unknown(true)
+  .required()
+
+const isIssueTypeObject = createSchemeGuard<IssueTypeObject>(AUTOMATION_ISSUE_TYPE_OBJECT_SCHEME)
+
+const isInstanceWithInvalidIssueType = (
+  instance: InstanceElement,
+  projectsIssueTypeSchemes: {
+    key: string
+    value: string
+  }[],
+): { componentElemID: ElemID; invalidIssueType: string | undefined }[] | [] => {
+  const elemIDWithIssueType: { componentElemID: ElemID; invalidIssueType: string | undefined }[] = []
+  let createIssueProject: string
+  walkOnValue({
+    elemId: instance.elemID.createNestedID('components'),
+    value: instance.value.components,
+    func: ({ value, path }) => {
+      if (value.fieldType === PROJECT_FIELD) {
+        createIssueProject = value.value.value.elemID.getFullName()
+      }
+      if (isIssueTypeObject(value)) {
+        if (value.fieldType === ISSUE_TYPE_FIELD) {
+          const issueType = value.value.value !== 'current' ? value.value.value.elemID.getFullName() : undefined
+          if (createIssueProject) {
+            if (
+              !projectsIssueTypeSchemes.find(
+                project => project.key === createIssueProject && project.value.includes(issueType),
+              )
+            )
+              elemIDWithIssueType.push({ componentElemID: path, invalidIssueType: issueType })
+          }
+        }
+      }
+      return WALK_NEXT_STEP.RECURSE
+    },
+  })
+  return elemIDWithIssueType
+}
+
+const isNotGlobalAutomation = (instance: InstanceElement): boolean => 'projects' in instance.value
+
+const isIssueCreateActionAutomation = (instance: InstanceElement): boolean =>
+  instance.value.components.some((component: Component) => component.type === 'jira.issue.create')
+
+export const projectHasIssueTypeSchemeReference = (project: InstanceElement): boolean =>
+  project.value.issueTypeScheme instanceof ReferenceExpression
+
+export const automationIssueTypeValidator: ChangeValidator = async (changes, elementsSource) => {
+  if (elementsSource === undefined) {
+    return []
+  }
+
+  const projects = await getInstancesFromElementSource(elementsSource, [PROJECT_TYPE])
+  const projectsIssueTypeSchemes = await awu(projects)
+    .filter(projectHasIssueTypeSchemeReference)
+    .map(async project => {
+      const resolvedIssueTypeScheme =
+        (await (await elementsSource.get(project.value.issueTypeScheme.elemID))?.value.issueTypeIds) ?? []
+
+      return {
+        key: project.elemID.getFullName(),
+        value: resolvedIssueTypeScheme
+          .filter(isReferenceExpression)
+          .map((issueType: ReferenceExpression) => issueType.elemID.getFullName()),
+      }
+    })
+    .toArray()
+
+  return changes
+    .filter(isInstanceChange)
+    .filter(isAdditionOrModificationChange)
+    .map(getChangeData)
+    .filter(instance => instance.elemID.typeName === AUTOMATION_TYPE)
+    .filter(isNotGlobalAutomation)
+    .filter(isIssueCreateActionAutomation)
+    .flatMap(instance => isInstanceWithInvalidIssueType(instance, projectsIssueTypeSchemes))
+    .map(({ componentElemID, invalidIssueType }) => ({
+      elemID: componentElemID,
+      severity: 'Error' as SeverityLevel,
+      message: 'Cannot deploy automation due to issue types not aligned with the automation project type issue scheme.',
+      detailedMessage: `In order to deploy an automation you must use issue types from the automation project issue scheme. To fix it, change this issue type: ${invalidIssueType}`,
+    }))
+}

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -77,6 +77,7 @@ import { emptyProjectScopedContextValidator } from './field_contexts/empty_proje
 import { fieldValidator } from './field'
 import { globalTransitionValidator } from './workflowsV2/global_transition'
 import { htmlBodyContentValidator } from './automation/html_body_content'
+import { automationIssueTypeValidator } from './automation/automations_issue_types'
 
 const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsChangeValidatorCreator, SCOPE } =
   deployment.changeValidators
@@ -162,6 +163,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     kanbanBoardBacklog: kanbanBoardBacklogValidator,
     globalTransition: globalTransitionValidator,
     htmlBodyContentAction: htmlBodyContentValidator,
+    automationIssueType: automationIssueTypeValidator,
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -163,7 +163,7 @@ export default (client: JiraClient, config: JiraConfig, paginator: clientUtils.P
     kanbanBoardBacklog: kanbanBoardBacklogValidator,
     globalTransition: globalTransitionValidator,
     htmlBodyContentAction: htmlBodyContentValidator,
-    automationIssueType: automationIssueTypeValidator,
+    automationIssueType: automationIssueTypeValidator(client),
   }
 
   return createChangeValidator({

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -300,6 +300,7 @@ const CHANGE_VALIDATOR_NAMES = [
   'kanbanBoardBacklog',
   'globalTransition',
   'htmlBodyContentAction',
+  'automationIssueType',
 ]
 
 export type ChangeValidatorName = (typeof CHANGE_VALIDATOR_NAMES)[number]

--- a/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
@@ -32,7 +32,7 @@ describe('automationIssueTypeValidator', () => {
   let multipleProjectsScopeInstance: InstanceElement
   let globalValidInstance: InstanceElement
   let globalInvalidInstance: InstanceElement
-  let invalidInstance: InstanceElement
+  let invalidSingleProjectScopeInstance: InstanceElement
   let invalidTwoComponentsInstance: InstanceElement
   let invalidNestedComponentsInstance: InstanceElement
   let invalidAfterInstance: InstanceElement
@@ -570,7 +570,7 @@ describe('automationIssueTypeValidator', () => {
         },
       ],
     }) // this suppose to be invalid, issue type not from the project referenced
-    invalidInstance = new InstanceElement('invalidInstance', automationType, {
+    invalidSingleProjectScopeInstance = new InstanceElement('invalidSingleProjectScopeInstance', automationType, {
       name: '2',
       components: [
         {
@@ -615,7 +615,7 @@ describe('automationIssueTypeValidator', () => {
           projectId: testProjectReference,
         },
       ],
-    }) // this suppose to be invalid, single projects scope & project value is "current", issue type not from the project referenced
+    }) // this suppose to be invalid, single project scope & project value is "current", issue type not from the project referenced
     invalidTwoComponentsInstance = new InstanceElement('invalidTwoComponentsInstance', automationType, {
       name: 'invalidTwoComponentsInstance',
       components: [
@@ -849,7 +849,7 @@ describe('automationIssueTypeValidator', () => {
       instance3,
       multipleProjectsScopeInstance,
       instanceIssueTypeCurrentValue,
-      invalidInstance,
+      invalidSingleProjectScopeInstance,
       invalidAfterInstance,
       invalidTwoComponentsInstance,
       invalidNestedComponentsInstance,
@@ -892,7 +892,7 @@ describe('automationIssueTypeValidator', () => {
       toChange({ after: invalidTwoComponentsInstance }),
       toChange({ after: invalidNestedComponentsInstance }),
     ]
-    // should return in total 4 errors - 2 for invalidInstance, 2 for invalidNestedComponentsInstance, none for instance2
+    // should return in total 4 errors - 2 for invalidTwoComponentsInstance, 2 for invalidNestedComponentsInstance, none for instance2
     expect(await validator(changes, elementsSource)).toEqual([
       {
         elemID: new ElemID('jira', 'Automation', 'instance', 'invalidTwoComponentsInstance', 'components', '0'),
@@ -936,11 +936,11 @@ describe('automationIssueTypeValidator', () => {
     ])
   })
 
-  it('should return an error when the issue type is not from the relevant project issue type scheme, and the project value is "current"', async () => {
-    const changes = [toChange({ after: invalidInstance })]
+  it('should return an error when it is a single project scope, the project value is "current", and the issue type is not from the relevant project issue type scheme', async () => {
+    const changes = [toChange({ after: invalidSingleProjectScopeInstance })]
     expect(await validator(changes, elementsSource)).toEqual([
       {
-        elemID: new ElemID('jira', 'Automation', 'instance', 'invalidInstance', 'components', '0'),
+        elemID: new ElemID('jira', 'Automation', 'instance', 'invalidSingleProjectScopeInstance', 'components', '0'),
         severity: 'Error',
         message: 'Cannot deploy automation due to issue types not aligned with the relevant project issue type scheme.',
         detailedMessage:

--- a/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
@@ -27,11 +27,12 @@ describe('automationIssueTypeValidator', () => {
   let instance: InstanceElement
   let instance2: InstanceElement
   let instance3: InstanceElement
-  let instance4: InstanceElement
+  let multipleProjectsScopeInstance: InstanceElement
   let globalValidInstance: InstanceElement
   let globalInvalidInstance: InstanceElement
   let invalidInstance: InstanceElement
-  let invalidInstance2: InstanceElement
+  let invalidTwoComponentsInstance: InstanceElement
+  let invalidNestedComponentsInstance: InstanceElement
   let invalidAfterInstance: InstanceElement
   let instanceIssueTypeCurrentValue: InstanceElement
 
@@ -236,7 +237,7 @@ describe('automationIssueTypeValidator', () => {
         },
       ],
     }) // this suppose to be valid, not a 'issue.create' action
-    instance4 = new InstanceElement('instance4', automationType, {
+    multipleProjectsScopeInstance = new InstanceElement('multipleProjectsScopeInstance', automationType, {
       name: '4',
       components: [
         {
@@ -253,7 +254,7 @@ describe('automationIssueTypeValidator', () => {
                 type: 'SET',
                 value: {
                   value: 'current',
-                  type: 'ID',
+                  type: 'COPY',
                 },
               },
               {
@@ -268,7 +269,7 @@ describe('automationIssueTypeValidator', () => {
                 value: {
                   type: 'ID',
                   value: new ReferenceExpression(
-                    new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'someIssueTypeFromAnotherProject'),
+                    new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'notFromProjectsIssueType'),
                   ),
                 },
               },
@@ -284,7 +285,7 @@ describe('automationIssueTypeValidator', () => {
           projectId: someOtherProjectReference,
         },
       ],
-    }) // this suppose to be valid, project value is "current" but more than one project under 'projects' field
+    }) // this suppose to be valid, multiple projects scope & project value is "current", issue type from other project
     globalValidInstance = new InstanceElement('globalInstance', automationType, {
       name: '4',
       components: [
@@ -324,8 +325,42 @@ describe('automationIssueTypeValidator', () => {
             ],
           },
         },
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: new ReferenceExpression(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project')),
+                },
+                fieldType: PROJECT_FIELD,
+                type: 'SET',
+                value: {
+                  value: 'current',
+                  type: 'COPY',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: new ReferenceExpression(
+                    new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Issue_Type__issuetype@suu'),
+                  ),
+                },
+                fieldType: ISSUE_TYPE_FIELD,
+                type: 'SET',
+                value: {
+                  type: 'COPY',
+                  value: 'current',
+                },
+              },
+            ],
+          },
+        },
       ],
-    }) // this suppose to be valid, global automation, issue type from project
+    }) // this suppose to be valid, global automation, component with issue type from project, component with current project & issue type
     globalInvalidInstance = new InstanceElement('globalInvalidInstance', automationType, {
       name: '4',
       components: [
@@ -395,7 +430,7 @@ describe('automationIssueTypeValidator', () => {
                 fieldType: ISSUE_TYPE_FIELD,
                 type: 'SET',
                 value: {
-                  type: 'ID',
+                  type: 'COPY',
                   value: 'current',
                 },
               },
@@ -411,7 +446,7 @@ describe('automationIssueTypeValidator', () => {
           projectId: someOtherProjectReference,
         },
       ],
-    }) // this suppose to be valid, current issue type
+    }) // this suppose to be valid, single project scope, current issue type
     invalidAfterInstance = new InstanceElement('invalidAfterInstance', automationType, {
       name: '1',
       components: [
@@ -459,7 +494,53 @@ describe('automationIssueTypeValidator', () => {
       ],
     }) // this suppose to be invalid, issue type not from the project referenced
     invalidInstance = new InstanceElement('invalidInstance', automationType, {
-      name: 'invalidInstance',
+      name: '2',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: new ReferenceExpression(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project')),
+                },
+                fieldType: PROJECT_FIELD,
+                type: 'SET',
+                value: {
+                  value: 'current',
+                  type: 'COPY',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: new ReferenceExpression(
+                    new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Issue_Type__issuetype@suu'),
+                  ),
+                },
+                fieldType: ISSUE_TYPE_FIELD,
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: new ReferenceExpression(
+                    new ElemID(JIRA, ISSUE_TYPE_FIELD, 'instance', 'someInvalidIssueType'),
+                  ),
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectReference,
+        },
+      ],
+    }) // this suppose to be invalid, single projects scope & project value is "current", issue type not from the project referenced
+    invalidTwoComponentsInstance = new InstanceElement('invalidTwoComponentsInstance', automationType, {
+      name: 'invalidTwoComponentsInstance',
       components: [
         {
           component: 'ACTION',
@@ -543,8 +624,8 @@ describe('automationIssueTypeValidator', () => {
         },
       ],
     }) // this suppose to be invalid, two 'issue.create' components with issue type from another project from 'projects'
-    invalidInstance2 = new InstanceElement('invalidInstance2', automationType, {
-      name: '2',
+    invalidNestedComponentsInstance = new InstanceElement('invalidNestedComponentsInstance', automationType, {
+      name: 'invalidNestedComponentsInstance',
       components: [
         {
           component: 'ACTION',
@@ -559,7 +640,7 @@ describe('automationIssueTypeValidator', () => {
                 fieldType: PROJECT_FIELD,
                 type: 'SET',
                 value: {
-                  value: 'current',
+                  value: someOtherProjectReference,
                   type: 'ID',
                 },
               },
@@ -574,30 +655,129 @@ describe('automationIssueTypeValidator', () => {
                 type: 'SET',
                 value: {
                   type: 'ID',
-                  value: new ReferenceExpression(
-                    new ElemID(JIRA, ISSUE_TYPE_FIELD, 'instance', 'someInvalidIssueType'),
-                  ),
+                  value: new ReferenceExpression(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'someInvalidIssueType')),
                 },
               },
             ],
           },
+        },
+        {
+          component: 'CONDITION',
+          type: 'jira.condition.container.block',
+          children: [
+            {
+              component: 'CONDITION',
+              type: 'jira.condition.if.block',
+              children: [
+                {
+                  component: 'ACTION',
+                  type: 'jira.issue.create',
+                  value: {
+                    operations: [
+                      {
+                        field: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project'),
+                          ),
+                        },
+                        fieldType: PROJECT_FIELD,
+                        type: 'SET',
+                        value: {
+                          value: testProjectReference,
+                          type: 'ID',
+                        },
+                      },
+                      {
+                        field: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Issue_Type__issuetype@suu'),
+                          ),
+                        },
+                        fieldType: ISSUE_TYPE_FIELD,
+                        type: 'SET',
+                        value: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'moreIssueType'),
+                          ),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+            {
+              component: 'CONDITION',
+              type: 'jira.condition.else.block',
+              children: [
+                {
+                  component: 'ACTION',
+                  type: 'jira.issue.create',
+                  value: {
+                    operations: [
+                      {
+                        field: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Project__project'),
+                          ),
+                        },
+                        fieldType: PROJECT_FIELD,
+                        type: 'SET',
+                        value: {
+                          value: testProjectReference,
+                          type: 'ID',
+                        },
+                      },
+                      {
+                        field: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Issue_Type__issuetype@suu'),
+                          ),
+                        },
+                        fieldType: ISSUE_TYPE_FIELD,
+                        type: 'SET',
+                        value: {
+                          type: 'ID',
+                          value: new ReferenceExpression(
+                            new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'someIssueTypeFromAnotherProject'),
+                          ),
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
         },
       ],
       projects: [
         {
           projectId: testProjectReference,
         },
+        {
+          projectId: someOtherProjectReference,
+        },
       ],
-    }) // this suppose to be invalid, issue type not from the project referenced, project value is "current"
+    }) // this suppose to be invalid, nested 'issue.create' components with issue type not from the project
 
     elementsSource = buildElementsSourceFromElements([
       instance,
       instance2,
       instance3,
-      instance4,
+      multipleProjectsScopeInstance,
       instanceIssueTypeCurrentValue,
-      invalidAfterInstance,
       invalidInstance,
+      invalidAfterInstance,
+      invalidTwoComponentsInstance,
+      invalidNestedComponentsInstance,
+      globalValidInstance,
+      globalInvalidInstance,
       testProjectInstance,
       someOtherProjectInstance,
       testProjectIssueTypeSchemeInstance,
@@ -609,10 +789,9 @@ describe('automationIssueTypeValidator', () => {
     const changes = [
       toChange({ after: invalidAfterInstance }),
       toChange({ before: instance, after: invalidAfterInstance }),
-      toChange({ after: invalidInstance }),
       toChange({ after: instance2 }), // valid
     ]
-    // should return in total 4 errors - 2 for invalidAfterInstance, 2 for invalidInstance, none for instance2
+    // should return in 2 errors for invalidAfterInstance, none for instance2
     expect(await automationIssueTypeValidator(changes, elementsSource)).toEqual([
       {
         elemID: new ElemID(
@@ -648,12 +827,22 @@ describe('automationIssueTypeValidator', () => {
         detailedMessage:
           'In order to deploy an automation you must use issue types from the relevant project issue scheme. To fix it, change this issue type: someInvalidIssueType',
       },
+    ])
+  })
+
+  it('should return an error when the issue type is not from the relevant project issue type scheme, and the components are nested', async () => {
+    const changes = [
+      toChange({ after: invalidTwoComponentsInstance }),
+      toChange({ after: invalidNestedComponentsInstance }),
+    ]
+    // should return in total 4 errors - 2 for invalidInstance, 2 for invalidNestedComponentsInstance, none for instance2
+    expect(await automationIssueTypeValidator(changes, elementsSource)).toEqual([
       {
         elemID: new ElemID(
           'jira',
           'Automation',
           'instance',
-          'invalidInstance',
+          'invalidTwoComponentsInstance',
           'components',
           '0',
           'value',
@@ -670,9 +859,47 @@ describe('automationIssueTypeValidator', () => {
           'jira',
           'Automation',
           'instance',
-          'invalidInstance',
+          'invalidTwoComponentsInstance',
           'components',
           '1',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message: 'Cannot deploy automation due to issue types not aligned with the relevant project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the relevant project issue scheme. To fix it, change this issue type: someIssueTypeFromAnotherProject',
+      },
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidNestedComponentsInstance',
+          'components',
+          '0',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message: 'Cannot deploy automation due to issue types not aligned with the relevant project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the relevant project issue scheme. To fix it, change this issue type: someInvalidIssueType',
+      },
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidNestedComponentsInstance',
+          'components',
+          '1',
+          'children',
+          '1',
+          'children',
+          '0',
           'value',
           'operations',
           '1',
@@ -686,14 +913,14 @@ describe('automationIssueTypeValidator', () => {
   })
 
   it('should return an error when the issue type is not from the relevant project issue type scheme, and the project value is "current"', async () => {
-    const changes = [toChange({ after: invalidInstance2 })]
+    const changes = [toChange({ after: invalidInstance })]
     expect(await automationIssueTypeValidator(changes, elementsSource)).toEqual([
       {
         elemID: new ElemID(
           'jira',
           'Automation',
           'instance',
-          'invalidInstance2',
+          'invalidInstance',
           'components',
           '0',
           'value',
@@ -739,15 +966,15 @@ describe('automationIssueTypeValidator', () => {
     expect(await automationIssueTypeValidator([toChange({ after: instance })])).toEqual([])
   })
 
-  it('should not return an error when the issue type is current', async () => {
+  it('should not return an error for a single project scope when the issue type is current', async () => {
     expect(await automationIssueTypeValidator([toChange({ after: instanceIssueTypeCurrentValue })])).toEqual([])
   })
 
-  it('should not return an error for a global automation with issue type from the project referenced', async () => {
+  it('should not return an error for a global automation with issue type from the project referenced, and for "current" issue type and project', async () => {
     expect(await automationIssueTypeValidator([toChange({ after: globalValidInstance })])).toEqual([])
   })
 
-  it('should not return an error when the project value is "current" and there is more than one project under "projects"', async () => {
-    expect(await automationIssueTypeValidator([toChange({ after: instance4 })])).toEqual([])
+  it('should not return an error for a multiple project scope when the project value is "current"', async () => {
+    expect(await automationIssueTypeValidator([toChange({ after: multipleProjectsScopeInstance })])).toEqual([])
   })
 })

--- a/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
+++ b/packages/jira-adapter/test/change_validators/automations/automations_issue_types.test.ts
@@ -1,0 +1,484 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  ObjectType,
+  InstanceElement,
+  toChange,
+  ReadOnlyElementsSource,
+  ElemID,
+  ReferenceExpression,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import { AUTOMATION_TYPE } from '../../../src/constants'
+import { automationIssueTypeValidator } from '../../../src/change_validators/automation/automations_issue_types'
+import { createEmptyType } from '../../utils'
+
+describe('automationIssueTypeValidator', () => {
+  let elementsSource: ReadOnlyElementsSource
+
+  let automationType: ObjectType
+  let instance: InstanceElement
+  let instance2: InstanceElement
+  let instance3: InstanceElement
+  let invalidInstance: InstanceElement
+  let invalidAfterInstance: InstanceElement
+  let instanceIssueTypeCurrentValue: InstanceElement
+
+  let projectType: ObjectType
+  let testProjectInstance: InstanceElement
+  let someOtherProjectInstance: InstanceElement
+
+  let issueTypeSchemeType: ObjectType
+  let testProjectIssueTypeSchemeInstance: InstanceElement
+  let someOtherProjectInstanceIssueTypeSchemeInstance: InstanceElement
+
+  beforeEach(() => {
+    issueTypeSchemeType = createEmptyType('IssueTypeScheme')
+    const testProjectIssueTypesReference = [
+      new ReferenceExpression(new ElemID('jira', 'IssueType', 'instance', 'someValidIssueTypeFromTestProject')),
+      new ReferenceExpression(new ElemID('jira', 'IssueType', 'instance', 'moreIssueType')),
+    ]
+    const someOtherProjectIssueTypesReference = [
+      new ReferenceExpression(new ElemID('jira', 'IssueType', 'instance', 'someIssueTypeFromAnotherProject')),
+      new ReferenceExpression(new ElemID('jira', 'IssueType', 'instance', 'moreAndMoreIssueType')),
+    ]
+    testProjectIssueTypeSchemeInstance = new InstanceElement(
+      'testProjectIssueTypeSchemeInstance',
+      issueTypeSchemeType,
+      {
+        issueTypeIds: testProjectIssueTypesReference,
+      },
+    )
+    someOtherProjectInstanceIssueTypeSchemeInstance = new InstanceElement(
+      'someOtherProjectInstanceIssueTypeSchemeInstance',
+      issueTypeSchemeType,
+      {
+        issueTypeIds: someOtherProjectIssueTypesReference,
+      },
+    )
+
+    projectType = createEmptyType('Project')
+    testProjectInstance = new InstanceElement('testProjectInstance', projectType, {
+      name: 'testProjectInstance',
+      issueTypeScheme: new ReferenceExpression(
+        testProjectIssueTypeSchemeInstance.elemID,
+        testProjectIssueTypeSchemeInstance,
+      ),
+    })
+    someOtherProjectInstance = new InstanceElement('someOtherProjectInstance', projectType, {
+      name: 'someOtherProjectInstance',
+      issueTypeScheme: new ReferenceExpression(
+        someOtherProjectInstanceIssueTypeSchemeInstance.elemID,
+        someOtherProjectInstanceIssueTypeSchemeInstance,
+      ),
+    })
+
+    automationType = createEmptyType(AUTOMATION_TYPE)
+    instance = new InstanceElement('instance', automationType, {
+      name: '1',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someValidIssueTypeFromTestProject') },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectInstance,
+        },
+      ],
+    }) // this suppose to be valid, issue type from project & this is the project under 'projects'
+    instance2 = new InstanceElement('instance2', automationType, {
+      name: '2',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someValidIssueTypeFromTestProject') },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: someOtherProjectInstance,
+        },
+      ],
+    }) // this suppose to be valid, issue type from project & this is not a project under 'projects'
+    instance3 = new InstanceElement('instance3', automationType, {
+      name: '3',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.condition',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someIssueTypeFromAnotherProject') },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectInstance,
+        },
+        {
+          projectId: someOtherProjectInstance,
+        },
+      ],
+    }) // this suppose to be valid, not a 'issue.create' action
+    invalidInstance = new InstanceElement('invalidInstance', automationType, {
+      name: 'invalidInstance',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someIssueTypeFromAnotherProject') },
+                },
+              },
+            ],
+          },
+        },
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someIssueTypeFromAnotherProject') },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectInstance,
+        },
+        {
+          projectId: someOtherProjectInstance,
+        },
+      ],
+    }) // this suppose to be invalid, issue type from another project
+    instanceIssueTypeCurrentValue = new InstanceElement('instanceIssueTypeCurrentValue', automationType, {
+      name: '1',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: 'current',
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectInstance,
+        },
+        {
+          projectId: someOtherProjectInstance,
+        },
+      ],
+    }) // this suppose to be valid, current issue type
+    invalidAfterInstance = new InstanceElement('invalidAfterInstance', automationType, {
+      name: '1',
+      components: [
+        {
+          component: 'ACTION',
+          type: 'jira.issue.create',
+          value: {
+            operations: [
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Project__project',
+                },
+                fieldType: 'project',
+                type: 'SET',
+                value: {
+                  value: testProjectInstance,
+                  type: 'ID',
+                },
+              },
+              {
+                field: {
+                  type: 'ID',
+                  value: 'jira.Field.instance.Issue_Type__issuetype@suu',
+                },
+                fieldType: 'issuetype',
+                type: 'SET',
+                value: {
+                  type: 'ID',
+                  value: { elemID: new ElemID('jira.IssueType.instance.someInvalidIssueType') },
+                },
+              },
+            ],
+          },
+        },
+      ],
+      projects: [
+        {
+          projectId: testProjectInstance,
+        },
+      ],
+    }) // this suppose to be invalid, issue type not from the project referred
+
+    elementsSource = buildElementsSourceFromElements([
+      instance,
+      instance2,
+      instance3,
+      invalidInstance,
+      instanceIssueTypeCurrentValue,
+      invalidAfterInstance,
+      testProjectInstance,
+      someOtherProjectInstance,
+      testProjectIssueTypeSchemeInstance,
+      someOtherProjectInstanceIssueTypeSchemeInstance,
+    ])
+  })
+
+  it('should return an error when the issue type is not from the project issue type scheme', async () => {
+    const changes = [
+      toChange({ after: invalidAfterInstance }),
+      toChange({ before: instance, after: invalidAfterInstance }),
+      toChange({ after: invalidInstance }),
+      toChange({ after: instance2 }),
+    ]
+    expect(await automationIssueTypeValidator(changes, elementsSource)).toEqual([
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidAfterInstance',
+          'components',
+          '0',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message:
+          'Cannot deploy automation due to issue types not aligned with the automation project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the automation project issue scheme. To fix it, change this issue type: jira.IssueType.instance.someInvalidIssueType',
+      },
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidAfterInstance',
+          'components',
+          '0',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message:
+          'Cannot deploy automation due to issue types not aligned with the automation project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the automation project issue scheme. To fix it, change this issue type: jira.IssueType.instance.someInvalidIssueType',
+      },
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidInstance',
+          'components',
+          '0',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message:
+          'Cannot deploy automation due to issue types not aligned with the automation project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the automation project issue scheme. To fix it, change this issue type: jira.IssueType.instance.someIssueTypeFromAnotherProject',
+      },
+      {
+        elemID: new ElemID(
+          'jira',
+          'Automation',
+          'instance',
+          'invalidInstance',
+          'components',
+          '1',
+          'value',
+          'operations',
+          '1',
+        ),
+        severity: 'Error',
+        message:
+          'Cannot deploy automation due to issue types not aligned with the automation project type issue scheme.',
+        detailedMessage:
+          'In order to deploy an automation you must use issue types from the automation project issue scheme. To fix it, change this issue type: jira.IssueType.instance.someIssueTypeFromAnotherProject',
+      },
+    ])
+  })
+
+  it('should not check when the operation is not jira.issue.create', async () => {
+    expect(await automationIssueTypeValidator([toChange({ after: instance3 })])).toEqual([])
+  })
+
+  it('should not return an error when the issue type is one of the project issue type scheme', async () => {
+    expect(await automationIssueTypeValidator([toChange({ after: instance })])).toEqual([])
+  })
+
+  it('should not return an error when the issue type is current', async () => {
+    expect(await automationIssueTypeValidator([toChange({ after: instanceIssueTypeCurrentValue })])).toEqual([])
+  })
+})


### PR DESCRIPTION
CV that blocks Automation with issueTypes that are out of scope.

I blocked the following cases (for `jira.issue.create` automation actions):

1. When the issue type value is not one of the project’s issue type scheme referenced (in the field directly above it).
2. When it is a single project scope automation, the project value is current, and the issue type value is not from that project’s issue type scheme.

---
_Release Notes_: 
_Jira_adapter_:
- Added a new CV to block Automations with issueTypes out of scope
---
_User Notifications_: 
