### PR TITLE
SALTO-7456: Add reference from Form to CustomFieldContextOption

### DIFF
--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -220,7 +220,7 @@ const filter: FilterCreator = ({ config, client, fetchQuery }) => ({
       .filter(isDefined)
 
     forms.forEach(form => {
-      if (form.value.design?.conditions && config.fetch.splitFieldContextOptions) {
+      if ((form.value.design?.conditions || form.value.design?.questions) && config.fetch.splitFieldContextOptions) {
         transformFormValues(form)
       }
       form.value = mapKeysRecursive(form.value, ({ key }) => naclCase(key))

--- a/packages/jira-adapter/src/filters/forms/forms.ts
+++ b/packages/jira-adapter/src/filters/forms/forms.ts
@@ -66,7 +66,8 @@ const transformFormValues = (form: InstanceElement): void => {
       if (
         path !== undefined &&
         !isTransformedFormObject(value) &&
-        form.elemID.createNestedID('design', 'conditions').isParentOf(path) &&
+        (form.elemID.createNestedID('design', 'conditions').isParentOf(path) ||
+          (form.elemID.createNestedID('design', 'questions').isParentOf(path) && path.name === 'defaultAnswer')) &&
         Object.values(value).some(Array.isArray)
       ) {
         const newValue = Object.entries(value).map(([key, val]) => ({ key, value: val }))

--- a/packages/jira-adapter/src/filters/forms/forms_types.ts
+++ b/packages/jira-adapter/src/filters/forms/forms_types.ts
@@ -137,6 +137,17 @@ export const createFormType = (): {
       },
     },
   })
+  const defaultAnswerType = new ObjectType({
+    elemID: new ElemID(JIRA, 'DefaultAnswer'),
+    fields: {
+      key: {
+        refType: BuiltinTypes.STRING,
+      },
+      value: {
+        refType: new ListType(BuiltinTypes.STRING),
+      },
+    },
+  })
   const questionType = new ObjectType({
     elemID: new ElemID(JIRA, 'Question'),
     fields: {
@@ -154,6 +165,9 @@ export const createFormType = (): {
       },
       jiraField: {
         refType: BuiltinTypes.STRING,
+      },
+      defaultAnswer: {
+        refType: new ListType(defaultAnswerType),
       },
     },
   })
@@ -260,6 +274,7 @@ export const createFormType = (): {
       conditionType,
       coType,
       cIdsType,
+      defaultAnswerType,
     ],
   }
 }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1187,6 +1187,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: PROJECT_ROLE_TYPE },
   },
+  {
+    src: { field: 'value', parentTypes: ['DefaultAnswer'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: FIELD_CONTEXT_OPTION_TYPE_NAME },
+  },
   // ScriptRunner
   {
     src: { field: 'projects', parentTypes: [SCRIPT_RUNNER_LISTENER_TYPE] },

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1190,7 +1190,6 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   {
     src: { field: 'value', parentTypes: ['DefaultAnswer'] },
     serializationStrategy: 'id',
-    missingRefStrategy: 'typeAndValue',
     target: { type: FIELD_CONTEXT_OPTION_TYPE_NAME },
   },
   // ScriptRunner
@@ -1463,15 +1462,17 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
   },
 ]
 
-/* Due to changes in the form structure during preDeploy and the resolution of references occurring during deploy,
- * the resolved reference definitions are unavailable. As a result, we need to explicitly specify the serialization strategy.
+/* Due to changes in the structure of form fields during `preDeploy`,
+ * resolved reference definitions are unavailable during reference resolution in `deploy`.
+ * Therefore, we need to explicitly define the serialization strategy to correctly resolve these references.
  */
-const getConditionsLookUpName: GetLookupNameFunc = ({ ref, path }) => {
+const getFormsLookUpName: GetLookupNameFunc = ({ ref, path }) => {
+  const fullName = path?.getFullName()
   if (
     path !== undefined &&
     path.typeName === 'Form' &&
-    (path.getFullName().includes('cIds') ||
-      (path.getFullName().includes('defaultAnswer') && path.getFullName().includes('choices')))
+    fullName !== undefined &&
+    (fullName.includes('cIds') || (fullName.includes('defaultAnswer') && fullName.includes('choices')))
   ) {
     return ref.value.value.id
   }
@@ -1480,7 +1481,7 @@ const getConditionsLookUpName: GetLookupNameFunc = ({ ref, path }) => {
 
 const lookupNameFuncs: GetLookupNameFunc[] = [
   getFieldsLookUpName,
-  getConditionsLookUpName,
+  getFormsLookUpName,
   // The second param is needed to resolve references by serializationStrategy
   referenceUtils.generateLookupFunc(referencesRules, defs => new JiraFieldReferenceResolver(defs)),
 ]

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -1467,7 +1467,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
  * the resolved reference definitions are unavailable. As a result, we need to explicitly specify the serialization strategy.
  */
 const getConditionsLookUpName: GetLookupNameFunc = ({ ref, path }) => {
-  if (path !== undefined && path.typeName === 'Form' && path.getFullName().includes('cIds')) {
+  if (
+    path !== undefined &&
+    path.typeName === 'Form' &&
+    (path.getFullName().includes('cIds') ||
+      (path.getFullName().includes('defaultAnswer') && path.getFullName().includes('choices')))
+  ) {
     return ref.value.value.id
   }
   return ref

--- a/packages/jira-adapter/test/filters/forms/forms.test.ts
+++ b/packages/jira-adapter/test/filters/forms/forms.test.ts
@@ -38,6 +38,9 @@ describe('forms filter', () => {
     id: '123456',
     name: 'project1',
   })
+  const CustomFieldContextOptionInstance2 = new InstanceElement('choices1', CustomFieldContextOptionType, {
+    id: '123',
+  })
   let projectInstance: InstanceElement
   let elements: Element[]
   afterEach(() => {
@@ -147,6 +150,9 @@ describe('forms filter', () => {
                   },
                 ],
                 questionKey: '',
+                defaultAnswer: {
+                  choices: ['123'],
+                },
               },
             },
           },
@@ -234,6 +240,12 @@ describe('forms filter', () => {
                 },
               ],
               questionKey: '',
+              defaultAnswer: [
+                {
+                  key: 'choices',
+                  value: ['123'],
+                },
+              ],
             },
           },
         },
@@ -681,6 +693,16 @@ describe('forms filter', () => {
                   },
                 ],
                 questionKey: '',
+                defaultAnswer: [
+                  {
+                    choices: [
+                      new ReferenceExpression(
+                        CustomFieldContextOptionInstance2.elemID,
+                        CustomFieldContextOptionInstance2,
+                      ),
+                    ],
+                  },
+                ],
               },
             },
           },
@@ -731,6 +753,32 @@ describe('forms filter', () => {
                   t: 'sh',
                 },
               },
+              questions: {
+                2: {
+                  type: 'cs',
+                  label: 'What is the impact on IT resources?',
+                  description: '',
+                  validation: {
+                    rq: false,
+                  },
+                  choices: [
+                    {
+                      id: '1',
+                      label: 'No Risk – Involves a single IT resource from a workgroup',
+                    },
+                    {
+                      id: '2',
+                      label: 'Low Risk – Involves one workgroup from the same IT division',
+                    },
+                  ],
+                  questionKey: '',
+                  defaultAnswer: [
+                    {
+                      choices: ['123'],
+                    },
+                  ],
+                },
+              },
             }),
           }),
         }),
@@ -763,6 +811,32 @@ describe('forms filter', () => {
                     sIds: ['1'],
                   },
                   t: 'sh',
+                },
+              },
+              questions: {
+                2: {
+                  type: 'cs',
+                  label: 'What is the impact on IT resources?',
+                  description: '',
+                  validation: {
+                    rq: false,
+                  },
+                  choices: [
+                    {
+                      id: '1',
+                      label: 'No Risk – Involves a single IT resource from a workgroup',
+                    },
+                    {
+                      id: '2',
+                      label: 'Low Risk – Involves one workgroup from the same IT division',
+                    },
+                  ],
+                  questionKey: '',
+                  defaultAnswer: [
+                    {
+                      choices: ['123'],
+                    },
+                  ],
                 },
               },
             }),
@@ -912,6 +986,12 @@ describe('forms filter', () => {
                   },
                 ],
                 questionKey: '',
+                defaultAnswer: [
+                  {
+                    key: 'choices',
+                    value: ['123'],
+                  },
+                ],
               },
             },
           },
@@ -945,6 +1025,30 @@ describe('forms filter', () => {
           },
           o: {
             sIds: ['1'],
+          },
+        },
+      })
+      expect(formInstance.value.design.questions).toEqual({
+        2: {
+          type: 'cs',
+          label: 'What is the impact on IT resources?',
+          description: '',
+          validation: {
+            rq: false,
+          },
+          choices: [
+            {
+              id: '1',
+              label: 'No Risk – Involves a single IT resource from a workgroup',
+            },
+            {
+              id: '2',
+              label: 'Low Risk – Involves one workgroup from the same IT division',
+            },
+          ],
+          questionKey: '',
+          defaultAnswer: {
+            choices: ['123'],
           },
         },
       })


### PR DESCRIPTION
#### Added reference from Form to CustomFieldContextOption.
---
#### _Additional context for reviewer_:
#### Form field defaults were being deployed incorrectly while reporting a successful deployment. This happened because they relied on an 'id' that is different between environments. Previously, the defaults were stored as raw IDs, To resolve this, they have now been updated to use key-value objects, where value is a reference expression.
---
_Release Notes_: 
_Jira_adapter_:
- Users can now safely deploy forms that include default form fields.
---
_User Notifications_: 
- The default answer field in the forms NACL has been updated. It previously stored 'choices' as a list of string IDs. It has now been updated to use a list of key-value objects, where the IDs have been converted to references.