### PR TITLE
SALTO-7532: Stop loading SFDX project after dump

### DIFF
--- a/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
+++ b/packages/salesforce-adapter/src/sfdx_parser/sfdx_dump.ts
@@ -35,7 +35,6 @@ import {
 } from './salesforce_imports'
 import { SyncZipTreeContainer } from './tree_container'
 import { detailedMessageFromSfError } from './errors'
-import { loadElementsFromFolder } from './sfdx_parser'
 
 const log = logger(module)
 const { withLimitedConcurrency } = promises.array
@@ -238,14 +237,6 @@ export const dumpElementsToFolder: DumpElementsToFolderFunc = async ({ baseDir, 
     pathsToDelete.map(pathToDelete => () => rm(pathToDelete)),
     FILE_DELETE_CONCURRENCY,
   )
-
-  log.debug('Loading elements from folder to validate dump.')
-  const { errors: loadErrors } = await loadElementsFromFolder({ baseDir, elementsSource })
-  loadErrors?.forEach(error => {
-    log.error('Got an error validating dumped SFDX: %o', error)
-    error.message = 'Error validating dumped SFDX project'
-    errors.push(error)
-  })
 
   return { errors, unappliedChanges }
 }


### PR DESCRIPTION
It's too slow.

---

_Additional context for reviewer_

---

_Release Notes_: 
None.

---

_User Notifications_: 
None.
