### PR TITLE
SALTO-7363: Removing unused exports from Stripe adapter

### DIFF
--- a/packages/stripe-adapter/src/client/connection.ts
+++ b/packages/stripe-adapter/src/client/connection.ts
@@ -14,11 +14,7 @@ const log = logger(module)
 
 const BASE_URL = 'https://api.stripe.com'
 
-export const validateCredentials = async ({
-  connection,
-}: {
-  connection: clientUtils.APIConnection
-}): Promise<AccountInfo> => {
+const validateCredentials = async ({ connection }: { connection: clientUtils.APIConnection }): Promise<AccountInfo> => {
   try {
     const res = await connection.get('/v1/products')
     if (res.status !== 200) {

--- a/packages/stripe-adapter/src/config.ts
+++ b/packages/stripe-adapter/src/config.ts
@@ -7,7 +7,7 @@
  */
 import { elements, definitions } from '@salto-io/adapter-components'
 
-export type UserFetchConfig = definitions.UserFetchConfig<{
+type UserFetchConfig = definitions.UserFetchConfig<{
   customNameMappingOptions: never
   fetchCriteria: definitions.DefaultFetchCriteria
 }>

--- a/packages/stripe-adapter/src/definitions/types.ts
+++ b/packages/stripe-adapter/src/definitions/types.ts
@@ -7,12 +7,12 @@
  */
 import { definitions } from '@salto-io/adapter-components'
 
-export type AdditionalAction = never
-export type ClientOptions = 'main'
+type AdditionalAction = never
+type ClientOptions = 'main'
 type PaginationOptions = 'cursor'
 export type ReferenceContextStrategies = never
 export type CustomReferenceSerializationStrategyName = never
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
