### PR TITLE
SALTO-7509: Fix GroupPush uniqueness validator

### DIFF
--- a/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
+++ b/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
@@ -57,10 +57,7 @@ export const groupPushToApplicationUniquenessValidator: ChangeValidator = async 
     )
     .toArray()
 
-  const groupPushByApp = groupBy(
-    existingGroupPushInstances,
-    groupPush => getParentElemID(groupPush).getFullName(),
-  )
+  const groupPushByApp = groupBy(existingGroupPushInstances, groupPush => getParentElemID(groupPush).getFullName())
 
   return addedGroupPushInstances.flatMap((instance): ChangeError[] => {
     const groupElemId = instance.value.userGroupId.elemID

--- a/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
+++ b/packages/okta-adapter/src/change_validators/group_push_to_application_uniqueness.ts
@@ -17,6 +17,7 @@ import {
 } from '@salto-io/adapter-api'
 import { collections } from '@salto-io/lowerdash'
 import { logger } from '@salto-io/logging'
+import { getParentElemID } from '@salto-io/adapter-utils'
 import { groupBy } from 'lodash'
 import { GROUP_PUSH_TYPE_NAME } from '../constants'
 
@@ -58,7 +59,7 @@ export const groupPushToApplicationUniquenessValidator: ChangeValidator = async 
 
   const groupPushByApp = groupBy(
     existingGroupPushInstances,
-    groupPush => groupPush.annotations[CORE_ANNOTATIONS.PARENT][0],
+    groupPush => getParentElemID(groupPush).getFullName(),
   )
 
   return addedGroupPushInstances.flatMap((instance): ChangeError[] => {
@@ -66,7 +67,7 @@ export const groupPushToApplicationUniquenessValidator: ChangeValidator = async 
     const applicationElemId = instance.annotations[CORE_ANNOTATIONS.PARENT][0].elemID
     const groupName = groupElemId.getFullName()
     const applicationName = applicationElemId.getFullName()
-    const existingGroupPushInstance = (groupPushByApp[applicationElemId] ?? []).find(
+    const existingGroupPushInstance = (groupPushByApp[applicationName] ?? []).find(
       groupPush =>
         groupPush.value.userGroupId.elemID.isEqual(groupElemId) && !groupPush.elemID.isEqual(instance.elemID),
     )

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -95,15 +95,24 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     )
     expect(changeErrors).toHaveLength(0)
   })
+  it('should return empty list with same group is mapped to a different app', async () => {
+    const elementSource = buildElementsSourceFromElements([
+      groupPush1,
+      groupPush2,
+    ])
+    const changeErrors = await groupPushToApplicationUniquenessValidator(
+      [toChange({ after: groupPush1 })],
+      elementSource,
+    )
+    expect(changeErrors).toHaveLength(0)
+  })
   it('should return errors only when group to application are defined in element source', async () => {
     const elementSource = buildElementsSourceFromElements([
       groupPushInElementSource,
       groupPush1,
-      groupPush2,
-      groupPush3,
     ])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
-      [toChange({ after: groupPush1 }), toChange({ after: groupPush2 }), toChange({ after: groupPush3 })],
+      [toChange({ after: groupPush1 })],
       elementSource,
     )
     expect(changeErrors).toEqual([

--- a/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
+++ b/packages/okta-adapter/test/change_validators/group_push_to_application_uniqueness.test.ts
@@ -96,10 +96,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should return empty list with same group is mapped to a different app', async () => {
-    const elementSource = buildElementsSourceFromElements([
-      groupPush1,
-      groupPush2,
-    ])
+    const elementSource = buildElementsSourceFromElements([groupPush1, groupPush2])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [toChange({ after: groupPush1 })],
       elementSource,
@@ -107,10 +104,7 @@ describe('groupPushToApplicationUniquenessValidator', () => {
     expect(changeErrors).toHaveLength(0)
   })
   it('should return errors only when group to application are defined in element source', async () => {
-    const elementSource = buildElementsSourceFromElements([
-      groupPushInElementSource,
-      groupPush1,
-    ])
+    const elementSource = buildElementsSourceFromElements([groupPushInElementSource, groupPush1])
     const changeErrors = await groupPushToApplicationUniquenessValidator(
       [toChange({ after: groupPush1 })],
       elementSource,


### PR DESCRIPTION
The validator was using _groupBy by element id instead of element id full name 

---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta Adapter_:
- Fix a bug in deployment of Group Push, blocking deployment of group push if the group is mapped to a different app.

---
_User Notifications_: 
None
