### PR TITLE
Revert "SALTO-5942 - Salesforce - fix salesforce fields and instances…

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -568,14 +568,12 @@ const runPostFetch = async ({
 // SALTO-5878 safety due to changed order of precedence when resolving referenced values / types - can remove if we don't see this log
 const updateInconsistentTypes = (validAccountElements: Element[]): void =>
   log.timeDebug(() => {
-    const objectTypesByElemID = _.groupBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
+    const objectTypesByElemID = _.keyBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
     const isInconsistentType = (e: InstanceElement | Field): boolean =>
       e.refType.type !== undefined &&
       objectTypesByElemID[e.refType.elemID.getFullName()] !== undefined &&
-      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()][0]) &&
-      !(objectTypesByElemID[e.refType.elemID.getFullName()].length > 1)
+      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()])
     const fields = Object.values(objectTypesByElemID)
-      .flat()
       .flatMap(obj => Object.values(obj.fields))
       .filter(f => isObjectType(f.refType.type))
     const elementsWithInconsistentTypes: (InstanceElement | Field)[] = validAccountElements

--- a/packages/salesforce-adapter/src/filters/hide_types_folder.ts
+++ b/packages/salesforce-adapter/src/filters/hide_types_folder.ts
@@ -5,7 +5,7 @@
  *
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
-import { Element, CORE_ANNOTATIONS, isObjectType } from '@salto-io/adapter-api'
+import { Element, CORE_ANNOTATIONS } from '@salto-io/adapter-api'
 import { SALESFORCE, TYPES_PATH } from '../constants'
 import { FilterCreator } from '../filter'
 import { ensureSafeFilterFetch } from './utils'
@@ -22,14 +22,6 @@ const filterCreator: FilterCreator = ({ config }) => ({
     fetchFilterFunc: async elements => {
       elements.filter(isElementWithinTypesFolder).forEach(element => {
         element.annotations[CORE_ANNOTATIONS.HIDDEN] = true
-        if (isObjectType(element)) {
-          const objFields = Object.values(element.fields)
-          objFields.forEach(f => {
-            if (f.refType?.type?.annotations) {
-              f.refType.type.annotations[CORE_ANNOTATIONS.HIDDEN] = true
-            }
-          })
-        }
       })
     },
   }),

--- a/packages/salesforce-adapter/test/filters/hide_types_folder.test.ts
+++ b/packages/salesforce-adapter/test/filters/hide_types_folder.test.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-import { CORE_ANNOTATIONS, ElemID, Field, ObjectType } from '@salto-io/adapter-api'
+import { CORE_ANNOTATIONS, ElemID, ObjectType } from '@salto-io/adapter-api'
 import { buildFetchProfile } from '../../src/fetch_profile/fetch_profile'
 import { defaultFilterContext } from '../utils'
 import { SALESFORCE, TYPES_PATH } from '../../src/constants'
@@ -19,7 +19,6 @@ describe('hideTypesFolder filter', () => {
     let elementWithinTypesFolder: ObjectType
     let elementNestedWithinTypesFolder: ObjectType
     let elementOutsideTypesFolder: ObjectType
-    let fields
 
     const toBeHidden = (element: ObjectType): boolean => element.annotations?.[CORE_ANNOTATIONS.HIDDEN] === true
 
@@ -54,23 +53,6 @@ describe('hideTypesFolder filter', () => {
         expect(elementWithinTypesFolder).toSatisfy(toBeHidden)
         expect(elementNestedWithinTypesFolder).toSatisfy(toBeHidden)
         expect(elementOutsideTypesFolder).not.toSatisfy(toBeHidden)
-      })
-      describe('when element has inner fields', () => {
-        beforeEach(() => {
-          fields = {
-            mockField__c: new Field(elementWithinTypesFolder.clone(), 'mockField__c', elementWithinTypesFolder.clone()),
-          }
-          elementWithinTypesFolder.fields = fields
-        })
-        it('should update inner types fields type to be hidden', async () => {
-          expect(
-            elementWithinTypesFolder.fields.mockField__c.refType.type?.annotations[CORE_ANNOTATIONS.HIDDEN],
-          ).toBeFalsy()
-          await filter.onFetch([elementWithinTypesFolder])
-          expect(
-            elementWithinTypesFolder.fields.mockField__c.refType.type?.annotations[CORE_ANNOTATIONS.HIDDEN],
-          ).toBeTrue()
-        })
       })
     })
 


### PR DESCRIPTION
… with incorrect types (#7295)"

This reverts commit 09e1fec6d296af929d5c84c85c3526acc8b7e96f.

---

_Additional context for reviewer_

---

_Release Notes_: 
_Replace me with a short sentence that describes the effect of this change on Salto users_

---

_User Notifications_: 
_Replace me with a short sentence that describes changes that will appear in NaCls and are not caused by user actions (e.g. a new annotation, field values that are converted to references, etc). Hidden changes should not be listed._
