### PR TITLE
SALTO-7531: Fix parser wrong escape handling in multiline template expressions

### DIFF
--- a/packages/parser/src/parser/internal/native/consumers/values.ts
+++ b/packages/parser/src/parser/internal/native/consumers/values.ts
@@ -81,33 +81,6 @@ const createSimpleStringValue = (
   }
 }
 
-type TokenGroup =
-  | {
-      type: 'reference'
-      token: Required<Token>
-    }
-  | {
-      type: 'non-reference'
-      tokens: Required<Token>[]
-    }
-
-const groupNonReferenceTokens = (tokens: Required<Token>[]): TokenGroup[] => {
-  const result: TokenGroup[] = []
-  tokens.forEach(token => {
-    if (token.type === TOKEN_TYPES.REFERENCE) {
-      result.push({ type: 'reference', token })
-    } else {
-      const lastGroup = _.last(result)
-      if (lastGroup?.type === 'non-reference') {
-        lastGroup.tokens.push(token)
-      } else {
-        result.push({ type: 'non-reference', tokens: [token] })
-      }
-    }
-  })
-  return result
-}
-
 const createTemplateExpressions = (
   context: Pick<ParseContext, 'errors' | 'filename'>,
   tokens: Required<Token>[],
@@ -116,27 +89,17 @@ const createTemplateExpressions = (
     tokens: Required<Token>[],
     isNextPartReference?: boolean,
   ) => string,
-): TemplateExpression => {
-  // We must group non reference tokens so that when we unescape the string parts in createSimpleStringValueFunc
-  // we won't miss things due to them being split between two tokens.
-  //
-  // For example, if we had this part in a multiline string: "bla \''' foo" it would be split into the following tokens:
-  //  - "bla "
-  //  - "\'" - an escape token
-  //  - "''' foo"
-  // Sending each token on its own would prevent unescaping the \''' because createSimpleStringValueFunc wouldn't see it in a single call.
-  const tokenGroups = groupNonReferenceTokens(tokens)
-  return createTemplateExpression({
-    parts: tokenGroups.map((tokenGroup, idx) => {
-      if (tokenGroup.type === 'reference') {
-        const ref = createReferenceExpression(tokenGroup.token.value)
-        return ref instanceof IllegalReference ? tokenGroup.token.text : ref
+): TemplateExpression =>
+  createTemplateExpression({
+    parts: tokens.map((token, idx) => {
+      if (token.type === TOKEN_TYPES.REFERENCE) {
+        const ref = createReferenceExpression(token.value)
+        return ref instanceof IllegalReference ? token.text : ref
       }
-      const isNextPartReference = tokenGroups[idx + 1]?.type === 'reference'
-      return createSimpleStringValueFunc(context, tokenGroup.tokens, isNextPartReference)
+      const isNextPartReference = tokens[idx + 1]?.type === TOKEN_TYPES.REFERENCE
+      return createSimpleStringValueFunc(context, [token], isNextPartReference)
     }),
   })
-}
 
 export const createStringValue = (
   context: Pick<ParseContext, 'errors' | 'filename'>,

--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -101,6 +101,12 @@ export const rules: Record<string, moo.Rules> = {
   },
 }
 
+// Note: These rules are used for both single and multiline strings.
+// They are not fully correct for the two cases, specifically, in single line strings "\'''" is no a valid escape token
+// and in multiline strings it is valid.
+// Ideally we should use different rules for the two cases, but this is more complex to implement.
+// We chose to err on the side of having bigger tokens since down the line the code for single line strings merges all tokens anyway
+// whereas the code for multiline strings may sometimes consume token-by-token which makes it more sensitive to wrong token splits.
 const stringWithReferencesRules = moo.compile({
   // This handles escaped multiline end (\'''),regular escapes, unicode escapes and escaped template markers ('\${')
   [TOKEN_TYPES.ESCAPE]: { match: /(?:\\'''|\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?)+/ },

--- a/packages/parser/src/parser/internal/native/lexer.ts
+++ b/packages/parser/src/parser/internal/native/lexer.ts
@@ -102,8 +102,8 @@ export const rules: Record<string, moo.Rules> = {
 }
 
 const stringWithReferencesRules = moo.compile({
-  // This handles regular escapes, unicode escapes and escaped template markers ('\${')
-  [TOKEN_TYPES.ESCAPE]: { match: /(?:\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?)+/ },
+  // This handles escaped multiline end (\'''),regular escapes, unicode escapes and escaped template markers ('\${')
+  [TOKEN_TYPES.ESCAPE]: { match: /(?:\\'''|\\[^$u]|\\u[0-9a-fA-F]{4}|\\\$\{?)+/ },
   [TOKEN_TYPES.REFERENCE]: { match: REFERENCE, value: s => s.slice(2, -1).trim() },
   // Template markers are added to prevent incorrect parsing of user created strings that look like Salto references.
   [TOKEN_TYPES.CONTENT]: {

--- a/packages/parser/test/parser/dump.test.ts
+++ b/packages/parser/test/parser/dump.test.ts
@@ -162,7 +162,7 @@ describe('Salto Dump', () => {
         // eslint-disable-next-line no-template-curly-in-string
         'Hello \\${ not.reference } and \n line with escaped ref \\',
         new ReferenceExpression(new ElemID('salto', 'ref')),
-        '\n and another \\\\ line\\',
+        "\n and ''' and another \\\\ line\\",
       ],
     }),
     doubleEscapedTemplate: new TemplateExpression({
@@ -292,7 +292,7 @@ describe('Salto Dump', () => {
         expect(body).toMatch(/Hello \\\\\\\$\{ not.reference \}/m)
       })
       it('should not escape backslashes that do not appear before ${', () => {
-        expect(body).toMatch(/and another \\\\ line\\\n\s*'''/m)
+        expect(body).toMatch(/and \\''' and another \\\\ line\\\n\s*'''/m)
       })
     })
 

--- a/packages/parser/test/parser/parse.test.ts
+++ b/packages/parser/test/parser/parse.test.ts
@@ -1420,12 +1420,12 @@ describe('Salto parser', () => {
       const body = `
         type salesforce.multiline_templates {
           tmpl = '''
-multiline
+multiline \\'''
 template {{$\{te@mp.late.instance.multiline_stuff@us}}}
 value
 '''
           escapedTemplateMarker = '''
-multiline
+$\{ template.as.instance.first_part }multiline '''
 \${{$\{te@mp.late.instance.multiline_stuff@us}}} and {{$\{te@mp.late.instance.multiline_stuff@us}}}\${{$\{te@mp.late.instance.multiline_stuff@us}}}{{$\{te@mp.late.instance.multiline_stuff@us}}} hello
 line where the original content looks like an escaped reference but it it is actually not a reference: \\\\\\\${ not.reference }
 line that has \\\\\\\\ and ends with \\
@@ -1442,7 +1442,7 @@ line that has \\\\\\\\ and ends with \\
       it('should parse references to template as TemplateExpression', () => {
         expect(multilineRefObj.annotations.tmpl).toBeInstanceOf(TemplateExpression)
         expect(multilineRefObj.annotations.tmpl.parts).toEqual([
-          'multiline\ntemplate {{',
+          "multiline '''\ntemplate {{",
           expect.objectContaining({
             elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
           }),
@@ -1453,7 +1453,10 @@ line that has \\\\\\\\ and ends with \\
       it('should parse references that exist on the same line as an escaped template marker as TemplateExpression', () => {
         expect(multilineRefObj.annotations.escapedTemplateMarker).toBeInstanceOf(TemplateExpression)
         expect(multilineRefObj.annotations.escapedTemplateMarker.parts).toEqual([
-          'multiline\n${{',
+          expect.objectContaining({
+            elemID: new ElemID('template', 'as', 'instance', 'first_part'),
+          }),
+          "multiline '''\n${{",
           expect.objectContaining({
             elemID: new ElemID('te@mp', 'late', 'instance', 'multiline_stuff@us'),
           }),


### PR DESCRIPTION
In multiline template expressions the parser would not properly handle escaped multiline string endings. so if there was an escaped ''' in the template expression, it would not be unescaped

---

_Additional context for reviewer_

---
_Release Notes_: 
Parser:
- Fixed issue with parsing multiline template expressions that would lead to unintended pending changes

---
_User Notifications_: 
_None_