### PR TITLE
SALTO-7319 Remove large regex pattern

### DIFF
--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -335,6 +335,9 @@ const formulaToTemplate = ({
       return handleDynamicContentReference(expression, dynamicContentReference)
     }
     if (extractReferencesFromFreeText) {
+      // Check if the expression is a link to a zendesk page without a subdomain
+      // href="/hc/en-us/sections/5678/articles/123123"
+
       // There are multiple regexes that can reach this part, only one section is relevant here
       const isHelpCenterUrlMatch = expression.match(HELP_CENTER_URL)
       if (isHelpCenterUrlMatch !== null) {

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -56,8 +56,8 @@ const BRACKETS = [
 const REFERENCE_MARKER_REGEX = /\$\{({{.+?}})\}/
 const DYNAMIC_CONTENT_REGEX = /(dc\.[\w-]+)/g
 const DYNAMIC_CONTENT_REGEX_WITH_BRACKETS = /({{dc\.[\w-]+}})/g
-const INNER_HELP_CENTER_URL = /\/?hc\/[^"\s]+?/g
-const HELP_CENTER_URL = new RegExp(`"(${INNER_HELP_CENTER_URL})["\\s]`, 'g')
+// The non capturing group inside the group is needed because of the way regex.split consumes the matched groups
+const HELP_CENTER_URL = /("\/?hc\/[^"\s]+?(?:["\s]|$))/g
 const TICKET_FIELD_SPLIT = '(?:(ticket.ticket_field|ticket.ticket_field_option_title)_([\\d]+))'
 const KEY_SPLIT = '(?:([^ ]+\\.custom_fields)\\.)'
 const TITLE_SPLIT = '(?:([^ ]+)\\.(title))'
@@ -336,8 +336,7 @@ const formulaToTemplate = ({
     }
     if (extractReferencesFromFreeText) {
       // There are multiple regexes that can reach this part, only one section is relevant here
-      // We use the INNER_HELP_CENTER_URL regex because we don't capture the wrapping quotes (or chars)
-      const isHelpCenterUrlMatch = expression.match(INNER_HELP_CENTER_URL)
+      const isHelpCenterUrlMatch = expression.match(HELP_CENTER_URL)
       if (isHelpCenterUrlMatch !== null) {
         const transformedUrl = extractTemplate(
           expression,

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -370,7 +370,7 @@ describe('handle templates filter', () => {
     'articleTranslation',
     new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TRANSLATION_TYPE_NAME) }),
     {
-      body: `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test\n"hc/test/no-references/index.html"`,
+      body: `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test"\n"hc/test/no-references/index.html"\n"hc/test/test/sections/${article.value.id}/test`,
     },
   )
 
@@ -760,7 +760,7 @@ describe('handle templates filter', () => {
         .filter(isInstanceElement)
         .find(i => i.elemID.name === 'articleTranslation')
       expect(fetchedArticleTranslation?.value.body).toEqual(
-        `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test\n"hc/test/no-references/index.html"`,
+        `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test"\n"hc/test/no-references/index.html"\n"hc/test/test/sections/${article.value.id}/test`,
       )
     })
     it('should resolve urls correctly when config flags are on', async () => {
@@ -781,9 +781,9 @@ describe('handle templates filter', () => {
             new ReferenceExpression(article.elemID, article),
             '/test"\n"hc/test/test/articles/',
             new ReferenceExpression(macro1.elemID, macro1),
-            '/test\n"hc/test/test/sections/',
+            '/test"\n"hc/test/no-references/index.html"\n"hc/test/test/sections/',
             new ReferenceExpression(article.elemID, article),
-            '/test\n"hc/test/no-references/index.html"',
+            '/test',
           ],
         }),
       )

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -370,7 +370,7 @@ describe('handle templates filter', () => {
     'articleTranslation',
     new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TRANSLATION_TYPE_NAME) }),
     {
-      body: `"/hc/test/test/articles/${article.value.id}/test\n"hc/test/test/articles/${macro1.value.id}/test`,
+      body: `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test`,
     },
   )
 
@@ -760,7 +760,7 @@ describe('handle templates filter', () => {
         .filter(isInstanceElement)
         .find(i => i.elemID.name === 'articleTranslation')
       expect(fetchedArticleTranslation?.value.body).toEqual(
-        `"/hc/test/test/articles/${article.value.id}/test\n"hc/test/test/articles/${macro1.value.id}/test`,
+        `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test`,
       )
     })
     it('should resolve urls correctly when config flags are on', async () => {
@@ -779,8 +779,10 @@ describe('handle templates filter', () => {
           parts: [
             '"/hc/test/test/articles/',
             new ReferenceExpression(article.elemID, article),
-            '/test\n"hc/test/test/articles/',
+            '/test"\n"hc/test/test/articles/',
             new ReferenceExpression(macro1.elemID, macro1),
+            '/test\n"hc/test/test/sections/',
+            new ReferenceExpression(article.elemID, article),
             '/test',
           ],
         }),

--- a/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
+++ b/packages/zendesk-adapter/test/filters/handle_template_expressions.test.ts
@@ -370,7 +370,7 @@ describe('handle templates filter', () => {
     'articleTranslation',
     new ObjectType({ elemID: new ElemID(ZENDESK, ARTICLE_TRANSLATION_TYPE_NAME) }),
     {
-      body: `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test`,
+      body: `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test\n"hc/test/no-references/index.html"`,
     },
   )
 
@@ -760,7 +760,7 @@ describe('handle templates filter', () => {
         .filter(isInstanceElement)
         .find(i => i.elemID.name === 'articleTranslation')
       expect(fetchedArticleTranslation?.value.body).toEqual(
-        `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test`,
+        `"/hc/test/test/articles/${article.value.id}/test"\n"hc/test/test/articles/${macro1.value.id}/test\n"hc/test/test/sections/${article.value.id}/test\n"hc/test/no-references/index.html"`,
       )
     })
     it('should resolve urls correctly when config flags are on', async () => {
@@ -783,7 +783,7 @@ describe('handle templates filter', () => {
             new ReferenceExpression(macro1.elemID, macro1),
             '/test\n"hc/test/test/sections/',
             new ReferenceExpression(article.elemID, article),
-            '/test',
+            '/test\n"hc/test/no-references/index.html"',
           ],
         }),
       )


### PR DESCRIPTION
We saw cases where the `expression` was very large and threw a `Regular expression too large` error. 
Changed the way we search - we now look for a help center url, and then split that into potential references

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
