### PR TITLE
SALTO-7559: Remove merge errors when element is deleted

### DIFF
--- a/packages/workspace/src/workspace/nacl_files/elements_cache.ts
+++ b/packages/workspace/src/workspace/nacl_files/elements_cache.ts
@@ -404,9 +404,15 @@ export const createMergeManager = async (
       await currentElements.clear()
     } else {
       const removalChanges = mergedChanges.changes.filter(isRemovalChange)
-      await currentElements.deleteAll(removalChanges.map(change => getChangeData(change).elemID))
+      const removedIds = removalChanges.map(change => getChangeData(change).elemID)
+      await currentElements.deleteAll(removedIds)
       logChanges(removalChanges)
-      await currentErrors.deleteAll(noErrorMergeIds.filter(id => !_.isEmpty(currentMergeErrors[id])))
+      await currentErrors.deleteAll(
+        removedIds
+          .map(id => id.getFullName())
+          .concat(noErrorMergeIds)
+          .filter(id => !_.isEmpty(currentMergeErrors[id])),
+      )
     }
     await currentErrors.setAll(awu(mergeErrors).filter(err => !_.isEqual(err.value, currentMergeErrors[err.key])))
     const additionOrModificationChanges = mergedChanges.changes.filter(isAdditionOrModificationChange)


### PR DESCRIPTION
Before this fix, if an element that had merge errors was removed, its errors would persist until the cache was cleared

---

_Additional context for reviewer_

---
_Release Notes_: 
Core:
- Fixed issue where merge errors would persist even if the offending element was removed

---
_User Notifications_: 
_None_