### PR TITLE
SALTO-7414: fail fieldContextOption when the relevant feildContext fails

### DIFF
--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -85,6 +85,7 @@ const removeOptionsOfFailedContexts = ({
   })
 
   const optionErrors = optionsOfFailedContext
+    // had to filter by isInstanceChange again because TS doesn't understand the partition well
     .filter(isInstanceChange)
     .map(getChangeData)
     .map(optionInstance => {

--- a/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_deployment_filter.ts
@@ -7,12 +7,14 @@
  */
 import {
   Change,
+  DeployResult,
   Element,
   getChangeData,
   isAdditionChange,
   isInstanceChange,
   isInstanceElement,
   isRemovalChange,
+  SeverityLevel,
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import { hasValidParent } from '@salto-io/adapter-utils'
@@ -43,6 +45,93 @@ const removeOptionsWithDeletedContext = (
       deletedContextElemIDs.has(getContextParent(getChangeData(change)).elemID.getFullName()),
   )
   return { leftoverChanges, optionsWithDeletedContext }
+}
+
+const removeOptionsOfFailedContexts = ({
+  deployResult,
+  leftoverChanges,
+  relevantChanges,
+}: {
+  deployResult: DeployResult
+  leftoverChanges: Change[]
+  relevantChanges: Change[]
+}): {
+  updatedDeployResult: DeployResult
+  updatedLeftoverChanges: Change[]
+} => {
+  // this function find the failure contexts addition and remove the options that depend on them
+  const contextAppliedChangesFullName = new Set(
+    deployResult.appliedChanges.map(change => getChangeData(change).elemID.getFullName()),
+  )
+  const failureContextsNames = new Set(
+    relevantChanges
+      .filter(isAdditionChange)
+      .map(getChangeData)
+      .map(contextInstance => contextInstance.elemID.getFullName())
+      // filter out the contexts that were successfully deployed
+      .filter(contextName => !contextAppliedChangesFullName.has(contextName)),
+  )
+
+  const relevantOptionInstancesByFullName = _.keyBy(
+    leftoverChanges
+      .filter(isInstanceChange)
+      .map(getChangeData)
+      .filter(
+        instance =>
+          instance.elemID.typeName === FIELD_CONTEXT_OPTION_TYPE_NAME &&
+          failureContextsNames.has(getContextParent(instance).elemID.getFullName()),
+      ),
+    instance => instance.elemID.getFullName(),
+  )
+
+  const errors = Object.values(relevantOptionInstancesByFullName).map(optionInstance => {
+    const contextParent = getContextParent(optionInstance)
+    const message = `Element was not deployed, as it depends on ${contextParent.elemID.getFullName()} which failed to deploy`
+    return {
+      elemID: optionInstance.elemID,
+      severity: 'Error' as SeverityLevel,
+      message,
+      detailedMessage: message,
+    }
+  })
+
+  const updateLeftoverChanges = leftoverChanges.filter(
+    change => relevantOptionInstancesByFullName[getChangeData(change).elemID.getFullName()] === undefined,
+  )
+  return {
+    updatedDeployResult: {
+      ...deployResult,
+      errors: deployResult.errors.concat(errors),
+    },
+    updatedLeftoverChanges: updateLeftoverChanges,
+  }
+}
+
+const updateDeployResultAndChanges = ({
+  leftoverChanges,
+  relevantChanges,
+  deployResult,
+}: {
+  leftoverChanges: Change[]
+  relevantChanges: Change[]
+  deployResult: DeployResult
+}): { leftoverChanges: Change[]; deployResult: DeployResult } => {
+  const { updatedDeployResult, updatedLeftoverChanges } = removeOptionsOfFailedContexts({
+    deployResult,
+    leftoverChanges,
+    relevantChanges,
+  })
+  const changesUpdates = removeOptionsWithDeletedContext(updatedLeftoverChanges, updatedDeployResult.appliedChanges)
+
+  return {
+    // we remove the removal options as they were deleted, and we add the applied changes as
+    // we should deploy the default values after the options deployment
+    leftoverChanges: changesUpdates.leftoverChanges.concat(updatedDeployResult.appliedChanges),
+    deployResult: {
+      errors: updatedDeployResult.errors,
+      appliedChanges: changesUpdates.optionsWithDeletedContext,
+    },
+  }
 }
 
 const filter: FilterCreator = ({ client, config, paginator, elementsSource }) => ({
@@ -88,17 +177,11 @@ const filter: FilterCreator = ({ client, config, paginator, elementsSource }) =>
             })
         })
 
-      const changesUpdates = removeOptionsWithDeletedContext(leftoverChanges, deployResult.appliedChanges)
-
-      return {
-        // we remove the removal options as they were deleted, and we add the applied changes as
-        // we should deploy the default values after the options deployment
-        leftoverChanges: changesUpdates.leftoverChanges.concat(deployResult.appliedChanges),
-        deployResult: {
-          errors: deployResult.errors,
-          appliedChanges: changesUpdates.optionsWithDeletedContext,
-        },
-      }
+      return updateDeployResultAndChanges({
+        leftoverChanges,
+        relevantChanges,
+        deployResult,
+      })
     }
 
     return {

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -260,6 +260,7 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'projectIds', parentTypes: ['CustomFieldContext'] },
     serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_TYPE },
   },
   {


### PR DESCRIPTION
_fail fieldContextOption when the relevant feildContext fails_

---

_Additional context for reviewer_

---
_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---
_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
