### PR TITLE
SALTO-7363: Removing unused exports from Google Workspace adapter

### DIFF
--- a/packages/google-workspace-adapter/e2e_test/adapter.ts
+++ b/packages/google-workspace-adapter/e2e_test/adapter.ts
@@ -19,7 +19,7 @@ export type Reals = {
   adapter: AdapterOperations
 }
 
-export type Opts = {
+type Opts = {
   credentials: Credentials
   elementsSource: ReadOnlyElementsSource
 }

--- a/packages/google-workspace-adapter/src/auth.ts
+++ b/packages/google-workspace-adapter/src/auth.ts
@@ -11,7 +11,7 @@ import { createMatchingObjectType } from '@salto-io/adapter-utils'
 import { OauthAccessTokenCredentials, oauthAccessTokenCredentialsType } from './client/oauth'
 import * as constants from './constants'
 
-export type BasicCredentials = {
+type BasicCredentials = {
   accessToken: string
 }
 

--- a/packages/google-workspace-adapter/src/client/connection.ts
+++ b/packages/google-workspace-adapter/src/client/connection.ts
@@ -14,7 +14,7 @@ import { OauthAccessTokenCredentials } from './oauth'
 
 const log = logger(module)
 
-export const validateDirectoryCredentials = async ({
+const validateDirectoryCredentials = async ({
   connection,
 }: {
   connection: clientUtils.APIConnection
@@ -33,10 +33,10 @@ export const validateDirectoryCredentials = async ({
 }
 
 // There is no endPoints for groupSettings that we can use to validate the credentials with.
-export const validateGroupSettingsCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
+const validateGroupSettingsCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
 
 // There is no endPoints for groupSettings that we can use to validate the credentials with.
-export const validateCloudIdentityCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
+const validateCloudIdentityCredentials = async (): Promise<AccountInfo> => ({ accountId: 'googoo' })
 
 const validateCredentialsPerApp: Record<
   string,

--- a/packages/google-workspace-adapter/src/client/oauth.ts
+++ b/packages/google-workspace-adapter/src/client/oauth.ts
@@ -60,7 +60,7 @@ export const createOAuthRequest = (userInput: InstanceElement): OAuthRequestPara
   }
 }
 
-export type OauthRequestParameters = {
+type OauthRequestParameters = {
   clientId: string
   clientSecret: string
   port: number

--- a/packages/google-workspace-adapter/src/config.ts
+++ b/packages/google-workspace-adapter/src/config.ts
@@ -7,12 +7,12 @@
  */
 import { elements, definitions } from '@salto-io/adapter-components'
 
-export type UserFetchConfig = definitions.UserFetchConfig<{
+type UserFetchConfig = definitions.UserFetchConfig<{
   customNameMappingOptions: never
   fetchCriteria: definitions.DefaultFetchCriteria
 }>
 
-export type UserDeployConfig = definitions.UserDeployConfig & {
+type UserDeployConfig = definitions.UserDeployConfig & {
   defaultDomain?: string
 }
 

--- a/packages/google-workspace-adapter/src/definitions/index.ts
+++ b/packages/google-workspace-adapter/src/definitions/index.ts
@@ -9,4 +9,3 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/google-workspace-adapter/src/definitions/requests/index.ts
+++ b/packages/google-workspace-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'

--- a/packages/google-workspace-adapter/src/definitions/types.ts
+++ b/packages/google-workspace-adapter/src/definitions/types.ts
@@ -13,7 +13,7 @@ type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = 'roleId' | 'orgUnitId' | 'buildingId' | 'email'
 
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions
   paginationOptions: PaginationOptions


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
