### PR TITLE
SALTO-7395: (Bugfix) Fix false positives for FlowElements with non-unique names in the Unique FlowElement Name CV

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
+++ b/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
@@ -14,26 +14,34 @@ import {
   isAdditionOrModificationChange,
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
-import { WALK_NEXT_STEP, walkOnElement, WalkOnFunc } from '@salto-io/adapter-utils'
+import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import { isInstanceOfTypeSync } from '../filters/utils'
-import { FLOW_METADATA_TYPE } from '../constants'
+import { FLOW_ELEMENTS_WITH_UNIQUE_NAMES, FLOW_METADATA_TYPE } from '../constants'
 
 const { DefaultMap } = collections.map
 
 const createChangeErrors = (element: InstanceElement): ChangeError[] => {
   const duplicates = new Set<string>()
   const nameToElemIds = new DefaultMap<string, ElemID[]>(() => [])
-  const mapNameToElemIds: WalkOnFunc = ({ value, path }) => {
-    if (path === undefined || path.name !== 'name') return WALK_NEXT_STEP.RECURSE
+  const mapNameToElemIds: TransformFuncSync = ({ value, path, field }) => {
+    if (
+      field === undefined ||
+      path === undefined ||
+      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(field.elemID.typeName) ||
+      path.name !== 'name'
+    )
+      return value
     if (nameToElemIds.get(value).length > 0) {
       duplicates.add(value)
     }
     nameToElemIds.get(value).push(path)
-    return WALK_NEXT_STEP.RECURSE
+    return value
   }
-  walkOnElement({
-    element,
-    func: mapNameToElemIds,
+  transformValuesSync({
+    values: element.value,
+    pathID: element.elemID,
+    type: element.getTypeSync(),
+    transformFunc: mapNameToElemIds,
   })
   return Array.from(duplicates).flatMap(name =>
     nameToElemIds.get(name).map(elemId => ({

--- a/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
+++ b/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
@@ -15,7 +15,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
-import { isInstanceOfTypeSync } from '../filters/utils'
+import { apiNameSync, isInstanceOfTypeSync } from '../filters/utils'
 import { FLOW_ELEMENTS_WITH_UNIQUE_NAMES, FLOW_METADATA_TYPE } from '../constants'
 
 const { DefaultMap } = collections.map
@@ -27,7 +27,7 @@ const createChangeErrors = (element: InstanceElement): ChangeError[] => {
     if (
       field === undefined ||
       path === undefined ||
-      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(field.elemID.typeName) ||
+      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.parent) ?? '') ||
       path.name !== 'name'
     )
       return value

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -113,6 +113,24 @@ export enum FLOW_NODE_FIELD_NAMES {
   LOCATION_X = 'locationX',
   LOCATION_Y = 'locationY',
 }
+export const FLOW_ELEMENTS_WITH_UNIQUE_NAMES = [
+  'FlowChoice',
+  'FlowConstant',
+  'FlowDynamicChoiceSet',
+  'FlowExitRule',
+  'FlowExperimentPath',
+  'FlowFormula',
+  'FlowNode',
+  'FlowRule',
+  'FlowScheduledPath',
+  'FlowScreenField',
+  'FlowStage',
+  'FlowCapability',
+  'FlowCapabilityInput',
+  'FlowTextTemplate',
+  'FlowVariable',
+  'FlowWaitEvent',
+]
 
 export const FLOW_FIELD_TYPE_NAMES = {
   FLOW_ASSIGNMENT_ITEM: 'FlowAssignmentItem',

--- a/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
@@ -14,11 +14,11 @@ import { FLOW_METADATA_TYPE } from '../../src/constants'
 describe('uniqueFlowElementName change validator', () => {
   let flowChange: Change
   let flowElement: MetadataObjectType
-  let flowElementWithNonuniqueName: MetadataObjectType
+  let flowElementWithNonUniqueName: MetadataObjectType
   let flow: MetadataObjectType
   let flowInstance: InstanceElement
   beforeEach(() => {
-    flowElementWithNonuniqueName = createMetadataObjectType({
+    flowElementWithNonUniqueName = createMetadataObjectType({
       annotations: {
         metadataType: 'FlowMetadataValue',
       },
@@ -44,7 +44,7 @@ describe('uniqueFlowElementName change validator', () => {
         dynamicChoiceSets: { refType: new ListType(flowElement), annotations: { required: false } },
         screens: { refType: new ListType(flowElement), annotations: { required: false } },
         processMetadataValues: {
-          refType: new ListType(flowElementWithNonuniqueName),
+          refType: new ListType(flowElementWithNonUniqueName),
           annotations: { required: false },
         },
       },

--- a/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
@@ -13,11 +13,20 @@ import { FLOW_METADATA_TYPE } from '../../src/constants'
 
 describe('uniqueFlowElementName change validator', () => {
   let flowChange: Change
-  let FlowElement: MetadataObjectType
+  let flowElement: MetadataObjectType
+  let flowElementWithNonuniqueName: MetadataObjectType
   let flow: MetadataObjectType
   let flowInstance: InstanceElement
   beforeEach(() => {
-    FlowElement = createMetadataObjectType({
+    flowElementWithNonuniqueName = createMetadataObjectType({
+      annotations: {
+        metadataType: 'FlowMetadataValue',
+      },
+      fields: {
+        name: { refType: BuiltinTypes.STRING },
+      },
+    })
+    flowElement = createMetadataObjectType({
       annotations: {
         metadataType: 'FlowConstant',
       },
@@ -30,10 +39,14 @@ describe('uniqueFlowElementName change validator', () => {
         metadataType: FLOW_METADATA_TYPE,
       },
       fields: {
-        constants: { refType: new ListType(FlowElement), annotations: { required: false } },
-        decisions: { refType: new ListType(FlowElement), annotations: { required: false } },
-        dynamicChoiceSets: { refType: new ListType(FlowElement), annotations: { required: false } },
-        screens: { refType: new ListType(FlowElement), annotations: { required: false } },
+        constants: { refType: new ListType(flowElement), annotations: { required: false } },
+        decisions: { refType: new ListType(flowElement), annotations: { required: false } },
+        dynamicChoiceSets: { refType: new ListType(flowElement), annotations: { required: false } },
+        screens: { refType: new ListType(flowElement), annotations: { required: false } },
+        processMetadataValues: {
+          refType: new ListType(flowElementWithNonuniqueName),
+          annotations: { required: false },
+        },
       },
     })
   })
@@ -46,6 +59,7 @@ describe('uniqueFlowElementName change validator', () => {
           decisions: [{ name: 'decision1' }],
           dynamicChoiceSets: [{ name: 'dynamicChoice1' }],
           screens: [{ name: 'screen1' }],
+          processMetadataValues: [{ name: 'value1' }],
         },
         flow,
       )
@@ -62,15 +76,16 @@ describe('uniqueFlowElementName change validator', () => {
         {
           fullName: 'TestFlow',
           constants: [{ name: 'duplicateName' }, { name: 'duplicateName' }],
-          decisions: [{ name: 'uniqueName' }],
+          decisions: [{ name: 'uniqueName' }, { name: 'ThirdDuplicateName' }],
           dynamicChoiceSets: [{ name: 'duplicateName' }],
           screens: [{ name: 'anotherDuplicateName' }, { name: 'anotherDuplicateName' }],
+          processMetadataValues: [{ name: 'ThirdDuplicateName' }, { name: 'ThirdDuplicateName' }],
         },
         flow,
       )
       flowChange = toChange({ after: flowInstance })
     })
-    it('should return change errors for duplicate names', async () => {
+    it('should return change errors for duplicate names in FlowElements with unique name only', async () => {
       const errors = await uniqueFlowElementName([flowChange])
       const expectedErrors = [
         {


### PR DESCRIPTION
SALTO-7395: (Bugfix) Fix false positives for FlowElements with non-unique names in the Unique FlowElement Name CV

---
_Release Notes_: 
None

---
_User Notifications_: 
None
