### PR TITLE
SALTO-7570: Add Okta admin console session time settings

### DIFF
--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -1765,6 +1765,13 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
         },
       },
     },
+    AdminConsoleSession: {
+      requestsByAction: {
+        customizations: {
+          modify: [{ request: { endpoint: { path: '/api/v1/first-party-app-settings/admin-console', method: 'put' } } }],
+        }
+      }
+    }
   }
 
   return _.merge(standardRequestDefinitions, customDefinitions)

--- a/packages/okta-adapter/src/definitions/deploy/deploy.ts
+++ b/packages/okta-adapter/src/definitions/deploy/deploy.ts
@@ -1768,10 +1768,12 @@ const createCustomizations = (): Record<string, InstanceDeployApiDefinitions> =>
     AdminConsoleSession: {
       requestsByAction: {
         customizations: {
-          modify: [{ request: { endpoint: { path: '/api/v1/first-party-app-settings/admin-console', method: 'put' } } }],
-        }
-      }
-    }
+          modify: [
+            { request: { endpoint: { path: '/api/v1/first-party-app-settings/admin-console', method: 'put' } } },
+          ],
+        },
+      },
+    },
   }
 
   return _.merge(standardRequestDefinitions, customDefinitions)

--- a/packages/okta-adapter/src/definitions/fetch/fetch.ts
+++ b/packages/okta-adapter/src/definitions/fetch/fetch.ts
@@ -1625,6 +1625,16 @@ const createCustomizations = ({
     },
   },
   // singleton types
+  AdminConsoleSession: {
+    requests: [{ endpoint: { path: '/api/v1/first-party-app-settings/admin-console' } }],
+    resource: { directFetch: true },
+    element: {
+      topLevel: {
+        isTopLevel: true,
+        singleton: true,
+      },
+    },
+  },
   ThreatInsightConfiguration: {
     requests: [{ endpoint: { path: '/api/v1/threats/configuration' } }],
     resource: { directFetch: true },


### PR DESCRIPTION
_Replace me with a description of the changes in this PR_

---

_Additional context for reviewer_

---
_Release Notes_: 

_Okta Adapter_:
- Add support for Okta Admin console session settings

---
_User Notifications_: 

_Okta Adapter_:
- Okta Admin console session settings will be added 