### PR TITLE
SALTO-7345 add timeIterator methods to logger

### DIFF
--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -100,8 +100,8 @@ function timeIterator<T>(
   desc: string,
   ...descArgs: unknown[]
 ): Iterable<T> {
-  const before = Date.now()
-  let start: number | undefined
+  const createTime = Date.now()
+  let startTime: number | undefined
   let netTimeTaken = 0
 
   const formattedDescription = format(desc, ...descArgs)
@@ -116,8 +116,8 @@ function timeIterator<T>(
         ...iter,
         next: () => {
           const callStartTime = Date.now()
-          if (start === undefined) {
-            start = callStartTime
+          if (startTime === undefined) {
+            startTime = callStartTime
           }
           const res = iter.next()
           const endTime = Date.now()
@@ -125,10 +125,10 @@ function timeIterator<T>(
           if (res.done) {
             this.log(
               level,
-              '%s took %o ms (tts=%o net=%o)',
+              '%s took %o ms (tts=%o ms net=%o ms)',
               formattedDescription,
-              endTime - before,
-              start - before,
+              endTime - createTime,
+              startTime - createTime,
               netTimeTaken,
             )
           }

--- a/packages/logging/test/pino_logger.test.ts
+++ b/packages/logging/test/pino_logger.test.ts
@@ -643,8 +643,8 @@ describe('pino based logger', () => {
       expect(logLines).toEqual([
         expect.stringContaining(`debug ${NAMESPACE} first func 12 starting`),
         expect.stringContaining(`debug ${NAMESPACE} second func starting`),
-        expect.stringContaining(`debug ${NAMESPACE} second func took 9 ms (tts=2 net=4)`),
-        expect.stringContaining(`debug ${NAMESPACE} first func 12 took 20 ms (tts=13 net=4)`),
+        expect.stringContaining(`debug ${NAMESPACE} second func took 9 ms (tts=2 ms net=4 ms)`),
+        expect.stringContaining(`debug ${NAMESPACE} first func 12 took 20 ms (tts=13 ms net=4 ms)`),
       ])
     })
   })


### PR DESCRIPTION
Add the ability to log the running time of an iterator, including:
1. total run time
2. time to start iterating the iterator (`tts`)
3. total time to retrieve iterated items (`net`)

---

_Additional context for reviewer_

---
_Release Notes_: 
Logger:
- add `timeIterator` methods to logger

---
_User Notifications_: 
None
