### PR TITLE
SALTO-7363: Removing unused exports from Service Placeholder Adapter

### DIFF
--- a/packages/serviceplaceholder-adapter/src/adapter_creator.ts
+++ b/packages/serviceplaceholder-adapter/src/adapter_creator.ts
@@ -12,7 +12,7 @@ import { DEFAULT_CONFIG, UserConfig } from './config'
 import { createConnection } from './client/connection'
 import { ADAPTER_NAME } from './constants'
 import { createClientDefinitions, createDeployDefinitions, createFetchDefinitions } from './definitions'
-import { PAGINATION } from './definitions/requests/pagination'
+import { pagination } from './definitions/requests'
 import { Options } from './definitions/types'
 import { REFERENCES } from './definitions/references'
 
@@ -28,7 +28,7 @@ export const adapter = createAdapter<Credentials, Options, UserConfig>({
   defaultConfig: DEFAULT_CONFIG,
   definitionsCreator: ({ clients, userConfig }) => ({
     clients: createClientDefinitions(clients),
-    pagination: PAGINATION,
+    pagination,
     fetch: createFetchDefinitions(userConfig.fetch),
     deploy: createDeployDefinitions(),
     references: REFERENCES,

--- a/packages/serviceplaceholder-adapter/src/client/connection.ts
+++ b/packages/serviceplaceholder-adapter/src/client/connection.ts
@@ -13,7 +13,7 @@ import { Credentials } from '../auth'
 
 const log = logger(module)
 
-export const validateCredentials = async ({
+const validateCredentials = async ({
   connection,
   credentials,
 }: {

--- a/packages/serviceplaceholder-adapter/src/definitions/deploy/business_hours_schedule.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/deploy/business_hours_schedule.ts
@@ -7,7 +7,8 @@
  */
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
-import { AdditionalAction, ClientOptions } from '../types'
+import { ClientOptions } from '..'
+import { AdditionalAction } from '../types'
 
 type InstanceDeployApiDefinitions = definitions.deploy.InstanceDeployApiDefinitions<AdditionalAction, ClientOptions>
 

--- a/packages/serviceplaceholder-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/deploy/deploy.ts
@@ -7,7 +7,8 @@
  */
 import _ from 'lodash'
 import { definitions, deployment } from '@salto-io/adapter-components'
-import { AdditionalAction, ClientOptions } from '../types'
+import { ClientOptions } from '..'
+import { AdditionalAction } from '../types'
 import { getBusinessHoursScheduleDefinition } from './business_hours_schedule'
 
 type InstanceDeployApiDefinitions = definitions.deploy.InstanceDeployApiDefinitions<AdditionalAction, ClientOptions>

--- a/packages/serviceplaceholder-adapter/src/definitions/types.ts
+++ b/packages/serviceplaceholder-adapter/src/definitions/types.ts
@@ -15,7 +15,7 @@ type PaginationOptions = 'cursor'
 // TODO set these to never if not needed
 export type ReferenceContextStrategies = 'parentType'
 export type CustomReferenceSerializationStrategyName = 'otherFieldName'
-export type CustomIndexField = CustomReferenceSerializationStrategyName
+type CustomIndexField = CustomReferenceSerializationStrategyName
 
 export type Options = definitions.APIDefinitionsOptions & {
   clientOptions: ClientOptions


### PR DESCRIPTION
Preparation for enabling unused exports rules in knip.

---

_Additional context for reviewer_:
Where possible I used the unused exports instead of removing them. If we want to keep the others we will need to find some solution (if we want to ignore we would have to ignore entire files which I think is best avoided).

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
