### PR TITLE
SALTO-7253: automation references

### DIFF
--- a/packages/jira-adapter/src/change_validators/index.ts
+++ b/packages/jira-adapter/src/change_validators/index.ts
@@ -83,7 +83,7 @@ const { deployTypesNotSupportedValidator, createChangeValidator, uniqueFieldsCha
 
 const TYPE_TO_UNIQUE_FIELD: Record<string, deployment.changeValidators.ScopeAndUniqueFields> = {
   [ISSUE_TYPE_NAME]: { scope: SCOPE.global, uniqueFields: ['name'] },
-  [PORTAL_GROUP_TYPE]: { scope: SCOPE.global, uniqueFields: ['name'] },
+  [PORTAL_GROUP_TYPE]: { scope: SCOPE.parent, uniqueFields: ['name'] },
   [SLA_TYPE_NAME]: { scope: SCOPE.parent, uniqueFields: ['name'] },
   [PROJECT_TYPE]: { scope: SCOPE.global, uniqueFields: ['name', 'key'] },
   [FIELD_CONTEXT_TYPE_NAME]: { scope: SCOPE.parent, uniqueFields: ['name'] },

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -83,7 +83,9 @@ const SMART_QUERY_SCHEME = Joi.object({
   query: Joi.object({
     type: Joi.string().required(),
     value: Joi.string().required(),
-  }).required(),
+  })
+    .unknown(true)
+    .required(),
 })
   .required()
   .unknown(true)

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -188,6 +188,7 @@ export const createAutomationTypes = (): {
       templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
       cmdbField: { refType: BuiltinTypes.UNKNOWN },
+      customFieldId: { refType: BuiltinTypes.UNKNOWN },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -187,8 +187,9 @@ export const createAutomationTypes = (): {
       objectTypeId: { refType: BuiltinTypes.STRING },
       templateFormsConfig: { refType: templateFormsConfigType },
       requestType: { refType: BuiltinTypes.UNKNOWN }, // can be string or { type: string; value: string }
-      cmdbField: { refType: BuiltinTypes.UNKNOWN },
-      customFieldId: { refType: BuiltinTypes.UNKNOWN },
+      cmdbField: { refType: BuiltinTypes.UNKNOWN }, // string or reference
+      customFieldId: { refType: BuiltinTypes.UNKNOWN }, // string or reference
+      fieldId: { refType: BuiltinTypes.UNKNOWN }, // string or reference
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1387,6 +1387,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: FIELD_TYPE_NAME },
   },
   {
+    src: { field: 'customFieldId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: FIELD_TYPE_NAME },
+  },
+  {
     src: { field: 'portalRequestTypeIds', parentTypes: ['FormPortal'] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -881,6 +881,11 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     target: { type: GROUP_TYPE_NAME },
   },
   {
+    src: { field: 'value', parentTypes: [AUTOMATION_EMAIL_RECIPENT] },
+    serializationStrategy: 'id',
+    target: { type: FIELD_TYPE_NAME },
+  },
+  {
     src: { field: 'field', parentTypes: [AUTOMATION_CONDITION] },
     serializationStrategy: 'id',
     target: { type: 'Field' },
@@ -1388,6 +1393,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   },
   {
     src: { field: 'customFieldId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: FIELD_TYPE_NAME },
+  },
+  {
+    src: { field: 'fieldId', parentTypes: [AUTOMATION_COMPONENT_VALUE_TYPE] },
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_TYPE_NAME },


### PR DESCRIPTION
Added support for additional references in automation rules

---

I added cover for the following:
1. Smart queries (places where the user can add smart tags)
2. Smart queries in IQL
3. Triggers of type jira.sla.threshold.trigger
4. Outgoing mails- the `to` is populated by a field (of a user or a group)
5. Conditions of type affected.service.condition

I also added a minor fix- the portals CV was too strict, it did not allow the deploy valid portal groups.
There are 4 commits- the first  for the minor fix,  the second for fix number 3, the third for fixes 4 & 5, and the last for fixes 1 & 2

Noise reduction will follow

---
_Release Notes_: 
Jira Adapter:
* Added support for additional references in Automations
---
_User Notifications_: 
Jira Adapter:
* References will replace values in relevant automation NaCls
