### PR TITLE
SALTO-3221-4531-4207-5929: Added custom references from Flow and FlexiPage to CustomFields

### DIFF
--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -108,6 +108,8 @@ export enum FLEXI_PAGE_FIELD_NAMES {
 export const FLOW_NODE = 'FlowNode'
 export const TARGET_REFERENCE = 'targetReference'
 export const ASSIGN_TO_REFERENCE = 'assignToReference'
+export const LEFT_VALUE_REFERENCE = 'leftValueReference'
+export const ELEMENT_REFERENCE = 'elementReference'
 export enum FLOW_NODE_FIELD_NAMES {
   NAME = 'name',
   LOCATION_X = 'locationX',
@@ -115,6 +117,10 @@ export enum FLOW_NODE_FIELD_NAMES {
 }
 
 export const FLOW_FIELD_TYPE_NAMES = {
+  FLOW_RULE: 'FlowRule',
+  FLOW_DECISION: 'FlowDecision',
+  FLOW_ELEMENT_REFERENCE_OR_VALUE: 'flowElementReferenceOrValue',
+  FLOW_CONDITION: 'FlowCondition',
   FLOW_ASSIGNMENT_ITEM: 'FlowAssignmentItem',
   FLOW_STAGE_STEP_OUTPUT_PARAMETER: 'FlowStageStepOutputParameter',
   FLOW_SUBFLOW_OUTPUT_ASSIGNMENT: 'FlowSubflowOutputAssignment',

--- a/packages/salesforce-adapter/src/custom_references/flow_and_flexi_page.ts
+++ b/packages/salesforce-adapter/src/custom_references/flow_and_flexi_page.ts
@@ -46,13 +46,15 @@ const getInstanceParent = (instance: InstanceElement): ReferenceExpression | und
   return parentRef
 }
 
+const recordPrefixes = ['$Record.']
+
 const referenceInfoFromFieldValue = (
   instance: InstanceElement,
   path: ElemID,
   value: Value,
 ): ReferenceInfo[] | undefined => {
   if (isReferenceExpression(value)) return undefined
-  if (value.startsWith('$Record.')) {
+  if (recordPrefixes.some(prefix => value.startsWith(prefix))) {
     const parentRef = getInstanceParent(instance)
     if (parentRef === undefined) {
       return undefined

--- a/packages/salesforce-adapter/src/custom_references/flow_and_flexi_page.ts
+++ b/packages/salesforce-adapter/src/custom_references/flow_and_flexi_page.ts
@@ -19,7 +19,7 @@ import { values } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
 import { inspectValue, WALK_NEXT_STEP, walkOnElement, WalkOnFunc } from '@salto-io/adapter-utils'
 import { WeakReferencesHandler } from '../types'
-import { isInstanceOfTypeSync } from '../filters/utils'
+import { apiNameSync, isInstanceOfTypeSync } from '../filters/utils'
 import { API_NAME_SEPARATOR, FLEXI_PAGE_TYPE, FLOW_METADATA_TYPE } from '../constants'
 
 const log = logger(module)
@@ -150,7 +150,7 @@ const findWeakReferences: WeakReferencesHandler['findWeakReferences'] = async (
 ): Promise<ReferenceInfo[]> => {
   const fetchedInstances = elements.filter(isInstanceOfTypeSync(...Object.keys(referenceExtractors)))
   return fetchedInstances.flatMap(instance =>
-    referenceExtractors[instance.elemID.typeName].flatMap(refExtractor => {
+    referenceExtractors[apiNameSync(instance.getTypeSync()) ?? ''].flatMap(refExtractor => {
       try {
         const addedCustomReferences = refExtractor(instance).filter(isDefined)
         if (addedCustomReferences.length > 0) {

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -32,14 +32,14 @@ const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {
 const defaultCustomReferencesConfiguration: Required<CustomReferencesSettings> = {
   profilesAndPermissionSets: true,
   managedElements: true,
-  formulaRefs: false,
+  formulaRefs: true,
   omitNonExistingFields: false,
 }
 
 const defaultFixElementsConfiguration: Required<FixElementsSettings> = {
   profilesAndPermissionSets: true,
   managedElements: true,
-  formulaRefs: false,
+  formulaRefs: true,
   omitNonExistingFields: true,
 }
 

--- a/packages/salesforce-adapter/src/custom_references/handlers.ts
+++ b/packages/salesforce-adapter/src/custom_references/handlers.ts
@@ -19,7 +19,7 @@ import {
 } from '../types'
 import { profilesAndPermissionSetsHandler } from './profiles_and_permission_sets'
 import { managedElementsHandler } from './managed_elements'
-import { formulaRefsHandler } from './formula_refs'
+import { formulaRefsHandler } from './flow_and_flexi_page'
 import { omitNonExistingFieldsHandler } from './omit_non_existing_fields'
 
 const handlers: Record<CustomReferencesHandlers, WeakReferencesHandler> = {

--- a/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
@@ -7,7 +7,7 @@
  */
 import { ElemID, InstanceElement, ObjectType, ReferenceInfo } from '@salto-io/adapter-api'
 import { mockTypes } from '../mock_elements'
-import { formulaRefsHandler } from '../../src/custom_references/formula_refs'
+import { formulaRefsHandler } from '../../src/custom_references/flow_and_flexi_page'
 import { SALESFORCE } from '../../src/constants'
 
 describe('formulaRefs', () => {

--- a/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
@@ -8,7 +8,7 @@
 import { CORE_ANNOTATIONS, ReferenceInfo, Element, ReferenceExpression } from '@salto-io/adapter-api'
 import { mockTypes } from '../mock_elements'
 import { formulaRefsHandler } from '../../src/custom_references/flow_and_flexi_page'
-import { FLOW_METADATA_TYPE } from '../../src/constants'
+import { FLEXI_PAGE_TYPE, FLOW_METADATA_TYPE } from '../../src/constants'
 import { createInstanceElement } from '../../src/transformers/transformer'
 
 describe('Flow and FlexiPage custom references', () => {
@@ -92,6 +92,59 @@ describe('Flow and FlexiPage custom references', () => {
               '0',
               'rightValue',
               'elementReference',
+            ),
+            target,
+            type,
+          },
+        ]
+        expect(refs).toIncludeSameMembers(expectedRefs)
+      })
+    })
+    describe('FlexiPage', () => {
+      beforeEach(() => {
+        referringInstance = createInstanceElement(
+          {
+            fullName: FLEXI_PAGE_TYPE,
+            flexiPageRegions: [
+              {
+                itemInstances: [
+                  {
+                    componentInstance: {
+                      visibilityRule: {
+                        criteria: [
+                          {
+                            leftValue: 'Record.Name',
+                          },
+                        ],
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+          mockTypes.FlexiPage,
+          undefined,
+          { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(mockTypes.Account.elemID)] },
+        )
+        elements = [referringInstance]
+      })
+      it('should generate references', async () => {
+        refs = await formulaRefsHandler.findWeakReferences(elements)
+        const target = mockTypes.Account.elemID.createNestedID('field', 'Name')
+        const type = 'strong'
+        const expectedRefs = [
+          {
+            source: referringInstance.elemID.createNestedID(
+              'flexiPageRegions',
+              '0',
+              'itemInstances',
+              '0',
+              'componentInstance',
+              'visibilityRule',
+              'criteria',
+              '0',
+              'leftValue',
             ),
             target,
             type,

--- a/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
+++ b/packages/salesforce-adapter/test/custom_references/flow_and_flexi_page.test.ts
@@ -113,7 +113,7 @@ describe('Flow and FlexiPage custom references', () => {
                       visibilityRule: {
                         criteria: [
                           {
-                            leftValue: 'Record.Name',
+                            leftValue: '{!Record.Name',
                           },
                         ],
                       },

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -63,6 +63,8 @@ import {
   ASSIGN_TO_REFERENCE,
   LIVE_CHAT_BUTTON,
   APPROVAL_PROCESS_METADATA_TYPE,
+  LEFT_VALUE_REFERENCE,
+  ELEMENT_REFERENCE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -485,6 +487,52 @@ export const mockTypes = {
             fields: {
               [ASSIGN_TO_REFERENCE]: {
                 refType: BuiltinTypes.STRING,
+              },
+            },
+          }),
+        ),
+      },
+      decisions: {
+        refType: new ListType(
+          createMetadataObjectType({
+            annotations: {
+              metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_DECISION,
+            },
+            fields: {
+              rules: {
+                refType: new ListType(
+                  createMetadataObjectType({
+                    annotations: {
+                      metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_RULE,
+                    },
+                    fields: {
+                      conditions: {
+                        refType: new ListType(
+                          createMetadataObjectType({
+                            annotations: {
+                              metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_CONDITION,
+                            },
+                            fields: {
+                              [LEFT_VALUE_REFERENCE]: {
+                                refType: BuiltinTypes.STRING,
+                              },
+                              rightValue: {
+                                refType: createMetadataObjectType({
+                                  annotations: { metadataType: FLOW_FIELD_TYPE_NAMES.FLOW_ELEMENT_REFERENCE_OR_VALUE },
+                                  fields: {
+                                    [ELEMENT_REFERENCE]: {
+                                      refType: BuiltinTypes.STRING,
+                                    },
+                                  },
+                                }),
+                              },
+                            },
+                          }),
+                        ),
+                      },
+                    },
+                  }),
+                ),
               },
             },
           }),

--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -65,6 +65,11 @@ import {
   APPROVAL_PROCESS_METADATA_TYPE,
   LEFT_VALUE_REFERENCE,
   ELEMENT_REFERENCE,
+  FLEXI_PAGE_TYPE,
+  FLOW_METADATA_TYPE,
+  FLEXI_PAGE_REGION,
+  ITEM_INSTANCE,
+  COMPONENT_INSTANCE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -471,7 +476,68 @@ export const mockTypes = {
       suffix: 'recordType',
     },
   }),
-  Flow: createMetadataObjectType({
+  [FLEXI_PAGE_TYPE]: createMetadataObjectType({
+    annotations: {
+      metadataType: FLEXI_PAGE_TYPE,
+    },
+    fields: {
+      flexiPageRegions: {
+        refType: new ListType(
+          createMetadataObjectType({
+            annotations: {
+              metadataType: FLEXI_PAGE_REGION,
+            },
+            fields: {
+              itemInstances: {
+                refType: new ListType(
+                  createMetadataObjectType({
+                    annotations: {
+                      metadataType: ITEM_INSTANCE,
+                    },
+                    fields: {
+                      componentInstance: {
+                        refType: createMetadataObjectType({
+                          annotations: {
+                            metadataType: COMPONENT_INSTANCE,
+                          },
+                          fields: {
+                            visibilityRule: {
+                              refType: createMetadataObjectType({
+                                annotations: {
+                                  metadataType: 'UiFormulaRule',
+                                },
+                                fields: {
+                                  criteria: {
+                                    refType: new ListType(
+                                      createMetadataObjectType({
+                                        annotations: {
+                                          metadataType: 'UiFormulaCriterion',
+                                        },
+                                        fields: {
+                                          leftValue: {
+                                            refType: BuiltinTypes.STRING,
+                                          },
+                                        },
+                                      }),
+                                    ),
+                                  },
+                                },
+                              }),
+                            },
+                          },
+                        }),
+                      },
+                    },
+                  }),
+                ),
+              },
+            },
+          }),
+        ),
+      },
+    },
+  }),
+  [FLOW_METADATA_TYPE]: createMetadataObjectType({
     annotations: {
       metadataType: 'Flow',
       suffix: 'flow',


### PR DESCRIPTION
SALTO-3221-4531-4207-5929: Added custom references from Flow and FlexiPage to CustomFields

---

_Additional context for reviewer_:
Adding custom reference log message:
<img width="1312" alt="image" src="https://github.com/user-attachments/assets/d4c17ac4-8dbd-4fa0-941c-53e2858f35e9" />


---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between Flow and CustomFields.
- Improved IA between FlexiPage and CustomFields.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from Flow and FlexiPage to CustomFields.
