### PR TITLE
SALTO-4207: Missing reference in FlexiPage criterias

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
+++ b/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
@@ -18,7 +18,7 @@ import {
 } from '@salto-io/adapter-api'
 import { TransformFuncSync, transformValuesSync } from '@salto-io/adapter-utils'
 import {
-  COMPONENT_INSTANCE_PROPERTY_FILED_NAMES,
+  COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES,
   FLEXI_PAGE_FIELD_NAMES,
   FLEXI_PAGE_REGION_FIELD_NAMES,
   FLEXI_PAGE_TYPE,
@@ -50,7 +50,7 @@ const getFacetDefinitionsAndReferences = (
     if (field.name === FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS && isFlexiPageRegion(value)) {
       facetDefinitions[value.name] = path
     }
-    if (path.name === COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE) {
+    if (path.name === COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE) {
       potentialFacetReferences.get(value).push(path)
     }
     return value

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -78,15 +78,32 @@ export enum FIELD_TYPE_NAMES {
 }
 
 // FlexiPage constants
+export const UI_FORMULA_CRITERION = 'UiFormulaCriterion'
+export const UI_FORMULA_RULE = 'UiFormulaRule'
 export const COMPONENT_INSTANCE_PROPERTY = 'ComponentInstanceProperty'
 export const COMPONENT_INSTANCE = 'ComponentInstance'
+export const FIELD_INSTANCE = 'FieldInstance'
 export const ITEM_INSTANCE = 'ItemInstance'
 export const FLEXI_PAGE_REGION = 'flexiPageRegion'
-export enum COMPONENT_INSTANCE_PROPERTY_FILED_NAMES {
+export enum UI_FORMULA_CRITERION_FIELD_NAMES {
+  LEFT_VALUE = 'leftValue',
+}
+export enum UI_FORMULA_RULE_FIELD_NAMES {
+  CRITERIA = 'criteria',
+}
+export enum COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES {
   VALUE = 'value',
 }
-export enum COMPONENT_INSTANCE_FILED_NAMES {
+export enum FIELD_INSTANCE_FIELD_NAMES {
+  VISIBILITY_RULE = 'visibilityRule',
+}
+export enum COMPONENT_INSTANCE_FIELD_NAMES {
   COMPONENT_INSTANCE_PROPERTIES = 'componentInstanceProperties',
+  VISIBILITY_RULE = 'visibilityRule',
+}
+export enum ITEM_INSTANCE_FIELD_NAMES {
+  COMPONENT = 'componentInstance',
+  FIELD = 'fieldInstance',
 }
 export enum FLEXI_PAGE_REGION_FIELD_NAMES {
   COMPONENT_INSTANCES = 'componentInstances',

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -107,7 +107,7 @@ type ReferenceSerializationStrategyName =
   | 'fromDataInstance'
   | 'recordField'
   | 'recordFieldDollarPrefix'
-  | 'leftValueField'
+  | 'flexiPageleftValueField'
 export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName,
   ReferenceSerializationStrategy
@@ -180,7 +180,7 @@ export const ReferenceSerializationStrategyLookup: Record<
       return val
     },
   },
-  leftValueField: {
+  flexiPageleftValueField: {
     serialize: async ({ ref, path }) =>
       `{!Record${API_NAME_SEPARATOR}${await safeApiName({ ref, path, relative: true })}}`,
     lookup: (val, context) => {
@@ -1032,7 +1032,7 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'leftValue', parentTypes: ['UiFormulaCriterion'] },
-    serializationStrategy: 'leftValueField',
+    serializationStrategy: 'flexiPageleftValueField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
 ]

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -107,6 +107,7 @@ type ReferenceSerializationStrategyName =
   | 'fromDataInstance'
   | 'recordField'
   | 'recordFieldDollarPrefix'
+  | 'leftValue'
 export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName,
   ReferenceSerializationStrategy
@@ -175,6 +176,16 @@ export const ReferenceSerializationStrategyLookup: Record<
     lookup: (val, context) => {
       if (context !== undefined && _.isString(val) && val.startsWith('$Record.')) {
         return [context, val.split(API_NAME_SEPARATOR)[1]].join(API_NAME_SEPARATOR)
+      }
+      return val
+    },
+  },
+  leftValue: {
+    serialize: async ({ ref, path }) =>
+      `{!Record${API_NAME_SEPARATOR}${await safeApiName({ ref, path, relative: true })}}`,
+    lookup: (val, context) => {
+      if (context !== undefined && _.isString(val) && val.startsWith('{!Record.')) {
+        return [context, val.split(API_NAME_SEPARATOR)[1].replace(/}$/, '')].join(API_NAME_SEPARATOR)
       }
       return val
     },
@@ -1018,6 +1029,11 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   {
     src: { field: 'logo', parentTypes: ['CustomApplication'] },
     target: { type: 'Document' },
+  },
+  {
+    src: { field: 'leftValue', parentTypes: ['UiFormulaCriterion'] },
+    serializationStrategy: 'leftValue',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
 ]
 

--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -107,7 +107,7 @@ type ReferenceSerializationStrategyName =
   | 'fromDataInstance'
   | 'recordField'
   | 'recordFieldDollarPrefix'
-  | 'leftValue'
+  | 'leftValueField'
 export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName,
   ReferenceSerializationStrategy
@@ -180,7 +180,7 @@ export const ReferenceSerializationStrategyLookup: Record<
       return val
     },
   },
-  leftValue: {
+  leftValueField: {
     serialize: async ({ ref, path }) =>
       `{!Record${API_NAME_SEPARATOR}${await safeApiName({ ref, path, relative: true })}}`,
     lookup: (val, context) => {
@@ -1032,7 +1032,7 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
   },
   {
     src: { field: 'leftValue', parentTypes: ['UiFormulaCriterion'] },
-    serializationStrategy: 'leftValue',
+    serializationStrategy: 'leftValueField',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
 ]

--- a/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
@@ -16,14 +16,15 @@ import {
 } from '../../src/transformers/transformer'
 import {
   COMPONENT_INSTANCE,
-  COMPONENT_INSTANCE_FILED_NAMES,
+  COMPONENT_INSTANCE_FIELD_NAMES,
   COMPONENT_INSTANCE_PROPERTY,
-  COMPONENT_INSTANCE_PROPERTY_FILED_NAMES,
+  COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES,
   FLEXI_PAGE_FIELD_NAMES,
   FLEXI_PAGE_REGION,
   FLEXI_PAGE_REGION_FIELD_NAMES,
   FLEXI_PAGE_TYPE,
   ITEM_INSTANCE,
+  ITEM_INSTANCE_FIELD_NAMES,
   LIGHTNING_PAGE_TYPE,
   PAGE_REGION_TYPE_VALUES,
 } from '../../src/constants'
@@ -42,7 +43,7 @@ describe('changeValidator', () => {
         metadataType: COMPONENT_INSTANCE_PROPERTY,
       },
       fields: {
-        [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: { refType: BuiltinTypes.STRING },
+        [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: { refType: BuiltinTypes.STRING },
       },
     })
     componentInstance = createMetadataObjectType({
@@ -50,7 +51,7 @@ describe('changeValidator', () => {
         metadataType: COMPONENT_INSTANCE,
       },
       fields: {
-        [COMPONENT_INSTANCE_FILED_NAMES.COMPONENT_INSTANCE_PROPERTIES]: {
+        [COMPONENT_INSTANCE_FIELD_NAMES.COMPONENT_INSTANCE_PROPERTIES]: {
           refType: new ListType(componentInstanceProperty),
         },
       },
@@ -60,8 +61,8 @@ describe('changeValidator', () => {
         metadataType: ITEM_INSTANCE,
       },
       fields: {
-        [COMPONENT_INSTANCE_FILED_NAMES.COMPONENT_INSTANCE_PROPERTIES]: {
-          refType: new ListType(componentInstanceProperty),
+        [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+          refType: componentInstance,
         },
       },
     })
@@ -94,7 +95,7 @@ describe('changeValidator', () => {
           flexiPageRegions: [
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet2' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-Facet2' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-Facet1',
@@ -105,7 +106,11 @@ describe('changeValidator', () => {
                 { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NameWithoutFacetPrefix' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet1' },
+                {
+                  [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+                    [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-Facet1',
+                  },
+                },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-Facet2',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
@@ -143,7 +148,7 @@ describe('changeValidator', () => {
           flexiPageRegions: [
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet2' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-Facet2' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-Facet1',
@@ -151,10 +156,14 @@ describe('changeValidator', () => {
             },
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-MissingFacet' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-MissingFacet' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet1' },
+                {
+                  [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+                    [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-Facet1',
+                  },
+                },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-Facet2',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
@@ -178,7 +187,7 @@ describe('changeValidator', () => {
             '1',
             FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES,
             '0',
-            COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE,
+            COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE,
           ),
         },
       ])
@@ -194,7 +203,7 @@ describe('changeValidator', () => {
           flexiPageRegions: [
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'NotAFacet' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-UnusedFacet',
@@ -243,10 +252,14 @@ describe('changeValidator', () => {
           flexiPageRegions: [
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'NotAFacet' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-MissingFacet' },
+                {
+                  [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+                    [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-MissingFacet',
+                  },
+                },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-UnusedFacet',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
@@ -276,7 +289,8 @@ describe('changeValidator', () => {
             '0',
             FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES,
             '0',
-            COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE,
+            ITEM_INSTANCE_FIELD_NAMES.COMPONENT,
+            COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE,
           ),
         },
       ])

--- a/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
@@ -103,7 +103,7 @@ describe('changeValidator', () => {
             },
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NameWithoutFacetPrefix' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'NameWithoutFacetPrefix' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
                 {
@@ -118,10 +118,10 @@ describe('changeValidator', () => {
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
                 // Avoid false positives for values without the 'Facet-' prefix that are genuinely not facets
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'NotAFacet' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet1' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'Facet-Facet1' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'NameWithoutFacetPrefix',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
@@ -211,7 +211,7 @@ describe('changeValidator', () => {
             },
             {
               [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
-                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+                { [COMPONENT_INSTANCE_PROPERTY_FIELD_NAMES.VALUE]: 'NotAFacet' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'UnusedFacetWithoutPrefix',

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -1041,7 +1041,7 @@ describe('Serialization Strategies', () => {
       expect(fieldInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
       // Make sure serialization works on the created reference
       expect(
-        await ReferenceSerializationStrategyLookup.leftValueField.serialize({
+        await ReferenceSerializationStrategyLookup.flexiPageleftValueField.serialize({
           ref: componentInstanceCreatedReference,
           element: flexiPageInstance,
         }),

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -48,8 +48,29 @@ import {
   CPQ_DISCOUNT_SCHEDULE,
   CPQ_CONSTRAINT_FIELD,
   ASSIGN_TO_REFERENCE,
+  UI_FORMULA_CRITERION,
+  UI_FORMULA_CRITERION_FIELD_NAMES,
+  COMPONENT_INSTANCE,
+  COMPONENT_INSTANCE_FIELD_NAMES,
+  ITEM_INSTANCE,
+  FLEXI_PAGE_REGION,
+  FLEXI_PAGE_REGION_FIELD_NAMES,
+  FLEXI_PAGE_TYPE,
+  FLEXI_PAGE_FIELD_NAMES,
+  FIELD_INSTANCE,
+  UI_FORMULA_RULE,
+  UI_FORMULA_RULE_FIELD_NAMES,
+  FIELD_INSTANCE_FIELD_NAMES,
+  ITEM_INSTANCE_FIELD_NAMES,
 } from '../../src/constants'
-import { metadataType, apiName, createInstanceElement } from '../../src/transformers/transformer'
+import {
+  metadataType,
+  apiName,
+  createInstanceElement,
+  MetadataInstanceElement,
+  MetadataObjectType,
+  createMetadataObjectType,
+} from '../../src/transformers/transformer'
 import { CUSTOM_OBJECT_TYPE_ID } from '../../src/filters/custom_objects_to_object_type'
 import { createCustomObjectType, defaultFilterContext } from '../utils'
 import { mockTypes } from '../mock_elements'
@@ -855,6 +876,174 @@ describe('Serialization Strategies', () => {
         await ReferenceSerializationStrategyLookup.recordFieldDollarPrefix.serialize({
           ref: createdReference,
           element: flowInstance,
+        }),
+      ).toEqual(RESOLVED_VALUE)
+    })
+  })
+  describe('leftValueField', () => {
+    const RESOLVED_VALUE = '{!Record.TestCustomField__c}'
+    let filter: FilterWith<'onFetch'>
+    let targetType: ObjectType
+    let uiFormulaCriterion: MetadataObjectType
+    let uiFormulaRule: MetadataObjectType
+    let componentInstance: MetadataObjectType
+    let fieldInstance: MetadataObjectType
+    let itemInstance: MetadataObjectType
+    let flexiPageRegion: MetadataObjectType
+    let flexiPage: MetadataObjectType
+    let flexiPageInstance: MetadataInstanceElement
+    beforeEach(() => {
+      targetType = createCustomObjectType('TestType__c', {
+        fields: {
+          TestCustomField__c: {
+            refType: BuiltinTypes.STRING,
+            annotations: { [API_NAME]: 'TestType__c.TestCustomField__c' },
+          },
+        },
+      })
+      uiFormulaCriterion = createMetadataObjectType({
+        annotations: {
+          metadataType: UI_FORMULA_CRITERION,
+        },
+        fields: {
+          [UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE]: { refType: BuiltinTypes.STRING },
+        },
+      })
+      uiFormulaRule = createMetadataObjectType({
+        annotations: {
+          metadataType: UI_FORMULA_RULE,
+        },
+        fields: {
+          [UI_FORMULA_RULE_FIELD_NAMES.CRITERIA]: { refType: new ListType(uiFormulaCriterion) },
+        },
+      })
+      fieldInstance = createMetadataObjectType({
+        annotations: {
+          metadataType: FIELD_INSTANCE,
+        },
+        fields: {
+          [FIELD_INSTANCE_FIELD_NAMES.VISIBILITY_RULE]: {
+            refType: uiFormulaRule,
+          },
+        },
+      })
+      componentInstance = createMetadataObjectType({
+        annotations: {
+          metadataType: COMPONENT_INSTANCE,
+        },
+        fields: {
+          [COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE]: {
+            refType: uiFormulaRule,
+          },
+        },
+      })
+      itemInstance = createMetadataObjectType({
+        annotations: {
+          metadataType: ITEM_INSTANCE,
+        },
+        fields: {
+          [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+            refType: componentInstance,
+          },
+          [ITEM_INSTANCE_FIELD_NAMES.FIELD]: {
+            refType: fieldInstance,
+          },
+        },
+      })
+      flexiPageRegion = createMetadataObjectType({
+        annotations: {
+          metadataType: FLEXI_PAGE_REGION,
+        },
+        fields: {
+          [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: { refType: new ListType(componentInstance) },
+          [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: { refType: new ListType(itemInstance) },
+        },
+      })
+      flexiPage = createMetadataObjectType({
+        annotations: {
+          metadataType: FLEXI_PAGE_TYPE,
+        },
+        fields: {
+          [FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS]: { refType: new ListType(flexiPageRegion) },
+        },
+      })
+      flexiPageInstance = createInstanceElement(
+        {
+          fullName: 'TestFlexiPage',
+          flexiPageRegions: [
+            {
+              [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
+                {
+                  [COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE]: {
+                    [UI_FORMULA_RULE_FIELD_NAMES.CRITERIA]: [
+                      { [UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE]: RESOLVED_VALUE },
+                    ],
+                  },
+                },
+              ],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
+                {
+                  [ITEM_INSTANCE_FIELD_NAMES.COMPONENT]: {
+                    [COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE]: {
+                      [UI_FORMULA_RULE_FIELD_NAMES.CRITERIA]: [
+                        { [UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE]: RESOLVED_VALUE },
+                      ],
+                    },
+                  },
+                },
+                {
+                  [ITEM_INSTANCE_FIELD_NAMES.FIELD]: {
+                    [FIELD_INSTANCE_FIELD_NAMES.VISIBILITY_RULE]: {
+                      [UI_FORMULA_RULE_FIELD_NAMES.CRITERIA]: [
+                        { [UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE]: RESOLVED_VALUE },
+                      ],
+                    },
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        flexiPage,
+        undefined,
+        {
+          [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(targetType.elemID, targetType),
+        },
+      )
+      filter = filterCreator({
+        config: {
+          ...defaultFilterContext,
+          fetchProfile: buildFetchProfile({
+            fetchParams: { target: [] },
+          }),
+        },
+      }) as FilterWith<'onFetch'>
+    })
+    it('should create reference to the CustomField and deserialize it to the original value', async () => {
+      await filter.onFetch([flexiPageInstance, flexiPage, targetType])
+      const componentInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
+        FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES
+      ][0][COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][UI_FORMULA_RULE_FIELD_NAMES.CRITERIA][0][
+        UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE
+      ] as ReferenceExpression
+      const itemComponentInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
+        FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES
+      ][0][ITEM_INSTANCE_FIELD_NAMES.COMPONENT][COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][
+        UI_FORMULA_RULE_FIELD_NAMES.CRITERIA
+      ][0][UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE] as ReferenceExpression
+      const fieldInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
+        FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES
+      ][1][ITEM_INSTANCE_FIELD_NAMES.FIELD][FIELD_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][
+        UI_FORMULA_RULE_FIELD_NAMES.CRITERIA
+      ][0][UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE] as ReferenceExpression
+      expect(componentInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
+      expect(itemComponentInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
+      expect(fieldInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
+      // Make sure serialization works on the created reference
+      expect(
+        await ReferenceSerializationStrategyLookup.leftValueField.serialize({
+          ref: componentInstanceCreatedReference,
+          element: flexiPageInstance,
         }),
       ).toEqual(RESOLVED_VALUE)
     })

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -1021,24 +1021,30 @@ describe('Serialization Strategies', () => {
     })
     it('should create reference to the CustomField and deserialize it to the original value', async () => {
       await filter.onFetch([flexiPageInstance, flexiPage, targetType])
-      const componentInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
-        FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES
-      ][0][COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][UI_FORMULA_RULE_FIELD_NAMES.CRITERIA][0][
-        UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE
-      ] as ReferenceExpression
-      const itemComponentInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
-        FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES
-      ][0][ITEM_INSTANCE_FIELD_NAMES.COMPONENT][COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][
-        UI_FORMULA_RULE_FIELD_NAMES.CRITERIA
-      ][0][UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE] as ReferenceExpression
+      const expectedReference = 'salesforce.TestType__c.field.TestCustomField__c'
+      const getFullName = (val: string | ReferenceExpression): string => {
+        expect(val).toBeInstanceOf(ReferenceExpression)
+        return (val as ReferenceExpression).elemID.getFullName()
+      }
+      const componentInstanceCreatedReference =
+        flexiPageInstance.value.flexiPageRegions[0][FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES][0][
+          COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE
+        ][UI_FORMULA_RULE_FIELD_NAMES.CRITERIA][0][UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE]
+      const itemComponentInstanceCreatedReference =
+        flexiPageInstance.value.flexiPageRegions[0][FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES][0][
+          ITEM_INSTANCE_FIELD_NAMES.COMPONENT
+        ][COMPONENT_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][UI_FORMULA_RULE_FIELD_NAMES.CRITERIA][0][
+          UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE
+        ]
       const fieldInstanceCreatedReference = flexiPageInstance.value.flexiPageRegions[0][
         FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES
       ][1][ITEM_INSTANCE_FIELD_NAMES.FIELD][FIELD_INSTANCE_FIELD_NAMES.VISIBILITY_RULE][
         UI_FORMULA_RULE_FIELD_NAMES.CRITERIA
       ][0][UI_FORMULA_CRITERION_FIELD_NAMES.LEFT_VALUE] as ReferenceExpression
-      expect(componentInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
-      expect(itemComponentInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
-      expect(fieldInstanceCreatedReference).toBeInstanceOf(ReferenceExpression)
+
+      expect(getFullName(componentInstanceCreatedReference)).toEqual(expectedReference)
+      expect(getFullName(itemComponentInstanceCreatedReference)).toEqual(expectedReference)
+      expect(getFullName(fieldInstanceCreatedReference)).toEqual(expectedReference)
       // Make sure serialization works on the created reference
       expect(
         await ReferenceSerializationStrategyLookup.flexiPageleftValueField.serialize({


### PR DESCRIPTION
SALTO-4207: Missing reference in FlexiPage criterias

---

Workspace Diff: https://github.com/salto-io/almog-sf/commit/75f4631f409655ca88977ec0214246b87b109356#diff-bf6841af5dcdd8f35c9cacd4cbee8c00d31a550c52f2d40ab84298d222163cc8

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between LightningPages and CustomFields.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from UiFormulaCriterion (LightningPage) to CustomField.
