### PR TITLE
SALTO-7440: Deploy Intune ScopeTags one by one

### DIFF
--- a/packages/microsoft-security-adapter/src/definitions/deploy/intune/deploy.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/intune/deploy.ts
@@ -219,13 +219,16 @@ const graphBetaCustomDefinitions: DeployCustomDefinitions = {
       },
     },
   },
-  [APPLICATION_PROTECTION_WINDOWS_INFORMATION_PROTECTION_TYPE_NAME]:
-    assignments.createBasicDeployDefinitionForTypeWithAssignments({
+  [APPLICATION_PROTECTION_WINDOWS_INFORMATION_PROTECTION_TYPE_NAME]: {
+    requestsByAction: assignments.createBasicDeployDefinitionForTypeWithAssignments({
       resourcePath: '/deviceAppManagement/mdmWindowsInformationProtectionPolicies',
     }),
-  [DEVICE_CONFIGURATION_TYPE_NAME]: assignments.createBasicDeployDefinitionForTypeWithAssignments({
-    resourcePath: '/deviceManagement/deviceConfigurations',
-  }),
+  },
+  [DEVICE_CONFIGURATION_TYPE_NAME]: {
+    requestsByAction: assignments.createBasicDeployDefinitionForTypeWithAssignments({
+      resourcePath: '/deviceManagement/deviceConfigurations',
+    }),
+  },
   [DEVICE_CONFIGURATION_SETTING_CATALOG_TYPE_NAME]:
     deviceConfigurationSettings.DEVICE_CONFIGURATION_SETTINGS_DEPLOY_DEFINITION,
   [DEVICE_COMPLIANCE_TYPE_NAME]: {
@@ -305,17 +308,25 @@ const graphBetaCustomDefinitions: DeployCustomDefinitions = {
     },
   },
   [PLATFORM_SCRIPT_LINUX_TYPE_NAME]: deviceConfigurationSettings.DEVICE_CONFIGURATION_SETTINGS_DEPLOY_DEFINITION,
-  [PLATFORM_SCRIPT_WINDOWS_TYPE_NAME]: assignments.createBasicDeployDefinitionForTypeWithAssignments({
-    resourcePath: '/deviceManagement/deviceManagementScripts',
-    assignmentRootField: 'deviceManagementScriptAssignments',
-  }),
-  [PLATFORM_SCRIPT_MAC_OS_TYPE_NAME]: assignments.createBasicDeployDefinitionForTypeWithAssignments({
-    resourcePath: '/deviceManagement/deviceShellScripts',
-    assignmentRootField: 'deviceManagementScriptAssignments',
-  }),
-  [SCOPE_TAG_TYPE_NAME]: assignments.createBasicDeployDefinitionForTypeWithAssignments({
-    resourcePath: '/deviceManagement/roleScopeTags',
-  }),
+  [PLATFORM_SCRIPT_WINDOWS_TYPE_NAME]: {
+    requestsByAction: assignments.createBasicDeployDefinitionForTypeWithAssignments({
+      resourcePath: '/deviceManagement/deviceManagementScripts',
+      assignmentRootField: 'deviceManagementScriptAssignments',
+    }),
+  },
+  [PLATFORM_SCRIPT_MAC_OS_TYPE_NAME]: {
+    requestsByAction: assignments.createBasicDeployDefinitionForTypeWithAssignments({
+      resourcePath: '/deviceManagement/deviceShellScripts',
+      assignmentRootField: 'deviceManagementScriptAssignments',
+    }),
+  },
+  [SCOPE_TAG_TYPE_NAME]: {
+    requestsByAction: assignments.createBasicDeployDefinitionForTypeWithAssignments({
+      resourcePath: '/deviceManagement/roleScopeTags',
+    }),
+    changeGroupId: deployment.grouping.groupByType,
+    concurrency: 1,
+  },
   ..._.mapValues(
     TYPES_WITH_TARGET_APPS_PATH_MAP,
     ({ resourcePath, targetTypeFieldName }): InstanceDeployApiDefinitions => ({

--- a/packages/microsoft-security-adapter/src/definitions/deploy/intune/utils/assignments.ts
+++ b/packages/microsoft-security-adapter/src/definitions/deploy/intune/utils/assignments.ts
@@ -50,52 +50,50 @@ export const createBasicDeployDefinitionForTypeWithAssignments = ({
 }: {
   resourcePath: EndpointPath
   assignmentRootField?: string
-}): InstanceDeployApiDefinitions => ({
-  requestsByAction: {
-    customizations: {
-      add: [
-        {
-          request: {
-            endpoint: {
-              path: resourcePath,
-              method: 'post',
-            },
-            transformation: {
-              omit: [ASSIGNMENTS_FIELD_NAME],
-            },
+}): InstanceDeployApiDefinitions['requestsByAction'] => ({
+  customizations: {
+    add: [
+      {
+        request: {
+          endpoint: {
+            path: resourcePath,
+            method: 'post',
+          },
+          transformation: {
+            omit: [ASSIGNMENTS_FIELD_NAME],
           },
         },
-        createAssignmentsRequest({ resourcePath, rootField: assignmentRootField }),
-      ],
-      modify: [
-        {
-          request: {
-            endpoint: {
-              path: `${resourcePath}/{id}`,
-              method: 'patch',
-            },
-            transformation: {
-              omit: [ASSIGNMENTS_FIELD_NAME],
-            },
+      },
+      createAssignmentsRequest({ resourcePath, rootField: assignmentRootField }),
+    ],
+    modify: [
+      {
+        request: {
+          endpoint: {
+            path: `${resourcePath}/{id}`,
+            method: 'patch',
           },
-          condition: {
-            transformForCheck: {
-              omit: [ASSIGNMENTS_FIELD_NAME],
-            },
+          transformation: {
+            omit: [ASSIGNMENTS_FIELD_NAME],
           },
         },
-        createAssignmentsRequest({ resourcePath, rootField: assignmentRootField }),
-      ],
-      remove: [
-        {
-          request: {
-            endpoint: {
-              path: `${resourcePath}/{id}`,
-              method: 'delete',
-            },
+        condition: {
+          transformForCheck: {
+            omit: [ASSIGNMENTS_FIELD_NAME],
           },
         },
-      ],
-    },
+      },
+      createAssignmentsRequest({ resourcePath, rootField: assignmentRootField }),
+    ],
+    remove: [
+      {
+        request: {
+          endpoint: {
+            path: `${resourcePath}/{id}`,
+            method: 'delete',
+          },
+        },
+      },
+    ],
   },
 })

--- a/packages/microsoft-security-adapter/test/definitions/deploy/intune/utils/group_assignments.test.ts
+++ b/packages/microsoft-security-adapter/test/definitions/deploy/intune/utils/group_assignments.test.ts
@@ -67,97 +67,95 @@ describe('Intune assignments deploy utils', () => {
 
   describe(`${assignments.createBasicDeployDefinitionForTypeWithAssignments.name} function`, () => {
     it('should return a correct deploy definition', () => {
-      const definition = assignments.createBasicDeployDefinitionForTypeWithAssignments({
+      const requestsByAction = assignments.createBasicDeployDefinitionForTypeWithAssignments({
         resourcePath: '/test',
         assignmentRootField: 'testField',
       })
-      expect(definition).toEqual({
-        requestsByAction: {
-          customizations: {
-            add: [
-              {
-                request: {
-                  endpoint: {
-                    path: '/test',
-                    method: 'post',
-                  },
-                  transformation: {
-                    omit: ['assignments'],
-                  },
+      expect(requestsByAction).toEqual({
+        customizations: {
+          add: [
+            {
+              request: {
+                endpoint: {
+                  path: '/test',
+                  method: 'post',
+                },
+                transformation: {
+                  omit: ['assignments'],
                 },
               },
-              {
-                request: {
-                  endpoint: {
-                    path: '/test/{id}/assign',
-                    method: 'post',
-                  },
-                  transformation: {
-                    rename: [
-                      {
-                        from: 'assignments',
-                        to: 'testField',
-                        onConflict: 'skip',
-                      },
-                    ],
-                    pick: ['testField'],
-                  },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/test/{id}/assign',
+                  method: 'post',
                 },
-                condition: {
-                  custom: expect.any(Function),
+                transformation: {
+                  rename: [
+                    {
+                      from: 'assignments',
+                      to: 'testField',
+                      onConflict: 'skip',
+                    },
+                  ],
+                  pick: ['testField'],
                 },
               },
-            ],
-            modify: [
-              {
-                request: {
-                  endpoint: {
-                    path: '/test/{id}',
-                    method: 'patch',
-                  },
-                  transformation: {
-                    omit: ['assignments'],
-                  },
+              condition: {
+                custom: expect.any(Function),
+              },
+            },
+          ],
+          modify: [
+            {
+              request: {
+                endpoint: {
+                  path: '/test/{id}',
+                  method: 'patch',
                 },
-                condition: {
-                  transformForCheck: {
-                    omit: ['assignments'],
-                  },
+                transformation: {
+                  omit: ['assignments'],
                 },
               },
-              {
-                request: {
-                  endpoint: {
-                    path: '/test/{id}/assign',
-                    method: 'post',
-                  },
-                  transformation: {
-                    rename: [
-                      {
-                        from: 'assignments',
-                        to: 'testField',
-                        onConflict: 'skip',
-                      },
-                    ],
-                    pick: ['testField'],
-                  },
-                },
-                condition: {
-                  custom: expect.any(Function),
+              condition: {
+                transformForCheck: {
+                  omit: ['assignments'],
                 },
               },
-            ],
-            remove: [
-              {
-                request: {
-                  endpoint: {
-                    path: '/test/{id}',
-                    method: 'delete',
-                  },
+            },
+            {
+              request: {
+                endpoint: {
+                  path: '/test/{id}/assign',
+                  method: 'post',
+                },
+                transformation: {
+                  rename: [
+                    {
+                      from: 'assignments',
+                      to: 'testField',
+                      onConflict: 'skip',
+                    },
+                  ],
+                  pick: ['testField'],
                 },
               },
-            ],
-          },
+              condition: {
+                custom: expect.any(Function),
+              },
+            },
+          ],
+          remove: [
+            {
+              request: {
+                endpoint: {
+                  path: '/test/{id}',
+                  method: 'delete',
+                },
+              },
+            },
+          ],
         },
       })
     })


### PR DESCRIPTION
Deploy scope tags one by one 

---

_Additional context for reviewer_

Tested when adding and removing multiple scope tags in the same deployments
Requests are enqueued one after the other

---
_Release Notes_: 

_Microsoft Security Adapter_:
- Fix a bug in deployment of Intune ScopeTags when deploying concurrently multiple tags.

---
_User Notifications_: 
None