### PR TITLE
SALTO-7521: Expose getPlan from Core package

### DIFF
--- a/packages/core/index.ts
+++ b/packages/core/index.ts
@@ -6,7 +6,7 @@
  * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
  */
 
-export { Plan, PlanItem, ChangeWithDetails } from './src/core/plan'
+export { Plan, PlanItem, ChangeWithDetails, getPlan } from './src/core/plan'
 export { FetchProgressEvents, StepEmitter } from './src/core/fetch'
 export * from './src/api'
 export {


### PR DESCRIPTION
Expose getPlan from core package, so we can easily create plan objects and provide them "change-errors". This is needed for SAAS-13046.

---

_Additional context for reviewer_
None

---

_Release Notes_: 
None

---

_User Notifications_: 
None