### PR TITLE
SALTO-7421: Fixing bug in metadata query validation

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_query.ts
@@ -297,6 +297,11 @@ export const buildMetadataQueryForFetchWithChangesDetection = async (
 }
 
 const validateMetadataQueryParams = (params: MetadataQueryParams[], fieldPath: string[]): void => {
+  if (!Array.isArray(params)) {
+    const errMessage = `Metadata query parameters must be a list, got: ${inspectValue(params)}`
+    throw new ConfigValidationError(fieldPath, errMessage)
+  }
+
   params.forEach(queryParams =>
     Object.entries(queryParams).forEach(([queryField, pattern]) => {
       if (pattern === undefined) {

--- a/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
+++ b/packages/salesforce-adapter/test/fetch_profile/metadata_query.test.ts
@@ -23,14 +23,20 @@ import {
   SETTINGS_METADATA_TYPE,
   TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../../src/constants'
-import { MetadataInstance, MetadataQuery } from '../../src/types'
+import { MetadataInstance, MetadataQuery, MetadataQueryParams } from '../../src/types'
 import { mockInstances } from '../mock_elements'
 import { mockFileProperties } from '../connection'
 import { emptyLastChangeDateOfTypesWithNestedInstances } from '../utils'
 import { getMetadataIncludeFromFetchTargets } from '../../src/filters/utils'
 
 describe('validateMetadataParams', () => {
-  describe('invalid regex in include list', () => {
+  describe('invalid include list', () => {
+    it('non array value', () => {
+      expect(() => {
+        validateMetadataParams({ include: {} as unknown as MetadataQueryParams[] }, ['aaa'])
+      }).toThrow('Metadata query parameters must be a list, got:')
+    })
+
     it('invalid metadataType', () => {
       expect(() =>
         validateMetadataParams(
@@ -71,7 +77,13 @@ describe('validateMetadataParams', () => {
     })
   })
 
-  describe('invalid regex in exclude list', () => {
+  describe('invalid exclude list', () => {
+    it('non array value', () => {
+      expect(() => {
+        validateMetadataParams({ exclude: {} as unknown as MetadataQueryParams[] }, ['aaa'])
+      }).toThrow('Metadata query parameters must be a list, got:')
+    })
+
     it('invalid metadataType', () => {
       expect(() =>
         validateMetadataParams(


### PR DESCRIPTION
We can get this flow if a user defines a non-array metadata query.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
