### PR TITLE
SALTO-7413: sort collaborators order

### DIFF
--- a/packages/jira-adapter/src/filters/sort_lists.ts
+++ b/packages/jira-adapter/src/filters/sort_lists.ts
@@ -62,6 +62,7 @@ const TYPES_AND_VALUES_TO_SORT: Record<string, Record<string, Record<string, str
     [AUTOMATION_TYPE]: {
       tags: ['tagType', 'tagValue'],
       projects: ['projectId.elemID.name', 'projectTypeKey'],
+      collaborators: [],
     },
   },
   [FIELD_CONFIGURATION_SCHEME_TYPE]: {

--- a/packages/jira-adapter/test/filters/sort_lists.test.ts
+++ b/packages/jira-adapter/test/filters/sort_lists.test.ts
@@ -195,6 +195,11 @@ describe('sortListsFilter', () => {
           projectId: new ReferenceExpression(new ElemID(JIRA, 'Project', 'instance', 'a'), {}),
         },
       ],
+      collaborators: [
+        '712020:386ad937-3ff4-437e-ab8e-07d08d3703ed',
+        '5d53f3cbc6b9320d9ea5bdc2',
+        '63a22fb348b367d78a14c15b',
+      ],
     })
     sortedAutomationValues = {
       projects: [
@@ -207,6 +212,11 @@ describe('sortListsFilter', () => {
         {
           projectId: new ReferenceExpression(new ElemID(JIRA, 'Project', 'instance', 'c'), {}),
         },
+      ],
+      collaborators: [
+        '5d53f3cbc6b9320d9ea5bdc2',
+        '63a22fb348b367d78a14c15b',
+        '712020:386ad937-3ff4-437e-ab8e-07d08d3703ed',
       ],
     }
     const workflowType = new ObjectType({
@@ -295,7 +305,7 @@ describe('sortListsFilter', () => {
       await filter.onFetch?.([permissionSchemeInstance])
       expect(permissionSchemeInstance.value).toEqual(sortedPermissionValues)
     })
-    it('should sort the automation projects', async () => {
+    it('should sort the automation projects and collaborators', async () => {
       await filter.onFetch?.([automationInstance])
       expect(automationInstance.value).toEqual(sortedAutomationValues)
     })


### PR DESCRIPTION
Re-ordered the collaborators in automations to preserve order
---

Noise reduction [here](https://github.com/salto-io/salto_private/pull/10557) 
The collaborators should be changed to show the names and not only the ids. I opened a [ticket](https://salto-io.atlassian.net/browse/SALTO-7417) 

---
_Release Notes_: 
Jira Adapter:
* Automation collaborators will now be sorted 

---
_User Notifications_: 
Jira Adapter:
* Automation collaborators will now be sorted 

