### PR TITLE
SALTO-7504: Reducing logs spam during deploy

### DIFF
--- a/packages/salesforce-adapter/src/transformers/transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/transformer.ts
@@ -46,7 +46,7 @@ import {
   Values,
 } from '@salto-io/adapter-api'
 import { collections, promises, values as lowerDashValues } from '@salto-io/lowerdash'
-import { naclCase, pathNaclCase, transformElement, TransformFunc, TransformFuncSync } from '@salto-io/adapter-utils'
+import { naclCase, pathNaclCase, TransformFunc, TransformFuncSync, transformValues } from '@salto-io/adapter-utils'
 
 import { logger } from '@salto-io/logging'
 import { SalesforceRecord } from '../client/types'
@@ -1426,13 +1426,20 @@ export const toDeployableInstance = async (element: InstanceElement): Promise<In
     }
     return value
   }
-  return transformElement({
-    element,
-    transformFunc: removeNonDeployableValues,
-    strict: false,
-    allowEmptyArrays: true,
-    allowExistingEmptyObjects: true,
-  })
+  // Annotations are not deployed.
+  return new InstanceElement(
+    element.elemID.name,
+    element.refType,
+    await transformValues({
+      values: element.value,
+      type: await element.getType(),
+      transformFunc: removeNonDeployableValues,
+      strict: false,
+      pathID: element.elemID,
+      allowEmptyArrays: true,
+      allowExistingEmptyObjects: true,
+    }),
+  )
 }
 
 export const toMetadataInfo = async (instance: InstanceElement): Promise<MetadataInfo> => ({

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -611,7 +611,7 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
       const instanceName = await apiName(instance)
       const setAndLogZipFile = (fileName: string, content: string | Buffer): void => {
         zipContent.set(fileName, content)
-        log.trace('Added XML file %s with content %s', fileName, content)
+        log.trace('Added XML file %s', fileName)
       }
       const removeNamespacePrefix = (name: string): string => name.replace(/^\w+__/g, '')
       try {

--- a/packages/salesforce-adapter/src/transformers/xml_transformer.ts
+++ b/packages/salesforce-adapter/src/transformers/xml_transformer.ts
@@ -611,7 +611,7 @@ export const createDeployPackage = (deleteBeforeUpdate?: boolean): DeployPackage
       const instanceName = await apiName(instance)
       const setAndLogZipFile = (fileName: string, content: string | Buffer): void => {
         zipContent.set(fileName, content)
-        log.trace('Added XML file %s', fileName)
+        log.debug('Added XML file %s', fileName)
       }
       const removeNamespacePrefix = (name: string): string => name.replace(/^\w+__/g, '')
       try {


### PR DESCRIPTION
* We get a log for every element with a parent because we drop the annotation in the transform even though we don't need the annotations during deploy.
* Logging the content of files added to the zip is extremely spammy and unintelligible anyway.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
