### PR TITLE
Revert "SALTO-7443: Fix assigning lifecycle policy to Entra group is flaky (#7263)

### DIFF
--- a/packages/microsoft-security-adapter/jest.config.js
+++ b/packages/microsoft-security-adapter/jest.config.js
@@ -15,7 +15,7 @@ module.exports = deepMerge(require('../../jest.base.config.js'), {
   coverageThreshold: {
     global: {
       statements: 97.14,
-      branches: 85.91,
+      branches: 88.06,
       functions: 91.64,
       lines: 97.03,
     },

--- a/packages/microsoft-security-adapter/src/definitions/requests/clients.ts
+++ b/packages/microsoft-security-adapter/src/definitions/requests/clients.ts
@@ -41,10 +41,7 @@ export const createClientDefinitions = (
               polling: {
                 interval: 6000,
                 retries: 3,
-                checkStatus: response =>
-                  response.status === 200 ||
-                  (response.status === 400 &&
-                    _.get(response, 'data.error.message')?.includes('is already present in the policy')),
+                checkStatus: response => response.status === 200,
                 retryOnStatus: [404],
               },
             },


### PR DESCRIPTION
The fix didn’t solve the issue since we don’t use checkStatus when an error is thrown. See the relevant code: https://github.com/salto-io/salto/blob/3592a0cde603d8039173bc53702dd58b62e8a055/packages/adapter-components/src/client/polling.ts#L24-L32.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
