### PR TITLE
SALTO-3221 SALTO-4531: Added custom references in Flow for the leftValueReference, elementReference, assignToReference fields starting with $Record.

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -108,6 +108,8 @@ export enum FLEXI_PAGE_FIELD_NAMES {
 export const FLOW_NODE = 'FlowNode'
 export const TARGET_REFERENCE = 'targetReference'
 export const ASSIGN_TO_REFERENCE = 'assignToReference'
+export const LEFT_VALUE_REFERENCE = 'leftValueReference'
+export const ELEMENT_REFERENCE = 'elementReference'
 export enum FLOW_NODE_FIELD_NAMES {
   NAME = 'name',
   LOCATION_X = 'locationX',
@@ -115,6 +117,10 @@ export enum FLOW_NODE_FIELD_NAMES {
 }
 
 export const FLOW_FIELD_TYPE_NAMES = {
+  FLOW_RULE: 'FlowRule',
+  FLOW_DECISION: 'FlowDecision',
+  FLOW_ELEMENT_REFERENCE_OR_VALUE: 'flowElementReferenceOrValue',
+  FLOW_CONDITION: 'FlowCondition',
   FLOW_ASSIGNMENT_ITEM: 'FlowAssignmentItem',
   FLOW_STAGE_STEP_OUTPUT_PARAMETER: 'FlowStageStepOutputParameter',
   FLOW_SUBFLOW_OUTPUT_ASSIGNMENT: 'FlowSubflowOutputAssignment',

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -32,14 +32,14 @@ const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
 const defaultCustomReferencesConfiguration: Required<CustomReferencesSettings> = {
   profilesAndPermissionSets: true,
   managedElements: true,
-  formulaRefs: false,
+  formulaRefs: true,
   omitNonExistingFields: false,
 }
 
 const defaultFixElementsConfiguration: Required<FixElementsSettings> = {
   profilesAndPermissionSets: true,
   managedElements: true,
-  formulaRefs: false,
+  formulaRefs: true,
   omitNonExistingFields: true,
 }
 

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -19,7 +19,7 @@ import {
 } from '../types'
 import { profilesAndPermissionSetsHandler } from './profiles_and_permission_sets'
 import { managedElementsHandler } from './managed_elements'
-import { formulaRefsHandler } from './formula_refs'
+import { formulaRefsHandler } from './flow_and_flexi_page'
 import { omitNonExistingFieldsHandler } from './omit_non_existing_fields'
 
 const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {

--- a/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
@@ -7,7 +7,7 @@
  */
 import { ElemID, InstanceElement, ObjectType, ReferenceInfo } from '@salto-io/adapter-api'
 import { mockTypes } from '../mock_elements'
-import { formulaRefsHandler } from '../../src/custom_references/formula_refs'
+import { formulaRefsHandler } from '../../src/custom_references/flow_and_flexi_page'
 import { SALESFORCE } from '../../src/constants'
 
 describe('formulaRefs', () => {

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -63,6 +63,8 @@ import {
   ASSIGN_TO_REFERENCE,
   LIVE_CHAT_BUTTON,
   APPROVAL_PROCESS_METADATA_TYPE,
+  LEFT_VALUE_REFERENCE,
+  ELEMENT_REFERENCE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -485,6 +487,52 @@ export const mockTypes = {
             fields: {
               [ASSIGN_TO_REFERENCE]: {
                 refType: BuiltinTypes.STRING,
+              },
+            },
+          }),
+        ),
+      },
+      decisions: {
+        refType: new ListType(
+          createMetadataObjectType({
+            annotations: {
+              metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_DECISION,
+            },
+            fields: {
+              rules: {
+                refType: new ListType(
+                  createMetadataObjectType({
+                    annotations: {
+                      metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_RULE,
+                    },
+                    fields: {
+                      conditions: {
+                        refType: new ListType(
+                          createMetadataObjectType({
+                            annotations: {
+                              metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_CONDITION,
+                            },
+                            fields: {
+                              [LEFT_VALUE_REFERENCE]: {
+                                refType: BuiltinTypes.STRING,
+                              },
+                              rightValue: {
+                                refType: createMetadataObjectType({
+                                  annotations: { metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_ELEMENT_REFERENCE_OR_VALUE },
+                                  fields: {
+                                    [ELEMENT_REFERENCE]: {
+                                      refType: BuiltinTypes.STRING,
+                                    },
+                                  },
+                                }),
+                              },
+                            },
+                          }),
+                        ),
+                      },
+                    },
+                  }),
+                ),
               },
             },
           }),


### PR DESCRIPTION
SALTO-3221-4531: Added custom references in Flow for the leftValueReference, elementReference, assignToReference fields starting with $Record.

---

_Additional context for reviewer_:
Adding custom reference log message:
<img width="1430" alt="image" src="https://github.com/user-attachments/assets/10b764d6-c328-46ab-bbe7-1fb40641d2e1" />

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between Flow and CustomFields.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from Flow to CustomFields.
