### PR TITLE
SALTO-7409: (Bugfix) Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

### DIFF
--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -470,23 +470,21 @@ export const retrieveMetadataInstances = async ({
     if (result.errors !== undefined && result.errors.length > 0) {
       if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
         log.debug('Excluding non retrievable instances:')
-        result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
-        if (result.errors && result.errors.length > 0) {
-          result.errors.forEach(({ type, instance, error }) => {
-            configChanges.push(
-              createSkippedListConfigChange({
-                type,
-                instance,
-                reason: error.message,
-              }),
-            )
-          })
-        }
+        result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
+        result.errors.forEach(({ type, instance, error }) => {
+          configChanges.push(
+            createSkippedListConfigChange({
+              type,
+              instance,
+              reason: error.message,
+            }),
+          )
+        })
       } else {
         log.debug(
           'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion:',
         )
-        result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
+        result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
       }
     }
 

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -467,25 +467,27 @@ export const retrieveMetadataInstances = async ({
 
     log.debug('retrieve result for types %s: %o', typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']))
 
-    if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
-      log.debug('Excluding non retrievable instances:')
-      result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
-      if (result.errors && result.errors.length > 0) {
-        result.errors.forEach(({ type, instance, error }) => {
-          configChanges.push(
-            createSkippedListConfigChange({
-              type,
-              instance,
-              reason: error.message,
-            }),
-          )
-        })
+    if (result.errors !== undefined && result.errors.length > 0) {
+      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+        log.debug('Excluding non retrievable instances:')
+        result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
+        if (result.errors && result.errors.length > 0) {
+          result.errors.forEach(({ type, instance, error }) => {
+            configChanges.push(
+              createSkippedListConfigChange({
+                type,
+                instance,
+                reason: error.message,
+              }),
+            )
+          })
+        }
+      } else {
+        log.debug(
+          'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion:',
+        )
+        result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
       }
-    } else {
-      log.debug(
-        'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion:',
-      )
-      result.errors?.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
     }
 
     if (result.errorStatusCode === RETRIEVE_SIZE_LIMIT_ERROR) {

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -470,8 +470,8 @@ export const retrieveMetadataInstances = async ({
     if (result.errors !== undefined && result.errors.length > 0) {
       if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
         log.debug('Excluding non retrievable instances:')
-        result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
         result.errors.forEach(({ type, instance, error }) => {
+          log.debug(`Type: ${type}, Instance: ${instance}`)
           configChanges.push(
             createSkippedListConfigChange({
               type,


### PR DESCRIPTION
SALTO-7409: (Bugfix) Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

---

_Additional context for reviewer_:
- The error was not detected because it is received through a RetrieveResult errorMessage rather than a thrown error.
- Removed the error from the suppressed errors in readMetadata.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
