### PR TITLE
SALTO-7438: duplicate values in cascading options

### DIFF
--- a/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
@@ -25,6 +25,8 @@ import { getContextParentAsync } from '../../common/fields'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
+// the optionId is the option of the parent option for cascading options. Cascade options can have the same value.
+// The value will be undefined for non-cascade options
 const uniqueOptionIdentifier = (option: Value): string => `${naclCase(option.value)}-${option.optionId}`
 
 const processContextOptionsPrivateApiResponse = (allUpdatedOptions: Option[], addedOptions: Value[]): void => {

--- a/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
+++ b/packages/jira-adapter/src/filters/fields/context_options_splitted.ts
@@ -25,6 +25,8 @@ import { getContextParentAsync } from '../../common/fields'
 const log = logger(module)
 const { awu } = collections.asynciterable
 
+const uniqueOptionIdentifier = (option: Value): string => `${naclCase(option.value)}-${option.optionId}`
+
 const processContextOptionsPrivateApiResponse = (allUpdatedOptions: Option[], addedOptions: Value[]): void => {
   const optionsMap = _.keyBy(allUpdatedOptions, option => option.value)
   addedOptions.forEach(option => {
@@ -120,9 +122,9 @@ const updateContextOptions = async ({
         throw new Error('Received unexpected response from Jira API')
       }
       if (Array.isArray(resp.data.options)) {
-        const optionsMap = _.keyBy(chunk, option => naclCase(option.value))
+        const optionsMap = _.keyBy(chunk, option => uniqueOptionIdentifier(option))
         resp.data.options.forEach(newOption => {
-          optionsMap[naclCase(newOption.value)].id = newOption.id
+          optionsMap[uniqueOptionIdentifier(newOption)].id = newOption.id
         })
       }
     })


### PR DESCRIPTION
In case two cascade options had the same value we would not populate some of them with ids

---

For non-cascading option the optionId will be undefined, and it will be a part of the map name

---
_Release Notes_: 
Jira Adapter:
* Fixed a bug with deployment of same-name cascading options

---
_User Notifications_: 
None
