### PR TITLE
SALTO-7409: Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in readMetadata  

### DIFF
--- a/packages/salesforce-adapter/src/adapter.ts
+++ b/packages/salesforce-adapter/src/adapter.ts
@@ -954,6 +954,7 @@ export default class SalesforceAdapter implements SalesforceAdapterOperations {
       metadataQuery: fetchProfile.metadataQuery,
       maxInstancesPerType: fetchProfile.maxInstancesPerType,
       addNamespacePrefixToFullName: fetchProfile.addNamespacePrefixToFullName,
+      fetchProfile,
     })
     return {
       elements: instances.elements,

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -1002,7 +1002,7 @@ export default class SalesforceClient implements ISalesforceClient {
         instancesErrors.forEach(({ instance, error }) => {
           log.debug(`Instance: ${instance}, Error: ${error.message}`)
         })
-        if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntityInRetrieve')) {
+        if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
           log.debug('Excluding the following instances from retrieve:')
           instancesErrors.forEach(({ type, instance }) => {
             log.debug(`Type: ${type}, Instance: ${instance}`)
@@ -1014,7 +1014,7 @@ export default class SalesforceClient implements ISalesforceClient {
           }
         }
         log.debug(
-          'handleInsufficientAccessRightsOnEntityInRetrieve is disabled. Logging instances without exclusion from retrieve:',
+          'handleInsufficientAccessRightsOnEntity is disabled. Logging instances without exclusion from retrieve:',
         )
         instancesErrors.forEach(({ type, instance }) => {
           log.debug(`Type: ${type}, Instance: ${instance}`)

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -853,7 +853,7 @@ export default class SalesforceClient implements ISalesforceClient {
             // some way on sandboxes and for some reason this causes the SF API to fail reading
             (this.credentials.isSandbox && type === 'QuickAction' && error.message === 'targetObject is invalid') ||
             error.name === 'sf:INSUFFICIENT_ACCESS',
-      isUnhandledError,
+      isUnhandledError: isUnhandledError ?? isSFDCUnhandledException,
     })
   }
 

--- a/packages/salesforce-adapter/src/client/client.ts
+++ b/packages/salesforce-adapter/src/client/client.ts
@@ -842,7 +842,7 @@ export default class SalesforceClient implements ISalesforceClient {
       input: name,
       sendChunk: chunk => this.retryOnBadResponse(() => this.conn.metadata.read(type, chunk)),
       chunkSize: this.readMetadataChunkSize.overrides[type] ?? this.readMetadataChunkSize.default,
-      isSuppressedError: fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')
+      isSuppressedError: fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntityInRead')
         ? error =>
             // This seems to happen with actions that relate to sending emails - these are disabled in
             // some way on sandboxes and for some reason this causes the SF API to fail reading
@@ -1002,7 +1002,7 @@ export default class SalesforceClient implements ISalesforceClient {
         instancesErrors.forEach(({ instance, error }) => {
           log.debug(`Instance: ${instance}, Error: ${error.message}`)
         })
-        if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+        if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntityInRetrieve')) {
           log.debug('Excluding the following instances from retrieve:')
           instancesErrors.forEach(({ type, instance }) => {
             log.debug(`Type: ${type}, Instance: ${instance}`)
@@ -1014,7 +1014,7 @@ export default class SalesforceClient implements ISalesforceClient {
           }
         }
         log.debug(
-          'handleInsufficientAccessRightsOnEntity is disabled. Logging instances without exclusion from retrieve:',
+          'handleInsufficientAccessRightsOnEntityInRetrieve is disabled. Logging instances without exclusion from retrieve:',
         )
         instancesErrors.forEach(({ type, instance }) => {
           log.debug(`Type: ${type}, Instance: ${instance}`)

--- a/packages/salesforce-adapter/src/config_change.ts
+++ b/packages/salesforce-adapter/src/config_change.ts
@@ -23,7 +23,12 @@ import {
   MetadataQueryParams,
 } from './types'
 import * as constants from './constants'
-import { SALESFORCE_ERRORS, SalesforceErrorName, SOCKET_TIMEOUT } from './constants'
+import {
+  SALESFORCE_ERRORS,
+  SalesforceErrorName,
+  SOCKET_TIMEOUT,
+  INSUFFICIENT_ACCESS_RIGHTS_ON_ENTITY,
+} from './constants'
 
 const { isDefined } = values
 const { makeArray } = collections.array
@@ -124,7 +129,6 @@ const isInvalidCrossReferenceKeyError: CreateConfigSuggestionPredicate = (e: Err
   const errorCode = _.get(e, 'errorCode')
   return _.isString(errorCode) && errorCode === INVALID_CROSS_REFERENCE_KEY
 }
-const INSUFFICIENT_ACCESS_RIGHTS_ON_ENTITY = 'INSUFFICIENT_ACCESS: insufficient access rights on entity'
 const isInsufficientAccessRightsOnEntitySalesforceError: CreateConfigSuggestionPredicate = (e: Error): boolean =>
   e.name === INSUFFICIENT_ACCESS && e.message.includes(INSUFFICIENT_ACCESS_RIGHTS_ON_ENTITY)
 

--- a/packages/salesforce-adapter/src/constants.ts
+++ b/packages/salesforce-adapter/src/constants.ts
@@ -814,6 +814,7 @@ export type ErrorProperty = types.ValueOf<typeof ERROR_PROPERTIES>
 
 // Salesforce Errors
 const SALESFORCE_ERROR_PREFIX = 'sf:'
+export const INSUFFICIENT_ACCESS_RIGHTS_ON_ENTITY = 'INSUFFICIENT_ACCESS: insufficient access rights on entity'
 
 export const SALESFORCE_ERRORS = {
   INVALID_CROSS_REFERENCE_KEY: `${SALESFORCE_ERROR_PREFIX}INVALID_CROSS_REFERENCE_KEY`,

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -472,7 +472,7 @@ export const retrieveMetadataInstances = async ({
     log.debug('retrieve result for types %s: %o', typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']))
 
     if (result.errors !== undefined && result.errors.length > 0) {
-      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntityInRetrieve')) {
+      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
         log.debug('Excluding non retrievable instances using config suggestion:')
         result.errors.forEach(({ type, instance, error }) => {
           log.debug(`Type: ${type}, Instance: ${instance}`)
@@ -486,7 +486,7 @@ export const retrieveMetadataInstances = async ({
         })
       } else {
         log.debug(
-          'handleInsufficientAccessRightsOnEntityInRetrieve is disabled. Logging non-retrievable instances without exclusion in config file:',
+          'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion in config file:',
         )
         result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
       }

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -225,7 +225,7 @@ export const fetchMetadataInstances = async ({
   metadataQuery: MetadataQuery
   maxInstancesPerType?: number
   addNamespacePrefixToFullName?: boolean
-  fetchProfile: FetchProfile
+  fetchProfile?: FetchProfile
 }): Promise<FetchElements<InstanceElement[]>> => {
   if (fileProps.length === 0) {
     return { elements: [], configChanges: [] }

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -217,6 +217,7 @@ export const fetchMetadataInstances = async ({
   metadataQuery,
   maxInstancesPerType = UNLIMITED_INSTANCES_VALUE,
   addNamespacePrefixToFullName = true,
+  fetchProfile,
 }: {
   client: SalesforceClient
   fileProps: FileProperties[]
@@ -224,6 +225,7 @@ export const fetchMetadataInstances = async ({
   metadataQuery: MetadataQuery
   maxInstancesPerType?: number
   addNamespacePrefixToFullName?: boolean
+  fetchProfile: FetchProfile
 }): Promise<FetchElements<InstanceElement[]>> => {
   if (fileProps.length === 0) {
     return { elements: [], configChanges: [] }
@@ -276,6 +278,8 @@ export const fetchMetadataInstances = async ({
   const { result: metadataInfos, errors } = await client.readMetadata(
     metadataTypeName,
     filePropsToRead.map(({ fullName }) => fullName),
+    undefined,
+    fetchProfile,
   )
 
   const fullNamesFromRead = new Set(metadataInfos.map(info => info?.fullName))

--- a/packages/salesforce-adapter/src/fetch.ts
+++ b/packages/salesforce-adapter/src/fetch.ts
@@ -472,7 +472,7 @@ export const retrieveMetadataInstances = async ({
     log.debug('retrieve result for types %s: %o', typesToRetrieve, _.omit(result, ['zipFile', 'fileProperties']))
 
     if (result.errors !== undefined && result.errors.length > 0) {
-      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntity')) {
+      if (fetchProfile?.isFeatureEnabled('handleInsufficientAccessRightsOnEntityInRetrieve')) {
         log.debug('Excluding non retrievable instances using config suggestion:')
         result.errors.forEach(({ type, instance, error }) => {
           log.debug(`Type: ${type}, Instance: ${instance}`)
@@ -486,7 +486,7 @@ export const retrieveMetadataInstances = async ({
         })
       } else {
         log.debug(
-          'handleInsufficientAccessRightsOnEntity is disabled. Logging non-retrievable instances without exclusion in config file:',
+          'handleInsufficientAccessRightsOnEntityInRetrieve is disabled. Logging non-retrievable instances without exclusion in config file:',
         )
         result.errors.forEach(({ type, instance }) => log.debug(`Type: ${type}, Instance: ${instance}`))
       }

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -27,7 +27,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   supportProfileTabVisibilities: false,
   disablePermissionsOmissions: true,
   omitStandardFieldsNonDeployableValues: true,
-  handleInsufficientAccessRightsOnEntityInRetrieve: false,
+  handleInsufficientAccessRightsOnEntity: false,
   shuffleRetrieveInstances: false,
   handleInsufficientAccessRightsOnEntityInRead: false,
 }

--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -27,8 +27,9 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   supportProfileTabVisibilities: false,
   disablePermissionsOmissions: true,
   omitStandardFieldsNonDeployableValues: true,
-  handleInsufficientAccessRightsOnEntity: false,
+  handleInsufficientAccessRightsOnEntityInRetrieve: false,
   shuffleRetrieveInstances: false,
+  handleInsufficientAccessRightsOnEntityInRead: false,
 }
 
 export const isFeatureEnabled = (name: keyof OptionalFeatures, optionalFeatures?: OptionalFeatures): boolean =>

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -109,8 +109,9 @@ const OPTIONAL_FEATURES = [
   'supportProfileTabVisibilities',
   'disablePermissionsOmissions',
   'omitStandardFieldsNonDeployableValues',
-  'handleInsufficientAccessRightsOnEntity',
+  'handleInsufficientAccessRightsOnEntityInRetrieve',
   'shuffleRetrieveInstances',
+  'handleInsufficientAccessRightsOnEntityInRead',
 ] as const
 const DEPRECATED_OPTIONAL_FEATURES = [
   'addMissingIds',

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -109,7 +109,7 @@ const OPTIONAL_FEATURES = [
   'supportProfileTabVisibilities',
   'disablePermissionsOmissions',
   'omitStandardFieldsNonDeployableValues',
-  'handleInsufficientAccessRightsOnEntityInRetrieve',
+  'handleInsufficientAccessRightsOnEntity',
   'shuffleRetrieveInstances',
   'handleInsufficientAccessRightsOnEntityInRead',
 ] as const

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2924,7 +2924,8 @@ describe('Fetch via retrieve API', () => {
       zipFile: { $: { 'xsi:nil': 'true' } },
       messages: [],
     }
-    const instanceError = 'INSUFFICIENT_ACCESS: insufficient access rights on entity: ProblematicApexClass'
+    const instanceErrorName = 'sf:INSUFFICIENT_ACCESS'
+    const instanceErrorMessage = 'INSUFFICIENT_ACCESS: insufficient access rights on entity: ProblematicApexClass'
     beforeEach(async () => {
       metadataRetrieveSpy = jest.spyOn(connection.metadata, 'retrieve')
       metadataReadSpy = jest.spyOn(connection.metadata, 'read')
@@ -2945,7 +2946,9 @@ describe('Fetch via retrieve API', () => {
       })
       connection.metadata.read.mockImplementation(async (_type, fullNames) => {
         if (fullNames.includes('ProblematicApexClass')) {
-          throw new Error(instanceError)
+          const error = new Error(instanceErrorMessage)
+          error.name = instanceErrorName
+          throw error
         }
         return []
       })
@@ -2977,7 +2980,7 @@ describe('Fetch via retrieve API', () => {
           expect.arrayContaining([
             {
               type: 'metadataExclude',
-              reason: instanceError,
+              reason: instanceErrorMessage,
               value: {
                 metadataType: 'ApexClass',
                 name: 'ProblematicApexClass',

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2409,7 +2409,7 @@ public class LargeClass${index} {
             config: {
               fetch: {
                 optionalFeatures: {
-                  handleInsufficientAccessRightsOnEntity: true,
+                  handleInsufficientAccessRightsOnEntityInRead: true,
                 },
                 metadata: {
                   exclude: metadataExclude,
@@ -2958,7 +2958,7 @@ describe('Fetch via retrieve API', () => {
         fetchProfile = buildFetchProfile({
           fetchParams: {
             optionalFeatures: {
-              handleInsufficientAccessRightsOnEntity: true,
+              handleInsufficientAccessRightsOnEntityInRetrieve: true,
             },
             addNamespacePrefixToFullName: false,
             metadata: {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2403,6 +2403,25 @@ public class LargeClass${index} {
       const ROLE_INSTANCE_NAMES = ['CEO', 'JiraAdmin']
       const FAILING_ROLE_INSTANCE_NAMES = ['SalesforceAdmin', 'ProductManager']
       beforeEach(() => {
+        ;({ connection, adapter } = mockAdapter({
+          adapterParams: {
+            getElemIdFunc: mockGetElemIdFunc,
+            config: {
+              fetch: {
+                optionalFeatures: {
+                  handleInsufficientAccessRightsOnEntity: true,
+                },
+                metadata: {
+                  exclude: metadataExclude,
+                },
+              },
+              maxItemsInRetrieveRequest: testMaxItemsInRetrieveRequest,
+              client: {
+                readMetadataChunkSize: { default: 3, overrides: { Test: 2 } },
+              },
+            },
+          },
+        }))
         mockMetadataType(
           { xmlName: 'Role', directoryName: 'roles' },
           {
@@ -2459,6 +2478,7 @@ public class LargeClass${index} {
           errorCode: INVALID_CROSS_REFERENCE_KEY,
         }),
         ...NON_TRANSIENT_SALESFORCE_ERRORS.map(errorName => new SFError(errorName)),
+        new SFError(SALESFORCE_ERRORS.INSUFFICIENT_ACCESS, constants.INSUFFICIENT_ACCESS_RIGHTS_ON_ENTITY),
       ])('when client throws %p', thrownError => {
         beforeEach(() => {
           connection.metadata.read.mockImplementation(async (_typeName, fullNames) => {

--- a/packages/salesforce-adapter/test/adapter.discover.test.ts
+++ b/packages/salesforce-adapter/test/adapter.discover.test.ts
@@ -2958,7 +2958,7 @@ describe('Fetch via retrieve API', () => {
         fetchProfile = buildFetchProfile({
           fetchParams: {
             optionalFeatures: {
-              handleInsufficientAccessRightsOnEntityInRetrieve: true,
+              handleInsufficientAccessRightsOnEntity: true,
             },
             addNamespacePrefixToFullName: false,
             metadata: {

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -29,7 +29,7 @@ import SalesforceClient, {
   validateCredentials,
 } from '../src/client/client'
 import mockClient from './client'
-import { OauthAccessTokenCredentials, UsernamePasswordCredentials } from '../src/types'
+import { FetchProfile, OauthAccessTokenCredentials, UsernamePasswordCredentials } from '../src/types'
 import Connection from '../src/client/jsforce'
 import {
   APEX_CLASS_METADATA_TYPE,
@@ -43,6 +43,7 @@ import {
   SALESFORCE_DEPLOY_ERROR_MESSAGES,
   SALESFORCE_ERRORS,
   VALIDATION_RULES_METADATA_TYPE,
+  PROFILE_METADATA_TYPE,
 } from '../src/constants'
 import { mockFileProperties, mockRetrieveLocator, mockRetrieveResult } from './connection'
 import {
@@ -61,6 +62,7 @@ import {
   enrichSaltoDeployErrors,
 } from '../src/client/user_facing_errors'
 import { createInstanceElement, createMetadataObjectType } from '../src/transformers/transformer'
+import { buildFetchProfile } from '../src/fetch_profile/fetch_profile'
 
 const { array, asynciterable } = collections
 const { makeArray } = array
@@ -369,6 +371,86 @@ describe('salesforce client', () => {
         ],
       })
       expect(dodoScope.isDone()).toBeTruthy()
+    })
+    describe('handle insufficient access rights on entity', () => {
+      let fetchProfile: FetchProfile
+      describe('when the feature is enabled', () => {
+        beforeEach(() => {
+          fetchProfile = buildFetchProfile({
+            fetchParams: {
+              optionalFeatures: {
+                handleInsufficientAccessRightsOnEntity: true,
+              },
+              addNamespacePrefixToFullName: false,
+              metadata: {
+                exclude: [{ metadataType: PROFILE_METADATA_TYPE }],
+              },
+            },
+          })
+        })
+        it('should return error when response is insufficient access rights on entity salesforce error', async () => {
+          const dodoScope = nock(`http://dodo22/services/Soap/m/${API_VERSION}`)
+            .post(/.*/)
+            .times(1)
+            .reply(
+              500,
+              {
+                'a:Envelope': {
+                  'a:Body': {
+                    'a:Fault': {
+                      faultcode: 'sf:INSUFFICIENT_ACCESS',
+                      faultstring: 'INSUFFICIENT_ACCESS: insufficient access rights on entity: FakeName',
+                    },
+                  },
+                },
+              },
+              headers,
+            )
+          expect(
+            (await client.readMetadata('FakeType', 'FakeName', undefined, fetchProfile)).errors[0].error.message,
+          ).toEqual('INSUFFICIENT_ACCESS: insufficient access rights on entity: FakeName')
+          expect(dodoScope.isDone()).toBeTruthy()
+        })
+      })
+      describe('when the feature is disabled', () => {
+        beforeEach(() => {
+          fetchProfile = buildFetchProfile({
+            fetchParams: {
+              optionalFeatures: {
+                handleInsufficientAccessRightsOnEntity: false,
+              },
+              addNamespacePrefixToFullName: false,
+              metadata: {
+                exclude: [{ metadataType: PROFILE_METADATA_TYPE }],
+              },
+            },
+          })
+        })
+        it('should return error when response is insufficient access rights on entity salesforce error', async () => {
+          const dodoScope = nock(`http://dodo22/services/Soap/m/${API_VERSION}`)
+            .post(/.*/)
+            .times(1)
+            .reply(
+              500,
+              {
+                'a:Envelope': {
+                  'a:Body': {
+                    'a:Fault': {
+                      faultcode: 'sf:INSUFFICIENT_ACCESS',
+                      faultstring: 'INSUFFICIENT_ACCESS: insufficient access rights on entity: FakeName',
+                    },
+                  },
+                },
+              },
+              headers,
+            )
+          expect(await client.readMetadata('FakeType', 'FakeName')).toEqual({
+            result: [],
+            errors: [],
+          })
+          expect(dodoScope.isDone()).toBeTruthy()
+        })
+      })
     })
   })
 

--- a/packages/salesforce-adapter/test/client.test.ts
+++ b/packages/salesforce-adapter/test/client.test.ts
@@ -379,7 +379,7 @@ describe('salesforce client', () => {
           fetchProfile = buildFetchProfile({
             fetchParams: {
               optionalFeatures: {
-                handleInsufficientAccessRightsOnEntity: true,
+                handleInsufficientAccessRightsOnEntityInRead: true,
               },
               addNamespacePrefixToFullName: false,
               metadata: {
@@ -417,7 +417,7 @@ describe('salesforce client', () => {
           fetchProfile = buildFetchProfile({
             fetchParams: {
               optionalFeatures: {
-                handleInsufficientAccessRightsOnEntity: false,
+                handleInsufficientAccessRightsOnEntityInRead: false,
               },
               addNamespacePrefixToFullName: false,
               metadata: {


### PR DESCRIPTION
SALTO-7409: Handle "INSUFFICIENT_ACCESS: insufficient access rights on entity" errors in readMetadata  

---

_Additional context for reviewer_:
- Currently all errors with faultcode: 'sf:INSUFFICIENT_ACCESS' are suppressed.

---
_Release Notes_: 
None

---
_User Notifications_: 
None
