### PR TITLE
SALTO-7478: (Bugfix) Remove references that cause field integrity exception

### DIFF
--- a/packages/salesforce-adapter/src/transformers/reference_mapping.ts
+++ b/packages/salesforce-adapter/src/transformers/reference_mapping.ts
@@ -1011,22 +1011,6 @@ export const fieldNameToTypeMappingDefs: FieldReferenceDefinition[] = [
     target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
   },
   {
-    src: {
-      field: 'leftValueReference',
-      parentTypes: ['FlowCondition'],
-    },
-    serializationStrategy: 'recordFieldDollarPrefix',
-    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
-  },
-  {
-    src: {
-      field: 'elementReference',
-      parentTypes: ['FlowElementReferenceOrValue'],
-    },
-    serializationStrategy: 'recordFieldDollarPrefix',
-    target: { parentContext: 'instanceParent', type: CUSTOM_FIELD },
-  },
-  {
     src: { field: 'logo', parentTypes: ['CustomApplication'] },
     target: { type: 'Document' },
   },


### PR DESCRIPTION
SALTO-7478: (Bugfix) Remove references that cause field integrity exception

---
_Release Notes_: 
None

---
_User Notifications_: 
None
