### PR TITLE
SALTO-7225: Change the elemID of dashboards to contain the user id

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/cloud/dashboard.ts
+++ b/packages/jira-adapter/e2e_test/instances/cloud/dashboard.ts
@@ -12,6 +12,7 @@ export const createDashboardValues = (name: string): Values => ({
   description: 'desc!',
   layout: 'AAA',
   sharePermissions: [{ type: 'authenticated' }],
+  owner: { id: '123', displayName: 'Testing salto' },
 })
 
 export const createGadget1Values = (name: string): Values => ({

--- a/packages/jira-adapter/src/config/api_config.ts
+++ b/packages/jira-adapter/src/config/api_config.ts
@@ -134,6 +134,7 @@ const DEFAULT_TYPE_CUSTOMIZATIONS: JiraApiConfig['types'] = {
 
   Dashboard: {
     transformation: {
+      idFields: ['name', 'owner.accountId'],
       fieldTypeOverrides: [
         { fieldName: 'gadgets', fieldType: 'List<DashboardGadget>' },
         { fieldName: 'layout', fieldType: 'string' },


### PR DESCRIPTION
Added idFields to generate an elemId composed of the dashboard name and the owner's name.

---
_Release Notes_: 
_Jira_adapter_:
- Dashboard elemIDs will now be determined by a combination of their name and owner ID.

---
_User Notifications_: 
_Jira_adapter_:
- Dashboard elemIDs will now be determined by a combination of their name and owner ID.
