### PR TITLE
SALTO-7423: re-enable jira E2E

### DIFF
--- a/packages/jira-adapter/e2e_test/adapter.test.ts
+++ b/packages/jira-adapter/e2e_test/adapter.test.ts
@@ -135,8 +135,7 @@ each([
     ])
   })
 
-  // eslint-disable-next-line jest/no-disabled-tests
-  describe.skip('deploy', () => {
+  describe('deploy', () => {
     let addDeployResults: DeployResult[]
     let modifyDeployResults: DeployResult[]
     let addInstanceGroups: InstanceElement[][]


### PR DESCRIPTION
There was a problem with the specific server. I created a new one (as there was no way to debug the old one)

---

None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
