### PR TITLE
SALTO-7409: Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -305,20 +305,6 @@ const sendChunked = async <TIn, TOut>({
   const sendSingleChunk = async (chunkInput: TIn[]): Promise<SendChunkedResult<TIn, TOut>> => {
     try {
       log.debug('Sending chunked %s on %o', operationInfo, chunkInput)
-      const isStringArray = (value: unknown): value is string[] =>
-        Array.isArray(value) && value.every(item => typeof item === 'string')
-      if (
-        (isStringArray(chunkInput) && chunkInput.includes('SalesCloudMobile_UtilityBar')) ||
-        (_.isString(chunkInput) && chunkInput === 'SalesCloudMobile_UtilityBar')
-      ) {
-        throw new Error('INSUFFICIENT_ACCESS: insufficient access rights on entity: SalesCloudMobile_UtilityBar')
-      }
-      if (
-        (isStringArray(chunkInput) && chunkInput.includes('FlowsApp_UtilityBar')) ||
-        (_.isString(chunkInput) && chunkInput === 'FlowsApp_UtilityBar')
-      ) {
-        throw new Error('INSUFFICIENT_ACCESS: insufficient access rights on entity: FlowsApp_UtilityBar')
-      }
       const result = makeArray(await sendChunk(chunkInput)).map(flatValues)
       if (chunkSize === 1 && chunkInput.length > 0) {
         log.debug('Finished %s on %o', operationInfo, chunkInput[0])
@@ -939,20 +925,6 @@ export default class SalesforceClient implements ISalesforceClient {
     fetchProfile?: FetchProfile,
   ): Promise<RetrieveResult & { errors?: { type: string; instance: string; error: Error }[] }> {
     try {
-      if (
-        retrieveRequest.unpackaged?.types
-          .find(type => type.name === 'FlexiPage')
-          ?.members.includes('SalesCloudMobile_UtilityBar')
-      ) {
-        throw new Error('INSUFFICIENT_ACCESS: insufficient access rights on entity: FlexiPage')
-      }
-      if (
-        retrieveRequest.unpackaged?.types
-          .find(type => type.name === 'FlexiPage')
-          ?.members.includes('FlowsApp_UtilityBar')
-      ) {
-        throw new Error('INSUFFICIENT_ACCESS: insufficient access rights on entity: FlexiPage')
-      }
       return flatValues(await this.retryOnBadResponse(() => this.conn.metadata.retrieve(retrieveRequest).complete()))
     } catch (e) {
       const typesWithInsufficientAccess = new Set<string>()

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -967,11 +967,14 @@ export default class SalesforceClient implements ISalesforceClient {
             return type
           }) ?? []
       }
-      const retrieveResult = await this.retrieve(retrieveRequest)
-      return {
-        ...retrieveResult,
-        errors: [...(retrieveResult.errors ?? []), ...instancesErrors],
+      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+        const retrieveResult = await this.retrieve(retrieveRequest)
+        return {
+          ...retrieveResult,
+          errors: [...(retrieveResult.errors ?? []), ...instancesErrors],
+        }
       }
+      throw e
     }
   }
 

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -935,7 +935,8 @@ export default class SalesforceClient implements ISalesforceClient {
   @logDecorator()
   @requiresLogin()
   public async retrieve(
-    retrieveRequest: RetrieveRequest & { fetchProfile?: FetchProfile },
+    retrieveRequest: RetrieveRequest,
+    fetchProfile?: FetchProfile,
   ): Promise<RetrieveResult & { errors?: { type: string; instance: string; error: Error }[] }> {
     try {
       if (
@@ -978,7 +979,7 @@ export default class SalesforceClient implements ISalesforceClient {
             errors.forEach(({ input, error }) => {
               if (error.message.match(errorPattern)) {
                 log.debug(`Failed to read ${failedType}.${input} due to: ${error.message}`)
-                if (retrieveRequest.fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+                if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
                   instancesErrors.push({ type: failedType, instance: input, error })
                   instancesWithInsufficientAccess.add(input)
                 }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import _, { concat } from 'lodash'
+import _ from 'lodash'
 import { EOL } from 'os'
 import requestretry, { RequestRetryOptions, RetryStrategies, RetryStrategy } from 'requestretry'
 import { collections, decorators, hash } from '@salto-io/lowerdash'
@@ -937,7 +937,7 @@ export default class SalesforceClient implements ISalesforceClient {
         matches.map(async match => {
           const failedType = match[1]
           typesWithInsufficientAccess.add(failedType)
-          log.debug(`Failed to retrieve due ${concat(match[0], match[1])}`)
+          log.debug(`Failed to retrieve due ${match[0] + match[1]}`)
           log.debug('Reading each instance separately to find the ones with insufficient access rights')
           const instancesOfFailedType = unpackaged.types.find(t => t.name === failedType)?.members ?? []
           const { errors } = await sendChunked({

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -944,7 +944,7 @@ export default class SalesforceClient implements ISalesforceClient {
           typesWithInsufficientAccess.add(failedType)
           log.debug(`Failed to retrieve due ${match[0] + match[1]}`)
           log.debug('Reading each instance separately to find the ones with insufficient access rights')
-          const instancesOfFailedType = unpackaged?.types.find(t => t.name === failedType)?.members ?? []
+          const instancesOfFailedType = unpackaged.types.find(t => t.name === failedType)?.members ?? []
           const { errors } = await sendChunked({
             input: instancesOfFailedType,
             chunkSize: 1,

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -463,7 +463,7 @@ export const retrieveMetadataInstances = async ({
     const typesToRetrieve = [...new Set(filesToRetrieve.map(prop => prop.type))].join(',')
     log.debug('retrieving types %s', typesToRetrieve)
     const request = toRetrieveRequest(filesToRetrieve)
-    const result = await client.retrieve(request)
+    const result = await client.retrieve(request, fetchProfile)
 
     log.debug('retrieve result for types %s: %o', typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']))
 

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -467,6 +467,18 @@ export const retrieveMetadataInstances = async ({
 
     log.debug('retrieve result for types %s: %o', typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']))
 
+    if (result.errors && result.errors.length > 0) {
+      result.errors.forEach(({ type, instance, error }) => {
+        configChanges.push(
+          createSkippedListConfigChange({
+            type,
+            instance,
+            reason: error.message,
+          }),
+        )
+      })
+    }
+
     if (result.errorStatusCode === RETRIEVE_SIZE_LIMIT_ERROR) {
       if (fileProps.length <= 1) {
         if (filePropsToSendWithEveryChunk.length > 0) {

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -27,6 +27,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   supportProfileTabVisibilities: false,
   disablePermissionsOmissions: true,
   omitStandardFieldsNonDeployableValues: true,
+  handleInsufficientAccessRightsOnEntity: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -109,6 +109,7 @@ const OPTIONAL_FEATURES = [
   'supportProfileTabVisibilities',
   'disablePermissionsOmissions',
   'omitStandardFieldsNonDeployableValues',
+  'handleInsufficientAccessRightsOnEntity',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2979,10 +2979,9 @@ describe('Fetch via retrieve API', () => {
         } catch (error) {
           expect(metadataRetrieveSpy).toHaveBeenCalledOnce()
           expect(error.message).toEqual(typeError)
-          expect(metadataReadSpy).toHaveBeenCalledWith(
-            'ApexClass',
-            expect.arrayContaining(['SomeApexClass', 'ProblematicApexClass']),
-          )
+          expect(metadataReadSpy).toHaveBeenCalledTimes(2)
+          expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['SomeApexClass']))
+          expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['ProblematicApexClass']))
         }
       })
     })


### PR DESCRIPTION
SALTO-7409: Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

---
_Release Notes_: 
None

---
_User Notifications_: 
None
