### PR TITLE
SALTO-7460: Jira JSM: add references from Automations to Forms

### DIFF
--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -254,7 +254,7 @@ const isHTMLBodyContentAutomationValue = ({ value }: TransformFuncArgs): boolean
 
 const extractHTMLContentToStaticFile =
   (): TransformFuncSync =>
-  async ({ value, path }) => {
+  ({ value, path }) => {
     if (path !== undefined && isHTMLBodyContentAutomationValue({ value })) {
       value.body = new StaticFile({
         filepath: `${JIRA}/${AUTOMATION_TYPE}/${getHTMLStaticFileName(path)}.html`,
@@ -266,9 +266,19 @@ const extractHTMLContentToStaticFile =
 
 const transformStaticFileBufferToHTML =
   (): TransformFuncSync =>
-  async ({ value }) => {
+  ({ value }) => {
     if (isHTMLBodyContentAutomationValue({ value })) {
       value.body = value.body.toString()
+    }
+    return value
+  }
+
+const transformIdNumberToString =
+  (): TransformFuncSync =>
+  ({ value }) => {
+    if (_.isPlainObject(value) && value?.type === 'jira.proforma.form.add.action') {
+      const templateFormIdsAsString = String(value.value.templateFormsConfig.templateFormIds)
+      value.value.templateFormsConfig.templateFormIds = templateFormIdsAsString
     }
     return value
   }
@@ -395,6 +405,7 @@ const filter: FilterCreator = ({ client }) => {
             createTransformDeleteLinkTypesFunc(),
             createTransformHasAttachmentValueFunc(),
             extractHTMLContentToStaticFile(),
+            transformIdNumberToString(),
           ])
           instance.value = (
             await transformElement({

--- a/packages/jira-adapter/src/filters/automation/automation_structure.ts
+++ b/packages/jira-adapter/src/filters/automation/automation_structure.ts
@@ -277,7 +277,7 @@ const transformIdNumberToString =
   (): TransformFuncSync =>
   ({ value }) => {
     if (_.isPlainObject(value) && value?.type === 'jira.proforma.form.add.action') {
-      const templateFormIdsAsString = String(value.value.templateFormsConfig.templateFormIds)
+      const templateFormIdsAsString = value.value.templateFormsConfig.templateFormIds.map(String)
       value.value.templateFormsConfig.templateFormIds = templateFormIdsAsString
     }
     return value

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -149,16 +149,16 @@ export const createAutomationTypes = (): {
   })
 
   const templateFormIdsType = new ObjectType({
-    elemID: new ElemID(JIRA, 'TemplateFormsConfig'),
+    elemID: new ElemID(JIRA, 'TemplateFormsIds'),
     fields: {
       key: {
         refType: BuiltinTypes.STRING,
       },
       value: {
-        refType: new ListType(BuiltinTypes.STRING),
+        refType: new ListType(BuiltinTypes.NUMBER),
       },
     },
-    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, 'TemplateFormsConfig'],
+    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, 'TemplateFormsIds'],
   })
 
   const templateFormsConfigType = new ObjectType({

--- a/packages/jira-adapter/src/filters/automation/types.ts
+++ b/packages/jira-adapter/src/filters/automation/types.ts
@@ -148,11 +148,24 @@ export const createAutomationTypes = (): {
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, DELETE_LINK_TYPES],
   })
 
+  const templateFormIdsType = new ObjectType({
+    elemID: new ElemID(JIRA, 'TemplateFormsConfig'),
+    fields: {
+      key: {
+        refType: BuiltinTypes.STRING,
+      },
+      value: {
+        refType: new ListType(BuiltinTypes.STRING),
+      },
+    },
+    path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, 'TemplateFormsConfig'],
+  })
+
   const templateFormsConfigType = new ObjectType({
     elemID: new ElemID(JIRA, 'TemplateFormsConfig'),
     fields: {
       projectId: { refType: BuiltinTypes.NUMBER },
-      templateFormIds: { refType: new ListType(BuiltinTypes.NUMBER) },
+      templateFormIds: { refType: new ListType(templateFormIdsType) },
     },
     path: [JIRA, elements.TYPES_PATH, elements.SUBTYPES_PATH, 'TemplateFormsConfig'],
   })
@@ -283,6 +296,7 @@ export const createAutomationTypes = (): {
       compareFieldValueType,
       deleteLinkTypes,
       queryType,
+      templateFormIdsType,
     ],
   }
 }

--- a/packages/jira-adapter/src/reference_mapping.ts
+++ b/packages/jira-adapter/src/reference_mapping.ts
@@ -75,6 +75,7 @@ import {
   SLA_CONDITIONS_STOP_TYPE,
   SLA_CONDITIONS_START_TYPE,
   SLA_CONDITIONS_PAUSE_TYPE,
+  FORM_TYPE,
 } from './constants'
 import { getFieldsLookUpName } from './filters/fields/field_type_references_filter'
 import { getRefType } from './references/workflow_properties'
@@ -1459,6 +1460,12 @@ export const referencesRules: JiraFieldReferenceDefinition[] = [
     serializationStrategy: 'id',
     missingRefStrategy: 'typeAndValue',
     target: { type: 'UnknownType' },
+  },
+  {
+    src: { field: 'templateFormIds', parentTypes: ['TemplateFormsConfig'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: FORM_TYPE },
   },
 ]
 

--- a/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
+++ b/packages/jira-adapter/test/filters/automation/automation_structure.test.ts
@@ -148,6 +148,14 @@ describe('automationStructureFilter', () => {
           type: 'jira.issue.outgoing.email',
           value: { body: HTML_BODY_TEST, mimeType: 'text/html' },
         },
+        {
+          id: '10',
+          component: 'ACTION',
+          type: 'jira.proforma.form.add.action',
+          value: {
+            templateFormsConfig: { projectId: 10010, templateFormIds: [1, 5] },
+          },
+        },
       ],
       projects: [
         {
@@ -313,6 +321,14 @@ describe('automationStructureFilter', () => {
       await filter.onFetch([longNamedInstance])
       expect(longNamedInstance.value.components[9].value.body).toBeInstanceOf(StaticFile)
       expect(longNamedInstance.value.components[9].value.body.filepath.length).toBeLessThan(255)
+    })
+
+    it('should transform the id type of a templateFormIds from number to string in jira.proforma.form.add.action', async () => {
+      await filter.onFetch([instance])
+      expect(Array.isArray(instance.value.components[10].value.templateFormsConfig.templateFormIds)).toBe(true)
+      expect(instance.value.components[10].value.templateFormsConfig.templateFormIds).toEqual(
+        expect.arrayContaining(['1', '5']),
+      )
     })
 
     it('should not throw if wrong structure', async () => {


### PR DESCRIPTION
#### Added a (broken) reference expression (intentionally) to attached forms in automations.
[the new salto-base PR
](https://github.com/salto-io/salto-base/pull/16)
---
_Release Notes_: 

---
_User Notifications_: 
