### PR TITLE
SALTO-7363: Remove unused exports from Salesforce adapter

### DIFF
--- a/packages/salesforce-adapter/e2e_test/adapter.ts
+++ b/packages/salesforce-adapter/e2e_test/adapter.ts
@@ -12,12 +12,12 @@ import SalesforceClient from '../src/client/client'
 import SalesforceAdapter, { SalesforceAdapterParams } from '../src/adapter'
 import { SalesforceConfig, Credentials } from '../src/types'
 
-export type Reals = {
+type Reals = {
   client: SalesforceClient
   adapter: SalesforceAdapter
 }
 
-export type Opts = {
+type Opts = {
   adapterParams?: Partial<SalesforceAdapterParams>
   credentials: Credentials
 }

--- a/packages/salesforce-adapter/e2e_test/jest_environment.ts
+++ b/packages/salesforce-adapter/e2e_test/jest_environment.ts
@@ -25,7 +25,7 @@ const log = logger(module)
 const MIN_API_REQUESTS_NEEDED = 2000
 const NOT_ENOUGH_API_REQUESTS_SUSPENSION_TIMEOUT = 1000 * 60 * 60
 
-export const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentials> => {
+const credsSpec = (envName?: string): CredsSpec<UsernamePasswordCredentials> => {
   const addEnvName = (varName: string): string => (envName === undefined ? varName : [varName, envName].join('_'))
   const userEnvVarName = addEnvName('SF_USER')
   const passwordEnvVarName = addEnvName('SF_PASSWORD')
@@ -63,7 +63,7 @@ export default class SalesforceE2EJestEnvironment extends SaltoE2EJestEnvironmen
   }
 }
 
-export type TestHelpers = {
+type TestHelpers = {
   credentials: (envName?: string) => Promise<CredsLease<UsernamePasswordCredentials>>
   CUSTOM_OBJECT: string
 }

--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -428,7 +428,7 @@ export const NESTED_METADATA_TYPES = {
 }
 
 // See: https://developer.salesforce.com/docs/atlas.en-us.api.meta/api/sforce_api_objects_custom_object__c.htm
-export const SYSTEM_FIELDS = [
+const SYSTEM_FIELDS = [
   'ConnectionReceivedId',
   'ConnectionSentId',
   'CreatedById',
@@ -447,7 +447,7 @@ export const SYSTEM_FIELDS = [
   'SetupOwnerId',
 ]
 
-export const UNSUPPORTED_SYSTEM_FIELDS = ['LastReferencedDate', 'LastViewedDate']
+const UNSUPPORTED_SYSTEM_FIELDS = ['LastReferencedDate', 'LastViewedDate']
 
 const getIncludedTypesFromElementsSource = async (
   elementsSource: ReadOnlyElementsSource,

--- a/packages/salesforce-adapter/src/adapter_creator.ts
+++ b/packages/salesforce-adapter/src/adapter_creator.ts
@@ -175,7 +175,7 @@ const adapterConfigFromConfig = (config: Readonly<InstanceElement> | undefined):
   return adapterConfig
 }
 
-export const createUrlFromUserInput = (value: Values): string => {
+const createUrlFromUserInput = (value: Values): string => {
   const endpoint = value.sandbox ? 'test' : 'login'
   return `https://${endpoint}.salesforce.com/services/oauth2/authorize?response_type=token&client_id=${value.consumerKey}&scope=refresh_token%20full&redirect_uri=http://localhost:${value.port}&prompt=login%20consent`
 }

--- a/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
+++ b/packages/salesforce-adapter/src/change_validators/case_assignmentRules.ts
@@ -22,7 +22,7 @@ import { apiName } from '../transformers/transformer'
 
 const { awu } = collections.asynciterable
 
-export const CASE = 'Case'
+const CASE = 'Case'
 
 type RuleEntry = {
   // with team

--- a/packages/salesforce-adapter/src/change_validators/flows.ts
+++ b/packages/salesforce-adapter/src/change_validators/flows.ts
@@ -34,7 +34,7 @@ import { FLOW_URL_SUFFIX } from '../elements_url_retriever/lightning_url_resolve
 
 const ENABLE_FLOW_DEPLOY_AS_ACTIVE_ENABLED_DEFAULT = false
 
-export const getDeployAsActiveFlag = async (
+const getDeployAsActiveFlag = async (
   elementsSource: ReadOnlyElementsSource | undefined,
   defaultValue: boolean,
 ): Promise<boolean> => {
@@ -46,15 +46,15 @@ export const getDeployAsActiveFlag = async (
     : flowSettings.value.enableFlowDeployAsActiveEnabled
 }
 
-export const getFlowStatus = (instance: InstanceElement): string => instance.value[STATUS]
+const getFlowStatus = (instance: InstanceElement): string => instance.value[STATUS]
 
-export const isActiveFlowChange = (change: ModificationChange<InstanceElement>): boolean =>
+const isActiveFlowChange = (change: ModificationChange<InstanceElement>): boolean =>
   getFlowStatus(change.data.before) === ACTIVE && getFlowStatus(change.data.after) === ACTIVE
 
-export const isActivatingChange = (change: ModificationChange<InstanceElement>): boolean =>
+const isActivatingChange = (change: ModificationChange<InstanceElement>): boolean =>
   getFlowStatus(change.data.before) !== ACTIVE && getFlowStatus(change.data.after) === ACTIVE
 
-export const isActivatingChangeOnly = (change: ModificationChange<InstanceElement>): boolean => {
+const isActivatingChangeOnly = (change: ModificationChange<InstanceElement>): boolean => {
   const beforeClone = change.data.before.clone()
   beforeClone.value[STATUS] = ACTIVE
   const diffWithoutStatus = detailedCompare(beforeClone, change.data.after)

--- a/packages/salesforce-adapter/src/change_validators/full_name_changed.ts
+++ b/packages/salesforce-adapter/src/change_validators/full_name_changed.ts
@@ -15,7 +15,7 @@ import {
 } from '@salto-io/adapter-api'
 import { INSTANCE_FULL_NAME_FIELD } from '../constants'
 
-export const wasFullNameChanged = (change: ModificationChange<InstanceElement>): boolean => {
+const wasFullNameChanged = (change: ModificationChange<InstanceElement>): boolean => {
   const { before, after } = change.data
   return before.value[INSTANCE_FULL_NAME_FIELD] !== after.value[INSTANCE_FULL_NAME_FIELD]
 }

--- a/packages/salesforce-adapter/src/change_validators/invalid_list_view_filter_scope.ts
+++ b/packages/salesforce-adapter/src/change_validators/invalid_list_view_filter_scope.ts
@@ -34,7 +34,7 @@ const INVALID_FILTERSCOPES: ForbiddenFilterScope[] = [
   },
 ]
 
-export const isFilterScopeInvalid = (instance: InstanceElement): boolean => {
+const isFilterScopeInvalid = (instance: InstanceElement): boolean => {
   if (apiNameSync(instance.getTypeSync()) !== 'ListView') {
     return false
   }

--- a/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
+++ b/packages/salesforce-adapter/src/change_validators/ordered_maps.ts
@@ -27,7 +27,7 @@ import {
 } from '../filters/convert_maps'
 import { FetchProfile } from '../types'
 
-export const getOrderedMapErrors = (element: Element, fieldName: string): ChangeError[] => {
+const getOrderedMapErrors = (element: Element, fieldName: string): ChangeError[] => {
   const elementValues = getElementValueOrAnnotations(element)
   const fieldValue = _.get(elementValues, fieldName)
   if (fieldValue === undefined) {

--- a/packages/salesforce-adapter/src/change_validators/unknown_field.ts
+++ b/packages/salesforce-adapter/src/change_validators/unknown_field.ts
@@ -16,7 +16,7 @@ import {
 } from '@salto-io/adapter-api'
 import { Types } from '../transformers/transformer'
 
-export const isUnknownField = (changedElement: ChangeDataType): changedElement is Field =>
+const isUnknownField = (changedElement: ChangeDataType): changedElement is Field =>
   isField(changedElement) && changedElement.refType.elemID.isEqual(Types.primitiveDataTypes.Unknown.elemID)
 
 const createChangeError = (field: Field): ChangeError => ({

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -73,7 +73,7 @@ const { logDecorator, throttle, requiresLogin, createRateLimitersFromConfig } = 
 type DeployOptions = Pick<JSForceDeployOptions, 'checkOnly'>
 
 export const API_VERSION = '62.0'
-export const METADATA_NAMESPACE = 'http://soap.sforce.com/2006/04/metadata'
+const METADATA_NAMESPACE = 'http://soap.sforce.com/2006/04/metadata'
 
 // Salesforce limitation of maximum number of items per create/update/delete call
 //  https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_createMetadata.htm
@@ -193,7 +193,7 @@ const validateCRUDResult = (isDelete: boolean): decorators.InstanceMethodDecorat
 const validateDeleteResult = validateCRUDResult(true)
 const validateSaveResult = validateCRUDResult(false)
 
-export type SalesforceClientOpts = {
+type SalesforceClientOpts = {
   credentials: Credentials
   connection?: Connection
   config?: SalesforceClientConfig
@@ -205,29 +205,25 @@ const DEFAULT_POLLING_CONFIG = {
   fetchTimeout: 1000 * 60 * 30, // 30 minutes
 }
 
-export const setPollIntervalForConnection = (
-  connection: Connection,
-  pollingConfig: Required<ClientPollingConfig>,
-): void => {
+const setPollIntervalForConnection = (connection: Connection, pollingConfig: Required<ClientPollingConfig>): void => {
   // Set poll interval for fetch & bulk ops (e.g. CSV deletes)
   connection.metadata.pollInterval = pollingConfig.interval
   connection.bulk.pollInterval = pollingConfig.interval
 }
 
-export const createRequestModuleFunction =
-  (retryOptions: RequestRetryOptions) => (opts: Options, callback: RequestCallback) =>
-    requestretry({ ...retryOptions, ...opts }, (err, response, body) => {
-      const attempts = _.get(response, 'attempts') || _.get(err, 'attempts')
-      if (attempts && attempts > 1) {
-        log.warn('sfdc client retry attempts: %o', attempts)
-      }
-      // Temp code to check to have more details to fix https://salto-io.atlassian.net/browse/SALTO-1600
-      // response can be undefined when there was an error
-      if (response !== undefined && !response.request.path.startsWith('/services/Soap')) {
-        log.debug('Received headers: %o from request to path: %s', response.headers, response.request.path)
-      }
-      return callback(err, response, body)
-    })
+const createRequestModuleFunction = (retryOptions: RequestRetryOptions) => (opts: Options, callback: RequestCallback) =>
+  requestretry({ ...retryOptions, ...opts }, (err, response, body) => {
+    const attempts = _.get(response, 'attempts') || _.get(err, 'attempts')
+    if (attempts && attempts > 1) {
+      log.warn('sfdc client retry attempts: %o', attempts)
+    }
+    // Temp code to check to have more details to fix https://salto-io.atlassian.net/browse/SALTO-1600
+    // response can be undefined when there was an error
+    if (response !== undefined && !response.request.path.startsWith('/services/Soap')) {
+      log.debug('Received headers: %o from request to path: %s', response.headers, response.request.path)
+    }
+    return callback(err, response, body)
+  })
 
 type OauthConnectionParams = {
   instanceUrl: string
@@ -293,7 +289,7 @@ type SendChunkedError<TIn> = {
   error: Error
 }
 
-export type SendChunkedResult<TIn, TOut> = {
+type SendChunkedResult<TIn, TOut> = {
   result: TOut[]
   errors: SendChunkedError<TIn>[]
 }
@@ -443,7 +439,7 @@ const retryOnBadResponse = async <T extends object>(
   return requestWithRetry(retryAttempts)
 }
 
-export const loginFromCredentialsAndReturnOrgId = async (
+const loginFromCredentialsAndReturnOrgId = async (
   connection: Connection,
   credentials: Credentials,
 ): Promise<string> => {
@@ -584,7 +580,7 @@ interface ISalesforceClient {
 }
 
 type ListMetadataObjectsResult = ReturnType<ISalesforceClient['listMetadataObjects']>
-export type CustomListFunc = (client: ISalesforceClient) => ListMetadataObjectsResult
+type CustomListFunc = (client: ISalesforceClient) => ListMetadataObjectsResult
 
 type CustomListFuncMode = 'partial' | 'full' | 'extendsOriginal'
 

--- a/packages/salesforce-adapter/src/client/jsforce.ts
+++ b/packages/salesforce-adapter/src/client/jsforce.ts
@@ -60,15 +60,15 @@ export interface Soap {
   describeSObjects(typeNames: string | string[]): Promise<DescribeSObjectResult | DescribeSObjectResult[]>
 }
 
-export interface Global {
+interface Global {
   sobjects: DescribeGlobalSObjectResult[]
 }
 
-export type Limit = {
+type Limit = {
   Remaining: number
 }
 
-export type Limits = {
+type Limits = {
   DailyApiRequests: Limit
 }
 
@@ -120,7 +120,7 @@ export interface RunTestFailure {
   time: number
 }
 
-export interface CodeCoverageWarning {
+interface CodeCoverageWarning {
   id: string
   message: string
   name?: string

--- a/packages/salesforce-adapter/src/client/types.ts
+++ b/packages/salesforce-adapter/src/client/types.ts
@@ -21,19 +21,19 @@ const isRelationshipFieldName = (fieldName: string): boolean => RELATIONSHIP_FIE
 
 export type JSONBool = boolean | 'true' | 'false'
 
-export type ObjectPermissionsOptionsFields =
+type ObjectPermissionsOptionsFields =
   | 'allowCreate'
   | 'allowDelete'
   | 'allowEdit'
   | 'allowRead'
   | 'modifyAllRecords'
   | 'viewAllRecords'
-export type ObjectPermissionsOptions = {
+type ObjectPermissionsOptions = {
   [option in ObjectPermissionsOptionsFields]: JSONBool
 }
 
-export type FieldPermissionsOptionsFields = 'editable' | 'readable'
-export type FieldPermissionsOptions = {
+type FieldPermissionsOptionsFields = 'editable' | 'readable'
+type FieldPermissionsOptions = {
   [option in FieldPermissionsOptionsFields]: JSONBool
 }
 
@@ -44,12 +44,6 @@ export interface ProfileInfo extends MetadataInfo {
   fullName: string
   fieldPermissions: FieldPermissions[]
   objectPermissions: ObjectPermissions[]
-}
-
-// https://developer.salesforce.com/docs/atlas.en-us.api_meta.meta/api_meta/meta_metadatawithcontent.htm
-export interface MetadataWithContent extends MetadataInfo {
-  fullName: string
-  content: string
 }
 
 export class TopicsForObjectsInfo implements MetadataInfo {
@@ -80,22 +74,17 @@ export class CustomPicklistValue implements MetadataInfo {
   }
 }
 
-export interface ValueSettings {
+interface ValueSettings {
   controllingFieldValue: string[]
   valueName: string
 }
 
-export interface PicklistValue {
+interface PicklistValue {
   fullName: string
   label: string
   default: boolean
   color: string
   isActive: boolean
-}
-
-export interface ValueSet {
-  restricted: boolean
-  valueSetDefinition: { value: PicklistValue[] }
 }
 
 export interface FilterItem {
@@ -105,7 +94,7 @@ export interface FilterItem {
   valueField: string
 }
 
-export interface LookupFilter {
+interface LookupFilter {
   active: boolean
   booleanFilter: string
   errorMessage: string

--- a/packages/salesforce-adapter/src/client/user_facing_errors.ts
+++ b/packages/salesforce-adapter/src/client/user_facing_errors.ts
@@ -80,7 +80,7 @@ export type ErrorMappers = {
   [SALESFORCE_ERRORS.INSUFFICIENT_ACCESS]: ErrorMapper<Error>
 }
 
-export const withSalesforceError = (salesforceError: string, saltoErrorMessage: string): string =>
+const withSalesforceError = (salesforceError: string, saltoErrorMessage: string): string =>
   `${saltoErrorMessage}\n\nUnderlying Error: ${salesforceError}`
 
 export const ERROR_MAPPERS: ErrorMappers = {
@@ -162,21 +162,21 @@ export type DeployErrorMessageMappers = {
   [SALESFORCE_DEPLOY_ERROR_MESSAGES.FIELD_CUSTOM_VALIDATION_EXCEPTION]: DeployErrorMessageMapper
 }
 
-export const SCHEDULABLE_CLASS_MESSAGE =
+const SCHEDULABLE_CLASS_MESSAGE =
   'This deployment contains a scheduled Apex class (or a class related to one).' +
   ' By default, Salesforce does not allow changes to scheduled apex.' +
   ' Please follow the instructions here: https://help.salesforce.com/s/articleView?id=000384960&type=1'
 
-export const MAX_METADATA_DEPLOY_LIMIT_MESSAGE =
+const MAX_METADATA_DEPLOY_LIMIT_MESSAGE =
   'The metadata deployment exceeded the maximum allowed size of 50MB.' +
   ' To avoid this issue, please split your deployment to smaller chunks.' +
   ' For more info you may refer to: https://help.salto.io/en/articles/8263355-the-metadata-deployment-exceeded-the-maximum-allowed-size-of-50mb'
 
-export const INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE =
+const INVALID_DASHBOARD_UNIQUE_NAME_MESSAGE =
   "Please make sure you're managing Dashboards in your Salto environment and that your deployment contains the referenced Dashboard instance.\n" +
   'For more information, please refer to: https://help.salto.io/en/articles/7439350-supported-salesforce-types'
 
-export const FIELD_CUSTOM_VALIDATION_EXCEPTION_MESSAGE =
+const FIELD_CUSTOM_VALIDATION_EXCEPTION_MESSAGE =
   'The element does not meet the validation rules. Try deactivating the validation rules if possible.'
 
 export const DEPLOY_ERROR_MESSAGE_MAPPER: DeployErrorMessageMappers = {

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -141,7 +141,7 @@ type ConfigSuggestionCreator = {
   create: CreateConfigSuggestionFunc
 }
 
-export const createSocketTimeoutConfigSuggestion: CreateConfigSuggestionFunc = (
+const createSocketTimeoutConfigSuggestion: CreateConfigSuggestionFunc = (
   input: ConfigSuggestionsCreatorInput,
 ): MetadataConfigSuggestion => ({
   type: 'metadataExclude',
@@ -149,7 +149,7 @@ export const createSocketTimeoutConfigSuggestion: CreateConfigSuggestionFunc = (
   reason: `${input.metadataType} with name ${input.name} exceeded fetch timeout`,
 })
 
-export const createInvalidCrossReferenceKeyConfigSuggestion: CreateConfigSuggestionFunc = (
+const createInvalidCrossReferenceKeyConfigSuggestion: CreateConfigSuggestionFunc = (
   input: ConfigSuggestionsCreatorInput,
 ): MetadataConfigSuggestion => ({
   type: 'metadataExclude',
@@ -157,7 +157,7 @@ export const createInvalidCrossReferenceKeyConfigSuggestion: CreateConfigSuggest
   reason: `${input.metadataType} with name ${input.name} failed due to INVALID_CROSS_REFERENCE_KEY`,
 })
 
-export const createNonTransientSalesforceErrorConfigSuggestion: CreateConfigSuggestionFunc = (
+const createNonTransientSalesforceErrorConfigSuggestion: CreateConfigSuggestionFunc = (
   input: ConfigSuggestionsCreatorInput,
 ): MetadataConfigSuggestion => ({
   type: 'metadataExclude',

--- a/packages/salesforce-adapter/src/config_creator.ts
+++ b/packages/salesforce-adapter/src/config_creator.ts
@@ -28,7 +28,7 @@ import { CPQ_NAMESPACE, CUSTOM_OBJECT_ID_FIELD } from './constants'
 
 const log = logger(module)
 
-export const CONFIG_WITH_CPQ = new InstanceElement(ElemID.CONFIG_NAME, configType, {
+const CONFIG_WITH_CPQ = new InstanceElement(ElemID.CONFIG_NAME, configType, {
   fetch: {
     metadata: {
       include: [

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -88,9 +88,6 @@ export enum COMPONENT_INSTANCE_PROPERTY_FILED_NAMES {
 export enum COMPONENT_INSTANCE_FILED_NAMES {
   COMPONENT_INSTANCE_PROPERTIES = 'componentInstanceProperties',
 }
-export enum ITEM_INSTANCE_FILED_NAMES {
-  COMPONENT_INSTANCE_PROPERTIES = 'componentInstanceProperties',
-}
 export enum FLEXI_PAGE_REGION_FIELD_NAMES {
   COMPONENT_INSTANCES = 'componentInstances',
   ITEM_INSTANCES = 'itemInstances',
@@ -105,7 +102,6 @@ export enum FLEXI_PAGE_FIELD_NAMES {
 }
 
 // Flow constants
-export const FLOW_NODE = 'FlowNode'
 export const TARGET_REFERENCE = 'targetReference'
 export const ELEMENT_REFERENCE = 'elementReference'
 export const LEFT_VALUE_REFERENCE = 'leftValueReference'
@@ -496,13 +492,12 @@ export const APEX_TRIGGER_METADATA_TYPE = 'ApexTrigger'
 export const APEX_COMPONENT_METADATA_TYPE = 'ApexComponent'
 export const GLOBAL_VALUE_SET_TRANSLATION_METADATA_TYPE = 'GlobalValueSetTranslation'
 export const ASSIGNMENT_RULE_METADATA_TYPE = 'AssignmentRule'
-export const AUTO_RESPONSE_RULES_METADATA_TYPE = 'AutoResponseRules'
+const AUTO_RESPONSE_RULES_METADATA_TYPE = 'AutoResponseRules'
 export const AUTO_RESPONSE_RULE_METADATA_TYPE = 'AutoResponseRule'
-export const SHARING_RULE_METADATA_TYPE = 'SharingRuleMetadataType'
-export const ESCALATION_RULES_TYPE = 'EscalationRules'
+const ESCALATION_RULES_TYPE = 'EscalationRules'
 export const ESCALATION_RULE_TYPE = 'EscalationRule'
-export const CUSTOM_PERMISSION_METADATA_TYPE = 'CustomPermission'
-export const EXTERNAL_DATA_SOURCE_METADATA_TYPE = 'ExternalDataSource'
+const CUSTOM_PERMISSION_METADATA_TYPE = 'CustomPermission'
+const EXTERNAL_DATA_SOURCE_METADATA_TYPE = 'ExternalDataSource'
 export const OPPORTUNITY_METADATA_TYPE = 'Opportunity'
 export const ANIMATION_RULE_METADATA_TYPE = 'AnimationRule'
 export const CANVAS_METADATA_TYPE = 'CanvasMetadata'
@@ -535,7 +530,6 @@ export const CHANGED_AT_SINGLETON = 'ChangedAtSingleton'
 export const PROFILE_AND_PERMISSION_SETS_BROKEN_PATHS = 'ProfilesAndPermissionSetsBrokenPaths'
 export const PATHS_FIELD = 'paths'
 export const FETCH_TARGETS = 'FetchTargets'
-export const TARGETS_FIELD = 'targets'
 export const CUSTOM_OBJECTS_FIELD = 'customObjects'
 export const CUSTOM_OBJECTS_LOOKUPS_FIELD = 'customObjectsLookups'
 export const METADATA_TYPES_FIELD = 'metadataTypes'
@@ -615,9 +609,9 @@ export const CPQ_FIELD_METADATA = 'SBQQ__FieldMetadata__c'
 export const CPQ_CUSTOM_SCRIPT = 'SBQQ__CustomScript__c'
 export const CPQ_CONFIGURATION_ATTRIBUTE = 'SBQQ__ConfigurationAttribute__c'
 export const CPQ_QUOTE = 'SBQQ__Quote__c'
-export const CPQ_QUOTE_LINE_GROUP = 'SBQQ__QuoteLineGroup__c'
-export const CPQ_QUOTE_LINE = 'SBQQ__QuoteLine__c'
-export const CPQ_PRODUCT_OPTION = 'SBQQ__ProductOption__c'
+const CPQ_QUOTE_LINE_GROUP = 'SBQQ__QuoteLineGroup__c'
+const CPQ_QUOTE_LINE = 'SBQQ__QuoteLine__c'
+const CPQ_PRODUCT_OPTION = 'SBQQ__ProductOption__c'
 export const CPQ_PRICE_SCHEDULE = 'SBQQ__PriceSchedule__c'
 export const CPQ_DISCOUNT_SCHEDULE = 'SBQQ__DiscountSchedule__c'
 export const CPQ_SUBSCRIPTION = 'SBQQ__Subscription__c'
@@ -662,16 +656,16 @@ export const SBAA_ADVANCED_CONDITION_FIELD = 'sbaa__AdvancedCondition__c'
 export const SBAA_INDEX_FIELD = 'sbaa__Index__c'
 
 export const CPQ_QUOTE_NO_PRE = 'Quote__c'
-export const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'
+const CPQ_QUOTE_LINE_GROUP_NO_PRE = 'QuoteLineGroup__c'
 export const CPQ_ACCOUNT_NO_PRE = 'Account__c'
 export const DEFAULT_OBJECT_TO_API_MAPPING = {
   [CPQ_QUOTE_NO_PRE]: CPQ_QUOTE,
   [CPQ_QUOTE_LINE_GROUP_NO_PRE]: CPQ_QUOTE_LINE_GROUP,
 } as Record<string, string>
 
-export const CPQ_QUOTE_NAME = 'Quote'
-export const CPQ_QUOTE_LINE_NAME = 'Quote Line'
-export const CPQ_PRODUCT_OPTION_NAME = 'Product Option'
+const CPQ_QUOTE_NAME = 'Quote'
+const CPQ_QUOTE_LINE_NAME = 'Quote Line'
+const CPQ_PRODUCT_OPTION_NAME = 'Product Option'
 export const TEST_OBJECT_TO_API_MAPPING = {
   [CPQ_QUOTE_NAME]: CPQ_QUOTE,
   [CPQ_QUOTE_LINE_NAME]: CPQ_QUOTE_LINE,
@@ -681,9 +675,6 @@ export const TEST_OBJECT_TO_API_MAPPING = {
 export const SCHEDULE_CONSTRAINT_FIELD_TO_API_MAPPING = {
   [CPQ_ACCOUNT_NO_PRE]: CPQ_ACCOUNT,
 } as Record<string, string>
-
-// sbaa
-export const SBAA_NAMESPACE = 'sbaa'
 
 // sbaa Objects
 export const SBAA_APPROVAL_CONDITION = 'sbaa__ApprovalCondition__c'
@@ -802,7 +793,7 @@ export const ERROR_PROPERTIES = {
 export type ErrorProperty = types.ValueOf<typeof ERROR_PROPERTIES>
 
 // Salesforce Errors
-export const SALESFORCE_ERROR_PREFIX = 'sf:'
+const SALESFORCE_ERROR_PREFIX = 'sf:'
 
 export const SALESFORCE_ERRORS = {
   INVALID_CROSS_REFERENCE_KEY: `${SALESFORCE_ERROR_PREFIX}INVALID_CROSS_REFERENCE_KEY`,

--- a/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
+++ b/packages/salesforce-adapter/src/custom_references/profiles_and_permission_sets.ts
@@ -210,7 +210,7 @@ const sectionsReferenceParams: Record<ProfileSection, ReferenceFromSectionParams
   },
 }
 
-export const mapInstanceSections = <T>({
+const mapInstanceSections = <T>({
   instance,
   func,
   applyFilter,

--- a/packages/salesforce-adapter/src/elements_url_retriever/lightning_url_resolvers.ts
+++ b/packages/salesforce-adapter/src/elements_url_retriever/lightning_url_resolvers.ts
@@ -26,11 +26,7 @@ const { isDefined } = values
 
 export type ElementIDResolver = (id: ElemID) => Promise<Element | undefined>
 
-export type UrlResolver = (
-  element: Element,
-  baseUrl: URL,
-  elementIDResolver: ElementIDResolver,
-) => Promise<URL | undefined>
+type UrlResolver = (element: Element, baseUrl: URL, elementIDResolver: ElementIDResolver) => Promise<URL | undefined>
 
 export const FLOW_URL_SUFFIX = 'lightning/setup/Flows/home'
 

--- a/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/metadata_types.ts
@@ -17,7 +17,7 @@ import {
   TOPICS_FOR_OBJECTS_METADATA_TYPE,
 } from '../constants'
 
-export const FOLDER_METADATA_TYPES = ['ReportFolder', 'DashboardFolder', 'DocumentFolder', 'EmailFolder'] as const
+const FOLDER_METADATA_TYPES = ['ReportFolder', 'DashboardFolder', 'DocumentFolder', 'EmailFolder'] as const
 
 export const CUSTOM_OBJECT_FIELDS = [
   'WebLink',
@@ -41,7 +41,7 @@ export const WORKFLOW_FIELDS = [
   'WorkflowRule',
 ] as const
 
-export const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
+const METADATA_TYPES_WITHOUT_DEPENDENCIES = [
   'AIApplication',
   'AIApplicationConfig',
   'AccessMapping',
@@ -585,7 +585,7 @@ export const METADATA_TYPES_WITH_DEPENDENCIES = [
   PROFILE_METADATA_TYPE,
 ] as const
 
-export const EXCLUDED_METADATA_TYPES = [
+const EXCLUDED_METADATA_TYPES = [
   'AssignmentRule', // Fetched through parent type
   'CustomField', // Has a specific handling in Salto
   'CustomIndex', // Cannot retrieve by Record name
@@ -605,15 +605,13 @@ export const SUPPORTED_METADATA_TYPES = [
 export const SALESFORCE_METADATA_TYPES = [...SUPPORTED_METADATA_TYPES, ...EXCLUDED_METADATA_TYPES] as const
 
 export type MetadataTypeWithoutDependencies = (typeof METADATA_TYPES_WITHOUT_DEPENDENCIES)[number]
-export type MetadataTypeWithDependencies = (typeof METADATA_TYPES_WITH_DEPENDENCIES)[number]
-export type ExcludedMetadataType = (typeof EXCLUDED_METADATA_TYPES)[number]
-export type SupportedMetadataType = (typeof SUPPORTED_METADATA_TYPES)[number]
-export type SalesforceMetadataType = (typeof SALESFORCE_METADATA_TYPES)[number]
+type MetadataTypeWithDependencies = (typeof METADATA_TYPES_WITH_DEPENDENCIES)[number]
+type SalesforceMetadataType = (typeof SALESFORCE_METADATA_TYPES)[number]
 
 export type CustomObjectField = (typeof CUSTOM_OBJECT_FIELDS)[number]
 export type WorkflowField = (typeof WORKFLOW_FIELDS)[number]
 
-export const METADATA_TYPE_TO_DEPENDENCIES: Record<MetadataTypeWithDependencies, SalesforceMetadataType[]> = {
+const METADATA_TYPE_TO_DEPENDENCIES: Record<MetadataTypeWithDependencies, SalesforceMetadataType[]> = {
   CustomMetadata: ['CustomMetadata', 'CustomObject'],
   BusinessProcess: ['CustomObject'],
   CompactLayout: ['CustomObject'],
@@ -636,12 +634,7 @@ export const METADATA_TYPE_TO_DEPENDENCIES: Record<MetadataTypeWithDependencies,
   Profile: [...PROFILE_RELATED_METADATA_TYPES],
 }
 
-export const isMetadataTypeWithoutDependencies = (
-  metadataType: SalesforceMetadataType,
-): metadataType is MetadataTypeWithoutDependencies =>
-  (METADATA_TYPES_WITHOUT_DEPENDENCIES as ReadonlyArray<string>).includes(metadataType)
-
-export const isMetadataTypeWithDependency = (metadataType: string): metadataType is MetadataTypeWithDependencies =>
+const isMetadataTypeWithDependency = (metadataType: string): metadataType is MetadataTypeWithDependencies =>
   (METADATA_TYPES_WITH_DEPENDENCIES as ReadonlyArray<string>).includes(metadataType)
 
 export const includesSettingsTypes = (typeNames: readonly string[]): boolean =>

--- a/packages/salesforce-adapter/src/filter.ts
+++ b/packages/salesforce-adapter/src/filter.ts
@@ -21,7 +21,7 @@ export type FilterContext = {
   lastChangeDateOfTypesWithNestedInstances?: LastChangeDateOfTypesWithNestedInstances
 }
 
-export type FilterOpts = {
+type FilterOpts = {
   client?: SalesforceClient
   config: FilterContext
 }

--- a/packages/salesforce-adapter/src/filters/add_missing_ids.ts
+++ b/packages/salesforce-adapter/src/filters/add_missing_ids.ts
@@ -45,7 +45,7 @@ const shouldHaveInternalId = (element: Element): boolean => {
   return false
 }
 
-export const getIdsForType = async (client: SalesforceClient, type: string): Promise<Record<string, string>> => {
+const getIdsForType = async (client: SalesforceClient, type: string): Promise<Record<string, string>> => {
   const { result, errors } = await client.listMetadataObjects({ type })
   if (errors && errors.length > 0) {
     log.debug(`Encountered errors while listing ${type}: ${errors}`)

--- a/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/custom_objects.ts
@@ -126,7 +126,7 @@ const CUSTOM_OBJECT_SUB_INSTANCES_METADATA_TYPES: Set<string> = new Set(
 const isCustomObjectSubInstance = (instance: MetadataInstanceElement): boolean =>
   CUSTOM_OBJECT_SUB_INSTANCES_METADATA_TYPES.has(metadataTypeSync(instance))
 
-export const WARNING_MESSAGE =
+const WARNING_MESSAGE =
   'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
 
 /*

--- a/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/data_instances.ts
@@ -44,7 +44,7 @@ const moveInstancesAuthorFieldsToAnnotations = (
   instances.forEach(instance => moveAuthorFieldsToAnnotations(instance, IDToNameMap))
 }
 
-export const WARNING_MESSAGE =
+const WARNING_MESSAGE =
   'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
 
 /*

--- a/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/nested_instances.ts
@@ -17,7 +17,7 @@ import SalesforceClient from '../../client/client'
 
 const log = logger(module)
 
-export const WARNING_MESSAGE =
+const WARNING_MESSAGE =
   'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
 
 const NESTED_INSTANCES_METADATA_TYPES = [

--- a/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
+++ b/packages/salesforce-adapter/src/filters/author_information/sharing_rules.ts
@@ -50,7 +50,7 @@ const getLastSharingRuleFileProperties = (
   return rules[rules.length - 1]
 }
 
-export const WARNING_MESSAGE =
+const WARNING_MESSAGE =
   'Encountered an error while trying to populate author information in some of the Salesforce configuration elements.'
 
 /*

--- a/packages/salesforce-adapter/src/filters/convert_maps.ts
+++ b/packages/salesforce-adapter/src/filters/convert_maps.ts
@@ -91,7 +91,7 @@ type MapDef = {
 }
 
 export const ORDERED_MAP_VALUES_FIELD = 'values'
-export const ORDERED_MAP_ORDER_FIELD = 'order'
+const ORDERED_MAP_ORDER_FIELD = 'order'
 
 export const createOrderedMapType = <T extends TypeElement>(innerType: T): ObjectType =>
   new ObjectType({
@@ -129,7 +129,7 @@ const BUSINESS_HOURS_MAP_FIELD_DEF: Record<string, MapDef> = {
   businessHours: { key: 'name' },
 }
 
-export const PERMISSIONS_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
+const PERMISSIONS_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
   // One-level maps
   applicationVisibilities: { key: 'application' },
   classAccesses: { key: 'apexClass' },
@@ -148,7 +148,7 @@ export const PERMISSIONS_SET_MAP_FIELD_DEF: Record<string, MapDef> = {
   recordTypeVisibilities: { key: 'recordType', nested: true },
 }
 
-export const PROFILE_MAP_FIELD_DEF: Record<string, MapDef> = {
+const PROFILE_MAP_FIELD_DEF: Record<string, MapDef> = {
   // sharing map field def with permission set
   ...PERMISSIONS_SET_MAP_FIELD_DEF,
 
@@ -590,7 +590,7 @@ const convertFieldTypesBackToLists = async (
   })
 }
 
-export const getInstanceChanges = (
+const getInstanceChanges = (
   changes: ReadonlyArray<Change>,
   targetMetadataType: string,
 ): Promise<ReadonlyArray<Change<InstanceElement>>> =>
@@ -624,7 +624,7 @@ export const findInstancesToConvert = (elements: Element[], targetMetadataType: 
   return instances.filter(e => metadataTypeSync(e) === targetMetadataType)
 }
 
-export const findTypeToConvert = (elements: Element[], targetMetadataType: string): ObjectType | undefined => {
+const findTypeToConvert = (elements: Element[], targetMetadataType: string): ObjectType | undefined => {
   const types = elements.filter(isObjectType)
   return types.filter(e => metadataTypeSync(e) === targetMetadataType)[0]
 }

--- a/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
+++ b/packages/salesforce-adapter/src/filters/extend_triggers_metadata.ts
@@ -46,7 +46,7 @@ export enum TriggerType {
   UsageAfterUpdate = 'UsageAfterUpdate',
   UsageAfterUndelete = 'UsageAfterUndelete',
 }
-export const TRIGGER_TYPE_FIELDS = Object.values(TriggerType)
+const TRIGGER_TYPE_FIELDS = Object.values(TriggerType)
 
 export const TRIGGER_TYPES_FIELD_NAME = 'triggerTypes'
 

--- a/packages/salesforce-adapter/src/filters/layouts.ts
+++ b/packages/salesforce-adapter/src/filters/layouts.ts
@@ -18,7 +18,7 @@ import {
   isInstanceOfTypeSync,
   isCustomObjectOrCustomMetadataRecordTypeSync,
 } from './utils'
-import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE, WEBLINK_METADATA_TYPE } from '../constants'
+import { SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE } from '../constants'
 import { getObjectDirectoryPath } from './custom_objects_to_object_type'
 
 const { awu } = collections.asynciterable
@@ -26,7 +26,6 @@ const { awu } = collections.asynciterable
 const log = logger(module)
 
 export const LAYOUT_TYPE_ID = new ElemID(SALESFORCE, LAYOUT_TYPE_ID_METADATA_TYPE)
-export const WEBLINK_TYPE_ID = new ElemID(SALESFORCE, WEBLINK_METADATA_TYPE)
 
 const fixLayoutPath = async (layout: InstanceElement, customObject: ObjectType, layoutName: string): Promise<void> => {
   layout.path = [

--- a/packages/salesforce-adapter/src/filters/organization_settings.ts
+++ b/packages/salesforce-adapter/src/filters/organization_settings.ts
@@ -147,7 +147,7 @@ const addLatestSupportedAPIVersion = async ({
 }
 
 const FILTER_NAME = 'organizationSettings'
-export const WARNING_MESSAGE = 'Failed to fetch OrganizationSettings.'
+const WARNING_MESSAGE = 'Failed to fetch OrganizationSettings.'
 
 const filterCreator: FilterCreator = ({ client, config }) => ({
   name: FILTER_NAME,

--- a/packages/salesforce-adapter/src/filters/picklist_references.ts
+++ b/packages/salesforce-adapter/src/filters/picklist_references.ts
@@ -50,7 +50,7 @@ const getValueSetFieldName = (typeName: string): string => {
       return 'valueSet'
   }
 }
-export type RecordTypePicklistValuesItem = {
+type RecordTypePicklistValuesItem = {
   picklist: ReferenceExpression<Field>
   values: {
     fullName: string

--- a/packages/salesforce-adapter/src/filters/profile_paths.ts
+++ b/packages/salesforce-adapter/src/filters/profile_paths.ts
@@ -38,7 +38,7 @@ const replacePath = async (profile: InstanceElement, profileInternalIdToName: Ma
   }
 }
 
-export const WARNING_MESSAGE =
+const WARNING_MESSAGE =
   'Failed to update the NaCl file names for some of your salesforce profiles. Therefore, profiles NaCl file names might differ from their display names in some cases.'
 
 /**

--- a/packages/salesforce-adapter/src/filters/topics_for_objects.ts
+++ b/packages/salesforce-adapter/src/filters/topics_for_objects.ts
@@ -47,7 +47,7 @@ const { ENABLE_TOPICS, ENTITY_API_NAME } = TOPICS_FOR_OBJECTS_FIELDS
 
 const log = logger(module)
 
-export const DEFAULT_ENABLE_TOPICS_VALUE = false
+const DEFAULT_ENABLE_TOPICS_VALUE = false
 
 const getTopicsForObjects = (obj: ObjectType): Values => obj.annotations[TOPICS_FOR_OBJECTS_ANNOTATION] || {}
 

--- a/packages/salesforce-adapter/src/filters/workflow.ts
+++ b/packages/salesforce-adapter/src/filters/workflow.ts
@@ -53,9 +53,9 @@ const log = logger(module)
 
 export const WORKFLOW_ALERTS_FIELD = 'alerts'
 export const WORKFLOW_FIELD_UPDATES_FIELD = 'fieldUpdates'
-export const WORKFLOW_FLOW_ACTIONS_FIELD = 'flowActions'
-export const WORKFLOW_OUTBOUND_MESSAGES_FIELD = 'outboundMessages'
-export const WORKFLOW_KNOWLEDGE_PUBLISHES_FIELD = 'knowledgePublishes'
+const WORKFLOW_FLOW_ACTIONS_FIELD = 'flowActions'
+const WORKFLOW_OUTBOUND_MESSAGES_FIELD = 'outboundMessages'
+const WORKFLOW_KNOWLEDGE_PUBLISHES_FIELD = 'knowledgePublishes'
 export const WORKFLOW_TASKS_FIELD = 'tasks'
 export const WORKFLOW_RULES_FIELD = 'rules'
 

--- a/packages/salesforce-adapter/src/last_change_date_of_types_with_nested_instances.ts
+++ b/packages/salesforce-adapter/src/last_change_date_of_types_with_nested_instances.ts
@@ -52,7 +52,7 @@ export const isTypeWithNestedInstances = (typeName: string): typeName is TypeWit
 export const isTypeWithNestedInstancesPerParent = (typeName: string): typeName is TypeWithNestedInstancesPerParent =>
   (TYPES_WITH_NESTED_INSTANCES_PER_PARENT as ReadonlyArray<string>).includes(typeName)
 
-export const TYPE_TO_NESTED_TYPES: TypeToNestedTypes = {
+const TYPE_TO_NESTED_TYPES: TypeToNestedTypes = {
   AssignmentRules: [ASSIGNMENT_RULE_METADATA_TYPE],
   AutoResponseRules: [AUTO_RESPONSE_RULE_METADATA_TYPE],
   CustomLabels: [CUSTOM_LABEL_METADATA_TYPE],

--- a/packages/salesforce-adapter/src/transformers/missing_fields.ts
+++ b/packages/salesforce-adapter/src/transformers/missing_fields.ts
@@ -21,7 +21,7 @@ type BooleanMissingFieldDefinition = {
 
 type MissingFieldDefinition = FullMissingFieldDefinition | BooleanMissingFieldDefinition
 
-export type MissingFieldsDataItem = {
+type MissingFieldsDataItem = {
   id: string
   fields: MissingFieldDefinition[]
 }

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -74,7 +74,7 @@ const log = logger(module)
 const { awu } = collections.asynciterable
 type LookupFunc = (val: Value, context?: string) => string
 
-export type ReferenceSerializationStrategy = {
+type ReferenceSerializationStrategy = {
   serialize: GetLookupNameFunc
   lookup: LookupFunc
 }

--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -1435,8 +1435,6 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
   })
 }
 
-export const fromMetadataInfo = (info: MetadataInfo): Values => info
-
 export const toMetadataInfo = async (instance: InstanceElement): Promise<MetadataInfo> => ({
   fullName: await apiName(instance),
   ...(await toDeployableInstance(instance)).value,

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -29,7 +29,6 @@ type UserDeployConfig = definitions.UserDeployConfig
 export const CLIENT_CONFIG = 'client'
 export const MAX_ITEMS_IN_RETRIEVE_REQUEST = 'maxItemsInRetrieveRequest'
 export const MAX_INSTANCES_PER_TYPE = 'maxInstancesPerType'
-export const CUSTOM_OBJECTS_DEPLOY_RETRY_OPTIONS = 'customObjectsDeployRetryOptions'
 export const FETCH_CONFIG = 'fetch'
 export const DEPLOY_CONFIG = 'deploy'
 export const METADATA_CONFIG = 'metadata'
@@ -45,7 +44,7 @@ export const DATA_CONFIGURATION = 'data'
 export const METADATA_TYPES_SKIPPED_LIST = 'metadataTypesSkippedList'
 export const DATA_MANAGEMENT = 'dataManagement'
 export const INSTANCES_REGEX_SKIPPED_LIST = 'instancesRegexSkippedList'
-export const SHOULD_FETCH_ALL_CUSTOM_SETTINGS = 'fetchAllCustomSettings'
+const SHOULD_FETCH_ALL_CUSTOM_SETTINGS = 'fetchAllCustomSettings'
 
 // Based on the list in https://salesforce.stackexchange.com/questions/101844/what-are-the-object-and-field-name-suffixes-that-salesforce-uses-such-as-c-an
 export const INSTANCE_SUFFIXES = [
@@ -216,14 +215,14 @@ export type SaltoAliasSettings = {
   overrides?: ObjectAliasSettings[]
 }
 
-export type SaltoManagementFieldSettings = {
+type SaltoManagementFieldSettings = {
   defaultFieldName: string
 }
 
 export const outgoingReferenceBehaviors = ['ExcludeInstance', 'BrokenReference', 'InternalId'] as const
 export type OutgoingReferenceBehavior = (typeof outgoingReferenceBehaviors)[number]
 
-export type BrokenOutgoingReferencesSettings = {
+type BrokenOutgoingReferencesSettings = {
   defaultBehavior: OutgoingReferenceBehavior
   perTargetTypeOverrides?: Record<string, OutgoingReferenceBehavior>
 }
@@ -369,7 +368,7 @@ const warningSettingsType = new ObjectType({
   },
 })
 
-export type WarningSettings = {
+type WarningSettings = {
   nonQueryableFields: boolean
 }
 
@@ -386,7 +385,7 @@ export type DataManagementConfig = {
   regenerateSaltoIds?: boolean
 }
 
-export type FetchLimits = {
+type FetchLimits = {
   maxExtraDependenciesQuerySize?: number
   maxExtraDependenciesResponseSize?: number
   extendTriggersMetadataChunkSize?: number
@@ -501,7 +500,7 @@ export type MetadataConfigSuggestion = {
   reason?: string
 }
 
-export type RetrieveSizeConfigSuggestion = {
+type RetrieveSizeConfigSuggestion = {
   type: typeof MAX_ITEMS_IN_RETRIEVE_REQUEST
   value: number
   reason?: string
@@ -1005,7 +1004,7 @@ export type MetadataQuery<T = MetadataInstance> = {
   logData: () => void
 }
 
-export type TypeFetchCategory = 'Always' | 'IfReferenced' | 'Never'
+type TypeFetchCategory = 'Always' | 'IfReferenced' | 'Never'
 
 export type DataManagement = {
   shouldFetchObjectType: (objectType: ObjectType) => Promise<TypeFetchCategory>

--- a/packages/salesforce-adapter/test/adapter.ts
+++ b/packages/salesforce-adapter/test/adapter.ts
@@ -12,13 +12,13 @@ import SalesforceClient from '../src/client/client'
 import SalesforceAdapter, { SalesforceAdapterParams } from '../src/adapter'
 import createClient from './client'
 
-export type Mocks = {
+type Mocks = {
   connection: MockInterface<Connection>
   client: SalesforceClient
   adapter: SalesforceAdapter
 }
 
-export type Opts = {
+type Opts = {
   adapterParams?: Partial<SalesforceAdapterParams>
 }
 

--- a/packages/salesforce-adapter/test/connection.ts
+++ b/packages/salesforce-adapter/test/connection.ts
@@ -31,7 +31,7 @@ import {
 import Connection, { Metadata, Soap, Bulk, Tooling, RunTestsResult, RunTestFailure } from '../src/client/jsforce'
 import { createEncodedZipContent, ZipFile } from './utils'
 
-export const MOCK_INSTANCE_URL = 'https://url.com/'
+const MOCK_INSTANCE_URL = 'https://url.com/'
 
 const { sleep } = promises.timeout
 
@@ -53,7 +53,7 @@ export const mockDescribeResult = (
   partialSaveAllowed: true,
 })
 
-export type MockValueTypeFieldInput = Pick<ValueTypeField, 'name' | 'soapType'> &
+type MockValueTypeFieldInput = Pick<ValueTypeField, 'name' | 'soapType'> &
   Partial<Omit<ValueTypeField, 'fields'> & { fields: MockValueTypeFieldInput[] }>
 
 export const mockValueTypeField = (props: MockValueTypeFieldInput): ValueTypeField => ({
@@ -99,7 +99,7 @@ export const mockFileProperties = (props: MockFilePropertiesInput): FileProperti
   ...props,
 })
 
-export type MockRetrieveResultInput = Partial<Omit<RetrieveResult, 'zipFile'>> & {
+type MockRetrieveResultInput = Partial<Omit<RetrieveResult, 'zipFile'>> & {
   zipFiles?: ZipFile[]
 }
 export const mockRetrieveResult = async (props: MockRetrieveResultInput): Promise<RetrieveResult> => ({
@@ -147,7 +147,7 @@ type PartialRunTestResult = Omit<Partial<RunTestsResult>, 'failures'> & {
   failures?: Partial<RunTestFailure>[]
 }
 
-export const mockRunTestResult = (params?: PartialRunTestResult): RunTestsResult | undefined =>
+const mockRunTestResult = (params?: PartialRunTestResult): RunTestsResult | undefined =>
   params === undefined
     ? undefined
     : {
@@ -225,7 +225,7 @@ export const mockDeployResultComplete = ({
   }
 }
 
-export const mockDeployResultInProgress = ({
+const mockDeployResultInProgress = ({
   id,
   runTestResult = undefined,
   ignoreWarnings = true,


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
