### PR TITLE
SALTO-7243: Fix element paths for adapter format functions

### DIFF
--- a/packages/core/src/core/adapter_format.ts
+++ b/packages/core/src/core/adapter_format.ts
@@ -25,7 +25,7 @@ import { logger } from '@salto-io/logging'
 import { collections } from '@salto-io/lowerdash'
 import { merger, Workspace, ElementSelector, expressions, elementSource, hiddenValues } from '@salto-io/workspace'
 import { FetchResult } from '../types'
-import { MergeErrorWithElements, getFetchAdapterAndServicesSetup, calcFetchChanges } from './fetch'
+import { MergeErrorWithElements, getFetchAdapterAndServicesSetup, calcFetchChanges, unmergeElements } from './fetch'
 import { getPlan } from './plan'
 
 const log = logger(module)
@@ -332,6 +332,37 @@ export const calculatePatch = async ({
   }
 }
 
+const fixAdditionPaths = async (workspace: Workspace, changes: ReadonlyArray<Change>): Promise<Change<Element>[]> => {
+  const additionElements = changes.filter(isAdditionChange).map(getChangeData)
+  const unmergedAdditionElements = await unmergeElements(workspace, workspace.currentEnv(), additionElements)
+  const unmergedElementsById = _.groupBy(unmergedAdditionElements, elem => elem.elemID.getFullName())
+
+  const fixAddition = (change: Change): Change<Element>[] =>
+    unmergedElementsById[getChangeData(change).elemID.getFullName()].map(elem => toChange({ after: elem }))
+
+  return changes.flatMap(change => (isAdditionChange(change) ? fixAddition(change) : [change]))
+}
+
+const updateToWorkspace = async ({
+  workspace,
+  toWorkspace,
+  changes,
+}: {
+  workspace: Workspace
+  toWorkspace: Workspace | undefined
+  changes: ReadonlyArray<Change>
+}): Promise<ReadonlyArray<Change>> => {
+  if (!toWorkspace) {
+    return changes
+  }
+
+  const fixedUnappliedChanges = await fixAdditionPaths(workspace, changes)
+  log.debug('Updating nacl files with the %d unapplied changes', fixedUnappliedChanges.length)
+  await toWorkspace.updateNaclFiles(fixedUnappliedChanges.flatMap(change => getDetailedChanges(change)))
+  await toWorkspace.flush()
+  return []
+}
+
 type SyncWorkspaceToFolderArgs = {
   baseDir: string
   toWorkspace?: Workspace
@@ -428,12 +459,7 @@ export const syncWorkspaceToFolder = ({
         elementsSource: adapterContext.elementsSource,
       })
 
-      if (toWorkspace) {
-        log.debug('Updating nacl files with the %d unapplied changes', unappliedChanges.length)
-        await toWorkspace.updateNaclFiles(unappliedChanges.map(change => getDetailedChanges(change)).flat())
-        await toWorkspace.flush()
-      }
-
+      await updateToWorkspace({ workspace, toWorkspace, changes: unappliedChanges })
       return { errors }
     },
     'syncWorkspaceToFolder %s',
@@ -491,13 +517,9 @@ export const updateElementFolder = ({
         elementsSource: adapterContext.elementsSource,
       })
 
-      if (toWorkspace) {
-        log.debug('Updating nacl files with the %d unapplied changes', unappliedChanges.length)
-        await toWorkspace.updateNaclFiles(unappliedChanges.map(change => getDetailedChanges(change)).flat())
-        await toWorkspace.flush()
-      }
+      const finalUnappliedChanges = await updateToWorkspace({ workspace, toWorkspace, changes: unappliedChanges })
 
-      return { errors, unappliedChanges: toWorkspace ? [] : unappliedChanges }
+      return { errors, unappliedChanges: finalUnappliedChanges }
     },
     'updateElementFolder %s',
     baseDir,


### PR DESCRIPTION
Re-use the logic from fetch from to get the path from the index path or by getting the element nacl files.

---

_Additional context for reviewer_

---
_Release Notes_: 

_Core_:
 * Store elements with the correct nacl file path for adapter format commands.

---
_User Notifications_: 

N/A