### PR TITLE
SALTO-7411: (Bugfix) False positive for unused FlexiPage facets. Added detection for unused FlexiPage facets without the ‘Facet-’ prefix.

### DIFF
--- a/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
+++ b/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
@@ -44,14 +44,14 @@ const getFacetDefinitionsAndReferences = (
   element: InstanceElement,
 ): { facetDefinitions: Record<string, ElemID>; facetReferences: Map<string, ElemID[]> } => {
   const facetDefinitions: Record<string, ElemID> = {}
-  const facetReferences = new DefaultMap<string, ElemID[]>(() => [])
+  const unFilteredFacetReferences = new DefaultMap<string, ElemID[]>(() => [])
   const findDefinitionsAndReferences: TransformFuncSync = ({ value, path, field }) => {
     if (field === undefined || path === undefined) return value
     if (field.name === FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS && isFlexiPageRegion(value)) {
       facetDefinitions[value.name] = path
     }
-    if (path.name === COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE && isFacetReference(value)) {
-      facetReferences.get(value).push(path)
+    if (path.name === COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE) {
+      unFilteredFacetReferences.get(value).push(path)
     }
     return value
   }
@@ -61,6 +61,9 @@ const getFacetDefinitionsAndReferences = (
     type: element.getTypeSync(),
     transformFunc: findDefinitionsAndReferences,
   })
+  const facetReferences = new Map(
+    [...unFilteredFacetReferences.entries()].filter(([key]) => isFacetReference(key) || key in facetDefinitions),
+  )
   return { facetDefinitions, facetReferences }
 }
 

--- a/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
+++ b/packages/salesforce-adapter/src/change_validators/flexi_page_unused_or_missing_facets.ts
@@ -44,14 +44,14 @@ const getFacetDefinitionsAndReferences = (
   element: InstanceElement,
 ): { facetDefinitions: Record<string, ElemID>; facetReferences: Map<string, ElemID[]> } => {
   const facetDefinitions: Record<string, ElemID> = {}
-  const unFilteredFacetReferences = new DefaultMap<string, ElemID[]>(() => [])
+  const potentialFacetReferences = new DefaultMap<string, ElemID[]>(() => [])
   const findDefinitionsAndReferences: TransformFuncSync = ({ value, path, field }) => {
     if (field === undefined || path === undefined) return value
     if (field.name === FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS && isFlexiPageRegion(value)) {
       facetDefinitions[value.name] = path
     }
     if (path.name === COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE) {
-      unFilteredFacetReferences.get(value).push(path)
+      potentialFacetReferences.get(value).push(path)
     }
     return value
   }
@@ -62,7 +62,7 @@ const getFacetDefinitionsAndReferences = (
     transformFunc: findDefinitionsAndReferences,
   })
   const facetReferences = new Map(
-    [...unFilteredFacetReferences.entries()].filter(([key]) => isFacetReference(key) || key in facetDefinitions),
+    [...potentialFacetReferences.entries()].filter(([key]) => isFacetReference(key) || key in facetDefinitions),
   )
   return { facetDefinitions, facetReferences }
 }

--- a/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/flexi_page_unused_or_missing_facets.test.ts
@@ -101,11 +101,24 @@ describe('changeValidator', () => {
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
             },
             {
-              [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
+                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NameWithoutFacetPrefix' },
+              ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
                 { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet1' },
               ],
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-Facet2',
+              [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
+            },
+            {
+              [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
+                // Avoid false positives for values without the 'Facet-' prefix that are genuinely not facets
+                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+              ],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [
+                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'Facet-Facet1' },
+              ],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'NameWithoutFacetPrefix',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
             },
           ],
@@ -159,7 +172,7 @@ describe('changeValidator', () => {
         {
           severity: 'Warning',
           message: 'Reference to missing Facet',
-          detailedMessage: `The Facet "${'Facet-MissingFacet'}" does not exist.`,
+          detailedMessage: 'The Facet "Facet-MissingFacet" does not exist.',
           elemID: flexiPageInstance.elemID.createNestedID(
             FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS,
             '1',
@@ -187,6 +200,14 @@ describe('changeValidator', () => {
               [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'Facet-UnusedFacet',
               [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
             },
+            {
+              [FLEXI_PAGE_REGION_FIELD_NAMES.COMPONENT_INSTANCES]: [
+                { [COMPONENT_INSTANCE_PROPERTY_FILED_NAMES.VALUE]: 'NotAFacet' },
+              ],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.ITEM_INSTANCES]: [],
+              [FLEXI_PAGE_REGION_FIELD_NAMES.NAME]: 'UnusedFacetWithoutPrefix',
+              [FLEXI_PAGE_REGION_FIELD_NAMES.TYPE]: PAGE_REGION_TYPE_VALUES.FACET,
+            },
           ],
         },
         flexiPage,
@@ -200,8 +221,14 @@ describe('changeValidator', () => {
         {
           severity: 'Warning',
           message: 'Unused Facet',
-          detailedMessage: `The Facet "${'Facet-UnusedFacet'}" isn’t being used in the ${LIGHTNING_PAGE_TYPE}.`,
+          detailedMessage: `The Facet "Facet-UnusedFacet" isn’t being used in the ${LIGHTNING_PAGE_TYPE}.`,
           elemID: flexiPageInstance.elemID.createNestedID(FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS, '0'),
+        },
+        {
+          severity: 'Warning',
+          message: 'Unused Facet',
+          detailedMessage: `The Facet "UnusedFacetWithoutPrefix" isn’t being used in the ${LIGHTNING_PAGE_TYPE}.`,
+          elemID: flexiPageInstance.elemID.createNestedID(FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS, '1'),
         },
       ])
     })
@@ -237,13 +264,13 @@ describe('changeValidator', () => {
         {
           severity: 'Warning',
           message: 'Unused Facet',
-          detailedMessage: `The Facet "${'Facet-UnusedFacet'}" isn’t being used in the ${LIGHTNING_PAGE_TYPE}.`,
+          detailedMessage: `The Facet "Facet-UnusedFacet" isn’t being used in the ${LIGHTNING_PAGE_TYPE}.`,
           elemID: flexiPageInstance.elemID.createNestedID(FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS, '0'),
         },
         {
           severity: 'Warning',
           message: 'Reference to missing Facet',
-          detailedMessage: `The Facet "${'Facet-MissingFacet'}" does not exist.`,
+          detailedMessage: 'The Facet "Facet-MissingFacet" does not exist.',
           elemID: flexiPageInstance.elemID.createNestedID(
             FLEXI_PAGE_FIELD_NAMES.FLEXI_PAGE_REGIONS,
             '0',


### PR DESCRIPTION
SALTO-7411: (Bugfix) False positive for unused FlexiPage facets. Added detection for unused FlexiPage facets without the ‘Facet-’ prefix.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
