### PR TITLE
SALTO-7227: (Bugfix) Salesforce CustomMetadata sub instances are not being extracted

### DIFF
--- a/packages/salesforce-adapter/test/mock_elements.ts
+++ b/packages/salesforce-adapter/test/mock_elements.ts
@@ -63,6 +63,7 @@ import {
   ASSIGN_TO_REFERENCE,
   LIVE_CHAT_BUTTON,
   APPROVAL_PROCESS_METADATA_TYPE,
+  VALIDATION_RULES_METADATA_TYPE,
 } from '../src/constants'
 import { createInstanceElement, createMetadataObjectType, Types } from '../src/transformers/transformer'
 import { allMissingSubTypes } from '../src/transformers/salesforce_types'
@@ -182,6 +183,16 @@ const compactLayoutType = createMetadataObjectType({
   },
 })
 
+const validationRuleType = createMetadataObjectType({
+  annotations: { metadataType: VALIDATION_RULES_METADATA_TYPE },
+  fields: {
+    fullName: { refType: BuiltinTypes.STRING },
+    active: { refType: BuiltinTypes.BOOLEAN },
+    errorConditionFormula: { refType: BuiltinTypes.STRING },
+    errorMessage: { refType: BuiltinTypes.STRING },
+  },
+})
+
 export const mockTypes = {
   ApexClass: createMetadataObjectType({
     annotations: {
@@ -247,6 +258,7 @@ export const mockTypes = {
       listViews: { refType: listViewType },
       fieldSets: { refType: fieldSetType },
       compactLayouts: { refType: compactLayoutType },
+      validationRules: { refType: validationRuleType },
     },
   }),
   StaticResource: createMetadataObjectType({


### PR DESCRIPTION
SALTO-7227: (Bugfix) Salesforce CustomMetadata sub instances are not being extracted

---

_Additional context for reviewer_
Workspace diff: [here](https://github.com/salto-io/almog-sf/commit/121f646a262a465bc97b2c523188e80c1a2e48bf#diff-5254514af3c3d3222797a2298114b4212bda1efce3acb39562cffbf2c997241f)

---
_Release Notes_: 
- Sub instances of CustomMetadata will be added to the workspace.
- Additional fields will be added to CustomMetadata types.

---
_User Notifications_: 
- New nacl files will be created for sub instances of CustomMetadata.
- New fields will be added to CustomMetadata types.
