### PR TITLE
SALTO-7445: Automation References types

### DIFF
--- a/packages/jira-adapter/src/constants.ts
+++ b/packages/jira-adapter/src/constants.ts
@@ -152,6 +152,7 @@ export const SHARE_PERMISSION_FIELDS = ['sharePermissions', 'editPermissions']
 export const CONTENT_TYPE_HEADER = 'Content-Type'
 export const JSON_CONTENT_TYPE = 'application/json'
 export const KANBAN_TYPE = 'kanban'
+export const AUTOMATION_QUERY = 'AutomationQuery'
 // almost constant functions
 export const fetchFailedWarnings = (name: string): string =>
   `Salto could not access the ${name} resource. Elements from that type were not fetched. Please make sure that this type is enabled in your service, and that the supplied user credentials have sufficient permissions to access this data. You can also exclude this data from Salto's fetches by changing the environment configuration. Learn more at https://help.salto.io/en/articles/6947061-salto-could-not-access-the-resource`

--- a/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
+++ b/packages/jira-adapter/src/filters/automation/smart_values/smart_value_reference_filter.ts
@@ -74,7 +74,7 @@ type SmartQuery = {
   type: string
   query: {
     type: string
-    value: string
+    value: string | object
   }
 }
 
@@ -82,7 +82,7 @@ const SMART_QUERY_SCHEME = Joi.object({
   type: Joi.string().required(),
   query: Joi.object({
     type: Joi.string().required(),
-    value: Joi.string().required(),
+    value: Joi.alternatives(Joi.string(), Joi.object()).required(),
   })
     .unknown(true)
     .required(),

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -25,6 +25,7 @@ import {
   AUTOMATION_COMPONENT_VALUE_TYPE,
   JIRA,
   DELETE_LINK_TYPES,
+  AUTOMATION_QUERY,
 } from '../../constants'
 
 export const createAutomationTypes = (): {
@@ -144,6 +145,7 @@ export const createAutomationTypes = (): {
       direction: { refType: BuiltinTypes.STRING },
       name: { refType: BuiltinTypes.STRING },
     },
+    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, DELETE_LINK_TYPES],
   })
 
   const templateFormsConfigType = new ObjectType({
@@ -152,6 +154,16 @@ export const createAutomationTypes = (): {
       projectId: { refType: BuiltinTypes.NUMBER },
       templateFormIds: { refType: new ListType(BuiltinTypes.NUMBER) },
     },
+    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, 'TemplateFormsConfig'],
+  })
+
+  const queryType = new ObjectType({
+    elemID: new ElemID(JIRA, AUTOMATION_QUERY),
+    fields: {
+      type: { refType: BuiltinTypes.STRING },
+      value: { refType: BuiltinTypes.UNKNOWN }, // string or reference
+    },
+    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_QUERY],
   })
 
   const componentValueType = new ObjectType({
@@ -190,9 +202,11 @@ export const createAutomationTypes = (): {
       cmdbField: { refType: BuiltinTypes.UNKNOWN }, // string or reference
       customFieldId: { refType: BuiltinTypes.UNKNOWN }, // string or reference
       fieldId: { refType: BuiltinTypes.UNKNOWN }, // string or reference
+      query: { refType: queryType },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_VALUE_TYPE],
   })
+  componentValueType.fields.customSmartValue = new Field(componentValueType, 'customSmartValue', componentValueType)
 
   const componentType = new ObjectType({
     elemID: new ElemID(JIRA, AUTOMATION_COMPONENT_TYPE),
@@ -206,9 +220,7 @@ export const createAutomationTypes = (): {
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, AUTOMATION_COMPONENT_TYPE],
   })
-
   componentType.fields.children = new Field(componentType, 'children', new ListType(componentType))
-
   componentType.fields.conditions = new Field(componentType, 'conditions', new ListType(componentType))
 
   const tagType = new ObjectType({
@@ -270,6 +282,7 @@ export const createAutomationTypes = (): {
       subtaskType,
       compareFieldValueType,
       deleteLinkTypes,
+      queryType,
     ],
   }
 }

--- a/packages/jira-adapter/src/filters/script_runner/workflow/workflow_filter.ts
+++ b/packages/jira-adapter/src/filters/script_runner/workflow/workflow_filter.ts
@@ -61,7 +61,7 @@ const addObjectTypes = (elements: Element[]): void => {
         annotations: fullDeploymentAnnotation,
       },
     },
-    path: [JIRA, componentElements.SUBTYPES_PATH, componentElements.TYPES_PATH, MAIL_LIST_TYPE_NAME],
+    path: [JIRA, componentElements.TYPES_PATH, componentElements.SUBTYPES_PATH, MAIL_LIST_TYPE_NAME],
   })
 
   const linkDirectionType = new ObjectType({


### PR DESCRIPTION
Fixed type and smart value deploy issues

---

I did some order on the types on the way

---
_Release Notes_: 
Jira Adapter:
* Solved a bug with deployment of automation when parseAdditionalAutomationExpressions is on

---
_User Notifications_: 
None
