### PR TITLE
SALTO-7282: Extend CV for missing referenced FlowElements in Flow to support more FlowElements

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
+++ b/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
@@ -83,7 +83,7 @@ const getFlowElementsAndReferences = (
 
 const createMissingReferencedElementChangeError = (elemId: ElemID, elemName: string): ChangeError => ({
   elemID: elemId,
-  severity: 'Error',
+  severity: 'Warning',
   message: 'Reference to missing Flow Element',
   detailedMessage: `The Flow Element "${elemName}" does not exist.`,
 })

--- a/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
+++ b/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
@@ -19,10 +19,10 @@ import {
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { collections } from '@salto-io/lowerdash'
-import { isInstanceOfTypeSync } from '../filters/utils'
+import { apiNameSync, isInstanceOfTypeSync } from '../filters/utils'
 import {
   ELEMENT_REFERENCE,
-  FLOW_ELEMENTS_WITH_NONUNIQUE_NAMES,
+  FLOW_ELEMENTS_WITH_UNIQUE_NAMES,
   FLOW_METADATA_TYPE,
   FLOW_NODE_FIELD_NAMES,
   LEFT_VALUE_REFERENCE,
@@ -51,7 +51,7 @@ const getFlowElementsAndReferences = (
   const findFlowElementsAndTargetReferences: TransformFuncSync = ({ value, path, field }) => {
     if (_.isUndefined(field) || _.isUndefined(path)) return value
     if (
-      !FLOW_ELEMENTS_WITH_NONUNIQUE_NAMES.includes(field.elemID.typeName) &&
+      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.elemID.typeName) ?? '') &&
       path.name === FLOW_NODE_FIELD_NAMES.NAME &&
       _.isString(value)
     ) {

--- a/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
+++ b/packages/salesforce-adapter/src/change_validators/flow_referenced_elements.ts
@@ -49,12 +49,13 @@ const getFlowElementsAndReferences = (
   const elementReferences = new DefaultMap<string, ElemID[]>(() => [])
   const leftValueReferences = new DefaultMap<string, ElemID[]>(() => [])
   const findFlowElementsAndTargetReferences: TransformFuncSync = ({ value, path, field }) => {
-    if (_.isUndefined(field) || _.isUndefined(path)) return value
     if (
-      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.elemID.typeName) ?? '') &&
-      path.name === FLOW_NODE_FIELD_NAMES.NAME &&
-      _.isString(value)
-    ) {
+      field === undefined ||
+      path === undefined ||
+      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.parent) ?? '')
+    )
+      return value
+    if (path.name === FLOW_NODE_FIELD_NAMES.NAME && _.isString(value)) {
       if (isFlowNode(field.parent.fields)) flowNodes[value] = path
       else flowElements[value] = path
     }

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -115,7 +115,24 @@ export enum FLOW_NODE_FIELD_NAMES {
   LOCATION_X = 'locationX',
   LOCATION_Y = 'locationY',
 }
-export const FLOW_ELEMENTS_WITH_NONUNIQUE_NAMES = ['FlowActionCallInputParameter', 'FlowActionCallOutputParameter']
+export const FLOW_ELEMENTS_WITH_UNIQUE_NAMES = [
+  'FlowChoice',
+  'FlowConstant',
+  'FlowDynamicChoiceSet',
+  'FlowExitRule',
+  'FlowExperimentPath',
+  'FlowFormula',
+  'FlowNode',
+  'FlowRule',
+  'FlowScheduledPath',
+  'FlowScreenField',
+  'FlowStage',
+  'FlowCapability',
+  'FlowCapabilityInput',
+  'FlowTextTemplate',
+  'FlowVariable',
+  'FlowWaitEvent',
+]
 
 export const FLOW_FIELD_TYPE_NAMES = {
   FLOW_ASSIGNMENT_ITEM: 'FlowAssignmentItem',

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -107,12 +107,15 @@ export enum FLEXI_PAGE_FIELD_NAMES {
 // Flow constants
 export const FLOW_NODE = 'FlowNode'
 export const TARGET_REFERENCE = 'targetReference'
+export const ELEMENT_REFERENCE = 'elementReference'
+export const LEFT_VALUE_REFERENCE = 'leftValueReference'
 export const ASSIGN_TO_REFERENCE = 'assignToReference'
 export enum FLOW_NODE_FIELD_NAMES {
   NAME = 'name',
   LOCATION_X = 'locationX',
   LOCATION_Y = 'locationY',
 }
+export const FLOW_ELEMENTS_WITH_NONUNIQUE_NAMES = ['FlowActionCallInputParameter', 'FlowActionCallOutputParameter']
 
 export const FLOW_FIELD_TYPE_NAMES = {
   FLOW_ASSIGNMENT_ITEM: 'FlowAssignmentItem',

--- a/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
@@ -31,17 +31,10 @@ describe('flowReferencedElements change validator', () => {
   let flowElement: MetadataObjectType
   let flowElementWithNonUniqueName: MetadataObjectType
   let flowExitRule: MetadataObjectType
+  let flowActionCall: MetadataObjectType
   let flow: MetadataObjectType
   let flowInstance: MetadataInstanceElement
   beforeEach(() => {
-    flowElementWithNonUniqueName = createMetadataObjectType({
-      annotations: {
-        metadataType: 'FlowActionCallOutputParameter',
-      },
-      fields: {
-        name: { refType: BuiltinTypes.STRING },
-      },
-    })
     flowElement = createMetadataObjectType({
       annotations: {
         metadataType: 'FlowConstant',
@@ -56,6 +49,15 @@ describe('flowReferencedElements change validator', () => {
       },
       fields: {
         [ELEMENT_REFERENCE]: { refType: BuiltinTypes.STRING },
+      },
+    })
+    flowElementWithNonUniqueName = createMetadataObjectType({
+      annotations: {
+        metadataType: 'FlowActionCallInputParameter',
+      },
+      fields: {
+        name: { refType: BuiltinTypes.STRING },
+        value: { refType: flowElementReferenceOrValue, annotations: { required: false } },
       },
     })
     flowCondition = createMetadataObjectType({
@@ -83,6 +85,18 @@ describe('flowReferencedElements change validator', () => {
         [TARGET_REFERENCE]: { refType: BuiltinTypes.STRING },
       },
     })
+    flowActionCall = createMetadataObjectType({
+      annotations: {
+        metadataType: 'FlowActionCall',
+      },
+      fields: {
+        [FLOW_NODE_FIELD_NAMES.NAME]: { refType: BuiltinTypes.STRING },
+        [FLOW_NODE_FIELD_NAMES.LOCATION_X]: { refType: BuiltinTypes.NUMBER, annotations: { constant: 1 } },
+        [FLOW_NODE_FIELD_NAMES.LOCATION_Y]: { refType: BuiltinTypes.NUMBER, annotations: { constant: 1 } },
+        connector: { refType: flowConnector, annotations: { required: false } },
+        inputParameters: { refType: new ListType(flowElementWithNonUniqueName) },
+      },
+    })
     flowNode = createMetadataObjectType({
       annotations: {
         metadataType: 'FlowNode',
@@ -92,7 +106,6 @@ describe('flowReferencedElements change validator', () => {
         [FLOW_NODE_FIELD_NAMES.LOCATION_X]: { refType: BuiltinTypes.NUMBER, annotations: { constant: 1 } },
         [FLOW_NODE_FIELD_NAMES.LOCATION_Y]: { refType: BuiltinTypes.NUMBER, annotations: { constant: 1 } },
         connector: { refType: flowConnector, annotations: { required: false } },
-        inputParameters: { refType: flowElementWithNonUniqueName, annotations: { required: false } },
       },
     })
     flow = createMetadataObjectType({
@@ -101,7 +114,7 @@ describe('flowReferencedElements change validator', () => {
       },
       fields: {
         start: { refType: flowNode },
-        actionCalls: { refType: new ListType(flowNode), annotations: { required: false } },
+        actionCalls: { refType: new ListType(flowActionCall), annotations: { required: false } },
         assignments: { refType: new ListType(flowNode), annotations: { required: false } },
         decisions: { refType: new ListType(flowNode), annotations: { required: false } },
         recordCreates: { refType: new ListType(flowNode), annotations: { required: false } },
@@ -203,6 +216,94 @@ describe('flowReferencedElements change validator', () => {
       ])
     })
   })
+  describe('when all flow elements exists in the flow', () => {
+    beforeEach(() => {
+      flowInstance = createInstanceElement(
+        {
+          fullName: 'TestFlow',
+          constants: [{ name: 'Const1' }, { name: 'Const2' }],
+          exitRules: [
+            { conditions: [{ [LEFT_VALUE_REFERENCE]: 'Const1', rightValue: { [ELEMENT_REFERENCE]: 'Const2' } }] },
+          ],
+          actionCalls: [
+            {
+              name: 'ActionCall1',
+              inputParameters: [{ name: 'Param1', value: { [ELEMENT_REFERENCE]: 'ActionCall2.Param2' } }],
+              connector: { [TARGET_REFERENCE]: 'ActionCall2' },
+            },
+            {
+              name: 'ActionCall2',
+              inputParameters: [{ name: 'Param2', value: { [ELEMENT_REFERENCE]: 'ActionCall1.Param1' } }],
+            },
+          ],
+          start: {
+            connector: { [TARGET_REFERENCE]: 'ActionCall1' },
+          },
+        },
+        flow,
+      )
+      flowChange = toChange({ after: flowInstance })
+    })
+    it('should not return any errors', async () => {
+      const errors = await flowReferencedElements([flowChange])
+      expect(errors).toBeEmpty()
+    })
+  })
+  describe('when there are references to missing flow elements', () => {
+    beforeEach(() => {
+      flowInstance = createInstanceElement(
+        {
+          fullName: 'TestFlow',
+          constants: [{ name: 'Const1' }],
+          exitRules: [
+            { conditions: [{ [LEFT_VALUE_REFERENCE]: 'Const1', rightValue: { [ELEMENT_REFERENCE]: 'Const2' } }] },
+          ],
+          actionCalls: [
+            {
+              name: 'ActionCall2',
+              inputParameters: [{ name: 'Param2', value: { [ELEMENT_REFERENCE]: 'ActionCall1.Param1' } }],
+            },
+          ],
+          start: {
+            connector: { [TARGET_REFERENCE]: 'ActionCall2' },
+          },
+        },
+        flow,
+      )
+      flowChange = toChange({ after: flowInstance })
+    })
+    it('should return Missing Flow Element errors', async () => {
+      const errors = await flowReferencedElements([flowChange])
+      expect(errors).toIncludeSameMembers([
+        {
+          severity: 'Warning',
+          message: 'Reference to missing Flow Element',
+          detailedMessage: `The Flow Element "${'Const2'}" does not exist.`,
+          elemID: flowInstance.elemID.createNestedID(
+            'exitRules',
+            '0',
+            'conditions',
+            '0',
+            'rightValue',
+            ELEMENT_REFERENCE,
+          ),
+        },
+        {
+          severity: 'Warning',
+          message: 'Reference to missing Flow Element',
+          detailedMessage: `The Flow Element "${'ActionCall1'}" does not exist.`,
+          elemID: flowInstance.elemID.createNestedID(
+            'actionCalls',
+            '0',
+            'inputParameters',
+            '0',
+            'value',
+            ELEMENT_REFERENCE.split(API_NAME_SEPARATOR)[0],
+          ),
+        },
+      ])
+    })
+  })
   describe('when there are multiple errors in one flow', () => {
     beforeEach(() => {
       flowInstance = createInstanceElement(
@@ -223,6 +324,10 @@ describe('flowReferencedElements change validator', () => {
               connector: { [TARGET_REFERENCE]: 'RecordCreate' },
             },
           ],
+          constants: [{ name: 'Const' }],
+          exitRules: [
+            { conditions: [{ [LEFT_VALUE_REFERENCE]: 'Const', rightValue: { [ELEMENT_REFERENCE]: 'Const2' } }] },
+          ],
         },
         flow,
       )
@@ -230,7 +335,7 @@ describe('flowReferencedElements change validator', () => {
     })
     it('should create change error per issue', async () => {
       const errors = await flowReferencedElements([flowChange])
-      expect(errors).toEqual([
+      expect(errors).toIncludeSameMembers([
         {
           severity: 'Info',
           message: 'Unused Flow Element',
@@ -248,6 +353,19 @@ describe('flowReferencedElements change validator', () => {
           message: 'Reference to missing Flow Element',
           detailedMessage: `The Flow Element "${'RecordCreate'}" does not exist.`,
           elemID: flowInstance.elemID.createNestedID('decisions', '0', 'connector', TARGET_REFERENCE),
+        },
+        {
+          severity: 'Warning',
+          message: 'Reference to missing Flow Element',
+          detailedMessage: `The Flow Element "${'Const2'}" does not exist.`,
+          elemID: flowInstance.elemID.createNestedID(
+            'exitRules',
+            '0',
+            'conditions',
+            '0',
+            'rightValue',
+            ELEMENT_REFERENCE,
+          ),
         },
       ])
     })
@@ -270,6 +388,21 @@ describe('flowReferencedElements change validator', () => {
             {
               [FLOW_NODE_FIELD_NAMES.NAME]: 'Decision',
               connector: { [TARGET_REFERENCE]: 'ActionCall' },
+            },
+          ],
+          constants: [{ name: 'Const' }],
+          exitRules: [
+            { conditions: [{ [LEFT_VALUE_REFERENCE]: 'Const', rightValue: { [ELEMENT_REFERENCE]: 'ActionCall' } }] },
+          ],
+          actionCalls: [
+            {
+              name: 'ActionCall1',
+              inputParameters: [{ name: 'Param', value: { [ELEMENT_REFERENCE]: 'ActionCall.Param' } }],
+              connector: { [TARGET_REFERENCE]: 'ActionCall2' },
+            },
+            {
+              name: 'ActionCall2',
+              connector: { [TARGET_REFERENCE]: 'ActionCall1' },
             },
           ],
         },
@@ -298,71 +431,28 @@ describe('flowReferencedElements change validator', () => {
           detailedMessage: `The Flow Element "${'Decision'}" isn’t being used in the Flow.`,
           elemID: flowInstance.elemID.createNestedID('decisions', '0', FLOW_NODE_FIELD_NAMES.NAME),
         },
-      ])
-    })
-  })
-  describe('when all flow elements exists in the flow', () => {
-    beforeEach(() => {
-      flowInstance = createInstanceElement(
-        {
-          fullName: 'TestFlow',
-          constants: [{ name: 'Const1' }, { name: 'Const2' }],
-          exitRules: [{ [LEFT_VALUE_REFERENCE]: 'Const1', rightValue: { [ELEMENT_REFERENCE]: 'Const2' } }],
-          actionCalls: [
-            {
-              name: 'ActionCall1',
-              inputParameters: { name: 'Param1', value: { [ELEMENT_REFERENCE]: 'Action2.Param2' } },
-            },
-            {
-              name: 'ActionCall2',
-              inputParameters: { name: 'Param2', value: { [ELEMENT_REFERENCE]: 'Action1.Param1' } },
-            },
-          ],
-        },
-        flow,
-      )
-      flowChange = toChange({ after: flowInstance })
-    })
-    it('should not return any errors', async () => {
-      const errors = await flowReferencedElements([flowChange])
-      expect(errors).toBeEmpty()
-    })
-  })
-  describe('when there are references to missing flow elements', () => {
-    beforeEach(() => {
-      flowInstance = createInstanceElement(
-        {
-          fullName: 'TestFlow',
-          constants: [{ name: 'Const1' }],
-          exitRules: [{ [LEFT_VALUE_REFERENCE]: 'Const1', rightValue: { [ELEMENT_REFERENCE]: 'Const2' } }],
-          actionCalls: [
-            {
-              name: 'ActionCall2',
-              inputParameters: { name: 'Param2', value: { [ELEMENT_REFERENCE]: 'Action1.Param1' } },
-            },
-          ],
-        },
-        flow,
-      )
-      flowChange = toChange({ after: flowInstance })
-    })
-    it('should return Missing Flow Element errors', async () => {
-      const errors = await flowReferencedElements([flowChange])
-      expect(errors).toEqual([
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'Const2'}" does not exist.`,
-          elemID: flowInstance.elemID.createNestedID('exitRules', '0', 'rightValue', ELEMENT_REFERENCE),
+          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          elemID: flowInstance.elemID.createNestedID(
+            'exitRules',
+            '0',
+            'conditions',
+            '0',
+            'rightValue',
+            ELEMENT_REFERENCE,
+          ),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall1'}" does not exist.`,
+          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
           elemID: flowInstance.elemID.createNestedID(
             'actionCalls',
             '0',
             'inputParameters',
+            '0',
             'value',
             ELEMENT_REFERENCE.split(API_NAME_SEPARATOR)[0],
           ),

--- a/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
@@ -14,16 +14,41 @@ import {
   MetadataInstanceElement,
   MetadataObjectType,
 } from '../../src/transformers/transformer'
-import { FLOW_NODE_FIELD_NAMES, TARGET_REFERENCE } from '../../src/constants'
+import {
+  ELEMENT_REFERENCE,
+  FLOW_ELEMENTS_WITH_UNIQUE_NAMES,
+  FLOW_FIELD_TYPE_NAMES,
+  FLOW_NODE_FIELD_NAMES,
+  LEFT_VALUE_REFERENCE,
+  TARGET_REFERENCE,
+} from '../../src/constants'
 
 describe('flowReferencedElements change validator', () => {
   let flowChange: Change
   let flowConnector: MetadataObjectType
   let flowElementReferenceOrValue: MetadataObjectType
+  let flowCondition: MetadataObjectType
   let flowNode: MetadataObjectType
   let flow: MetadataObjectType
   let flowInstance: MetadataInstanceElement
   beforeEach(() => {
+    flowElementReferenceOrValue = createMetadataObjectType({
+      annotations: {
+        metadataType: 'FlowElementReferenceOrValue',
+      },
+      fields: {
+        [ELEMENT_REFERENCE]: { refType: BuiltinTypes.STRING },
+      },
+    })
+    flowCondition = createMetadataObjectType({
+      annotations: {
+        metadataType: 'FlowCondition',
+      },
+      fields: {
+        [LEFT_VALUE_REFERENCE]: { refType: BuiltinTypes.STRING },
+        rightValue: { refType: flowElementReferenceOrValue },
+      },
+    })
     flowConnector = createMetadataObjectType({
       annotations: {
         metadataType: 'FlowConnector',

--- a/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flow_referenced_elements.test.ts
@@ -183,7 +183,7 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID('start', 'connector', TARGET_REFERENCE),
         },
       ])
@@ -210,7 +210,7 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Info',
           message: 'Unused Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" isn’t being used in the Flow.`,
+          detailedMessage: 'The Flow Element "ActionCall" isn’t being used in the Flow.',
           elemID: flowInstance.elemID.createNestedID('actionCalls', '0', FLOW_NODE_FIELD_NAMES.NAME),
         },
       ])
@@ -278,7 +278,7 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'Const2'}" does not exist.`,
+          detailedMessage: 'The Flow Element "Const2" does not exist.',
           elemID: flowInstance.elemID.createNestedID(
             'exitRules',
             '0',
@@ -291,7 +291,7 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall1'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall1" does not exist.',
           elemID: flowInstance.elemID.createNestedID(
             'actionCalls',
             '0',
@@ -339,25 +339,25 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Info',
           message: 'Unused Flow Element',
-          detailedMessage: `The Flow Element "${'Assignment'}" isn’t being used in the Flow.`,
+          detailedMessage: 'The Flow Element "Assignment" isn’t being used in the Flow.',
           elemID: flowInstance.elemID.createNestedID('assignments', '0', FLOW_NODE_FIELD_NAMES.NAME),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID('start', 'connector', TARGET_REFERENCE),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'RecordCreate'}" does not exist.`,
+          detailedMessage: 'The Flow Element "RecordCreate" does not exist.',
           elemID: flowInstance.elemID.createNestedID('decisions', '0', 'connector', TARGET_REFERENCE),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'Const2'}" does not exist.`,
+          detailedMessage: 'The Flow Element "Const2" does not exist.',
           elemID: flowInstance.elemID.createNestedID(
             'exitRules',
             '0',
@@ -416,25 +416,25 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID('assignments', '0', 'connector', TARGET_REFERENCE),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID('decisions', '0', 'connector', TARGET_REFERENCE),
         },
         {
           severity: 'Info',
           message: 'Unused Flow Element',
-          detailedMessage: `The Flow Element "${'Decision'}" isn’t being used in the Flow.`,
+          detailedMessage: 'The Flow Element "Decision" isn’t being used in the Flow.',
           elemID: flowInstance.elemID.createNestedID('decisions', '0', FLOW_NODE_FIELD_NAMES.NAME),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID(
             'exitRules',
             '0',
@@ -447,7 +447,7 @@ describe('flowReferencedElements change validator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Flow Element',
-          detailedMessage: `The Flow Element "${'ActionCall'}" does not exist.`,
+          detailedMessage: 'The Flow Element "ActionCall" does not exist.',
           elemID: flowInstance.elemID.createNestedID(
             'actionCalls',
             '0',


### PR DESCRIPTION
SALTO-7282: Extend CV for missing referenced FlowElements in Flow to support more FlowElements

---

_Additional context for reviewer_:
Error message format:
<img width="954" alt="image" src="https://github.com/user-attachments/assets/4f1d2355-3e61-4477-a141-7022f1800d2c" />

---
_Release Notes_: 
None

---
_User Notifications_: 
None
