### PR TITLE
SALTO-7385: Fix incorrect parsing of backslashes in multi line template expressions

### DIFF
--- a/packages/parser/src/parser/internal/dump.ts
+++ b/packages/parser/src/parser/internal/dump.ts
@@ -94,7 +94,7 @@ const dumpExpression = (exp: Value, indentationLevel = 0): string[] => {
         .map((part, idx) =>
           isExpression(part)
             ? `\${ ${dumpExpression(part).join('\n')} }`
-            : escapeTemplateMarker(part, { isLastPart: idx === parts.length - 1 }),
+            : escapeTemplateMarker(part, { isNextPartReference: isExpression(parts[idx + 1]) }),
         )
         .join(''),
       indentationLevel,

--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -87,7 +87,7 @@ const createTemplateExpressions = (
   createSimpleStringValueFunc: (
     context: Pick<ParseContext, 'errors' | 'filename'>,
     tokens: Required<Token>[],
-    isLastPart?: boolean,
+    isNextPartReference?: boolean,
   ) => string,
 ): TemplateExpression =>
   createTemplateExpression({
@@ -96,8 +96,8 @@ const createTemplateExpressions = (
         const ref = createReferenceExpression(token.value)
         return ref instanceof IllegalReference ? token.text : ref
       }
-      const isLastPart = idx === tokens.length - 1
-      return createSimpleStringValueFunc(context, [token], isLastPart)
+      const isNextPartReference = tokens[idx + 1]?.type === TOKEN_TYPES.REFERENCE
+      return createSimpleStringValueFunc(context, [token], isNextPartReference)
     }),
   })
 
@@ -247,8 +247,12 @@ const consumeArrayItems = (context: ParseContext, closingTokenType: string, idPr
 
 const unescapeMultilineMarker = (prim: string): string => prim.replace(/\\'''/g, "'''")
 
-const createMultilineSimpleStringValue = (_context: unknown, tokens: Required<Token>[], isLastPart = true): string =>
-  unescapeMultilineMarker(unescapeTemplateMarker(tokens.map(token => token.text).join(''), { isLastPart }))
+const createMultilineSimpleStringValue = (
+  _context: unknown,
+  tokens: Required<Token>[],
+  isNextPartReference?: boolean,
+): string =>
+  unescapeMultilineMarker(unescapeTemplateMarker(tokens.map(token => token.text).join(''), { isNextPartReference }))
 
 const consumeMultilineString: Consumer<string | TemplateExpression> = context => {
   // Getting the position of the start marker

--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -103,7 +103,7 @@ export const rules: Record<string, moo.Rules> = {
 
 const stringWithReferencesRules = moo.compile({
   // This handles regular escapes, unicode escapes and escaped template markers ('\${')
-  [TOKEN_TYPES.ESCAPE]: { match: /\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?/ },
+  [TOKEN_TYPES.ESCAPE]: { match: /(?:\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?)+/ },
   [TOKEN_TYPES.REFERENCE]: { match: REFERENCE, value: s => s.slice(2, -1).trim() },
   // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
   [TOKEN_TYPES.CONTENT]: {

--- a/packages/parser/src/parser/internal/utils.ts
+++ b/packages/parser/src/parser/internal/utils.ts
@@ -20,16 +20,16 @@
 // A string with \ followed by a reference will be \\${
 // and so on...
 type EscapeTemplateMarkerOptions = {
-  isLastPart?: boolean
+  isNextPartReference?: boolean
 }
 
 export const escapeTemplateMarker = (
   prim: string,
-  { isLastPart = true }: EscapeTemplateMarkerOptions | undefined = {},
+  { isNextPartReference = false }: EscapeTemplateMarkerOptions | undefined = {},
 ): string =>
   prim.replace(
     // In the last part we don't need to escape a \ at the end
-    isLastPart ? /(\\*)(\$\{)/g : /(\\*)(\$\{|$)/g,
+    isNextPartReference ? /(\\*)(\$\{|$)/g : /(\\*)(\$\{)/g,
     (_, backslashes, ending) =>
       // Double all leading backslashes and escape the ${
       `${backslashes.replace(/\\/g, '\\\\')}${ending === '' ? '' : '\\${'}`,
@@ -50,7 +50,7 @@ type UnescapeTemplateMarkerOptions = EscapeTemplateMarkerOptions & {
 
 export const unescapeTemplateMarker = (
   text: string,
-  { isLastPart = true, unescapeStrategy = 'all' }: UnescapeTemplateMarkerOptions | undefined = {},
+  { isNextPartReference = false, unescapeStrategy = 'all' }: UnescapeTemplateMarkerOptions | undefined = {},
 ): string => {
   if (unescapeStrategy === 'leadingBackslashOnly') {
     return text.replace(/(\\*)(\\\\\$\{)/g, (_match, backslashes, ending) =>
@@ -60,7 +60,7 @@ export const unescapeTemplateMarker = (
   }
   return text.replace(
     // In the last part we don't need to unescape \ at the end
-    isLastPart ? /(\\*)(\\\$\{)/g : /(\\*)(\\\$\{|$)/g,
+    isNextPartReference ? /(\\*)(\\\$\{|$)/g : /(\\*)(\\\$\{)/g,
     (_, backslashes, ending) => {
       const leadingBackslashes = unescapeStrategy === 'markerOnly' ? backslashes : backslashes.replace(/\\\\/g, '\\')
       if (ending === '') {

--- a/packages/parser/src/utils/template_static_file.ts
+++ b/packages/parser/src/utils/template_static_file.ts
@@ -16,8 +16,8 @@ import { ParseError } from '../parser'
 
 const log = logger(module)
 
-const createSimpleStringValue = (_context: unknown, tokens: Required<Token>[], isLastPart?: boolean): string =>
-  unescapeTemplateMarker(tokens.map(token => token.text).join(''), { isLastPart })
+const createSimpleStringValue = (_context: unknown, tokens: Required<Token>[], isNextPartReference?: boolean): string =>
+  unescapeTemplateMarker(tokens.map(token => token.text).join(''), { isNextPartReference })
 
 const parseBufferToTemplateExpression = (
   buffer: Buffer,
@@ -41,7 +41,7 @@ export const templateExpressionToStaticFile = (expression: TemplateExpression, f
     .map((part, idx) =>
       isReferenceExpression(part)
         ? `\${ ${[part.elemID.getFullName()]} }`
-        : escapeTemplateMarker(part, { isLastPart: idx === expression.parts.length - 1 }),
+        : escapeTemplateMarker(part, { isNextPartReference: isReferenceExpression(expression.parts[idx + 1]) }),
     )
     .join('')
   return new StaticFile({ filepath, content: Buffer.from(string), isTemplate: true, encoding: 'utf8' })

--- a/packages/parser/test/parser/dump.test.ts
+++ b/packages/parser/test/parser/dump.test.ts
@@ -162,7 +162,7 @@ describe('Salto Dump', () => {
         // eslint-disable-next-line no-template-curly-in-string
         'Hello \\${ not.reference } and \n line with escaped ref \\',
         new ReferenceExpression(new ElemID('salto', 'ref')),
-        '\n and another line\\',
+        '\n and another \\\\ line\\',
       ],
     }),
     doubleEscapedTemplate: new TemplateExpression({
@@ -173,7 +173,7 @@ describe('Salto Dump', () => {
       'string with two backslashes before template marker \\\\${ not.reference } and after \\',
     multiLineNonTemplate:
       // eslint-disable-next-line no-template-curly-in-string
-      'multi line string\nwith two \\ before template marker \\\\${ not.reference } \\\n and one at the end \\',
+      'multi line string\nwith two \\\\ before template marker \\\\${ not.reference } \\\n and one at the end \\',
   })
 
   describe('dump elements', () => {
@@ -292,14 +292,14 @@ describe('Salto Dump', () => {
         expect(body).toMatch(/Hello \\\\\\\$\{ not.reference \}/m)
       })
       it('should not escape backslashes that do not appear before ${', () => {
-        expect(body).toMatch(/and another line\\\n\s*'''/m)
+        expect(body).toMatch(/and another \\\\ line\\\n\s*'''/m)
       })
     })
 
     describe('dumped multi line string with escaped template marker', () => {
       it('should escape the template marker and all leading backslashes before it', () => {
         expect(body).toMatch(
-          /multi line string\nwith two \\ before template marker \\\\\\\\\\\$\{ not.reference \} \\\n and one at the end \\/m,
+          /multi line string\nwith two \\\\ before template marker \\\\\\\\\\\$\{ not.reference \} \\\n and one at the end \\/m,
         )
       })
     })

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -1428,7 +1428,7 @@ value
 multiline
 \${{$\{te@mp.late.instance.multiline_stuff@us}}} and {{$\{te@mp.late.instance.multiline_stuff@us}}}\${{$\{te@mp.late.instance.multiline_stuff@us}}}{{$\{te@mp.late.instance.multiline_stuff@us}}} hello
 line where the original content looks like an escaped reference but it it is actually not a reference: \\\\\\\${ not.reference }
-line that ends with \\
+line that has \\\\\\\\ and ends with \\
 '''
         }
       `
@@ -1470,7 +1470,7 @@ line that ends with \\
             elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
           }),
           // eslint-disable-next-line no-template-curly-in-string
-          '}} hello\nline where the original content looks like an escaped reference but it it is actually not a reference: \\${ not.reference }\nline that ends with \\',
+          '}} hello\nline where the original content looks like an escaped reference but it it is actually not a reference: \\${ not.reference }\nline that has \\\\\\\\ and ends with \\',
         ])
       })
 


### PR DESCRIPTION
Before this fix, we would incorrectly unescape `\\` that appear in a template expression not before `${`

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fix incorrect parsing of backslashes in multi line template expressions

---
_User Notifications_: 
_None_