### PR TITLE
SALTO-7399: advanced fields references

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -67,6 +67,9 @@ const excludedTypes = [
 const nullProgressReporter: ProgressReporter = {
   reportProgress: () => {},
 }
+
+const deleteElementsAtTheEnd = true // use for debugging
+
 each([
   ['Cloud', false],
   ['Data Center', true],
@@ -250,6 +253,9 @@ each([
     })
 
     afterAll(async () => {
+      if (!deleteElementsAtTheEnd) {
+        return
+      }
       const removalChangeGroups = addDeployResults
         .map(res => res.appliedChanges)
         .map(changeGroup =>

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -7,7 +7,6 @@
  */
 import {
   Change,
-  CORE_ANNOTATIONS,
   DeployResult,
   Element,
   getChangeData,
@@ -304,21 +303,13 @@ each([
         .filter(instance => instance.elemID.name.includes('createdByOssE2e'))
         .filter(instance => !removalInstancesNames.includes(instance.elemID.getFullName()))
         .filter(instance => instance.elemID.typeName !== FIELD_TYPE_NAME || !instance.value.isLocked) // do not delete locked fields, isLocked can also be undefined
-        .filter(
-          instance =>
-            instance.elemID.typeName !== FIELD_CONTEXT_TYPE_NAME ||
-            !instance.annotations[CORE_ANNOTATIONS.PARENT]?.[0].value.isLocked,
-        ) // do not delete contexts of locked fields
+        .filter(instance => instance.elemID.typeName !== FIELD_CONTEXT_TYPE_NAME) // do not delete contexts as they will be deleted with their fields
         .filter(instance => instance.elemID.typeName !== FIELD_CONTEXT_OPTION_TYPE_NAME) // do not delete options, they will be deleted with their contexts
         .map(instance => toChange({ before: instance }))
 
-      if (!isDataCenter) {
-        const allRemovalErrors = await deployChanges([allOssCreatedElements], () => true) // do not fail on errors
-        if (allRemovalErrors.length) {
-          throw new Error(
-            `Failed to clean older e2e changes: ${allRemovalErrors.map(e => safeJsonStringify(e)).join(', ')}`,
-          )
-        }
+      const allRemovalErrors = await deployChanges([allOssCreatedElements], () => true) // do not fail on errors
+      if (allRemovalErrors.length) {
+        log.error(`Failed to clean e2e changes: ${allRemovalErrors.map(e => safeJsonStringify(e)).join(', ')}`)
       }
     })
   })

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -297,11 +297,11 @@ each([
         .filter(isInstanceElement)
         .filter(instance => instance.elemID.name.includes('createdByOssE2e'))
         .filter(instance => !removalInstancesNames.includes(instance.elemID.getFullName()))
-        .filter(instance => instance.elemID.typeName !== FIELD_TYPE_NAME || instance.value.isLocked === false) // do not delete locked fields
+        .filter(instance => instance.elemID.typeName !== FIELD_TYPE_NAME || !instance.value.isLocked) // do not delete locked fields, isLocked can also be undefined
         .filter(
           instance =>
             instance.elemID.typeName !== FIELD_CONTEXT_TYPE_NAME ||
-            instance.annotations[CORE_ANNOTATIONS.PARENT]?.[0].value.isLocked === false,
+            !instance.annotations[CORE_ANNOTATIONS.PARENT]?.[0].value.isLocked,
         ) // do not delete contexts of locked fields
         .filter(instance => instance.elemID.typeName !== FIELD_CONTEXT_OPTION_TYPE_NAME) // do not delete options, they will be deleted with their contexts
         .map(instance => toChange({ before: instance }))

--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -67,7 +67,7 @@ const nullProgressReporter: ProgressReporter = {
   reportProgress: () => {},
 }
 
-const deleteElementsAtTheEnd = true // use for debugging
+const deleteElementsAtTheEnd = true // when debugging you can change to false to keep the created elements and see the deployed elements in the service
 
 each([
   ['Cloud', false],

--- a/packages/jira-adapter/e2e_test/instances/cloud/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/automation.ts
@@ -317,6 +317,33 @@ export const createAutomationValues = (name: string, allElements: Element[]): Va
       ],
       conditions: [],
     },
+    {
+      component: 'ACTION',
+      type: 'jira.issue.edit',
+      value: {
+        operations: [
+          {
+            field: {
+              type: 'ID',
+              value: createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Assignee__user'), allElements),
+            },
+            fieldType: 'assignee',
+            type: 'SET',
+            value: {
+              type: 'CLEAR',
+              value: 'clear',
+            },
+          },
+        ],
+        advancedFields: new TemplateExpression({
+          parts: [
+            '{\n"update": {\n"',
+            createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Sprint__gh_sprint__c@uubuu'), allElements),
+            '" : [\n{\n"remove": {\n"value":"Pre-ship containment"\n}\n}\n]\n}\n}',
+          ],
+        }),
+      },
+    },
   ],
   canOtherRuleTrigger: false,
   notifyOnError: 'FIRSTERROR',

--- a/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/automation.ts
@@ -5,13 +5,14 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { ElemID, ReferenceExpression, StaticFile, Values } from '@salto-io/adapter-api'
+import { ElemID, ReferenceExpression, StaticFile, TemplateExpression, Values, Element } from '@salto-io/adapter-api'
 import * as path from 'path'
 import * as fs from 'fs'
 import { AUTOMATION_TYPE, JIRA } from '../../../src/constants'
 import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+import { createReference } from '../../utils'
 
-export const createAutomationValues = (name: string): Values => ({
+export const createAutomationValues = (name: string, allElements: Element[]): Values => ({
   name,
   state: 'ENABLED',
   canOtherRuleTrigger: false,
@@ -218,6 +219,36 @@ export const createAutomationValues = (name: string): Values => ({
           newComponent: false,
         },
       ],
+      conditions: [],
+      optimisedIds: [],
+      newComponent: false,
+    },
+    {
+      component: 'ACTION',
+      type: 'jira.issue.edit',
+      value: {
+        operations: [
+          {
+            fieldId: 'assignee',
+            fieldType: 'assignee',
+            type: 'SET',
+            value: {
+              type: 'CLEAR',
+              value: 'clear',
+            },
+          },
+        ],
+        advancedFields: new TemplateExpression({
+          parts: [
+            '{\n"update": {\n"',
+            createReference(new ElemID(JIRA, FIELD_TYPE_NAME, 'instance', 'Sprint__gh_sprint__c@uubuu'), allElements),
+            '" : [\n{\n"remove": {\n"value":"Pre-ship containment"\n}\n}\n]\n}\n}',
+          ],
+        }),
+        sendNotifications: true,
+        useLegacyRendering: false,
+      },
+      children: [],
       conditions: [],
       optimisedIds: [],
       newComponent: false,

--- a/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
+++ b/packages/jira-adapter/e2e_test/instances/datacenter/index.ts
@@ -31,7 +31,7 @@ export const createInstances = (randomString: string, fetchedElements: Element[]
   const automation = new InstanceElement(
     randomString,
     findType(AUTOMATION_TYPE, fetchedElements),
-    createAutomationValues(randomString),
+    createAutomationValues(randomString, fetchedElements),
   )
 
   const workflow = new InstanceElement(

--- a/packages/jira-adapter/src/config/config.ts
+++ b/packages/jira-adapter/src/config/config.ts
@@ -76,6 +76,7 @@ type JiraFetchConfig = definitions.UserFetchConfig<{ fetchCriteria: JiraFetchFil
   splitFieldContextOptions?: boolean
   enableRequestTypeFieldNameAlignment?: boolean
   removeFieldConfigurationDefaultValues?: boolean
+  walkOnReferences?: boolean
   remove10KOptionsContexts: boolean
 }
 
@@ -187,6 +188,7 @@ const PARTIAL_DEFAULT_CONFIG: Omit<JiraConfig, 'apiDefinitions'> = {
     removeFieldConfigurationDefaultValues: false,
     splitFieldContextOptions: true,
     remove10KOptionsContexts: false, // starting value, to be changed
+    walkOnReferences: true,
   },
   deploy: {
     forceDelete: false,
@@ -355,6 +357,7 @@ const fetchConfigType = definitions.createUserFetchConfigType({
     enableRequestTypeFieldNameAlignment: { refType: BuiltinTypes.BOOLEAN },
     removeFieldConfigurationDefaultValues: { refType: BuiltinTypes.BOOLEAN },
     remove10KOptionsContexts: { refType: BuiltinTypes.BOOLEAN },
+    walkOnReferences: { refType: BuiltinTypes.BOOLEAN },
   },
   fetchCriteriaType: fetchFiltersType,
   omitElemID: true,
@@ -427,6 +430,7 @@ export const configType = createMatchingObjectType<Partial<JiraConfig>>({
       'fetch.parseAdditionalAutomationExpressions',
       'fetch.enableRequestTypeFieldNameAlignment',
       'fetch.removeFieldConfigurationDefaultValues',
+      'fetch.walkOnReferences',
       'deploy.taskMaxRetries',
       'deploy.taskRetryDelay',
       'deploy.ignoreMissingExtensions',

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -45,7 +45,7 @@ type Component = {
   children?: Component[]
 }
 
-type AutomationInstance = InstanceElement & {
+export type AutomationInstance = InstanceElement & {
   value: {
     trigger: Component
     components?: Component[]
@@ -65,7 +65,7 @@ const AUTOMATION_INSTANCE_SCHEME = Joi.object({
   }).unknown(true),
 }).unknown(true)
 
-const isAutomationInstance = createSchemeGuard<AutomationInstance>(
+export const isAutomationInstance = createSchemeGuard<AutomationInstance>(
   AUTOMATION_INSTANCE_SCHEME,
   'Received an invalid automation',
 )

--- a/packages/jira-adapter/src/filters/automation/walk_on_automation.ts
+++ b/packages/jira-adapter/src/filters/automation/walk_on_automation.ts
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { WALK_NEXT_STEP, WalkOnFunc, walkOnValue } from '@salto-io/adapter-utils'
+import { InstanceElement, Value } from '@salto-io/adapter-api'
+import { AutomationInstance, isAutomationInstance } from './smart_values/smart_value_reference_filter'
+
+const FIELDS_TO_WALK_ON = (): string[] => ['trigger', 'components']
+const ADVANCED_FIELDS = 'advancedFields'
+
+export const walkOnAutomation = ({ instance, func }: { instance: AutomationInstance; func: WalkOnFunc }): void => {
+  FIELDS_TO_WALK_ON().forEach(fieldName => {
+    if (instance.value[fieldName] !== undefined) {
+      walkOnValue({
+        elemId: instance.elemID.createNestedID(fieldName),
+        value: instance.value[fieldName],
+        func,
+      })
+    }
+  })
+}
+
+export const walkOnAutomations = (instances: InstanceElement[], func: WalkOnFunc): void => {
+  instances.filter(isAutomationInstance).forEach(instance => walkOnAutomation({ instance, func }))
+}
+
+export const advancedFieldsReferenceFunc =
+  (func: (value: Value, fieldName: string) => void): WalkOnFunc =>
+  ({ value }): WALK_NEXT_STEP => {
+    if (value == null) {
+      return WALK_NEXT_STEP.SKIP
+    }
+    if (Object.prototype.hasOwnProperty.call(value, ADVANCED_FIELDS)) {
+      func(value, ADVANCED_FIELDS)
+      return WALK_NEXT_STEP.SKIP
+    }
+    return WALK_NEXT_STEP.RECURSE
+  }

--- a/packages/jira-adapter/src/filters/automation/walk_on_automation.ts
+++ b/packages/jira-adapter/src/filters/automation/walk_on_automation.ts
@@ -34,7 +34,7 @@ export const advancedFieldsReferenceFunc =
     if (value == null) {
       return WALK_NEXT_STEP.SKIP
     }
-    if (Object.prototype.hasOwnProperty.call(value, ADVANCED_FIELDS)) {
+    if (value[ADVANCED_FIELDS] !== undefined) {
       func(value, ADVANCED_FIELDS)
       return WALK_NEXT_STEP.SKIP
     }

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -43,15 +43,14 @@ const addWalkOnReferences = (instances: InstanceElement[], config: JiraConfig): 
 const filter: FilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
   onFetch: async elements => {
-    addWalkOnReferences(elements.filter(isInstanceElement), config)
+    const instances = elements.filter(isInstanceElement)
+    addWalkOnReferences(instances, config)
 
     const fixedDefs = referencesRules.map(def =>
       config.fetch.enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
     // Remove once SALTO-6889 is done: ProjectComponents have no references, so don't need to scan them
-    const relevantElements = elements
-      .filter(isInstanceElement)
-      .filter(instance => !NO_REFERENCES_TYPES().includes(instance.elemID.typeName))
+    const relevantElements = instances.filter(instance => !NO_REFERENCES_TYPES().includes(instance.elemID.typeName))
     await referenceUtils.addReferences({
       elements: relevantElements,
       contextElements: elements,

--- a/packages/jira-adapter/src/filters/field_references.ts
+++ b/packages/jira-adapter/src/filters/field_references.ts
@@ -5,29 +5,52 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { Element, isInstanceElement } from '@salto-io/adapter-api'
+import { Element, InstanceElement, isInstanceElement } from '@salto-io/adapter-api'
 import { references as referenceUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
 import { referencesRules, JiraFieldReferenceResolver, contextStrategyLookup } from '../reference_mapping'
 import { FilterCreator } from '../filter'
-import { FIELD_CONFIGURATION_TYPE_NAME, PROJECT_COMPONENT_TYPE } from '../constants'
+import { AUTOMATION_TYPE, FIELD_CONFIGURATION_TYPE_NAME, PROJECT_COMPONENT_TYPE } from '../constants'
+import { JiraConfig } from '../config/config'
+import { FIELD_TYPE_NAME } from './fields/constants'
+import { advancedFieldsReferenceFunc, walkOnAutomations } from './automation/walk_on_automation'
+import { addFieldsTemplateReferences } from './fields/reference_to_fields'
 
 /**
  * Convert field values into references, based on predefined rules.
  */
 
-const noReferencesTypes = [PROJECT_COMPONENT_TYPE, FIELD_CONFIGURATION_TYPE_NAME]
+const NO_REFERENCES_TYPES = (): string[] => [PROJECT_COMPONENT_TYPE, FIELD_CONFIGURATION_TYPE_NAME]
+
+const addWalkOnReferences = (elements: Element[], config: JiraConfig): void => {
+  if (!config.fetch.walkOnReferences) {
+    return
+  }
+  const instances = elements.filter(isInstanceElement)
+  const fieldInstances = instances.filter(instance => instance.elemID.typeName === FIELD_TYPE_NAME)
+  const fieldInstancesById = new Map(
+    fieldInstances.map(instance => [instance.value.id, instance] as [string, InstanceElement]),
+  )
+  walkOnAutomations(
+    instances.filter(instance => instance.elemID.typeName === AUTOMATION_TYPE),
+    advancedFieldsReferenceFunc(
+      addFieldsTemplateReferences(fieldInstancesById, config.fetch.enableMissingReferences ?? true),
+    ),
+  )
+}
 
 const filter: FilterCreator = ({ config }) => ({
   name: 'fieldReferencesFilter',
-  onFetch: async (elements: Element[]) => {
+  onFetch: async elements => {
+    addWalkOnReferences(elements, config)
+
     const fixedDefs = referencesRules.map(def =>
       config.fetch.enableMissingReferences ? def : _.omit(def, 'missingRefStrategy'),
     )
     // Remove once SALTO-6889 is done: ProjectComponents have no references, so don't need to scan them
     const relevantElements = elements
       .filter(isInstanceElement)
-      .filter(instance => !noReferencesTypes.includes(instance.elemID.typeName))
+      .filter(instance => !NO_REFERENCES_TYPES().includes(instance.elemID.typeName))
     await referenceUtils.addReferences({
       elements: relevantElements,
       contextElements: elements,

--- a/packages/jira-adapter/src/filters/fields/reference_to_fields.ts
+++ b/packages/jira-adapter/src/filters/fields/reference_to_fields.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import { InstanceElement, ReferenceExpression, TemplateExpression, Value } from '@salto-io/adapter-api'
+import { extractTemplate } from '@salto-io/adapter-utils'
+import { referenceFunc } from '../script_runner/walk_on_scripts'
+
+const CUSTOM_FIELD_PATTERN = /(customfield_\d+)/
+
+const referenceCustomFields = (
+  text: string,
+  fieldInstancesById: Map<string, InstanceElement>,
+): TemplateExpression | string =>
+  extractTemplate(text, [CUSTOM_FIELD_PATTERN], expression => {
+    const instance = fieldInstancesById.get(expression)
+    if (!expression.match(CUSTOM_FIELD_PATTERN) || instance === undefined) {
+      return expression
+    }
+    return new ReferenceExpression(instance.elemID, instance)
+  })
+
+export const addFieldsTemplateReferences =
+  (fieldInstancesById: Map<string, InstanceElement>): referenceFunc =>
+  (value: Value, fieldName: string): void => {
+    if (typeof value[fieldName] === 'string') {
+      value[fieldName] = referenceCustomFields(value[fieldName], fieldInstancesById)
+    }
+  }

--- a/packages/jira-adapter/src/filters/fields/reference_to_fields.ts
+++ b/packages/jira-adapter/src/filters/fields/reference_to_fields.ts
@@ -15,11 +15,15 @@ import { FIELD_TYPE_NAME } from './constants'
 
 const CUSTOM_FIELD_PATTERN = /(customfield_\d+)/
 
-const referenceCustomFields = (
-  text: string,
-  fieldInstancesById: Map<string, InstanceElement>,
-  enableMissingReferences: boolean,
-): TemplateExpression | string =>
+const referenceCustomFields = ({
+  text,
+  fieldInstancesById,
+  enableMissingReferences,
+}: {
+  text: string
+  fieldInstancesById: Map<string, InstanceElement>
+  enableMissingReferences: boolean
+}): TemplateExpression | string =>
   extractTemplate(text, [CUSTOM_FIELD_PATTERN], expression => {
     if (!expression.match(CUSTOM_FIELD_PATTERN)) {
       return expression
@@ -37,6 +41,6 @@ export const addFieldsTemplateReferences =
   (fieldInstancesById: Map<string, InstanceElement>, enableMissingReferences: boolean): referenceFunc =>
   (value: Value, fieldName: string): void => {
     if (typeof value[fieldName] === 'string') {
-      value[fieldName] = referenceCustomFields(value[fieldName], fieldInstancesById, enableMissingReferences)
+      value[fieldName] = referenceCustomFields({ text: value[fieldName], fieldInstancesById, enableMissingReferences })
     }
   }

--- a/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
@@ -62,7 +62,11 @@ const filter: FilterCreator = ({ config, client }) => {
         fieldInstances.map(instance => [instance.value.id, instance] as [string, InstanceElement]),
       )
 
-      walkOnScripts({ func: addFieldsTemplateReferences(fieldInstancesById), isDc: client.isDataCenter, instances })
+      walkOnScripts({
+        func: addFieldsTemplateReferences(fieldInstancesById, config.fetch.enableMissingReferences ?? true),
+        isDc: client.isDataCenter,
+        instances,
+      })
     },
     preDeploy: async changes => {
       if (!config.fetch.enableScriptRunnerAddon) {

--- a/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
+++ b/packages/jira-adapter/src/filters/script_runner/script_template_expressions.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { extractTemplate, replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
+import { replaceTemplatesWithValues, resolveTemplates } from '@salto-io/adapter-utils'
 import {
   InstanceElement,
   isInstanceElement,
@@ -22,8 +22,7 @@ import {
 import { FilterCreator } from '../../filter'
 import { FIELD_TYPE_NAME } from '../fields/constants'
 import { referenceFunc, walkOnScripts } from './walk_on_scripts'
-
-const CUSTOM_FIELD_PATTERN = /(customfield_\d+)/
+import { addFieldsTemplateReferences } from '../fields/reference_to_fields'
 
 const removeTemplateReferences =
   (originalInstances: Record<string, TemplateExpression>): referenceFunc =>
@@ -48,26 +47,6 @@ const restoreTemplateReferences =
     resolveTemplates({ values: [value], fieldName }, originalInstances)
   }
 
-const referenceCustomFields = (
-  script: string,
-  fieldInstancesById: Map<string, InstanceElement>,
-): TemplateExpression | string =>
-  extractTemplate(script, [CUSTOM_FIELD_PATTERN], expression => {
-    const instance = fieldInstancesById.get(expression)
-    if (!expression.match(CUSTOM_FIELD_PATTERN) || instance === undefined) {
-      return expression
-    }
-    return new ReferenceExpression(instance.elemID, instance)
-  })
-
-const addTemplateReferences =
-  (fieldInstancesById: Map<string, InstanceElement>): referenceFunc =>
-  (value: Value, fieldName: string): void => {
-    if (typeof value[fieldName] === 'string') {
-      value[fieldName] = referenceCustomFields(value[fieldName], fieldInstancesById)
-    }
-  }
-
 // This filter is used to add and remove template expressions in scriptRunner scripts
 const filter: FilterCreator = ({ config, client }) => {
   const deployTemplateMapping: Record<string, TemplateExpression> = {}
@@ -83,7 +62,7 @@ const filter: FilterCreator = ({ config, client }) => {
         fieldInstances.map(instance => [instance.value.id, instance] as [string, InstanceElement]),
       )
 
-      walkOnScripts({ func: addTemplateReferences(fieldInstancesById), isDc: client.isDataCenter, instances })
+      walkOnScripts({ func: addFieldsTemplateReferences(fieldInstancesById), isDc: client.isDataCenter, instances })
     },
     preDeploy: async changes => {
       if (!config.fetch.enableScriptRunnerAddon) {

--- a/packages/jira-adapter/test/filters/automation/walk_on_automation.test.ts
+++ b/packages/jira-adapter/test/filters/automation/walk_on_automation.test.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import { InstanceElement, Value } from '@salto-io/adapter-api'
+import { WALK_NEXT_STEP, WalkOnFunc, walkOnValue } from '@salto-io/adapter-utils'
+import { createEmptyType } from '../../utils'
+import { AUTOMATION_TYPE } from '../../../src/constants'
+import { AutomationInstance } from '../../../src/filters/automation/smart_values/smart_value_reference_filter'
+import {
+  advancedFieldsReferenceFunc,
+  walkOnAutomation,
+  walkOnAutomations,
+} from '../../../src/filters/automation/walk_on_automation'
+
+describe('walk_on_automation', () => {
+  let instance: InstanceElement
+  const changeValueFunc: WalkOnFunc = ({ value }): WALK_NEXT_STEP => {
+    if (value == null) {
+      return WALK_NEXT_STEP.SKIP
+    }
+    if (value.value !== undefined) {
+      value.value = 'replaced'
+      return WALK_NEXT_STEP.SKIP
+    }
+    return WALK_NEXT_STEP.RECURSE
+  }
+  beforeEach(async () => {
+    instance = new InstanceElement('instance', createEmptyType(AUTOMATION_TYPE), {
+      id: '111',
+      trigger: {
+        children: [
+          {
+            id: '0',
+            value: null,
+            updated: 1234,
+          },
+        ],
+        type: 'jira.issue.event.trigger:created',
+      },
+      components: [
+        {
+          id: '0',
+          value: { a: '12' },
+          updated: 1234,
+        },
+        {
+          id: '1',
+          component: 'CONDITION',
+          value: { a: 'priority > Medium' },
+          updated: 1111,
+        },
+        {
+          id: '3',
+          component: 'CONDITION',
+          otherValue: {
+            selectedFieldType: 'priority',
+            comparison: 'NOT_ONE_OF',
+            compareValue: {
+              type: 'ID',
+              multiValue: true,
+              value: '["\\"123","234","345","a]"]',
+            },
+          },
+        },
+      ],
+      projects: [
+        {
+          value: 'doNotReplaceMe',
+        },
+      ],
+    })
+  })
+  describe('walkOnAutomation', () => {
+    it('should walk on trigger and components', () => {
+      walkOnAutomation({ instance: instance as AutomationInstance, func: changeValueFunc })
+      expect(instance.value.trigger.children[0].value).toEqual('replaced')
+      expect(instance.value.components[0].value).toEqual('replaced')
+      expect(instance.value.components[1].value).toEqual('replaced')
+      expect(instance.value.components[2].otherValue.compareValue.value).toEqual('replaced')
+    })
+    it('should not walk on projects', () => {
+      walkOnAutomation({ instance: instance as AutomationInstance, func: changeValueFunc })
+      expect(instance.value.projects[0].value).toEqual('doNotReplaceMe')
+    })
+  })
+  describe('walkOnAutomations', () => {
+    it('should walk on all automations', () => {
+      const automation2 = instance.clone()
+      walkOnAutomations([instance, automation2], changeValueFunc)
+      expect(instance.value.trigger.children[0].value).toEqual('replaced')
+      expect(automation2.value.trigger.children[0].value).toEqual('replaced')
+    })
+    it('should not walk on other instances', () => {
+      const automation2 = instance.clone()
+      delete automation2.value.trigger
+      walkOnAutomations([instance, automation2], changeValueFunc)
+      expect(instance.value.trigger.children[0].value).toEqual('replaced')
+      expect(automation2.value.components[0].value).toEqual({ a: '12' })
+    })
+  })
+  describe('advancedFieldsReferenceFunc', () => {
+    it('should operate the function on advancedFields', () => {
+      const advancedFieldsInstance = new InstanceElement('advancedFieldsInstance', createEmptyType(AUTOMATION_TYPE), {
+        a: {
+          advancedFields: { value: 'toBeReplaced' },
+        },
+        b: {
+          bb: {
+            advancedFields: { value: 'toBeReplaced' },
+          },
+        },
+        c: {
+          value: 'doNotReplaceMe',
+        },
+        d: {
+          value: undefined,
+        },
+      })
+      const changeAdvancedFieldsFunc = (value: Value, fieldName: string): void => {
+        value[fieldName].value = 'replaced'
+      }
+      walkOnValue({
+        elemId: advancedFieldsInstance.elemID,
+        value: advancedFieldsInstance.value,
+        func: advancedFieldsReferenceFunc(changeAdvancedFieldsFunc),
+      })
+      expect(advancedFieldsInstance.value.a.advancedFields.value).toEqual('replaced')
+      expect(advancedFieldsInstance.value.b.bb.advancedFields.value).toEqual('replaced')
+      expect(advancedFieldsInstance.value.c.value).toEqual('doNotReplaceMe')
+    })
+  })
+})

--- a/packages/jira-adapter/test/filters/fields/field_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_references.test.ts
@@ -9,10 +9,29 @@
 import { ElemID, InstanceElement, Element, ObjectType, ReferenceExpression, BuiltinTypes } from '@salto-io/adapter-api'
 import { filterUtils } from '@salto-io/adapter-components'
 import _ from 'lodash'
-import { getFilterParams } from '../../utils'
+import { createEmptyType, getFilterParams } from '../../utils'
 import { JIRA, SCREEN_SCHEME_TYPE } from '../../../src/constants'
 import fieldReferencesFilter from '../../../src/filters/field_references'
-import { getDefaultConfig } from '../../../src/config/config'
+import { getDefaultConfig, JiraConfig } from '../../../src/config/config'
+import { FIELD_TYPE_NAME } from '../../../src/filters/fields/constants'
+
+const mockWalkOnAutomations = jest.fn()
+jest.mock('../../../src/filters/automation/walk_on_automation', () => {
+  const actual = jest.requireActual('../../../src/filters/automation/walk_on_automation')
+  return {
+    ...actual,
+    walkOnAutomations: jest.fn((...args) => mockWalkOnAutomations(...args)),
+  }
+})
+
+const mockAddFieldReferences = jest.fn()
+jest.mock('../../../src/filters/fields/reference_to_fields', () => {
+  const actual = jest.requireActual('../../../src/filters/fields/reference_to_fields')
+  return {
+    ...actual,
+    addFieldsTemplateReferences: jest.fn((...args) => mockAddFieldReferences(...args)),
+  }
+})
 
 describe('fieldReferencesFilter', () => {
   type filterType = filterUtils.FilterWith<'onFetch'>
@@ -72,6 +91,51 @@ describe('fieldReferencesFilter', () => {
       await filter.onFetch(elements)
       const screenScheme2 = elements.find(e => e.elemID.name === 'screenScheme2') as InstanceElement
       expect(screenScheme2.value.screens.default).toBe(444)
+    })
+    describe('walkOnReferences', () => {
+      let filter: filterType
+      let config: JiraConfig
+      let fields: InstanceElement[]
+      let idToField: Map<string, InstanceElement>
+      beforeEach(() => {
+        jest.clearAllMocks()
+        config = _.cloneDeep(getDefaultConfig({ isDataCenter: false }))
+        config.fetch.walkOnReferences = true
+        filter = fieldReferencesFilter(getFilterParams({ config })) as filterType
+        const fieldType = createEmptyType(FIELD_TYPE_NAME)
+        fields = [
+          new InstanceElement('field1', fieldType, { id: 555 }),
+          new InstanceElement('field2', fieldType, { id: 666 }),
+        ]
+        idToField = new Map(fields.map(field => [field.value.id, field] as [string, InstanceElement]))
+        elements.push(...fields)
+      })
+      it('should call walkOnAutomations with the correct parameters', async () => {
+        const automationInstance = new InstanceElement('automation', createEmptyType('Automation'), {
+          id: 1,
+          components: [
+            {
+              advancedFields: 'abc cusomtfield_555 def',
+            },
+          ],
+          trigger: {},
+        })
+        elements.push(automationInstance)
+        await filter.onFetch(elements)
+        expect(mockWalkOnAutomations).toHaveBeenCalledWith([automationInstance], expect.any(Function))
+        expect(mockAddFieldReferences).toHaveBeenCalledWith(idToField, true)
+      })
+      it('should not call walkOnAutomations if walkOnReferences is disabled', async () => {
+        config.fetch.walkOnReferences = false
+        filter = fieldReferencesFilter(getFilterParams({ config })) as filterType
+        await filter.onFetch(elements)
+        expect(mockWalkOnAutomations).not.toHaveBeenCalled()
+      })
+      it('should fill missing references if enableMissingReferences does not exist', async () => {
+        delete config.fetch.enableMissingReferences
+        await filter.onFetch(elements)
+        expect(mockAddFieldReferences).toHaveBeenCalledWith(idToField, true)
+      })
     })
   })
 })

--- a/packages/jira-adapter/test/filters/fields/field_references.test.ts
+++ b/packages/jira-adapter/test/filters/fields/field_references.test.ts
@@ -104,15 +104,15 @@ describe('fieldReferencesFilter', () => {
         filter = fieldReferencesFilter(getFilterParams({ config })) as filterType
         const fieldType = createEmptyType(FIELD_TYPE_NAME)
         fields = [
-          new InstanceElement('field1', fieldType, { id: 555 }),
-          new InstanceElement('field2', fieldType, { id: 666 }),
+          new InstanceElement('field1', fieldType, { id: '555' }),
+          new InstanceElement('field2', fieldType, { id: '666' }),
         ]
         idToField = new Map(fields.map(field => [field.value.id, field] as [string, InstanceElement]))
         elements.push(...fields)
       })
       it('should call walkOnAutomations with the correct parameters', async () => {
         const automationInstance = new InstanceElement('automation', createEmptyType('Automation'), {
-          id: 1,
+          id: '1',
           components: [
             {
               advancedFields: 'abc cusomtfield_555 def',

--- a/packages/jira-adapter/test/filters/fields/reference_to_fields.test.ts
+++ b/packages/jira-adapter/test/filters/fields/reference_to_fields.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+import {
+  InstanceElement,
+  isReferenceExpression,
+  isTemplateExpression,
+  ReferenceExpression,
+  Value,
+} from '@salto-io/adapter-api'
+import _ from 'lodash'
+import { createEmptyType } from '../../utils'
+import { addFieldsTemplateReferences } from '../../../src/filters/fields/reference_to_fields'
+
+describe('addFieldsTemplateReferences', () => {
+  const fieldsMap = new Map(
+    _.range(5).map(index => {
+      const id = `customfield_${index + 1}`
+      return [id, new InstanceElement(`field_${index + 1}`, createEmptyType('Field'), { id })]
+    }),
+  )
+
+  // beforeEach(() => {
+  //   context = new InstanceElement(
+  //     'context',
+  //     new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') }),
+  //     {
+  //       id: 2,
+  //       projectIds: ['3', '4'],
+  //     },
+  //     undefined,
+  //     {
+  //       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)],
+  //     },
+  //   )
+  // })
+
+  it('should make a reference to a custom field', async () => {
+    const value: Value = {
+      script: 'abc customfield_2 def',
+    }
+    addFieldsTemplateReferences(fieldsMap, false)(value, 'script')
+    expect(isTemplateExpression(value.script)).toBeTruthy()
+    expect(value.script.parts.length).toEqual(3)
+    expect(value.script.parts[0]).toEqual('abc ')
+    expect(value.script.parts[1]).toEqual(
+      new ReferenceExpression(fieldsMap.get('customfield_2')!.elemID, fieldsMap.get('customfield_2')!),
+    )
+    expect(value.script.parts[2]).toEqual(' def')
+  })
+  it('should make several references in the same string', async () => {
+    const value: Value = {
+      script: 'abc customfield_2 def customfield_3',
+    }
+    addFieldsTemplateReferences(fieldsMap, false)(value, 'script')
+    expect(isTemplateExpression(value.script)).toBeTruthy()
+    expect(value.script.parts.length).toEqual(4)
+    expect(value.script.parts[1]).toEqual(
+      new ReferenceExpression(fieldsMap.get('customfield_2')!.elemID, fieldsMap.get('customfield_2')),
+    )
+    expect(value.script.parts[3]).toEqual(
+      new ReferenceExpression(fieldsMap.get('customfield_3')!.elemID, fieldsMap.get('customfield_3')),
+    )
+  })
+  it('should not make a reference when value is not string', async () => {
+    const value = {
+      script: 1,
+    }
+    addFieldsTemplateReferences(fieldsMap, false)(value, 'script')
+    expect(value.script).toEqual(1)
+  })
+  it('should not make a reference when the pattern is not found', async () => {
+    const value = {
+      script: 'abc def',
+    }
+    addFieldsTemplateReferences(fieldsMap, false)(value, 'script')
+    expect(value.script).toEqual('abc def')
+  })
+  it('should not make a reference when there is no such field', async () => {
+    const value = {
+      script: 'abc customfield_6 def',
+    }
+    addFieldsTemplateReferences(fieldsMap, false)(value, 'script')
+    expect(value.script).toEqual('abc customfield_6 def')
+  })
+  it('should make a missing reference when the field is missing', async () => {
+    const value: Value = {
+      script: 'abc customfield_6 def',
+    }
+    addFieldsTemplateReferences(fieldsMap, true)(value, 'script')
+    expect(isTemplateExpression(value.script)).toBeTruthy()
+    expect(value.script.parts.length).toEqual(3)
+    expect(value.script.parts[0]).toEqual('abc ')
+    expect(isReferenceExpression(value.script.parts[1])).toBeTruthy()
+    expect(value.script.parts[1].elemID.getFullName()).toEqual('jira.Field.instance.missing_customfield_6')
+    expect(value.script.parts[2]).toEqual(' def')
+  })
+})

--- a/packages/jira-adapter/test/filters/fields/reference_to_fields.test.ts
+++ b/packages/jira-adapter/test/filters/fields/reference_to_fields.test.ts
@@ -23,22 +23,6 @@ describe('addFieldsTemplateReferences', () => {
       return [id, new InstanceElement(`field_${index + 1}`, createEmptyType('Field'), { id })]
     }),
   )
-
-  // beforeEach(() => {
-  //   context = new InstanceElement(
-  //     'context',
-  //     new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') }),
-  //     {
-  //       id: 2,
-  //       projectIds: ['3', '4'],
-  //     },
-  //     undefined,
-  //     {
-  //       [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(field.elemID, field)],
-  //     },
-  //   )
-  // })
-
   it('should make a reference to a custom field', async () => {
     const value: Value = {
       script: 'abc customfield_2 def',


### PR DESCRIPTION
Added support for advanced fields reference
---

Required some refactoring, made that in a different commit.
I also fixed a problem (missing functionality) in ScriptRunner where there were no missing references
(also a small bug in the E2E)
[Noise reduction](https://github.com/salto-io/salto_private/pull/10558) (also for scriptRunner) 

---
_Release Notes_: 
Jira Adapter:
* Added support to references in advanced fields in automations
* Added support for missing references in ScriptRunner scripts

---
_User Notifications_: 
Jira Adapter:
* customfields IDs in advacedFields (in automation type) will become references. 
* ScriptRunner scripts that uses missing custom fields will be replaced with missing references
