### PR TITLE
SALTO-7561-SALTO-7562-Add Features deploy support, add Threat Insights type

### DIFF
--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -51,6 +51,7 @@ import {
   APP_PROVISIONING_FIELD_NAMES,
   USER_ROLES_TYPE_NAME,
   API_SCOPES_FIELD_NAME,
+  FEATURE_TYPE_NAME,
 } from '../../constants'
 import {
   APP_POLICIES,
@@ -1731,6 +1732,40 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
           return ['modify']
         }
         return [change.action]
+      },
+    },
+    [FEATURE_TYPE_NAME]: {
+      requestsByAction: {
+        customizations: {
+          modify: [
+            {
+              request: {
+                endpoint: {
+                  path: '/api/v1/features/{id}/{lifecycle}',
+                  method: 'post',
+                  queryArgs: {
+                    // Whether to enable or disable the feature
+                    lifecycle: '{lifecycle}',
+                  },
+                },
+                context: {
+                  custom:
+                    () =>
+                    ({ change }) => ({
+                      lifecycle: getChangeData(change).value.status === 'ENABLED' ? 'ENABLE' : 'DISABLE',
+                    }),
+                },
+              },
+            },
+          ],
+        },
+      },
+    },
+    ThreatInsightConfiguration: {
+      requestsByAction: {
+        customizations: {
+          modify: [{ request: { endpoint: { path: '/api/v1/threats/configuration', method: 'post' } } }],
+        },
       },
     },
   }

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -1743,15 +1743,12 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
                 endpoint: {
                   path: '/api/v1/features/{id}/{lifecycle}',
                   method: 'post',
-                  queryArgs: {
-                    // Whether to enable or disable the feature
-                    lifecycle: '{lifecycle}',
-                  },
                 },
                 context: {
                   custom:
                     () =>
                     ({ change }) => ({
+                      // Whether to enable or disable the feature
                       lifecycle: getChangeData(change).value.status === 'ENABLED' ? 'ENABLE' : 'DISABLE',
                     }),
                 },

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1625,6 +1625,20 @@ const createCustomizations = ({
     },
   },
   // singleton types
+  ThreatInsightConfiguration: {
+    requests: [{ endpoint: { path: '/api/v1/threats/configuration' } }],
+    resource: { directFetch: true },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+        singleton: true,
+        serviceUrl: { path: '/admin/access/general' },
+      },
+      fieldCustomizations: {
+        _links: { omit: true },
+      },
+    },
+  },
   OrgSetting: {
     requests: [{ endpoint: { path: '/api/v1/org' }, transformation: { root: '.' } }],
     resource: {

--- a/packages/okta-adapter/src/reference_mapping.ts
+++ b/packages/okta-adapter/src/reference_mapping.ts
@@ -335,6 +335,12 @@ const referencesRules: OktaFieldReferenceDefinition[] = [
     missingRefStrategy: 'typeAndValue',
     target: { type: 'ResourceSet' },
   },
+  {
+    src: { field: 'excludeZones', parentTypes: ['ThreatInsightConfiguration'] },
+    serializationStrategy: 'id',
+    missingRefStrategy: 'typeAndValue',
+    target: { type: NETWORK_ZONE_TYPE_NAME },
+  },
 ]
 
 const userReferenceRules: OktaFieldReferenceDefinition[] = [


### PR DESCRIPTION
1. Support deploy for `Feature` type
2. Add new type called Threat Insights (singleton)

---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta Adapter_:
- Support managing tenant features via Salto
- Support managing Threat Insights configurations 

---
_User Notifications_: 

_Okta Adapter_:
- Threat Insights configuration will be added to workspace 
