### PR TITLE
SALTO-7409: (Bugfix-2) Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -928,53 +928,47 @@ export default class SalesforceClient implements ISalesforceClient {
     fetchProfile?: FetchProfile,
   ): Promise<RetrieveResultWithErrors> {
     const errorPattern = /INSUFFICIENT_ACCESS: insufficient access rights on entity: (\w+)/g
-    const handleInsufficientAccessErrors = async (
-      matches: RegExpMatchArray[],
-    ): Promise<{ instancesErrors: ErrorInfo[]; newRetrieveRequest: RetrieveRequest }> => {
+    const handleInsufficientAccessErrors = async (): Promise<{
+      instancesErrors: ErrorInfo[]
+      newRetrieveRequest: RetrieveRequest
+    }> => {
       if (retrieveRequest.unpackaged === undefined || retrieveRequest.unpackaged.types === undefined) {
         return { instancesErrors: [], newRetrieveRequest: retrieveRequest }
       }
       const typesWithInsufficientAccess = new Set<string>()
       const instancesWithInsufficientAccess = new Set<string>()
       const instancesErrors: ErrorInfo[] = []
-      const { unpackaged } = retrieveRequest
-      await Promise.all(
-        matches.map(async match => {
-          const failedType = match[1]
-          typesWithInsufficientAccess.add(failedType)
-          log.debug(`Failed to retrieve due ${match[0] + match[1]}`)
-          log.debug('Reading each instance separately to find the ones with insufficient access rights')
-          const instancesOfFailedType = unpackaged.types.find(t => t.name === failedType)?.members ?? []
-          const { errors } = await sendChunked({
-            input: instancesOfFailedType,
-            chunkSize: 1,
-            sendChunk: chunk => this.conn.metadata.read(failedType, chunk),
-            operationInfo: `readMetadata (${failedType})`,
-            isUnhandledError: () => false,
-          })
-          errors.forEach(({ input, error }) => {
-            if (error.message.match(errorPattern)) {
-              log.debug(`Failed to read ${failedType}.${input} due to: ${error.message}`)
-              instancesErrors.push({ type: failedType, instance: input, error })
-              instancesWithInsufficientAccess.add(input)
-            }
-          })
-        }),
-      )
+      await retrieveRequest.unpackaged.types.reduce(async (prevPromise, type) => {
+        await prevPromise
+        const { errors } = await sendChunked({
+          input: type.members,
+          chunkSize: type.members.length,
+          sendChunk: chunk => this.conn.metadata.read(type.name, chunk),
+          operationInfo: `readMetadata (${type.name})`,
+          isUnhandledError: () => false,
+        })
+        errors.forEach(({ input, error }) => {
+          if (error.message.match(errorPattern)) {
+            log.debug(`Failed to read ${type.name}.${input} due to: ${error.message}`)
+            instancesErrors.push({ type: type.name, instance: input, error })
+            typesWithInsufficientAccess.add(type.name)
+            instancesWithInsufficientAccess.add(input)
+          }
+        })
+      }, Promise.resolve())
       const newRetrieveRequest = {
         ...retrieveRequest,
         unpackaged: {
-          ...unpackaged,
-          types:
-            unpackaged.types.map(type => {
-              if (typesWithInsufficientAccess.has(type.name)) {
-                return {
-                  ...type,
-                  members: type.members.filter(member => !instancesWithInsufficientAccess.has(member)),
-                }
+          ...retrieveRequest.unpackaged,
+          types: retrieveRequest.unpackaged.types.map(type => {
+            if (typesWithInsufficientAccess.has(type.name)) {
+              return {
+                ...type,
+                members: type.members.filter(member => !instancesWithInsufficientAccess.has(member)),
               }
-              return type
-            }) ?? retrieveRequest.unpackaged.types,
+            }
+            return type
+          }),
         },
       }
       return { instancesErrors, newRetrieveRequest }
@@ -985,30 +979,34 @@ export default class SalesforceClient implements ISalesforceClient {
     ) as RetrieveResult
     if (_.isString(result.zipFile)) return result
     const errorMessage = result.errorMessage ?? ''
-    const matches = [...errorMessage.matchAll(errorPattern)]
-    if (matches.length > 0) {
-      const { instancesErrors, newRetrieveRequest } = await handleInsufficientAccessErrors(matches)
-      log.debug('Found the following errors while trying to retrieve:')
-      instancesErrors.forEach(({ instance, error }) => {
-        log.debug(`Instance: ${instance}, Error: ${error.message}`)
-      })
-      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
-        log.debug(
-          'updating original retrieve request: %s to new retrieve request: %s',
-          inspectValue(retrieveRequest.unpackaged?.types),
-          inspectValue(newRetrieveRequest.unpackaged?.types),
-        )
-        const retrieveResult = await this.retrieve(newRetrieveRequest)
-        return {
-          ...retrieveResult,
-          errors: [...(retrieveResult.errors ?? []), ...instancesErrors],
+    if (errorMessage.match(errorPattern)) {
+      log.debug(`Failed to retrieve due to: ${errorMessage} reading each type separately`)
+      const { instancesErrors, newRetrieveRequest } = await handleInsufficientAccessErrors()
+      if (instancesErrors.length > 0) {
+        log.debug('Found the following errors while trying to retrieve:')
+        instancesErrors.forEach(({ instance, error }) => {
+          log.debug(`Instance: ${instance}, Error: ${error.message}`)
+        })
+        if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+          log.debug('Excluding the following instances from retrieve:')
+          instancesErrors.forEach(({ type, instance }) => {
+            log.debug(`Type: ${type}, Instance: ${instance}`)
+          })
+          const retrieveResult = await this.retrieve(newRetrieveRequest)
+          return {
+            ...retrieveResult,
+            errors: [...(retrieveResult.errors ?? []), ...instancesErrors],
+          }
         }
+        log.debug(
+          'handleInsufficientAccessRightsOnEntity is disabled. Logging instances without exclusion from retrieve:',
+        )
+        instancesErrors.forEach(({ type, instance }) => {
+          log.debug(`Type: ${type}, Instance: ${instance}`)
+        })
+      } else {
+        log.debug('No errors found while reading')
       }
-      log.debug(
-        'handleInsufficientAccessRightsOnEntity is disabled. Skipping retrieve call. original retrieve request: %s new retrieve request: %s',
-        inspectValue(retrieveRequest.unpackaged?.types),
-        inspectValue(newRetrieveRequest.unpackaged?.types),
-      )
     }
     return result
   }

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -942,7 +942,7 @@ export default class SalesforceClient implements ISalesforceClient {
         retrieveRequest.unpackaged.types.map(async type => {
           const { errors } = await sendChunked({
             input: type.members,
-            chunkSize: type.members.length,
+            chunkSize: MAX_ITEMS_IN_READ_METADATA_REQUEST,
             sendChunk: chunk => this.conn.metadata.read(type.name, chunk),
             operationInfo: `readMetadata (${type.name})`,
             isUnhandledError: () => false,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -947,7 +947,6 @@ export default class SalesforceClient implements ISalesforceClient {
             operationInfo: `readMetadata (${type.name})`,
             isUnhandledError: () => false,
           })
-
           errors.forEach(({ input, error }) => {
             if (error.message.match(errorPattern)) {
               log.debug(`Failed to read ${type.name}.${input} due to: ${error.message}`)

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -469,7 +469,7 @@ export const retrieveMetadataInstances = async ({
 
     if (result.errors !== undefined && result.errors.length > 0) {
       if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
-        log.debug('Excluding non retrievable instances:')
+        log.debug('Excluding non retrievable instances using config suggestion:')
         result.errors.forEach(({ type, instance, error }) => {
           log.debug(`Type: ${type}, Instance: ${instance}`)
           configChanges.push(
@@ -482,7 +482,7 @@ export const retrieveMetadataInstances = async ({
         })
       } else {
         log.debug(
-          'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion:',
+          'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion in config file:',
         )
         result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
       }

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2896,7 +2896,7 @@ describe('Fetch via retrieve API', () => {
     let fetchProfile: FetchProfile
     const retrieveResult = {
       done: 'true',
-      errorMessage: 'INSUFFICIENT_ACCESS: insufficient access rights on entity: ApexClass',
+      errorMessage: 'INSUFFICIENT_ACCESS: insufficient access rights on entity: ProblematicType',
       errorStatusCode: 'UNKNOWN_EXCEPTION',
       id: '09SVg000005gpT3MAI',
       status: 'Failed',
@@ -2912,6 +2912,7 @@ describe('Fetch via retrieve API', () => {
         { type: mockTypes.ApexClass, instanceName: 'SomeApexClass' },
         { type: mockTypes.ApexClass, instanceName: 'ProblematicApexClass' },
         { type: mockTypes.CustomObject, instanceName: 'Account' },
+        { type: mockTypes.CustomObject, instanceName: 'Lead' },
       ])
       connection.metadata.retrieve.mockImplementation(retrieveRequest => {
         const hasProblematicApexClass = retrieveRequest.unpackaged?.types.some(type =>
@@ -2964,9 +2965,16 @@ describe('Fetch via retrieve API', () => {
             },
           ]),
         )
-        expect(metadataReadSpy).toHaveBeenCalledTimes(2)
-        expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['SomeApexClass']))
+      })
+      it('should call read once for each type, and for the type that contains the problematic instance, there should be as many read calls as the number of members of that type', () => {
+        expect(metadataReadSpy).toHaveBeenCalledTimes(4)
+        expect(metadataReadSpy).toHaveBeenCalledWith('CustomObject', expect.arrayContaining(['Account', 'Lead']))
+        expect(metadataReadSpy).toHaveBeenCalledWith(
+          'ApexClass',
+          expect.arrayContaining(['SomeApexClass', 'ProblematicApexClass']),
+        )
         expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['ProblematicApexClass']))
+        expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['SomeApexClass']))
         expect(metadataRetrieveSpy).toHaveBeenCalledTimes(2)
         expect(metadataRetrieveSpy).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -3032,9 +3040,14 @@ describe('Fetch via retrieve API', () => {
           expect(error.message).toContain(
             `Retrieve request for ApexClass,CustomObject failed. messages: ${makeArray(safeJsonStringify(retrieveResult.messages)).concat(retrieveResult.errorMessage ?? [])}`,
           )
-          expect(metadataReadSpy).toHaveBeenCalledTimes(2)
-          expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['SomeApexClass']))
+          expect(metadataReadSpy).toHaveBeenCalledTimes(4)
+          expect(metadataReadSpy).toHaveBeenCalledWith('CustomObject', expect.arrayContaining(['Account', 'Lead']))
+          expect(metadataReadSpy).toHaveBeenCalledWith(
+            'ApexClass',
+            expect.arrayContaining(['SomeApexClass', 'ProblematicApexClass']),
+          )
           expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['ProblematicApexClass']))
+          expect(metadataReadSpy).toHaveBeenCalledWith('ApexClass', expect.arrayContaining(['SomeApexClass']))
         }
       })
     })


### PR DESCRIPTION
SALTO-7409: (Bugfix-2) Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

---

_Additional context for reviewer_:
- No read request was made because the problematic type is referenced but does not directly exist in the retrieve request.
- The log of the original and updated retrieve request is too long and not helpful. 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
