### PR TITLE
SALTO-2490 Remove export of closeRemoteMapsOfLocation

### DIFF
--- a/packages/local-workspace/index.ts
+++ b/packages/local-workspace/index.ts
@@ -33,7 +33,6 @@ export {
 export {
   createRemoteMapCreator,
   closeAllRemoteMaps,
-  closeRemoteMapsOfLocation,
   replicateDB,
   createReadOnlyRemoteMap,
   cleanDatabases,

--- a/packages/local-workspace/src/remote_map/index.ts
+++ b/packages/local-workspace/src/remote_map/index.ts
@@ -9,7 +9,6 @@ export {
   createRemoteMapCreator,
   createReadOnlyRemoteMap,
   closeAllRemoteMaps,
-  closeRemoteMapsOfLocation,
   cleanDatabases,
   replicateDB,
 } from './remote_map'

--- a/packages/local-workspace/src/remote_map/remote_map.ts
+++ b/packages/local-workspace/src/remote_map/remote_map.ts
@@ -261,10 +261,7 @@ const closeTmpConnection = async (
   log.debug('closed temporary connection to %s', tmpLocation)
 }
 
-/**
- * @deprecated use `workspace.close()` / `remoteMapCreator.close()` instead.
- */
-export const closeRemoteMapsOfLocation = async (location: string): Promise<boolean> =>
+const closeRemoteMapsOfLocation = async (location: string): Promise<boolean> =>
   log.timeDebug(
     async () => {
       let didClose = false

--- a/packages/local-workspace/test/remote_map/remote_map.test.ts
+++ b/packages/local-workspace/test/remote_map/remote_map.test.ts
@@ -20,7 +20,6 @@ import {
   TMP_DB_DIR,
   cleanDatabases,
   closeAllRemoteMaps,
-  closeRemoteMapsOfLocation,
 } from '../../src/remote_map/remote_map'
 import { remoteMapLocations } from '../../src/remote_map/location_pool'
 
@@ -901,37 +900,6 @@ describe('test operations on remote db', () => {
   })
   it('should throw exception if the namespace is invalid', async () => {
     await expect(createMap('inval:d')).rejects.toThrow()
-  })
-
-  describe('closeRemoteMapsOfLocation', () => {
-    const location = '/tmp/test_db_location'
-    let didClose: boolean
-
-    describe('when no connection was opened', () => {
-      beforeEach(async () => {
-        didClose = await closeRemoteMapsOfLocation(location)
-      })
-      it('should return false', async () => {
-        expect(didClose).toEqual(false)
-      })
-    })
-
-    describe('when there are opened connections', () => {
-      beforeEach(async () => {
-        const result = await createMap('namespace', true, location)
-        await result.remoteMap.has('key')
-        didClose = await closeRemoteMapsOfLocation(location)
-      })
-
-      it('should return true', async () => {
-        expect(didClose).toEqual(true)
-      })
-
-      it('should return false the second time', async () => {
-        didClose = await closeRemoteMapsOfLocation(location)
-        expect(didClose).toEqual(false)
-      })
-    })
   })
 
   describe('closeAllRemoteMaps', () => {

--- a/packages/local-workspace/test/remote_map/remote_map_connection.test.ts
+++ b/packages/local-workspace/test/remote_map/remote_map_connection.test.ts
@@ -12,7 +12,6 @@ import {
   createReadOnlyRemoteMap,
   MAX_CONNECTIONS,
   closeAllRemoteMaps,
-  closeRemoteMapsOfLocation,
 } from '../../src/remote_map/remote_map'
 import { remoteMapLocations } from '../../src/remote_map/location_pool'
 
@@ -78,23 +77,6 @@ describe('connection creation', () => {
       expect(readOnlyCalls).toHaveLength(2)
       // 2 tmp connections
       expect(writeCalls).toHaveLength(2)
-    })
-    describe('closeRemoteMapsOfLocation', () => {
-      let cacheReturnSpy: jest.SpyInstance
-      beforeEach(() => {
-        cacheReturnSpy = jest.spyOn(remoteMapLocations, 'return')
-      })
-      describe('with a location that was not opened', () => {
-        beforeEach(async () => {
-          await closeRemoteMapsOfLocation('dummy_location')
-        })
-        it('should not close anything', async () => {
-          expect(mockClose).not.toHaveBeenCalled()
-        })
-        it('should not return the cache of the location', () => {
-          expect(cacheReturnSpy).not.toHaveBeenCalled()
-        })
-      })
     })
     describe('close', () => {
       let cacheReturnSpy: jest.SpyInstance


### PR DESCRIPTION
use `workspace.close()` / `remoteMapCreator.close()` instead.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- Removed export of `closeRemoteMapsOfLocation`. use `workspace.close()` / `remoteMapCreator.close()` instead.

---
_User Notifications_: 
None
