### PR TITLE
Remove installation of old suitecloud version

### DIFF
--- a/packages/netsuite-adapter/e2e_test/adapter.test.ts
+++ b/packages/netsuite-adapter/e2e_test/adapter.test.ts
@@ -166,9 +166,8 @@ describe('Netsuite adapter E2E with real account', () => {
   jest.setTimeout(1000000)
 
   describe.each([
-    ['without SuiteApp', { withSuiteApp: false, withOAuth: false }],
-    ['with SuiteApp', { withSuiteApp: true, withOAuth: false }],
-    ['with OAuth', { withSuiteApp: true, withOAuth: true }],
+    ['without SuiteApp', { withSuiteApp: false, withOAuth: true }],
+    ['with SuiteApp', { withSuiteApp: true, withOAuth: true }],
   ])('%s', (_text, { withSuiteApp, withOAuth }) => {
     let fetchResult: FetchResult
     let fetchedElements: Element[]

--- a/packages/netsuite-adapter/src/adapter_creator.ts
+++ b/packages/netsuite-adapter/src/adapter_creator.ts
@@ -16,7 +16,6 @@ import {
   AdapterOperationsContext,
   AdapterOperations,
 } from '@salto-io/adapter-api'
-import { SdkDownloadService as LegacySdkDownloadService } from '@salto-io/suitecloud-cli-legacy'
 import { SdkDownloadService as NewSdkDownloadService } from '@salto-io/suitecloud-cli-new'
 import { combineCustomReferenceGetters } from '@salto-io/adapter-components'
 import _ from 'lodash'
@@ -211,17 +210,12 @@ export const adapter: Adapter = {
   configType,
   install: async (): Promise<AdapterInstallResult> => {
     try {
-      const legacyResult = await LegacySdkDownloadService.download()
-      log.info('Legacy SDF installation result: %o', legacyResult)
-      if (!legacyResult.success) {
-        return legacyResult
-      }
       const newResult = await NewSdkDownloadService.download()
       log.info('New SDF installation result: %o', newResult)
       if (!newResult.success) {
         return newResult
       }
-      const installedVersions = [legacyResult.installedVersion, newResult.installedVersion]
+      const installedVersions = [newResult.installedVersion]
       return { ...newResult, installedVersions }
     } catch (err) {
       return { success: false, errors: [err.message ?? err] }

--- a/packages/netsuite-adapter/test/adapter_creator.test.ts
+++ b/packages/netsuite-adapter/test/adapter_creator.test.ts
@@ -6,7 +6,6 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { ElemID, InstanceElement, isAdapterSuccessInstallResult, ObjectType } from '@salto-io/adapter-api'
-import * as legacySuitecloud from '@salto-io/suitecloud-cli-legacy'
 import * as newSuitecloud from '@salto-io/suitecloud-cli-new'
 import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
 import Bottleneck from 'bottleneck'
@@ -24,13 +23,10 @@ jest.mock('../src/client/suiteapp_client/suiteapp_client')
 jest.mock('../src/adapter')
 
 describe('NetsuiteAdapter creator', () => {
-  let mockLegacyDownload: jest.SpyInstance
   let mockNewDownload: jest.SpyInstance
 
   beforeEach(async () => {
     jest.clearAllMocks()
-    mockLegacyDownload = jest.spyOn(legacySuitecloud.SdkDownloadService, 'download')
-    mockLegacyDownload.mockResolvedValue({ success: true, installedVersion: '123' })
     mockNewDownload = jest.spyOn(newSuitecloud.SdkDownloadService, 'download')
     mockNewDownload.mockResolvedValue({ success: true, installedVersion: '456' })
   })
@@ -850,23 +846,9 @@ describe('NetsuiteAdapter creator', () => {
       expect(res).toEqual({
         success: true,
         installedVersion: '456',
-        installedVersions: ['123', '456'],
+        installedVersions: ['456'],
       })
-      expect(mockLegacyDownload).toHaveBeenCalled()
       expect(mockNewDownload).toHaveBeenCalled()
-    })
-    it('when legacy installation fails with an expection', async () => {
-      mockLegacyDownload.mockImplementationOnce(() => {
-        throw new Error('FAILED')
-      })
-      const res = await install()
-      expect(isAdapterSuccessInstallResult(res)).toBe(false)
-      expect(res).toEqual({
-        success: false,
-        errors: ['FAILED'],
-      })
-      expect(mockLegacyDownload).toHaveBeenCalled()
-      expect(mockNewDownload).not.toHaveBeenCalled()
     })
     it('when new installation fails with an expection', async () => {
       mockNewDownload.mockImplementationOnce(() => {
@@ -878,19 +860,7 @@ describe('NetsuiteAdapter creator', () => {
         success: false,
         errors: ['FAILED'],
       })
-      expect(mockLegacyDownload).toHaveBeenCalled()
       expect(mockNewDownload).toHaveBeenCalled()
-    })
-    it('when legacy installation fails with sdf errors in return value', async () => {
-      mockLegacyDownload.mockImplementationOnce(() => ({ errors: ['FAILED'], success: false }))
-      const res = await install()
-      expect(isAdapterSuccessInstallResult(res)).toBe(false)
-      expect(res).toEqual({
-        success: false,
-        errors: ['FAILED'],
-      })
-      expect(mockLegacyDownload).toHaveBeenCalled()
-      expect(mockNewDownload).not.toHaveBeenCalled()
     })
     it('when new installation fails with sdf errors in return value', async () => {
       mockNewDownload.mockImplementationOnce(() => ({ errors: ['FAILED'], success: false }))
@@ -900,7 +870,6 @@ describe('NetsuiteAdapter creator', () => {
         success: false,
         errors: ['FAILED'],
       })
-      expect(mockLegacyDownload).toHaveBeenCalled()
       expect(mockNewDownload).toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
Cannot be installed anymore

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- Remove installation of old suitecloud version. TBA won't be supported in new installations- OAuth authenrication will be required.

---
_User Notifications_: 
None