### PR TITLE
DOC-123: add salto management field to the examples

### DIFF
--- a/packages/salesforce-adapter/cpq-sbaa-config-doc.md
+++ b/packages/salesforce-adapter/cpq-sbaa-config-doc.md
@@ -200,6 +200,9 @@ salesforce {
           User = "InternalId"
         }
       }
+      saltoManagementFieldSettings = {
+              defaultFieldName = "ManagedBySalto__c"
+      }
     }
   }
   maxItemsInRetrieveRequest = 2500
@@ -496,6 +499,9 @@ salesforce {
               ]
             },
           ]
+        }
+        saltoManagementFieldSettings = {
+              defaultFieldName = "ManagedBySalto__c"
         }
     }
   }


### PR DESCRIPTION
Update examples in md to expsoe salto manage field for salesforce data fetch config