### PR TITLE
SALTO-7363: Removing unused exports from Zendesk adapter

### DIFF
--- a/packages/zendesk-adapter-e2e/e2e_test/adapter.ts
+++ b/packages/zendesk-adapter-e2e/e2e_test/adapter.ts
@@ -7,29 +7,9 @@
  */
 import { creds, CredsLease } from '@salto-io/e2e-credentials-store'
 import { logger } from '@salto-io/logging'
-import { ReadOnlyElementsSource } from '@salto-io/adapter-api'
 import { e2eUtils } from '@salto-io/zendesk-adapter'
 import { credsSpec } from './jest_environment'
 
-const { ZendeskClient, DEFAULT_CONFIG, FETCH_CONFIG, ZendeskAdapter } = e2eUtils
 const log = logger(module)
-
-export type Reals = {
-  client: e2eUtils.ZendeskClient
-  adapter: e2eUtils.ZendeskAdapter
-}
-
-export type Opts = {
-  adapterParams?: Partial<e2eUtils.ZendeskAdapterParams>
-  credentials: e2eUtils.Credentials
-  elementsSource: ReadOnlyElementsSource
-}
-
-export const realAdapter = ({ adapterParams, credentials, elementsSource }: Opts, config = DEFAULT_CONFIG): Reals => {
-  config[FETCH_CONFIG].useNewInfra = true
-  const client = (adapterParams && adapterParams.client) || new ZendeskClient({ credentials, config: config.client })
-  const adapter = new ZendeskAdapter({ client, credentials, config, elementsSource, accountName: 'zendesk' })
-  return { client, adapter }
-}
 
 export const credsLease = (): Promise<CredsLease<e2eUtils.Credentials>> => creds(credsSpec(), log)

--- a/packages/zendesk-adapter/src/adapter.ts
+++ b/packages/zendesk-adapter/src/adapter.ts
@@ -188,7 +188,7 @@ const { awu } = collections.asynciterable
 const { concatObjects } = objects
 const SECTIONS_TYPE_NAME = 'sections'
 
-export const DEFAULT_FILTERS = [
+const DEFAULT_FILTERS = [
   addRecurseIntoFieldFilter,
   ticketStatusCustomStatusDeployFilter,
   ticketFieldFilter,

--- a/packages/zendesk-adapter/src/change_validators/child_parent/utils.ts
+++ b/packages/zendesk-adapter/src/change_validators/child_parent/utils.ts
@@ -51,7 +51,7 @@ export const getChildAndParentTypeNames = (config: ZendeskApiConfig): ChildParen
     .concat(ADDITIONAL_CHILD_PARENT_RELATIONSHIPS)
 }
 
-export const getIdsFromReferenceExpressions = (values: unknown): ElemID[] =>
+const getIdsFromReferenceExpressions = (values: unknown): ElemID[] =>
   makeArray(values)
     .filter(isReferenceExpression)
     .map(ref => ref.elemID)

--- a/packages/zendesk-adapter/src/change_validators/guide_creation_or_removal.ts
+++ b/packages/zendesk-adapter/src/change_validators/guide_creation_or_removal.ts
@@ -20,7 +20,7 @@ import ZendeskClient from '../client/client'
 import { ZendeskApiConfig } from '../user_config'
 import { isBrand, invalidBrandChange } from './guide_activation'
 
-export const invalidBrandAdditionChange = (
+const invalidBrandAdditionChange = (
   change: Change<InstanceElement>,
   fieldToCheck: 'has_help_center' | 'help_center_state',
 ): boolean => {

--- a/packages/zendesk-adapter/src/change_validators/index.ts
+++ b/packages/zendesk-adapter/src/change_validators/index.ts
@@ -6,12 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { accountSettingsValidator } from './account_settings'
-export {
-  duplicateCustomFieldOptionValuesValidator,
-  isRelevantChange,
-  RELEVANT_PARENT_AND_CHILD_TYPES,
-  CHECKBOX_TYPE_NAME,
-} from './duplicate_option_values'
+export { duplicateCustomFieldOptionValuesValidator } from './duplicate_option_values'
 export { emptyCustomFieldOptionsValidator } from './empty_custom_field_options'
 export { emptyVariantsValidator } from './empty_variants'
 export { noDuplicateLocaleIdInDynamicContentItemValidator } from './unique_locale_per_variant'

--- a/packages/zendesk-adapter/src/client/client.ts
+++ b/packages/zendesk-adapter/src/client/client.ts
@@ -34,17 +34,17 @@ type LogsFilterConfig = {
   allowOrganizationNames?: boolean
 }
 
-export type HolidayRes = {
+type HolidayRes = {
   data: {
     holidays: Values[]
   }
 }
-export type SupportAddressRes = {
+type SupportAddressRes = {
   data: {
     recipient_addresses: Values[]
   }
 }
-export type AttachmentRes = {
+type AttachmentRes = {
   data: {
     article_attachments: Values[]
   }

--- a/packages/zendesk-adapter/src/definitions/index.ts
+++ b/packages/zendesk-adapter/src/definitions/index.ts
@@ -8,4 +8,3 @@
 
 export * from './fetch'
 export * from './requests'
-export { ClientOptions } from './types'

--- a/packages/zendesk-adapter/src/definitions/requests/index.ts
+++ b/packages/zendesk-adapter/src/definitions/requests/index.ts
@@ -6,4 +6,3 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 export { createClientDefinitions } from './clients'
-export { PAGINATION as pagination } from './pagination'

--- a/packages/zendesk-adapter/src/definitions/requests/pagination.ts
+++ b/packages/zendesk-adapter/src/definitions/requests/pagination.ts
@@ -11,7 +11,7 @@ import { CURSOR_BASED_PAGINATION_FIELD, PAGE_SIZE } from '../../config'
 
 const { cursorPagination } = fetchUtils.request.pagination
 
-export const pathChecker: fetchUtils.request.pagination.PathCheckerFunc = (current, next) =>
+const pathChecker: fetchUtils.request.pagination.PathCheckerFunc = (current, next) =>
   next === `${current}.json` || next === `${current}`
 
 export const PAGINATION: definitions.ApiDefinitions<Options>['pagination'] = {

--- a/packages/zendesk-adapter/src/filters/add_alias.ts
+++ b/packages/zendesk-adapter/src/filters/add_alias.ts
@@ -13,7 +13,7 @@ import { THEME_SETTINGS_TYPE_NAME } from '../constants'
 
 const THEME_SETTINGS = 'Theme settings'
 
-export const aliasMap: Record<string, AliasData> = {
+const aliasMap: Record<string, AliasData> = {
   [THEME_SETTINGS_TYPE_NAME]: {
     aliasComponents: [
       {

--- a/packages/zendesk-adapter/src/filters/article/article.ts
+++ b/packages/zendesk-adapter/src/filters/article/article.ts
@@ -69,7 +69,7 @@ const USER_SEGMENT_ID_FIELD = 'user_segment_id'
 const ATTACHMENTS_IDS_REGEX = new RegExp(`(?<url>/${ARTICLE_ATTACHMENTS_FIELD}/)(?<id>\\d+)`, 'g')
 const RATE_LIMIT_FOR_UNASSOCIATED_ATTACHMENT = 50
 
-export type TranslationType = {
+type TranslationType = {
   title: string
   body?: string
   locale: { locale: string }

--- a/packages/zendesk-adapter/src/filters/article/utils.ts
+++ b/packages/zendesk-adapter/src/filters/article/utils.ts
@@ -112,7 +112,7 @@ const EXPECTED_ATTACHMENT_RESPONSE_SCHEMA = Joi.array()
   )
   .required()
 
-export const isAttachmentsResponse = (value: unknown): value is AttachmentResponse[] => {
+const isAttachmentsResponse = (value: unknown): value is AttachmentResponse[] => {
   const { error } = EXPECTED_ATTACHMENT_RESPONSE_SCHEMA.validate(value)
   if (error !== undefined) {
     log.error(`Received an invalid response for the attachments values: ${error.message}, ${inspectValue(value)}`)

--- a/packages/zendesk-adapter/src/filters/bot_builder_arrange_paths.ts
+++ b/packages/zendesk-adapter/src/filters/bot_builder_arrange_paths.ts
@@ -21,8 +21,8 @@ import { FilterCreator } from '../filter'
 const { RECORDS_PATH } = elementsUtils
 const log = logger(module)
 
-export const UNSORTED = 'unsorted'
-export const BOT_BUILDER_PATH = [ZENDESK, RECORDS_PATH, CONVERSATION_BOT]
+const UNSORTED = 'unsorted'
+const BOT_BUILDER_PATH = [ZENDESK, RECORDS_PATH, CONVERSATION_BOT]
 
 const BOT_BUILDER_ELEMENT_DIRECTORY: Record<string, string> = {
   [CONVERSATION_BOT]: 'bots',

--- a/packages/zendesk-adapter/src/filters/custom_objects/utils.ts
+++ b/packages/zendesk-adapter/src/filters/custom_objects/utils.ts
@@ -31,7 +31,7 @@ type MissingTemplateArgs = {
   missingInstanceType: string
 }
 
-export const createMissingTemplate = ({
+const createMissingTemplate = ({
   ticketField,
   customKey,
   missingInstanceName,

--- a/packages/zendesk-adapter/src/filters/field_references.ts
+++ b/packages/zendesk-adapter/src/filters/field_references.ts
@@ -279,7 +279,7 @@ const ZendeskReferenceSerializationStrategyLookup: Record<
   },
 }
 
-export type ReferenceContextStrategyName =
+type ReferenceContextStrategyName =
   | 'neighborField'
   | 'allowlistedNeighborField'
   | 'allowlistedNeighborSubject'
@@ -294,7 +294,7 @@ export type ReferenceContextStrategyName =
   | 'neighborSubjectReferenceTicketField'
   | 'neighborSubjectReferenceUserAndOrgField'
   | 'neighborParentType'
-export const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
+const contextStrategyLookup: Record<ReferenceContextStrategyName, referenceUtils.ContextFunc> = {
   neighborField: neighborContextFunc({ contextFieldName: 'field', contextValueMapper: getValueLookupType }),
   // We use allow lists because there are types we don't support (such as organization or requester)
   // and they'll end up being false positives

--- a/packages/zendesk-adapter/src/filters/guide_section_and_category.ts
+++ b/packages/zendesk-adapter/src/filters/guide_section_and_category.ts
@@ -16,7 +16,7 @@ import {
 } from '@salto-io/adapter-api'
 import _ from 'lodash'
 import Joi from 'joi'
-import { createSchemeGuard, createSchemeGuardForInstance } from '@salto-io/adapter-utils'
+import { createSchemeGuard } from '@salto-io/adapter-utils'
 import { logger } from '@salto-io/logging'
 import { FilterCreator } from '../filter'
 import { deployChange, deployChanges } from '../deployment'
@@ -38,14 +38,6 @@ export type TranslationType = {
   locale: ReferenceExpression | string
 }
 
-type ParentType = InstanceElement & {
-  value: {
-    source_locale: string
-    name?: string
-    description?: string
-  }
-}
-
 const TRANSLATION_SCHEMA = Joi.object({
   locale: Joi.required(),
   body: [Joi.string(), Joi.object()],
@@ -54,22 +46,9 @@ const TRANSLATION_SCHEMA = Joi.object({
   .unknown(true)
   .required()
 
-const PARENT_SCHEMA = Joi.object({
-  source_locale: Joi.string().required(),
-  name: Joi.string(),
-  description: Joi.string().allow(''),
-})
-  .unknown(true)
-  .required()
-
 export const isTranslation = createSchemeGuard<TranslationType>(
   TRANSLATION_SCHEMA,
   'Received an invalid value for translation',
-)
-
-export const isParent = createSchemeGuardForInstance<ParentType>(
-  PARENT_SCHEMA,
-  'Received an invalid value for section/category',
 )
 
 /**

--- a/packages/zendesk-adapter/src/filters/guide_themes/types.ts
+++ b/packages/zendesk-adapter/src/filters/guide_themes/types.ts
@@ -59,7 +59,7 @@ export type PendingJob<JobData> = {
   data: JobData
 }
 
-export type CompletedJob<JobData> = {
+type CompletedJob<JobData> = {
   id: string
   status: 'completed'
   data: JobData

--- a/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
+++ b/packages/zendesk-adapter/src/filters/handle_template_expressions.ts
@@ -70,7 +70,7 @@ export const TICKET_USER_FIELD = 'ticket.requester.custom_fields'
 const ID = 'id'
 const KEY = 'key'
 
-export const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
+const ZENDESK_REFERENCE_TYPE_TO_SALTO_TYPE: Record<string, string> = {
   [TICKET_TICKET_FIELD]: TICKET_FIELD_TYPE_NAME,
   [TICKET_TICKET_FIELD_OPTION_TITLE]: TICKET_FIELD_TYPE_NAME,
   [TICKET_ORGANIZATION_FIELD]: ORG_FIELD_TYPE_NAME,

--- a/packages/zendesk-adapter/src/filters/reorder/queue.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/queue.ts
@@ -8,7 +8,7 @@
 import { QUEUE_TYPE_NAME } from '../../constants'
 import { createReorderFilterCreator } from './creator'
 
-export const TYPE_NAME = QUEUE_TYPE_NAME
+const TYPE_NAME = QUEUE_TYPE_NAME
 
 /**
  * Add sla policy order element with all the sla policies ordered

--- a/packages/zendesk-adapter/src/filters/reorder/user_field.ts
+++ b/packages/zendesk-adapter/src/filters/reorder/user_field.ts
@@ -8,7 +8,7 @@
 import { USER_FIELD_TYPE_NAME } from '../../constants'
 import { createReorderFilterCreator } from './creator'
 
-export const TYPE_NAME = USER_FIELD_TYPE_NAME
+const TYPE_NAME = USER_FIELD_TYPE_NAME
 
 /**
  * Add user field order element with all the user fields ordered

--- a/packages/zendesk-adapter/src/user_config.ts
+++ b/packages/zendesk-adapter/src/user_config.ts
@@ -56,7 +56,7 @@ export type ZendeskFetchConfig = definitions.UserFetchConfig<{
   fetchBotBuilder?: boolean
 }
 
-export type ZendeskClientRateLimitConfig = definitions.ClientRateLimitConfig & { rateLimitBuffer?: number }
+type ZendeskClientRateLimitConfig = definitions.ClientRateLimitConfig & { rateLimitBuffer?: number }
 
 export type ZendeskClientConfig = definitions.ClientBaseConfig<ZendeskClientRateLimitConfig> & {
   unassociatedAttachmentChunkSize: number

--- a/packages/zendesk-adapter/test/utils.ts
+++ b/packages/zendesk-adapter/test/utils.ts
@@ -20,11 +20,7 @@ import { createClientDefinitions, createFetchDefinitions } from '../src/definiti
 import { Options } from '../src/definitions/types'
 import { PAGINATION } from '../src/definitions/requests/pagination'
 
-export const createDefinitions = ({
-  client,
-}: {
-  client: ZendeskClient
-}): definitionsUtils.RequiredDefinitions<Options> => ({
+const createDefinitions = ({ client }: { client: ZendeskClient }): definitionsUtils.RequiredDefinitions<Options> => ({
   clients: createClientDefinitions({ main: client, guide: client }),
   pagination: PAGINATION,
   fetch: createFetchDefinitions({ baseUrl: client.getUrl().href }),


### PR DESCRIPTION
Also Zendesk E2E tests.

Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
