### PR TITLE
SALTO-7537 fix SuiteApp files counts query fails

### DIFF
--- a/packages/netsuite-adapter/src/adapter.ts
+++ b/packages/netsuite-adapter/src/adapter.ts
@@ -379,6 +379,7 @@ export default class NetsuiteAdapter implements AdapterOperations {
         extensionsToExclude: this.config.fetch.exclude.fileCabinet.filter(reg => reg.startsWith(EXTENSION_REGEX)),
         maxFilesPerFileCabinetFolder: this.config.client?.maxFilesPerFileCabinetFolder ?? [],
         wrapFolderIdsWithQuotes: this.config.fetch.wrapFolderIdsWithQuotes ?? false,
+        numOfFolderIdsPerFilesQuery: this.config.suiteAppClient?.numOfFolderIdsPerFilesQuery,
       })
       progressReporter.reportProgress({ message: 'Fetching instances' })
       return result

--- a/packages/netsuite-adapter/src/config/types.ts
+++ b/packages/netsuite-adapter/src/config/types.ts
@@ -210,6 +210,7 @@ export type SuiteAppClientConfig = {
   httpTimeoutLimitInMinutes?: number
   wsdlVersion?: WSDLVersion
   additionalSuiteQLTables?: AdditionalSuiteQLTable[]
+  numOfFolderIdsPerFilesQuery?: number
 }
 
 export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientConfig> = {
@@ -217,6 +218,7 @@ export const SUITEAPP_CLIENT_CONFIG: lowerdashTypes.TypeKeysEnum<SuiteAppClientC
   httpTimeoutLimitInMinutes: 'httpTimeoutLimitInMinutes',
   wsdlVersion: 'wsdlVersion',
   additionalSuiteQLTables: 'additionalSuiteQLTables',
+  numOfFolderIdsPerFilesQuery: 'numOfFolderIdsPerFilesQuery',
 }
 
 export type NetsuiteConfig = {
@@ -462,6 +464,9 @@ const suiteAppClientConfigType = createMatchingObjectType<SuiteAppClientConfig>(
     },
     additionalSuiteQLTables: {
       refType: new ListType(additionalSuiteQLTableType),
+    },
+    numOfFolderIdsPerFilesQuery: {
+      refType: BuiltinTypes.NUMBER,
     },
   },
   annotations: {

--- a/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
+++ b/packages/netsuite-adapter/test/client/suiteapp_client/suiteapp_file_cabinet.test.ts
@@ -479,17 +479,6 @@ describe('suiteapp_file_cabinet', () => {
 
     it("return empty result when no top level folder matches the adapter's query", async () => {
       query.isParentFolderMatch.mockReturnValue(false)
-      // mockSuiteAppClient.runSuiteQL.mockImplementation(async suiteQlQuery => {
-      //   if (suiteQlQuery.from === 'file') {
-      //     return getFilesResponse(suiteQlQuery)
-      //   }
-
-      //   if (suiteQlQuery.from === 'mediaitemfolder') {
-      //     return getFoldersResponse(suiteQlQuery)
-      //   }
-      //   throw new Error(`Unexpected query: ${suiteQlQuery}`)
-      // })
-
       expect(await importFileCabinet(suiteAppClient, importFileCabinetParams)).toEqual({
         elements: [],
         failedPaths: { lockedError: [], largeSizeFoldersError: [], largeFilesCountFoldersError: [], otherError: [] },
@@ -595,6 +584,42 @@ describe('suiteapp_file_cabinet', () => {
         expectedResults[4],
         expectedResults[5],
       ])
+    })
+
+    it('should use custom files query chunk size when numOfFolderIdsPerFilesQuery is given', async () => {
+      const { elements } = await importFileCabinet(suiteAppClient, {
+        ...importFileCabinetParams,
+        numOfFolderIdsPerFilesQuery: 4,
+      })
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(3, {
+        select: 'folder, count(*) as count',
+        from: 'file',
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (5, 3, 4, 11)",
+        orderBy: 'folder',
+        groupBy: 'folder',
+      })
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(4, {
+        select: 'folder, count(*) as count',
+        from: 'file',
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (111, 22, 222)",
+        orderBy: 'folder',
+        groupBy: 'folder',
+      })
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(5, {
+        select:
+          'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
+        from: 'file',
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (5, 3, 4, 11)",
+        orderBy: 'id',
+      })
+      expect(suiteAppClient.runSuiteQL).toHaveBeenNthCalledWith(6, {
+        select:
+          'id, name, filesize, isinactive, isonline, addtimestamptourl, description, folder, islink, url, bundleable, hideinbundle',
+        from: 'file',
+        where: "NOT REGEXP_LIKE(name, '.*\\.csv') AND hideinbundle = 'F' AND folder IN (111)",
+        orderBy: 'id',
+      })
+      expect(_.uniqBy(elements, row => row.values.internalId)).toEqual(expectedResults)
     })
 
     it('should filter out paths under excluded large folders', async () => {
@@ -777,6 +802,60 @@ describe('suiteapp_file_cabinet', () => {
           current: 1900,
         },
       ])
+    })
+
+    it('should not filter large folders when files count query fails', async () => {
+      mockSuiteAppClient.runSuiteQL.mockImplementation(async suiteQlQuery => {
+        if (suiteQlQuery.from === 'file') {
+          if (suiteQlQuery.groupBy === 'folder') {
+            return undefined
+          }
+          return filesQueryResponse
+        }
+
+        if (suiteQlQuery.from === 'mediaitemfolder') {
+          return getFoldersResponse(suiteQlQuery)
+        }
+        throw new Error(`Unexpected query: ${suiteQlQuery}`)
+      })
+
+      const { elements, failedPaths, largeFilesCountFolderWarnings } = await importFileCabinet(
+        suiteAppClient,
+        importFileCabinetParams,
+      )
+      const [folders, files] = _.partition(expectedResults, row => row.typeName === 'folder')
+      const largeFoldersResults = [
+        {
+          path: ['folder5', 'largeFolder2'],
+          typeName: 'folder',
+          values: {
+            bundleable: 'T',
+            isinactive: 'T',
+            isprivate: 'T',
+            description: '',
+            internalId: largeFolders.largeFolder2,
+          },
+        },
+        {
+          path: ['folder5', 'largeFolder2', 'innerNormalFolder'],
+          typeName: 'folder',
+          values: {
+            bundleable: 'T',
+            isinactive: 'T',
+            isprivate: 'T',
+            description: '',
+            internalId: '222',
+          },
+        },
+      ]
+      expect(elements).toEqual(folders.concat(largeFoldersResults).concat(files))
+      expect(failedPaths).toEqual({
+        lockedError: [],
+        otherError: [],
+        largeSizeFoldersError: [],
+        largeFilesCountFoldersError: [],
+      })
+      expect(largeFilesCountFolderWarnings).toEqual([])
     })
   })
 


### PR DESCRIPTION
1. add the `netsuite.suiteAppClient.numOfFolderIdsPerFilesQuery` config to set a custom chunk size
2. don't throw in case of a failure in a files count query

---

_Additional context for reviewer_

---
_Release Notes_: 
Netsuite Adapter:
- fix SuiteApp files counts query fails

---
_User Notifications_: 
None
