### PR TITLE
SALTO-7222 - Salesforce - add cv for email quick action

### DIFF
--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -568,14 +568,12 @@ const runPostFetch = async ({
 // SALTO-5878 safety due to changed order of precedence when resolving referenced values / types - can remove if we don't see this log
 const updateInconsistentTypes = (validAccountElements: Element[]): void =>
   log.timeDebug(() => {
-    const objectTypesByElemID = _.groupBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
+    const objectTypesByElemID = _.keyBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
     const isInconsistentType = (e: InstanceElement | Field): boolean =>
       e.refType.type !== undefined &&
       objectTypesByElemID[e.refType.elemID.getFullName()] !== undefined &&
-      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()][0]) &&
-      !(objectTypesByElemID[e.refType.elemID.getFullName()].length > 1)
+      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()])
     const fields = Object.values(objectTypesByElemID)
-      .flat()
       .flatMap(obj => Object.values(obj.fields))
       .filter(f => isObjectType(f.refType.type))
     const elementsWithInconsistentTypes: (InstanceElement | Field)[] = validAccountElements

--- a/packages/core/src/core/fetch.ts
+++ b/packages/core/src/core/fetch.ts
@@ -568,12 +568,14 @@ const runPostFetch = async ({
 // SALTO-5878 safety due to changed order of precedence when resolving referenced values / types - can remove if we don't see this log
 const updateInconsistentTypes = (validAccountElements: Element[]): void =>
   log.timeDebug(() => {
-    const objectTypesByElemID = _.keyBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
+    const objectTypesByElemID = _.groupBy(validAccountElements.filter(isObjectType), e => e.elemID.getFullName())
     const isInconsistentType = (e: InstanceElement | Field): boolean =>
       e.refType.type !== undefined &&
       objectTypesByElemID[e.refType.elemID.getFullName()] !== undefined &&
-      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()])
+      !isEqualElements(e.refType.type, objectTypesByElemID[e.refType.elemID.getFullName()][0]) &&
+      !(objectTypesByElemID[e.refType.elemID.getFullName()].length > 1)
     const fields = Object.values(objectTypesByElemID)
+      .flat()
       .flatMap(obj => Object.values(obj.fields))
       .filter(f => isObjectType(f.refType.type))
     const elementsWithInconsistentTypes: (InstanceElement | Field)[] = validAccountElements

--- a/packages/salesforce-adapter/src/change_validator.ts
+++ b/packages/salesforce-adapter/src/change_validator.ts
@@ -57,6 +57,7 @@ import flowReferencedElements from './change_validators/flow_referenced_elements
 import liveChatButtonRoutingType from './change_validators/live_chat_button_routing_type'
 import flexiPageUnusedOrMissingFacets from './change_validators/flexi_page_unused_or_missing_facets'
 import uniqueFlowElementName from './change_validators/unique_flow_element_name'
+import accessToSendEmail from './change_validators/access_to_send_email'
 
 const { createChangeValidator, getDefaultChangeValidators } = deployment.changeValidators
 
@@ -120,6 +121,7 @@ export const changeValidators: Record<ChangeValidatorName, ChangeValidatorCreato
   liveChatButtonRoutingType: () => liveChatButtonRoutingType,
   flexiPageUnusedOrMissingFacets: () => flexiPageUnusedOrMissingFacets,
   uniqueFlowElementName: () => uniqueFlowElementName,
+  accessToSendEmail: () => accessToSendEmail,
   ..._.mapValues(getDefaultChangeValidators(), validator => () => validator),
 }
 

--- a/packages/salesforce-adapter/src/change_validators/access_to_send_email.ts
+++ b/packages/salesforce-adapter/src/change_validators/access_to_send_email.ts
@@ -25,7 +25,7 @@ const accessToSendEmailsError = (instance: InstanceElement): ChangeError => ({
   message:
     "Cannot deploy instances of 'emailActions' when 'Access to Send Email (All Email Services)' is not set to 'All email'",
   detailedMessage:
-    "In order to deploy, you can go to the service, go to setup, in the 'quick find' box search for 'Deliverability', choose it and change the 'Access to Send Email (All Email Services)' to 'All email'",
+    "In order to deploy, you can go to the service at your target environment, go to setup, in the 'quick find' box search for 'Deliverability', choose it and change the 'Access to Send Email (All Email Services)' to 'All email'",
 })
 
 const changeValidator: ChangeValidator = async (changes, elementSource) => {

--- a/packages/salesforce-adapter/src/change_validators/access_to_send_email.ts
+++ b/packages/salesforce-adapter/src/change_validators/access_to_send_email.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  ChangeError,
+  ChangeValidator,
+  ElemID,
+  getChangeData,
+  InstanceElement,
+  isObjectType,
+} from '@salto-io/adapter-api'
+import { QUICK_ACTION_METADATA_TYPE, SALESFORCE } from '../constants'
+import { isInstanceOfTypeSync } from '../filters/utils'
+
+export const TYPES_EMAILS: string[] = [QUICK_ACTION_METADATA_TYPE]
+
+const accessToSendEmailsError = (instance: InstanceElement): ChangeError => ({
+  elemID: instance.elemID,
+  severity: 'Warning',
+  message:
+    "Cannot deploy instances of 'emailActions' when 'Access to Send Email (All Email Services)' is not set to 'All email'",
+  detailedMessage:
+    "In order to deploy, you can go to the service, go to setup, in the 'quick find' box search for 'Deliverability', choose it and change the 'Access to Send Email (All Email Services)' to 'All email'",
+})
+
+const changeValidator: ChangeValidator = async (changes, elementSource) => {
+  const elements = changes.map(getChangeData).filter(isInstanceOfTypeSync(...TYPES_EMAILS))
+  const userSettings: unknown = await elementSource?.get(new ElemID(SALESFORCE, 'User'))
+  if (
+    isObjectType(userSettings) &&
+    userSettings.fields.UserPreferencesNativeEmailClient === undefined &&
+    elements.length > 0
+  ) {
+    return elements.map(accessToSendEmailsError)
+  }
+  return []
+}
+
+export default changeValidator

--- a/packages/salesforce-adapter/src/types.ts
+++ b/packages/salesforce-adapter/src/types.ts
@@ -192,6 +192,7 @@ const CHANGE_VALIDATORS = [
   'liveChatButtonRoutingType',
   'flexiPageUnusedOrMissingFacets',
   'uniqueFlowElementName',
+  'accessToSendEmail',
 ] as const
 const DEPRECATED_CHANGE_VALIDATORS = ['multipleDefaults'] as const
 export type ChangeValidatorName = (typeof CHANGE_VALIDATORS)[number]

--- a/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
@@ -34,7 +34,7 @@ describe('access to send email CV', () => {
       userObject = new ObjectType({
         elemID: new ElemID(SALESFORCE, 'User'),
         fields: {
-          UserPreferencesNativeEmailClient: { refType: BuiltinTypes.STRING },
+          UserPreferencesNativeEmailClient: { refType: BuiltinTypes.BOOLEAN },
           someOtherField: { refType: BuiltinTypes.STRING },
         },
       })
@@ -42,7 +42,7 @@ describe('access to send email CV', () => {
     })
     it('should return no errors', async () => {
       const errors = await changeValidator(createEmailElementsChanges(), elementsSource)
-      expect(errors).toHaveLength(TYPES_EMAILS.length)
+      expect(errors).toBeEmpty()
     })
   })
   describe("when 'Access to Send Email (All Email Services)' is set to 'No access' or 'System email only'", () => {
@@ -53,6 +53,9 @@ describe('access to send email CV', () => {
       })
       elementsSource = buildElementsSourceFromElements([userObject])
     })
-    it('should return an error', async () => {})
+    it('should return an error for each email type', async () => {
+      const errors = await changeValidator(createEmailElementsChanges(), elementsSource)
+      expect(errors).toHaveLength(TYPES_EMAILS.length)
+    })
   })
 })

--- a/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
@@ -42,7 +42,6 @@ describe('access to send email CV', () => {
     })
     it('should return no errors', async () => {
       const errors = await changeValidator(createEmailElementsChanges(), elementsSource)
-      // console.log(errors)
       expect(errors).toHaveLength(TYPES_EMAILS.length)
     })
   })

--- a/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
+++ b/packages/salesforce-adapter/test/change_validators/access_to_send_email.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2025 Salto Labs Ltd.
+ * Licensed under the Salto Terms of Use (the "License");
+ * You may not use this file except in compliance with the License.  You may obtain a copy of the License at https://www.salto.io/terms-of-use
+ *
+ * CERTAIN THIRD PARTY SOFTWARE MAY BE CONTAINED IN PORTIONS OF THE SOFTWARE. See NOTICE FILE AT https://github.com/salto-io/salto/blob/main/NOTICES
+ */
+
+import {
+  BuiltinTypes,
+  Change,
+  ElemID,
+  InstanceElement,
+  ObjectType,
+  ReadOnlyElementsSource,
+  toChange,
+} from '@salto-io/adapter-api'
+import { buildElementsSourceFromElements } from '@salto-io/adapter-utils'
+import changeValidator, { TYPES_EMAILS } from '../../src/change_validators/access_to_send_email'
+import { SALESFORCE } from '../../src/constants'
+
+const createEmailElementsChanges = (): Change[] => {
+  const elements: InstanceElement[] = []
+  TYPES_EMAILS.forEach(type =>
+    elements.push(new InstanceElement(type, new ObjectType({ elemID: new ElemID(SALESFORCE, type) }))),
+  )
+  return elements.map(element => toChange({ after: element }))
+}
+describe('access to send email CV', () => {
+  let userObject: ObjectType
+  let elementsSource: ReadOnlyElementsSource
+  describe("when 'Access to Send Email (All Email Services)' is set to 'All email'", () => {
+    beforeEach(() => {
+      userObject = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'User'),
+        fields: {
+          UserPreferencesNativeEmailClient: { refType: BuiltinTypes.STRING },
+          someOtherField: { refType: BuiltinTypes.STRING },
+        },
+      })
+      elementsSource = buildElementsSourceFromElements([userObject])
+    })
+    it('should return no errors', async () => {
+      const errors = await changeValidator(createEmailElementsChanges(), elementsSource)
+      // console.log(errors)
+      expect(errors).toHaveLength(TYPES_EMAILS.length)
+    })
+  })
+  describe("when 'Access to Send Email (All Email Services)' is set to 'No access' or 'System email only'", () => {
+    beforeEach(() => {
+      userObject = new ObjectType({
+        elemID: new ElemID(SALESFORCE, 'User'),
+        fields: { someOtherField: { refType: BuiltinTypes.STRING } },
+      })
+      elementsSource = buildElementsSourceFromElements([userObject])
+    })
+    it('should return an error', async () => {})
+  })
+})


### PR DESCRIPTION
add cv for email quick action

---

added CV to check if deployment of email quick action is valid, based on the value of `Access to Send Email (All Email Services)` (must be `All emails` in order to deploy, can fetched right now only with full fetch)

---
_Release Notes_: 
_Salesforce_
new change validator 

---
_User Notifications_: 
none
