### PR TITLE
SALTO-7433: fixing default value for contexts

### DIFF
--- a/packages/jira-adapter/e2e_test/instances/field.ts
+++ b/packages/jira-adapter/e2e_test/instances/field.ts
@@ -14,10 +14,16 @@ import {
   CORE_ANNOTATIONS,
   ReferenceExpression,
 } from '@salto-io/adapter-api'
-import { invertNaclCase } from '@salto-io/adapter-utils'
-import { createReference } from '../utils'
-import { ISSUE_TYPE_NAME, JIRA } from '../../src/constants'
-import { ORDER_INSTANCE_SUFFIX } from '../../src/filters/fields/constants'
+import { invertNaclCase, naclCase } from '@salto-io/adapter-utils'
+import { createReference, findType } from '../utils'
+import { ISSUE_TYPE_NAME, JIRA, PROJECT_TYPE } from '../../src/constants'
+import {
+  CUSTOM_FIELDS_SUFFIX,
+  FIELD_CONTEXT_OPTION_TYPE_NAME,
+  FIELD_CONTEXT_TYPE_NAME,
+  OPTIONS_ORDER_TYPE_NAME,
+  ORDER_INSTANCE_SUFFIX,
+} from '../../src/filters/fields/constants'
 
 const createOptionName = (parentName: string, optionValue: string): string =>
   `${invertNaclCase(parentName)}_${optionValue}`
@@ -25,65 +31,48 @@ const createOptionName = (parentName: string, optionValue: string): string =>
 const createOrderName = (parent: InstanceElement): string =>
   `${invertNaclCase(parent.elemID.name)}_${ORDER_INSTANCE_SUFFIX}`
 
-export const createOptionsAndOrders = ({
+const createOptionInstance = ({
+  value,
+  parent,
   optionsType,
-  orderType,
-  contextInstance,
+  disabled = false,
 }: {
+  value: string
+  parent: InstanceElement
   optionsType: ObjectType
+  disabled?: boolean
+}): InstanceElement =>
+  new InstanceElement(
+    createOptionName(parent.elemID.name, value),
+    optionsType,
+    {
+      value,
+      disabled,
+    },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
+  )
+
+const createOrderInstance = ({
+  parent,
+  options,
+  orderType,
+}: {
+  parent: InstanceElement
+  options: InstanceElement[]
   orderType: ObjectType
-  contextInstance: InstanceElement
-}): { contextOptions: InstanceElement[]; contextOrders: InstanceElement[] } => {
-  const createOptionInstance = (value: string, parent: InstanceElement, disabled = false): InstanceElement =>
-    new InstanceElement(
-      createOptionName(parent.elemID.name, value),
-      optionsType,
-      {
-        value,
-        disabled,
-      },
-      undefined,
-      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
-    )
+}): InstanceElement =>
+  new InstanceElement(
+    createOrderName(parent),
+    orderType,
+    {
+      options: options.map(option => new ReferenceExpression(option.elemID, option)),
+    },
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
+  )
 
-  const createOrderInstance = (parent: InstanceElement, options: InstanceElement[]): InstanceElement =>
-    new InstanceElement(
-      createOrderName(parent),
-      orderType,
-      {
-        options: options.map(option => new ReferenceExpression(option.elemID, option)),
-      },
-      undefined,
-      { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(parent.elemID, parent)] },
-    )
-
-  const cascadingOptionP1 = createOptionInstance('p1', contextInstance)
-  const cascadingOptionP2 = createOptionInstance('p2', contextInstance)
-  const cascadingOptionP1C11 = createOptionInstance('c11', cascadingOptionP1)
-  const cascadingOptionP1C12 = createOptionInstance('c12', cascadingOptionP1)
-  const cascadingOptionP2C22 = createOptionInstance('c22', cascadingOptionP2)
-  const optionP3 = createOptionInstance('p3', contextInstance, true)
-  const optionP4 = createOptionInstance('p4', contextInstance)
-
-  return {
-    contextOptions: [
-      cascadingOptionP1,
-      cascadingOptionP1C11,
-      cascadingOptionP1C12,
-      cascadingOptionP2,
-      cascadingOptionP2C22,
-      optionP3,
-      optionP4,
-    ],
-    contextOrders: [
-      createOrderInstance(contextInstance, [cascadingOptionP1, cascadingOptionP2, optionP3, optionP4]),
-      createOrderInstance(cascadingOptionP1, [cascadingOptionP1C11, cascadingOptionP1C12]),
-      createOrderInstance(cascadingOptionP2, [cascadingOptionP2C22]),
-    ],
-  }
-}
-
-export const createFieldValues = (name: string): Values => ({
+export const createCascadeFieldValues = (name: string): Values => ({
   name,
   description: 'desc!',
   searcherKey: 'com.atlassian.jira.plugin.system.customfieldtypes:cascadingselectsearcher',
@@ -97,3 +86,122 @@ export const createContextValues = (name: string, allElements: Element[]): Value
     createReference(new ElemID(JIRA, ISSUE_TYPE_NAME, 'instance', 'Story'), allElements),
   ],
 })
+
+export const createProjectScopeContextValues = (name: string, allElements: Element[]): Values => ({
+  name,
+  projectIds: [createReference(new ElemID(JIRA, PROJECT_TYPE, 'instance', 'Test_Project@s'), allElements)],
+})
+
+const createContextName = (randomString: string, type: string): string =>
+  naclCase(`${randomString}__${type}__${CUSTOM_FIELDS_SUFFIX}_${randomString}`)
+
+export const createCascadeContextAndRelatedInstances = ({
+  allElements,
+  randomString,
+  fieldInstance,
+}: {
+  allElements: Element[]
+  randomString: string
+  fieldInstance: InstanceElement
+}): {
+  contextInstance: InstanceElement
+  contextOptions: InstanceElement[]
+  contextOrders: InstanceElement[]
+} => {
+  const contextInstance = new InstanceElement(
+    createContextName(randomString, 'cascadingselect'),
+    findType(FIELD_CONTEXT_TYPE_NAME, allElements),
+    createContextValues(randomString, allElements),
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] },
+  )
+  const optionsType = findType(FIELD_CONTEXT_OPTION_TYPE_NAME, allElements)
+  const orderType = findType(OPTIONS_ORDER_TYPE_NAME, allElements)
+  const cascadingOptionP1 = createOptionInstance({ value: 'p1', parent: contextInstance, optionsType })
+  const cascadingOptionP2 = createOptionInstance({ value: 'p2', parent: contextInstance, optionsType })
+  const cascadingOptionP1C11 = createOptionInstance({ value: 'c11', parent: cascadingOptionP1, optionsType })
+  const cascadingOptionP1C12 = createOptionInstance({ value: 'c12', parent: cascadingOptionP1, optionsType })
+  const cascadingOptionP2C22 = createOptionInstance({ value: 'c22', parent: cascadingOptionP2, optionsType })
+  const optionP3 = createOptionInstance({ value: 'p3', parent: contextInstance, optionsType, disabled: true })
+  const optionP4 = createOptionInstance({ value: 'p4', parent: contextInstance, optionsType })
+
+  contextInstance.value.defaultValue = {
+    type: 'option.cascading',
+    cascadingOptionId: new ReferenceExpression(cascadingOptionP1C11.elemID, cascadingOptionP1C11),
+    optionId: new ReferenceExpression(cascadingOptionP1.elemID, cascadingOptionP1),
+  }
+
+  return {
+    contextInstance,
+    contextOptions: [
+      cascadingOptionP1,
+      cascadingOptionP1C11,
+      cascadingOptionP1C12,
+      cascadingOptionP2,
+      cascadingOptionP2C22,
+      optionP3,
+      optionP4,
+    ],
+    contextOrders: [
+      createOrderInstance({
+        parent: contextInstance,
+        options: [cascadingOptionP1, cascadingOptionP2, optionP3, optionP4],
+        orderType,
+      }),
+      createOrderInstance({
+        parent: cascadingOptionP1,
+        options: [cascadingOptionP1C11, cascadingOptionP1C12],
+        orderType,
+      }),
+      createOrderInstance({ parent: cascadingOptionP2, options: [cascadingOptionP2C22], orderType }),
+    ],
+  }
+}
+
+export const createMultiSelectFieldValues = (name: string): Values => ({
+  name,
+  description: 'desc!',
+  searcherKey: 'com.atlassian.jira.plugin.system.customfieldtypes:multiselectsearcher',
+  type: 'com.atlassian.jira.plugin.system.customfieldtypes:multiselect',
+})
+
+export const createMultiSelectContextAndRelatedInstances = ({
+  allElements,
+  randomString,
+  fieldInstance,
+}: {
+  allElements: Element[]
+  randomString: string
+  fieldInstance: InstanceElement
+}): {
+  contextInstance: InstanceElement
+  contextOptions: InstanceElement[]
+  contextOrders: InstanceElement[]
+} => {
+  const contextInstance = new InstanceElement(
+    createContextName(randomString, 'multiselect'),
+    findType(FIELD_CONTEXT_TYPE_NAME, allElements),
+    createProjectScopeContextValues(randomString, allElements),
+    undefined,
+    { [CORE_ANNOTATIONS.PARENT]: [new ReferenceExpression(fieldInstance.elemID, fieldInstance)] },
+  )
+  const optionsType = findType(FIELD_CONTEXT_OPTION_TYPE_NAME, allElements)
+  const orderType = findType(OPTIONS_ORDER_TYPE_NAME, allElements)
+  const optionMP1 = createOptionInstance({ value: 'mp1', parent: contextInstance, optionsType })
+  const optionMP2 = createOptionInstance({ value: 'mp2', parent: contextInstance, optionsType })
+  const optionMP3 = createOptionInstance({ value: 'mp3', parent: contextInstance, optionsType })
+  contextInstance.value.defaultValue = {
+    type: 'option.multiple',
+    optionIds: [
+      new ReferenceExpression(optionMP2.elemID, optionMP2),
+      new ReferenceExpression(optionMP1.elemID, optionMP1),
+    ],
+  }
+  return {
+    contextInstance,
+    contextOptions: [optionMP1, optionMP2, optionMP3],
+    contextOrders: [
+      createOrderInstance({ parent: contextInstance, options: [optionMP1, optionMP2, optionMP3], orderType }),
+    ],
+  }
+}

--- a/packages/jira-adapter/src/filters/fields/constants.ts
+++ b/packages/jira-adapter/src/filters/fields/constants.ts
@@ -17,3 +17,6 @@ export const FIELD_CONTEXT_OPTIONS_ORDER_FILE_NAME = 'Order'
 export const ORDER_INSTANCE_SUFFIX = 'order_child'
 export const PARENT_NAME_FIELD = 'parentName'
 export const OPTIONS_ORDER_TYPE_NAME = 'FieldContextOptionsOrder'
+// Added to avoid conflicts with names
+// of custom fields and system fields
+export const CUSTOM_FIELDS_SUFFIX = 'c'

--- a/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
@@ -12,7 +12,9 @@ import {
   SeverityLevel,
   getChangeData,
   isAdditionChange,
+  isAdditionOrModificationChange,
   isInstanceChange,
+  isInstanceElement,
   isModificationChange,
 } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
@@ -20,9 +22,10 @@ import { logger } from '@salto-io/logging'
 import _ from 'lodash'
 import { inspectValue } from '@salto-io/adapter-utils'
 import { FilterCreator } from '../../filter'
-import { FIELD_CONTEXT_OPTION_TYPE_NAME } from './constants'
+import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME } from './constants'
 import { setContextOptionsSplitted } from './context_options_splitted'
 import { getContextAndFieldIds } from '../../common/fields'
+import { updateDefaultValueIds } from './default_values'
 
 const log = logger(module)
 
@@ -106,6 +109,14 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
         appliedChanges = []
       }
     }
+    updateDefaultValueIds({
+      contextInstances: leftoverChanges
+        .filter(isAdditionOrModificationChange)
+        .map(getChangeData)
+        .filter(isInstanceElement)
+        .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME),
+      addedOptionInstances: addChanges.map(getChangeData),
+    })
 
     return {
       leftoverChanges,

--- a/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_deployment_filter.ts
@@ -8,6 +8,7 @@
 import {
   Change,
   InstanceElement,
+  ReferenceExpression,
   SaltoElementError,
   SeverityLevel,
   getChangeData,
@@ -16,6 +17,7 @@ import {
   isInstanceChange,
   isInstanceElement,
   isModificationChange,
+  isReferenceExpression,
 } from '@salto-io/adapter-api'
 import { client as clientUtils } from '@salto-io/adapter-components'
 import { logger } from '@salto-io/logging'
@@ -25,9 +27,46 @@ import { FilterCreator } from '../../filter'
 import { FIELD_CONTEXT_OPTION_TYPE_NAME, FIELD_CONTEXT_TYPE_NAME } from './constants'
 import { setContextOptionsSplitted } from './context_options_splitted'
 import { getContextAndFieldIds } from '../../common/fields'
-import { updateDefaultValueIds } from './default_values'
+import { getAllDefaultValuePaths, updateDefaultValueIds } from './default_values'
+import { AddOrModifyInstanceChange } from '../../common/general'
 
 const log = logger(module)
+
+const preventDefaultValuesDeployment = (
+  leftoverChanges: Change[],
+  contextId: string,
+  errors: SaltoElementError[],
+): void => {
+  const getContextChange = (searchChanges: Change[], id: string): AddOrModifyInstanceChange | undefined =>
+    searchChanges
+      .filter(isAdditionOrModificationChange)
+      .filter(isInstanceChange)
+      .filter(change => getChangeData(change).elemID.typeName === FIELD_CONTEXT_TYPE_NAME)
+      .find((change: Change<InstanceElement>) => getChangeData(change).value.id === id)
+
+  const findOptionWithoutId = (contextChange: Change<InstanceElement>): ReferenceExpression | undefined => {
+    const defaultValues = getChangeData(contextChange).value.defaultValue
+    return getAllDefaultValuePaths(defaultValues)
+      .map(path => _.get(defaultValues, path))
+      .filter(isReferenceExpression)
+      .find(
+        value => value.value.id == null, // undefined or null
+      )
+  }
+
+  const contextChange = getContextChange(leftoverChanges, contextId)
+  if (contextChange === undefined) return
+  const optionReferenceWithoutId = findOptionWithoutId(contextChange)
+  if (optionReferenceWithoutId !== undefined) {
+    errors.push({
+      message: 'Could not deploy default value',
+      detailedMessage: `The context field will be deployed without the default value, as the default value depends on a field context option ${optionReferenceWithoutId.elemID.getFullName()} that could not be deployed.`,
+      severity: 'Error',
+      elemID: getChangeData(contextChange).elemID,
+    })
+    _.remove(leftoverChanges, change => getChangeData(change).elemID.isEqual(getChangeData(contextChange).elemID))
+  }
+}
 
 const allOptionsWithSameContextAndField = (
   relevantChanges: Change<InstanceElement>[],
@@ -86,6 +125,14 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
         elementsSource,
         paginator,
       })
+      updateDefaultValueIds({
+        contextInstances: leftoverChanges
+          .filter(isAdditionOrModificationChange)
+          .map(getChangeData)
+          .filter(isInstanceElement)
+          .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME),
+        addedOptionInstances: addChanges.map(getChangeData),
+      })
     } catch (err) {
       if (
         addChanges.length === 0 &&
@@ -107,16 +154,9 @@ const filter: FilterCreator = ({ config, client, paginator, elementsSource }) =>
           })),
         )
         appliedChanges = []
+        preventDefaultValuesDeployment(leftoverChanges, contextId, errors)
       }
     }
-    updateDefaultValueIds({
-      contextInstances: leftoverChanges
-        .filter(isAdditionOrModificationChange)
-        .map(getChangeData)
-        .filter(isInstanceElement)
-        .filter(instance => instance.elemID.typeName === FIELD_CONTEXT_TYPE_NAME),
-      addedOptionInstances: addChanges.map(getChangeData),
-    })
 
     return {
       leftoverChanges,

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -46,8 +46,8 @@ export const getAllDefaultValuePaths = (defaultValue: Value): string[][] => {
 }
 
 const applyOnDefaultValues = (defaultValue: Value, applyFunc: (value: Value, valuePath: string[]) => void): void => {
-  const valueLocations = getAllDefaultValuePaths(defaultValue)
-  valueLocations.forEach(pathArray => {
+  const valuePaths = getAllDefaultValuePaths(defaultValue)
+  valuePaths.forEach(pathArray => {
     applyFunc(defaultValue, pathArray)
   })
 }
@@ -70,9 +70,9 @@ export const updateDefaultValueIds = ({
 
   relevantContexts.forEach(contextInstance => {
     applyOnDefaultValues(contextInstance.value.defaultValue, (value, valuePath) => {
-      const defaultValueField = _.get(contextInstance, valuePath)
+      const defaultValueField = _.get(value, valuePath)
       if (
-        isResolvedReferenceExpression(_.get(value, valuePath)) &&
+        isResolvedReferenceExpression(defaultValueField) &&
         optionsIdByFullName[defaultValueField.elemID.getFullName()] !== undefined
       ) {
         defaultValueField.value.value.id = optionsIdByFullName[defaultValueField.elemID.getFullName()]

--- a/packages/jira-adapter/src/filters/fields/default_values.ts
+++ b/packages/jira-adapter/src/filters/fields/default_values.ts
@@ -70,11 +70,12 @@ export const updateDefaultValueIds = ({
 
   relevantContexts.forEach(contextInstance => {
     applyOnDefaultValues(contextInstance.value.defaultValue, (value, valuePath) => {
+      const defaultValueField = _.get(contextInstance, valuePath)
       if (
         isResolvedReferenceExpression(_.get(value, valuePath)) &&
-        optionsIdByFullName[_.get(value, valuePath).elemID.getFullName()] !== undefined
+        optionsIdByFullName[defaultValueField.elemID.getFullName()] !== undefined
       ) {
-        _.get(value, valuePath).value.value.id = optionsIdByFullName[_.get(value, valuePath).elemID.getFullName()]
+        defaultValueField.value.value.id = optionsIdByFullName[defaultValueField.elemID.getFullName()]
       }
     })
   })

--- a/packages/jira-adapter/src/filters/fields/field_name_filter.ts
+++ b/packages/jira-adapter/src/filters/fields/field_name_filter.ts
@@ -14,15 +14,11 @@ import _ from 'lodash'
 import { JiraConfig } from '../../config/config'
 import { JIRA } from '../../constants'
 import { FilterCreator } from '../../filter'
-import { FIELD_TYPE_NAME } from './constants'
+import { CUSTOM_FIELDS_SUFFIX, FIELD_TYPE_NAME } from './constants'
 
 const log = logger(module)
 
 const { generateInstanceNameFromConfig } = elementUtils
-
-// Added to avoid conflicts with names
-// of custom fields and system fields
-export const CUSTOM_FIELDS_SUFFIX = 'c'
 
 const getFieldType = (instance: InstanceElement): string | undefined =>
   instance.value.schema?.custom?.split(':').slice(-1)[0] ?? instance.value.schema?.type

--- a/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/fields/context_options_deployment.test.ts
@@ -60,15 +60,7 @@ describe('ContextOptionsDeployment', () => {
   let elementsSource: ReadOnlyElementsSource
   // Done here as it is needed got the 10K options, and we want to create them once
   const fieldInstance = new InstanceElement('field', createEmptyType(FIELD_TYPE_NAME), { id: '1field' })
-  const contextInstance = new InstanceElement(
-    'context',
-    createEmptyType(FIELD_CONTEXT_TYPE_NAME),
-    { id: '1context' },
-    undefined,
-    {
-      [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
-    },
-  )
+  let contextInstance: InstanceElement
   let changes: Change<InstanceElement>[]
   let addOption1: InstanceElement
   let addOption2: InstanceElement
@@ -78,6 +70,15 @@ describe('ContextOptionsDeployment', () => {
     config.fetch.splitFieldContextOptions = true
     ;({ connection, client, paginator } = mockClient())
     const optionType = createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME)
+    contextInstance = new InstanceElement(
+      'context',
+      createEmptyType(FIELD_CONTEXT_TYPE_NAME),
+      { id: '1context' },
+      undefined,
+      {
+        [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+      },
+    )
     addOption1 = new InstanceElement('option0', optionType, { value: 'p1' }, undefined, {
       [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(contextInstance.elemID, contextInstance),
     })
@@ -623,12 +624,37 @@ describe('ContextOptionsDeployment', () => {
       undefined,
     )
   })
+  it('should prevent deployment of default values if options deployment fails', async () => {
+    connection.post.mockRejectedValueOnce(new Error('error'))
+    contextInstance.value.defaultValue = {
+      optionId: new ReferenceExpression(addOption1.elemID, addOption1),
+    }
+    const result = await filter.deploy([toChange({ after: contextInstance }), toChange({ after: addOption1 })])
+    expect(result.leftoverChanges).toHaveLength(0)
+    expect(result.deployResult.errors).toHaveLength(2)
+    expect(result.deployResult.appliedChanges).toHaveLength(0)
+    expect(result.deployResult.errors[1]).toEqual({
+      elemID: contextInstance.elemID,
+      message: 'Could not deploy default value',
+      detailedMessage: `The context field will be deployed without the default value, as the default value depends on a field context option ${addOption1.elemID.getFullName()} that could not be deployed.`,
+      severity: 'Error',
+    })
+  })
   describe('more than 10K', () => {
     describe('setContextOptions', () => {
       describe('change has over 10K options', () => {
         // Set long timeout as we create instance with more than 10K options
         jest.setTimeout(1000 * 60 * 1)
-        const tenKOptions = generateOptions(10010, contextInstance, true)
+        const tenKContext = new InstanceElement(
+          'context10k',
+          createEmptyType(FIELD_CONTEXT_TYPE_NAME),
+          { id: '1context10K' },
+          undefined,
+          {
+            [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(fieldInstance.elemID, fieldInstance),
+          },
+        )
+        const tenKOptions = generateOptions(10010, tenKContext, true)
         const order10k = new InstanceElement(
           'order10k',
           createEmptyType(OPTIONS_ORDER_TYPE_NAME),
@@ -637,12 +663,12 @@ describe('ContextOptionsDeployment', () => {
           },
           undefined,
           {
-            [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(contextInstance.elemID, contextInstance),
+            [CORE_ANNOTATIONS.PARENT]: new ReferenceExpression(tenKContext.elemID, tenKContext),
           },
         )
 
         beforeEach(async () => {
-          elementsSource = buildElementsSourceFromElements([order10k, contextInstance, ...tenKOptions])
+          elementsSource = buildElementsSourceFromElements([order10k, tenKContext, ...tenKOptions])
           filter = optionsDeploymentFilter(
             getFilterParams({
               client,
@@ -712,7 +738,7 @@ describe('ContextOptionsDeployment', () => {
           expect(connection.post).toHaveBeenNthCalledWith(
             11,
             '/secure/admin/EditCustomFieldOptions!add.jspa',
-            new URLSearchParams({ addValue: 'auto10000', fieldConfigId: '1context' }),
+            new URLSearchParams({ addValue: 'auto10000', fieldConfigId: '1context10K' }),
             {
               headers: JSP_API_HEADERS,
               params: undefined,
@@ -732,7 +758,7 @@ describe('ContextOptionsDeployment', () => {
           expect(connection.post).toHaveBeenNthCalledWith(
             1,
             '/secure/admin/EditCustomFieldOptions!add.jspa',
-            new URLSearchParams({ addValue: 'auto10010', fieldConfigId: '1context' }),
+            new URLSearchParams({ addValue: 'auto10010', fieldConfigId: '1context10K' }),
             {
               headers: JSP_API_HEADERS,
               params: undefined,
@@ -761,7 +787,7 @@ describe('ContextOptionsDeployment', () => {
             '/secure/admin/EditCustomFieldOptions!add.jspa',
             new URLSearchParams({
               addValue: 'c11',
-              fieldConfigId: '1context',
+              fieldConfigId: '1context10K',
               selectedParentOptionId: '10001',
             }),
             {

--- a/packages/jira-adapter/test/filters/fields/default_values.test.ts
+++ b/packages/jira-adapter/test/filters/fields/default_values.test.ts
@@ -18,6 +18,7 @@ import { mockFunction, MockInterface } from '@salto-io/test-utils'
 import _ from 'lodash'
 import {
   setDefaultValueTypeDeploymentAnnotations,
+  updateDefaultValueIds,
   updateDefaultValues,
 } from '../../../src/filters/fields/default_values'
 import { JIRA } from '../../../src/constants'
@@ -302,5 +303,29 @@ describe('default values', () => {
       const contextType = new ObjectType({ elemID: new ElemID(JIRA, 'CustomFieldContext') })
       await expect(setDefaultValueTypeDeploymentAnnotations(contextType)).rejects.toThrow()
     })
+  })
+  describe('updateDefaultValueIds', () => {
+    let contextInstance: InstanceElement
+    let optionInstances: InstanceElement[]
+    beforeEach(() => {
+      contextInstance = new InstanceElement('instance', createEmptyType(FIELD_CONTEXT_TYPE_NAME), {
+        name: 'a',
+        id: 3,
+      })
+      optionInstances = [
+        new InstanceElement('option1', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {
+          id: 1,
+        }),
+        new InstanceElement('option2', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {
+          id: 2,
+        }),
+      ]
+    })
+    it('should not run if there are no default values', async () => {
+      delete contextInstance.value.defaultValue
+      updateDefaultValueIds({ contextInstances: [contextInstance], addedOptionInstances: optionInstances })
+      expect(contextInstance.value.defaultValue).toBeUndefined()
+    })
+    // it('should ')
   })
 })

--- a/packages/jira-adapter/test/filters/fields/default_values.test.ts
+++ b/packages/jira-adapter/test/filters/fields/default_values.test.ts
@@ -313,12 +313,9 @@ describe('default values', () => {
         id: 3,
       })
       optionInstances = [
-        new InstanceElement('option1', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {
-          id: 1,
-        }),
-        new InstanceElement('option2', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {
-          id: 2,
-        }),
+        new InstanceElement('option1', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {}),
+        new InstanceElement('option2', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {}),
+        new InstanceElement('option3', createEmptyType(FIELD_CONTEXT_OPTION_TYPE_NAME), {}),
       ]
     })
     it('should not run if there are no default values', async () => {
@@ -326,6 +323,37 @@ describe('default values', () => {
       updateDefaultValueIds({ contextInstances: [contextInstance], addedOptionInstances: optionInstances })
       expect(contextInstance.value.defaultValue).toBeUndefined()
     })
-    // it('should ')
+    it('should update value id in optionId', async () => {
+      contextInstance.value.defaultValue = {
+        optionId: new ReferenceExpression(optionInstances[0].elemID, optionInstances[0].clone()),
+      }
+      optionInstances[0].value.id = '1'
+      updateDefaultValueIds({ contextInstances: [contextInstance], addedOptionInstances: optionInstances })
+      expect(contextInstance.value.defaultValue.optionId.value.value.id).toEqual('1')
+    })
+    it('should update value id in optionIds', async () => {
+      contextInstance.value.defaultValue = {
+        optionIds: [
+          new ReferenceExpression(optionInstances[0].elemID, optionInstances[0].clone()),
+          new ReferenceExpression(optionInstances[1].elemID, optionInstances[1].clone()),
+        ],
+      }
+      optionInstances[0].value.id = '1'
+      optionInstances[1].value.id = '2'
+      updateDefaultValueIds({ contextInstances: [contextInstance], addedOptionInstances: optionInstances })
+      expect(contextInstance.value.defaultValue.optionIds[0].value.value.id).toEqual('1')
+      expect(contextInstance.value.defaultValue.optionIds[1].value.value.id).toEqual('2')
+    })
+    it('should update value id in cascadingOptionId', async () => {
+      contextInstance.value.defaultValue = {
+        optionId: new ReferenceExpression(optionInstances[0].elemID, optionInstances[0].clone()),
+        cascadingOptionId: new ReferenceExpression(optionInstances[1].elemID, optionInstances[1].clone()),
+      }
+      optionInstances[0].value.id = '1'
+      optionInstances[1].value.id = '2'
+      updateDefaultValueIds({ contextInstances: [contextInstance], addedOptionInstances: optionInstances })
+      expect(contextInstance.value.defaultValue.cascadingOptionId.value.value.id).toEqual('2')
+      expect(contextInstance.value.defaultValue.optionId.value.value.id).toEqual('1')
+    })
   })
 })


### PR DESCRIPTION
Fixed default values- the value of the references for options in the default value was not updated in add

---

Tests will follow

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug with deployment of default values for field contexts 

---
_User Notifications_: 
None
