### PR TITLE
SALTO-7403: (Bugfix)  Fix FlowNodes support for Unique FlowElement Name in CV

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
+++ b/packages/salesforce-adapter/src/change_validators/unique_flow_element_name.ts
@@ -9,6 +9,7 @@ import {
   ChangeError,
   ChangeValidator,
   ElemID,
+  FieldMap,
   getChangeData,
   InstanceElement,
   isAdditionOrModificationChange,
@@ -16,9 +17,12 @@ import {
 import { collections } from '@salto-io/lowerdash'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import { apiNameSync, isInstanceOfTypeSync } from '../filters/utils'
-import { FLOW_ELEMENTS_WITH_UNIQUE_NAMES, FLOW_METADATA_TYPE } from '../constants'
+import { FLOW_ELEMENTS_WITH_UNIQUE_NAMES, FLOW_METADATA_TYPE, FLOW_NODE_FIELD_NAMES } from '../constants'
 
 const { DefaultMap } = collections.map
+
+const isFlowNode = (fields: FieldMap): boolean =>
+  FLOW_NODE_FIELD_NAMES.LOCATION_X in fields && FLOW_NODE_FIELD_NAMES.LOCATION_Y in fields
 
 const createChangeErrors = (element: InstanceElement): ChangeError[] => {
   const duplicates = new Set<string>()
@@ -27,8 +31,8 @@ const createChangeErrors = (element: InstanceElement): ChangeError[] => {
     if (
       field === undefined ||
       path === undefined ||
-      !FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.parent) ?? '') ||
-      path.name !== 'name'
+      path.name !== 'name' ||
+      (!FLOW_ELEMENTS_WITH_UNIQUE_NAMES.includes(apiNameSync(field.parent) ?? '') && !isFlowNode(field.parent.fields))
     )
       return value
     if (nameToElemIds.get(value).length > 0) {

--- a/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/unique_flow_element_name.test.ts
@@ -83,16 +83,18 @@ describe('uniqueFlowElementName change validator', () => {
       expect(errors).toBeEmpty()
     })
   })
-  describe('when there duplicate FlowElement names', () => {
+  describe('when there are duplicate FlowElement names', () => {
     beforeEach(() => {
       flowInstance = createInstanceElement(
         {
           fullName: 'TestFlow',
+          // Flow element extending FlowNode. Should be checked for uniqueness.
           actionCalls: [{ name: 'duplicateName' }, { name: 'anotherDuplicateName' }],
           constants: [{ name: 'duplicateName' }, { name: 'duplicateName' }],
           decisions: [{ name: 'uniqueName' }, { name: 'ThirdDuplicateName' }],
           dynamicChoiceSets: [{ name: 'duplicateName' }],
           screens: [{ name: 'anotherDuplicateName' }, { name: 'anotherDuplicateName' }],
+          // Flow element with a non-unique name. uniqueness check not required.
           processMetadataValues: [{ name: 'ThirdDuplicateName' }, { name: 'ThirdDuplicateName' }],
         },
         flow,
@@ -123,6 +125,7 @@ describe('uniqueFlowElementName change validator', () => {
         {
           elemID: flowInstance.elemID.createNestedID('screens', '0', 'name'),
           severity: 'Warning',
+
           message: 'Duplicate Name in Flow',
           detailedMessage: 'The name "anotherDuplicateName" is used multiple times in this Flow.',
         },


### PR DESCRIPTION
SALTO-7403: (Bugfix)  Fix FlowNodes support for Unique FlowElement Name in CV

---
_Release Notes_: 
None

---
_User Notifications_: 
None
