### PR TITLE
SALTO-7363: Removing unused exports from Workato adapter

### DIFF
--- a/packages/workato-adapter/src/adapter.ts
+++ b/packages/workato-adapter/src/adapter.ts
@@ -51,7 +51,7 @@ import { WorkatoUserConfig, ENABLE_DEPLOY_SUPPORT_FLAG } from './user_config'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
-export const DEFAULT_FILTERS = [
+const DEFAULT_FILTERS = [
   addRootFolderFilter,
   jiraProjectIssueTypeFilter,
   // fieldReferencesFilter should run after all element manipulations are done
@@ -62,7 +62,7 @@ export const DEFAULT_FILTERS = [
   ...Object.values(commonFilters),
 ]
 
-export interface WorkatoAdapterParams {
+interface WorkatoAdapterParams {
   filterCreators?: FilterCreator[]
   client: WorkatoClient
   config: WorkatoUserConfig

--- a/packages/workato-adapter/src/auth.ts
+++ b/packages/workato-adapter/src/auth.ts
@@ -18,7 +18,7 @@ export const workatoBaseUrlOptions = [
   'https://app.au.workato.com',
 ]
 
-export type UsernameTokenCredentials = {
+type UsernameTokenCredentials = {
   username?: string
   baseUrl?: string
   token: string

--- a/packages/workato-adapter/src/definitions/types.ts
+++ b/packages/workato-adapter/src/definitions/types.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-export type ClientOptions = 'main'
+type ClientOptions = 'main'
 
 type PaginationOptions = 'pageOffset' | 'minSinceId'
 

--- a/packages/workato-adapter/src/filter.ts
+++ b/packages/workato-adapter/src/filter.ts
@@ -6,19 +6,15 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 import { filterUtils, elements as elementUtils } from '@salto-io/adapter-components'
-import { WorkatoFetchConfig, WorkatoUserConfig } from './user_config'
+import { WorkatoUserConfig } from './user_config'
 import { WorkatoOptions } from './definitions/types'
 
 export const { filterRunner } = filterUtils
 
 export type Filter = filterUtils.Filter<filterUtils.FilterResult>
 
-export type FilterAdditionalParams = {
+type FilterAdditionalParams = {
   fetchQuery: elementUtils.query.ElementQuery
-}
-
-export type FilterContext = {
-  fetch: WorkatoFetchConfig
 }
 
 export type FilterCreator = filterUtils.AdapterFilterCreator<

--- a/packages/workato-adapter/src/filters/add_root_folder.ts
+++ b/packages/workato-adapter/src/filters/add_root_folder.ts
@@ -16,7 +16,7 @@ const { RECORDS_PATH } = elementUtils
 
 // using a single-word folder name guarantees the id will be unique,
 // because all other folder ids include their parent as well as their own name
-export const ROOT_FOLDER_NAME = 'Root'
+const ROOT_FOLDER_NAME = 'Root'
 const ROOT_FOLDER_PATH = 'Root'
 
 /**

--- a/packages/workato-adapter/src/filters/cross_service/salesforce/element_index.ts
+++ b/packages/workato-adapter/src/filters/cross_service/salesforce/element_index.ts
@@ -11,7 +11,7 @@ import _ from 'lodash'
 export type SalesforceIndex = Record<string, Record<string, Readonly<Element>[]>>
 
 const API_NAME = 'apiName'
-export const METADATA_TYPE = 'metadataType'
+const METADATA_TYPE = 'metadataType'
 
 const metadataType: (elem: Readonly<Element>) => string | undefined = elem => elem.annotations[METADATA_TYPE]
 

--- a/packages/workato-adapter/src/reference_mapping.ts
+++ b/packages/workato-adapter/src/reference_mapping.ts
@@ -43,7 +43,7 @@ const WorkatoReferenceSerializationStrategyLookup: Record<
   },
 }
 
-export class WorkatoFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<
+class WorkatoFieldReferenceResolver extends referenceUtils.FieldReferenceResolver<
   never,
   WorkatoReferenceSerializationStrategyName
 > {
@@ -93,7 +93,7 @@ export const fieldNameToTypeMappingDefs: referenceUtils.FieldReferenceDefinition
   },
 ]
 
-export const deployResolveRules: WorkatoFieldReferenceDefinition[] = [
+const deployResolveRules: WorkatoFieldReferenceDefinition[] = [
   // This rule is needed while deploying the recipe using rlm
   // While importing zip by rlm we need to get all resolved data from the connection to the recipe config
   {

--- a/packages/workato-adapter/src/rlm.ts
+++ b/packages/workato-adapter/src/rlm.ts
@@ -169,12 +169,12 @@ const RECIPE_SCHEMA = Joi.object({
   config: RECIPE_CONFIG_SCHEMA.required(),
 }).unknown(true)
 
-export const isConnection = createSchemeGuardForInstance<Connection & InstanceElement>(
+const isConnection = createSchemeGuardForInstance<Connection & InstanceElement>(
   CONNECTION_SCHEMA.required(),
   'Received an invalid value for connection',
 )
 
-export const isRecipe = createSchemeGuardForInstance<JsonRecipe & InstanceElement>(
+const isRecipe = createSchemeGuardForInstance<JsonRecipe & InstanceElement>(
   RECIPE_SCHEMA.required(),
   'Received an invalid value for recipe',
 )

--- a/packages/workato-adapter/src/user_config.ts
+++ b/packages/workato-adapter/src/user_config.ts
@@ -11,14 +11,14 @@ import { WORKATO } from './constants'
 
 export const ENABLE_DEPLOY_SUPPORT_FLAG = 'enableDeploySupport'
 
-export type WorkatoFetchConfig = definitions.UserFetchConfig<{
+type WorkatoFetchConfig = definitions.UserFetchConfig<{
   customNameMappingOptions: never
   fetchCriteria: definitions.DefaultFetchCriteria
 }> & {
   serviceConnectionNames?: Record<string, string[]>
 }
 
-export type WorkatoClientConfig = definitions.ClientBaseConfig<definitions.ClientRateLimitConfig>
+type WorkatoClientConfig = definitions.ClientBaseConfig<definitions.ClientRateLimitConfig>
 
 export type WorkatoUserConfig = definitions.UserConfig<
   never,
@@ -29,7 +29,7 @@ export type WorkatoUserConfig = definitions.UserConfig<
   [ENABLE_DEPLOY_SUPPORT_FLAG]?: boolean
 }
 
-export const changeValidatorNames = [
+const changeValidatorNames = [
   'deployTypesNotSupported',
   'notSupportedTypes',
   'notSupportedRemoval',

--- a/packages/workato-adapter/test/utils.ts
+++ b/packages/workato-adapter/test/utils.ts
@@ -12,23 +12,14 @@ import {
   definitions as definitionsUtils,
 } from '@salto-io/adapter-components'
 import { mockFunction, MockInterface } from '@salto-io/test-utils'
-import { InstanceElement, ElemID, ObjectType } from '@salto-io/adapter-api'
-import { adapter } from '../src/adapter_creator'
 import WorkatoClient from '../src/client/client'
 import { FilterCreator } from '../src/filter'
-import { Credentials } from '../src/auth'
 import { DEFAULT_CONFIG, WorkatoUserConfig } from '../src/user_config'
 import { WorkatoOptions } from '../src/definitions/types'
 import { createClientDefinitions } from '../src/definitions/requests/clients'
 import { PAGINATION } from '../src/definitions/requests/pagination'
 import { createFetchDefinitions } from '../src/definitions/fetch/fetch'
 import fetchCriteria from '../src/fetch_criteria'
-
-export const createCredentialsInstance = (credentials: Credentials): InstanceElement =>
-  new InstanceElement(ElemID.CONFIG_NAME, adapter.authenticationMethods.basic.credentialsType, credentials)
-
-export const createConfigInstance = (config: WorkatoUserConfig): InstanceElement =>
-  new InstanceElement(ElemID.CONFIG_NAME, adapter.configType as ObjectType, config)
 
 const mockConnection = (): MockInterface<clientUtils.APIConnection> => ({
   get: mockFunction<clientUtils.APIConnection['get']>().mockResolvedValue({ status: 200, data: '' }),
@@ -44,7 +35,7 @@ type ClientWithMockConnection = {
   client: WorkatoClient
   connection: MockInterface<clientUtils.APIConnection>
 }
-export const mockClient = (): ClientWithMockConnection => {
+const mockClient = (): ClientWithMockConnection => {
   const connection = mockConnection()
   const client = new WorkatoClient({
     credentials: {
@@ -62,10 +53,10 @@ export const mockClient = (): ClientWithMockConnection => {
   return { client, connection }
 }
 
-export const createFetchQuery = (config?: WorkatoUserConfig): elementUtils.query.ElementQuery =>
+const createFetchQuery = (config?: WorkatoUserConfig): elementUtils.query.ElementQuery =>
   elementUtils.query.createElementQuery(config?.fetch ?? DEFAULT_CONFIG?.fetch, fetchCriteria)
 
-export const createDefinitions = (): definitionsUtils.RequiredDefinitions<WorkatoOptions> => {
+const createDefinitions = (): definitionsUtils.RequiredDefinitions<WorkatoOptions> => {
   const cli = mockClient().client
   return {
     clients: createClientDefinitions({ main: cli }),


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
