### PR TITLE
SALTO-7437 Jira Automation partial success on deploy

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -479,7 +479,7 @@ const createAutomation = async (
       await updateAutomation(instance, client, cloudId)
     } catch (e) {
       log.error(`Could not update automation ${instance.elemID.getFullName()} state to 'enabled'. ${e}`)
-      throw new Error(`Failed to update automation state to 'enabled'. ${e}`)
+      throw new Error(`Automation was created, but failed to update the automation state to 'enabled'. ${e}`)
     }
   }
 }

--- a/packages/jira-adapter/src/filters/automation/automation_deployment.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_deployment.ts
@@ -475,7 +475,12 @@ const createAutomation = async (
   instance.value.created = automationResponse.created
   if (instance.value.state === 'ENABLED') {
     // Import automation ignore the state and always create the automation as disabled
-    await updateAutomation(instance, client, cloudId)
+    try {
+      await updateAutomation(instance, client, cloudId)
+    } catch (e) {
+      log.error(`Could not update automation ${instance.elemID.getFullName()} state to 'enabled'. ${e}`)
+      throw new Error(`Failed to update automation state to 'enabled'. ${e}`)
+    }
   }
 }
 

--- a/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_deployment.test.ts
@@ -286,6 +286,7 @@ describe('automationDeploymentFilter', () => {
         },
       )
     })
+
     it('should create automation with unsorted many projects', async () => {
       connection.post.mockImplementation(async url =>
         createPostMockResponse([
@@ -317,6 +318,7 @@ describe('automationDeploymentFilter', () => {
       expect(instance.value.id).toBe(3)
       expect(instance.value.created).toBe(1)
     })
+
     describe('retries', () => {
       beforeEach(() => {
         const { client: cli, paginator, connection: conn } = mockClient(false)
@@ -518,6 +520,20 @@ describe('automationDeploymentFilter', () => {
       )
 
       expect(connection.put).not.toHaveBeenCalled()
+    })
+
+    it('should throw with the right explanation whan fail to update automation state', async () => {
+      connection.put.mockImplementation(async url => {
+        if (url === '/gateway/api/automation/internal-api/jira/cloudId/pro/rest/GLOBAL/rule/3') {
+          throw new Error('update automation state failed')
+        }
+        throw new Error(`Unexpected url ${url}`)
+      })
+
+      const { deployResult } = await filter.deploy([toChange({ after: instance })])
+
+      expect(deployResult.errors).toHaveLength(1)
+      expect(deployResult.errors[0].message).toContain('update automation state failed')
     })
 
     it('should deploy automation of all projects', async () => {


### PR DESCRIPTION
When deploying an Automation creation we have another call to update its state to 'enabled'. This call could fail, and we need to inform the user the automation was created, but the state isn't 'enabled' as requested.

---

_Additional context for reviewer_

---
_Release Notes_: 
None

---
_User Notifications_: 
None
