### PR TITLE
SALTO-7389 deploy forms one by one

### DIFF
--- a/packages/jira-adapter/src/dependency_changers/forms.ts
+++ b/packages/jira-adapter/src/dependency_changers/forms.ts
@@ -6,13 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import {
-  dependencyChange,
-  DependencyChanger,
-  getChangeData,
-  isAdditionOrModificationChange,
-  isInstanceChange,
-} from '@salto-io/adapter-api'
+import { dependencyChange, DependencyChanger, getChangeData, isInstanceChange } from '@salto-io/adapter-api'
 import { getParent } from '@salto-io/adapter-utils'
 import _ from 'lodash'
 import { FORM_TYPE } from '../constants'
@@ -20,12 +14,7 @@ import { FORM_TYPE } from '../constants'
 export const formsDependencyChanger: DependencyChanger = async changes => {
   const formChanges = Array.from(changes.entries())
     .map(([key, change]) => ({ key, change }))
-    .filter(
-      change =>
-        isInstanceChange(change.change) &&
-        isAdditionOrModificationChange(change.change) &&
-        getChangeData(change.change).elemID.typeName === FORM_TYPE,
-    )
+    .filter(change => isInstanceChange(change.change) && getChangeData(change.change).elemID.typeName === FORM_TYPE)
 
   const formsByProject = _.groupBy(formChanges, ({ change }) => getParent(getChangeData(change)).elemID.getFullName())
 

--- a/packages/jira-adapter/src/dependency_changers/forms.ts
+++ b/packages/jira-adapter/src/dependency_changers/forms.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  dependencyChange,
+  DependencyChanger,
+  getChangeData,
+  isAdditionOrModificationChange,
+  isInstanceChange,
+} from '@salto-io/adapter-api'
+import { getParent } from '@salto-io/adapter-utils'
+import _ from 'lodash'
+import { FORM_TYPE } from '../constants'
+
+export const formsDependencyChanger: DependencyChanger = async changes => {
+  const formChanges = Array.from(changes.entries())
+    .map(([key, change]) => ({ key, change }))
+    .filter(
+      change =>
+        isInstanceChange(change.change) &&
+        isAdditionOrModificationChange(change.change) &&
+        getChangeData(change.change).elemID.typeName === FORM_TYPE,
+    )
+
+  const formsByProject = _.groupBy(formChanges, ({ change }) => getParent(getChangeData(change)).elemID.getFullName())
+
+  return Object.values(formsByProject).flatMap(formList =>
+    formList.slice(1).map((currentPolicyChange, index) => {
+      const previousPolicyChange = formList[index]
+      return dependencyChange('add', previousPolicyChange.key, currentPolicyChange.key)
+    }),
+  )
+}

--- a/packages/jira-adapter/src/dependency_changers/index.ts
+++ b/packages/jira-adapter/src/dependency_changers/index.ts
@@ -9,6 +9,7 @@ import { DependencyChanger } from '@salto-io/adapter-api'
 import { deployment } from '@salto-io/adapter-components'
 import { collections } from '@salto-io/lowerdash'
 import { dashboardGadgetsDependencyChanger } from './dashboard_gadgets'
+import { formsDependencyChanger } from './forms'
 import { globalFieldContextsDependencyChanger } from './global_field_contexts'
 import { projectDependencyChanger } from './project'
 import { projectContextsDependencyChanger } from './project_contexts'
@@ -28,6 +29,7 @@ const DEPENDENCY_CHANGERS: DependencyChanger[] = [
   projectDependencyChanger,
   workflowDependencyChanger,
   dashboardGadgetsDependencyChanger,
+  formsDependencyChanger,
   rootObjectTypeToObjectSchemaDependencyChanger, // Must run before removalsDependencyChanger
   objectTypeParentDependencyChanger,
   removalsDependencyChanger,

--- a/packages/jira-adapter/test/dependency_changers/forms.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/forms.test.ts
@@ -50,7 +50,7 @@ describe('formDependencyChanger', () => {
     const inputChanges = new Map([
       [0, toChange({ after: formInstance1 })],
       [1, toChange({ before: formInstance2, after: formInstance2 })],
-      [2, toChange({ after: formInstance3 })],
+      [2, toChange({ before: formInstance3 })],
     ])
     const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
 
@@ -63,22 +63,6 @@ describe('formDependencyChanger', () => {
     expect(dependencyChanges[1].action).toEqual('add')
     expect(dependencyChanges[1].dependency.source).toEqual(1)
     expect(dependencyChanges[1].dependency.target).toEqual(2)
-  })
-
-  it('should not add dependency to deletion form changes', async () => {
-    const inputChanges = new Map([
-      [0, toChange({ after: formInstance1 })],
-      [1, toChange({ before: formInstance2 })],
-      [2, toChange({ after: formInstance3 })],
-    ])
-    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
-
-    const dependencyChanges = [...(await formsDependencyChanger(inputChanges, inputDeps))]
-
-    expect(dependencyChanges).toHaveLength(1)
-    expect(dependencyChanges[0].action).toEqual('add')
-    expect(dependencyChanges[0].dependency.source).toEqual(0)
-    expect(dependencyChanges[0].dependency.target).toEqual(2)
   })
 
   describe('forms from several projects', () => {
@@ -101,7 +85,7 @@ describe('formDependencyChanger', () => {
         [0, toChange({ after: formInstance1 })],
         [1, toChange({ before: formInstance2, after: formInstance2 })],
         [2, toChange({ after: formInstance4DifferentProject })],
-        [3, toChange({ before: formInstance5DifferentProject, after: formInstance5DifferentProject })],
+        [3, toChange({ before: formInstance5DifferentProject })],
       ])
       const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
 

--- a/packages/jira-adapter/test/dependency_changers/forms.test.ts
+++ b/packages/jira-adapter/test/dependency_changers/forms.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  CORE_ANNOTATIONS,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReferenceExpression,
+  toChange,
+} from '@salto-io/adapter-api'
+import { collections } from '@salto-io/lowerdash'
+import { formsDependencyChanger } from '../../src/dependency_changers/forms'
+import { FORM_TYPE, JIRA, PROJECT_TYPE } from '../../src/constants'
+import { createEmptyType } from '../utils'
+
+describe('formDependencyChanger', () => {
+  let formType: ObjectType
+  let formInstance1: InstanceElement
+  let formInstance2: InstanceElement
+  let formInstance3: InstanceElement
+
+  let projectType: ObjectType
+  let projectInstance1: InstanceElement
+
+  beforeEach(() => {
+    projectType = createEmptyType(PROJECT_TYPE)
+    projectInstance1 = new InstanceElement('project_1', projectType)
+
+    formType = new ObjectType({
+      elemID: new ElemID(JIRA, FORM_TYPE),
+    })
+    formInstance1 = new InstanceElement('inst', formType, { id: '1' }, undefined, {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance1.elemID, projectInstance1)],
+    })
+    formInstance2 = new InstanceElement('inst', formType, { id: '2' }, undefined, {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance1.elemID, projectInstance1)],
+    })
+    formInstance3 = new InstanceElement('inst', formType, { id: '3' }, undefined, {
+      [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance1.elemID, projectInstance1)],
+    })
+  })
+
+  it('should add dependency between addition and modification form changes', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: formInstance1 })],
+      [1, toChange({ before: formInstance2, after: formInstance2 })],
+      [2, toChange({ after: formInstance3 })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [...(await formsDependencyChanger(inputChanges, inputDeps))]
+
+    expect(dependencyChanges).toHaveLength(2)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(1)
+    expect(dependencyChanges[1].action).toEqual('add')
+    expect(dependencyChanges[1].dependency.source).toEqual(1)
+    expect(dependencyChanges[1].dependency.target).toEqual(2)
+  })
+
+  it('should not add dependency to deletion form changes', async () => {
+    const inputChanges = new Map([
+      [0, toChange({ after: formInstance1 })],
+      [1, toChange({ before: formInstance2 })],
+      [2, toChange({ after: formInstance3 })],
+    ])
+    const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+    const dependencyChanges = [...(await formsDependencyChanger(inputChanges, inputDeps))]
+
+    expect(dependencyChanges).toHaveLength(1)
+    expect(dependencyChanges[0].action).toEqual('add')
+    expect(dependencyChanges[0].dependency.source).toEqual(0)
+    expect(dependencyChanges[0].dependency.target).toEqual(2)
+  })
+
+  describe('forms from several projects', () => {
+    let formInstance4DifferentProject: InstanceElement
+    let formInstance5DifferentProject: InstanceElement
+
+    beforeEach(() => {
+      const projectInstance2 = new InstanceElement('project_2', projectType)
+
+      formInstance4DifferentProject = new InstanceElement('inst', formType, { id: '4' }, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance2.elemID, projectInstance2)],
+      })
+      formInstance5DifferentProject = new InstanceElement('inst', formType, { id: '5' }, undefined, {
+        [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(projectInstance2.elemID, projectInstance2)],
+      })
+    })
+
+    it('should add dependencies between forms in the same project', async () => {
+      const inputChanges = new Map([
+        [0, toChange({ after: formInstance1 })],
+        [1, toChange({ before: formInstance2, after: formInstance2 })],
+        [2, toChange({ after: formInstance4DifferentProject })],
+        [3, toChange({ before: formInstance5DifferentProject, after: formInstance5DifferentProject })],
+      ])
+      const inputDeps = new Map<collections.set.SetId, Set<collections.set.SetId>>([])
+
+      const dependencyChanges = [...(await formsDependencyChanger(inputChanges, inputDeps))]
+
+      expect(dependencyChanges).toHaveLength(2)
+      expect(dependencyChanges[0].action).toEqual('add')
+      expect(dependencyChanges[0].dependency.source).toEqual(0)
+      expect(dependencyChanges[0].dependency.target).toEqual(1)
+      expect(dependencyChanges[1].action).toEqual('add')
+      expect(dependencyChanges[1].dependency.source).toEqual(2)
+      expect(dependencyChanges[1].dependency.target).toEqual(3)
+    })
+  })
+})


### PR DESCRIPTION
SALTO-7389 Workaround for a Jira bug: when trying to deploy (addition/modification) several forms of the same project, only one is deployed. deploying the changes one-by-one (per project) solves this

---

_Additional context for reviewer_
None

---
_Release Notes_: 

_Jira_adapter_:
- SALTO-7389 solve bug of failing to deploy forms

---
_User Notifications_: 
None
