### PR TITLE
SALTO-7363: Removing unused exports from PagerDuty adapter

### DIFF
--- a/packages/pagerduty-adapter/src/client/connection.ts
+++ b/packages/pagerduty-adapter/src/client/connection.ts
@@ -12,7 +12,7 @@ import { Credentials } from '../auth'
 
 const log = logger(module)
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   connection,
   credentials,
 }: {

--- a/packages/pagerduty-adapter/src/config.ts
+++ b/packages/pagerduty-adapter/src/config.ts
@@ -7,7 +7,7 @@
  */
 import { elements, definitions } from '@salto-io/adapter-components'
 
-export type UserFetchConfig = definitions.UserFetchConfig<{
+type UserFetchConfig = definitions.UserFetchConfig<{
   customNameMappingOptions: never
   fetchCriteria: definitions.DefaultFetchCriteria
 }> & {

--- a/packages/pagerduty-adapter/src/definitions/index.ts
+++ b/packages/pagerduty-adapter/src/definitions/index.ts
@@ -9,4 +9,3 @@
 export * from './deploy'
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/pagerduty-adapter/src/definitions/requests/index.ts
+++ b/packages/pagerduty-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
