### PR TITLE
SALTO-7409: (Bugfix) Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in retrieve

### DIFF
--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -845,7 +845,7 @@ export default class SalesforceClient implements ISalesforceClient {
         // This seems to happen with actions that relate to sending emails - these are disabled in
         // some way on sandboxes and for some reason this causes the SF API to fail reading
         (this.credentials.isSandbox && type === 'QuickAction' && error.message === 'targetObject is invalid') ||
-        (error.name === 'sf:INSUFFICIENT_ACCESS' && !error.message.includes('insufficient access rights on entity')),
+        error.name === 'sf:INSUFFICIENT_ACCESS',
       isUnhandledError,
     })
   }


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_:
- INSUFFICIENT_ACCESS: insufficient access rights on entity throw error in readMetadata

---
_Release Notes_: 
None

---
_User Notifications_: 
None
