### PR TITLE
SALTO-7434 Refine validators config message

### DIFF
--- a/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
+++ b/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
@@ -17,7 +17,6 @@ import {
   UnresolvedReference,
   UnresolvedReferenceError,
   SaltoErrorType,
-  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   walkOnElement,
@@ -72,7 +71,7 @@ export const createOutgoingUnresolvedReferencesValidator =
           elemID: element.elemID,
           severity: 'Error' as SeverityLevel,
           message: ERROR_MESSAGES.UNRESOLVED_REFERENCE,
-          detailedMessage: `Element ${element.annotations[CORE_ANNOTATIONS.ALIAS] ?? element.elemID.getFullName()} contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+          detailedMessage: `This element contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
           unresolvedElemIds: unresolvedReferences,
           type: 'unresolvedReferences' as SaltoErrorType,
         }

--- a/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
+++ b/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
@@ -16,7 +16,8 @@ import {
   isAdditionOrModificationChange,
   UnresolvedReference,
   UnresolvedReferenceError,
-  SaltoErrorType, CORE_ANNOTATIONS,
+  SaltoErrorType,
+  CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
 import {
   walkOnElement,

--- a/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
+++ b/packages/adapter-components/src/deployment/change_validators/outgoing_unresolved_references.ts
@@ -16,9 +16,15 @@ import {
   isAdditionOrModificationChange,
   UnresolvedReference,
   UnresolvedReferenceError,
-  SaltoErrorType,
+  SaltoErrorType, CORE_ANNOTATIONS,
 } from '@salto-io/adapter-api'
-import { walkOnElement, WalkOnFunc, WALK_NEXT_STEP, getIndependentElemIDs } from '@salto-io/adapter-utils'
+import {
+  walkOnElement,
+  WalkOnFunc,
+  WALK_NEXT_STEP,
+  getIndependentElemIDs,
+  ERROR_MESSAGES,
+} from '@salto-io/adapter-utils'
 import { values, collections } from '@salto-io/lowerdash'
 
 const { awu } = collections.asynciterable
@@ -64,8 +70,8 @@ export const createOutgoingUnresolvedReferencesValidator =
         return {
           elemID: element.elemID,
           severity: 'Error' as SeverityLevel,
-          message: 'Element has unresolved references',
-          detailedMessage: `Element ${element.elemID.getFullName()} contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+          message: ERROR_MESSAGES.UNRESOLVED_REFERENCE,
+          detailedMessage: `Element ${element.annotations[CORE_ANNOTATIONS.ALIAS] ?? element.elemID.getFullName()} contains unresolved references: ${unresolvedReferences.map(e => e.getFullName()).join(', ')}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
           unresolvedElemIds: unresolvedReferences,
           type: 'unresolvedReferences' as SaltoErrorType,
         }

--- a/packages/adapter-components/test/deployment/change_validators/outgoing_unresolved_references.test.ts
+++ b/packages/adapter-components/test/deployment/change_validators/outgoing_unresolved_references.test.ts
@@ -27,7 +27,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([unresolvedElemId])
   })
@@ -46,7 +46,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([unresolvedElemId])
     expect(errors[0].type).toEqual('unresolvedReferences')
@@ -64,7 +64,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(type.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([unresolvedElemId])
     expect(errors[0].type).toEqual('unresolvedReferences')
@@ -87,7 +87,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(type.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${type.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([unresolvedElemId])
     expect(errors[0].type).toEqual('unresolvedReferences')
@@ -105,7 +105,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${instance.elemID.getFullName()} contains unresolved references: ${typeElemID.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${typeElemID.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([typeElemID])
   })
@@ -124,7 +124,7 @@ describe('unresolved_references', () => {
     expect(errors).toHaveLength(1)
     expect(errors[0].elemID).toEqual(instance.elemID)
     expect(errors[0].detailedMessage).toEqual(
-      `Element ${instance.elemID.getFullName()} contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
+      `This element contains unresolved references: ${unresolvedElemId.getFullName()}. Add the missing dependencies and try again. To learn more about fixing this error, go to https://help.salto.io/en/articles/6947056-element-contains-unresolved-references`,
     )
     expect(errors[0].unresolvedElemIds).toEqual([unresolvedElemId])
     expect(errors[0].type).toEqual('unresolvedReferences')

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -70,7 +70,7 @@ export abstract class ValidationError
   message = ERROR_MESSAGES.INVALID_NACL_CONTENT
 
   get detailedMessage(): string {
-    return `Error validating element: ${this.error}`
+    return this.error
   }
 
   toString(): string {
@@ -188,7 +188,7 @@ export class InvalidTypeValidationError extends ValidationError {
   constructor(readonly elemID: ElemID) {
     super({
       elemID,
-      error: `type ${elemID.typeName} of instance ${elemID.name} does not exist`,
+      error: `Type ${elemID.typeName} of instance ${elemID.name} does not exist`,
       severity: 'Warning',
     })
   }
@@ -342,7 +342,11 @@ export class AdditionalPropertiesValidationError extends ValidationError {
 export class UnresolvedReferenceValidationError extends ValidationError {
   readonly target: ElemID
   constructor({ elemID, target }: { elemID: ElemID; target: ElemID }) {
-    super({ elemID, error: `unresolved reference ${target.getFullName()}`, severity: 'Warning' })
+    super({
+      elemID,
+      error: `Unresolved reference ${target.getFullName()}`,
+      severity: 'Warning'
+    })
     this.target = target
   }
 
@@ -355,7 +359,7 @@ export const isUnresolvedRefError = (err: SaltoError): err is UnresolvedReferenc
 export class IllegalReferenceValidationError extends ValidationError {
   readonly reason: string
   constructor({ elemID, reason }: { elemID: ElemID; reason: string }) {
-    super({ elemID, error: `illegal reference target, ${reason}`, severity: 'Warning' })
+    super({ elemID, error: `Illegal reference target, ${reason}`, severity: 'Warning' })
     this.reason = reason
   }
 }
@@ -363,7 +367,7 @@ export class IllegalReferenceValidationError extends ValidationError {
 export class CircularReferenceValidationError extends ValidationError {
   readonly ref: string
   constructor({ elemID, ref }: { elemID: ElemID; ref: string }) {
-    super({ elemID, error: `circular reference ${ref}`, severity: 'Warning' })
+    super({ elemID, error: `Circular reference ${ref}`, severity: 'Warning' })
     this.ref = ref
   }
 }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -345,7 +345,7 @@ export class UnresolvedReferenceValidationError extends ValidationError {
     super({
       elemID,
       error: `Unresolved reference ${target.getFullName()}`,
-      severity: 'Warning'
+      severity: 'Warning',
     })
     this.target = target
   }

--- a/packages/workspace/src/validator.ts
+++ b/packages/workspace/src/validator.ts
@@ -70,7 +70,7 @@ export abstract class ValidationError
   message = ERROR_MESSAGES.INVALID_NACL_CONTENT
 
   get detailedMessage(): string {
-    return `Error validating "${this.elemID.getFullName()}": ${this.error}`
+    return `Error validating element: ${this.error}`
   }
 
   toString(): string {

--- a/packages/workspace/test/validator.test.ts
+++ b/packages/workspace/test/validator.test.ts
@@ -854,15 +854,15 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(2)
           expect(errors[0].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[0].elemID.getFullName()).toMatch('salto.nested.instance.nested_inst')
           expect(errors[0].detailedMessage).toMatch(
-            'Error validating "salto.nested.instance.nested_inst":' +
-              " Field 'additional' is not defined in the 'nested' type which does not allow additional properties.",
+            "Field 'additional' is not defined in the 'nested' type which does not allow additional properties.",
           )
           expect(errors[0].elemID).toEqual(extInst.elemID)
           expect(errors[1].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[1].elemID.getFullName()).toMatch('salto.nested.instance.nested_inst')
           expect(errors[1].detailedMessage).toMatch(
-            'Error validating "salto.nested.instance.nested_inst":' +
-              " Field 'additional2' is not defined in the 'nested' type which does not allow additional properties.",
+            "Field 'additional2' is not defined in the 'nested' type which does not allow additional properties.",
           )
           expect(errors[1].elemID).toEqual(extInst.elemID)
         })
@@ -911,9 +911,9 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(1)
           expect(errors[0].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[0].elemID.getFullName()).toMatch('salto.nested.instance.nested_inst.reqNested')
           expect(errors[0].detailedMessage).toMatch(
-            'Error validating "salto.nested.instance.nested_inst.reqNested":' +
-              " Field 'additional' is not defined in the 'simple' type which does not allow additional properties.",
+            "Field 'additional' is not defined in the 'simple' type which does not allow additional properties.",
           )
           temp.annotations = simpleTypeClone.annotations
         })
@@ -944,19 +944,19 @@ describe('Elements validation', () => {
           )
           expect(errors).toHaveLength(3)
           expect(errors[0].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[0].elemID.getFullName()).toMatch('salto.top.instance.test_inst.mapFieldValidating.d')
           expect(errors[0].detailedMessage).toMatch(
-            'Error validating "salto.top.instance.test_inst.mapFieldValidating.d":' +
-              " Field 'additional4' is not defined in the 'validating' type which does not allow additional properties.",
+            "Field 'additional4' is not defined in the 'validating' type which does not allow additional properties.",
           )
           expect(errors[1].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[1].elemID.getFullName()).toMatch('salto.top.instance.test_inst.listFieldValidating.0')
           expect(errors[1].detailedMessage).toMatch(
-            'Error validating "salto.top.instance.test_inst.listFieldValidating.0":' +
-              " Field 'additional2' is not defined in the 'validating' type which does not allow additional properties.",
+            "Field 'additional2' is not defined in the 'validating' type which does not allow additional properties.",
           )
           expect(errors[2].message).toMatch(INVALID_NACL_CONTENT_ERROR)
+          expect(errors[2].elemID.getFullName()).toMatch('salto.top.instance.test_inst.listFieldValidating.2')
           expect(errors[2].detailedMessage).toMatch(
-            'Error validating "salto.top.instance.test_inst.listFieldValidating.2":' +
-              " Field 'additional3' is not defined in the 'validating' type which does not allow additional properties.",
+            "Field 'additional3' is not defined in the 'validating' type which does not allow additional properties.",
           )
         })
       })
@@ -2095,9 +2095,8 @@ describe('Elements validation', () => {
       const errors = await getValidationErrors([instance], createInMemoryElementSource([instance]))
       expect(errors).toHaveLength(1)
       expect(errors[0].message).toMatch(INVALID_NACL_CONTENT_ERROR)
-      expect(errors[0].detailedMessage).toBe(
-        'Error validating "instance.notExists.instance.name": type notExists of instance name does not exist',
-      )
+      expect(errors[0].elemID.getFullName()).toBe('instance.notExists.instance.name')
+      expect(errors[0].detailedMessage).toBe('Type notExists of instance name does not exist')
     })
 
     it('should handle circular references in the same instance', async () => {
@@ -2148,9 +2147,8 @@ describe('Elements validation', () => {
         error: new MissingStaticFile('path').message,
       })
       expect(invalidStaticFileError.message).toMatch(INVALID_NACL_CONTENT_ERROR)
-      expect(invalidStaticFileError.detailedMessage).toEqual(
-        'Error validating "adapter.bla": Missing static file: path',
-      )
+      expect(invalidStaticFileError.elemID.getFullName()).toEqual('adapter.bla')
+      expect(invalidStaticFileError.detailedMessage).toEqual('Missing static file: path')
     })
 
     it('should have correct message for invalid', () => {
@@ -2159,9 +2157,8 @@ describe('Elements validation', () => {
         error: new AccessDeniedStaticFile('path').message,
       })
       expect(invalidStaticFileError.message).toMatch(INVALID_NACL_CONTENT_ERROR)
-      expect(invalidStaticFileError.detailedMessage).toEqual(
-        'Error validating "adapter.bla": Unable to access static file: path',
-      )
+      expect(invalidStaticFileError.elemID.getFullName()).toEqual('adapter.bla')
+      expect(invalidStaticFileError.detailedMessage).toEqual('Unable to access static file: path')
     })
   })
 })

--- a/packages/workspace/test/workspace/workspace.test.ts
+++ b/packages/workspace/test/workspace/workspace.test.ts
@@ -696,11 +696,10 @@ describe('workspace', () => {
 
       const errors = await erroredWorkspace.errors()
       expect(errors.hasErrors()).toBeTruthy()
-      expect(errors.strings()).toEqual(['unresolved reference some.type.instance.notExists'])
+      expect(errors.strings()).toEqual(['Unresolved reference some.type.instance.notExists'])
       expect(errors.validation[0].message).toBe('Element has unresolved references')
-      expect(errors.validation[0].detailedMessage).toBe(
-        'Error validating "some.type.instance.instance.a": unresolved reference some.type.instance.notExists',
-      )
+      expect(errors.validation[0].elemID.getFullName()).toBe('some.type.instance.instance.a')
+      expect(errors.validation[0].detailedMessage).toBe('Unresolved reference some.type.instance.notExists')
 
       expect(await erroredWorkspace.hasErrors()).toBeTruthy()
       const workspaceErrors = await Promise.all(wu(errors.all()).map(error => erroredWorkspace.transformError(error)))


### PR DESCRIPTION
Validators' config messages look bad when the elemId is very long. Given the fact we already have the elemId as another field, should we omit it? Like we do in CV messages. We have these messages in the CLI as well, need to take into consideration.

Options:
1. Write a general term instead ('element' for example)
2. Provide the alias and use it instead.
3. Move the elemId to the end of the message

Attached approach (1) for a single validator. We'll need to do the same for all the rest once having a decision.

Current state:
<img width="834" alt="Screen Shot 2025-02-23 at 20 54 15" src="https://github.com/user-attachments/assets/8e0b68db-4d95-470a-969f-4c12ba4cf391" />

---

_Additional context for reviewer_
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None
