### PR TITLE
SALTO-7193: Fix complex fields NaCl representation where all inner fields are hidden

### DIFF
--- a/packages/adapter-components/src/deployment/filtering.ts
+++ b/packages/adapter-components/src/deployment/filtering.ts
@@ -26,7 +26,7 @@ export const filterUndeployableValues = async (
     element: instance,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
     elementsSource,
     transformFunc: ({ value, field }) => {
       // The === false is because if the value is undefined, we don't want to filter it out
@@ -48,7 +48,7 @@ export const filterIgnoredValues = async (
         element: instance,
         strict: false,
         allowEmptyArrays: true,
-        allowEmptyObjects: true,
+        allowExistingEmptyObjects: true,
         elementsSource,
         transformFunc: ({ value, path }) => {
           if (path !== undefined && fieldsToIgnore(path)) {

--- a/packages/adapter-components/src/elements_deprecated/swagger/deployment/additional_properties.ts
+++ b/packages/adapter-components/src/elements_deprecated/swagger/deployment/additional_properties.ts
@@ -65,7 +65,7 @@ export const flattenAdditionalProperties = async (
       element,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
       elementsSource,
       transformFunc: async ({ value, field, path }) => {
         const type = path?.isTopLevel() ? await element.getType(elementsSource) : await field?.getType(elementsSource)

--- a/packages/adapter-components/src/fetch/element/standalone.ts
+++ b/packages/adapter-components/src/fetch/element/standalone.ts
@@ -190,7 +190,7 @@ export const extractStandaloneInstances = <Options extends FetchApiDefinitionsOp
         definedTypes,
       }),
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })
     if (value !== undefined) {
       inst.value = value

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -443,12 +443,14 @@ export const removeNullValues = ({
   values,
   type,
   allowEmptyArrays = false,
-  allowEmptyObjects = false,
+  allowExistingEmptyObjects = false,
+  allowNewEmptyObjects = false,
 }: {
   values: Values
   type: ObjectType
   allowEmptyArrays?: boolean
-  allowEmptyObjects?: boolean
+  allowExistingEmptyObjects?: boolean
+  allowNewEmptyObjects?: boolean
 }): Values =>
   transformValuesSync({
     values,
@@ -456,7 +458,8 @@ export const removeNullValues = ({
     transformFunc: removeNullValuesTransformFunc,
     strict: false,
     allowEmptyArrays,
-    allowEmptyObjects,
+    allowExistingEmptyObjects,
+    allowNewEmptyObjects,
   }) ?? {}
 
 /**

--- a/packages/adapter-components/src/fetch/element/type_utils.ts
+++ b/packages/adapter-components/src/fetch/element/type_utils.ts
@@ -444,13 +444,13 @@ export const removeNullValues = ({
   type,
   allowEmptyArrays = false,
   allowExistingEmptyObjects = false,
-  allowNewEmptyObjects = false,
+  allowAllEmptyObjects = false,
 }: {
   values: Values
   type: ObjectType
   allowEmptyArrays?: boolean
   allowExistingEmptyObjects?: boolean
-  allowNewEmptyObjects?: boolean
+  allowAllEmptyObjects?: boolean
 }): Values =>
   transformValuesSync({
     values,
@@ -459,7 +459,7 @@ export const removeNullValues = ({
     strict: false,
     allowEmptyArrays,
     allowExistingEmptyObjects,
-    allowNewEmptyObjects,
+    allowAllEmptyObjects,
   }) ?? {}
 
 /**

--- a/packages/adapter-components/src/filters/referenced_instance_names.ts
+++ b/packages/adapter-components/src/filters/referenced_instance_names.ts
@@ -125,9 +125,9 @@ const createNewInstance = async (
     element: currentInstance,
     transformFunc: createReferencesTransformFunc(currentInstance.elemID, newElemId),
     strict: false,
-    // We don't want to update the element, so we are permissive with the allowEmptyArrays and allowEmptyObjects
+    // We don't want to update the element, so we are permissive with the allowEmptyArrays and allowExistingEmptyObjects
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
   })
   return new InstanceElement(
     newElemId.name,

--- a/packages/adapter-components/src/filters/sort_lists.ts
+++ b/packages/adapter-components/src/filters/sort_lists.ts
@@ -39,7 +39,7 @@ const sortLists = (instance: InstanceElement, defQuery: DefQuery<ElementFetchDef
       type: instance.getTypeSync(),
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
       transformFunc: ({ value, field }: TransformFuncArgs) => {
         if (field === undefined || !Array.isArray(value)) {
           return value

--- a/packages/adapter-components/src/references/field_references.ts
+++ b/packages/adapter-components/src/references/field_references.ts
@@ -224,7 +224,7 @@ export const replaceReferenceValues = async <TContext extends string, CustomInde
       strict: false,
       pathID: instance.elemID,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? instance.value
   )
 }

--- a/packages/adapter-components/src/resolve_utils.ts
+++ b/packages/adapter-components/src/resolve_utils.ts
@@ -77,7 +77,7 @@ export const resolveValues: ResolveValuesFunc = async (element, getLookUpName, e
     strict: false,
     elementsSource,
     allowEmptyArrays: allowEmpty,
-    allowEmptyObjects: allowEmpty,
+    allowExistingEmptyObjects: allowEmpty,
   })
 }
 

--- a/packages/adapter-components/src/restore_utils.ts
+++ b/packages/adapter-components/src/restore_utils.ts
@@ -110,7 +110,7 @@ export const restoreValues: RestoreValuesFunc = async (source, targetElement, ge
     transformFunc: restoreValuesFunc,
     strict: false,
     allowEmptyArrays: allowEmpty,
-    allowEmptyObjects: allowEmpty,
+    allowExistingEmptyObjects: allowEmpty,
   })
 }
 

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -183,12 +183,8 @@ const removeEmptyParts = ({
   }
   if (_.isPlainObject(value)) {
     const filtered = _.omitBy(value, _.isUndefined)
-    const isExistingEmptyObject = _.isEmpty(filtered) && _.isEmpty(value)
-    const isNewEmptyObject = _.isEmpty(filtered) && !_.isEmpty(value)
-    return (isExistingEmptyObject && !allowExistingEmptyObjects && !allowAllEmptyObjects) ||
-      (isNewEmptyObject && !allowAllEmptyObjects)
-      ? undefined
-      : filtered
+    const isEmptyAllowed = allowAllEmptyObjects || (allowExistingEmptyObjects && _.isEmpty(value))
+    return _.isEmpty(filtered) && !isEmptyAllowed : undefined : filtered
   }
   return value
 }

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -80,7 +80,7 @@ type TransformValuesBaseArgs = {
   // Keep empty objects in the result if they were originally empty
   allowExistingEmptyObjects?: boolean
   // Keep all empty objects, even if they became empty as a result of the transformation
-  allowNewEmptyObjects?: boolean
+  allowAllEmptyObjects?: boolean
 }
 
 type TransformValuesSyncArgs = TransformValuesBaseArgs & { transformFunc: TransformFuncSync }
@@ -170,12 +170,12 @@ const removeEmptyParts = ({
   value,
   allowEmptyArrays,
   allowExistingEmptyObjects,
-  allowNewEmptyObjects = false,
+  allowAllEmptyObjects = false,
 }: {
   value: Value
   allowEmptyArrays: boolean
   allowExistingEmptyObjects: boolean
-  allowNewEmptyObjects?: boolean
+  allowAllEmptyObjects?: boolean
 }): Value => {
   if (Array.isArray(value)) {
     const filtered = value.filter(isDefined)
@@ -185,7 +185,7 @@ const removeEmptyParts = ({
     const filtered = _.omitBy(value, _.isUndefined)
     const isExistingEmptyObject = _.isEmpty(filtered) && _.isEmpty(value)
     const isNewEmptyObject = _.isEmpty(filtered) && !_.isEmpty(value)
-    return (isExistingEmptyObject && !allowExistingEmptyObjects) || (isNewEmptyObject && !allowNewEmptyObjects)
+    return (isExistingEmptyObject && !allowExistingEmptyObjects) || (isNewEmptyObject && !allowAllEmptyObjects)
       ? undefined
       : filtered
   }
@@ -292,7 +292,7 @@ export const transformValues = async ({
   isTopLevel = true,
   allowEmptyArrays = false,
   allowExistingEmptyObjects = false,
-  allowNewEmptyObjects = false,
+  allowAllEmptyObjects = false,
 }: TransformValuesArgs): Promise<Values | undefined> => {
   const transformValue = async (value: Value, keyPathID?: ElemID, field?: Field): Promise<Value> => {
     if (field === undefined && strict) {
@@ -314,7 +314,7 @@ export const transformValues = async ({
       field,
       fieldType: await field?.getType(elementsSource),
     })
-    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowExistingEmptyObjects, allowNewEmptyObjects })
+    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowExistingEmptyObjects, allowAllEmptyObjects })
   }
 
   const fieldMapper = fieldMapperGenerator(type, values)
@@ -327,7 +327,7 @@ export const transformValues = async ({
       ),
       _.isUndefined,
     )
-    return _.isEmpty(result) && (!allowExistingEmptyObjects || !allowNewEmptyObjects) ? undefined : result
+    return _.isEmpty(result) && (!allowExistingEmptyObjects || !allowAllEmptyObjects) ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = await awu(newVal)
@@ -348,7 +348,7 @@ export const transformValuesSync = ({
   isTopLevel = true,
   allowEmptyArrays = false,
   allowExistingEmptyObjects = false,
-  allowNewEmptyObjects = false,
+  allowAllEmptyObjects = false,
 }: TransformValuesSyncArgs): lowerDashTypes.NonPromise<Value> | undefined => {
   const transformValue = (value: Value, keyPathID?: ElemID, field?: Field): lowerDashTypes.NonPromise<Value> => {
     if (field === undefined && strict) {
@@ -370,7 +370,7 @@ export const transformValuesSync = ({
       field,
       fieldType: field?.getTypeSync(),
     })
-    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowExistingEmptyObjects, allowNewEmptyObjects })
+    return removeEmptyParts({ value: recursed, allowEmptyArrays, allowExistingEmptyObjects, allowAllEmptyObjects })
   }
 
   const fieldMapper = fieldMapperGenerator(type, values)
@@ -423,7 +423,7 @@ export const transformElementAnnotations = async <T extends Element>({
   elementsSource,
   allowEmptyArrays,
   allowExistingEmptyObjects,
-  allowNewEmptyObjects,
+  allowAllEmptyObjects,
 }: {
   element: T
   transformFunc: TransformFunc
@@ -431,7 +431,7 @@ export const transformElementAnnotations = async <T extends Element>({
   elementsSource?: ReadOnlyElementsSource
   allowEmptyArrays?: boolean
   allowExistingEmptyObjects?: boolean
-  allowNewEmptyObjects?: boolean
+  allowAllEmptyObjects?: boolean
 }): Promise<Values> =>
   (await transformValues({
     values: element.annotations,
@@ -442,7 +442,7 @@ export const transformElementAnnotations = async <T extends Element>({
     elementsSource,
     allowEmptyArrays,
     allowExistingEmptyObjects,
-    allowNewEmptyObjects,
+    allowAllEmptyObjects,
     isTopLevel: false,
   })) || {}
 
@@ -454,7 +454,7 @@ export const transformElement = async <T extends Element>({
   runOnFields,
   allowEmptyArrays,
   allowExistingEmptyObjects,
-  allowNewEmptyObjects,
+  allowAllEmptyObjects,
 }: {
   element: T
   transformFunc: TransformFunc
@@ -463,7 +463,7 @@ export const transformElement = async <T extends Element>({
   runOnFields?: boolean
   allowEmptyArrays?: boolean
   allowExistingEmptyObjects?: boolean
-  allowNewEmptyObjects?: boolean
+  allowAllEmptyObjects?: boolean
 }): Promise<T> => {
   let newElement: Element
   const transformedAnnotations = await transformElementAnnotations({
@@ -473,7 +473,7 @@ export const transformElement = async <T extends Element>({
     elementsSource,
     allowEmptyArrays,
     allowExistingEmptyObjects,
-    allowNewEmptyObjects,
+    allowAllEmptyObjects,
   })
 
   if (isInstanceElement(element)) {
@@ -487,7 +487,7 @@ export const transformElement = async <T extends Element>({
         pathID: element.elemID,
         allowEmptyArrays,
         allowExistingEmptyObjects,
-        allowNewEmptyObjects,
+        allowAllEmptyObjects,
       })) || {}
 
     newElement = new InstanceElement(
@@ -513,7 +513,7 @@ export const transformElement = async <T extends Element>({
             runOnFields,
             allowEmptyArrays,
             allowExistingEmptyObjects,
-            allowNewEmptyObjects,
+            allowAllEmptyObjects,
           })
         }
         return undefined
@@ -562,7 +562,7 @@ export const transformElement = async <T extends Element>({
         runOnFields,
         allowEmptyArrays,
         allowExistingEmptyObjects,
-        allowNewEmptyObjects,
+        allowAllEmptyObjects,
       }),
     )
     return newElement as T
@@ -578,7 +578,7 @@ export const transformElement = async <T extends Element>({
         runOnFields,
         allowEmptyArrays,
         allowExistingEmptyObjects,
-        allowNewEmptyObjects,
+        allowAllEmptyObjects,
       }),
     )
     return newElement as T

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -185,7 +185,8 @@ const removeEmptyParts = ({
     const filtered = _.omitBy(value, _.isUndefined)
     const isExistingEmptyObject = _.isEmpty(filtered) && _.isEmpty(value)
     const isNewEmptyObject = _.isEmpty(filtered) && !_.isEmpty(value)
-    return (isExistingEmptyObject && !allowExistingEmptyObjects) || (isNewEmptyObject && !allowAllEmptyObjects)
+    return (isExistingEmptyObject && !allowExistingEmptyObjects && !allowAllEmptyObjects) ||
+      (isNewEmptyObject && !allowAllEmptyObjects)
       ? undefined
       : filtered
   }
@@ -294,10 +295,6 @@ export const transformValues = async ({
   allowExistingEmptyObjects = false,
   allowAllEmptyObjects = false,
 }: TransformValuesArgs): Promise<Values | undefined> => {
-  if (allowAllEmptyObjects && !allowExistingEmptyObjects) {
-    throw new Error('allowExistingEmptyObjects must be true when allowAllEmptyObjects is true')
-  }
-
   const transformValue = async (value: Value, keyPathID?: ElemID, field?: Field): Promise<Value> => {
     if (field === undefined && strict) {
       return undefined
@@ -385,7 +382,7 @@ export const transformValuesSync = ({
       _.mapValues(newVal ?? {}, (value, key) => transformValue(value, pathID?.createNestedID(key), fieldMapper(key))),
       _.isUndefined,
     )
-    return _.isEmpty(result) && !allowExistingEmptyObjects ? undefined : result
+    return _.isEmpty(result) && !allowExistingEmptyObjects && !allowAllEmptyObjects ? undefined : result
   }
   if (_.isArray(newVal)) {
     const result = newVal

--- a/packages/adapter-utils/src/utils.ts
+++ b/packages/adapter-utils/src/utils.ts
@@ -170,12 +170,12 @@ const removeEmptyParts = ({
   value,
   allowEmptyArrays,
   allowExistingEmptyObjects,
-  allowAllEmptyObjects = false,
+  allowAllEmptyObjects,
 }: {
   value: Value
   allowEmptyArrays: boolean
   allowExistingEmptyObjects: boolean
-  allowAllEmptyObjects?: boolean
+  allowAllEmptyObjects: boolean
 }): Value => {
   if (Array.isArray(value)) {
     const filtered = value.filter(isDefined)
@@ -294,6 +294,10 @@ export const transformValues = async ({
   allowExistingEmptyObjects = false,
   allowAllEmptyObjects = false,
 }: TransformValuesArgs): Promise<Values | undefined> => {
+  if (allowAllEmptyObjects && !allowExistingEmptyObjects) {
+    throw new Error('allowExistingEmptyObjects must be true when allowAllEmptyObjects is true')
+  }
+
   const transformValue = async (value: Value, keyPathID?: ElemID, field?: Field): Promise<Value> => {
     if (field === undefined && strict) {
       return undefined

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -906,41 +906,22 @@ describe('Test utils.ts', () => {
       })
 
       describe('with allowExistingEmptyObjects', () => {
-        it('should remove empty lists and not remove empty objects', async () => {
-          const result = await transformValues({
-            values: {
-              arr: [],
-              obj: {
-                nestedArr: [],
-                val: 'a',
+        describe('with the top-level values becoming empty', () => {
+          it('should return undefined', async () => {
+            const result = await transformValues({
+              values: {
+                key: 'value',
               },
-              emptyObj: {
-                nested: {},
-              },
-              newEmptyObj: {
-                deletedNested: undefined,
-              },
-            },
-            type,
-            transformFunc: ({ value }) => value,
-            allowExistingEmptyObjects: true,
-          })
+              type,
+              transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+              allowExistingEmptyObjects: true,
+            })
 
-          expect(result).toEqual({
-            obj: {
-              val: 'a',
-            },
-            emptyObj: {
-              nested: {},
-            },
+            expect(result).toBeUndefined()
           })
         })
-      })
-
-      describe.each([true, false])(
-        'with allowExistingEmptyObjects=%s and allowAllEmptyObjects=true',
-        allowExistingEmptyObjects => {
-          it('Should not remove any empty objects, regardless of allowExistingEmptyObjects', async () => {
+        describe('with nested empty objects', () => {
+          it('should remove empty lists and not remove empty objects', async () => {
             const result = await transformValues({
               values: {
                 arr: [],
@@ -957,8 +938,7 @@ describe('Test utils.ts', () => {
               },
               type,
               transformFunc: ({ value }) => value,
-              allowExistingEmptyObjects,
-              allowAllEmptyObjects: true,
+              allowExistingEmptyObjects: true,
             })
 
             expect(result).toEqual({
@@ -968,7 +948,59 @@ describe('Test utils.ts', () => {
               emptyObj: {
                 nested: {},
               },
-              newEmptyObj: {},
+            })
+          })
+        })
+      })
+
+      describe.each([true, false])(
+        'with allowExistingEmptyObjects=%s and allowAllEmptyObjects=true',
+        allowExistingEmptyObjects => {
+          describe('with the top-level values becoming empty', () => {
+            it('should return an empty object', async () => {
+              const result = await transformValues({
+                values: {
+                  key: 'value',
+                },
+                type,
+                transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result).toEqual({})
+            })
+          })
+          describe('with nested empty objects', () => {
+            it('Should not remove any empty objects, regardless of allowExistingEmptyObjects', async () => {
+              const result = await transformValues({
+                values: {
+                  arr: [],
+                  obj: {
+                    nestedArr: [],
+                    val: 'a',
+                  },
+                  emptyObj: {
+                    nested: {},
+                  },
+                  newEmptyObj: {
+                    deletedNested: undefined,
+                  },
+                },
+                type,
+                transformFunc: ({ value }) => value,
+                allowExistingEmptyObjects,
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result).toEqual({
+                obj: {
+                  val: 'a',
+                },
+                emptyObj: {
+                  nested: {},
+                },
+                newEmptyObj: {},
+              })
             })
           })
         },
@@ -1561,8 +1593,8 @@ describe('Test utils.ts', () => {
         },
       })
       describe('with allowEmptyArrays', () => {
-        it('should remove empty objects and not remove empty lists', async () => {
-          const result = await transformValues({
+        it('should remove empty objects and not remove empty lists', () => {
+          const result = transformValuesSync({
             values: {
               arr: [],
               obj: {
@@ -1589,37 +1621,106 @@ describe('Test utils.ts', () => {
       })
 
       describe('with allowExistingEmptyObjects', () => {
-        it('should not remove empty objects and remove empty list', async () => {
-          const result = await transformValues({
-            values: {
-              arr: [],
+        describe('with the top-level values becoming empty', () => {
+          it('should return undefined', async () => {
+            const result = await transformValues({
+              values: {
+                key: 'value',
+              },
+              type,
+              transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+              allowExistingEmptyObjects: true,
+            })
+
+            expect(result).toBeUndefined()
+          })
+        })
+        describe('with nested empty objects', () => {
+          it('should not remove empty objects and remove empty list', () => {
+            const result = transformValuesSync({
+              values: {
+                arr: [],
+                obj: {
+                  nestedArr: [],
+                  val: 'a',
+                },
+                emptyObj: {
+                  nested: {},
+                },
+              },
+              type,
+              transformFunc: ({ value }) => value,
+              allowExistingEmptyObjects: true,
+            })
+
+            expect(result).toEqual({
               obj: {
-                nestedArr: [],
                 val: 'a',
               },
               emptyObj: {
                 nested: {},
               },
-            },
-            type,
-            transformFunc: ({ value }) => value,
-            allowExistingEmptyObjects: true,
-          })
-
-          expect(result).toEqual({
-            obj: {
-              val: 'a',
-            },
-            emptyObj: {
-              nested: {},
-            },
+            })
           })
         })
       })
 
+      describe.each([true, false])(
+        'with allowExistingEmptyObjects=%s and allowAllEmptyObjects=true',
+        allowExistingEmptyObjects => {
+          describe('with the top-level values becoming empty', () => {
+            it('should return an empty object', () => {
+              const result = transformValuesSync({
+                values: {
+                  key: 'value',
+                },
+                type,
+                transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result).toEqual({})
+            })
+          })
+          describe('with nested empty objects', () => {
+            it('Should not remove any empty objects, regardless of allowExistingEmptyObjects', () => {
+              const result = transformValuesSync({
+                values: {
+                  arr: [],
+                  obj: {
+                    nestedArr: [],
+                    val: 'a',
+                  },
+                  emptyObj: {
+                    nested: {},
+                  },
+                  newEmptyObj: {
+                    deletedNested: undefined,
+                  },
+                },
+                type,
+                transformFunc: ({ value }) => value,
+                allowExistingEmptyObjects,
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result).toEqual({
+                obj: {
+                  val: 'a',
+                },
+                emptyObj: {
+                  nested: {},
+                },
+                newEmptyObj: {},
+              })
+            })
+          })
+        },
+      )
+
       describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {
-          const result = await transformValues({
+          const result = transformValuesSync({
             values: {
               arr: [],
               obj: {
@@ -1942,6 +2043,9 @@ describe('Test utils.ts', () => {
         emptyObj: {
           nested: {},
         },
+        newEmptyObj: {
+          deletedNested: undefined,
+        },
       })
       describe('with allowEmptyArrays', () => {
         it('should remove empty objects and not remove empty list', async () => {
@@ -1962,24 +2066,76 @@ describe('Test utils.ts', () => {
       })
 
       describe('with allowExistingEmptyObjects', () => {
-        it('should remove empty lists and not remove empty objects', async () => {
-          const result = await transformElement({
-            element,
-            transformFunc: ({ value }) => value,
-            strict: false,
-            allowExistingEmptyObjects: true,
-          })
+        describe('with the top-level values becoming empty', () => {
+          it('should return an empty object', async () => {
+            const result = await transformElement({
+              element: new InstanceElement('instance', type, { key: 'value' }),
+              transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+              allowExistingEmptyObjects: true,
+            })
 
-          expect(result.value).toEqual({
-            obj: {
-              val: 'a',
-            },
-            emptyObj: {
-              nested: {},
-            },
+            // While this is a new empty object, an instance element always has a defined `values` object.
+            expect(result.value).toEqual({})
+          })
+        })
+        describe('with nested empty objects', () => {
+          it('should remove empty lists and not remove empty objects', async () => {
+            const result = await transformElement({
+              element,
+              transformFunc: ({ value }) => value,
+              strict: false,
+              allowExistingEmptyObjects: true,
+            })
+
+            expect(result.value).toEqual({
+              obj: {
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+            })
           })
         })
       })
+
+      describe.each([true, false])(
+        'with allowExistingEmptyObjects=%s and allowAllEmptyObjects=true',
+        allowExistingEmptyObjects => {
+          describe('with the top-level values becoming empty', () => {
+            it('should return an empty object', async () => {
+              const result = await transformElement({
+                element: new InstanceElement('instance', type, { key: 'value' }),
+                transformFunc: ({ field, value }) => (field?.name === 'key' ? undefined : value),
+                allowExistingEmptyObjects,
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result.value).toEqual({})
+            })
+          })
+          describe('with nested empty objects', () => {
+            it('Should not remove any empty objects, regardless of allowExistingEmptyObjects', async () => {
+              const result = await transformElement({
+                element,
+                transformFunc: ({ value }) => value,
+                allowExistingEmptyObjects,
+                allowAllEmptyObjects: true,
+              })
+
+              expect(result.value).toEqual({
+                obj: {
+                  val: 'a',
+                },
+                emptyObj: {
+                  nested: {},
+                },
+                newEmptyObj: {},
+              })
+            })
+          })
+        },
+      )
 
       describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -937,52 +937,42 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowExistingEmptyObjects and allowAllEmptyObjects', () => {
-        it('should remove empty lists and not remove empty objects', async () => {
-          const result = await transformValues({
-            values: {
-              arr: [],
+      describe.each([true, false])(
+        'with allowExistingEmptyObjects=%s and allowAllEmptyObjects=true',
+        allowExistingEmptyObjects => {
+          it('Should not remove any empty objects, regardless of allowExistingEmptyObjects', async () => {
+            const result = await transformValues({
+              values: {
+                arr: [],
+                obj: {
+                  nestedArr: [],
+                  val: 'a',
+                },
+                emptyObj: {
+                  nested: {},
+                },
+                newEmptyObj: {
+                  deletedNested: undefined,
+                },
+              },
+              type,
+              transformFunc: ({ value }) => value,
+              allowExistingEmptyObjects,
+              allowAllEmptyObjects: true,
+            })
+
+            expect(result).toEqual({
               obj: {
-                nestedArr: [],
                 val: 'a',
               },
               emptyObj: {
                 nested: {},
               },
-              newEmptyObj: {
-                deletedNested: undefined,
-              },
-            },
-            type,
-            transformFunc: ({ value }) => value,
-            allowExistingEmptyObjects: true,
-            allowAllEmptyObjects: true,
+              newEmptyObj: {},
+            })
           })
-
-          expect(result).toEqual({
-            obj: {
-              val: 'a',
-            },
-            emptyObj: {
-              nested: {},
-            },
-            newEmptyObj: {},
-          })
-        })
-      })
-
-      describe('with allowAllEmptyObjects but not allowExistingEmptyObjects', () => {
-        it('should throw an error', async () => {
-          await expect(
-            transformValues({
-              values: {},
-              type,
-              transformFunc: ({ value }) => value,
-              allowAllEmptyObjects: true,
-            }),
-          ).rejects.toThrow()
-        })
-      })
+        },
+      )
 
       describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -917,6 +917,9 @@ describe('Test utils.ts', () => {
               emptyObj: {
                 nested: {},
               },
+              newEmptyObj: {
+                deletedNested: undefined,
+              },
             },
             type,
             transformFunc: ({ value }) => value,
@@ -931,6 +934,53 @@ describe('Test utils.ts', () => {
               nested: {},
             },
           })
+        })
+      })
+
+      describe('with allowExistingEmptyObjects and allowAllEmptyObjects', () => {
+        it('should remove empty lists and not remove empty objects', async () => {
+          const result = await transformValues({
+            values: {
+              arr: [],
+              obj: {
+                nestedArr: [],
+                val: 'a',
+              },
+              emptyObj: {
+                nested: {},
+              },
+              newEmptyObj: {
+                deletedNested: undefined,
+              },
+            },
+            type,
+            transformFunc: ({ value }) => value,
+            allowExistingEmptyObjects: true,
+            allowAllEmptyObjects: true,
+          })
+
+          expect(result).toEqual({
+            obj: {
+              val: 'a',
+            },
+            emptyObj: {
+              nested: {},
+            },
+            newEmptyObj: {},
+          })
+        })
+      })
+
+      describe('with allowAllEmptyObjects but not allowExistingEmptyObjects', () => {
+        it('should throw an error', async () => {
+          await expect(
+            transformValues({
+              values: {},
+              type,
+              transformFunc: ({ value }) => value,
+              allowAllEmptyObjects: true,
+            }),
+          ).rejects.toThrow()
         })
       })
 

--- a/packages/adapter-utils/test/utils.test.ts
+++ b/packages/adapter-utils/test/utils.test.ts
@@ -905,7 +905,7 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects', () => {
+      describe('with allowExistingEmptyObjects', () => {
         it('should remove empty lists and not remove empty objects', async () => {
           const result = await transformValues({
             values: {
@@ -920,7 +920,7 @@ describe('Test utils.ts', () => {
             },
             type,
             transformFunc: ({ value }) => value,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
           })
 
           expect(result).toEqual({
@@ -934,7 +934,7 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+      describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {
           const result = await transformValues({
             values: {
@@ -949,7 +949,7 @@ describe('Test utils.ts', () => {
             },
             type,
             transformFunc: ({ value }) => value,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
             allowEmptyArrays: true,
           })
 
@@ -1548,7 +1548,7 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects', () => {
+      describe('with allowExistingEmptyObjects', () => {
         it('should not remove empty objects and remove empty list', async () => {
           const result = await transformValues({
             values: {
@@ -1563,7 +1563,7 @@ describe('Test utils.ts', () => {
             },
             type,
             transformFunc: ({ value }) => value,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
           })
 
           expect(result).toEqual({
@@ -1577,7 +1577,7 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+      describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {
           const result = await transformValues({
             values: {
@@ -1592,7 +1592,7 @@ describe('Test utils.ts', () => {
             },
             type,
             transformFunc: ({ value }) => value,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
             allowEmptyArrays: true,
           })
 
@@ -1921,13 +1921,13 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects', () => {
+      describe('with allowExistingEmptyObjects', () => {
         it('should remove empty lists and not remove empty objects', async () => {
           const result = await transformElement({
             element,
             transformFunc: ({ value }) => value,
             strict: false,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
           })
 
           expect(result.value).toEqual({
@@ -1941,14 +1941,14 @@ describe('Test utils.ts', () => {
         })
       })
 
-      describe('with allowEmptyObjects and allowEmptyArrays', () => {
+      describe('with allowExistingEmptyObjects and allowEmptyArrays', () => {
         it('should not remove empty lists and not remove empty objects', async () => {
           const result = await transformElement({
             element,
             transformFunc: ({ value }) => value,
             strict: false,
             allowEmptyArrays: true,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
           })
 
           expect(result.value).toEqual({

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -401,7 +401,7 @@ const filter: FilterCreator = ({ client }) => {
               element: instance,
               strict: false,
               allowEmptyArrays: true,
-              allowEmptyObjects: true,
+              allowExistingEmptyObjects: true,
               transformFunc: automationTransformFunc,
             })
           ).value
@@ -438,7 +438,7 @@ const filter: FilterCreator = ({ client }) => {
                 element: resolvedInstance,
                 strict: false,
                 allowEmptyArrays: true,
-                allowEmptyObjects: true,
+                allowExistingEmptyObjects: true,
                 transformFunc: automationTransformFunc,
               })
             ).value
@@ -465,7 +465,7 @@ const filter: FilterCreator = ({ client }) => {
                 element: instance,
                 strict: false,
                 allowEmptyArrays: true,
-                allowEmptyObjects: true,
+                allowExistingEmptyObjects: true,
                 transformFunc: automationTransformFunc,
               })
             ).value

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -61,7 +61,7 @@ const transformFormValues = (form: InstanceElement): void => {
     pathID: form.elemID,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
     transformFunc: ({ value, path }) => {
       if (
         path !== undefined &&
@@ -84,7 +84,7 @@ const transformFormValuesToOriginalValues = (form: InstanceElement): void => {
     pathID: form.elemID,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
     transformFunc: ({ value, path }) => {
       if (path !== undefined && Array.isArray(value) && value.length > 0 && value.every(isTransformedFormObject)) {
         const originalValue = value.reduce((acc, { key, value: val }) => {

--- a/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
+++ b/packages/jira-adapter/src/filters/hidden_value_in_lists.ts
@@ -27,7 +27,7 @@ const filter: FilterCreator = () => ({
           type: instance.getTypeSync(),
           pathID: instance.elemID,
           allowEmptyArrays: true,
-          allowEmptyObjects: true,
+          allowExistingEmptyObjects: true,
           strict: false,
           transformFunc: ({ value, field, path }) => {
             const isInArray = path?.getFullNameParts().some(isStringNumber)

--- a/packages/jira-adapter/src/filters/masking.ts
+++ b/packages/jira-adapter/src/filters/masking.ts
@@ -50,7 +50,7 @@ const maskValues = (instance: InstanceElement, masking: MaskingConfig): void => 
       pathID: instance.elemID,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
       transformFunc: ({ value, path }) => {
         if (path?.name === 'headers' && isHeaders(value)) {
           maskHeaders(value, masking.automationHeaders, instance.elemID)

--- a/packages/jira-adapter/src/filters/references_by_self_link.ts
+++ b/packages/jira-adapter/src/filters/references_by_self_link.ts
@@ -90,7 +90,7 @@ const filter: FilterCreator = () => ({
           transformFunc: transformSelfLinkToReference(elementsBySelfLink),
           strict: false,
           allowEmptyArrays: true,
-          allowEmptyObjects: true,
+          allowExistingEmptyObjects: true,
         }) ?? inst.value
     })
   },

--- a/packages/jira-adapter/src/filters/remove_self.ts
+++ b/packages/jira-adapter/src/filters/remove_self.ts
@@ -23,7 +23,7 @@ const filter: FilterCreator = () => ({
           pathID: instance.elemID,
           strict: false,
           allowEmptyArrays: true,
-          allowEmptyObjects: true,
+          allowExistingEmptyObjects: true,
           transformFunc: ({ value, path }) => {
             if (path?.name === 'self') {
               return undefined

--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -150,7 +150,7 @@ const sortLists = (instance: InstanceElement): void => {
       type: instance.getTypeSync(),
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
       transformFunc: ({ value, field }) => {
         if (field === undefined || !Array.isArray(value)) {
           return value

--- a/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
+++ b/packages/jira-adapter/src/filters/workflow/workflow_modification_filter.ts
@@ -49,7 +49,7 @@ const replaceWorkflowInScheme = async (
     element: scheme,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
     elementsSource,
     transformFunc: ({ value }) => {
       if (isReferenceExpression(value) && value.elemID.isEqual(beforeWorkflow.elemID)) {

--- a/packages/salesforce-adapter/src/change_validators/map_keys.ts
+++ b/packages/salesforce-adapter/src/change_validators/map_keys.ts
@@ -85,7 +85,7 @@ const getMapKeyErrors = (after: InstanceElement, fetchProfile: FetchProfile): Ch
         transformFunc: findInvalidPaths,
         strict: false,
         allowEmptyArrays: true,
-        allowEmptyObjects: true,
+        allowExistingEmptyObjects: true,
         pathID: after.elemID.createNestedID(fieldName),
       })
     })

--- a/packages/salesforce-adapter/src/filters/convert_types.ts
+++ b/packages/salesforce-adapter/src/filters/convert_types.ts
@@ -35,7 +35,7 @@ const filterCreator: FilterCreator = () => ({
             transformFunc: transformPrimitive,
             strict: false,
             allowEmptyArrays: true,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
           }) || {}
       })
   },

--- a/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
+++ b/packages/salesforce-adapter/src/filters/custom_object_instances_references.ts
@@ -270,7 +270,7 @@ const replaceLookupsWithRefsAndCreateRefMap = async ({
         transformFunc,
         strict: false,
         allowEmptyArrays: true,
-        allowEmptyObjects: true,
+        allowExistingEmptyObjects: true,
       })) ?? instance.value
     )
   }

--- a/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
+++ b/packages/salesforce-adapter/src/filters/custom_objects_to_object_type.ts
@@ -366,7 +366,7 @@ export const transformFieldAnnotations = async (
       transformFunc: transformPrimitive,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) || {}
   )
 }
@@ -381,7 +381,7 @@ const transformObjectAnnotationValues = (
     type: annotationsObject,
     transformFunc: transformPrimitive,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
   })
 }
 

--- a/packages/salesforce-adapter/src/filters/foreign_key_references.ts
+++ b/packages/salesforce-adapter/src/filters/foreign_key_references.ts
@@ -56,7 +56,7 @@ const resolveReferences = async (
       transformFunc: transformPrimitive,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? instance.value
 }
 

--- a/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
+++ b/packages/salesforce-adapter/src/filters/remove_fields_and_values.ts
@@ -52,7 +52,7 @@ export const removeValuesFromInstances = (
           transformFunc: removeValuesFunc,
           strict: true,
           allowEmptyArrays: true,
-          allowEmptyObjects: true,
+          allowExistingEmptyObjects: true,
           pathID: inst.elemID,
         }) || inst.value
     })

--- a/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
+++ b/packages/salesforce-adapter/src/filters/replace_instance_field_values.ts
@@ -105,7 +105,7 @@ const replaceInstanceValues = async (
       transformFunc,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? values
 }
 

--- a/packages/salesforce-adapter/src/filters/value_to_static_file.ts
+++ b/packages/salesforce-adapter/src/filters/value_to_static_file.ts
@@ -60,7 +60,7 @@ const extractToStaticFile = async (instance: InstanceElement): Promise<void> => 
       transformFunc,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? values
 }
 

--- a/packages/salesforce-adapter/src/filters/xml_attributes.ts
+++ b/packages/salesforce-adapter/src/filters/xml_attributes.ts
@@ -48,7 +48,7 @@ const removeAttributePrefix = async (instance: InstanceElement): Promise<void> =
       type,
       strict: false,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
       transformFunc: async ({ value, field }) => {
         const fieldType = await field?.getType()
         return isObjectType(fieldType) ? handleAttributeValues(value, fieldType) : value

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1431,7 +1431,7 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
     transformFunc: removeNonDeployableValues,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
   })
 }
 

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -551,7 +551,7 @@ const cloneValuesWithAttributePrefixes = async (instance: InstanceElement): Prom
     pathID: instance.elemID,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
   })
 
   const addAttributePrefixFunc: MapKeyFunc = ({ key, pathID }) => {

--- a/packages/workspace/src/workspace/adapters_config_source.ts
+++ b/packages/workspace/src/workspace/adapters_config_source.ts
@@ -154,7 +154,7 @@ export const buildAdaptersConfigSource = async ({
         element: instance,
         strict: false,
         allowEmptyArrays: true,
-        allowEmptyObjects: true,
+        allowExistingEmptyObjects: true,
         transformFunc: ({ value }) => value,
         elementsSource: naclSource,
       })

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -204,6 +204,7 @@ export const removeHiddenFromElement = <T extends Element>(
     elementsSource,
     allowEmptyArrays: true,
     allowEmptyObjects: true,
+    allowEmptiedObjects: true,
   })
 
 const removeHiddenFromValues = (

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -139,7 +139,7 @@ export const getElementHiddenParts = async <T extends Element>(
       path !== undefined && (isAncestorOfHiddenPath(path) || isNestedHiddenPath(path)) ? value : undefined,
     strict: true,
     allowEmptyArrays: true,
-    allowExistingEmptyObjects: true,
+    allowAllEmptyObjects: true,
     elementsSource,
   })
   // remove all annotation types from the hidden element so they don't cause merge conflicts
@@ -203,7 +203,6 @@ export const removeHiddenFromElement = <T extends Element>(
     strict: false,
     elementsSource,
     allowEmptyArrays: true,
-    allowExistingEmptyObjects: true,
     allowAllEmptyObjects: true,
   })
 
@@ -221,7 +220,6 @@ const removeHiddenFromValues = (
     elementsSource,
     strict: false,
     allowEmptyArrays: true,
-    allowExistingEmptyObjects: true,
     allowAllEmptyObjects: true,
   })
 
@@ -578,7 +576,6 @@ const getHiddenFieldAndAnnotationValueChanges = async (
       elementsSource: state,
       runOnFields: true,
       allowEmptyArrays: true,
-      allowExistingEmptyObjects: true,
       allowAllEmptyObjects: true,
     })
 

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -222,7 +222,7 @@ const removeHiddenFromValues = (
     strict: false,
     allowEmptyArrays: true,
     allowExistingEmptyObjects: true,
-    allowNewEmptyObjects: true
+    allowNewEmptyObjects: true,
   })
 
 const isAttributeChangeToHidden = (change: DetailedChange, hiddenValue: boolean): boolean =>

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -204,7 +204,7 @@ export const removeHiddenFromElement = <T extends Element>(
     elementsSource,
     allowEmptyArrays: true,
     allowExistingEmptyObjects: true,
-    allowNewEmptyObjects: true,
+    allowAllEmptyObjects: true,
   })
 
 const removeHiddenFromValues = (
@@ -222,7 +222,7 @@ const removeHiddenFromValues = (
     strict: false,
     allowEmptyArrays: true,
     allowExistingEmptyObjects: true,
-    allowNewEmptyObjects: true,
+    allowAllEmptyObjects: true,
   })
 
 const isAttributeChangeToHidden = (change: DetailedChange, hiddenValue: boolean): boolean =>

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -139,7 +139,7 @@ export const getElementHiddenParts = async <T extends Element>(
       path !== undefined && (isAncestorOfHiddenPath(path) || isNestedHiddenPath(path)) ? value : undefined,
     strict: true,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
     elementsSource,
   })
   // remove all annotation types from the hidden element so they don't cause merge conflicts
@@ -203,8 +203,8 @@ export const removeHiddenFromElement = <T extends Element>(
     strict: false,
     elementsSource,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
-    allowEmptiedObjects: true,
+    allowExistingEmptyObjects: true,
+    allowNewEmptyObjects: true,
   })
 
 const removeHiddenFromValues = (
@@ -221,7 +221,8 @@ const removeHiddenFromValues = (
     elementsSource,
     strict: false,
     allowEmptyArrays: true,
-    allowEmptyObjects: true,
+    allowExistingEmptyObjects: true,
+    allowNewEmptyObjects: true
   })
 
 const isAttributeChangeToHidden = (change: DetailedChange, hiddenValue: boolean): boolean =>
@@ -577,7 +578,7 @@ const getHiddenFieldAndAnnotationValueChanges = async (
       elementsSource: state,
       runOnFields: true,
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })
 
     return clonedVisibleElement

--- a/packages/workspace/src/workspace/hidden_values.ts
+++ b/packages/workspace/src/workspace/hidden_values.ts
@@ -579,6 +579,7 @@ const getHiddenFieldAndAnnotationValueChanges = async (
       runOnFields: true,
       allowEmptyArrays: true,
       allowExistingEmptyObjects: true,
+      allowAllEmptyObjects: true,
     })
 
     return clonedVisibleElement

--- a/packages/workspace/test/workspace/hidden_values.test.ts
+++ b/packages/workspace/test/workspace/hidden_values.test.ts
@@ -473,6 +473,66 @@ describe('handleHiddenChanges', () => {
     })
   })
 
+  describe('when a field has an inner field with hidden value annotation', () => {
+    it('should only hide the inner field', async () => {
+      const fieldType = new ObjectType({
+        elemID: new ElemID('test', 'fieldType'),
+        fields: {
+          innerField: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+          },
+        },
+      })
+      const objectType = new ObjectType({
+        elemID: new ElemID('test', 'type'),
+        fields: {
+          field: {
+            refType: fieldType,
+          },
+        },
+      })
+      const instance = new InstanceElement('instance', objectType, {
+        field: { innerField: 'hidden' },
+      })
+      const changes = [
+        toDetailedChangeFromBaseChange(toChange({ after: fieldType })),
+        toDetailedChangeFromBaseChange(toChange({ after: objectType })),
+        toDetailedChangeFromBaseChange(toChange({ after: instance })),
+      ]
+      const { visible, hidden } = await handleHiddenChanges(
+        changes,
+        mockState([fieldType, objectType, instance]),
+        createInMemoryElementSource([]),
+      )
+      expect(visible).toHaveLength(3)
+      expect(visible).toContainEqual(
+        expect.objectContaining({
+          id: instance.elemID,
+          // contains `field` but not `innerField`
+          data: expect.objectContaining({
+            after: expect.objectContaining({
+              value: { field: {} },
+            }),
+          }),
+          action: 'add',
+        }),
+      )
+      expect(hidden).toHaveLength(1)
+      expect(hidden).toContainEqual(
+        expect.objectContaining({
+          id: instance.elemID,
+          data: expect.objectContaining({
+            after: expect.objectContaining({
+              value: { field: { innerField: 'hidden' } },
+            }),
+          }),
+          action: 'add',
+        }),
+      )
+    })
+  })
+
   describe('hidden_string in instance annotations', () => {
     let instance: InstanceElement
     let instanceType: ObjectType
@@ -1016,7 +1076,7 @@ describe('handleHiddenChanges', () => {
   })
 })
 
-describe('getElemHiddenParts', () => {
+describe('getElementHiddenParts', () => {
   describe('ObjectType attribute handling', () => {
     let elementsSource: ReadOnlyElementsSource
     let testElement: ObjectType
@@ -1136,6 +1196,57 @@ describe('getElemHiddenParts', () => {
       expect(fieldWithPartiallyHiddenAnnotations.annotations).toEqual({ hiddenStringValue: 'testHidden' })
       expect(hiddenFieldWithNoHiddenAnnotations.annotations).toEqual({})
       expect(hiddenValueFieldWithNoHiddenAnnotations.annotations).toEqual({})
+    })
+  })
+  describe('Instance Handling', () => {
+    it('should hide the hidden value of a primitive field with _hidden_value', async () => {
+      const type = new ObjectType({
+        elemID: new ElemID('test', 'type'),
+        fields: {
+          hiddenString: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+          },
+        },
+      })
+      const instance = new InstanceElement('instance', type, {
+        hiddenString: 'test',
+      })
+
+      const elementsSource = buildElementsSourceFromElements([instance, type])
+      const result = (await getElementHiddenParts(instance, elementsSource)) as InstanceElement
+      expect(result).toBeDefined()
+      expect(result.value).toEqual({ hiddenString: 'test' })
+    })
+
+    it('should hide the hidden value of a non-primitive field with _hidden_value', async () => {
+      const fieldType = new ObjectType({
+        elemID: new ElemID('test', 'fieldType'),
+        fields: {
+          hiddenString: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [CORE_ANNOTATIONS.HIDDEN_VALUE]: true },
+          },
+        },
+      })
+      const type = new ObjectType({
+        elemID: new ElemID('test', 'type'),
+        fields: {
+          field: {
+            refType: fieldType,
+          },
+        },
+      })
+      const instance = new InstanceElement('instance', type, {
+        field: {
+          hiddenString: 'test',
+        },
+      })
+
+      const elementsSource = buildElementsSourceFromElements([instance, type, fieldType])
+      const result = (await getElementHiddenParts(instance, elementsSource)) as InstanceElement
+      expect(result).toBeDefined()
+      expect(result.value).toEqual({ field: { hiddenString: 'test' } })
     })
   })
 })

--- a/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
+++ b/packages/zendesk-adapter/src/filters/dynamic_content_references.ts
@@ -76,7 +76,7 @@ const transformDynamicContentDependencies = async (
         return value
       },
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? instance.value
 }
 
@@ -116,7 +116,7 @@ const returnDynamicContentsToApiValue = async (
         return value
       },
       allowEmptyArrays: true,
-      allowEmptyObjects: true,
+      allowExistingEmptyObjects: true,
     })) ?? instance.value
 }
 
@@ -165,7 +165,7 @@ const filterCreator: FilterCreator = ({ config }) => {
               return value
             },
             allowEmptyArrays: true,
-            allowEmptyObjects: true,
+            allowExistingEmptyObjects: true,
             strict: false,
           })) ?? instance.value
       }),


### PR DESCRIPTION
This PR fixes a core bug in hidden value representation in NaCl files. The bug is described in the attached ticket, but in short, when we have an instance of a type with a non-primitive field with fields of its own, and all of the inner fields are hidden, we wrongly hide the field itself in the instance, instead of making it visible but empty.

The low-level issue here is that `transformValues` calls `removeEmptyParts` as a cleanup action, which removes empty objects. While it has an `allowEmptyObjects` flag, it still removes empty objects if those objects _became_ empty during the transformation. This PR renames this flag to `allowExistingEmptyObjects` to be more descriptive, and adds a new `allowNewEmptyObjects` parameter to make our desired behavior possible.

---

_Additional context for reviewer_:

~I considered making the new parameter `allowAllEmptyObjects`, but that creates more complication as we have to handle cases where `allowExistingEmptyObjects` is false and `allowAllEmptyObjects` is true. With the current implementation, we make sure the parameters don't overlap in their semantics.~

Most of the changed files are simple the rename of the existing parameter. The meaningful changes are in the following files:
- `packages/adapter-utils/src/utils.ts`
- `packages/workspace/src/workspace/hidden_values.ts`
- `packages/workspace/test/workspace/hidden_values.test.ts`

---
_Release Notes_: 
- Fixed a bug where non-primitive fields were hidden from NaCl files if all of their inner fields were hidden

---
_User Notifications_: 
None