### PR TITLE
SALTO-7392: (Bugfix) Salesforce fetch name-spaced instances within Folders and add CustomApplication logo reference

### DIFF
--- a/packages/salesforce-adapter/src/filters/utils.ts
+++ b/packages/salesforce-adapter/src/filters/utils.ts
@@ -438,7 +438,11 @@ export const addElementParentReference = (instance: InstanceElement, element: El
 export const fullApiName = (parent: string, child: string): string => [parent, child].join(API_NAME_SEPARATOR)
 
 export const getFullName = (obj: FileProperties, addNamespacePrefixToFullName = true): string => {
-  if (!obj.namespacePrefix) {
+  if (
+    !obj.namespacePrefix ||
+    // Instances within folders fullNames are correct and will include a `/` character
+    obj.fullName.includes('/')
+  ) {
     return obj.fullName
   }
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -999,6 +999,10 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     serializationStrategy: 'assignToReferenceField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
+  {
+    src: { field: 'logo', parentTypes: ['CustomApplication'] },
+    target: { type: 'Document' },
+  },
 ]
 
 const matchName = (name: string, matcher: string | RegExp): boolean =>

--- a/packages/salesforce-adapter/test/filters/utils.test.ts
+++ b/packages/salesforce-adapter/test/filters/utils.test.ts
@@ -948,6 +948,16 @@ describe('filter utils', () => {
           false,
         ),
       ).toEqual('Parent.Test')
+      // Instances within folders
+      expect(
+        getFullName(
+          mockFileProperties({
+            fullName: 'DocumentsFolder/logo.png',
+            namespacePrefix: 'test',
+            type: 'Document',
+          }),
+        ),
+      ).toEqual('DocumentsFolder/logo.png')
     })
   })
   describe('isInstanceOfCustomObjectSync', () => {


### PR DESCRIPTION
(Bugfix) Salesforce fetch name-spaced instances within Folders and add CustomApplication logo reference

---

Workspace Diff: https://github.com/salto-io/tamir-sf/commit/9f2a92bf63a806a5a98b5279d8ac81bbff7f71b7
The adapter returned incorrect fullName for the fileProperties of instances within folder that has a namespace

---
_Release Notes_: 
_Salesforce Adapter_:
- (Bugfix) fetch name-spaced instances within Folders.
- Add reference to CustomApplication logos.

---
_User Notifications_: 
_None_
