### PR TITLE
SALTO-7427 return static file with content when there are common and …

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
+++ b/packages/workspace/src/workspace/nacl_files/multi_env/multi_env_source.ts
@@ -42,7 +42,7 @@ import {
 import { Errors } from '../../errors'
 import { RemoteElementSource, ElementsSource } from '../../elements_source'
 import { serialize, deserializeSingleElement, deserializeMergeErrors } from '../../../serializer/elements'
-import { MissingStaticFile } from '../../static_files'
+import { PlaceholderStaticFile, MissingStaticFile } from '../../static_files'
 import { ReferenceIndexEntry } from '../../reference_indexes'
 
 const log = logger(module)
@@ -194,7 +194,8 @@ const buildMultiEnvSource = (
     if (sourcesFiles.length > 1 && !_.every(sourcesFiles, sf => sf.hash === sourcesFiles[0].hash)) {
       log.warn(`Found different hashes for static file ${filePath}`)
     }
-    return sourcesFiles[0] ?? new MissingStaticFile(filePath)
+    const fileWithContent = sourcesFiles.find(sf => !(sf instanceof PlaceholderStaticFile))
+    return fileWithContent ?? sourcesFiles[0] ?? new MissingStaticFile(filePath)
   }
 
   const buildStateForSingleEnv = async (envName: string): Promise<SingleState> => {

--- a/packages/workspace/src/workspace/static_files/index.ts
+++ b/packages/workspace/src/workspace/static_files/index.ts
@@ -6,7 +6,13 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { StaticFilesCache, StaticFilesData } from './cache'
-export { buildStaticFilesSource, buildInMemStaticFilesSource, LazyStaticFile, AbsoluteStaticFile } from './source'
+export {
+  buildStaticFilesSource,
+  buildInMemStaticFilesSource,
+  LazyStaticFile,
+  AbsoluteStaticFile,
+  PlaceholderStaticFile,
+} from './source'
 export {
   StaticFilesSource,
   MissingStaticFile,

--- a/packages/workspace/src/workspace/static_files/source.ts
+++ b/packages/workspace/src/workspace/static_files/source.ts
@@ -70,6 +70,8 @@ export class LazyStaticFile extends AbsoluteStaticFile {
   }
 }
 
+export class PlaceholderStaticFile extends StaticFile {}
+
 export const buildStaticFilesSource = (
   staticFilesDirStore: DirectoryStore<Buffer>,
   staticFilesCache: StaticFilesCache,
@@ -182,12 +184,12 @@ export const buildStaticFilesSource = (
       try {
         const staticFileData = await getStaticFileData(args.filepath)
         if (args.hash !== undefined && staticFileData.hash !== args.hash) {
-          // We return a StaticFile in this case and not a MissingStaticFile to be able to differ
+          // We return a PlaceholderStaticFile in this case and not a MissingStaticFile to be able to differ
           // in the elements cache between a file that was really missing when the cache was
           // written, and a file that existed but was modified since the cache was written,
           // as the latter should not be represented in the element that is returned from
           // the cache as MissingStaticFile
-          return new StaticFile({
+          return new PlaceholderStaticFile({
             filepath: args.filepath,
             encoding: args.encoding,
             hash: args.hash,
@@ -227,12 +229,12 @@ export const buildStaticFilesSource = (
         )
       } catch (e) {
         if (args.hash !== undefined) {
-          // We return a StaticFile in this case and not a MissingStaticFile to be able to differ
+          // We return a PlaceholderStaticFile in this case and not a MissingStaticFile to be able to differ
           // in the elements cache between a file that was really missing when the cache was
           // written, and a file that existed but was removed since the cache was written,
           // as the latter should not be represented in the element that is returned from
           // the cache as MissingStaticFile
-          return new StaticFile({
+          return new PlaceholderStaticFile({
             filepath: args.filepath,
             encoding: args.encoding,
             hash: args.hash,

--- a/packages/workspace/test/workspace/static_files/source.test.ts
+++ b/packages/workspace/test/workspace/static_files/source.test.ts
@@ -16,6 +16,8 @@ import {
   StaticFilesCache,
   LazyStaticFile,
   buildInMemStaticFilesSource,
+  AbsoluteStaticFile,
+  PlaceholderStaticFile,
 } from '../../../src/workspace/static_files'
 
 import {
@@ -92,8 +94,8 @@ describe('Static Files', () => {
 
             expect(mockDirStore.mtimestamp).toHaveBeenCalledWith(filepathFromCache)
             expect(result).toHaveProperty('hash', hashedContent)
-            expect(result).toBeInstanceOf(StaticFile)
-            expect(await (result as StaticFile).getContent()).toBe(defaultBuffer)
+            expect(result).toBeInstanceOf(AbsoluteStaticFile)
+            expect(await (result as AbsoluteStaticFile).getContent()).toBe(defaultBuffer)
           })
         })
         describe('hashing', () => {
@@ -164,8 +166,8 @@ describe('Static Files', () => {
 
             expect(mockDirStore.mtimestamp).toHaveBeenCalledTimes(0)
             expect(result).toHaveProperty('hash', 'aaa')
-            expect(result).toBeInstanceOf(StaticFile)
-            expect(await (result as StaticFile).getContent()).toBe(defaultBuffer)
+            expect(result).toBeInstanceOf(AbsoluteStaticFile)
+            expect(await (result as AbsoluteStaticFile).getContent()).toBe(defaultBuffer)
           })
         })
         describe('hashing disregards mtimestamp', () => {
@@ -186,7 +188,7 @@ describe('Static Files', () => {
             expect(mockDirStore.mtimestamp).toHaveBeenCalledTimes(0)
             expect(result).toHaveProperty('hash', 'aaa')
             expect(mockDirStore.get).not.toHaveBeenCalled()
-            const staticFileRes = result as StaticFile
+            const staticFileRes = result as AbsoluteStaticFile
             expect(await staticFileRes.getContent()).toEqual(defaultBuffer)
             expect(mockDirStore.get).toHaveBeenCalled()
           })
@@ -222,8 +224,8 @@ describe('Static Files', () => {
           })
           it('return without content when hash requested and not matching', async () => {
             const result = await staticFilesSource.getStaticFile({ filepath: 'aa', encoding: 'binary', hash: 'hash' })
-            expect(result).toBeInstanceOf(StaticFile)
-            return expect(await (result as StaticFile).getContent()).toBeUndefined()
+            expect(result).toBeInstanceOf(PlaceholderStaticFile)
+            return expect(await (result as PlaceholderStaticFile).getContent()).toBeUndefined()
           })
 
           it('return without content when matching with wrong hash', async () => {
@@ -244,8 +246,8 @@ describe('Static Files', () => {
               hash: 'bbb',
             })
 
-            expect(result).toBeInstanceOf(StaticFile)
-            expect(await (result as StaticFile).getContent()).toBeUndefined()
+            expect(result).toBeInstanceOf(PlaceholderStaticFile)
+            expect(await (result as PlaceholderStaticFile).getContent()).toBeUndefined()
           })
         })
 
@@ -266,7 +268,7 @@ describe('Static Files', () => {
             expect(mockDirStore.get).toHaveBeenCalledTimes(0)
             expect(result).toHaveProperty('hash', 'aaa')
             expect(mockDirStore.get).not.toHaveBeenCalled()
-            const staticFileRes = result as StaticFile
+            const staticFileRes = result as LazyStaticFile
             expect(await staticFileRes.getContent()).toEqual(defaultBuffer)
             expect(mockDirStore.get).toHaveBeenCalled()
           })


### PR DESCRIPTION
…env source

in case that there are nacl files in both common and env folder, we may return an empty static file from multi env, because we filter out empty sources only when asking for the static file, and since there are elements in both common and env folders, one of them will return an empty static file.

we should instead return the real static file, that has content (and not the placeholder) if one existed.

---

_Additional context for reviewer_

---
_Release Notes_: 
Workspace:
- return static file with content when there are common and env source

---
_User Notifications_: 
None