### PR TITLE
SALTO-7409: Make handleInsufficientAccessRightsOnEntity optional feature enabled by default 

### DIFF
--- a/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
+++ b/packages/salesforce-adapter/src/fetch_profile/optional_features.ts
@@ -27,7 +27,7 @@ const optionalFeaturesDefaultValues: OptionalFeaturesDefaultValues = {
   supportProfileTabVisibilities: false,
   disablePermissionsOmissions: true,
   omitStandardFieldsNonDeployableValues: true,
-  handleInsufficientAccessRightsOnEntity: false,
+  handleInsufficientAccessRightsOnEntity: true,
   shuffleRetrieveInstances: false,
 }
 


### PR DESCRIPTION
SALTO-7409: Make handleInsufficientAccessRightsOnEntity optional feature enabled by default 

---
_Release Notes_: 
None

---
_User Notifications_: 
None
