### PR TITLE
SALTO-7363: Removing unused exports from Confluence adapter

### DIFF
--- a/packages/confluence-adapter/e2e_test/adapter.ts
+++ b/packages/confluence-adapter/e2e_test/adapter.ts
@@ -16,7 +16,7 @@ import { credsSpec } from './jest_environment'
 
 const log = logger(module)
 
-export type Opts = {
+type Opts = {
   credentials: Credentials
   elementsSource: ReadOnlyElementsSource
 }

--- a/packages/confluence-adapter/src/client/connection.ts
+++ b/packages/confluence-adapter/src/client/connection.ts
@@ -12,7 +12,7 @@ import { Credentials } from '../auth'
 
 const log = logger(module)
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   connection,
   credentials,
 }: {

--- a/packages/confluence-adapter/src/config.ts
+++ b/packages/confluence-adapter/src/config.ts
@@ -8,7 +8,7 @@
 import { elements, definitions } from '@salto-io/adapter-components'
 import { FetchCriteria } from './definitions/types'
 
-export type UserFetchConfig = definitions.UserFetchConfig<{
+type UserFetchConfig = definitions.UserFetchConfig<{
   customNameMappingOptions: never
   fetchCriteria: FetchCriteria
 }> & { managePagesForSpaces?: string[] }

--- a/packages/confluence-adapter/src/definitions/index.ts
+++ b/packages/confluence-adapter/src/definitions/index.ts
@@ -9,4 +9,3 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/confluence-adapter/src/definitions/requests/index.ts
+++ b/packages/confluence-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
