### PR TITLE
SALTO-7510: Fix deployment of GroupPush type

### DIFF
--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -547,6 +547,7 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
         urlParamsToFields: {
           appId: '_parent.0.id',
         },
+        fieldsToIgnore: ['newAppGroupName'] // determined by the service
       },
       remove: {
         url: '/api/internal/instance/{appId}/grouppush/{pushId}/delete',

--- a/packages/okta-adapter/src/config.ts
+++ b/packages/okta-adapter/src/config.ts
@@ -547,7 +547,7 @@ const DUCKTYPE_TYPES: OktaDuckTypeApiConfig['types'] = {
         urlParamsToFields: {
           appId: '_parent.0.id',
         },
-        fieldsToIgnore: ['newAppGroupName'] // determined by the service
+        fieldsToIgnore: ['newAppGroupName'], // determined by the service
       },
       remove: {
         url: '/api/internal/instance/{appId}/grouppush/{pushId}/delete',


### PR DESCRIPTION
Remove a field in deployment

---

_Additional context for reviewer_
The field should be omitted as it's created by Okta post deploy

---
_Release Notes_: 

_Okta adapter_:
- Fix a bug in additions of GroupPush

---
_User Notifications_: 
None
