### PR TITLE
SALTO-7496: Fix service URL computation for deep-path into parent instances

### DIFF
--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -66,9 +66,7 @@ export const addUrlToInstance: <Options extends FetchApiDefinitionsOptions = {}>
   )
   const parentContext = parentValues?.reduce((result: Values, parentVal: Values, idx: number) => {
     Object.entries(parentVal).forEach(([key, value]) => {
-      // Fancy one-liner for doing "result._parent[idx][key] = value" while initializing all intermediate missing objects.
-      // eslint-disable-next-line no-underscore-dangle
-      ;((result._parent ??= {})[idx] ??= {})[key] = value
+      _.set(result, `_parent.${idx}.${key}`, value)
     })
     return result
   }, {})

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -66,7 +66,9 @@ export const addUrlToInstance: <Options extends FetchApiDefinitionsOptions = {}>
   )
   const parentContext = parentValues?.reduce((result: Values, parentVal: Values, idx: number) => {
     Object.entries(parentVal).forEach(([key, value]) => {
-      result[`_parent.${idx}.${key}`] = value
+      // Fancy one-liner for doing "result._parent[idx][key] = value" while initializing all intermediate missing objects.
+      // eslint-disable-next-line no-underscore-dangle
+      ((result._parent ??= {})[idx] ??= {})[key] = value
     })
     return result
   }, {})

--- a/packages/adapter-components/src/filters/service_url.ts
+++ b/packages/adapter-components/src/filters/service_url.ts
@@ -68,7 +68,7 @@ export const addUrlToInstance: <Options extends FetchApiDefinitionsOptions = {}>
     Object.entries(parentVal).forEach(([key, value]) => {
       // Fancy one-liner for doing "result._parent[idx][key] = value" while initializing all intermediate missing objects.
       // eslint-disable-next-line no-underscore-dangle
-      ((result._parent ??= {})[idx] ??= {})[key] = value
+      ;((result._parent ??= {})[idx] ??= {})[key] = value
     })
     return result
   }, {})

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -23,7 +23,7 @@ describe('service url filter', () => {
   type FilterType = FilterWith<'onFetch' | 'onDeploy'>
   let filter: FilterType
   const roleObjType = new ObjectType({ elemID: new ElemID('adapter', 'role') })
-  const roleInst = new InstanceElement('role', roleObjType, { id: 11, name: 'role' })
+  const roleInst = new InstanceElement('role', roleObjType, { id: 11, name: 'role', obj: { inner: 'bar'} })
   const testObjType = new ObjectType({ elemID: new ElemID('adapter', 'test') })
   const testInst = new InstanceElement('test', testObjType, { id: 11, name: 'test' })
   const baseUrl = 'https://www.example.com'
@@ -51,7 +51,7 @@ describe('service url filter', () => {
               },
             },
             foo: {
-              transformation: { serviceUrl: 'roles/{_parent.0.id}/foo/{id}' },
+              transformation: { serviceUrl: 'roles/{_parent.0.id}/foo/{_parent.0.obj.inner}/{id}' },
             },
           },
           typeDefaults: {
@@ -75,7 +75,7 @@ describe('service url filter', () => {
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
-      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/ab')
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/bar/ab')
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const elements = [testInst].map(e => e.clone())
@@ -101,7 +101,7 @@ describe('service url filter', () => {
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
-      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/ab')
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/bar/ab')
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const changes = [testInst].map(e => e.clone()).map(inst => toChange({ after: inst }))

--- a/packages/adapter-components/test/filters/service_url.test.ts
+++ b/packages/adapter-components/test/filters/service_url.test.ts
@@ -23,7 +23,7 @@ describe('service url filter', () => {
   type FilterType = FilterWith<'onFetch' | 'onDeploy'>
   let filter: FilterType
   const roleObjType = new ObjectType({ elemID: new ElemID('adapter', 'role') })
-  const roleInst = new InstanceElement('role', roleObjType, { id: 11, name: 'role', obj: { inner: 'bar'} })
+  const roleInst = new InstanceElement('role', roleObjType, { id: 11, name: 'role', obj: { inner: 'bar' } })
   const testObjType = new ObjectType({ elemID: new ElemID('adapter', 'test') })
   const testInst = new InstanceElement('test', testObjType, { id: 11, name: 'test' })
   const baseUrl = 'https://www.example.com'
@@ -75,7 +75,9 @@ describe('service url filter', () => {
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
-      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/bar/ab')
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        'https://www.example.com/roles/11/foo/bar/ab',
+      )
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const elements = [testInst].map(e => e.clone())
@@ -101,7 +103,9 @@ describe('service url filter', () => {
       expect(role.annotations).toEqual({
         [CORE_ANNOTATIONS.SERVICE_URL]: 'https://www.example.com/roles/11',
       })
-      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual('https://www.example.com/roles/11/foo/bar/ab')
+      expect(withParent.annotations[CORE_ANNOTATIONS.SERVICE_URL]).toEqual(
+        'https://www.example.com/roles/11/foo/bar/ab',
+      )
     })
     it('should not add service url annotation if it is not exist in the config', async () => {
       const changes = [testInst].map(e => e.clone()).map(inst => toChange({ after: inst }))


### PR DESCRIPTION
When defining a service URL, we can use “template args” like so: `/account/{_parent.0.id}/home`. However, it fails to process args that use deep attribute under a parent, e.g., `_parent.0.account.id`. 

This is due to the fact that _parent has special handling, and we actually insert `_parent.0.account` into the context args. We then call lodash `_.get`, but it can’t handle string paths if one of the keys has dots in its name.

This PR changes the parent attributes insertion into args, to insert nested objects instead.

---

_Additional context for reviewer_:
None

---
_Release Notes_: 
None

---
_User Notifications_: 
None