### PR TITLE
SALTO-7363: Removing unused exports from Microsoft adapters

### DIFF
--- a/packages/microsoft-entra-adapter/src/client/connection.ts
+++ b/packages/microsoft-entra-adapter/src/client/connection.ts
@@ -13,7 +13,7 @@ import { Credentials, getAuthenticationBaseUrl } from './oauth'
 
 const log = logger(module)
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   credentials: { tenantId },
   connection,
 }: {

--- a/packages/microsoft-entra-adapter/src/client/oauth.ts
+++ b/packages/microsoft-entra-adapter/src/client/oauth.ts
@@ -34,7 +34,7 @@ export const OAUTH_REQUIRED_SCOPES = [
   'UserAuthenticationMethod.ReadWrite.All',
 ]
 
-export type OauthRequestParameters = {
+type OauthRequestParameters = {
   tenantId: string
   clientId: string
   clientSecret: string

--- a/packages/microsoft-entra-adapter/src/constants.ts
+++ b/packages/microsoft-entra-adapter/src/constants.ts
@@ -18,16 +18,12 @@ export const APP_ROLES_FIELD_NAME = 'appRoles'
 export const AUTHENTICATION_METHOD_CONFIGURATIONS_FIELD_NAME = 'authenticationMethodConfigurations'
 export const CUSTOM_SECURITY_ATTRIBUTE_ALLOWED_VALUES_FIELD_NAME = 'allowedValues'
 export const DELEGATED_PERMISSION_CLASSIFICATIONS_FIELD_NAME = 'delegatedPermissionClassifications'
-export const DELEGATED_PERMISSION_IDS_FIELD_NAME = 'delegatedPermissionIds'
 export const DOMAIN_NAME_REFERENCES_FIELD_NAME = 'domainNameReferences'
 export const GROUP_ADDITIONAL_DATA_FIELD_NAME = 'additionalData'
 export const GROUP_LIFE_CYCLE_POLICY_FIELD_NAME = 'lifeCyclePolicy'
 export const IDENTIFIER_URIS_FIELD_NAME = 'identifierUris'
-export const INCLUDE_USERS_FIELD_NAME = 'includeUsers'
-export const EXCLUDE_USERS_FIELD_NAME = 'excludeUsers'
 export const MEMBERS_FIELD_NAME = 'members'
 export const PRE_AUTHORIZED_APPLICATIONS_FIELD_NAME = 'preAuthorizedApplications'
-export const TOKEN_ISSUANCE_POLICY_FIELD_NAME = 'tokenIssuancePolicies'
 // Used for service id purpose, when the id of the child is not globally unique
 export const PARENT_ID_FIELD_NAME = 'parent_id'
 
@@ -43,9 +39,8 @@ export const AUTHENTICATION_METHOD_CONFIGURATION_TYPE_NAME = toNestedTypeName(
   AUTHENTICATION_METHOD_POLICY_TYPE_NAME,
   AUTHENTICATION_METHOD_CONFIGURATIONS_FIELD_NAME,
 )
-export const CLAIM_MAPPING_POLICY_TYPE_NAME = 'claimMappingPolicy'
 export const CONDITIONAL_ACCESS_POLICY_TYPE_NAME = 'conditionalAccessPolicy'
-export const CONDITIONAL_ACCESS_POLICY_CONDITIONS_TYPE_NAME = toNestedTypeName(
+const CONDITIONAL_ACCESS_POLICY_CONDITIONS_TYPE_NAME = toNestedTypeName(
   CONDITIONAL_ACCESS_POLICY_TYPE_NAME,
   'conditions',
 )
@@ -78,7 +73,6 @@ export const GROUP_TYPE_NAME = 'group'
 export const GROUP_ADDITIONAL_DATA_TYPE_NAME = toNestedTypeName(GROUP_TYPE_NAME, GROUP_ADDITIONAL_DATA_FIELD_NAME)
 export const GROUP_APP_ROLE_ASSIGNMENT_TYPE_NAME = toNestedTypeName(GROUP_TYPE_NAME, APP_ROLE_ASSIGNMENT_FIELD_NAME)
 export const GROUP_LIFE_CYCLE_POLICY_TYPE_NAME = toNestedTypeName(GROUP_TYPE_NAME, GROUP_LIFE_CYCLE_POLICY_FIELD_NAME)
-export const HOME_REALM_DISCOVERY_POLICY_TYPE_NAME = 'homeRealmDiscoveryPolicy'
 export const LIFE_CYCLE_POLICY_TYPE_NAME = 'groupLifeCyclePolicy'
 export const OAUTH2_PERMISSION_GRANT_TYPE_NAME = 'oauth2PermissionGrant'
 export const PERMISSION_GRANT_POLICY_TYPE_NAME = 'permissionGrantPolicy'
@@ -92,8 +86,6 @@ export const DELEGATED_PERMISSION_CLASSIFICATION_TYPE_NAME = toNestedTypeName(
   SERVICE_PRINCIPAL_TYPE_NAME,
   DELEGATED_PERMISSION_CLASSIFICATIONS_FIELD_NAME,
 )
-export const TOKEN_ISSUANCE_POLICY_TYPE_NAME = toNestedTypeName(APPLICATION_TYPE_NAME, TOKEN_ISSUANCE_POLICY_FIELD_NAME)
-export const TOKEN_LIFETIME_POLICY_TYPE_NAME = 'tokenLifetimePolicy'
 
 // OData fields
 export const ODATA_ID_FIELD = '@odata.id'
@@ -102,7 +94,7 @@ export const ODATA_TYPE_FIELD = '@odata.type'
 export const ODATA_TYPE_FIELD_NACL_CASE = naclCase(ODATA_TYPE_FIELD)
 
 export const ODATA_PREFIX = '#microsoft.graph.'
-export const SUPPORTED_DIRECTORY_OBJECT_TYPE_NAME_TO_ODATA_TYPE_NAME: Record<string, string> = {
+const SUPPORTED_DIRECTORY_OBJECT_TYPE_NAME_TO_ODATA_TYPE_NAME: Record<string, string> = {
   [ADMINISTRATIVE_UNIT_TYPE_NAME]: `${ODATA_PREFIX}administrativeUnit`,
   [APPLICATION_TYPE_NAME]: `${ODATA_PREFIX}application`,
   [GROUP_TYPE_NAME]: `${ODATA_PREFIX}group`,

--- a/packages/microsoft-entra-adapter/src/definitions/deploy/types.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/deploy/types.ts
@@ -8,10 +8,7 @@
 import { definitions } from '@salto-io/adapter-components'
 import { AdditionalAction, ClientOptions } from '../types'
 
-export type InstanceDeployApiDefinitions = definitions.deploy.InstanceDeployApiDefinitions<
-  AdditionalAction,
-  ClientOptions
->
+type InstanceDeployApiDefinitions = definitions.deploy.InstanceDeployApiDefinitions<AdditionalAction, ClientOptions>
 export type DeployCustomDefinitions = Record<string, InstanceDeployApiDefinitions>
 export type DeployRequestDefinition = definitions.deploy.DeployRequestDefinition<ClientOptions>
 export type DeployableRequestDefinition = definitions.deploy.DeployableRequestDefinition<ClientOptions>

--- a/packages/microsoft-entra-adapter/src/definitions/index.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/index.ts
@@ -9,4 +9,3 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/microsoft-entra-adapter/src/definitions/requests/index.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'

--- a/packages/microsoft-entra-adapter/src/definitions/types.ts
+++ b/packages/microsoft-entra-adapter/src/definitions/types.ts
@@ -13,7 +13,7 @@ export type ClientOptions = 'main'
 type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = 'ODataType'
 export type CustomReferenceSerializationStrategyName = 'appId'
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions

--- a/packages/microsoft-entra-adapter/src/filters/array_fields_deployment.ts
+++ b/packages/microsoft-entra-adapter/src/filters/array_fields_deployment.ts
@@ -45,7 +45,7 @@ import { changeResolver } from '../definitions/references'
 
 const log = logger(module)
 
-export type ArrayElementChangeData = {
+type ArrayElementChangeData = {
   id: string
   name: string
   [key: string]: unknown

--- a/packages/microsoft-entra-adapter/test/mocks.ts
+++ b/packages/microsoft-entra-adapter/test/mocks.ts
@@ -25,11 +25,11 @@ export const objectTypeMock = new ObjectType({
   elemID: new ElemID(ADAPTER_NAME, 'testType'),
 })
 
-export const instanceElementMock = new InstanceElement('testInstance', objectTypeMock, {
+const instanceElementMock = new InstanceElement('testInstance', objectTypeMock, {
   testField: 'testValue',
 })
 
-export const instanceElementWithParentMock = new InstanceElement(
+const instanceElementWithParentMock = new InstanceElement(
   'testInstanceChild',
   objectTypeMock,
   {
@@ -63,12 +63,12 @@ export const removalChangeMock: RemovalChange<InstanceElement> = {
   },
 }
 
-export const changeGroupMock: ChangeGroup = {
+const changeGroupMock: ChangeGroup = {
   groupID: 'testGroup',
   changes: [additionChangeMock],
 }
 
-export const mockElementSource = buildElementsSourceFromElements([objectTypeMock, instanceElementMock])
+const mockElementSource = buildElementsSourceFromElements([objectTypeMock, instanceElementMock])
 
 export const contextMock: definitions.deploy.ChangeAndExtendedContext & definitions.ContextParams = {
   additionalContext: { parent_id: 'parent_id' },

--- a/packages/microsoft-security-adapter/src/auth.ts
+++ b/packages/microsoft-security-adapter/src/auth.ts
@@ -13,7 +13,7 @@ export const AVAILABLE_MICROSOFT_SECURITY_SERVICES = ['Entra', 'Intune'] as cons
 export type AvailableMicrosoftSecurityServices = (typeof AVAILABLE_MICROSOFT_SECURITY_SERVICES)[number]
 export type MicrosoftServicesToManage = Partial<Record<AvailableMicrosoftSecurityServices, boolean>>
 
-export type OauthRequestParameters = {
+type OauthRequestParameters = {
   tenantId: string
   clientId: string
   clientSecret: string

--- a/packages/microsoft-security-adapter/src/client/connection.ts
+++ b/packages/microsoft-security-adapter/src/client/connection.ts
@@ -15,7 +15,7 @@ import { Credentials } from '../auth'
 
 const log = logger(module)
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   credentials: { tenantId },
   connection,
 }: {

--- a/packages/microsoft-security-adapter/src/config/config.ts
+++ b/packages/microsoft-security-adapter/src/config/config.ts
@@ -19,7 +19,7 @@ type UserFetchConfig = definitions.UserFetchConfig<{
 }>
 
 type DeployConfigFieldsNames = typeof ASSIGNMENT_FIELDS_STRATEGY_CONFIG_FIELD_NAME
-export type AdditionalDeployConfigFields = {
+type AdditionalDeployConfigFields = {
   [ASSIGNMENT_FIELDS_STRATEGY_CONFIG_FIELD_NAME]?: AssignmentFieldsConfig
 }
 export const additionalDeployConfigFieldsType: Record<DeployConfigFieldsNames, FieldDefinition> = {

--- a/packages/microsoft-security-adapter/src/constants/entra.ts
+++ b/packages/microsoft-security-adapter/src/constants/entra.ts
@@ -74,8 +74,9 @@ export const TOP_LEVEL_TYPES = {
   SERVICE_PRINCIPAL_TYPE_NAME: 'EntraServicePrincipal',
 } as const
 
-// We only use the validateTypeNames for compilation time validation
-export const validateTypeNames: EntraTypeName[] = Object.values(TOP_LEVEL_TYPES)
+// This anonymous function is only used for compile time validation.
+// Once we upgrade to TS 4.9 or newer we can use the new `satisfies` syntax instead.
+;(<T extends Record<string, EntraTypeName>>(_value: T): void => {})(TOP_LEVEL_TYPES)
 
 // Nested types
 export const ADMINISTRATIVE_UNIT_MEMBERS_TYPE_NAME = recursiveNestedTypeName(
@@ -87,7 +88,7 @@ export const AUTHENTICATION_METHOD_CONFIGURATION_TYPE_NAME = recursiveNestedType
   TOP_LEVEL_TYPES.AUTHENTICATION_METHOD_POLICY_TYPE_NAME,
   AUTHENTICATION_METHOD_CONFIGURATIONS_FIELD_NAME,
 )
-export const CONDITIONAL_ACCESS_POLICY_CONDITIONS_TYPE_NAME = recursiveNestedTypeName(
+const CONDITIONAL_ACCESS_POLICY_CONDITIONS_TYPE_NAME = recursiveNestedTypeName(
   TOP_LEVEL_TYPES.CONDITIONAL_ACCESS_POLICY_TYPE_NAME,
   CONDITIONS_FIELD_NAME,
 )

--- a/packages/microsoft-security-adapter/src/constants/intune.ts
+++ b/packages/microsoft-security-adapter/src/constants/intune.ts
@@ -33,9 +33,9 @@ export const SETTINGS_FIELD_NAME = 'settings'
 export const SETTING_COUNT_FIELD_NAME = 'settingCount'
 
 // DeviceCompliance fields
-export const RESTRICTED_APPS_FIELD_NAME = 'restrictedApps'
+const RESTRICTED_APPS_FIELD_NAME = 'restrictedApps'
 export const SCHEDULED_ACTIONS_FIELD_NAME = 'scheduledActionsForRule'
-export const SCHEDULED_ACTION_CONFIGURATIONS_FIELD_NAME = 'scheduledActionConfigurations'
+const SCHEDULED_ACTION_CONFIGURATIONS_FIELD_NAME = 'scheduledActionConfigurations'
 
 // Platform script fields
 // Linux
@@ -68,8 +68,9 @@ export const TOP_LEVEL_TYPES = {
   SCOPE_TAG_TYPE_NAME: 'IntuneScopeTag',
 } as const
 
-// We only use the validateTypeNames for compilation time validation
-export const validateTypeNames: IntuneTypeName[] = Object.values(TOP_LEVEL_TYPES)
+// This anonymous function is only used for compile time validation.
+// Once we upgrade to TS 4.9 or newer we can use the new `satisfies` syntax instead.
+;(<T extends Record<string, IntuneTypeName>>(_value: T): void => {})(TOP_LEVEL_TYPES)
 
 // Nested types
 export const DEVICE_CONFIGURATION_SETTING_CATALOG_SETTINGS_TYPE_NAME = recursiveNestedTypeName(

--- a/packages/microsoft-security-adapter/src/definitions/fetch/shared/types.ts
+++ b/packages/microsoft-security-adapter/src/definitions/fetch/shared/types.ts
@@ -11,10 +11,8 @@ import { Options } from '../../types'
 
 export type FetchApiDefinition = definitions.fetch.InstanceFetchApiDefinitions<Options>
 export type FetchCustomizations = Record<string, FetchApiDefinition>
-export type ElementFetchDefinition = definitions.fetch.ElementFetchDefinition<Options>
 export type ElementFieldCustomization = definitions.fetch.ElementFieldCustomization
 export type FieldIDPart = definitions.fetch.FieldIDPart
-export type AdjustFunction = definitions.AdjustFunction
 export type AdjustFunctionSingle = definitions.AdjustFunctionSingle
 export type AdjustFunctionMergeAndTransform = definitions.AdjustFunctionSingle<{
   fragments: definitions.GeneratedItem[]

--- a/packages/microsoft-security-adapter/src/definitions/index.ts
+++ b/packages/microsoft-security-adapter/src/definitions/index.ts
@@ -9,4 +9,3 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/microsoft-security-adapter/src/definitions/references/index.ts
+++ b/packages/microsoft-security-adapter/src/definitions/references/index.ts
@@ -6,5 +6,4 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-export { REFERENCES } from './references'
 export { changeResolver } from './references'

--- a/packages/microsoft-security-adapter/src/definitions/requests/index.ts
+++ b/packages/microsoft-security-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'

--- a/packages/microsoft-security-adapter/src/definitions/types.ts
+++ b/packages/microsoft-security-adapter/src/definitions/types.ts
@@ -13,7 +13,7 @@ export type ClientOptions = 'main'
 type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = 'ODataType' | 'resourceAccessType'
 export type CustomReferenceSerializationStrategyName = 'appId' | 'bundleId' | 'packageId' | 'servicePrincipalAppId'
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions

--- a/packages/microsoft-security-adapter/src/filters/shared/array_fields_deployment.ts
+++ b/packages/microsoft-security-adapter/src/filters/shared/array_fields_deployment.ts
@@ -45,7 +45,7 @@ import { changeResolver } from '../../definitions/references'
 
 const log = logger(module)
 
-export type ArrayElementChangeData = {
+type ArrayElementChangeData = {
   id: string
   name: string
   [key: string]: unknown

--- a/packages/microsoft-security-adapter/src/filters/shared/index.ts
+++ b/packages/microsoft-security-adapter/src/filters/shared/index.ts
@@ -6,5 +6,4 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-export { deployArrayFieldsFilterCreator } from './array_fields_deployment'
 export { mapMemberRefToChangeData } from './members_utils'

--- a/packages/microsoft-security-adapter/test/mocks.ts
+++ b/packages/microsoft-security-adapter/test/mocks.ts
@@ -25,11 +25,11 @@ export const objectTypeMock = new ObjectType({
   elemID: new ElemID(ADAPTER_NAME, 'testType'),
 })
 
-export const instanceElementMock = new InstanceElement('testInstance', objectTypeMock, {
+const instanceElementMock = new InstanceElement('testInstance', objectTypeMock, {
   testField: 'testValue',
 })
 
-export const instanceElementWithParentMock = new InstanceElement(
+const instanceElementWithParentMock = new InstanceElement(
   'testInstanceChild',
   objectTypeMock,
   {
@@ -63,12 +63,12 @@ export const removalChangeMock: RemovalChange<InstanceElement> = {
   },
 }
 
-export const changeGroupMock: ChangeGroup = {
+const changeGroupMock: ChangeGroup = {
   groupID: 'testGroup',
   changes: [additionChangeMock],
 }
 
-export const mockElementSource = buildElementsSourceFromElements([objectTypeMock, instanceElementMock])
+const mockElementSource = buildElementsSourceFromElements([objectTypeMock, instanceElementMock])
 
 export const contextMock: definitions.deploy.ChangeAndExtendedContext & definitions.ContextParams = {
   additionalContext: { parent_id: 'parent_id' },


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
