### PR TITLE
SALTO-7415: Omit Entra roleDefinition read-only-field

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/entra/deploy.ts
@@ -639,6 +639,9 @@ const graphV1CustomDefinitions: DeployCustomDefinitions = {
                 path: '/roleManagement/directory/roleDefinitions',
                 method: 'post',
               },
+              transformation: {
+                omit: ['isBuiltIn'],
+              },
             },
           },
         ],


### PR DESCRIPTION
We recently fixed the endpoint used to deploy EntraRoleDefinition.
However, deployments for additions are now failing due to the read-only field isBuiltIn.

---

It's okay to simply omit it, since we have a validator that disallows deploying role definitions when isBuiltIn is true, so the value at this point should always be false.


---
_Release Notes_: 
_Microsoft Security adapter:_
* Fix EntraAppRole deploy on addition

---
_User Notifications_: 
None
