### PR TITLE
SALTO-7363: Removing unused exports from Jamf adapter

### DIFF
--- a/packages/jamf-adapter/src/client/connection.ts
+++ b/packages/jamf-adapter/src/client/connection.ts
@@ -14,7 +14,7 @@ const log = logger(module)
 
 export const VALIDATE_CREDENTIALS_URL = '/JSSResource/classes'
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   connection,
   credentials,
 }: {

--- a/packages/jamf-adapter/src/config.ts
+++ b/packages/jamf-adapter/src/config.ts
@@ -12,7 +12,7 @@ export type UserFetchConfig = definitions.UserFetchConfig<{
   fetchCriteria: definitions.DefaultFetchCriteria
 }>
 
-export type UserDeployConfig = definitions.UserDeployConfig & {
+type UserDeployConfig = definitions.UserDeployConfig & {
   delayAfterDeploy?: number
 }
 

--- a/packages/jamf-adapter/src/definitions/requests/index.ts
+++ b/packages/jamf-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'

--- a/packages/jamf-adapter/src/definitions/types.ts
+++ b/packages/jamf-adapter/src/definitions/types.ts
@@ -13,7 +13,7 @@ type PaginationOptions = 'increasePageUntilEmpty'
 
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = 'idAndNameObject'
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
