### PR TITLE
SALTO-3221 SALTO-4531: Added references in Flow for the leftValueReference and elementReference fields starting with $Record.

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -106,7 +106,7 @@ type ReferenceSerializationStrategyName =
   | 'customLabel'
   | 'fromDataInstance'
   | 'recordField'
-  | 'assignToReferenceField'
+  | 'recordFieldDollarPrefix'
 export const ReferenceSerializationStrategyLookup: Record<
   ReferenceSerializationStrategyName,
   ReferenceSerializationStrategy
@@ -169,7 +169,7 @@ export const ReferenceSerializationStrategyLookup: Record<
       return val
     },
   },
-  assignToReferenceField: {
+  recordFieldDollarPrefix: {
     serialize: async ({ ref, path }) =>
       `$Record${API_NAME_SEPARATOR}${await safeApiName({ ref, path, relative: true })}`,
     lookup: (val, context) => {
@@ -996,7 +996,23 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
       field: ASSIGN_TO_REFERENCE,
       parentTypes: Object.values(FLOW_FIELD_TYPE_NAMES),
     },
-    serializationStrategy: 'assignToReferenceField',
+    serializationStrategy: 'recordFieldDollarPrefix',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: {
+      field: 'leftValueReference',
+      parentTypes: ['FlowCondition'],
+    },
+    serializationStrategy: 'recordFieldDollarPrefix',
+    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
+  },
+  {
+    src: {
+      field: 'elementReference',
+      parentTypes: ['FlowElementReferenceOrValue'],
+    },
+    serializationStrategy: 'recordFieldDollarPrefix',
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {

--- a/packages/salesforce-adapter/test/filters/field_references.test.ts
+++ b/packages/salesforce-adapter/test/filters/field_references.test.ts
@@ -852,7 +852,7 @@ describe('Serialization Strategies', () => {
       expect(createdReference).toBeInstanceOf(ReferenceExpression)
       // Make sure serialization works on the created reference
       expect(
-        await ReferenceSerializationStrategyLookup.assignToReferenceField.serialize({
+        await ReferenceSerializationStrategyLookup.recordFieldDollarPrefix.serialize({
           ref: createdReference,
           element: flowInstance,
         }),


### PR DESCRIPTION
SALTO-3221-4531: Added references in Flow for the leftValueReference and elementReference fields starting with $Record.

---

Workspace Diff: https://github.com/salto-io/almog-sf/commit/3f14c7fbbe3638420f5dba25113acc652eac22b7

---
_Release Notes_: 
_Salesforce Adapter_:
- Improved IA between Flow and CustomFields.

---
_User Notifications_: 
_Salesforce Adapter_:
- References will be added from Flow to CustomFields.
