### PR TITLE
SALTO-7474: Fixing failing SFDX dump UT

### DIFF
--- a/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
+++ b/packages/salesforce-adapter/test/sfdx_parser/sfdx_dump.test.ts
@@ -294,8 +294,8 @@ describe('dumpElementsToFolder', () => {
 <CustomField xmlns="http://soap.sforce.com/2006/04/metadata">
     <fullName>New__c</fullName>
     <type>Text</type>
-    <length>80</length>
     <required>false</required>
+    <length>80</length>
 </CustomField>
 `)
       })


### PR DESCRIPTION
No clear why it started failing after 7 months of stability. For now just aligning the expected output with what we're getting. If this happens again we should make the test more resilient to changes like this.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
